### PR TITLE
feat(drive-envs): move environments into the spawn palette, out of a sidebar icon

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,8 +19,14 @@ All notable user-facing changes to PageSpace are documented here. Format follows
   underneath, so you can see at a glance who is working on which filesystem. An environment with
   nothing running in it still appears: it is infrastructure your drive keeps, not something that
   vanishes on an idle afternoon. Starting a new session in a drive that has environments asks where
-  it should run — a fresh sandbox, or in one of them.
-- **Creating, renaming, rebuilding and deleting an environment** — all four are for drive owners and
+  it should run — a fresh sandbox, or in one of them. Each environment carries its own “+” for
+  starting a session straight into it, which skips that question because the row already answered
+  it.
+- **Making an environment is part of the “new session” palette** — press ⌥N on the Agents screens,
+  or use the “+”, and the same keyboard-first selector that starts a session also offers “New
+  environment”: from the first step in any drive, and from the “where should it run?” step, where
+  the one you just made becomes the answer. There is no separate icon to find in the sidebar.
+- **Renaming, rebuilding and deleting an environment** — all three are for drive owners and
   admins, and the two destructive ones say what they destroy before they do it. Deleting refuses
   while sessions are still running inside and then offers to end them, naming both halves of what
   that means; rebuilding says plainly that the environment comes back BLANK, with its name intact

--- a/apps/web/src/components/agents/useSpawnSession.tsx
+++ b/apps/web/src/components/agents/useSpawnSession.tsx
@@ -1,8 +1,9 @@
 'use client';
 
 import { useCallback, useEffect, useMemo, useState } from 'react';
-import { Bot, Boxes, SquareTerminal, Zap } from 'lucide-react';
+import { Bot, Boxes, Plus, SquareTerminal, Zap } from 'lucide-react';
 import { toast } from 'sonner';
