### PR TITLE
fix(editor): mentions were destroyed by reading a document's HTML back in

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -130,6 +130,12 @@ All notable user-facing changes to PageSpace are documented here. Format follows
 
 ### Fixed
 
+- **Mentions in a document survive being read back in** — a page mention was written as a link the
+  editor could not recognise on the way back, so anything that re-read a document's HTML turned its
+  mentions into ordinary links and the page quietly dropped out of the mention list on the pages it
+  referenced. Mentions of every kind now come back intact, and a mention of a person is finally its
+  own thing rather than being filed as a mention of a page with the person's id on it.
+
 - **Turning an uploaded file into a document no longer risks losing what you wrote in it** — file
   text extraction runs in the background, and a file converted to a document while that extraction
   was still queued could have the document you had started writing replaced by the raw extracted

--- a/apps/web/src/lib/ai/skills/bodies/writing-documents.ts
+++ b/apps/web/src/lib/ai/skills/bodies/writing-documents.ts
@@ -107,12 +107,13 @@ There are two mention representations, and which one works depends on the surfac
 - Page link: \`<a class="mention" data-mention-type="page" data-page-id="PAGE_ID">@Page Title</a>\`
 - Everyone: \`<span class="mention" data-mention-type="everyone" data-drive-id="DRIVE_ID">@everyone</span>\` — notifies the drive's owner and members; take the driveId from your LOCATION context if present, otherwise resolve via \`list_drives\`.
 - Role: \`<span class="mention" data-mention-type="role" data-role-id="ROLE_ID" data-drive-id="DRIVE_ID">@Role Name</span>\` — notifies drive members holding that role.
+- User: \`<a class="mention" data-mention-type="user" data-user-id="USER_ID">@Name</a>\` — deliberately has no \`href\`; there is no user page to link to.
 
 When editing around existing mention elements, **preserve them verbatim** — rewriting them as plain text destroys the link.
 
 **The \`@[Label](id:type)\` syntax belongs to chat and channel messages** (types: \`(pageId:page)\`, \`(userId:user)\`, \`(roleId:role)\`, \`(driveId:everyone)\`). Message surfaces render it as a chip and notify. When a user @mentions a page at you in a message, read it with \`read_page\` before responding.
 
-In documents that syntax is only a **fallback**: it is parsed solely when the page contains no HTML mention markers at all — one existing mention element switches extraction to HTML-only and every \`@[..](..)\` in the page is ignored. In html-mode documents it also renders to readers as literal text, not a chip. So in documents, write the HTML elements. There is no working HTML form for a **user** mention in documents; if you need to notify a specific user reliably, do it from a chat/channel message rather than document content. Mention extraction skips \`<pre>\`/\`<code>\` regions, so literal syntax examples are never parsed as real mentions.
+In documents that syntax is only a **fallback**: it is parsed solely when the page contains no HTML mention markers at all — one existing mention element switches extraction to HTML-only and every \`@[..](..)\` in the page is ignored. In html-mode documents it also renders to readers as literal text, not a chip. So in documents, write the HTML elements — all four types, user included, have a working HTML form. Mention extraction skips \`<pre>\`/\`<code>\` regions, so literal syntax examples are never parsed as real mentions.
 
 Notification mechanics: the mention author is never notified, and only **newly added** mentions notify (re-saving the same mention does not). On chat/channel surfaces recipients are filtered to users who can view the page; on document saves they are **not** — a role/everyone mention in a page some drive members cannot view still notifies them, so mention deliberately. Mentioning someone never grants access. Use page mentions for cross-references.
 

--- a/apps/web/src/lib/editor/__tests__/tiptap-mention-round-trip.test.ts
+++ b/apps/web/src/lib/editor/__tests__/tiptap-mention-round-trip.test.ts
@@ -1,0 +1,299 @@
+/**
+ * The mention HTML round trip.
+ *
+ * Seeding Y.Docs from `pages.content` parses stored HTML back into the editor
+ * schema. Before the fix these tests cover, that parse destroyed page mentions:
+ * the inherited `parseHTML` matched only `span[data-type="pageMention"]`, so an
+ * `<a>` mention fell through to StarterKit's `link` mark and re-rendered without
+ * `data-page-id` — the selector `syncMentions`
+ * (`services/api/page-mention-service.ts:61`) matches. Round-tripping a document
+ * would have deleted its mention graph.
+ *
+ * Three things are asserted, per mention type and per stored dialect:
+ *  1. the parse produces a `pageMention` node with its attributes intact;
+ *  2. the round trip is a fixpoint, so a projection cannot churn forever;
+ *  3. the re-rendered HTML still matches the selectors `syncMentions` uses.
+ *
+ * (3) mirrors those selectors rather than calling `syncMentions`, which is not
+ * exported and needs a database — so it proves the markup shape, not the
+ * service. The selectors are copied from `page-mention-service.ts:61-80`; if
+ * they move, this test does not notice.
+ */
+import { describe, it, expect } from 'vitest';
+import { generateHTML, generateJSON } from '@tiptap/core';
+import StarterKit from '@tiptap/starter-kit';
+import * as cheerio from 'cheerio';
+import { PageMention } from '../tiptap-mention-config';
+
+// The schema-affecting subset of RichEditor.tsx's list that this behaviour
+// depends on: StarterKit contributes the `link` mark that used to win the `<a>`.
+const extensions = [
+  StarterKit.configure({
+    heading: { levels: [1, 2, 3] },
+    link: {
+      openOnClick: true,
+      autolink: true,
+      linkOnPaste: true,
+      defaultProtocol: 'https',
+    },
+    codeBlock: false,
+  }),
+  PageMention,
+];
+
+interface MentionAttrs {
+  id: string | null;
+  label: string | null;
+  driveId: string | null;
+  driveSlug: string | null;
+  mentionType: string;
+}
+
+function parseMention(html: string): MentionAttrs | null {
+  const doc = generateJSON(html, extensions) as {
+    content?: Array<{ content?: Array<{ type: string; attrs?: MentionAttrs }> }>;
+  };
+  const inline = doc.content?.[0]?.content ?? [];
+  const node = inline.find((child) => child.type === 'pageMention');
+  return node?.attrs ?? null;
+}
+
+function roundTrip(html: string): string {
+  return generateHTML(generateJSON(html, extensions), extensions);
+}
+
+const DRIVE = 'drv00000000000000000000';
+const PAGE = 'pg000000000000000000000';
+const USER = 'usr00000000000000000000';
+const ROLE = 'rol00000000000000000000';
+
+describe('pageMention HTML round trip', () => {
+  describe('the dialect the editor writes today', () => {
+    const cases: Array<[string, string, MentionAttrs]> = [
+      [
+        'page',
+        `<p><a class="mention" contenteditable="false" data-mention-type="page" data-page-id="${PAGE}" data-drive-id="${DRIVE}" href="/dashboard/${DRIVE}/${PAGE}" rel="noopener noreferrer nofollow">@My Page</a></p>`,
+        { id: PAGE, label: 'My Page', driveId: DRIVE, driveSlug: null, mentionType: 'page' },
+      ],
+      [
+        'user',
+        `<p><a class="mention" contenteditable="false" data-mention-type="user" data-user-id="${USER}" data-drive-id="${DRIVE}">@Ada</a></p>`,
+        { id: USER, label: 'Ada', driveId: DRIVE, driveSlug: null, mentionType: 'user' },
+      ],
+      [
+        'role',
+        `<p><span class="mention" contenteditable="false" data-mention-type="role" data-role-id="${ROLE}" data-drive-id="${DRIVE}">@Editors</span></p>`,
+        { id: ROLE, label: 'Editors', driveId: DRIVE, driveSlug: null, mentionType: 'role' },
+      ],
+      [
+        'everyone',
+        `<p><span class="mention" contenteditable="false" data-mention-type="everyone" data-drive-id="${DRIVE}">@everyone</span></p>`,
+        { id: null, label: 'everyone', driveId: DRIVE, driveSlug: null, mentionType: 'everyone' },
+      ],
+    ];
+
+    it.each(cases)('parses a %s mention with every attribute intact', (_type, html, expected) => {
+      expect(parseMention(html)).toEqual(expected);
+    });
+
+    it.each(cases)('round-trips a %s mention to a fixpoint', (_type, html) => {
+      const once = roundTrip(html);
+      expect(roundTrip(once)).toBe(once);
+    });
+
+    it.each(cases)('keeps a %s mention a pageMention node, not a link mark', (_type, html) => {
+      expect(parseMention(roundTrip(html))).not.toBeNull();
+    });
+  });
+
+  describe('the legacy dialect, with literal attribute names', () => {
+    // These three are the VERBATIM bytes the pre-fix code emitted — captured by
+    // running the previous renderHTML through generateHTML and pasting the
+    // result, not transcribed by hand. Attributes with no per-attribute
+    // renderHTML fell back to their literal names (core's
+    // getRenderedAttributes); the serializer lowercases them, and getAttribute
+    // is case-insensitive, which is why `driveid` still reads back.
+    const legacyPage = `<p><a data-type="pageMention" class="mention" contenteditable="false" id="${PAGE}" label="My Page" driveid="${DRIVE}" driveslug="my-drive" mentiontype="page" href="/dashboard/${DRIVE}/${PAGE}" rel="noopener noreferrer nofollow" data-mention-type="page" data-page-id="${PAGE}">@My Page</a></p>`;
+    const legacyRole = `<p><span data-type="pageMention" class="mention" contenteditable="false" id="${ROLE}" label="Editors" driveid="${DRIVE}" driveslug="my-drive" mentiontype="role" data-mention-type="role" data-role-id="${ROLE}" data-drive-id="${DRIVE}">@Editors</span></p>`;
+    // Note `id=""` and, in other stored rows, `data-drive-id=""` — renderHTML
+    // wrote `id` from an attribute defaulting to '' rather than null. Reading
+    // those back as '' instead of null would leave a non-default value on the
+    // node forever.
+    const legacyEveryone = `<p><span data-type="pageMention" class="mention" contenteditable="false" id="" label="everyone" driveid="${DRIVE}" driveslug="my-drive" mentiontype="everyone" data-mention-type="everyone" data-drive-id="${DRIVE}">@everyone</span></p>`;
+
+    it('recovers every attribute from the literal names', () => {
+      expect(parseMention(legacyPage)).toEqual({
+        id: PAGE,
+        label: 'My Page',
+        driveId: DRIVE,
+        driveSlug: 'my-drive',
+        mentionType: 'page',
+      });
+    });
+
+    it('recovers a legacy role mention', () => {
+      expect(parseMention(legacyRole)).toEqual({
+        id: ROLE,
+        label: 'Editors',
+        driveId: DRIVE,
+        driveSlug: 'my-drive',
+        mentionType: 'role',
+      });
+    });
+
+    it('reads a legacy everyone mention’s empty id as null, not an empty string', () => {
+      expect(parseMention(legacyEveryone)).toEqual({
+        id: null,
+        label: 'everyone',
+        driveId: DRIVE,
+        driveSlug: 'my-drive',
+        mentionType: 'everyone',
+      });
+    });
+
+    it.each([
+      ['page', () => legacyPage],
+      ['role', () => legacyRole],
+      ['everyone', () => legacyEveryone],
+    ])('round-trips a legacy %s mention to a fixpoint', (_type, html) => {
+      const once = roundTrip(html());
+      expect(roundTrip(once)).toBe(once);
+    });
+
+    it('stops emitting the literal attribute names', () => {
+      const once = roundTrip(legacyPage);
+      expect(once).not.toContain(' label=');
+      expect(once).not.toContain(' driveid=');
+      expect(once).not.toContain(' mentiontype=');
+    });
+
+    it('preserves driveSlug through the new data-drive-slug attribute', () => {
+      expect(roundTrip(legacyPage)).toContain('data-drive-slug="my-drive"');
+      expect(parseMention(roundTrip(legacyPage))?.driveSlug).toBe('my-drive');
+    });
+  });
+
+  describe('the dialect the AI writes', () => {
+    // lib/ai/skills/bodies/writing-documents.ts:141 instructs models to write
+    // this shape: no data-type, no href, no label attribute.
+    const aiPage = `<p><a class="mention" data-mention-type="page" data-page-id="${PAGE}">@Quarterly Plan</a></p>`;
+
+    it('parses with the label recovered from the element text', () => {
+      expect(parseMention(aiPage)).toEqual({
+        id: PAGE,
+        label: 'Quarterly Plan',
+        driveId: null,
+        driveSlug: null,
+        mentionType: 'page',
+      });
+    });
+
+    it('round-trips to a fixpoint', () => {
+      const once = roundTrip(aiPage);
+      expect(roundTrip(once)).toBe(once);
+    });
+  });
+
+  describe('an anchor carrying only the identity attribute', () => {
+    // syncMentions selects on a[data-page-id] / a[data-user-id] alone, so
+    // content written against that contract need not carry data-mention-type.
+    it('reads a bare data-page-id anchor as a page mention', () => {
+      const html = `<p><a data-page-id="${PAGE}">@My Page</a></p>`;
+      expect(parseMention(html)).toMatchObject({ id: PAGE, mentionType: 'page' });
+    });
+
+    it('reads a bare data-user-id anchor as a user mention, not a page one', () => {
+      const html = `<p><a data-user-id="${USER}">@Ada</a></p>`;
+      expect(parseMention(html)).toMatchObject({ id: USER, mentionType: 'user' });
+      expect(roundTrip(html)).not.toContain('data-page-id');
+    });
+
+    it('reads a bare data-role-id span as a role mention', () => {
+      const html = `<p><span data-type="pageMention" data-role-id="${ROLE}">@Editors</span></p>`;
+      expect(parseMention(html)).toMatchObject({ id: ROLE, mentionType: 'role' });
+    });
+  });
+
+  describe('driveId recovery from the href', () => {
+    it('reads the driveId out of /dashboard/{driveId}/{pageId} when the attribute is absent', () => {
+      const html = `<p><a class="mention" data-mention-type="page" data-page-id="${PAGE}" href="/dashboard/${DRIVE}/${PAGE}">@My Page</a></p>`;
+      expect(parseMention(html)?.driveId).toBe(DRIVE);
+    });
+  });
+
+  describe('the selectors syncMentions matches', () => {
+    it('emits a[data-page-id] for a page mention', () => {
+      const html = roundTrip(
+        `<p><a class="mention" data-mention-type="page" data-page-id="${PAGE}" data-drive-id="${DRIVE}">@My Page</a></p>`
+      );
+      expect(cheerio.load(html)('a[data-page-id]').attr('data-page-id')).toBe(PAGE);
+    });
+
+    it('emits a[data-user-id] for a user mention, which nothing emitted before', () => {
+      const html = roundTrip(
+        `<p><a class="mention" data-mention-type="user" data-user-id="${USER}" data-drive-id="${DRIVE}">@Ada</a></p>`
+      );
+      expect(cheerio.load(html)('a[data-user-id]').attr('data-user-id')).toBe(USER);
+    });
+
+    it('never writes a user id into data-page-id', () => {
+      const html = roundTrip(
+        `<p><a class="mention" data-mention-type="user" data-user-id="${USER}">@Ada</a></p>`
+      );
+      expect(html).not.toContain('data-page-id');
+    });
+
+    it('emits span[data-mention-type="role"] with its role id', () => {
+      const html = roundTrip(
+        `<p><span class="mention" data-mention-type="role" data-role-id="${ROLE}" data-drive-id="${DRIVE}">@Editors</span></p>`
+      );
+      const $ = cheerio.load(html);
+      expect($('span[data-mention-type="role"]').attr('data-role-id')).toBe(ROLE);
+      expect($('span[data-mention-type="role"]').attr('data-drive-id')).toBe(DRIVE);
+    });
+
+    it('emits span[data-mention-type="everyone"] with its drive id', () => {
+      const html = roundTrip(
+        `<p><span class="mention" data-mention-type="everyone" data-drive-id="${DRIVE}">@everyone</span></p>`
+      );
+      expect(cheerio.load(html)('span[data-mention-type="everyone"]').attr('data-drive-id')).toBe(DRIVE);
+    });
+  });
+
+  describe('the link mark must not claim a mention anchor', () => {
+    const pageHtml = `<p><a class="mention" data-mention-type="page" data-page-id="${PAGE}" data-drive-id="${DRIVE}" href="/dashboard/${DRIVE}/${PAGE}">@My Page</a></p>`;
+
+    it('does not inject target="_blank", which breaks the Capacitor WebView', () => {
+      expect(roundTrip(pageHtml)).not.toContain('target=');
+    });
+
+    it('leaves a genuine link alone', () => {
+      const link = '<p><a href="https://example.test/x">a real link</a></p>';
+      const doc = generateJSON(link, extensions) as {
+        content?: Array<{ content?: Array<{ type: string; marks?: Array<{ type: string }> }> }>;
+      };
+      const text = doc.content?.[0]?.content?.[0];
+      expect(text?.type).toBe('text');
+      expect(text?.marks?.[0]?.type).toBe('link');
+    });
+  });
+
+  describe('a document with several mentions', () => {
+    it('preserves all of them in one pass', () => {
+      const html =
+        `<p>See <a class="mention" data-mention-type="page" data-page-id="${PAGE}" data-drive-id="${DRIVE}">@My Page</a>` +
+        ` and tell <a class="mention" data-mention-type="user" data-user-id="${USER}" data-drive-id="${DRIVE}">@Ada</a>` +
+        ` plus <span class="mention" data-mention-type="role" data-role-id="${ROLE}" data-drive-id="${DRIVE}">@Editors</span>` +
+        ` and <span class="mention" data-mention-type="everyone" data-drive-id="${DRIVE}">@everyone</span>.</p>`;
+
+      const doc = generateJSON(html, extensions) as {
+        content?: Array<{ content?: Array<{ type: string }> }>;
+      };
+      const mentions = (doc.content?.[0]?.content ?? []).filter((n) => n.type === 'pageMention');
+      expect(mentions).toHaveLength(4);
+
+      const once = roundTrip(html);
+      expect(roundTrip(once)).toBe(once);
+    });
+  });
+});

--- a/apps/web/src/lib/editor/__tests__/tiptap-mention-round-trip.test.ts
+++ b/apps/web/src/lib/editor/__tests__/tiptap-mention-round-trip.test.ts
@@ -214,6 +214,31 @@ describe('pageMention HTML round trip', () => {
     });
   });
 
+  describe('a page mention with no drive context', () => {
+    // The AI-authored shape carries data-page-id and nothing else. renderHTML
+    // used to fall back to a bare `/dashboard/` href, so the chip rendered as a
+    // link that navigated to the dashboard root instead of the mentioned page.
+    const noDrive = `<p><a class="mention" data-mention-type="page" data-page-id="${PAGE}">@Quarterly Plan</a></p>`;
+
+    it('emits no href at all rather than a bare /dashboard/', () => {
+      const once = roundTrip(noDrive);
+      expect(once).not.toContain('href=');
+      expect(once).toContain(`data-page-id="${PAGE}"`);
+    });
+
+    it('never emits the /p/ resolver into stored HTML, which publishing would not neutralize', () => {
+      // neutralizeDashboardLinks only rewrites hrefs starting with /dashboard/,
+      // so a /p/{pageId} href would publish as a live link into an auth-gated
+      // route. The resolver belongs to the node view, not to stored content.
+      expect(roundTrip(noDrive)).not.toContain('/p/');
+    });
+
+    it('still emits the dashboard href when the drive is known', () => {
+      const html = `<p><a class="mention" data-mention-type="page" data-page-id="${PAGE}" data-drive-id="${DRIVE}">@My Page</a></p>`;
+      expect(roundTrip(html)).toContain(`href="/dashboard/${DRIVE}/${PAGE}"`);
+    });
+  });
+
   describe('driveId recovery from the href', () => {
     it('reads the driveId out of /dashboard/{driveId}/{pageId} when the attribute is absent', () => {
       const html = `<p><a class="mention" data-mention-type="page" data-page-id="${PAGE}" href="/dashboard/${DRIVE}/${PAGE}">@My Page</a></p>`;

--- a/apps/web/src/lib/editor/tiptap-mention-config.tsx
+++ b/apps/web/src/lib/editor/tiptap-mention-config.tsx
@@ -138,6 +138,99 @@ function getMentionAttrs(attrs: Record<string, unknown>): MentionAttrs {
   };
 }
 
+/**
+ * The mention HTML dialects that exist in stored `pages.content` today, and
+ * which `parseHTML` below has to accept all of.
+ *
+ * 1. Editor-written. `renderHTML` emitted the node's attributes under their
+ *    literal names as well as the `data-*` forms, so old content carries
+ *    `id="…" label="…" driveid="…" driveslug="…" mentiontype="…"` alongside
+ *    `data-page-id` / `data-mention-type`. Those literal attributes are no
+ *    longer emitted — `id` in particular collided with real DOM ids — but they
+ *    are still parsed, or every mention written before this change loses its
+ *    attributes.
+ * 2. Group spans. `<span data-mention-type="everyone|role">` with `data-role-id`
+ *    and `data-drive-id`.
+ * 3. AI-written. `lib/ai/skills/bodies/writing-documents.ts` instructs models to
+ *    write `<a class="mention" data-mention-type="page" data-page-id="ID">@Title</a>`
+ *    — no `data-type`, no `href`, no label attribute. `label` therefore falls
+ *    back to the element's text and `driveId` to the `href` path.
+ *
+ * Before this, none of the `<a>` forms parsed at all: the inherited rule matched
+ * only `span[data-type="pageMention"]`, so a page mention fell through to
+ * StarterKit's `link` mark and re-rendered without `data-page-id` — the exact
+ * selector `syncMentions` (`services/api/page-mention-service.ts:61`) matches.
+ * Round-tripping a document therefore deleted its mention graph.
+ *
+ * The readers below are what accept all three; `parseHTML` picks the elements.
+ */
+
+const MENTION_TEXT_PREFIX = /^@/;
+
+/**
+ * First non-empty attribute, or null. Empty rather than absent is the common
+ * case in stored content: `renderHTML` writes `data-drive-id={driveId ?? ''}`
+ * and `data-page-id={id}` where `id` defaults to `''`, so a mention with no
+ * drive carries `data-drive-id=""`. Reading that back as `''` instead of null
+ * would put a meaningless non-default value on every such attribute.
+ */
+function readAttr(element: HTMLElement, ...names: string[]): string | null {
+  for (const name of names) {
+    const value = element.getAttribute(name);
+    if (value) {
+      return value;
+    }
+  }
+  return null;
+}
+
+function readLabel(element: HTMLElement): string | null {
+  const explicit = readAttr(element, 'label');
+  if (explicit) {
+    return explicit;
+  }
+  // One leading '@' only, so a label that is itself '@channel' survives.
+  const text = element.textContent?.trim().replace(MENTION_TEXT_PREFIX, '');
+  return text ? text : null;
+}
+
+/** `/dashboard/{driveId}/{pageId}` — the only href shape `renderHTML` produces. */
+function readDriveIdFromHref(element: HTMLElement): string | null {
+  const href = element.getAttribute('href');
+  const match = href?.match(/^\/dashboard\/([^/]+)\/[^/]+$/);
+  return match?.[1] ?? null;
+}
+
+/**
+ * `data-mention-type` when it is there, otherwise inferred from whichever
+ * identity attribute is present. `syncMentions` selects on `a[data-page-id]`
+ * and `a[data-user-id]` alone, so content written against that contract can
+ * carry an id with no type — and defaulting such an anchor to 'page' would
+ * file a user id as a page id, which is the bug this fix exists to remove.
+ */
+function readMentionType(element: HTMLElement): string {
+  const explicit = readAttr(element, 'data-mention-type', 'mentiontype');
+  if (explicit) {
+    return explicit;
+  }
+  if (readAttr(element, 'data-user-id')) {
+    return 'user';
+  }
+  if (readAttr(element, 'data-role-id')) {
+    return 'role';
+  }
+  return 'page';
+}
+
+/**
+ * The identity attribute is per mention type: a page mention's id lives in
+ * `data-page-id`, a user's in `data-user-id`, a role's in `data-role-id`. An
+ * `everyone` mention has no id.
+ */
+function readMentionId(element: HTMLElement): string | null {
+  return readAttr(element, 'data-page-id', 'data-user-id', 'data-role-id', 'id');
+}
+
 function dispatchInternalNavigation(href: string): void {
   const event = new CustomEvent('pagespace:navigate', {
     detail: { href },
@@ -155,14 +248,57 @@ const PageMentionNode = Mention.extend({
   selectable: false,
 
   addAttributes() {
+    // Every attribute renders as `{}` because the node's own renderHTML below
+    // emits the `data-*` forms itself. Without this, TipTap falls back to
+    // emitting each attribute under its literal name (core's
+    // `getRenderedAttributes`), which is where the stray `id="…" label="…"`
+    // attributes in existing content came from.
     return {
-      id: { default: null },
-      label: { default: null },
-      driveId: { default: null },
-      driveSlug: { default: null },
+      id: {
+        default: null,
+        parseHTML: readMentionId,
+        renderHTML: () => ({}),
+      },
+      label: {
+        default: null,
+        parseHTML: readLabel,
+        renderHTML: () => ({}),
+      },
+      driveId: {
+        default: null,
+        parseHTML: (element: HTMLElement) =>
+          readAttr(element, 'data-drive-id', 'driveid') ?? readDriveIdFromHref(element),
+        renderHTML: () => ({}),
+      },
+      driveSlug: {
+        default: null,
+        parseHTML: (element: HTMLElement) =>
+          readAttr(element, 'data-drive-slug', 'driveslug'),
+        renderHTML: () => ({}),
+      },
       // 'page' | 'user' | 'everyone' | 'role'
-      mentionType: { default: 'page' },
+      mentionType: {
+        default: 'page',
+        parseHTML: readMentionType,
+        renderHTML: () => ({}),
+      },
     };
+  },
+
+  /**
+   * `priority: 60` beats the default 50 that StarterKit's `link` mark rule
+   * (`a[href]`) carries, so a page mention's anchor is claimed by this node
+   * rather than degrading to a link. Extension priority does not propagate to
+   * parse rules — it only orders extensions — so it has to be set here.
+   */
+  parseHTML() {
+    return [
+      { tag: 'a[data-page-id]', priority: 60 },
+      { tag: 'a[data-user-id]', priority: 60 },
+      { tag: 'a[data-mention-type]', priority: 60 },
+      { tag: 'span[data-mention-type]', priority: 60 },
+      { tag: `span[data-type="${this.name}"]`, priority: 60 },
+    ];
   },
 
   addNodeView() {
@@ -176,6 +312,21 @@ const PageMentionNode = Mention.extend({
         dom.contentEditable = 'false';
         dom.setAttribute('data-mention-type', mentionType);
         if (mentionType === 'role') dom.setAttribute('data-role-id', id);
+        if (driveId) dom.setAttribute('data-drive-id', driveId);
+        dom.textContent = `@${label}`;
+        dom.addEventListener('mousedown', (event) => { event.preventDefault(); });
+        return { dom, contentDOM: null };
+      }
+
+      // A user mention has no page to navigate to. It used to build
+      // `/dashboard/{driveId}/{userId}`, which resolves to nothing — match
+      // renderHTML and emit an inert chip carrying `data-user-id`.
+      if (mentionType === 'user') {
+        const dom = document.createElement('a');
+        dom.className = 'mention';
+        dom.contentEditable = 'false';
+        dom.setAttribute('data-mention-type', 'user');
+        dom.setAttribute('data-user-id', id);
         if (driveId) dom.setAttribute('data-drive-id', driveId);
         dom.textContent = `@${label}`;
         dom.addEventListener('mousedown', (event) => { event.preventDefault(); });
@@ -212,13 +363,20 @@ export const PageMention = PageMentionNode.configure({
     contenteditable: 'false',
   },
   renderHTML({ options, node }) {
-    const { mentionType, id, label, driveId } = getMentionAttrs(node.attrs);
+    const { mentionType, id, label, driveId, driveSlug } = getMentionAttrs(node.attrs);
+
+    // Only emitted when set, so mentions that never carried a slug gain no
+    // attribute. Nothing reads it today; it is preserved because dropping a
+    // schema attribute is a decision for the COLLAB_SCHEMA_VERSION v1 leaf,
+    // not a side effect of a round-trip fix.
+    const slugAttrs = driveSlug ? { 'data-drive-slug': driveSlug } : {};
 
     if (mentionType === 'everyone') {
       return [
         'span',
         {
           ...options.HTMLAttributes,
+          ...slugAttrs,
           'data-mention-type': 'everyone',
           'data-drive-id': driveId ?? '',
           contenteditable: 'false',
@@ -232,8 +390,30 @@ export const PageMention = PageMentionNode.configure({
         'span',
         {
           ...options.HTMLAttributes,
+          ...slugAttrs,
           'data-mention-type': 'role',
           'data-role-id': id,
+          'data-drive-id': driveId ?? '',
+          contenteditable: 'false',
+        },
+        `@${label}`,
+      ];
+    }
+
+    // A user mention used to fall through to the page branch below, which
+    // wrote the user's id into `data-page-id` — so `syncMentions` read it as a
+    // page id, and the `a[data-user-id]` selector it actually looks for
+    // (`page-mention-service.ts:65`) was emitted by nothing in the codebase.
+    // Deliberately no `href`: there is no user route, and an anchor without one
+    // cannot be claimed by the `link` mark on the way back in.
+    if (mentionType === 'user') {
+      return [
+        'a',
+        {
+          ...options.HTMLAttributes,
+          ...slugAttrs,
+          'data-mention-type': 'user',
+          'data-user-id': id,
           'data-drive-id': driveId ?? '',
           contenteditable: 'false',
         },
@@ -246,11 +426,13 @@ export const PageMention = PageMentionNode.configure({
       'a',
       {
         ...options.HTMLAttributes,
+        ...slugAttrs,
         href,
         // NO target="_blank" - stays in WebView on Capacitor iOS
         rel: 'noopener noreferrer nofollow',
         'data-mention-type': 'page',
         'data-page-id': id,
+        'data-drive-id': driveId ?? '',
         contenteditable: 'false',
       },
       `@${label}`,

--- a/apps/web/src/lib/editor/tiptap-mention-config.tsx
+++ b/apps/web/src/lib/editor/tiptap-mention-config.tsx
@@ -202,6 +202,30 @@ function readDriveIdFromHref(element: HTMLElement): string | null {
 }
 
 /**
+ * Where a click on a page mention goes, in the editor's node view.
+ *
+ * With a driveId, the direct dashboard URL. Without one — the AI-authored shape
+ * carries `data-page-id` and nothing else — the `/p/{pageId}` resolver, which
+ * exists precisely so "mentions [can] link directly to a page ID without
+ * knowing the driveId" (`app/p/[pageId]/page.tsx`). Null when there is no id,
+ * so the chip simply does not navigate, rather than following the bare
+ * `/dashboard/` this used to fall back to, which landed on the dashboard root
+ * instead of the mentioned page.
+ *
+ * Deliberately NOT used by `renderHTML`. That output is stored and published,
+ * and `neutralizeDashboardLinks` (`packages/lib/src/publish/`) makes a mention
+ * inert on a published page by rewriting hrefs that start with `/dashboard/`.
+ * A `/p/{pageId}` href would slip past it and publish as a live link into an
+ * auth-gated route, so stored HTML gets the dashboard href or no href at all.
+ */
+function pageMentionNavigationHref(id: string, driveId: string | null): string | null {
+  if (!id) {
+    return null;
+  }
+  return driveId ? `/dashboard/${driveId}/${id}` : `/p/${id}`;
+}
+
+/**
  * `data-mention-type` when it is there, otherwise inferred from whichever
  * identity attribute is present. `syncMentions` selects on `a[data-page-id]`
  * and `a[data-user-id]` alone, so content written against that contract can
@@ -334,10 +358,10 @@ const PageMentionNode = Mention.extend({
       }
 
       const dom = document.createElement('a');
-      const href = driveId && id ? `/dashboard/${driveId}/${id}` : `/dashboard/`;
+      const href = pageMentionNavigationHref(id, driveId);
 
       // NO target="_blank" - stays in WebView on Capacitor
-      dom.href = href;
+      if (href) dom.href = href;
       dom.rel = 'noopener noreferrer nofollow';
       dom.className = 'mention';
       dom.contentEditable = 'false';
@@ -345,11 +369,13 @@ const PageMentionNode = Mention.extend({
       dom.setAttribute('data-page-id', id);
       dom.textContent = `@${label}`;
 
-      dom.addEventListener('click', (event) => {
-        event.preventDefault();
-        event.stopPropagation();
-        dispatchInternalNavigation(href);
-      });
+      if (href) {
+        dom.addEventListener('click', (event) => {
+          event.preventDefault();
+          event.stopPropagation();
+          dispatchInternalNavigation(href);
+        });
+      }
       dom.addEventListener('mousedown', (event) => { event.preventDefault(); });
 
       return { dom, contentDOM: null };
@@ -421,13 +447,20 @@ export const PageMention = PageMentionNode.configure({
       ];
     }
 
-    const href = driveId && id ? `/dashboard/${driveId}/${id}` : `/dashboard/`;
+    // Stored HTML only ever gets the dashboard href, and only when the drive is
+    // known. Without it there is no URL this output may carry: the old fallback
+    // wrote a bare `/dashboard/`, which reads as a link and lands on the
+    // dashboard root, and the `/p/{pageId}` resolver the node view uses would
+    // slip past `neutralizeDashboardLinks` (`packages/lib/src/publish/`) and
+    // publish as a live link into an auth-gated route. An href-less anchor is
+    // already inert on a published page.
+    const href = driveId && id ? `/dashboard/${driveId}/${id}` : null;
     return [
       'a',
       {
         ...options.HTMLAttributes,
         ...slugAttrs,
-        href,
+        ...(href ? { href } : {}),
         // NO target="_blank" - stays in WebView on Capacitor iOS
         rel: 'noopener noreferrer nofollow',
         'data-mention-type': 'page',

--- a/apps/web/src/services/api/__tests__/page-mention-service.test.ts
+++ b/apps/web/src/services/api/__tests__/page-mention-service.test.ts
@@ -228,6 +228,39 @@ describe('syncMentions — valid mentions still sync', () => {
   });
 });
 
+describe('syncMentions — a document whose only mentions are users', () => {
+  // The HTML branch selects on a[data-user-id], but the gate that decides
+  // whether to run it listed only the page, everyone and role markers. A
+  // document carrying nothing but user mentions therefore fell through to the
+  // markdown fallback, matched nothing, and the sync read that as "no mentions"
+  // — deleting the rows that were already there.
+  const userOnly = '<p>Hey <a class="mention" data-mention-type="user" data-user-id="user42">@Alice</a></p>';
+
+  it('takes the HTML branch and inserts the user mention', async () => {
+    const { tx, userMentionInserts } = makeTx({ existingUserIds: ['user42'] });
+
+    const result = await syncMentions('source-page', userOnly, tx as unknown as AnyTx, {
+      mentionedByUserId: 'author-1',
+    });
+
+    expect(userMentionInserts).toEqual([
+      { sourcePageId: 'source-page', targetUserId: 'user42', mentionedByUserId: 'author-1' },
+    ]);
+    expect(result.newlyMentionedUserIds).toEqual(['user42']);
+  });
+
+  it('does not delete an already-synced user mention that is still in the content', async () => {
+    const { tx, deletes } = makeTx({
+      existingUserIds: ['user42'],
+      existingUserMentions: ['user42'],
+    });
+
+    await syncMentions('source-page', userOnly, tx as unknown as AnyTx);
+
+    expect(deletes.filter(d => d.table === userMentions)).toHaveLength(0);
+  });
+});
+
 describe('syncMentions — nonexistent targets are dropped silently', () => {
   it('drops a mention of a nonexistent page ID without throwing', async () => {
     const { tx, mentionInserts } = makeTx({ existingPageIds: ['real-page'] });

--- a/apps/web/src/services/api/page-mention-service.ts
+++ b/apps/web/src/services/api/page-mention-service.ts
@@ -46,8 +46,13 @@ function findMentionNodes(content: unknown): MentionIds {
   const seenGroups = new Set<string>();
   const contentStr = Array.isArray(content) ? content.join('\n') : String(content);
 
+  // Every marker the HTML branch below selects on must appear here, or a
+  // document carrying only that kind of mention falls through to the markdown
+  // fallback, extracts nothing, and the sync treats the result as "no mentions"
+  // — which deletes the rows that were already there.
   const shouldParseHtml = contentStr.includes('<') && (
     contentStr.includes('data-page-id') ||
+    contentStr.includes('data-user-id') ||
     contentStr.includes('data-mention-type="everyone"') ||
     contentStr.includes('data-mention-type="role"')
   );


### PR DESCRIPTION
## The bug

The `pageMention` node inherited a `parseHTML` rule matching only `span[data-type="pageMention"]`, while the page branch of `renderHTML` emits an `<a>`. Nothing in the app re-parsed document HTML back into the editor, so this was invisible — but on any path that does, every page mention falls through to StarterKit's `link` mark and re-renders as:

```html
<a target="_blank" rel="noopener noreferrer nofollow" class="mention" href="/dashboard/…">@My Page</a>
```

`data-page-id` is gone. That is the selector `syncMentions` matches (`page-mention-service.ts:61`), so a round trip does not merely flatten the mention in the document — **it drops the page out of the mention graph on the next save.** It also injects `target="_blank"`, which the mention code comments explicitly avoid for the Capacitor WebView.

Seeding Y.Docs from `pages.content` is exactly such a path, which is why this lands before multiplayer Phase B rather than inside it.

**Group `<span>` mentions were never affected.** `data-type` *is* emitted — merged in by the base node's `renderHTML` — and attributes with no per-attribute `renderHTML` are emitted under their literal name and read back case-insensitively. Only the `<a>` branch is broken.

## Two more defects found alongside

- **User mentions had no working wire shape.** `renderHTML` branched on `everyone` and `role` and fell through to the *page* branch for everything else, so `mentionType: 'user'` serialised the user's id into `data-page-id`. Meanwhile `page-mention-service.ts:65` looks for `a[data-user-id]`, which **nothing in the codebase emitted**. `writing-documents.ts` documented this as a permanent limitation; it no longer is.
- **Every attribute was emitted twice.** With no per-attribute `renderHTML`, TipTap falls back to the literal attribute name, so stored content carries `id="…" label="…" driveid="…" driveslug="…" mentiontype="…"` — including a real DOM `id` collision on every mention in every document.

## The fix

- Explicit `parseHTML` rules at **`priority: 60`**. The default 50 loses the anchor to the `link` mark, and extension priority orders extensions without reaching parse rules.
- Per-attribute `parseHTML` accepting all three dialects in stored content: editor-written (literal names), group spans, and AI-written (`writing-documents.ts` shape — no `data-type`, no `href`, no label attribute, so `label` comes from the element text and `driveId` from the href path).
- Per-attribute `renderHTML: () => ({})` to stop writing the literal names. They are still parsed, so nothing already stored loses its attributes.
- A `user` branch in both `renderHTML` and the node view, emitting an **href-less** `<a data-user-id>` — there is no user route, and an anchor without an `href` cannot be claimed by the `link` mark on the way back in.
- `data-drive-slug` so `driveSlug` survives a round trip, and `mentionType` inferred from the identity attribute when `data-mention-type` is absent, so a bare `a[data-user-id]` is never filed as a page.
- Empty attribute values read back as `null`, not `''` — `renderHTML` writes `data-drive-id={driveId ?? ''}`, so stored content is full of empty attributes that would otherwise land as non-default values on every node.

## Verification

34 round-trip tests covering all four mention types across all three dialects. The legacy fixtures are the **verbatim bytes the pre-fix renderer emitted**, captured by running it, not transcribed.

**Every mechanism is mutation-checked** — broken, observed red, restored:

| Mutation | Tests red |
|---|---|
| drop the `a[data-page-id]` rule | 1 |
| drop the `a[data-user-id]` rule | 1 |
| drop `priority` from all parse rules | 8 |
| drop the `user` branch in `renderHTML` | 2 |
| drop the literal-attribute suppression | 1 |
| drop the text-content `label` fallback | 5 |
| drop the `data-drive-slug` emission | 1 |
| drop `driveId` recovery from the href | 1 |
| drop the `data-user-id` type inference | 1 |
| drop the `data-role-id` type inference | 1 |
| let `readAttr` accept empty strings | 1 |

Gates on the rebased tree: `bun run typecheck` 17/17, `bun run --filter web lint` clean, `bun run knip:check` within baseline, publish suites 123/123 (the neutralizer skips the href-less user anchor, so published pages are unaffected), editor + mention-service suites 161/161. Full web suite 18,035 passed / 10 failed — every failure is "test database not reachable", none in this blast radius.

## What is not verified

- **Not asserted against real drive content.** No drive reachable from this machine holds editor-written mention HTML. Carried to the multiplayer Phase B content-census task, which runs against a prod-shaped DB.
- **Not opened in a browser.** The node-view change renders user mentions as an inert chip; that path has no test.
- The DB-backed suites were not run locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GtkrTS2yrvfCqdC8WAC18t


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Document mentions now round-trip reliably without losing mention types or identity details.
  - Improved compatibility with legacy and AI-generated mention markup.
  - User, page, group, and role mentions display correctly without exposing technical attributes.
  - Preserved relevant page and drive information, including optional page slugs.
  - Improved synchronization for documents containing direct user mentions.
- **Tests**
  - Added comprehensive coverage for mention parsing, serialization, mixed mention types, link interactions, and user-mention synchronization.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->