+import { useSWRConfig } from 'swr';
 
 import {
   CommandDialog,
@@ -10,13 +11,17 @@ import {
   CommandInput,
   CommandItem,
   CommandList,
+  CommandSeparator,
 } from '@/components/ui/command';
 import { post } from '@/lib/auth/auth-fetch';
 import { useAgentSurfaceStore } from '@/stores/agents/useAgentSurfaceStore';
 import { useAgentWorkspaceStore } from '@/stores/agent-workspace/useAgentWorkspaceStore';
-import { useDriveEnvs } from '@/hooks/drive-envs/useDriveEnvs';
+import { useDriveEnvs, driveEnvsKey } from '@/hooks/drive-envs/useDriveEnvs';
+import { reportDriveEnvWriteFailure } from '@/hooks/drive-envs/drive-env-writes';
+import { useDriveStore } from '@/hooks/useDrive';
+import { canManageDrive } from '@/hooks/usePermissions';
 import type { DriveWithAgents } from '@/hooks/page-agents/usePageAgents';
-import type { DriveEnvDTO } from '@pagespace/lib/drive-envs/env-contract';
+import { MAX_DRIVE_ENV_NAME_LENGTH, type DriveEnvDTO } from '@pagespace/lib/drive-envs/env-contract';
 
 export type SpawnKind = 'agent' | 'shell' | 'assistant';
 
@@ -71,6 +76,25 @@ export function useSpawnSession(agentsByDrive: DriveWithAgents[], onSpawned?: ()
   // produces (it skips the picker entirely).
   const [spawnPick, setSpawnPick] = useState<SpawnPick | null>(null);
   const [spawning, setSpawning] = useState(false);
+  /**
+   * An environment the CALLER already chose, before any target was picked —
+   * set only by `openSpawnInEnv` (the sidebar's per-environment "+"). It cannot
+   * live on `spawnPick`, which is null until the target step is answered, so it
+   * waits here and is merged into the pick the moment one exists. The step
+   * machine then reads `envId !== undefined` and skips straight to naming: the
+   * row the user clicked already answered "where should it run?".
+   */
+  const [presetEnvId, setPresetEnvId] = useState<string | null>(null);
+  /**
+   * Which step asked for a new environment, or null when none did.
+   *
+   * It is both the "is the create step on screen" flag and the return address:
+   * from the target step, creating one returns THERE (the environment now
+   * exists and the env step will offer it); from the env step, the newly
+   * created environment is the answer to the question that step was asking, so
+   * the flow goes straight on to naming with it selected.
+   */
+  const [newEnvFrom, setNewEnvFrom] = useState<'target' | 'env' | null>(null);
 
   const spawn = useCallback(
     async (input: { driveId: string | null; envId: string | null; agentPageId: string | null; kind: SpawnKind; name: string }) => {
@@ -126,6 +150,21 @@ export function useSpawnSession(agentsByDrive: DriveWithAgents[], onSpawned?: ()
   const openSpawn = useCallback((driveId: string, driveName: string | null) => {
     setSpawnTarget({ driveId, driveName });
     setSpawnPick(null);
+    setPresetEnvId(null);
+    setNewEnvFrom(null);
+  }, []);
+
+  /**
+   * The same flow, opened from one ENVIRONMENT's row — its "+" in the sidebar.
+   * The row is the answer to "where should it run?", so that step never appears
+   * and the user picks a target and names it, exactly as they would in a drive
+   * with no environments at all.
+   */
+  const openSpawnInEnv = useCallback((driveId: string, driveName: string | null, envId: string) => {
+    setSpawnTarget({ driveId, driveName });
+    setSpawnPick(null);
+    setPresetEnvId(envId);
+    setNewEnvFrom(null);
   }, []);
 
   // The Assistant group has nothing to pick (the assistant IS the
@@ -133,6 +172,8 @@ export function useSpawnSession(agentsByDrive: DriveWithAgents[], onSpawned?: ()
   const openAssistantSpawn = useCallback(() => {
     setSpawnTarget({ driveId: null, driveName: null });
     setSpawnPick({ kind: 'assistant', agentPageId: null, label: 'Global Assistant' });
+    setPresetEnvId(null);
+    setNewEnvFrom(null);
   }, []);
 
   const handleSubmitName = useCallback(
@@ -183,6 +224,77 @@ export function useSpawnSession(agentsByDrive: DriveWithAgents[], onSpawned?: ()
     [agentsByDrive, spawnTarget],
   );
 
+  /**
+   * Whether the requester may create an environment in the targeted drive.
+   *
+   * Resolved HERE rather than passed in, from the same two facts the sidebar's
+   * own environment affordances used before this moved: environment CRUD is
+   * drive OWNER/ADMIN, and a drive on its way to deletion is not offered new
+   * infrastructure inside it. Computing it in the hook is what lets every
+   * caller (the sidebar, the Agents header) get the entry point without
+   * threading a permission through. A drive the store does not hold — the
+   * driveless Assistant target, an orphan group — resolves to `false`, which is
+   * the right answer for both.
+   */
+  const drives = useDriveStore((state) => state.drives);
+  const canCreateEnv = useMemo(() => {
+    if (!spawnTarget?.driveId) return false;
+    const drive = drives.find((entry) => entry.id === spawnTarget.driveId);
+    if (!drive || drive.isTrashed) return false;
+    return canManageDrive(drive);
+  }, [drives, spawnTarget]);
+
+  const { mutate: globalMutate } = useSWRConfig();
+
+  /**
+   * Create an environment from inside the palette, and answer what the palette
+   * should do next — `'retry'` on the one refusal retyping fixes (a name
+   * already taken), which keeps the step open with the user's text.
+   *
+   * On success it refreshes the SHARED environments key, so the sidebar's rows
+   * show the new environment without knowing this happened.
+   */
+  const createEnvironment = useCallback(
+    async (name: string): Promise<'retry' | 'failed' | { envId: string }> => {
+      const driveId = spawnTarget?.driveId;
+      if (!driveId) return 'failed';
+      let created: { env: DriveEnvDTO };
+      try {
+        created = await post<{ env: DriveEnvDTO }>(`/api/drives/${encodeURIComponent(driveId)}/envs`, { name });
+      } catch (error) {
+        // `'retry'` is the one refusal retyping fixes; everything else has been
+        // toasted and is `'failed'`.
+        return reportDriveEnvWriteFailure(error, 'Could not create the environment') === 'retry' ? 'retry' : 'failed';
+      }
+      globalMutate(driveEnvsKey(driveId));
+      return { envId: created.env.id };
+    },
+    [spawnTarget, globalMutate],
+  );
+
+  const handleCreateEnv = useCallback(
+    async (name: string) => {
+      const from = newEnvFrom;
+      const result = await createEnvironment(name);
+      // Retryable: hold the step, with what the user typed still in it.
+      if (result === 'retry') return;
+      // Not retryable: hand them back the step they came from rather than
+      // stranding them on a form that will refuse the same way again.
+      if (result === 'failed') {
+        setNewEnvFrom(null);
+        return;
+      }
+      if (from === 'env') {
+        // The environment the env step was asking about now exists, and it is
+        // the answer: go on to naming with it selected rather than making the
+        // user pick the thing they just created.
+        setSpawnPick((current) => (current ? { ...current, envId: result.envId } : current));
+      }
+      setNewEnvFrom(null);
+    },
+    [createEnvironment, newEnvFrom],
+  );
+
   const paletteElement = (
     <SpawnSessionPalette
       open={spawnTarget !== null}
@@ -193,31 +305,46 @@ export function useSpawnSession(agentsByDrive: DriveWithAgents[], onSpawned?: ()
       envsError={paletteEnvsError}
       onRetryEnvs={retryPaletteEnvs}
       canRunSandbox={canRunSandbox}
+      canCreateEnv={canCreateEnv}
+      newEnvFrom={newEnvFrom}
+      onStartNewEnv={setNewEnvFrom}
+      onCancelNewEnv={() => setNewEnvFrom(null)}
+      onCreateEnv={handleCreateEnv}
       pick={spawnPick}
       spawning={spawning}
       onOpenChange={(open) => {
         if (open) return;
         setSpawnTarget(null);
         setSpawnPick(null);
+        setPresetEnvId(null);
+        setNewEnvFrom(null);
       }}
-      onPickTarget={setSpawnPick}
+      onPickTarget={(pick) => setSpawnPick({ ...pick, ...(presetEnvId !== null && { envId: presetEnvId }) })}
       onPickEnv={(envId) => setSpawnPick((current) => (current ? { ...current, envId } : current))}
       onSubmitName={handleSubmitName}
     />
   );
 
-  return { openSpawn, openAssistantSpawn, spawning, paletteElement };
+  return { openSpawn, openSpawnInEnv, openAssistantSpawn, spawning, paletteElement };
 }
 
 /**
  * The spawn palette for a new session, Raycast-style: search or arrow-key to
  * a target and hit Enter — the same keyboard-first pattern `QuickCreatePalette`
  * established for page creation, reused here so a future mouseless-navigation
- * pass has one command-palette idiom to build on, not two. Two steps: pick a
- * target (an agent, Shell, or Global Assistant — `openAssistantSpawn` skips
- * straight here since it has nothing else to choose), then name the session.
- * Naming is always the last step, even for a one-click assistant spawn, so
- * every session gets a deliberate name.
+ * pass has one command-palette idiom to build on, not two. Pick a target (an
+ * agent, Shell, or Global Assistant — `openAssistantSpawn` skips straight past
+ * this since it has nothing else to choose), say where it runs when the drive
+ * has environments, then name the session. Naming is always the last step, even
+ * for a one-click assistant spawn, so every session gets a deliberate name.
+ *
+ * CREATING an environment is here too, on both of the steps that talk about
+ * them, and that is the whole reason it stopped being an icon button in the
+ * sidebar: the selector that offers environments as somewhere to run is the
+ * selector that should offer making one. From the target step it is reachable
+ * even in a drive with none (where the env step never renders at all); from the
+ * env step the environment just created becomes the answer to the question that
+ * step was asking.
  */
 function SpawnSessionPalette({
   open,
@@ -228,6 +355,11 @@ function SpawnSessionPalette({
   envsError,
   onRetryEnvs,
   canRunSandbox,
+  canCreateEnv,
+  newEnvFrom,
+  onStartNewEnv,
+  onCancelNewEnv,
+  onCreateEnv,
   pick,
   spawning,
   onOpenChange,
@@ -270,6 +402,16 @@ function SpawnSessionPalette({
    * naming step.
    */
   canRunSandbox: boolean;
+  /** Whether to offer creating one at all — drive OWNER/ADMIN, on a live drive. */
+  canCreateEnv: boolean;
+  /**
+   * Which step asked to create an environment, or null when none did. Doubles
+   * as the create step's on-screen flag and its return address.
+   */
+  newEnvFrom: 'target' | 'env' | null;
+  onStartNewEnv: (from: 'target' | 'env') => void;
+  onCancelNewEnv: () => void;
+  onCreateEnv: (name: string) => Promise<void>;
   pick: SpawnPick | null;
   spawning: boolean;
   onOpenChange: (open: boolean) => void;
@@ -279,12 +421,23 @@ function SpawnSessionPalette({
   onSubmitName: (name: string) => void;
 }) {
   const [name, setName] = useState('');
+  // The environment's name, kept apart from the session's: the create step can
+  // be refused (a name already taken) and hold its text while the session name
+  // below is still blank, and neither must ever prefill the other.
+  const [envName, setEnvName] = useState('');
+  const [creatingEnv, setCreatingEnv] = useState(false);
 
   // Blank by default every time a new naming step starts — a stale typed
   // value from resolving one spawn must never prefill the next.
   useEffect(() => {
     if (open) setName('');
   }, [open, pick]);
+
+  // Cleared when the create step OPENS, not when it closes: a 409 keeps the
+  // step open with what the user typed, so only a fresh opening may blank it.
+  useEffect(() => {
+    if (newEnvFrom !== null) setEnvName('');
+  }, [newEnvFrom]);
 
   // WHICH OF THE FOUR STEPS IS ON SCREEN, decided in one place rather than by
   // ternaries that could disagree. The environment step exists only when there
@@ -311,18 +464,24 @@ function SpawnSessionPalette({
   // not ask and spawn ephemerally into a drive whose environments it simply
   // failed to read. That is the silent-wrong-answer case again, just reached
   // by a different route.
-  const step: 'target' | 'pending' | 'error' | 'env' | 'name' =
-    pick === null
-      ? 'target'
-      : pick.envId !== undefined
-        ? 'name'
-        : envsLoading
-          ? 'pending'
-          : envsError != null
-            ? 'error'
-            : envs.length > 0
-              ? 'env'
-              : 'name';
+  //
+  // `'new-env'` PRE-EMPTS all of them, because it is a question asked ON TOP of
+  // whichever step asked it — the target step and the env step both open it,
+  // and `newEnvFrom` is what each of them returns to.
+  const step: 'target' | 'pending' | 'error' | 'env' | 'name' | 'new-env' =
+    newEnvFrom !== null
+      ? 'new-env'
+      : pick === null
+        ? 'target'
+        : pick.envId !== undefined
+          ? 'name'
+          : envsLoading
+            ? 'pending'
+            : envsError != null
+              ? 'error'
+              : envs.length > 0
+                ? 'env'
+                : 'name';
   const chosenEnv = pick?.envId ? (envs.find((env) => env.id === pick.envId) ?? null) : null;
 
   return (
@@ -330,14 +489,18 @@ function SpawnSessionPalette({
       open={open}
       onOpenChange={onOpenChange}
       title={
-        step === 'target'
-          ? 'New session'
-          : step === 'env' || step === 'pending' || step === 'error'
-            ? 'Where should it run?'
-            : 'Name your session'
+        step === 'new-env'
+          ? 'New environment'
+          : step === 'target'
+            ? 'New session'
+            : step === 'env' || step === 'pending' || step === 'error'
+              ? 'Where should it run?'
+              : 'Name your session'
       }
       description={
-        step === 'name'
+        step === 'new-env'
+          ? `A persistent machine ${driveName ? `${driveName}'s` : 'this drive’s'} sessions can run inside, sharing one filesystem that survives every session that ends. Name it for what it is for — “dev”, “staging”, “data-import”.`
+        : step === 'name'
           ? chosenEnv
             ? `In ${chosenEnv.name} · leave blank to use "${pick?.label ?? 'this session'}"`
             : `Leave blank to use "${pick?.label ?? 'this session'}"`
@@ -354,7 +517,50 @@ function SpawnSessionPalette({
       showCloseButton={false}
       className="max-w-[420px]"
     >
-      {step === 'pending' ? (
+      {step === 'new-env' ? (
+        /* The create form lives IN the palette rather than in a dialog over it:
+           this is one continuous keyboard flow, and a second Radix layer would
+           put two focus traps on screen at once. Cancel returns to whichever
+           step asked. */
+        <form
+          className="space-y-3 p-3"
+          onSubmit={(event) => {
+            event.preventDefault();
+            const trimmed = envName.trim();
+            if (!trimmed || creatingEnv) return;
+            setCreatingEnv(true);
+            void onCreateEnv(trimmed).finally(() => setCreatingEnv(false));
+          }}
+        >
+          <input
+            autoFocus
+            aria-label="Environment name"
+            value={envName}
+            onChange={(event) => setEnvName(event.target.value)}
+            maxLength={MAX_DRIVE_ENV_NAME_LENGTH}
+            placeholder="dev"
+            disabled={creatingEnv}
+            className="flex h-10 w-full rounded-md border border-input bg-transparent px-3 py-2 text-sm outline-hidden placeholder:text-muted-foreground disabled:cursor-not-allowed disabled:opacity-50"
+          />
+          <div className="flex items-center gap-2">
+            <button
+              type="submit"
+              className="rounded-md border border-input px-3 py-1.5 text-sm hover:bg-accent disabled:cursor-not-allowed disabled:opacity-50"
+              disabled={creatingEnv || envName.trim().length === 0}
+            >
+              {creatingEnv ? 'Creating…' : 'Create environment'}
+            </button>
+            <button
+              type="button"
+              className="rounded-md px-3 py-1.5 text-sm text-muted-foreground hover:text-foreground"
+              onClick={onCancelNewEnv}
+              disabled={creatingEnv}
+            >
+              Cancel
+            </button>
+          </div>
+        </form>
+      ) : step === 'pending' ? (
         /* Deliberately inert — no input to focus and nothing selectable. The
            question ("where should it run?") is already on screen; only its
            options are missing, so this holds the user's place rather than
@@ -420,6 +626,25 @@ function SpawnSessionPalette({
                 </CommandItem>
               ))}
             </CommandGroup>
+            {/* Creating one is an answer to the question this step is asking —
+                the new environment becomes the pick and the flow goes on to
+                naming. Only shown to someone who may create one; a member sees
+                the environments they can use and nothing they cannot do. */}
+            {canCreateEnv && (
+              <>
+                <CommandSeparator />
+                <CommandGroup>
+                  <CommandItem
+                    value="new-environment-New environment"
+                    disabled={spawning}
+                    onSelect={() => onStartNewEnv('env')}
+                  >
+                    <Plus className="size-3.5 shrink-0 text-muted-foreground" aria-hidden="true" />
+                    <span className="truncate">New environment…</span>
+                  </CommandItem>
+                </CommandGroup>
+              </>
+            )}
           </CommandList>
         </>
       ) : step === 'name' ? (
@@ -494,6 +719,29 @@ function SpawnSessionPalette({
                 )}
               </CommandItem>
             </CommandGroup>
+            {/* Its own group, below a separator, because it does not belong to
+                the list above it: everything there is something to start a
+                session WITH, and this is infrastructure to start sessions IN.
+                It replaced an icon button in the sidebar — a named row in the
+                selector that already offers environments is where the act
+                belongs, and it is reachable here even in a drive that has none
+                (where the env step never appears). */}
+            {canCreateEnv && (
+              <>
+                <CommandSeparator />
+                <CommandGroup>
+                  <CommandItem
+                    value="new-environment-New environment"
+                    disabled={spawning}
+                    onSelect={() => onStartNewEnv('target')}
+                  >
+                    <Boxes className="size-3.5 shrink-0 text-muted-foreground" aria-hidden="true" />
+                    <span className="truncate">New environment</span>
+                    <span className="ml-auto shrink-0 text-xs text-muted-foreground">Setup</span>
+                  </CommandItem>
+                </CommandGroup>
+              </>
+            )}
           </CommandList>
         </>
       )}

--- a/apps/web/src/components/agents/useSpawnSession.tsx
+++ b/apps/web/src/components/agents/useSpawnSession.tsx
@@ -251,8 +251,9 @@ export function useSpawnSession(agentsByDrive: DriveWithAgents[], onSpawned?: ()
    * should do next — `'retry'` on the one refusal retyping fixes (a name
    * already taken), which keeps the step open with the user's text.
    *
-   * On success it refreshes the SHARED environments key, so the sidebar's rows
-   * show the new environment without knowing this happened.
+   * On success it publishes the new environment into the SHARED environments
+   * key, so the sidebar's rows show it without knowing this happened — and so
+   * this palette's own next step is reading a listing that contains it.
    */
   const createEnvironment = useCallback(
     async (name: string): Promise<'retry' | 'failed' | { envId: string }> => {
@@ -266,7 +267,30 @@ export function useSpawnSession(agentsByDrive: DriveWithAgents[], onSpawned?: ()
         // toasted and is `'failed'`.
         return reportDriveEnvWriteFailure(error, 'Could not create the environment') === 'retry' ? 'retry' : 'failed';
       }
-      globalMutate(driveEnvsKey(driveId));
+      // PUBLISHED, not merely re-asked for. A bare `mutate(key)` is only a
+      // revalidation: the cache goes on holding the PREVIOUS listing until the
+      // network answers, and `isLoading` stays false throughout because data is
+      // already loaded (it flags a first load, not a refresh). So for the whole
+      // width of that request the step machine — which decides on `envs.length`
+      // and `isLoading` — reads "this drive has no environments" about a drive
+      // that just got one, and the two ways that lands are both silent: a quick
+      // pick goes straight to naming and spawns EPHEMERALLY into a drive whose
+      // environment the user just deliberately made, or the response arrives
+      // while they are typing a name and the form is swapped for the env step
+      // mid-keystroke. Writing the row in first means the answer is already
+      // true when the next render asks; the revalidation behind it only
+      // confirms it, and settles the ordering the server sorts by.
+      globalMutate(
+        driveEnvsKey(driveId),
+        (current?: { envs: DriveEnvDTO[] }) => {
+          const known = current?.envs ?? [];
+          // A revalidation already in flight may have brought it in first.
+          return known.some((env) => env.id === created.env.id)
+            ? { envs: known }
+            : { envs: [...known, created.env] };
+        },
+        { revalidate: true },
+      );
       return { envId: created.env.id };
     },
     [spawnTarget, globalMutate],

--- a/apps/web/src/components/agents/useSpawnSession.tsx
+++ b/apps/web/src/components/agents/useSpawnSession.tsx
@@ -313,6 +313,15 @@ export function useSpawnSession(agentsByDrive: DriveWithAgents[], onSpawned?: ()
         // the answer: go on to naming with it selected rather than making the
         // user pick the thing they just created.
         setSpawnPick((current) => (current ? { ...current, envId: result.envId } : current));
+      } else {
+        // From the TARGET step, where a preset may be in play: this flow can
+        // have been opened by one environment's "+" in the sidebar, which
+        // pre-answered "where should it run?". Making a NEW environment is a
+        // newer intent than that row's, and silently spawning into the row's
+        // environment anyway would be the palette quietly overruling the thing
+        // the user just did. Dropping the preset lets the env step ask once,
+        // now with both to choose between.
+        setPresetEnvId(null);
       }
       setNewEnvFrom(null);
     },

--- a/apps/web/src/components/agents/useSpawnSession.tsx
+++ b/apps/web/src/components/agents/useSpawnSession.tsx
@@ -496,6 +496,20 @@ function SpawnSessionPalette({
   const [envName, setEnvName] = useState('');
   const [creatingEnv, setCreatingEnv] = useState(false);
   const createEnvInputId = useId();
+  /**
+   * WHICH ATTEMPT AT CREATING ONE the pending request belongs to.
+   *
+   * `creatingEnv` is what disables this form while its POST is out, and a
+   * settling request clears it — but the request that settles is not
+   * necessarily the one on screen. Abandon a create (Escape), open another, and
+   * start its request: the FIRST one landing would clear the second's loading
+   * state and hand back an enabled button over a POST still in flight, which is
+   * a second, non-idempotent create one keystroke away.
+   *
+   * Bumped whenever the create step changes, so a late `finally` can tell
+   * whether the attempt it belongs to is still the one being shown.
+   */
+  const createAttempt = useRef(0);
 
   // The repo rule for a surface holding text the user typed, and here it is a
   // REGRESSION GUARD as much as a convention: this form used to be
@@ -516,6 +530,9 @@ function SpawnSessionPalette({
   // Cleared when the create step OPENS, not when it closes: a 409 keeps the
   // step open with what the user typed, so only a fresh opening may blank it.
   useEffect(() => {
+    // Every change of step — opened, cancelled, closed with the palette —
+    // retires whatever attempt was outstanding.
+    createAttempt.current += 1;
     if (newEnvFrom === null) return;
     setEnvName('');
     // `creatingEnv` too, and for a reason worth naming: a create still in
@@ -614,8 +631,14 @@ function SpawnSessionPalette({
             event.preventDefault();
             const trimmed = envName.trim();
             if (!trimmed || creatingEnv) return;
+            const attempt = createAttempt.current;
             setCreatingEnv(true);
-            void onCreateEnv(trimmed).finally(() => setCreatingEnv(false));
+            void onCreateEnv(trimmed).finally(() => {
+              // Only the attempt still on screen may re-enable the form. An
+              // older one landing must leave the current request's POST looking
+              // exactly as in-flight as it is.
+              if (createAttempt.current === attempt) setCreatingEnv(false);
+            });
           }}
         >
           <input

--- a/apps/web/src/components/agents/useSpawnSession.tsx
+++ b/apps/web/src/components/agents/useSpawnSession.tsx
@@ -281,6 +281,12 @@ export function useSpawnSession(agentsByDrive: DriveWithAgents[], onSpawned?: ()
       // mid-keystroke. Writing the row in first means the answer is already
       // true when the next render asks; the revalidation behind it only
       // confirms it, and settles the ordering the server sorts by.
+      // Said out loud, because nothing else says it any more. The dialog this
+      // replaced closed onto the sidebar, where the new row appearing WAS the
+      // confirmation; the palette covers that, and the target step it returns
+      // to looks identical to the one it left. The other environment writes
+      // (delete, rebuild) already answer this way.
+      toast.success(`Created “${created.env.name}”`);
       globalMutate(
         driveEnvsKey(driveId),
         (current?: { envs: DriveEnvDTO[] }) => {

--- a/apps/web/src/components/agents/useSpawnSession.tsx
+++ b/apps/web/src/components/agents/useSpawnSession.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useCallback, useEffect, useId, useMemo, useState } from 'react';
+import { useCallback, useEffect, useId, useMemo, useRef, useState } from 'react';
 import { Bot, Boxes, Plus, SquareTerminal, Zap } from 'lucide-react';
 import { toast } from 'sonner';
 import { useSWRConfig } from 'swr';
@@ -96,6 +96,23 @@ export function useSpawnSession(agentsByDrive: DriveWithAgents[], onSpawned?: ()
    * the flow goes straight on to naming with it selected.
    */
   const [newEnvFrom, setNewEnvFrom] = useState<'target' | 'env' | null>(null);
+  /**
+   * WHICH OPENING OF THIS PALETTE A DEFERRED ANSWER BELONGS TO.
+   *
+   * Creating an environment is a network round trip, and the flow that started
+   * it can be gone by the time it lands: Escape closes the palette while the
+   * POST is still out, and the next thing the user opens is a DIFFERENT flow,
+   * with its own target and possibly its own drive. Without something to check
+   * against, the late continuation writes into whatever is on screen now — it
+   * would select an environment belonging to another drive, drop the row preset
+   * the new flow was opened with, or close a create step the user is typing in.
+   *
+   * Bumped on every open and every close, so a continuation can ask whether the
+   * flow it belongs to is still the one in front of the user. Only the STATE
+   * continuation is gated: the environment really was created, so its toast and
+   * its cache write stand either way.
+   */
+  const flowToken = useRef(0);
 
   const spawn = useCallback(
     async (input: { driveId: string | null; envId: string | null; agentPageId: string | null; kind: SpawnKind; name: string }) => {
@@ -149,6 +166,7 @@ export function useSpawnSession(agentsByDrive: DriveWithAgents[], onSpawned?: ()
   // A drive group's "+" opens the picker first so the naming step's
   // placeholder can reflect whichever agent/shell was chosen.
   const openSpawn = useCallback((driveId: string, driveName: string | null) => {
+    flowToken.current += 1;
     setSpawnTarget({ driveId, driveName });
     setSpawnPick(null);
     setPresetEnvId(null);
@@ -162,6 +180,7 @@ export function useSpawnSession(agentsByDrive: DriveWithAgents[], onSpawned?: ()
    * with no environments at all.
    */
   const openSpawnInEnv = useCallback((driveId: string, driveName: string | null, envId: string) => {
+    flowToken.current += 1;
     setSpawnTarget({ driveId, driveName });
     setSpawnPick(null);
     setPresetEnvId(envId);
@@ -171,6 +190,7 @@ export function useSpawnSession(agentsByDrive: DriveWithAgents[], onSpawned?: ()
   // The Assistant group has nothing to pick (the assistant IS the
   // counterpart), so this skips straight to naming.
   const openAssistantSpawn = useCallback(() => {
+    flowToken.current += 1;
     setSpawnTarget({ driveId: null, driveName: null });
     setSpawnPick({ kind: 'assistant', agentPageId: null, label: 'Global Assistant' });
     setPresetEnvId(null);
@@ -306,7 +326,11 @@ export function useSpawnSession(agentsByDrive: DriveWithAgents[], onSpawned?: ()
   const handleCreateEnv = useCallback(
     async (name: string) => {
       const from = newEnvFrom;
+      const token = flowToken.current;
       const result = await createEnvironment(name);
+      // The flow that asked is gone — closed, or replaced by another opening.
+      // Its answer must not be applied to whatever took its place.
+      if (flowToken.current !== token) return;
       // Retryable: hold the step, with what the user typed still in it.
       if (result === 'retry') return;
       // Not retryable: hand them back the step they came from rather than
@@ -354,6 +378,7 @@ export function useSpawnSession(agentsByDrive: DriveWithAgents[], onSpawned?: ()
       spawning={spawning}
       onOpenChange={(open) => {
         if (open) return;
+        flowToken.current += 1;
         setSpawnTarget(null);
         setSpawnPick(null);
         setPresetEnvId(null);
@@ -487,7 +512,13 @@ function SpawnSessionPalette({
   // Cleared when the create step OPENS, not when it closes: a 409 keeps the
   // step open with what the user typed, so only a fresh opening may blank it.
   useEffect(() => {
-    if (newEnvFrom !== null) setEnvName('');
+    if (newEnvFrom === null) return;
+    setEnvName('');
+    // `creatingEnv` too, and for a reason worth naming: a create still in
+    // flight when the palette was closed never runs its `finally` against a
+    // visible form, so without this the next create step would open with its
+    // button already reading "Creating…" and disabled forever.
+    setCreatingEnv(false);
   }, [newEnvFrom]);
 
   // WHICH OF THE FOUR STEPS IS ON SCREEN, decided in one place rather than by

--- a/apps/web/src/components/agents/useSpawnSession.tsx
+++ b/apps/web/src/components/agents/useSpawnSession.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useCallback, useEffect, useId, useMemo, useState } from 'react';
 import { Bot, Boxes, Plus, SquareTerminal, Zap } from 'lucide-react';
 import { toast } from 'sonner';
 import { useSWRConfig } from 'swr';
@@ -20,6 +20,7 @@ import { useDriveEnvs, driveEnvsKey } from '@/hooks/drive-envs/useDriveEnvs';
 import { reportDriveEnvWriteFailure } from '@/hooks/drive-envs/drive-env-writes';
 import { useDriveStore } from '@/hooks/useDrive';
 import { canManageDrive } from '@/hooks/usePermissions';
+import { useEditingSession } from '@/stores/useEditingSession';
 import type { DriveWithAgents } from '@/hooks/page-agents/usePageAgents';
 import { MAX_DRIVE_ENV_NAME_LENGTH, type DriveEnvDTO } from '@pagespace/lib/drive-envs/env-contract';
 
@@ -459,6 +460,17 @@ function SpawnSessionPalette({
   // below is still blank, and neither must ever prefill the other.
   const [envName, setEnvName] = useState('');
   const [creatingEnv, setCreatingEnv] = useState(false);
+  const createEnvInputId = useId();
+
+  // The repo rule for a surface holding text the user typed, and here it is a
+  // REGRESSION GUARD as much as a convention: this form used to be
+  // `DriveEnvNameDialog`, which registered, and moving it into the palette
+  // would otherwise have quietly dropped the protection on the way. A
+  // background revalidation or an auth refresh landing mid-type must not tear
+  // down what someone is halfway through naming.
+  useEditingSession(`spawn-new-env-${createEnvInputId}`, newEnvFrom !== null, 'form', {
+    componentName: 'SpawnSessionPalette',
+  });
 
   // Blank by default every time a new naming step starts — a stale typed
   // value from resolving one spawn must never prefill the next.

--- a/apps/web/src/components/agents/useSpawnSession.tsx
+++ b/apps/web/src/components/agents/useSpawnSession.tsx
@@ -70,22 +70,25 @@ export function useSpawnSession(agentsByDrive: DriveWithAgents[], onSpawned?: ()
   const selectConversation = useAgentSurfaceStore((state) => state.selectConversation);
   const selectSession = useAgentSurfaceStore((state) => state.selectSession);
 
-  const [spawnTarget, setSpawnTarget] = useState<{ driveId: string | null; driveName: string | null } | null>(null);
+  /**
+   * The OPENING: which drive this palette was opened for, and — when it was
+   * opened from one environment's row — which environment that row already
+   * answered "where should it run?" with. Both belong to the opening rather
+   * than to the pick, which does not exist until the target step is answered,
+   * so they live and die together instead of as two states that could disagree.
+   */
+  const [spawnTarget, setSpawnTarget] = useState<{
+    driveId: string | null;
+    driveName: string | null;
+    /** The row's environment, or null when the flow was opened without one. */
+    envId: string | null;
+  } | null>(null);
   // Set once a target (agent/shell/assistant) is picked in the palette's first
   // step — its presence is what swaps the dialog to the naming step. Null
   // driveId + kind 'assistant' is the only shape `openAssistantSpawn` ever
   // produces (it skips the picker entirely).
   const [spawnPick, setSpawnPick] = useState<SpawnPick | null>(null);
   const [spawning, setSpawning] = useState(false);
-  /**
-   * An environment the CALLER already chose, before any target was picked —
-   * set only by `openSpawnInEnv` (the sidebar's per-environment "+"). It cannot
-   * live on `spawnPick`, which is null until the target step is answered, so it
-   * waits here and is merged into the pick the moment one exists. The step
-   * machine then reads `envId !== undefined` and skips straight to naming: the
-   * row the user clicked already answered "where should it run?".
-   */
-  const [presetEnvId, setPresetEnvId] = useState<string | null>(null);
   /**
    * Which step asked for a new environment, or null when none did.
    *
@@ -167,9 +170,8 @@ export function useSpawnSession(agentsByDrive: DriveWithAgents[], onSpawned?: ()
   // placeholder can reflect whichever agent/shell was chosen.
   const openSpawn = useCallback((driveId: string, driveName: string | null) => {
     flowToken.current += 1;
-    setSpawnTarget({ driveId, driveName });
+    setSpawnTarget({ driveId, driveName, envId: null });
     setSpawnPick(null);
-    setPresetEnvId(null);
     setNewEnvFrom(null);
   }, []);
 
@@ -181,9 +183,8 @@ export function useSpawnSession(agentsByDrive: DriveWithAgents[], onSpawned?: ()
    */
   const openSpawnInEnv = useCallback((driveId: string, driveName: string | null, envId: string) => {
     flowToken.current += 1;
-    setSpawnTarget({ driveId, driveName });
+    setSpawnTarget({ driveId, driveName, envId });
     setSpawnPick(null);
-    setPresetEnvId(envId);
     setNewEnvFrom(null);
   }, []);
 
@@ -191,9 +192,8 @@ export function useSpawnSession(agentsByDrive: DriveWithAgents[], onSpawned?: ()
   // counterpart), so this skips straight to naming.
   const openAssistantSpawn = useCallback(() => {
     flowToken.current += 1;
-    setSpawnTarget({ driveId: null, driveName: null });
+    setSpawnTarget({ driveId: null, driveName: null, envId: null });
     setSpawnPick({ kind: 'assistant', agentPageId: null, label: 'Global Assistant' });
-    setPresetEnvId(null);
     setNewEnvFrom(null);
   }, []);
 
@@ -345,14 +345,14 @@ export function useSpawnSession(agentsByDrive: DriveWithAgents[], onSpawned?: ()
         // user pick the thing they just created.
         setSpawnPick((current) => (current ? { ...current, envId: result.envId } : current));
       } else {
-        // From the TARGET step, where a preset may be in play: this flow can
-        // have been opened by one environment's "+" in the sidebar, which
-        // pre-answered "where should it run?". Making a NEW environment is a
-        // newer intent than that row's, and silently spawning into the row's
-        // environment anyway would be the palette quietly overruling the thing
-        // the user just did. Dropping the preset lets the env step ask once,
-        // now with both to choose between.
-        setPresetEnvId(null);
+        // From the TARGET step, where the OPENING may already carry an
+        // environment: this flow can have been started by one environment's "+"
+        // in the sidebar, which pre-answered "where should it run?". Making a
+        // NEW environment is a newer intent than that row's, and spawning into
+        // the row's environment anyway would be the palette quietly overruling
+        // what the user just did. Dropping the row's answer lets the env step
+        // ask once, now with both to choose between.
+        setSpawnTarget((current) => (current ? { ...current, envId: null } : current));
       }
       setNewEnvFrom(null);
     },
@@ -381,10 +381,14 @@ export function useSpawnSession(agentsByDrive: DriveWithAgents[], onSpawned?: ()
         flowToken.current += 1;
         setSpawnTarget(null);
         setSpawnPick(null);
-        setPresetEnvId(null);
         setNewEnvFrom(null);
       }}
-      onPickTarget={(pick) => setSpawnPick({ ...pick, ...(presetEnvId !== null && { envId: presetEnvId }) })}
+      onPickTarget={(pick) =>
+        // The opening's environment, when it had one, is the answer the env
+        // step would otherwise ask for — carried onto the pick so the step
+        // machine reads it as already given.
+        setSpawnPick({ ...pick, ...(spawnTarget?.envId != null && { envId: spawnTarget.envId }) })
+      }
       onPickEnv={(envId) => setSpawnPick((current) => (current ? { ...current, envId } : current))}
       onSubmitName={handleSubmitName}
     />

--- a/apps/web/src/components/create/QuickCreatePalette.tsx
+++ b/apps/web/src/components/create/QuickCreatePalette.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { useEffect, useRef, useState, useCallback, useMemo } from 'react';
-import { useParams } from 'next/navigation';
+import { useParams, usePathname } from 'next/navigation';
 import {
   ArrowLeft, Upload,
   FileText, FileCode, FileSpreadsheet, FileImage, File,
@@ -30,6 +30,7 @@ import { useDisplayPreferences } from '@/hooks/useDisplayPreferences';
 import { matchesKeyEvent, getEffectiveBinding } from '@/stores/useHotkeyStore';
 import { isEditingActive } from '@/stores/useEditingStore';
 import { findNodeAndParent } from '@/lib/tree/tree-utils';
+import { resolveSidebarVariant } from '@/components/layout/left-sidebar/sidebar-routes';
 import type { TreePage } from '@/hooks/usePageTree';
 import {
   PageType,
@@ -124,6 +125,14 @@ export default function QuickCreatePalette() {
     : Array.isArray(rawPath) ? rawPath[0]
     : undefined;
 
+  const pathname = usePathname();
+  // The Agents routes bind this hotkey to their OWN palette — the spawn
+  // selector, which is what "new" means there (a session, or an environment to
+  // run one in), not a page type. `AgentsSidebar` owns that handler, so this
+  // one must stand down or both would fire on the same keystroke. The matcher
+  // is the sidebar's own, rather than a second regex that could drift from it.
+  const onAgentsRoute = resolveSidebarVariant(pathname ?? '') === 'agents';
+
   const quickCreateOpen = useUIStore((s) => s.quickCreateOpen);
   const quickCreateParentOverride = useUIStore((s) => s.quickCreateParentOverride);
   const openQuickCreate = useUIStore((s) => s.openQuickCreate);
@@ -162,14 +171,14 @@ export default function QuickCreatePalette() {
   useEffect(() => {
     const handler = (e: KeyboardEvent) => {
       const binding = getEffectiveBinding('pages.quick-create');
-      if (matchesKeyEvent(binding, e) && !isEditingActive() && driveId && !quickCreateOpen) {
+      if (matchesKeyEvent(binding, e) && !isEditingActive() && driveId && !quickCreateOpen && !onAgentsRoute) {
         e.preventDefault();
         openQuickCreate(null);
       }
     };
     document.addEventListener('keydown', handler);
     return () => document.removeEventListener('keydown', handler);
-  }, [driveId, openQuickCreate, quickCreateOpen]);
+  }, [driveId, openQuickCreate, quickCreateOpen, onAgentsRoute]);
 
   // Reset when palette closes
   useEffect(() => {

--- a/apps/web/src/components/create/__tests__/QuickCreatePalette.test.tsx
+++ b/apps/web/src/components/create/__tests__/QuickCreatePalette.test.tsx
@@ -1,0 +1,76 @@
+/**
+ * WHO ANSWERS THE QUICK-CREATE HOTKEY.
+ *
+ * `Alt+N` means "new page" everywhere except the Agents routes, where "new"
+ * is a session — or the environment to run one in — and `AgentsSidebar`
+ * registers its own handler for the same binding. Two handlers on one keystroke
+ * is the failure this guards: the sidebar's half is tested at its own site, and
+ * this is the half that has to stand down.
+ */
+
+import { describe, test, expect, beforeEach, vi } from 'vitest';
+import { render, fireEvent } from '@testing-library/react';
+
+const mockUseParams = vi.fn<() => Record<string, string>>(() => ({ driveId: 'drive-1' }));
+const mockUsePathname = vi.fn<() => string>(() => '/dashboard/drive-1/some-page');
+vi.mock('next/navigation', () => ({
+  useParams: () => mockUseParams(),
+  usePathname: () => mockUsePathname(),
+}));
+
+const mockOpenQuickCreate = vi.fn();
+vi.mock('@/stores/useUIStore', () => ({
+  useUIStore: (selector: (state: unknown) => unknown) =>
+    selector({
+      quickCreateOpen: false,
+      quickCreateParentOverride: undefined,
+      openQuickCreate: mockOpenQuickCreate,
+      closeQuickCreate: vi.fn(),
+    }),
+}));
+
+vi.mock('swr', () => ({
+  default: () => ({ data: undefined }),
+  useSWRConfig: () => ({ mutate: vi.fn() }),
+}));
+vi.mock('@/hooks/usePageNavigation', () => ({ usePageNavigation: () => ({ navigateToPage: vi.fn() }) }));
+vi.mock('@/hooks/useBreadcrumbs', () => ({ useBreadcrumbs: () => ({ breadcrumbs: [] }) }));
+vi.mock('@/hooks/useDisplayPreferences', () => ({ useDisplayPreferences: () => ({ preferences: {} }) }));
+
+import QuickCreatePalette from '../QuickCreatePalette';
+
+const ALT_N = { key: 'Dead', code: 'KeyN', altKey: true } as const;
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockUseParams.mockReturnValue({ driveId: 'drive-1' });
+});
+
+describe('QuickCreatePalette hotkey', () => {
+  test('opens on an ordinary drive route', () => {
+    mockUsePathname.mockReturnValue('/dashboard/drive-1/page-1');
+    render(<QuickCreatePalette />);
+
+    fireEvent.keyDown(document, ALT_N);
+
+    expect(mockOpenQuickCreate).toHaveBeenCalledWith(null);
+  });
+
+  test('stands down on a drive-scoped agents route — the sidebar answers it there', () => {
+    mockUsePathname.mockReturnValue('/dashboard/drive-1/agents');
+    render(<QuickCreatePalette />);
+
+    fireEvent.keyDown(document, ALT_N);
+
+    expect(mockOpenQuickCreate).not.toHaveBeenCalled();
+  });
+
+  test('stands down on the global agents console too', () => {
+    mockUsePathname.mockReturnValue('/dashboard/agents');
+    render(<QuickCreatePalette />);
+
+    fireEvent.keyDown(document, ALT_N);
+
+    expect(mockOpenQuickCreate).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/src/components/layout/left-sidebar/AgentsSidebar.tsx
+++ b/apps/web/src/components/layout/left-sidebar/AgentsSidebar.tsx
@@ -21,6 +21,7 @@ import useSWR, { useSWRConfig } from 'swr';
 
 import EndSessionDialog from '@/components/agents/EndSessionDialog';
 import { useSpawnSession } from '@/components/agents/useSpawnSession';
+import DrivePickerDialog from '@/components/agents/DrivePickerDialog';
 import { Input } from '@/components/ui/input';
 import { cn, isElectron } from '@/lib/utils';
 import type { SidebarProps } from './index';
@@ -483,13 +484,41 @@ function SessionList({
     [openSpawn, openAssistantSpawn],
   );
 
+  // Whether the drive this surface is scoped to can be given new work at all.
+  // A trashed drive is on its way out: the group-header path has always
+  // withheld its spawn "+" for that reason, and everything below routes
+  // through this one answer so the drive-scoped header, the hotkey and the
+  // palette's environment entry cannot disagree about it.
+  const isLiveScopedDrive = driveId !== undefined && !trashedDriveIds.has(driveId);
+
+  // Global mode's own "where" question: with no drive in the route there is
+  // nothing to spawn INTO, so the flow starts by picking one — the same
+  // `DrivePickerDialog` step `AgentsListHeader` takes, including the Global
+  // Assistant, which is a valid destination for a session and for nothing else.
+  const [sessionDrivePickerOpen, setSessionDrivePickerOpen] = useState(false);
+
+  const startNewSession = useCallback(() => {
+    if (driveId) {
+      // A trashed drive gets nothing new — not a session, and not the drive
+      // dialog either, which would answer a question nobody asked.
+      if (!isLiveScopedDrive) return;
+      handleNewSession(driveId, null);
+      return;
+    }
+    setSessionDrivePickerOpen(true);
+  }, [driveId, isLiveScopedDrive, handleNewSession]);
+
   // THE QUICK-CREATE HOTKEY, ON THE AGENTS ROUTES, MEANS THIS SURFACE'S "NEW".
   //
   // Elsewhere it opens the page-type palette; here "new" is a session — or the
   // environment to run one in, which the spawn palette now offers too — so the
-  // binding is answered by whatever the header's "+" would do, and
-  // `QuickCreatePalette` stands down while this route is active. It is
-  // registered HERE, not in `AgentsListHeader`, because the header only renders
+  // binding opens the spawn flow, and `QuickCreatePalette` stands down while
+  // this route is active. That holds on the GLOBAL console too: it has no
+  // drive of its own, so it asks for one and carries on into the same palette,
+  // rather than diverting to drive creation, which is a different act that
+  // never reaches an environment or a session.
+  //
+  // Registered HERE, not in `AgentsListHeader`, because the header only renders
   // in the list/empty state (it is gone inside an open session) while this
   // sidebar is mounted on every Agents route. The header keeps its own
   // `useSpawnSession` and registers no hotkey, so exactly one handler fires.
@@ -499,17 +528,11 @@ function SessionList({
       if (!matchesKeyEvent(getEffectiveBinding('pages.quick-create'), event)) return;
       if (isEditingActive()) return;
       event.preventDefault();
-      if (driveId) {
-        handleNewSession(driveId, null);
-        return;
-      }
-      // Global mode has no drive to put a session in — same fallback its "+"
-      // already takes.
-      setCreateDriveOpen(true);
+      startNewSession();
     };
     document.addEventListener('keydown', handler);
     return () => document.removeEventListener('keydown', handler);
-  }, [canSpawn, driveId, handleNewSession]);
+  }, [canSpawn, startNewSession]);
 
   return (
     <div className="space-y-1">
@@ -517,7 +540,18 @@ function SessionList({
         <SessionSearchHeader
           value={searchQuery}
           onChange={setSearchQuery}
-          onAction={driveId ? () => handleNewSession(driveId, null) : () => setCreateDriveOpen(true)}
+          // A trashed drive is offered nothing new — the same withholding the
+          // group headers have always done one level down, applied here where
+          // the drive IS the whole surface. Global mode keeps "New drive": it
+          // is the only place that offers one, and the hotkey's session flow
+          // (which asks for a drive first) does not replace it.
+          onAction={
+            driveId
+              ? isLiveScopedDrive
+                ? () => handleNewSession(driveId, null)
+                : undefined
+              : () => setCreateDriveOpen(true)
+          }
           actionLabel={driveId ? 'New session' : 'New drive'}
         />
       )}
@@ -565,6 +599,18 @@ function SessionList({
       })}
       {notice}
       {paletteElement}
+      <DrivePickerDialog
+        open={sessionDrivePickerOpen}
+        onOpenChange={setSessionDrivePickerOpen}
+        onPick={(pickedDriveId, pickedDriveName) => {
+          setSessionDrivePickerOpen(false);
+          openSpawn(pickedDriveId, pickedDriveName);
+        }}
+        onPickGlobalAssistant={() => {
+          setSessionDrivePickerOpen(false);
+          openAssistantSpawn();
+        }}
+      />
       {!driveId && <CreateDriveDialog isOpen={createDriveOpen} setIsOpen={setCreateDriveOpen} />}
     </div>
   );
@@ -579,7 +625,8 @@ function SessionSearchHeader({
 }: {
   value: string;
   onChange: (value: string) => void;
-  onAction: () => void;
+  /** Omitted when there is nothing to create — a trashed drive gets no "+". */
+  onAction?: () => void;
   actionLabel: string;
 }) {
   return (
@@ -594,14 +641,16 @@ function SessionSearchHeader({
           onChange={(event) => onChange(event.target.value)}
         />
       </div>
-      <button
-        type="button"
-        aria-label={actionLabel}
-        className="shrink-0 text-muted-foreground hover:text-foreground"
-        onClick={onAction}
-      >
-        <Plus className="size-3.5" />
-      </button>
+      {onAction && (
+        <button
+          type="button"
+          aria-label={actionLabel}
+          className="shrink-0 text-muted-foreground hover:text-foreground"
+          onClick={onAction}
+        >
+          <Plus className="size-3.5" />
+        </button>
+      )}
     </div>
   );
 }

--- a/apps/web/src/components/layout/left-sidebar/AgentsSidebar.tsx
+++ b/apps/web/src/components/layout/left-sidebar/AgentsSidebar.tsx
@@ -30,7 +30,10 @@ import DashboardFooter from './DashboardFooter';
 import DriveFooter from './DriveFooter';
 import PrimaryNavigation from './PrimaryNavigation';
 import { SidebarLoading, SidebarNotice } from './sidebar-states';
+import { matchesKeyEvent, getEffectiveBinding } from '@/stores/useHotkeyStore';
+import { isEditingActive } from '@/stores/useEditingStore';
 import { useAuth } from '@/hooks/useAuth';
+import { useTouchDevice } from '@/hooks/useTouchDevice';
 import { useBreakpoint } from '@/hooks/useBreakpoint';
 import { useDriveStore, type Drive } from '@/hooks/useDrive';
 import { canManageDrive } from '@/hooks/usePermissions';
@@ -61,7 +64,8 @@ import { buildSessionGroups, ASSISTANT_GROUP_KEY } from './session-groups';
 import { partitionSessionsByEnv, type EnvGroup } from './env-groups';
 import { RowMenu, type RowMenuItem } from './RowMenu';
 import { DeleteDriveEnvDialog, DriveEnvNameDialog, RebuildDriveEnvDialog } from './DriveEnvDialogs';
-import { useDriveEnvs, driveEnvsKey } from '@/hooks/drive-envs/useDriveEnvs';
+import { useDriveEnvs } from '@/hooks/drive-envs/useDriveEnvs';
+import { reportDriveEnvWriteFailure, type DriveEnvWriteOutcome } from '@/hooks/drive-envs/drive-env-writes';
 import type { DriveEnvStatus } from '@pagespace/lib/drive-envs/env-contract';
 
 /**
@@ -461,28 +465,7 @@ function SessionList({
   );
 
   const [createDriveOpen, setCreateDriveOpen] = useState(false);
-  const { openSpawn, openAssistantSpawn, paletteElement } = useSpawnSession(agentsByDrive, onChanged);
-
-  // ONE "New environment" dialog for the whole list, parameterized by which
-  // drive asked — the same shape `useSpawnSession` gives the spawn palette.
-  // Every group header would otherwise carry its own copy of a dialog that can
-  // only ever be open once.
-  const [newEnvTarget, setNewEnvTarget] = useState<{ driveId: string; driveName: string | null } | null>(null);
-  const { mutate: globalMutate } = useSWRConfig();
-
-  const createEnvironment = useCallback(
-    async (name: string): Promise<DriveEnvWriteOutcome> => {
-      if (!newEnvTarget) return 'done';
-      try {
-        await post(`/api/drives/${encodeURIComponent(newEnvTarget.driveId)}/envs`, { name });
-      } catch (error) {
-        return reportDriveEnvWriteFailure(error, 'Could not create the environment');
-      }
-      globalMutate(driveEnvsKey(newEnvTarget.driveId));
-      return 'done';
-    },
-    [newEnvTarget, globalMutate],
-  );
+  const { openSpawn, openSpawnInEnv, openAssistantSpawn, paletteElement } = useSpawnSession(agentsByDrive, onChanged);
 
   // Sessions are always deliberately named now — both groups open the same
   // naming step. The ASSISTANT group has nothing to pick (the assistant IS
@@ -500,6 +483,34 @@ function SessionList({
     [openSpawn, openAssistantSpawn],
   );
 
+  // THE QUICK-CREATE HOTKEY, ON THE AGENTS ROUTES, MEANS THIS SURFACE'S "NEW".
+  //
+  // Elsewhere it opens the page-type palette; here "new" is a session — or the
+  // environment to run one in, which the spawn palette now offers too — so the
+  // binding is answered by whatever the header's "+" would do, and
+  // `QuickCreatePalette` stands down while this route is active. It is
+  // registered HERE, not in `AgentsListHeader`, because the header only renders
+  // in the list/empty state (it is gone inside an open session) while this
+  // sidebar is mounted on every Agents route. The header keeps its own
+  // `useSpawnSession` and registers no hotkey, so exactly one handler fires.
+  useEffect(() => {
+    if (!canSpawn) return;
+    const handler = (event: KeyboardEvent) => {
+      if (!matchesKeyEvent(getEffectiveBinding('pages.quick-create'), event)) return;
+      if (isEditingActive()) return;
+      event.preventDefault();
+      if (driveId) {
+        handleNewSession(driveId, null);
+        return;
+      }
+      // Global mode has no drive to put a session in — same fallback its "+"
+      // already takes.
+      setCreateDriveOpen(true);
+    };
+    document.addEventListener('keydown', handler);
+    return () => document.removeEventListener('keydown', handler);
+  }, [canSpawn, driveId, handleNewSession]);
+
   return (
     <div className="space-y-1">
       {canSpawn && (
@@ -508,23 +519,6 @@ function SessionList({
           onChange={setSearchQuery}
           onAction={driveId ? () => handleNewSession(driveId, null) : () => setCreateDriveOpen(true)}
           actionLabel={driveId ? 'New session' : 'New drive'}
-          // Drive-scoped mode suppresses its own group header (the drive is the
-          // whole surface), so this is where its environment affordance has to
-          // live — beside "New session", which is the act it sits next to
-          // everywhere else too. Global mode has no single drive to create one
-          // in, so it keeps just the two it had.
-          // `!trashedDriveIds.has` for the same reason the group-header path
-          // checks `isLiveDrive`: a drive on its way to deletion must not be
-          // offered new infrastructure inside it.
-          onNewEnvironment={
-            driveId && !trashedDriveIds.has(driveId) && manageableDriveIds.has(driveId)
-              ? () =>
-                  setNewEnvTarget({
-                    driveId,
-                    driveName: drives.find((d) => d.id === driveId)?.name ?? null,
-                  })
-              : undefined
-          }
         />
       )}
       {visibleGroups.map((group) => {
@@ -547,12 +541,6 @@ function SessionList({
                   ? undefined
                   : () => handleNewSession(group.driveId, group.driveName)
               }
-              newEnvironmentLabel={`New environment in ${group.driveName ?? 'this drive'}`}
-              onNewEnvironment={
-                isLiveDrive && manageableDriveIds.has(group.driveId)
-                  ? () => setNewEnvTarget({ driveId: group.driveId, driveName: group.driveName })
-                  : undefined
-              }
             />
           )}
           <DriveGroupRows
@@ -570,21 +558,13 @@ function SessionList({
             // a query is active every matching session renders at drive level
             // and the environment rows step aside.
             showEnvironments={canSpawn && isLiveDrive && !hasSearch}
+            onNewSessionInEnv={(envId) => openSpawnInEnv(group.driveId, group.driveName, envId)}
           />
         </div>
         );
       })}
       {notice}
       {paletteElement}
-      <DriveEnvNameDialog
-        open={newEnvTarget !== null}
-        onOpenChange={(open) => {
-          if (!open) setNewEnvTarget(null);
-        }}
-        mode="create"
-        driveName={newEnvTarget?.driveName ?? null}
-        onSubmit={createEnvironment}
-      />
       {!driveId && <CreateDriveDialog isOpen={createDriveOpen} setIsOpen={setCreateDriveOpen} />}
     </div>
   );
@@ -596,14 +576,11 @@ function SessionSearchHeader({
   onChange,
   onAction,
   actionLabel,
-  onNewEnvironment,
 }: {
   value: string;
   onChange: (value: string) => void;
   onAction: () => void;
   actionLabel: string;
-  /** Omitted for anyone who cannot administer the drive — environment CRUD is OWNER/ADMIN. */
-  onNewEnvironment?: () => void;
 }) {
   return (
     <div className="flex items-center gap-1 pl-2 pr-4 pb-1 pt-1.5">
@@ -617,17 +594,6 @@ function SessionSearchHeader({
           onChange={(event) => onChange(event.target.value)}
         />
       </div>
-      {onNewEnvironment && (
-        <button
-          type="button"
-          aria-label="New environment"
-          title="New environment"
-          className="shrink-0 text-muted-foreground hover:text-foreground"
-          onClick={onNewEnvironment}
-        >
-          <Boxes className="size-3.5" />
-        </button>
-      )}
       <button
         type="button"
         aria-label={actionLabel}
@@ -645,15 +611,10 @@ function SessionGroupHeader({
   label,
   newSessionLabel,
   onNewSession,
-  newEnvironmentLabel,
-  onNewEnvironment,
 }: {
   label: string;
   newSessionLabel?: string;
   onNewSession?: () => void;
-  newEnvironmentLabel?: string;
-  /** Omitted for anyone who cannot administer the drive — environment CRUD is OWNER/ADMIN. */
-  onNewEnvironment?: () => void;
 }) {
   return (
     <div className="flex items-center justify-between gap-1 pl-2 pr-4 pb-0.5 pt-1.5">
@@ -662,17 +623,6 @@ function SessionGroupHeader({
         <span className="truncate">{label}</span>
       </span>
       <span className="flex shrink-0 items-center gap-1">
-        {onNewEnvironment && (
-          <button
-            type="button"
-            aria-label={newEnvironmentLabel ?? 'New environment'}
-            title={newEnvironmentLabel ?? 'New environment'}
-            className="shrink-0 text-muted-foreground hover:text-foreground"
-            onClick={onNewEnvironment}
-          >
-            <Boxes className="size-3.5" />
-          </button>
-        )}
         {onNewSession && (
           <button
             type="button"
@@ -686,26 +636,6 @@ function SessionGroupHeader({
       </span>
     </div>
   );
-}
-
-/**
- * What a caller should do with the dialog after an environment write.
- *
- * `'retry'` is reserved for the ONE refusal the user can fix without leaving
- * the dialog: a name already taken in this drive. Every other failure — a
- * plan's environment ceiling, a role that turned out not to be enough, the
- * network — is toasted and the dialog closes, because retyping the name would
- * not change the answer.
- */
-type DriveEnvWriteOutcome = 'done' | 'retry';
-
-function reportDriveEnvWriteFailure(error: unknown, fallbackTitle: string): DriveEnvWriteOutcome {
-  const description = error instanceof Error ? error.message : 'Please try again.';
-  const nameTaken = error instanceof ApiRequestError && error.status === 409;
-  toast.error(nameTaken ? 'That name is already used in this drive' : fallbackTitle, {
-    description: nameTaken ? 'Environment names are unique within a drive.' : description,
-  });
-  return nameTaken ? 'retry' : 'done';
 }
 
 /**
@@ -728,12 +658,15 @@ function DriveGroupRows({
   agentNamesById,
   canManage,
   showEnvironments,
+  onNewSessionInEnv,
 }: {
   driveId: string;
   sessions: SessionListEntry[];
   agentNamesById: Map<string, string>;
   canManage: boolean;
   showEnvironments: boolean;
+  /** Start a session INSIDE one of this drive's environments — the row's own "+". */
+  onNewSessionInEnv: (envId: string) => void;
 }) {
   const { envs, error: envsError, mutate: refreshEnvs } = useDriveEnvs(driveId, { enabled: showEnvironments });
 
@@ -778,6 +711,7 @@ function DriveGroupRows({
           canManage={canManage}
           agentNamesById={agentNamesById}
           onEnvsChanged={refreshEnvs}
+          onNewSession={() => onNewSessionInEnv(group.envId)}
         />
       ))}
       {looseSessions.map((session) => (
@@ -833,14 +767,17 @@ function DriveEnvRow({
   canManage,
   agentNamesById,
   onEnvsChanged,
+  onNewSession,
 }: {
   driveId: string;
   group: EnvGroup<SessionListEntry>;
   canManage: boolean;
   agentNamesById: Map<string, string>;
   onEnvsChanged: () => void;
+  onNewSession: () => void;
 }) {
   const { mutate } = useSWRConfig();
+  const isTouchDevice = useTouchDevice();
   // Expanded by default: an environment's whole claim is that it is a place you
   // come back to, and its sessions are the reason to look at it.
   const [expanded, setExpanded] = useState(true);
@@ -943,6 +880,34 @@ function DriveEnvRow({
         <EnvStatusDot status={group.status} />
         <span className="truncate font-medium text-foreground">{displayName}</span>
       </span>
+      {/* Every other level of this tree offers one; the level that IS a place to
+          come back to was the only one that did not. Not gated on `canManage`:
+          binding a session to an environment is member-level server-side, and
+          management (rename/rebuild/delete) is the OWNER/ADMIN act — this is
+          not. Withheld from an ORPHAN, which names an environment this drive's
+          listing did not return: there is nothing here to spawn into. */}
+      {!isOrphan && (
+        <button
+          type="button"
+          aria-label={`New session in ${displayName}`}
+          title={`New session in ${displayName}`}
+          // Revealed exactly the way this row's menu trigger is — hover on a
+          // pointer, always on a touch device, where there is no hover to
+          // reveal it with.
+          className={cn(
+            'shrink-0 text-muted-foreground transition-opacity hover:text-foreground',
+            isTouchDevice ? 'opacity-100' : 'opacity-0 focus-visible:opacity-100 group-hover:opacity-100',
+          )}
+          onClick={(event) => {
+            // The row's own click targets (its context menu, its disclosure)
+            // must not also fire.
+            event.stopPropagation();
+            onNewSession();
+          }}
+        >
+          <Plus className="size-3.5" />
+        </button>
+      )}
     </>
   );
 
@@ -961,7 +926,6 @@ function DriveEnvRow({
       <DriveEnvNameDialog
         open={renaming}
         onOpenChange={setRenaming}
-        mode="rename"
         initialName={group.envName ?? ''}
         onSubmit={renameEnv}
       />

--- a/apps/web/src/components/layout/left-sidebar/DriveEnvDialogs.tsx
+++ b/apps/web/src/components/layout/left-sidebar/DriveEnvDialogs.tsx
@@ -44,9 +44,14 @@ import { MAX_DRIVE_ENV_NAME_LENGTH } from '@pagespace/lib/drive-envs/env-contrac
 import { useEditingSession } from '@/stores/useEditingSession';
 
 /**
- * Create or rename — one dialog, because an environment has exactly one
- * editable attribute and there is no kind to choose (the epic deleted the enum
- * rather than never writing it; see `env-contract.ts`).
+ * Rename — the only edit an environment has (it has exactly one editable
+ * attribute and there is no kind to choose; the epic deleted the enum rather
+ * than never writing it, see `env-contract.ts`).
+ *
+ * It used to create one too. CREATION now lives in the spawn palette, as a step
+ * in the same Raycast-style selector that offers environments as somewhere to
+ * run — so this dialog no longer carries a mode, and the sidebar no longer
+ * carries the icon button that opened it.
  *
  * `onSubmit` answers what should happen to the dialog, not whether the write
  * succeeded — `'retry'` keeps it open with the user's text intact. That exists
@@ -56,17 +61,12 @@ import { useEditingSession } from '@/stores/useEditingSession';
 export function DriveEnvNameDialog({
   open,
   onOpenChange,
-  mode,
-  driveName,
   initialName,
   onSubmit,
 }: {
   open: boolean;
   onOpenChange: (open: boolean) => void;
-  mode: 'create' | 'rename';
-  /** Named in the create dialog's description, when the caller has it. */
-  driveName?: string | null;
-  /** The current name, for a rename. */
+  /** The current name. */
   initialName?: string;
   onSubmit: (name: string) => Promise<'done' | 'retry'>;
 }) {
@@ -106,11 +106,9 @@ export function DriveEnvNameDialog({
     <Dialog open={open} onOpenChange={onOpenChange}>
       <DialogContent>
         <DialogHeader>
-          <DialogTitle>{mode === 'create' ? 'New environment' : 'Rename environment'}</DialogTitle>
+          <DialogTitle>Rename environment</DialogTitle>
           <DialogDescription>
-            {mode === 'create'
-              ? `A persistent machine ${driveName ? `${driveName}'s` : 'this drive’s'} sessions can run inside, sharing one filesystem that survives every session that ends. Name it for what it is for — “dev”, “staging”, “data-import”.`
-              : 'Sessions running inside it are unaffected — the name is a label, not an address.'}
+            Sessions running inside it are unaffected — the name is a label, not an address.
           </DialogDescription>
         </DialogHeader>
         <form onSubmit={handleSubmit}>
@@ -131,13 +129,7 @@ export function DriveEnvNameDialog({
           </div>
           <DialogFooter>
             <Button type="submit" disabled={submitting || trimmed.length === 0}>
-              {submitting
-                ? mode === 'create'
-                  ? 'Creating…'
-                  : 'Renaming…'
-                : mode === 'create'
-                  ? 'Create'
-                  : 'Rename'}
+              {submitting ? 'Renaming…' : 'Rename'}
             </Button>
           </DialogFooter>
         </form>

--- a/apps/web/src/components/layout/left-sidebar/__tests__/AgentsSidebar.test.tsx
+++ b/apps/web/src/components/layout/left-sidebar/__tests__/AgentsSidebar.test.tsx
@@ -1960,6 +1960,27 @@ describe('AgentsSidebar', () => {
       expect(screen.getByText('in staging')).toBeDefined();
     });
 
+    test('the create step registers with the editing store, as the dialog it replaced did', async () => {
+      const user = userEvent.setup();
+      respondWithSessions([], []);
+      renderSidebar();
+
+      await user.click(await screen.findByLabelText('New session'));
+      expect(useEditingStore.getState().isAnyActive()).toBe(false);
+
+      await user.click(await screen.findByText('New environment'));
+
+      // Registered while the form is up: a background revalidation or an auth
+      // refresh landing mid-type must not tear down what is being named.
+      await screen.findByLabelText('Environment name');
+      expect(useEditingStore.getState().isAnyActive()).toBe(true);
+
+      // And released when it closes, rather than leaving the app thinking
+      // someone is forever typing.
+      await user.click(screen.getByRole('button', { name: 'Cancel' }));
+      expect(useEditingStore.getState().isAnyActive()).toBe(false);
+    });
+
     test('a name already taken keeps the create step open with what was typed', async () => {
       const user = userEvent.setup();
       respondWithSessions([], []);

--- a/apps/web/src/components/layout/left-sidebar/__tests__/AgentsSidebar.test.tsx
+++ b/apps/web/src/components/layout/left-sidebar/__tests__/AgentsSidebar.test.tsx
@@ -1888,6 +1888,44 @@ describe('AgentsSidebar', () => {
       );
     });
 
+    /**
+     * THE WINDOW BETWEEN CREATING ONE AND THE LISTING SAYING SO.
+     *
+     * `mutate(key)` alone is a revalidation, and while it is in flight the
+     * cache still holds the listing from before — with `isLoading` false, since
+     * that flags a first load and not a refresh. The step machine reads exactly
+     * those two things, so for the width of that request it would answer "this
+     * drive has no environments" about a drive that just got one, and spawn
+     * ephemerally into it.
+     *
+     * The environments endpoint here never answers after the create, which is
+     * that window held open: what the palette offers next can only have come
+     * from the cache write.
+     */
+    test('the environment created from the target step is offered before the listing catches up', async () => {
+      const user = userEvent.setup();
+      respondWithSessions([], []);
+      let envsHang = false;
+      const listing = mockFetchWithAuth.getMockImplementation()!;
+      mockFetchWithAuth.mockImplementation(async (url: string, init?: { method?: string }) => {
+        if (typeof url === 'string' && url.includes('/envs') && envsHang) return new Promise<never>(() => {});
+        return listing(url, init);
+      });
+      mockPost.mockResolvedValue({ env: { id: 'env-new', name: 'dev', driveId: 'drive-1', status: 'none' } });
+      renderSidebar();
+
+      await user.click(await screen.findByLabelText('New session'));
+      await user.click(await screen.findByText('New environment'));
+      envsHang = true;
+      await user.type(await screen.findByLabelText('Environment name'), 'dev');
+      await user.click(screen.getByRole('button', { name: 'Create environment' }));
+
+      // Back on the target step. Picking an agent now must reach the question
+      // "where should it run?" — not skip it as though the drive had none.
+      await user.click(await screen.findByText('Researcher'));
+      expect(await screen.findByText('in dev')).toBeDefined();
+    });
+
     test('a name already taken keeps the create step open with what was typed', async () => {
       const user = userEvent.setup();
       respondWithSessions([], []);
@@ -1923,6 +1961,41 @@ describe('AgentsSidebar', () => {
       fireEvent.keyDown(document, { key: 'Dead', code: 'KeyN', altKey: true });
 
       expect(await screen.findByText('Researcher')).toBeDefined();
+    });
+
+    test('on the global console the hotkey asks which drive, then goes on into the same palette', async () => {
+      const user = userEvent.setup();
+      mockUseParams.mockReturnValue({});
+      mockUsePathname.mockReturnValue('/dashboard/agents');
+      respondWithSessions([], []);
+      renderSidebar();
+
+      await screen.findByLabelText('Search sessions');
+      fireEvent.keyDown(document, { key: 'Dead', code: 'KeyN', altKey: true });
+
+      // Not the New Drive dialog: creating a drive is a different act, and it
+      // never reaches a session or an environment.
+      const picker = await screen.findByRole('dialog', { name: 'Choose a destination' });
+      expect(within(picker).getByText('Global Assistant')).toBeDefined();
+
+      await user.click(within(picker).getByText('Alpha'));
+      expect(await screen.findByText('Researcher')).toBeDefined();
+    });
+
+    test('a trashed drive is offered nothing new — not by the hotkey, and not by the header', async () => {
+      useDriveStore.setState({ drives: [driveFixture('drive-1', 'Alpha', { isTrashed: true })] });
+      respondWithSessions([], []);
+      renderSidebar();
+
+      await screen.findByLabelText('Search sessions');
+      expect(screen.queryByLabelText('New session')).toBeNull();
+
+      fireEvent.keyDown(document, { key: 'Dead', code: 'KeyN', altKey: true });
+
+      // And it does not fall through to drive creation, which would answer a
+      // question nobody asked.
+      expect(screen.queryByText('Researcher')).toBeNull();
+      expect(screen.queryByText('Global Assistant')).toBeNull();
     });
 
     test('the environment row\'s "+" spawns INSIDE it — the row already answered where', async () => {

--- a/apps/web/src/components/layout/left-sidebar/__tests__/AgentsSidebar.test.tsx
+++ b/apps/web/src/components/layout/left-sidebar/__tests__/AgentsSidebar.test.tsx
@@ -1984,6 +1984,61 @@ describe('AgentsSidebar', () => {
       expect(useEditingStore.getState().isAnyActive()).toBe(false);
     });
 
+    /**
+     * A CREATE THAT LANDS AFTER ITS FLOW IS GONE.
+     *
+     * The POST is a round trip, and Escape closes the palette while it is still
+     * out. Whatever the user opens next is a different flow with its own
+     * answers — so the late continuation must not write into it: not select the
+     * environment it made, not drop the row preset the new flow carries, not
+     * close a step being typed in.
+     */
+    test('a create that resolves after its flow closed does not touch the flow that replaced it', async () => {
+      const user = userEvent.setup();
+      respondWithSessions([], [{ id: 'env-1', name: 'staging', status: 'running' }]);
+      let resolveCreate: ((value: unknown) => void) | undefined;
+      mockPost.mockImplementationOnce(() => new Promise((resolve) => { resolveCreate = resolve; }));
+      renderSidebar();
+
+      // Flow A: start creating an environment from the target step…
+      await screen.findByTestId('sidebar-env-env-1');
+      await user.click(screen.getByLabelText('New session'));
+      await user.click(await screen.findByText('New environment'));
+      await user.type(await screen.findByLabelText('Environment name'), 'dev');
+      await user.click(screen.getByRole('button', { name: 'Create environment' }));
+
+      // …then abandon it while the POST is still out.
+      await user.keyboard('{Escape}');
+
+      // Flow B: opened from staging's "+", which pre-answers where it runs.
+      const envRow = await screen.findByTestId('sidebar-env-env-1');
+      await user.click(within(envRow).getByLabelText('New session in staging'));
+
+      // Flow A's answer lands now.
+      mockPost.mockResolvedValue({
+        session: { workspaceId: 'ses-new', sessionId: 'ses-new' },
+        conversationId: 'conv-new',
+      });
+      await act(async () => {
+        resolveCreate?.({ env: { id: 'env-new', name: 'dev', driveId: 'drive-1', status: 'none' } });
+      });
+
+      // Flow B is untouched: still bound to staging, still going straight to
+      // naming rather than being asked again.
+      await user.click(await screen.findByText('Researcher'));
+      const nameInput = await screen.findByPlaceholderText('Researcher');
+      fireEvent.submit(nameInput.closest('form')!);
+
+      await waitFor(() =>
+        expect(mockPost).toHaveBeenLastCalledWith('/api/agent-workspaces', {
+          driveId: 'drive-1',
+          envId: 'env-1',
+          agentPageId: 'agent-1',
+          name: '',
+        }),
+      );
+    });
+
     test('a name already taken keeps the create step open with what was typed', async () => {
       const user = userEvent.setup();
       respondWithSessions([], []);

--- a/apps/web/src/components/layout/left-sidebar/__tests__/AgentsSidebar.test.tsx
+++ b/apps/web/src/components/layout/left-sidebar/__tests__/AgentsSidebar.test.tsx
@@ -1851,6 +1851,9 @@ describe('AgentsSidebar', () => {
       await waitFor(() =>
         expect(mockPost).toHaveBeenCalledWith('/api/drives/drive-1/envs', { name: 'dev' }),
       );
+      // Said out loud: the palette covers the sidebar, so the new row appearing
+      // there is no longer the confirmation it used to be.
+      expect(mockToastSuccess).toHaveBeenCalledWith('Created “dev”');
       // Back on the target step — the session it came here to start is still
       // unstarted, and the environment now exists for the step that asks where.
       expect(await screen.findByText('Researcher')).toBeDefined();

--- a/apps/web/src/components/layout/left-sidebar/__tests__/AgentsSidebar.test.tsx
+++ b/apps/web/src/components/layout/left-sidebar/__tests__/AgentsSidebar.test.tsx
@@ -125,6 +125,7 @@ import type { PaneTarget, WorkspaceNode } from '@pagespace/lib/agent-workspaces/
 import type { WorkspaceNodeTarget } from '@pagespace/lib/agent-workspaces/workspace-node-wire';
 import { useLayoutStore } from '@/stores/useLayoutStore';
 import { useDriveStore, type Drive } from '@/hooks/useDrive';
+import { useEditingStore } from '@/stores/useEditingStore';
 
 const driveFixture = (id: string, name: string, overrides: Partial<Drive> = {}): Drive => ({
   id,
@@ -309,6 +310,12 @@ beforeEach(() => {
   // Same leak risk for the tree: two tests opening the same workspace id would
   // otherwise see each other's nodes, since nothing else clears this store.
   __resetWorkspaceQueuesForTests();
+  // Same reason, one store over: the environment dialogs register an editing
+  // session while open, and a test that unmounts mid-dialog leaves it
+  // registered. A leaked session is not inert — `isEditingActive()` gates the
+  // quick-create hotkey handler, so the next test's keypress would silently do
+  // nothing.
+  useEditingStore.getState().clearAllSessions();
   // Deliberately a PLAIN, non-admin user: sessions/chat/panes are open to
   // every authenticated user now, so every test in this file that relies on
   // this default doubles as proof a non-admin gets full access too.
@@ -1792,6 +1799,7 @@ describe('AgentsSidebar', () => {
     });
 
     test('offers no environment management to a member who cannot administer the drive', async () => {
+      const user = userEvent.setup();
       useDriveStore.setState({ drives: [driveFixture('drive-1', 'Alpha', { isOwned: false, role: 'MEMBER' })] });
       respondWithSessions([], [{ id: 'env-1', name: 'staging', status: 'none' }]);
       renderSidebar();
@@ -1801,21 +1809,148 @@ describe('AgentsSidebar', () => {
       const envRow = await screen.findByTestId('sidebar-env-env-1');
       expect(within(envRow).getByText('staging')).toBeDefined();
       expect(within(envRow).queryByLabelText('Environment actions')).toBeNull();
-      expect(screen.queryByLabelText('New environment')).toBeNull();
+
+      // Creating one is not offered anywhere either — not as a sidebar button
+      // (there is no longer one for anybody) and not in the palette, which is
+      // where the act moved to.
+      await user.click(screen.getByLabelText('New session'));
+      expect(await screen.findByText('Researcher')).toBeDefined();
+      expect(screen.queryByText('New environment')).toBeNull();
     });
 
-    test('an admin gets the "New environment" affordance, and creating one POSTs just a name', async () => {
+    /**
+     * ENVIRONMENT CREATION LIVES IN THE PALETTE, NOT IN AN ICON BUTTON.
+     *
+     * The sidebar used to carry a `Boxes` button beside each "+". It is gone:
+     * the selector that already offers environments as somewhere to run is
+     * where making one belongs, and it is reachable from BOTH steps that talk
+     * about them — the target step (which exists even in a drive with no
+     * environments, where the env step never renders) and the env step (where
+     * the environment just created is the answer to the question being asked).
+     */
+    test('no icon button creates an environment any more — the sidebar has none for an admin either', async () => {
+      respondWithSessions([], [{ id: 'env-1', name: 'staging', status: 'none' }]);
+      renderSidebar();
+
+      await screen.findByTestId('sidebar-env-env-1');
+      expect(screen.queryByLabelText('New environment')).toBeNull();
+      expect(screen.queryByLabelText('New environment in Alpha')).toBeNull();
+    });
+
+    test('an admin creates one from the palette\'s target step, and lands back on that step with it offered', async () => {
       const user = userEvent.setup();
       respondWithSessions([], []);
       mockPost.mockResolvedValue({ env: { id: 'env-new', name: 'dev', driveId: 'drive-1', status: 'none' } });
       renderSidebar();
 
-      await user.click(await screen.findByLabelText('New environment'));
-      await user.type(await screen.findByLabelText('Name'), 'dev');
-      await user.click(screen.getByRole('button', { name: 'Create' }));
+      await user.click(await screen.findByLabelText('New session'));
+      await user.click(await screen.findByText('New environment'));
+      await user.type(await screen.findByLabelText('Environment name'), 'dev');
+      await user.click(screen.getByRole('button', { name: 'Create environment' }));
 
       await waitFor(() =>
         expect(mockPost).toHaveBeenCalledWith('/api/drives/drive-1/envs', { name: 'dev' }),
+      );
+      // Back on the target step — the session it came here to start is still
+      // unstarted, and the environment now exists for the step that asks where.
+      expect(await screen.findByText('Researcher')).toBeDefined();
+    });
+
+    test('creating from the environment step goes straight on to naming, with the new environment selected', async () => {
+      const user = userEvent.setup();
+      respondWithSessions([], [{ id: 'env-1', name: 'staging', status: 'running' }]);
+      mockPost.mockResolvedValueOnce({ env: { id: 'env-new', name: 'dev', driveId: 'drive-1', status: 'none' } });
+      mockPost.mockResolvedValueOnce({
+        session: { workspaceId: 'ses-new', sessionId: 'ses-new' },
+        conversationId: 'conv-new',
+      });
+      renderSidebar();
+
+      await screen.findByTestId('sidebar-env-env-1');
+      await user.click(screen.getByLabelText('New session'));
+      await user.click(await screen.findByText('Researcher'));
+      await user.click(await screen.findByText('New environment…'));
+      await user.type(await screen.findByLabelText('Environment name'), 'dev');
+      await user.click(screen.getByRole('button', { name: 'Create environment' }));
+
+      // No second trip through the environment step: what the user just made is
+      // the answer to it.
+      const nameInput = await screen.findByPlaceholderText('Researcher');
+      fireEvent.submit(nameInput.closest('form')!);
+
+      await waitFor(() =>
+        expect(mockPost).toHaveBeenLastCalledWith('/api/agent-workspaces', {
+          driveId: 'drive-1',
+          envId: 'env-new',
+          agentPageId: 'agent-1',
+          name: '',
+        }),
+      );
+    });
+
+    test('a name already taken keeps the create step open with what was typed', async () => {
+      const user = userEvent.setup();
+      respondWithSessions([], []);
+      mockPost.mockRejectedValueOnce(
+        new ApiRequestError('An environment with this name already exists', 409, {}),
+      );
+      renderSidebar();
+
+      await user.click(await screen.findByLabelText('New session'));
+      await user.click(await screen.findByText('New environment'));
+      await user.type(await screen.findByLabelText('Environment name'), 'dev');
+      await user.click(screen.getByRole('button', { name: 'Create environment' }));
+
+      await waitFor(() => expect(mockPost).toHaveBeenCalled());
+      // Still the create step, still holding the name — the one refusal
+      // retyping can actually fix.
+      expect((await screen.findByLabelText('Environment name') as HTMLInputElement).value).toBe('dev');
+    });
+
+    /**
+     * THE QUICK-CREATE HOTKEY MEANS THIS SURFACE'S "NEW".
+     *
+     * Elsewhere `Alt+N` opens the page-type palette. On the Agents routes "new"
+     * is a session — or the environment to run one in, which the spawn palette
+     * now offers — so the sidebar answers the binding and
+     * `QuickCreatePalette` stands down (its own guard, tested at its own site).
+     */
+    test('the quick-create hotkey opens the spawn palette on a drive-scoped agents route', async () => {
+      respondWithSessions([], []);
+      renderSidebar();
+
+      await screen.findByLabelText('New session');
+      fireEvent.keyDown(document, { key: 'Dead', code: 'KeyN', altKey: true });
+
+      expect(await screen.findByText('Researcher')).toBeDefined();
+    });
+
+    test('the environment row\'s "+" spawns INSIDE it — the row already answered where', async () => {
+      const user = userEvent.setup();
+      respondWithSessions([], [{ id: 'env-1', name: 'staging', status: 'running' }]);
+      mockPost.mockResolvedValue({
+        session: { workspaceId: 'ses-new', sessionId: 'ses-new' },
+        conversationId: 'conv-new',
+      });
+      renderSidebar();
+
+      const envRow = await screen.findByTestId('sidebar-env-env-1');
+      await user.click(within(envRow).getByLabelText('New session in staging'));
+      await user.click(await screen.findByText('Researcher'));
+
+      // Straight to naming: the environment step is not asked a question the
+      // row already answered.
+      const nameInput = await screen.findByPlaceholderText('Researcher');
+      expect(screen.queryByText('New sandbox')).toBeNull();
+      fireEvent.submit(nameInput.closest('form')!);
+
+      await waitFor(() =>
+        expect(mockPost).toHaveBeenCalledWith('/api/agent-workspaces', {
+          driveId: 'drive-1',
+          envId: 'env-1',
+          agentPageId: 'agent-1',
+          name: '',
+        }),
       );
     });
 

--- a/apps/web/src/components/layout/left-sidebar/__tests__/AgentsSidebar.test.tsx
+++ b/apps/web/src/components/layout/left-sidebar/__tests__/AgentsSidebar.test.tsx
@@ -2039,6 +2039,47 @@ describe('AgentsSidebar', () => {
       );
     });
 
+    /**
+     * TWO CREATES IN FLIGHT AT ONCE.
+     *
+     * `creatingEnv` is what holds this form closed while its POST is out, and
+     * the request that settles is not necessarily the one on screen: abandon a
+     * create, start another, and the FIRST landing would re-enable the form
+     * over a POST still in flight — a second, non-idempotent create one
+     * keystroke away.
+     */
+    test('an abandoned create landing later does not re-enable the form over a live request', async () => {
+      const user = userEvent.setup();
+      respondWithSessions([], []);
+      let resolveFirst: ((value: unknown) => void) | undefined;
+      mockPost.mockImplementationOnce(() => new Promise((resolve) => { resolveFirst = resolve; }));
+      mockPost.mockImplementationOnce(() => new Promise(() => {}));
+      renderSidebar();
+
+      // Attempt A, abandoned while its POST is still out.
+      await user.click(await screen.findByLabelText('New session'));
+      await user.click(await screen.findByText('New environment'));
+      await user.type(await screen.findByLabelText('Environment name'), 'a');
+      await user.click(screen.getByRole('button', { name: 'Create environment' }));
+      await user.keyboard('{Escape}');
+
+      // Attempt B, still in flight.
+      await user.click(await screen.findByLabelText('New session'));
+      await user.click(await screen.findByText('New environment'));
+      await user.type(await screen.findByLabelText('Environment name'), 'b');
+      await user.click(screen.getByRole('button', { name: 'Create environment' }));
+      expect(screen.getByRole('button', { name: 'Creating…' })).toBeDefined();
+
+      // A lands now.
+      await act(async () => {
+        resolveFirst?.({ env: { id: 'env-a', name: 'a', driveId: 'drive-1', status: 'none' } });
+      });
+
+      // B's request is still out, so B's form stays closed.
+      expect(screen.getByRole('button', { name: 'Creating…' })).toBeDefined();
+      expect(screen.queryByRole('button', { name: 'Create environment' })).toBeNull();
+    });
+
     test('a name already taken keeps the create step open with what was typed', async () => {
       const user = userEvent.setup();
       respondWithSessions([], []);

--- a/apps/web/src/components/layout/left-sidebar/__tests__/AgentsSidebar.test.tsx
+++ b/apps/web/src/components/layout/left-sidebar/__tests__/AgentsSidebar.test.tsx
@@ -1926,6 +1926,40 @@ describe('AgentsSidebar', () => {
       expect(await screen.findByText('in dev')).toBeDefined();
     });
 
+    test('making a new environment from a row-opened flow asks again rather than using the row\'s', async () => {
+      const user = userEvent.setup();
+      respondWithSessions([], [{ id: 'env-1', name: 'staging', status: 'running' }]);
+      // The listing never catches up after the create — the same held-open
+      // window the target-step test uses, so the new environment can only be
+      // here via the cache write rather than a revalidation that happened to
+      // win.
+      let envsHang = false;
+      const listing = mockFetchWithAuth.getMockImplementation()!;
+      mockFetchWithAuth.mockImplementation(async (url: string, init?: { method?: string }) => {
+        if (typeof url === 'string' && url.includes('/envs') && envsHang) return new Promise<never>(() => {});
+        return listing(url, init);
+      });
+      mockPost.mockResolvedValue({ env: { id: 'env-new', name: 'dev', driveId: 'drive-1', status: 'none' } });
+      renderSidebar();
+
+      // Opened from staging's "+", which pre-answers "where should it run?".
+      const envRow = await screen.findByTestId('sidebar-env-env-1');
+      await user.click(within(envRow).getByLabelText('New session in staging'));
+      envsHang = true;
+      // Then the user makes a DIFFERENT environment — a newer intent than the
+      // row's, which must not be silently overruled by it.
+      await user.click(await screen.findByText('New environment'));
+      await user.type(await screen.findByLabelText('Environment name'), 'dev');
+      await user.click(screen.getByRole('button', { name: 'Create environment' }));
+
+      await user.click(await screen.findByText('Researcher'));
+
+      // Asked once, with both to choose between — rather than spawning into
+      // staging as though the last minute had not happened.
+      expect(await screen.findByText('in dev')).toBeDefined();
+      expect(screen.getByText('in staging')).toBeDefined();
+    });
+
     test('a name already taken keeps the create step open with what was typed', async () => {
       const user = userEvent.setup();
       respondWithSessions([], []);

--- a/apps/web/src/hooks/drive-envs/drive-env-writes.ts
+++ b/apps/web/src/hooks/drive-envs/drive-env-writes.ts
@@ -1,0 +1,27 @@
+import { toast } from 'sonner';
+import { ApiRequestError } from '@/lib/auth/auth-fetch';
+
+/**
+ * What a caller should do with the surface it wrote from, after an environment
+ * write.
+ *
+ * `'retry'` is reserved for the ONE refusal the user can fix without leaving
+ * the form: a name already taken in this drive. Every other failure — a plan's
+ * environment ceiling, a role that turned out not to be enough, the network —
+ * is toasted and the form closes, because retyping the name would not change
+ * the answer.
+ *
+ * It lives here rather than beside either caller because BOTH write
+ * environments now: the spawn palette creates them and the sidebar row renames
+ * them, and the 409-is-retryable rule is the same rule in both places.
+ */
+export type DriveEnvWriteOutcome = 'done' | 'retry';
+
+export function reportDriveEnvWriteFailure(error: unknown, fallbackTitle: string): DriveEnvWriteOutcome {
+  const description = error instanceof Error ? error.message : 'Please try again.';
+  const nameTaken = error instanceof ApiRequestError && error.status === 409;
+  toast.error(nameTaken ? 'That name is already used in this drive' : fallbackTitle, {
+    description: nameTaken ? 'Environment names are unique within a drive.' : description,
+  });
+  return nameTaken ? 'retry' : 'done';
+}

--- a/docs/2.0-architecture/agent-sessions.md
+++ b/docs/2.0-architecture/agent-sessions.md
@@ -26,8 +26,10 @@ lives inside it.
 > **`envId` — owning versus borrowing a sandbox.** The schema now carries a nullable
 > `agent_workspaces.envId` pointing at a `drive_envs` row: a *persistent, drive-owned*
 > ENVIRONMENT that sessions can be spawned inside (epic "Deliberate Per-Drive
-> Environments"). The column **ships dark** — nothing writes it until that epic's Phase 3
-> — so everything below still describes every session that exists today.
+> Environments"). The column is **written now** — #2450 gave environments a surface and
+> #2452 moved creating one into the spawn palette, so a session started "in" an
+> environment carries its id. Everything below still describes every session that does
+> not: an ephemeral, self-owned sandbox remains the default and the common case.
 >
 > What changes when it is written: an env-bound session **borrows** its env's sandbox
 > instead of owning one, so it holds no Sprite pointer of its own. That is enforced by


### PR DESCRIPTION
#2450 shipped drive environments with two `Boxes` icon buttons in the Agents sidebar — one in the search header, one per drive-group header — that opened a "New environment" dialog. Two things wrong with that:

1. An icon button is the wrong affordance for a named, deliberate, admin-only creation act. A small glyph sitting next to `+` that means "create a *different* kind of thing" reads as decoration.
2. The app already has a keyboard-first selector for exactly this — the spawn palette, which asks **"Where should it run?"** and lists the drive's environments. Creating one belongs in the selector that consumes them.

Separately, an environment row had no `+`. Every other level of that tree offers one, so the row representing the most deliberate place to start a session was the one place you couldn't start one from.

## What changed

**Creation moved into the palette.** A `'new-env'` step rendered *inside* the CommandDialog rather than a dialog stacked over it — one continuous keyboard flow, and no second focus trap fighting cmdk's. It's reachable from both steps that talk about environments:

- **Target step** — a `New environment` row below a separator. Present even in a drive with zero environments, where the env step never renders at all.
- **Env step** — `New environment…` after the list. What you just created *is* the answer to the question that step is asking, so it goes straight on to naming with the new environment selected.

The zero-env fast path is preserved deliberately: a drive that has never made one keeps the original two-step flow rather than paying for a one-real-option question on every spawn.

**`canCreateEnv` resolves in the hook** from the same two facts the sidebar used (drive OWNER/ADMIN, live drive), so every caller gets the entry point without threading a permission through. A drive the store doesn't hold — the driveless Assistant target, an orphan group — is `false`, which is right for both.

**`+` on each environment row** spawns *inside* it, skipping the env step because the row already answered it. `presetEnvId` can't live on `spawnPick` (null until a target is picked), so it waits in its own state and merges in when a pick exists. Not gated on `canManage` — binding is member-level server-side, management is the OWNER/ADMIN act. Withheld from an orphan row, which has no environment to spawn into. Reveal mirrors the row's own `RowMenu` trigger, including always-visible on touch.

**`Alt+N` on the Agents routes** opens the spawn palette. `AgentsSidebar` owns the handler and `QuickCreatePalette` stands down, using the sidebar's own `resolveSidebarVariant` matcher rather than a second regex that could drift from it. The sidebar owns it rather than `AgentsListHeader`, which only renders in the list/empty state and disappears inside an open session.

**Cleanup:** `reportDriveEnvWriteFailure` moves beside `useDriveEnvs` now that two surfaces write environments; `DriveEnvNameDialog` loses its create mode rather than keeping copy nothing reaches; the #2450 changelog entries describing the old icon are rewritten.

## A real bug the tests found

The new hotkey test failed in the suite but passed alone. Cause: the environment dialogs register `useEditingStore` sessions, nothing cleared them between tests, and a leaked session silently disables anything gated on `isEditingActive()` — the keypress just did nothing. Cleared in `beforeEach`. This would have bitten every future editing-gated test in that file.

## Review round 1 — four findings, all real

**The created environment was not published** (codex + CodeRabbit, same defect). `mutate(key)` alone is a *revalidation*: the cache keeps the previous listing until the network answers, and `isLoading` stays false throughout because it flags a first load, not a refresh. So for the width of that request the step machine read "this drive has no environments" about a drive that had just been given one — and a quick pick spawned **ephemerally into the drive whose environment the user had just deliberately made**. `created.env` is now written into the shared cache (sync functional updater, dedup by id) before the create step closes, with `{ revalidate: true }` behind it.

**Alt+N on the global console opened the New Drive dialog** (codex). It mirrored the sidebar header's `+` rather than what the binding means. It now takes the same `DrivePickerDialog` step `AgentsListHeader` takes and carries on into the same palette, so "new" means one thing on every Agents route. The header's `+` keeps its New Drive meaning in global mode — nothing else there offers one.

**A trashed drive was still offered a spawn flow** (CodeRabbit). The drive-scoped header's `+` never checked (predates this branch) and the hotkey inherited it, while the palette's `canCreateEnv` *did* check — two answers to one question. Both now route through one `isLiveScopedDrive`, and a trashed drive falls through to nothing rather than to drive creation.

**A new environment was overruled by the row that opened the flow** (found reviewing the touched code, not reported). The per-env `+` pre-answers "where should it run?"; making a *new* environment from the target step then spawned into the row's environment anyway, with no step on screen that ever mentioned it. Creating one now drops the preset so the env step asks once, with both to choose between.

Each fix carries a test that was mutation-checked against the code as it was before it.

## Review round 2

**A create that lands after its flow closed** (CodeRabbit, out-of-diff). Escape closes the palette while the POST is still out; the late continuation then wrote into whatever flow replaced it — selecting an environment that can belong to a *different drive*, dropping the row preset the new flow carries, or closing a create step being typed in. Flow token, bumped on every open and close. Only the *state* continuation is gated: the toast and the cache write stand either way, because the environment really was created.

Three more found reviewing the move rather than reported:

- **The editing-store registration was lost in the move.** `DriveEnvNameDialog` registers a `useEditingSession` while open — the repo rule for a surface holding typed text. Lifting that form into the palette silently dropped the protection; restored for the `new-env` step.
- **A successful create looked like nothing happening.** The dialog used to close onto the sidebar where the new row appearing *was* the confirmation; the palette covers it. Now toasts, like delete and rebuild.
- **A create in flight when the palette closed left the button stuck.** Its `finally` never ran against a visible form, so the next create step opened permanently disabled reading "Creating…".

## Review round 3

**An abandoned create re-enabled a live one** (CodeRabbit). Worth noting the thread was auto-marked "Addressed in commits 5ed8207 to 89a6f96" — it was not, and checking rather than trusting is what caught it. Those commits reset `creatingEnv` when a create step *opens* (fixing a form left stuck disabled); they did nothing about the opposite direction, where an older request settling clears the loading state of the form on screen now. Start a create, Escape mid-POST, open another flow, start its create: the first landing re-enables the second's form over a request still in flight, one keystroke from a second non-idempotent POST. Attempts are now tokened.

## Verification

- `bun run typecheck` — 17/17 tasks green (including `web#build`)
- `bun run lint` — clean
- 450 tests across the agents / left-sidebar / create suites, including 7 new ones
- **Mutation-checked** four of the new tests — env-row `+` ignoring the env, create-then-select, the admin gate, the 409-retry-holds-the-step. Each went red when the mechanism was broken.

**Verified in a real browser**, against a production build behind the repo's own same-origin proxy with a migrated Postgres — 11/11 checks: the icon button is gone; `Alt+N` opens the spawn palette on both Agents routes (drive-scoped, and the global console via the drive picker) and not the page-type quick-create; creating from the target step succeeds, toasts, and lands the row in the sidebar; the row's `+` skips the env step; the env step is asked once the drive has environments and offers making another. Two behaviours confirmed incidentally on a dirty database: the 409 duplicate-name path holds the create step open with the typed text, and a create past the tier ceiling is refused.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WiDAGP1W2UPUVzj7LSr1dZ


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Create environments directly from the new-session palette during target or environment selection.
  - Newly created environments are automatically selected for session creation.
  - Start sessions for specific environments from environment rows.
  - Environment creation is available only to authorized users.

- **Bug Fixes**
  - Improved environment-loading, duplicate-name, and creation error handling.
  - Quick-create shortcuts now behave correctly across drive and Agents pages.
  - Quick-create is unavailable for trashed drives.

- **Updates**
  - Environment management now focuses on renaming, rebuilding, and deleting; creation has moved to the session flow.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->



