### PR TITLE
fix(tenant): correct the export/validate path — nine bugs, split out of #2455

### DIFF
--- a/scripts/__tests__/tenant-validate.test.ts
+++ b/scripts/__tests__/tenant-validate.test.ts
@@ -58,6 +58,22 @@ afterEach(async () => {
   }
 });
 
+/**
+ * HARNESS LIMITATION, stated once because three separate comments were arguing
+ * about it.
+ *
+ * Every case in this file passes the SAME `db` handle as source and target, and
+ * mostly the same storage path. `validateTable` runs one query object against
+ * both, so `missingIds`/`extraIds` are always empty: a table's `passed`, and
+ * therefore `result.passed`, is true for ANY predicate. Those assertions
+ * document intent; they cannot fail, and they must not be read as evidence that
+ * a predicate is right.
+ *
+ * `sourceCount` is the load-bearing assertion. It is a measurement of the
+ * SOURCE population, which is exactly where every exporter/validator asymmetry
+ * this file guards has lived. The file-blob comparison is the one check that
+ * can genuinely differ, and only when a case passes two different paths.
+ */
 describe('validateData', () => {
   it('reports success when source and target match', async () => {
     const result = await validateData(db as unknown as DbClient, db as unknown as DbClient, {
@@ -186,13 +202,10 @@ describe('validateData', () => {
         const messagesResult = result.tableResults.find((r) => r.table === 'messages');
         // Still 3 — the two owner messages plus Eve's; Mallory's is excluded.
         //
-        // `sourceCount` is the only assertion worth making here. Source and
-        // target are the SAME db handle (see the note above), so every id-based
-        // table compares a query against itself and `passed` is true whatever
-        // the predicate says — asserting it would look like a guarantee this
-        // harness cannot give. The count is what moves: without the user arm it
-        // is 4, and the bundle would be reported as missing a row it was never
-        // meant to carry.
+        // `sourceCount` only — see HARNESS LIMITATION at the top of this file
+        // for why `passed` cannot move here. The count is what does: without
+        // the user arm it is 4, and the bundle would be reported as missing a
+        // row it was never meant to carry.
         expect(messagesResult!.sourceCount).toBe(3);
       } finally {
         await db.execute(sql.raw(`DELETE FROM messages WHERE id = '${STRANGER_MSG}'`));
@@ -283,6 +296,15 @@ describe('validateData', () => {
       return result.tableResults.find((r) => r.table === table)!.sourceCount;
     };
 
+    it('does not count a user the export never carries', async () => {
+      // The UPPER bound on `users`, paired with the lower bound in the block
+      // above. `users` is the one query here whose failure mode is a false
+      // PASS, so it needs both: too narrow and a carried row goes unchecked,
+      // too wide and a row the bundle never held is reported missing. The
+      // stranger has a `users` row and is reachable by no discovery arm.
+      expect(await countFor('users')).toBe(2);
+    });
+
     it('does not count a page permission granted to a user outside the export set', async () => {
       // Still the ONE seeded grant. Without the user arm this is 2.
       expect(await countFor('page_permissions')).toBe(1);
@@ -322,6 +344,31 @@ describe('validateData', () => {
     const pagesResult = result.tableResults.find((r) => r.table === 'pages');
     expect(pagesResult).toBeDefined();
     expect(pagesResult!.sourceCount).toBe(2);
+  });
+
+  it('does not fault a file whose SOURCE blob is gone — the export skipped it', async () => {
+    // tenant-export.ts skips a `files` row whose blob is not on disk, so the
+    // bundle legitimately does not carry it. Checking the target first reported
+    // that row as 'missing in target' and failed a correct migration.
+    //
+    // Both paths point at empty directories: source blob absent, target blob
+    // absent, which is exactly the orphaned-row state. Before the fix this
+    // produced `{ reason: 'missing in target' }` and `passed: false`.
+    const emptySource = path.join(tmpDir, 'source-orphaned');
+    const emptyTarget = path.join(tmpDir, 'target-orphaned');
+    await mkdir(emptySource, { recursive: true });
+    await mkdir(emptyTarget, { recursive: true });
+
+    const result = await validateData(db as unknown as DbClient, db as unknown as DbClient, {
+      sourceDatabaseUrl: getTestDatabaseUrl(),
+      targetDatabaseUrl: getTestDatabaseUrl(),
+      userIds: [FIXTURES.users.owner.id, FIXTURES.users.member.id],
+      sourceFileStoragePath: emptySource,
+      targetFileStoragePath: emptyTarget,
+    });
+
+    expect(result.fileResults.mismatches).toEqual([]);
+    expect(result.fileResults.passed).toBe(true);
   });
 
   it('detects missing file blob in target', async () => {

--- a/scripts/__tests__/tenant-validate.test.ts
+++ b/scripts/__tests__/tenant-validate.test.ts
@@ -21,7 +21,7 @@ import {
   getTestDatabaseUrl,
   type TestDb,
 } from './setup';
-import { validateData, resolveSourceStorageRoot } from '../tenant-validate';
+import { validateData, resolveSourceStorageRoot, isSameStorageRoot } from '../tenant-validate';
 import { TABLE_IMPORT_ORDER } from '../lib/migration-types';
 import type { DbClient } from '../lib/migration-types';
 
@@ -109,6 +109,42 @@ describe('resolveSourceStorageRoot', () => {
       if (previous === undefined) delete process.env.FILE_STORAGE_PATH;
       else process.env.FILE_STORAGE_PATH = previous;
     }
+  });
+});
+
+describe('isSameStorageRoot', () => {
+  /**
+   * Both roots default to `./uploads`, so running the validator on the target
+   * host after an import with neither path flag points both sides at the same
+   * directory: every checksum matches, nothing is compared, success. This guard
+   * is what refuses that, and `main()` — where it is called — has no test, so it
+   * is asserted here instead of taken on faith.
+   */
+  it('detects the same directory reached by two different spellings', async () => {
+    const real = path.join(tmpDir, 'same-root-real');
+    await mkdir(real, { recursive: true });
+    const link = path.join(tmpDir, 'same-root-link');
+    await symlink(real, link, 'dir');
+
+    expect(isSameStorageRoot(real, real)).toBe(true);
+    expect(isSameStorageRoot(real, link), 'symlink to the same directory').toBe(true);
+    expect(isSameStorageRoot(real, real + path.sep), 'trailing separator').toBe(true);
+  });
+
+  it('does not fire for genuinely different roots', async () => {
+    const a = path.join(tmpDir, 'root-a');
+    const b = path.join(tmpDir, 'root-b');
+    await mkdir(a, { recursive: true });
+    await mkdir(b, { recursive: true });
+    expect(isSameStorageRoot(a, b)).toBe(false);
+  });
+
+  it('falls back to string equality when a root does not resolve', () => {
+    // A nonexistent root is the readable-directory check's job; this one must
+    // not throw on the way there.
+    const missing = path.join(tmpDir, 'not-here');
+    expect(isSameStorageRoot(missing, missing)).toBe(true);
+    expect(isSameStorageRoot(missing, path.join(tmpDir, 'also-not-here'))).toBe(false);
   });
 });
 

--- a/scripts/__tests__/tenant-validate.test.ts
+++ b/scripts/__tests__/tenant-validate.test.ts
@@ -6,7 +6,7 @@
  * Run: docker compose -f docker-compose.test.yml up -d && cd scripts && npx vitest run
  */
 import { describe, it, expect, beforeAll, afterAll, beforeEach, afterEach } from 'vitest';
-import { mkdir, mkdtemp, writeFile, rm } from 'fs/promises';
+import { mkdir, mkdtemp, writeFile, rm, symlink } from 'fs/promises';
 import { existsSync } from 'fs';
 import path from 'path';
 import os from 'os';
@@ -344,6 +344,38 @@ describe('validateData', () => {
     const pagesResult = result.tableResults.find((r) => r.table === 'pages');
     expect(pagesResult).toBeDefined();
     expect(pagesResult!.sourceCount).toBe(2);
+  });
+
+  it('does not fault a file whose storagePath escapes the storage root — the export skipped it', async () => {
+    // The export resolves the source blob with `resolvePathWithin`, which
+    // refuses a path escaping the storage root and SKIPS the row. A raw
+    // `path.join` here follows the symlink, finds the file, and then faults the
+    // row as 'missing in target' — failing a correct migration.
+    //
+    // A symlinked storage root is the practical trigger: `existsSync` follows
+    // symlinks, so the naive check sees a real file where the export saw an
+    // escape.
+    const realOutside = path.join(tmpDir, 'outside-root');
+    await mkdir(path.join(realOutside, 'test_file_blob_001'), { recursive: true });
+    await writeFile(path.join(realOutside, 'test_file_blob_001', 'data.txt'), 'escaped');
+
+    const linkedSource = path.join(tmpDir, 'linked-source');
+    await mkdir(linkedSource, { recursive: true });
+    await symlink(path.join(realOutside, 'test_file_blob_001'), path.join(linkedSource, 'test_file_blob_001'), 'dir');
+
+    const emptyTarget = path.join(tmpDir, 'target-escaped');
+    await mkdir(emptyTarget, { recursive: true });
+
+    const result = await validateData(db as unknown as DbClient, db as unknown as DbClient, {
+      sourceDatabaseUrl: getTestDatabaseUrl(),
+      targetDatabaseUrl: getTestDatabaseUrl(),
+      userIds: [FIXTURES.users.owner.id, FIXTURES.users.member.id],
+      sourceFileStoragePath: linkedSource,
+      targetFileStoragePath: emptyTarget,
+    });
+
+    expect(result.fileResults.mismatches).toEqual([]);
+    expect(result.fileResults.passed).toBe(true);
   });
 
   it('does not fault a file whose SOURCE blob is gone — the export skipped it', async () => {

--- a/scripts/__tests__/tenant-validate.test.ts
+++ b/scripts/__tests__/tenant-validate.test.ts
@@ -116,6 +116,17 @@ describe('validateData', () => {
         targetFileStoragePath: fileStoragePath,
       });
 
+    it('counts the DISCOVERED user themselves, not just the requested ones', async () => {
+      // The bundle carries Eve (her page chat pulled her in), so validating
+      // `users` on the REQUESTED set alone compares her row on neither side: if
+      // the import dropped it, this table would still print [PASS]. That is the
+      // opposite direction from the rest of the map — a false pass, not a false
+      // failure — and the only assertion here that catches it.
+      const result = await validate();
+      const usersResult = result.tableResults.find((r) => r.table === 'users');
+      expect(usersResult!.sourceCount).toBe(3);
+    });
+
     it('counts a page conversation owned by a NON-requested member', async () => {
       const result = await validate();
       const conversationsResult = result.tableResults.find((r) => r.table === 'conversations');
@@ -173,15 +184,123 @@ describe('validateData', () => {
       try {
         const result = await validate();
         const messagesResult = result.tableResults.find((r) => r.table === 'messages');
-        // Still 3 — the two owner messages plus Eve's. Mallory's is excluded on
-        // BOTH sides, which is what makes the migration report as correct.
+        // Still 3 — the two owner messages plus Eve's; Mallory's is excluded.
+        //
+        // `sourceCount` is the only assertion worth making here. Source and
+        // target are the SAME db handle (see the note above), so every id-based
+        // table compares a query against itself and `passed` is true whatever
+        // the predicate says — asserting it would look like a guarantee this
+        // harness cannot give. The count is what moves: without the user arm it
+        // is 4, and the bundle would be reported as missing a row it was never
+        // meant to carry.
         expect(messagesResult!.sourceCount).toBe(3);
-        expect(messagesResult!.passed).toBe(true);
-        expect(result.passed).toBe(true);
       } finally {
         await db.execute(sql.raw(`DELETE FROM messages WHERE id = '${STRANGER_MSG}'`));
         await db.execute(sql.raw(`DELETE FROM users WHERE id = '${STRANGER}'`));
       }
+    });
+  });
+
+  describe('rows the export deliberately leaves behind are not counted either', () => {
+    /**
+     * The mirror of the block above. Each row here is one the EXPORTER filters
+     * out, so the validator must filter it out too — otherwise it counts a row
+     * the bundle never held, reports it MISSING, and fails a correct migration.
+     *
+     * One case per predicate that was wrong, because a shared fixture proves
+     * nothing about which arm is doing the work: `page_permissions`,
+     * `user_mentions` and `channel_message_reactions` on the row's USER, and
+     * `mentions` on its TARGET PAGE. The existing fixtures could not catch any
+     * of them — every seeded row belongs to a requested user and points at an
+     * exported page, so all four predicates were satisfied trivially.
+     */
+    const STRANGER = 'test_user_stranger_100';
+    const OUTSIDE_DRIVE = 'test_drive_outside_100';
+    const OUTSIDE_PAGE = 'test_page_outside_100';
+    const CHANNEL_PAGE = 'test_page_channel_100';
+    const CHANNEL_MSG = 'test_chanmsg_100';
+
+    beforeEach(async () => {
+      // Reachable by NO discovery arm: owns no exported conversation, authors
+      // no channel message, and holds no drive_members row — so `discoverDrives`
+      // never finds their drive and they never enter `allExportedUserIdSet`.
+      await db.execute(sql.raw(
+        `INSERT INTO users (id, name, email, "emailBidx", provider, "createdAt", "updatedAt")`
+        + ` VALUES ('${STRANGER}', 'Mallory', 'mallory100@test.local', 'bidx_mallory_100', 'email', NOW(), NOW())`,
+      ));
+      await db.execute(sql.raw(
+        `INSERT INTO drives (id, name, slug, "ownerId", "createdAt", "updatedAt")`
+        + ` VALUES ('${OUTSIDE_DRIVE}', 'Outside', 'outside-100', '${STRANGER}', NOW(), NOW())`,
+      ));
+      await db.execute(sql.raw(
+        `INSERT INTO pages (id, title, type, position, "driveId", "createdAt", "updatedAt")`
+        + ` VALUES ('${OUTSIDE_PAGE}', 'Outside page', 'DOCUMENT', 1, '${OUTSIDE_DRIVE}', NOW(), NOW())`,
+      ));
+
+      // page_permissions: a grant to the stranger on an EXPORTED page.
+      await db.execute(sql.raw(
+        `INSERT INTO page_permissions (id, "pageId", "userId", "canView", "canEdit", "canShare", "canDelete", "grantedAt")`
+        + ` VALUES ('test_pp_100', '${FIXTURES.pages.root.id}', '${STRANGER}', TRUE, FALSE, FALSE, FALSE, NOW())`,
+      ));
+      // user_mentions: from an EXPORTED page, targeting the stranger.
+      await db.execute(sql.raw(
+        `INSERT INTO user_mentions (id, "sourcePageId", "targetUserId", "createdAt")`
+        + ` VALUES ('test_um_100', '${FIXTURES.pages.root.id}', '${STRANGER}', NOW())`,
+      ));
+      // mentions: from an EXPORTED page, pointing OUT of the exported page set.
+      await db.execute(sql.raw(
+        `INSERT INTO mentions (id, "sourcePageId", "targetPageId", "createdAt")`
+        + ` VALUES ('test_m_100', '${FIXTURES.pages.root.id}', '${OUTSIDE_PAGE}', NOW())`,
+      ));
+      // channel_message_reactions: the MESSAGE is the owner's (so authoring it
+      // does not pull the stranger in as a discovered user) and the REACTION is
+      // the stranger's.
+      await db.execute(sql.raw(
+        `INSERT INTO pages (id, title, type, position, "driveId", "createdAt", "updatedAt")`
+        + ` VALUES ('${CHANNEL_PAGE}', 'Channel', 'CHANNEL', 9, '${FIXTURES.drives.shared.id}', NOW(), NOW())`,
+      ));
+      await db.execute(sql.raw(
+        `INSERT INTO channel_messages (id, content, "createdAt", "pageId", "userId")`
+        + ` VALUES ('${CHANNEL_MSG}', 'hi', NOW(), '${CHANNEL_PAGE}', '${FIXTURES.users.owner.id}')`,
+      ));
+      await db.execute(sql.raw(
+        `INSERT INTO channel_message_reactions (id, "messageId", "userId", emoji, "createdAt")`
+        + ` VALUES ('test_cmr_100', '${CHANNEL_MSG}', '${STRANGER}', ':wave:', NOW())`,
+      ));
+    });
+
+    const validateOutside = () =>
+      validateData(db as unknown as DbClient, db as unknown as DbClient, {
+        sourceDatabaseUrl: getTestDatabaseUrl(),
+        targetDatabaseUrl: getTestDatabaseUrl(),
+        userIds: [FIXTURES.users.owner.id, FIXTURES.users.member.id],
+        sourceFileStoragePath: fileStoragePath,
+        targetFileStoragePath: fileStoragePath,
+      });
+
+    const countFor = async (table: string) => {
+      const result = await validateOutside();
+      return result.tableResults.find((r) => r.table === table)!.sourceCount;
+    };
+
+    it('does not count a page permission granted to a user outside the export set', async () => {
+      // Still the ONE seeded grant. Without the user arm this is 2.
+      expect(await countFor('page_permissions')).toBe(1);
+    });
+
+    it('does not count a user mention targeting a user outside the export set', async () => {
+      expect(await countFor('user_mentions')).toBe(1);
+    });
+
+    it('does not count a mention pointing at a page outside the export set', async () => {
+      // The exporter bounds BOTH endpoints. Without the target arm this is 2.
+      expect(await countFor('mentions')).toBe(1);
+    });
+
+    it('does not count a reaction by a user outside the export set', async () => {
+      // The stranger's is the only reaction seeded, so the correct answer is 0.
+      // Without the user arm this is 1.
+      expect(await countFor('channel_message_reactions')).toBe(0);
     });
   });
 

--- a/scripts/__tests__/tenant-validate.test.ts
+++ b/scripts/__tests__/tenant-validate.test.ts
@@ -21,7 +21,7 @@ import {
   getTestDatabaseUrl,
   type TestDb,
 } from './setup';
-import { validateData } from '../tenant-validate';
+import { validateData, resolveSourceStorageRoot } from '../tenant-validate';
 import { TABLE_IMPORT_ORDER } from '../lib/migration-types';
 import type { DbClient } from '../lib/migration-types';
 
@@ -74,6 +74,31 @@ afterEach(async () => {
  * this file guards has lived. The file-blob comparison is the one check that
  * can genuinely differ, and only when a case passes two different paths.
  */
+describe('resolveSourceStorageRoot', () => {
+  /**
+   * The base `resolvePathWithin` is called with must be the one the EXPORT
+   * used, or mirroring the call achieves nothing. tenant-export.ts:692 and
+   * tenant-import.ts:137 both read `FILE_STORAGE_PATH`; this file did not, so
+   * a deployment that sets it had the export build from one directory and the
+   * validator compare another.
+   *
+   * Asserted here rather than through `runValidation`, whose arg parsing the
+   * integration cases bypass entirely — which is exactly why the omission
+   * survived.
+   */
+  it('prefers the explicit flag', () => {
+    expect(resolveSourceStorageRoot('/flag', '/env')).toBe('/flag');
+  });
+
+  it('falls back to FILE_STORAGE_PATH, as the export and import both do', () => {
+    expect(resolveSourceStorageRoot(undefined, '/data/shared/files')).toBe('/data/shared/files');
+  });
+
+  it('falls back to ./uploads only when neither is set', () => {
+    expect(resolveSourceStorageRoot(undefined, undefined)).toBe('./uploads');
+  });
+});
+
 describe('validateData', () => {
   it('reports success when source and target match', async () => {
     const result = await validateData(db as unknown as DbClient, db as unknown as DbClient, {
@@ -346,6 +371,28 @@ describe('validateData', () => {
     expect(pagesResult!.sourceCount).toBe(2);
   });
 
+  it('FAILS when the source storage root does not exist, rather than passing vacuously', async () => {
+    // The false-PASS direction of the skip added alongside this test.
+    // `resolvePathWithin` returns null for every path under a base that does
+    // not exist, so a typo'd `--source-file-path` argument would skip every row and
+    // report zero mismatches — a green validation that compared nothing.
+    //
+    // Worth a case of its own precisely because the neighbouring tests assert
+    // that skipping is CORRECT: without this one, "skip more" always looks like
+    // an improvement.
+    const result = await validateData(db as unknown as DbClient, db as unknown as DbClient, {
+      sourceDatabaseUrl: getTestDatabaseUrl(),
+      targetDatabaseUrl: getTestDatabaseUrl(),
+      userIds: [FIXTURES.users.owner.id, FIXTURES.users.member.id],
+      sourceFileStoragePath: path.join(tmpDir, 'source-that-does-not-exist'),
+      targetFileStoragePath: path.join(tmpDir, 'target-that-does-not-exist'),
+    });
+
+    expect(result.fileResults.passed).toBe(false);
+    expect(result.fileResults.mismatches).toHaveLength(1);
+    expect(result.fileResults.mismatches[0].reason).toMatch(/source file storage path does not exist/);
+  });
+
   it('does not fault a file whose storagePath escapes the storage root — the export skipped it', async () => {
     // The export resolves the source blob with `resolvePathWithin`, which
     // refuses a path escaping the storage root and SKIPS the row. A raw
@@ -376,6 +423,10 @@ describe('validateData', () => {
 
     expect(result.fileResults.mismatches).toEqual([]);
     expect(result.fileResults.passed).toBe(true);
+    // …and says so, rather than looking identical to a run that compared it.
+    expect(result.fileResults.skipped).toEqual([
+      { file: 'test_file_blob_001/data.txt', reason: 'storagePath does not resolve inside the storage root' },
+    ]);
   });
 
   it('does not fault a file whose SOURCE blob is gone — the export skipped it', async () => {
@@ -401,6 +452,9 @@ describe('validateData', () => {
 
     expect(result.fileResults.mismatches).toEqual([]);
     expect(result.fileResults.passed).toBe(true);
+    expect(result.fileResults.skipped).toEqual([
+      { file: 'test_file_blob_001/data.txt', reason: 'source blob not on disk (the export skips these rows)' },
+    ]);
   });
 
   it('detects missing file blob in target', async () => {

--- a/scripts/__tests__/tenant-validate.test.ts
+++ b/scripts/__tests__/tenant-validate.test.ts
@@ -28,6 +28,17 @@ import type { DbClient } from '../lib/migration-types';
 let db: TestDb;
 let tmpDir: string;
 let fileStoragePath: string;
+/**
+ * A SECOND, REAL storage root — not an alias of the first.
+ *
+ * Every case in this file used to pass `fileStoragePath` as BOTH roots, so the
+ * blob comparison hashed each file against itself: the one check here that can
+ * genuinely differ was, in every such case, guaranteed to match. Those
+ * assertions had never compared anything. This root holds an independent copy
+ * of the same fixture blobs, so a green result now means two directory trees
+ * actually agreed.
+ */
+let targetFileStoragePath: string;
 
 beforeAll(async () => {
   db = createTestDb();
@@ -50,6 +61,12 @@ beforeEach(async () => {
   const blobDir = path.join(fileStoragePath, 'test_file_blob_001');
   await mkdir(blobDir, { recursive: true });
   await writeFile(path.join(blobDir, 'data.txt'), '0123456789');
+
+  // The matching TARGET tree: same relative paths, same bytes, different root.
+  targetFileStoragePath = path.join(tmpDir, 'target-files');
+  const targetBlobDir = path.join(targetFileStoragePath, 'test_file_blob_001');
+  await mkdir(targetBlobDir, { recursive: true });
+  await writeFile(path.join(targetBlobDir, 'data.txt'), '0123456789');
 });
 
 afterEach(async () => {
@@ -62,17 +79,21 @@ afterEach(async () => {
  * HARNESS LIMITATION, stated once because three separate comments were arguing
  * about it.
  *
- * Every case in this file passes the SAME `db` handle as source and target, and
- * mostly the same storage path. `validateTable` runs one query object against
- * both, so `missingIds`/`extraIds` are always empty: a table's `passed`, and
- * therefore `result.passed`, is true for ANY predicate. Those assertions
- * document intent; they cannot fail, and they must not be read as evidence that
- * a predicate is right.
+ * Every case in this file passes the SAME `db` handle as source and target.
+ * `validateTable` runs one query object against both, so `missingIds`/
+ * `extraIds` are always empty: a table's `passed`, and therefore
+ * `result.passed`, is true for ANY predicate. Those assertions document intent;
+ * they cannot fail, and they must not be read as evidence that a predicate is
+ * right.
  *
  * `sourceCount` is the load-bearing assertion. It is a measurement of the
  * SOURCE population, which is exactly where every exporter/validator asymmetry
- * this file guards has lived. The file-blob comparison is the one check that
- * can genuinely differ, and only when a case passes two different paths.
+ * this file guards has lived.
+ *
+ * The file-blob comparison is the one check that CAN genuinely differ — and it
+ * only does when a case passes two different roots. It used to pass one root
+ * twice, hashing every blob against itself, so it differed nowhere. Cases now
+ * use `fileStoragePath` against `targetFileStoragePath`, two real trees.
  */
 describe('resolveSourceStorageRoot', () => {
   /**
@@ -117,8 +138,10 @@ describe('isSameStorageRoot', () => {
    * Both roots default to `./uploads`, so running the validator on the target
    * host after an import with neither path flag points both sides at the same
    * directory: every checksum matches, nothing is compared, success. This guard
-   * is what refuses that, and `main()` — where it is called — has no test, so it
-   * is asserted here instead of taken on faith.
+   * is what detects that. `validateData` calls it — gated on there actually
+   * being `files` rows to compare — and these cases pin its resolution rules
+   * directly, because the two-spellings behaviour is not visible from the
+   * end-to-end cases below.
    */
   it('detects the same directory reached by two different spellings', async () => {
     const real = path.join(tmpDir, 'same-root-real');
@@ -155,7 +178,7 @@ describe('validateData', () => {
       targetDatabaseUrl: getTestDatabaseUrl(),
       userIds: [FIXTURES.users.owner.id, FIXTURES.users.member.id],
       sourceFileStoragePath: fileStoragePath,
-      targetFileStoragePath: fileStoragePath,
+      targetFileStoragePath,
     });
 
     expect(result.passed).toBe(true);
@@ -203,7 +226,7 @@ describe('validateData', () => {
         targetDatabaseUrl: getTestDatabaseUrl(),
         userIds: [FIXTURES.users.owner.id, FIXTURES.users.member.id],
         sourceFileStoragePath: fileStoragePath,
-        targetFileStoragePath: fileStoragePath,
+        targetFileStoragePath,
       });
 
     it('counts the DISCOVERED user themselves, not just the requested ones', async () => {
@@ -362,7 +385,7 @@ describe('validateData', () => {
         targetDatabaseUrl: getTestDatabaseUrl(),
         userIds: [FIXTURES.users.owner.id, FIXTURES.users.member.id],
         sourceFileStoragePath: fileStoragePath,
-        targetFileStoragePath: fileStoragePath,
+        targetFileStoragePath,
       });
 
     const countFor = async (table: string) => {
@@ -412,7 +435,7 @@ describe('validateData', () => {
       targetDatabaseUrl: getTestDatabaseUrl(),
       userIds: [FIXTURES.users.owner.id, FIXTURES.users.member.id],
       sourceFileStoragePath: fileStoragePath,
-      targetFileStoragePath: fileStoragePath,
+      targetFileStoragePath,
     });
 
     const pagesResult = result.tableResults.find((r) => r.table === 'pages');
@@ -476,6 +499,62 @@ describe('validateData', () => {
     });
     expect(result.fileResults.passed).toBe(true);
     expect(result.fileResults.mismatches).toEqual([]);
+  });
+
+  it('passes with no file rows even when both roots are the SAME defaulted path', async () => {
+    // The regression this guard's PLACEMENT caused. Both CLI flags default to
+    // `./uploads`, so a file-less migration validated without either flag hands
+    // `validateData` one path twice. While the self-comparison check sat
+    // unconditionally in `main()` — before any query ran — that invocation
+    // exited(1) having validated NOT ONE TABLE, even though `validateData`
+    // deliberately passes a zero-file population two lines up.
+    //
+    // With the check gated on `fileStorageData.length > 0` there is nothing
+    // that could self-compare, so the run is green and the tables are checked.
+    await db.execute(sql.raw(`DELETE FROM files`));
+    const bothRoots = resolveSourceStorageRoot(undefined);
+    expect(bothRoots, 'the CLI default both flags fall back to').toBe('./uploads');
+
+    const result = await validateData(db as unknown as DbClient, db as unknown as DbClient, {
+      sourceDatabaseUrl: getTestDatabaseUrl(),
+      targetDatabaseUrl: getTestDatabaseUrl(),
+      userIds: [FIXTURES.users.owner.id, FIXTURES.users.member.id],
+      sourceFileStoragePath: bothRoots,
+      targetFileStoragePath: bothRoots,
+    });
+
+    expect(result.fileResults.mismatches).toEqual([]);
+    expect(result.passed).toBe(true);
+    // …and the tables were actually validated, which is what the old placement
+    // skipped entirely.
+    expect(result.tableResults).toHaveLength(TABLE_IMPORT_ORDER.length);
+  });
+
+  it('FAILS when there ARE file rows and both roots resolve to one directory', async () => {
+    // The false pass the guard exists for: every blob hashed against itself,
+    // every checksum equal, nothing compared, green. Two spellings of the one
+    // directory, because a string compare would wave the second through.
+    const asLink = path.join(tmpDir, 'self-compare-link');
+    await symlink(fileStoragePath, asLink, 'dir');
+
+    for (const [label, targetRoot] of [
+      ['the identical path', fileStoragePath],
+      ['a symlink to it', asLink],
+      ['a trailing separator', fileStoragePath + path.sep],
+    ] as [string, string][]) {
+      const result = await validateData(db as unknown as DbClient, db as unknown as DbClient, {
+        sourceDatabaseUrl: getTestDatabaseUrl(),
+        targetDatabaseUrl: getTestDatabaseUrl(),
+        userIds: [FIXTURES.users.owner.id, FIXTURES.users.member.id],
+        sourceFileStoragePath: fileStoragePath,
+        targetFileStoragePath: targetRoot,
+      });
+
+      expect(result.fileResults.passed, label).toBe(false);
+      expect(result.passed, label).toBe(false);
+      expect(result.fileResults.mismatches.map((m) => m.reason).join(), label)
+        .toMatch(/resolve to the same directory/);
+    }
   });
 
   it('does not fault a file whose storagePath escapes the storage root — the export skipped it', async () => {
@@ -583,7 +662,7 @@ describe('validateData', () => {
       targetDatabaseUrl: getTestDatabaseUrl(),
       userIds: [FIXTURES.users.owner.id, FIXTURES.users.member.id],
       sourceFileStoragePath: fileStoragePath,
-      targetFileStoragePath: fileStoragePath,
+      targetFileStoragePath,
     });
 
     const tableNames = result.tableResults.map((r) => r.table);
@@ -600,7 +679,7 @@ describe('validateData', () => {
       targetDatabaseUrl: getTestDatabaseUrl(),
       userIds: [FIXTURES.users.owner.id, FIXTURES.users.member.id],
       sourceFileStoragePath: fileStoragePath,
-      targetFileStoragePath: fileStoragePath,
+      targetFileStoragePath,
     });
 
     const find = (t: string) => result.tableResults.find((r) => r.table === t)!;

--- a/scripts/__tests__/tenant-validate.test.ts
+++ b/scripts/__tests__/tenant-validate.test.ts
@@ -6,7 +6,7 @@
  * Run: docker compose -f docker-compose.test.yml up -d && cd scripts && npx vitest run
  */
 import { describe, it, expect, beforeAll, afterAll, beforeEach, afterEach } from 'vitest';
-import { mkdir, mkdtemp, writeFile, rm, symlink } from 'fs/promises';
+import { mkdir, mkdtemp, writeFile, rm, symlink, chmod } from 'fs/promises';
 import { existsSync } from 'fs';
 import path from 'path';
 import os from 'os';
@@ -92,10 +92,23 @@ describe('resolveSourceStorageRoot', () => {
     expect(resolveSourceStorageRoot(undefined)).toBe('./uploads');
   });
 
-  it('takes only one argument, so FILE_STORAGE_PATH cannot reach it', () => {
-    // A signature check, not a behaviour check: the failure mode is someone
-    // re-adding an env parameter, and arity is what makes that visible.
-    expect(resolveSourceStorageRoot.length).toBe(1);
+  it('ignores FILE_STORAGE_PATH even when it is set', () => {
+    // BEHAVIOUR, not signature. The first version of this asserted
+    // `resolveSourceStorageRoot.length === 1`, which is theatre:
+    // `Function.length` counts parameters before the first defaulted one, so
+    // `(argValue, envValue = process.env.FILE_STORAGE_PATH)` passes the arity
+    // check, keeps every call site working, and reintroduces the self-comparison
+    // in full. Setting the variable and asserting the result is the only form
+    // that catches all three spellings.
+    const previous = process.env.FILE_STORAGE_PATH;
+    process.env.FILE_STORAGE_PATH = '/data/target-host/files';
+    try {
+      expect(resolveSourceStorageRoot(undefined)).toBe('./uploads');
+      expect(resolveSourceStorageRoot('/explicit')).toBe('/explicit');
+    } finally {
+      if (previous === undefined) delete process.env.FILE_STORAGE_PATH;
+      else process.env.FILE_STORAGE_PATH = previous;
+    }
   });
 });
 
@@ -380,20 +393,36 @@ describe('validateData', () => {
     const asFile = path.join(tmpDir, 'root-is-a-file');
     await writeFile(asFile, 'not a directory');
 
-    for (const [label, sourceRoot] of [
-      ['does not exist', path.join(tmpDir, 'nope')],
-      ['is a regular file', asFile],
-    ] as [string, string][]) {
-      const result = await validateData(db as unknown as DbClient, db as unknown as DbClient, {
-        sourceDatabaseUrl: getTestDatabaseUrl(),
-        targetDatabaseUrl: getTestDatabaseUrl(),
-        userIds: [FIXTURES.users.owner.id, FIXTURES.users.member.id],
-        sourceFileStoragePath: sourceRoot,
-        targetFileStoragePath: path.join(tmpDir, 'target-none'),
-      });
-      expect(result.fileResults.passed, label).toBe(false);
-      expect(result.fileResults.mismatches.map((m) => m.reason).join(), label)
-        .toMatch(/not a readable directory/);
+    // Third shape: a real directory with no read permission. `statSync`
+    // succeeds on it — stat needs no permission on the directory itself — so an
+    // `isDirectory()` check waves it through while every row underneath still
+    // fails to resolve. The canonical deployment root is a root-owned Docker
+    // volume, so a validator run as a non-root user lands exactly here.
+    const unreadable = path.join(tmpDir, 'root-unreadable');
+    await mkdir(unreadable, { recursive: true });
+    await chmod(unreadable, 0o000);
+
+    try {
+      for (const [label, sourceRoot] of [
+        ['does not exist', path.join(tmpDir, 'nope')],
+        ['is a regular file', asFile],
+        ['is an unreadable directory', unreadable],
+      ] as [string, string][]) {
+        const result = await validateData(db as unknown as DbClient, db as unknown as DbClient, {
+          sourceDatabaseUrl: getTestDatabaseUrl(),
+          targetDatabaseUrl: getTestDatabaseUrl(),
+          userIds: [FIXTURES.users.owner.id, FIXTURES.users.member.id],
+          sourceFileStoragePath: sourceRoot,
+          targetFileStoragePath: path.join(tmpDir, 'target-none'),
+        });
+        expect(result.fileResults.passed, label).toBe(false);
+        expect(result.fileResults.mismatches.map((m) => m.reason).join(), label)
+          .toMatch(/not a readable directory/);
+      }
+    } finally {
+      // Restore before `afterEach`'s recursive rm, which cannot descend into a
+      // mode-000 directory.
+      await chmod(unreadable, 0o755);
     }
   });
 

--- a/scripts/__tests__/tenant-validate.test.ts
+++ b/scripts/__tests__/tenant-validate.test.ts
@@ -76,26 +76,26 @@ afterEach(async () => {
  */
 describe('resolveSourceStorageRoot', () => {
   /**
-   * The base `resolvePathWithin` is called with must be the one the EXPORT
-   * used, or mirroring the call achieves nothing. tenant-export.ts:692 and
-   * tenant-import.ts:137 both read `FILE_STORAGE_PATH`; this file did not, so
-   * a deployment that sets it had the export build from one directory and the
-   * validator compare another.
-   *
-   * Asserted here rather than through `runValidation`, whose arg parsing the
-   * integration cases bypass entirely — which is exactly why the omission
-   * survived.
+   * `FILE_STORAGE_PATH` is deliberately NOT consulted, and these cases exist so
+   * that stays deliberate. The export and the import both read it, so "mirror
+   * the export" argues for reading it here — I made that change and it was
+   * wrong: the variable names the root of whatever host you are standing on,
+   * and a validator naturally runs on the TARGET host after the import. Letting
+   * it fill the SOURCE slot there points both sides at the same directory, so
+   * every checksum matches and the run is green having compared nothing.
    */
-  it('prefers the explicit flag', () => {
-    expect(resolveSourceStorageRoot('/flag', '/env')).toBe('/flag');
+  it('uses the explicit flag', () => {
+    expect(resolveSourceStorageRoot('/flag')).toBe('/flag');
   });
 
-  it('falls back to FILE_STORAGE_PATH, as the export and import both do', () => {
-    expect(resolveSourceStorageRoot(undefined, '/data/shared/files')).toBe('/data/shared/files');
+  it('falls back to ./uploads when the flag is absent', () => {
+    expect(resolveSourceStorageRoot(undefined)).toBe('./uploads');
   });
 
-  it('falls back to ./uploads only when neither is set', () => {
-    expect(resolveSourceStorageRoot(undefined, undefined)).toBe('./uploads');
+  it('takes only one argument, so FILE_STORAGE_PATH cannot reach it', () => {
+    // A signature check, not a behaviour check: the failure mode is someone
+    // re-adding an env parameter, and arity is what makes that visible.
+    expect(resolveSourceStorageRoot.length).toBe(1);
   });
 });
 
@@ -371,26 +371,46 @@ describe('validateData', () => {
     expect(pagesResult!.sourceCount).toBe(2);
   });
 
-  it('FAILS when the source storage root does not exist, rather than passing vacuously', async () => {
-    // The false-PASS direction of the skip added alongside this test.
-    // `resolvePathWithin` returns null for every path under a base that does
-    // not exist, so a typo'd `--source-file-path` argument would skip every row and
-    // report zero mismatches — a green validation that compared nothing.
-    //
-    // Worth a case of its own precisely because the neighbouring tests assert
-    // that skipping is CORRECT: without this one, "skip more" always looks like
-    // an improvement.
+  it('FAILS when the source root is unusable, rather than passing vacuously', async () => {
+    // The false-PASS direction of the skips the neighbouring tests assert are
+    // CORRECT. Two shapes, both ordinary operator error, both previously green:
+    // a root that does not exist, and a root that is a regular FILE — the
+    // latter slips past `existsSync` because `resolvePathWithin` walks up to
+    // the first existing ancestor and returns the base itself.
+    const asFile = path.join(tmpDir, 'root-is-a-file');
+    await writeFile(asFile, 'not a directory');
+
+    for (const [label, sourceRoot] of [
+      ['does not exist', path.join(tmpDir, 'nope')],
+      ['is a regular file', asFile],
+    ] as [string, string][]) {
+      const result = await validateData(db as unknown as DbClient, db as unknown as DbClient, {
+        sourceDatabaseUrl: getTestDatabaseUrl(),
+        targetDatabaseUrl: getTestDatabaseUrl(),
+        userIds: [FIXTURES.users.owner.id, FIXTURES.users.member.id],
+        sourceFileStoragePath: sourceRoot,
+        targetFileStoragePath: path.join(tmpDir, 'target-none'),
+      });
+      expect(result.fileResults.passed, label).toBe(false);
+      expect(result.fileResults.mismatches.map((m) => m.reason).join(), label)
+        .toMatch(/not a readable directory/);
+    }
+  });
+
+  it('stays green when there are no file rows at all — nothing skipped is not nothing compared', async () => {
+    // Pins the `fileStorageData.length > 0` clause. Without it, a migration
+    // carrying no files trips the nothing-was-compared check (0 === 0) and a
+    // correct run fails — the exact regression class this branch is full of.
+    await db.execute(sql.raw(`DELETE FROM files`));
     const result = await validateData(db as unknown as DbClient, db as unknown as DbClient, {
       sourceDatabaseUrl: getTestDatabaseUrl(),
       targetDatabaseUrl: getTestDatabaseUrl(),
       userIds: [FIXTURES.users.owner.id, FIXTURES.users.member.id],
-      sourceFileStoragePath: path.join(tmpDir, 'source-that-does-not-exist'),
-      targetFileStoragePath: path.join(tmpDir, 'target-that-does-not-exist'),
+      sourceFileStoragePath: path.join(tmpDir, 'also-nope'),
+      targetFileStoragePath: path.join(tmpDir, 'also-nope-target'),
     });
-
-    expect(result.fileResults.passed).toBe(false);
-    expect(result.fileResults.mismatches).toHaveLength(1);
-    expect(result.fileResults.mismatches[0].reason).toMatch(/source file storage path does not exist/);
+    expect(result.fileResults.passed).toBe(true);
+    expect(result.fileResults.mismatches).toEqual([]);
   });
 
   it('does not fault a file whose storagePath escapes the storage root — the export skipped it', async () => {
@@ -425,7 +445,7 @@ describe('validateData', () => {
     expect(result.fileResults.passed).toBe(true);
     // …and says so, rather than looking identical to a run that compared it.
     expect(result.fileResults.skipped).toEqual([
-      { file: 'test_file_blob_001/data.txt', reason: 'storagePath does not resolve inside the storage root' },
+      { file: 'test_file_blob_001/data.txt', reason: 'did not resolve inside the source storage root' },
     ]);
   });
 

--- a/scripts/__tests__/tenant-validate.test.ts
+++ b/scripts/__tests__/tenant-validate.test.ts
@@ -137,6 +137,52 @@ describe('validateData', () => {
       expect(result.passed).toBe(true);
       expect(result.tableResults.every((r) => r.passed)).toBe(true);
     });
+
+    /**
+     * The MIRROR of the bug above, and the one the widening left open.
+     *
+     * Eve is DISCOVERED — her chat sits on an exported page, so the export
+     * carries her and her message, and validating them is correct. This case is
+     * the opposite: an author reachable by NO discovery arm, writing inside a
+     * conversation the export does carry.
+     *
+     * tenant-export.ts filters `messages` on
+     * `("userId" IS NULL OR "userId" IN (allExportedUserIdSet))`, so that row is
+     * deliberately left behind. If the validator selects messages on
+     * `conversationId` alone it counts a row the bundle was never meant to hold,
+     * reports it MISSING, and `allTablesPassed` fails a CORRECT migration.
+     *
+     * Same shape for `page_permissions`, `user_mentions` and
+     * `channel_message_reactions`, which carry the same user filter on the
+     * export side.
+     */
+    it('does NOT count a message from an author outside the export set, so a correct bundle still passes', async () => {
+      const STRANGER = 'test_user_stranger_004';
+      const STRANGER_MSG = 'test_msg_stranger_001';
+      await db.execute(sql.raw(
+        `INSERT INTO users (id, name, email, "emailBidx", provider, "createdAt", "updatedAt")`
+        + ` VALUES ('${STRANGER}', 'Mallory Stranger', 'mallory@test.local', 'bidx_mallory_test_local', 'email', NOW(), NOW())`,
+      ));
+      // Inside the OWNER's conversation — which the export carries — but from an
+      // author no discovery arm reaches.
+      await db.execute(sql.raw(
+        `INSERT INTO messages (id, "conversationId", role, content, "userId", "createdAt")`
+        + ` VALUES ('${STRANGER_MSG}', '${FIXTURES.conversations.pageChat.id}', 'user', 'not carried by the bundle', '${STRANGER}', NOW())`,
+      ));
+
+      try {
+        const result = await validate();
+        const messagesResult = result.tableResults.find((r) => r.table === 'messages');
+        // Still 3 — the two owner messages plus Eve's. Mallory's is excluded on
+        // BOTH sides, which is what makes the migration report as correct.
+        expect(messagesResult!.sourceCount).toBe(3);
+        expect(messagesResult!.passed).toBe(true);
+        expect(result.passed).toBe(true);
+      } finally {
+        await db.execute(sql.raw(`DELETE FROM messages WHERE id = '${STRANGER_MSG}'`));
+        await db.execute(sql.raw(`DELETE FROM users WHERE id = '${STRANGER}'`));
+      }
+    });
   });
 
   it('detects missing page in target', async () => {

--- a/scripts/lib/migration-utils.ts
+++ b/scripts/lib/migration-utils.ts
@@ -119,7 +119,7 @@ export function workspaceSelectionWhere(ownerInList: string, conversationInList:
  *
  * `content_tags."pageId"` is notNull for every target kind, so the page filter
  * alone reaches page-, text-, cell- and message-anchored rows uniformly — that
- * is what the denormalization is for. The two extra arms exist because a
+ * is what the denormalization is for. The three extra arms exist because a
  * message-anchored row also carries a REAL foreign key onto `channel_messages`
  * or `messages`, and those two tables are selected by their own rules (a
  * channel message by page, an AI message by conversation AND author). A tag

--- a/scripts/tenant-export.ts
+++ b/scripts/tenant-export.ts
@@ -472,7 +472,8 @@ export async function exportData(
   ));
   nullifyOrphanedUserRefs(pagePermissionsData, allExportedUserIdSet, 'grantedBy');
 
-  // Tag ASSIGNMENTS on exported pages, and the vocabulary rows they reference.
+  // Tag ASSIGNMENTS on exported pages. (The vocabulary follows below, selected
+  // by DRIVE rather than by what these rows happen to reference.)
   // The selection rule lives in `contentTagSelectionWhere` so the validator asks
   // exactly the question this answers; its docblock has the reasoning.
   const contentTagsData = await queryRows(db, sql.raw(

--- a/scripts/tenant-validate.ts
+++ b/scripts/tenant-validate.ts
@@ -98,7 +98,40 @@ export interface FullValidationResult {
   fileResults: {
     passed: boolean;
     mismatches: { file: string; reason: string }[];
+    /**
+     * Blobs the validator declined to compare, mirroring a skip the export
+     * made. Reported because `passed: true` otherwise means only "everything I
+     * chose to compare matched", with no machine-readable record of how much
+     * was declined — and the skips exist precisely where the export and the
+     * validator could disagree about a file. A run that compared nothing now
+     * says so instead of looking identical to a run that compared everything.
+     */
+    skipped: { file: string; reason: string }[];
   };
+}
+
+/**
+ * The SOURCE storage root, derived exactly the way tenant-export.ts:692 and
+ * tenant-import.ts:137 derive theirs.
+ *
+ * Extracted and exported so the mirror is ASSERTED rather than assumed. This
+ * file used to read `getArg('source-file-path') || './uploads'`, omitting
+ * `FILE_STORAGE_PATH` — so in any deployment that sets the variable, which is
+ * the normal one, the export built its bundle from `/data/shared/files` while
+ * the validator compared `./uploads`. Mirroring the `resolvePathWithin` CALL
+ * while deriving its BASE differently is half a mirror, and the half that was
+ * missing is the one that decides which directory is being talked about.
+ *
+ * SOURCE only, deliberately: the export runs on the source host and the import
+ * on the target host, so each sees its own `FILE_STORAGE_PATH`. One variable
+ * cannot give a validator comparing both hosts its two roots, so
+ * `--target-file-path` stays explicit.
+ */
+export function resolveSourceStorageRoot(
+  argValue: string | undefined,
+  envValue: string | undefined,
+): string {
+  return argValue || envValue || './uploads';
 }
 
 /**
@@ -323,6 +356,40 @@ export async function validateData(
   );
   const fileStorageData = fileStorageRows.rows as Record<string, unknown>[];
 
+  // ONE ARM OF THE EXPORT'S FILE SKIPPING IS NOT MIRRORED, and cannot be from
+  // here: the export also skips a row whose DESTINATION path fails
+  // `resolvePathWithin(outputDir/files, storagePath)`, and `validateData` is
+  // not given the bundle directory, so it cannot ask that question. It is only
+  // reachable once the source resolve and the source `existsSync` have both
+  // passed.
+  //
+  // The durable fix for this whole comparison is to validate against
+  // `manifest.fileChecksums` — the export's own record of exactly what it
+  // carried, already written and already readable via `validateChecksums` —
+  // rather than re-deriving the decision from the source database and disk.
+  // That is the move the shared selection helpers made for the queries, and it
+  // needs the bundle dir in `ValidateOptions`, so it belongs to a change that
+  // owns that API rather than being smuggled in here.
+
+  // A missing storage ROOT is a MISCONFIGURATION, not a per-row skip.
+  //
+  // `resolvePathWithin` returns null for every path under a base that does not
+  // exist, so without this check a typo'd `--source-file-path` argument skips every
+  // row and reports `passed: true` with zero mismatches: a green validation
+  // that compared nothing. That is the false-PASS direction, which is the one
+  // that hides a real problem rather than merely crying wolf.
+  //
+  // The target root needs no equivalent: if it is missing, every `tgtPath`
+  // check already fails and each row is reported 'missing in target'.
+  const fileSkips: { file: string; reason: string }[] = [];
+
+  if (fileStorageData.length > 0 && !existsSync(sourceFileStoragePath)) {
+    fileMismatches.push({
+      file: sourceFileStoragePath,
+      reason: 'source file storage path does not exist — nothing could be compared',
+    });
+  }
+
   for (const file of fileStorageData) {
     const storagePath = file.storagePath as string;
     // `resolvePathWithin`, not `path.join`, because that is what the EXPORT
@@ -338,7 +405,8 @@ export async function validateData(
     // the exporter's.
     const resolvedSrc = await resolvePathWithin(sourceFileStoragePath, storagePath);
     if (!resolvedSrc) {
-      console.warn(`WARNING: unsafe storagePath, not compared (the export skipped it too): ${storagePath}`);
+      console.warn(`WARNING: storagePath does not resolve inside the storage root, not compared: ${storagePath}`);
+      fileSkips.push({ file: storagePath, reason: 'storagePath does not resolve inside the storage root' });
       continue;
     }
     const srcPath = resolvedSrc;
@@ -354,21 +422,9 @@ export async function validateData(
     // is why sweeping the query maps did not reach it. An orphaned `files` row
     // (row present, blob long gone) is common enough that this was not
     // hypothetical.
-    //
-    // NOT MIRRORED, and it cannot be from here: the export ALSO skips a row
-    // whose DESTINATION path fails the same check
-    // (`resolvePathWithin(outputDir/files, storagePath)`), and `validateData`
-    // is not given the bundle directory, so it cannot ask that question. It is
-    // only reachable when the source check passed and the destination one did
-    // not. The real fix for the whole file-blob comparison is to validate
-    // against `manifest.fileChecksums` — the export's own record of exactly
-    // what it carried, already written and already readable via
-    // `validateChecksums` — instead of re-deriving the decision from the source
-    // database and disk. That needs the bundle dir in ValidateOptions, so it is
-    // deliberately left for a change that owns that API rather than smuggled in
-    // here.
     if (!existsSync(srcPath)) {
       console.warn(`WARNING: source file not found, not compared: ${srcPath}`);
+      fileSkips.push({ file: storagePath, reason: 'source blob not on disk (the export skips these rows)' });
       continue;
     }
 
@@ -393,6 +449,7 @@ export async function validateData(
     fileResults: {
       passed: filesPassed,
       mismatches: fileMismatches,
+      skipped: fileSkips,
     },
   };
 }
@@ -409,7 +466,7 @@ async function main(): Promise<void> {
   const sourceDatabaseUrl = getArg('source-url');
   const targetDatabaseUrl = getArg('target-url');
   const usersArg = getArg('users');
-  const sourceFileStoragePath = getArg('source-file-path') || './uploads';
+  const sourceFileStoragePath = resolveSourceStorageRoot(getArg('source-file-path'), process.env.FILE_STORAGE_PATH);
   const targetFileStoragePath = getArg('target-file-path') || './uploads';
 
   if (!sourceDatabaseUrl || !targetDatabaseUrl || !usersArg) {
@@ -445,6 +502,16 @@ async function main(): Promise<void> {
   if (result.fileResults.mismatches.length > 0) {
     console.log('\n  File mismatches:');
     for (const m of result.fileResults.mismatches) {
+      console.log(`    ${m.file}: ${m.reason}`);
+    }
+  }
+
+  // Printed even on a PASS: "0 mismatches" over 400 skipped blobs is not the
+  // same result as "0 mismatches" over 400 compared ones, and the operator is
+  // the only one who can tell which they meant.
+  if (result.fileResults.skipped.length > 0) {
+    console.log(`\n  Files not compared (${result.fileResults.skipped.length}):`);
+    for (const m of result.fileResults.skipped) {
       console.log(`    ${m.file}: ${m.reason}`);
     }
   }

--- a/scripts/tenant-validate.ts
+++ b/scripts/tenant-validate.ts
@@ -16,7 +16,7 @@
 import { drizzle } from 'drizzle-orm/node-postgres';
 import { Pool } from 'pg';
 import { sql } from 'drizzle-orm';
-import { existsSync } from 'fs';
+import { existsSync, statSync } from 'fs';
 import path from 'path';
 import { resolvePathWithin } from '@pagespace/lib/security/path-validator';
 import type { ValidateOptions, ValidationResult, DbClient } from './lib/migration-types';
@@ -110,28 +110,38 @@ export interface FullValidationResult {
   };
 }
 
+/** A path that exists AND is a directory we can list. Anything else cannot be a storage root. */
+function isUsableDirectory(candidate: string): boolean {
+  try {
+    return statSync(candidate).isDirectory();
+  } catch {
+    return false;
+  }
+}
+
 /**
- * The SOURCE storage root, derived exactly the way tenant-export.ts:692 and
- * tenant-import.ts:137 derive theirs.
+ * The SOURCE storage root.
  *
- * Extracted and exported so the mirror is ASSERTED rather than assumed. This
- * file used to read `getArg('source-file-path') || './uploads'`, omitting
- * `FILE_STORAGE_PATH` — so in any deployment that sets the variable, which is
- * the normal one, the export built its bundle from `/data/shared/files` while
- * the validator compared `./uploads`. Mirroring the `resolvePathWithin` CALL
- * while deriving its BASE differently is half a mirror, and the half that was
- * missing is the one that decides which directory is being talked about.
+ * `FILE_STORAGE_PATH` is deliberately NOT in this chain, and that is the
+ * opposite of what it looks like it should be. The export
+ * (tenant-export.ts:692) and the import (tenant-import.ts:137) both read it,
+ * and "mirror the export" argues for reading it here too — I made that change
+ * and it was wrong.
  *
- * SOURCE only, deliberately: the export runs on the source host and the import
- * on the target host, so each sees its own `FILE_STORAGE_PATH`. One variable
- * cannot give a validator comparing both hosts its two roots, so
- * `--target-file-path` stays explicit.
+ * The variable names the storage root of WHATEVER HOST YOU ARE STANDING ON. A
+ * validator needs TWO roots, source and target, and it naturally runs on the
+ * TARGET host after the import — where `FILE_STORAGE_PATH` is the target root
+ * that the import just used. Letting it fill the SOURCE slot there makes both
+ * sides read the same directory: every checksum matches, nothing is actually
+ * compared, and the run is green. A silent self-comparison is a worse outcome
+ * than the drift it was meant to fix, which surfaces as a loud failure via the
+ * nothing-was-compared check below.
+ *
+ * So the source root must be passed explicitly. Kept as a function, with tests
+ * asserting the env var is ignored, so this does not get "fixed" back.
  */
-export function resolveSourceStorageRoot(
-  argValue: string | undefined,
-  envValue: string | undefined,
-): string {
-  return argValue || envValue || './uploads';
+export function resolveSourceStorageRoot(argValue: string | undefined): string {
+  return argValue || './uploads';
 }
 
 /**
@@ -371,24 +381,7 @@ export async function validateData(
   // needs the bundle dir in `ValidateOptions`, so it belongs to a change that
   // owns that API rather than being smuggled in here.
 
-  // A missing storage ROOT is a MISCONFIGURATION, not a per-row skip.
-  //
-  // `resolvePathWithin` returns null for every path under a base that does not
-  // exist, so without this check a typo'd `--source-file-path` argument skips every
-  // row and reports `passed: true` with zero mismatches: a green validation
-  // that compared nothing. That is the false-PASS direction, which is the one
-  // that hides a real problem rather than merely crying wolf.
-  //
-  // The target root needs no equivalent: if it is missing, every `tgtPath`
-  // check already fails and each row is reported 'missing in target'.
   const fileSkips: { file: string; reason: string }[] = [];
-
-  if (fileStorageData.length > 0 && !existsSync(sourceFileStoragePath)) {
-    fileMismatches.push({
-      file: sourceFileStoragePath,
-      reason: 'source file storage path does not exist — nothing could be compared',
-    });
-  }
 
   for (const file of fileStorageData) {
     const storagePath = file.storagePath as string;
@@ -405,8 +398,8 @@ export async function validateData(
     // the exporter's.
     const resolvedSrc = await resolvePathWithin(sourceFileStoragePath, storagePath);
     if (!resolvedSrc) {
-      console.warn(`WARNING: storagePath does not resolve inside the storage root, not compared: ${storagePath}`);
-      fileSkips.push({ file: storagePath, reason: 'storagePath does not resolve inside the storage root' });
+      console.warn(`WARNING: did not resolve inside the source storage root, not compared: ${storagePath}`);
+      fileSkips.push({ file: storagePath, reason: 'did not resolve inside the source storage root' });
       continue;
     }
     const srcPath = resolvedSrc;
@@ -440,6 +433,35 @@ export async function validateData(
     }
   }
 
+  // AN UNUSABLE SOURCE ROOT is a failure, not a pass.
+  //
+  // The first attempt checked only `existsSync`, which closes one of three
+  // shapes. A root that is a REGULAR FILE also leaves every row skipped:
+  // `resolvePathWithin` walks up to the first existing ancestor, which is the
+  // base itself, returns non-null, and then `existsSync(srcPath)` fails. Both
+  // are ordinary operator error and both used to report `passed: true`.
+  // (Verified by running `validateData` against each.)
+  //
+  // The third shape — a root that exists, is a directory, but is the WRONG one
+  // — is NOT closed here, and deliberately so. Counting skips instead
+  // (`every row was skipped`) was the obvious generalisation and it is wrong:
+  // a bundle whose only blob was legitimately skipped, because the row is
+  // orphaned or its storagePath is genuinely unsafe, also skips every row. That
+  // rule fails correct migrations, which is the exact class this file is full
+  // of regressions for; two tests below assert those runs stay green.
+  //
+  // Nothing on disk distinguishes "wrong directory" from "right directory whose
+  // blobs are all legitimately absent". Only `manifest.fileChecksums` — the
+  // export's record of what it actually carried — does, which is the same
+  // reason it is the durable fix for this whole comparison. `fileResults.skipped`
+  // is the interim signal: a run that skipped everything says so.
+  if (fileStorageData.length > 0 && !isUsableDirectory(sourceFileStoragePath)) {
+    fileMismatches.push({
+      file: sourceFileStoragePath,
+      reason: 'source file storage path is not a readable directory — nothing could be compared',
+    });
+  }
+
   const allTablesPassed = tableResults.every((r) => r.passed);
   const filesPassed = fileMismatches.length === 0;
 
@@ -466,7 +488,7 @@ async function main(): Promise<void> {
   const sourceDatabaseUrl = getArg('source-url');
   const targetDatabaseUrl = getArg('target-url');
   const usersArg = getArg('users');
-  const sourceFileStoragePath = resolveSourceStorageRoot(getArg('source-file-path'), process.env.FILE_STORAGE_PATH);
+  const sourceFileStoragePath = resolveSourceStorageRoot(getArg('source-file-path'));
   const targetFileStoragePath = getArg('target-file-path') || './uploads';
 
   if (!sourceDatabaseUrl || !targetDatabaseUrl || !usersArg) {

--- a/scripts/tenant-validate.ts
+++ b/scripts/tenant-validate.ts
@@ -327,17 +327,30 @@ export async function validateData(
     const srcPath = path.join(sourceFileStoragePath, storagePath);
     const tgtPath = path.join(targetFileStoragePath, storagePath);
 
+    // SOURCE FIRST. If the source blob is not on disk, tenant-export.ts skipped
+    // this row outright ("WARNING: source file not found, skipping"), so the
+    // bundle legitimately does not carry it and there is nothing to compare.
+    //
+    // Testing the TARGET first reported exactly that row as 'missing in
+    // target' and failed a correct migration — the same false-failure class as
+    // the query asymmetries above, in the one check that is not a query, which
+    // is why sweeping the query maps did not reach it. An orphaned `files` row
+    // (row present, blob long gone) is common enough that this was not
+    // hypothetical.
+    if (!existsSync(srcPath)) {
+      console.warn(`WARNING: source file not found, not compared: ${srcPath}`);
+      continue;
+    }
+
     if (!existsSync(tgtPath)) {
       fileMismatches.push({ file: storagePath, reason: 'missing in target' });
       continue;
     }
 
-    if (existsSync(srcPath)) {
-      const srcHash = await fileChecksum(srcPath);
-      const tgtHash = await fileChecksum(tgtPath);
-      if (srcHash !== tgtHash) {
-        fileMismatches.push({ file: storagePath, reason: `checksum mismatch (source: ${srcHash}, target: ${tgtHash})` });
-      }
+    const srcHash = await fileChecksum(srcPath);
+    const tgtHash = await fileChecksum(tgtPath);
+    if (srcHash !== tgtHash) {
+      fileMismatches.push({ file: storagePath, reason: `checksum mismatch (source: ${srcHash}, target: ${tgtHash})` });
     }
   }
 

--- a/scripts/tenant-validate.ts
+++ b/scripts/tenant-validate.ts
@@ -18,6 +18,7 @@ import { Pool } from 'pg';
 import { sql } from 'drizzle-orm';
 import { existsSync } from 'fs';
 import path from 'path';
+import { resolvePathWithin } from '@pagespace/lib/security/path-validator';
 import type { ValidateOptions, ValidationResult, DbClient } from './lib/migration-types';
 import { TABLE_IMPORT_ORDER } from './lib/migration-types';
 import {
@@ -324,7 +325,23 @@ export async function validateData(
 
   for (const file of fileStorageData) {
     const storagePath = file.storagePath as string;
-    const srcPath = path.join(sourceFileStoragePath, storagePath);
+    // `resolvePathWithin`, not `path.join`, because that is what the EXPORT
+    // uses to resolve the source blob. It returns null for `..`/`.` segments,
+    // absolute paths, malformed encodings, and — the case that actually bites —
+    // a symlink escaping the storage root, and the export SKIPS such a row
+    // ("WARNING: skipping file with path traversal in storagePath").
+    //
+    // A raw join here follows the symlink, finds the file, and then faults the
+    // row as 'missing in target': the bundle correctly did not carry it, and
+    // the migration is reported as broken. Same class as everything else in
+    // this file — the validator re-deriving a decision instead of reproducing
+    // the exporter's.
+    const resolvedSrc = await resolvePathWithin(sourceFileStoragePath, storagePath);
+    if (!resolvedSrc) {
+      console.warn(`WARNING: unsafe storagePath, not compared (the export skipped it too): ${storagePath}`);
+      continue;
+    }
+    const srcPath = resolvedSrc;
     const tgtPath = path.join(targetFileStoragePath, storagePath);
 
     // SOURCE FIRST. If the source blob is not on disk, tenant-export.ts skipped
@@ -337,6 +354,19 @@ export async function validateData(
     // is why sweeping the query maps did not reach it. An orphaned `files` row
     // (row present, blob long gone) is common enough that this was not
     // hypothetical.
+    //
+    // NOT MIRRORED, and it cannot be from here: the export ALSO skips a row
+    // whose DESTINATION path fails the same check
+    // (`resolvePathWithin(outputDir/files, storagePath)`), and `validateData`
+    // is not given the bundle directory, so it cannot ask that question. It is
+    // only reachable when the source check passed and the destination one did
+    // not. The real fix for the whole file-blob comparison is to validate
+    // against `manifest.fileChecksums` — the export's own record of exactly
+    // what it carried, already written and already readable via
+    // `validateChecksums` — instead of re-deriving the decision from the source
+    // database and disk. That needs the bundle dir in ValidateOptions, so it is
+    // deliberately left for a change that owns that API rather than smuggled in
+    // here.
     if (!existsSync(srcPath)) {
       console.warn(`WARNING: source file not found, not compared: ${srcPath}`);
       continue;

--- a/scripts/tenant-validate.ts
+++ b/scripts/tenant-validate.ts
@@ -135,11 +135,11 @@ function isUsableDirectory(candidate: string): boolean {
 /**
  * Whether the two storage roots are the same directory.
  *
- * Extracted and exported so the guard is TESTABLE. `main()` has no test
- * anywhere in this file, and the previous round of this work shipped an
- * untestable guarantee that turned out to be theatre — an arity assertion a
- * defaulted parameter walked straight past. A guard whose whole job is to stop
- * a false pass should not itself be unverified.
+ * Extracted and exported so the guard is TESTABLE in isolation. Its resolution
+ * rules are subtle enough to deserve their own cases, and the previous round of
+ * this work shipped an untestable guarantee that turned out to be theatre — an
+ * arity assertion a defaulted parameter walked straight past. A guard whose
+ * whole job is to stop a false pass should not itself be unverified.
  *
  * `realpathSync` rather than a string compare so two spellings of one directory
  * — a symlink, a relative path, a trailing slash — cannot slip through. Falls
@@ -501,6 +501,31 @@ export async function validateData(
     });
   }
 
+  // A SELF-COMPARISON is the same false pass, reached from the other side.
+  //
+  // Both CLI roots default to `./uploads`, so running the validator on the
+  // target host after an import with neither path flag points both sides at one
+  // directory: every checksum matches itself and the run reports success having
+  // compared nothing. Removing `FILE_STORAGE_PATH` from the source fallback
+  // closed one route to that; the defaults are the other.
+  //
+  // Gated on `fileStorageData.length > 0` for the same reason as the check
+  // above, and this is the whole point of it living HERE rather than at the CLI
+  // boundary: with no `files` rows there is nothing that could self-compare, so
+  // an identical pair proves nothing and hides nothing. Refusing it at the CLI
+  // made a file-less migration exit(1) having validated not one table.
+  //
+  // Reported as a file mismatch rather than thrown or exited, so the caller
+  // gets the same machine-readable verdict as every other file finding and the
+  // TABLE results still get computed and printed.
+  if (fileStorageData.length > 0 && isSameStorageRoot(sourceFileStoragePath, targetFileStoragePath)) {
+    fileMismatches.push({
+      file: sourceFileStoragePath,
+      reason: 'source and target file storage paths resolve to the same directory — '
+        + 'comparing a directory against itself proves nothing about the migration',
+    });
+  }
+
   const allTablesPassed = tableResults.every((r) => r.passed);
   const filesPassed = fileMismatches.length === 0;
 
@@ -538,28 +563,13 @@ async function main(): Promise<void> {
   const userIds = usersArg.split(',').map((s) => s.trim()).filter(Boolean);
   validateIds(userIds, 'user ID');
 
-  // REFUSE A SELF-COMPARISON. Both roots default to `./uploads`, so running
-  // this on the target host after an import with neither path flag points both
-  // sides at the same directory: every checksum matches, nothing is compared,
-  // and the run reports success. Removing `FILE_STORAGE_PATH` from the source
-  // fallback closed one route to that; the defaults are the other.
-  //
-  // Checked here rather than inside `validateData` on purpose: identical roots
-  // are meaningless for an OPERATOR but are a legitimate harness pattern, and
-  // eight cases in the test suite rely on it. The operator error lives at the
-  // CLI boundary, which is where the bad defaults are.
-  //
-  // `realpathSync` so two spellings of one directory — a symlink, a relative
-  // path, a trailing slash — cannot slip through a string comparison.
-  if (isSameStorageRoot(sourceFileStoragePath, targetFileStoragePath)) {
-    console.error(
-      `Refusing to run: --source-file-path and --target-file-path resolve to the same directory `
-      + `(${sourceFileStoragePath}). Comparing a directory against itself proves nothing about the `
-      + `migration — pass both explicitly.`,
-    );
-    process.exit(1);
-  }
-
+  // NO SELF-COMPARISON GUARD HERE. It used to live at this boundary, where it
+  // ran unconditionally and BEFORE any database work: a migration scope with no
+  // `files` rows, validated with neither path flag, exited(1) with both roots
+  // defaulted to `./uploads` having checked not one table — while `validateData`
+  // deliberately passes a zero-file population. The guard now sits beside the
+  // readable-directory check in `validateData`, gated on the same
+  // `fileStorageData.length > 0` condition, and reports as a file mismatch.
   console.log('Validating migration integrity...');
 
   const result = await runValidation({

--- a/scripts/tenant-validate.ts
+++ b/scripts/tenant-validate.ts
@@ -193,25 +193,40 @@ export async function validateData(
   /**
    * ID-based queries for tables with a single PK.
    *
-   * EVERY query here must carry the exporter's user filter as well as its
-   * structural one. Four of them did not — `messages`, `page_permissions`,
-   * `user_mentions` and `channel_message_reactions` selected purely on the
-   * parent (conversation, page, message) while tenant-export.ts additionally
-   * requires the row's user to be in `allExportedUserIdSet`.
+   * EVERY query here must reproduce its counterpart in tenant-export.ts IN
+   * FULL — not "plus the user filter", which is how the first sweep was framed
+   * and is why it missed two of these.
    *
-   * That asymmetry is not harmless: the source side then counts rows the bundle
-   * deliberately never carried, they show up as MISSING, and `allTablesPassed`
-   * turns a CORRECT migration into a reported failure. It is the same defect
-   * the shared `conversationSelectionWhere` / `workspaceSelectionWhere` /
-   * `contentTagSelectionWhere` helpers were introduced to stop, just in the
-   * queries that never got a helper.
+   * Six were wrong. Five under-filtered relative to the export
+   * (`messages`, `page_permissions`, `user_mentions`,
+   * `channel_message_reactions` on the row's USER; `mentions` on its TARGET
+   * PAGE), so the source side counted rows the bundle deliberately never
+   * carried, they showed up as MISSING, and `allTablesPassed` turned a CORRECT
+   * migration into a reported failure.
+   *
+   * `users` was wrong in the OPPOSITE and more dangerous direction: it checked
+   * only the REQUESTED users while the bundle carries the discovered ones too,
+   * so a discovered user's row was compared on neither side and a dropped row
+   * would still have printed [PASS].
+   *
+   * Same defect the shared `conversationSelectionWhere` /
+   * `workspaceSelectionWhere` / `contentTagSelectionWhere` helpers exist to
+   * stop, in the queries that never got a helper. When adding a query here,
+   * read the exporter's line for that table and copy every arm of it.
    *
    * `exportedUserIn` is the exporter's `allExportedUserIdSet` — requested users
    * plus everyone discovered with them — which is why it is built above rather
    * than using the narrower requested-only `userIn`.
    */
   const idQueries: Record<string, ReturnType<typeof sql>> = {
-    users: sql.raw(`SELECT id FROM users WHERE id IN (${userIn})`),
+    // `exportedUserIn`, NOT `userIn`. The bundle carries the requested users
+    // PLUS everyone discovered with them, so checking only the requested set
+    // leaves a discovered user's row compared on NEITHER side: if the import
+    // dropped it, this still prints [PASS]. That is the opposite and more
+    // dangerous direction from the rest of this map — a false pass rather than
+    // a false failure — and it is the same scar `workspaceSelectionWhere`
+    // records for `agent_workspaces`.
+    users: sql.raw(`SELECT id FROM users WHERE id IN (${exportedUserIn})`),
     user_profiles: sql.raw(`SELECT "userId" AS id FROM user_profiles WHERE "userId" IN (${userIn})`),
     drives: sql.raw(`SELECT id FROM drives WHERE id IN (${driveIn})`),
     drive_roles: sql.raw(`SELECT id FROM drive_roles WHERE "driveId" IN (${driveIn})`),
@@ -266,7 +281,15 @@ export async function validateData(
       `SELECT id FROM page_permissions WHERE "pageId" IN (${pageIn})`
       + ` AND "userId" IN (${exportedUserIn})`,
     ),
-    mentions: sql.raw(`SELECT id FROM mentions WHERE "sourcePageId" IN (${pageIn})`),
+    // Both endpoints, as the exporter requires. A mention pointing OUT of the
+    // exported page set is deliberately not carried, so selecting on the source
+    // page alone counts a row the bundle never held and fails a correct
+    // migration. This one is a PAGE filter, which is why framing the previous
+    // sweep as "the exporter's user filter" missed it.
+    mentions: sql.raw(
+      `SELECT id FROM mentions WHERE "sourcePageId" IN (${pageIn})`
+      + ` AND "targetPageId" IN (${pageIn})`,
+    ),
     user_mentions: sql.raw(
       `SELECT id FROM user_mentions WHERE "sourcePageId" IN (${pageIn})`
       + ` AND "targetUserId" IN (${exportedUserIn})`,

--- a/scripts/tenant-validate.ts
+++ b/scripts/tenant-validate.ts
@@ -163,11 +163,10 @@ export async function validateData(
   const convoIds = (convoRows.rows as Record<string, unknown>[]).map((r) => r.id as string);
   const convoIn = toSqlInList(convoIds);
 
-  // The owners of those conversations, which is what the export scopes
-  // workspaces and shells on (`allExportedUserIdSet`) — the requested users
-  // PLUS the ones DISCOVERED through the page arms. Validating on the
-  // requested set alone left a discovered user's workspace, and its shells'
-  // `coldTail` terminal scrollback, carried but never checked.
+  // The export's `allExportedUserIdSet` — the requested users PLUS everyone
+  // DISCOVERED alongside them. Validating on the requested set alone left a
+  // discovered user's workspace, and its shells' `coldTail` terminal
+  // scrollback, carried but never checked.
   // BOTH discovery arms, which the comment above already claimed and the code
   // did not do: tenant-export.ts seeds `referencedUserIds` from the CHANNEL
   // MESSAGE authors as well as the conversation owners. Omitting the channel arm
@@ -191,7 +190,26 @@ export async function validateData(
   // happens when this is re-typed here instead.
   const contentTagWhere = contentTagSelectionWhere(pageIn, driveIn, channelMsgIn, convoIn, exportedUserIn);
 
-  // ID-based queries for tables with a single PK
+  /**
+   * ID-based queries for tables with a single PK.
+   *
+   * EVERY query here must carry the exporter's user filter as well as its
+   * structural one. Four of them did not — `messages`, `page_permissions`,
+   * `user_mentions` and `channel_message_reactions` selected purely on the
+   * parent (conversation, page, message) while tenant-export.ts additionally
+   * requires the row's user to be in `allExportedUserIdSet`.
+   *
+   * That asymmetry is not harmless: the source side then counts rows the bundle
+   * deliberately never carried, they show up as MISSING, and `allTablesPassed`
+   * turns a CORRECT migration into a reported failure. It is the same defect
+   * the shared `conversationSelectionWhere` / `workspaceSelectionWhere` /
+   * `contentTagSelectionWhere` helpers were introduced to stop, just in the
+   * queries that never got a helper.
+   *
+   * `exportedUserIn` is the exporter's `allExportedUserIdSet` — requested users
+   * plus everyone discovered with them — which is why it is built above rather
+   * than using the narrower requested-only `userIn`.
+   */
   const idQueries: Record<string, ReturnType<typeof sql>> = {
     users: sql.raw(`SELECT id FROM users WHERE id IN (${userIn})`),
     user_profiles: sql.raw(`SELECT "userId" AS id FROM user_profiles WHERE "userId" IN (${userIn})`),
@@ -208,7 +226,10 @@ export async function validateData(
     tags: sql.raw(`SELECT id FROM tags WHERE "driveId" IN (${driveIn})`),
     content_tags: sql.raw(`SELECT id FROM content_tags WHERE ${contentTagWhere}`),
     channel_messages: sql.raw(`SELECT id FROM channel_messages WHERE "pageId" IN (${pageIn})`),
-    channel_message_reactions: sql.raw(`SELECT id FROM channel_message_reactions WHERE "messageId" IN (${channelMsgIn})`),
+    channel_message_reactions: sql.raw(
+      `SELECT id FROM channel_message_reactions WHERE "messageId" IN (${channelMsgIn})`
+      + ` AND "userId" IN (${exportedUserIn})`,
+    ),
     // The export's rule, from the shared helper: the sessions the EXPORTED
     // conversations are bound to, owned by an EXPORTED user (requested or
     // discovered) — matching `allExportedUserIdSet` on the export side.
@@ -236,11 +257,20 @@ export async function validateData(
     conversations: sql.raw(
       `SELECT id FROM conversations WHERE ${conversationSelectionWhere(userIn, pageIn)}`,
     ),
-    messages: sql.raw(`SELECT id FROM messages WHERE "conversationId" IN (${convoIn})`),
+    messages: sql.raw(
+      `SELECT id FROM messages WHERE "conversationId" IN (${convoIn})`
+      + ` AND ("userId" IS NULL OR "userId" IN (${exportedUserIn}))`,
+    ),
     files: sql.raw(`SELECT id FROM files WHERE "driveId" IN (${driveIn})`),
-    page_permissions: sql.raw(`SELECT id FROM page_permissions WHERE "pageId" IN (${pageIn})`),
+    page_permissions: sql.raw(
+      `SELECT id FROM page_permissions WHERE "pageId" IN (${pageIn})`
+      + ` AND "userId" IN (${exportedUserIn})`,
+    ),
     mentions: sql.raw(`SELECT id FROM mentions WHERE "sourcePageId" IN (${pageIn})`),
-    user_mentions: sql.raw(`SELECT id FROM user_mentions WHERE "sourcePageId" IN (${pageIn})`),
+    user_mentions: sql.raw(
+      `SELECT id FROM user_mentions WHERE "sourcePageId" IN (${pageIn})`
+      + ` AND "targetUserId" IN (${exportedUserIn})`,
+    ),
     favorites: sql.raw(`SELECT id FROM favorites WHERE "userId" IN (${userIn})`),
   };
 

--- a/scripts/tenant-validate.ts
+++ b/scripts/tenant-validate.ts
@@ -133,6 +133,29 @@ function isUsableDirectory(candidate: string): boolean {
 }
 
 /**
+ * Whether the two storage roots are the same directory.
+ *
+ * Extracted and exported so the guard is TESTABLE. `main()` has no test
+ * anywhere in this file, and the previous round of this work shipped an
+ * untestable guarantee that turned out to be theatre — an arity assertion a
+ * defaulted parameter walked straight past. A guard whose whole job is to stop
+ * a false pass should not itself be unverified.
+ *
+ * `realpathSync` rather than a string compare so two spellings of one directory
+ * — a symlink, a relative path, a trailing slash — cannot slip through. Falls
+ * back to string equality when either path does not resolve, since a
+ * nonexistent root is caught by the readable-directory check instead and this
+ * one should not throw on the way there.
+ */
+export function isSameStorageRoot(sourceRoot: string, targetRoot: string): boolean {
+  try {
+    return realpathSync(sourceRoot) === realpathSync(targetRoot);
+  } catch {
+    return sourceRoot === targetRoot;
+  }
+}
+
+/**
  * The SOURCE storage root.
  *
  * `FILE_STORAGE_PATH` is deliberately NOT in this chain, and that is the
@@ -528,14 +551,7 @@ async function main(): Promise<void> {
   //
   // `realpathSync` so two spellings of one directory — a symlink, a relative
   // path, a trailing slash — cannot slip through a string comparison.
-  const sameRoot = (() => {
-    try {
-      return realpathSync(sourceFileStoragePath) === realpathSync(targetFileStoragePath);
-    } catch {
-      return sourceFileStoragePath === targetFileStoragePath;
-    }
-  })();
-  if (sameRoot) {
+  if (isSameStorageRoot(sourceFileStoragePath, targetFileStoragePath)) {
     console.error(
       `Refusing to run: --source-file-path and --target-file-path resolve to the same directory `
       + `(${sourceFileStoragePath}). Comparing a directory against itself proves nothing about the `

--- a/scripts/tenant-validate.ts
+++ b/scripts/tenant-validate.ts
@@ -16,7 +16,7 @@
 import { drizzle } from 'drizzle-orm/node-postgres';
 import { Pool } from 'pg';
 import { sql } from 'drizzle-orm';
-import { existsSync, statSync } from 'fs';
+import { existsSync, readdirSync, realpathSync } from 'fs';
 import path from 'path';
 import { resolvePathWithin } from '@pagespace/lib/security/path-validator';
 import type { ValidateOptions, ValidationResult, DbClient } from './lib/migration-types';
@@ -110,10 +110,23 @@ export interface FullValidationResult {
   };
 }
 
-/** A path that exists AND is a directory we can list. Anything else cannot be a storage root. */
+/**
+ * A path that exists, is a directory, AND can actually be listed.
+ *
+ * `readdirSync`, not `statSync`: stat needs no permission on the directory
+ * itself, so a mode-000 root passes an `isDirectory()` check while every row
+ * underneath it still fails to resolve — the same silent green as a missing
+ * root, one shape over. Not exotic: the canonical deployment root is a
+ * root-owned Docker volume (`infrastructure/docker-compose.tenant.yml`), and a
+ * validator run as a non-root user against it lands exactly here.
+ *
+ * This is also what the surrounding messages already claimed, so it closes the
+ * gap between what the code said and what it checked.
+ */
 function isUsableDirectory(candidate: string): boolean {
   try {
-    return statSync(candidate).isDirectory();
+    readdirSync(candidate);
+    return true;
   } catch {
     return false;
   }
@@ -137,8 +150,11 @@ function isUsableDirectory(candidate: string): boolean {
  * than the drift it was meant to fix, which surfaces as a loud failure via the
  * nothing-was-compared check below.
  *
- * So the source root must be passed explicitly. Kept as a function, with tests
- * asserting the env var is ignored, so this does not get "fixed" back.
+ * So the source root must be passed explicitly. Kept as a function so a test
+ * can set `FILE_STORAGE_PATH` and assert the result is unchanged — an arity
+ * check is not enough, because a DEFAULTED second parameter
+ * (`envValue = process.env.FILE_STORAGE_PATH`) reintroduces the bug and leaves
+ * `Function.length` at 1.
  */
 export function resolveSourceStorageRoot(argValue: string | undefined): string {
   return argValue || './uploads';
@@ -498,6 +514,35 @@ async function main(): Promise<void> {
 
   const userIds = usersArg.split(',').map((s) => s.trim()).filter(Boolean);
   validateIds(userIds, 'user ID');
+
+  // REFUSE A SELF-COMPARISON. Both roots default to `./uploads`, so running
+  // this on the target host after an import with neither path flag points both
+  // sides at the same directory: every checksum matches, nothing is compared,
+  // and the run reports success. Removing `FILE_STORAGE_PATH` from the source
+  // fallback closed one route to that; the defaults are the other.
+  //
+  // Checked here rather than inside `validateData` on purpose: identical roots
+  // are meaningless for an OPERATOR but are a legitimate harness pattern, and
+  // eight cases in the test suite rely on it. The operator error lives at the
+  // CLI boundary, which is where the bad defaults are.
+  //
+  // `realpathSync` so two spellings of one directory — a symlink, a relative
+  // path, a trailing slash — cannot slip through a string comparison.
+  const sameRoot = (() => {
+    try {
+      return realpathSync(sourceFileStoragePath) === realpathSync(targetFileStoragePath);
+    } catch {
+      return sourceFileStoragePath === targetFileStoragePath;
+    }
+  })();
+  if (sameRoot) {
+    console.error(
+      `Refusing to run: --source-file-path and --target-file-path resolve to the same directory `
+      + `(${sourceFileStoragePath}). Comparing a directory against itself proves nothing about the `
+      + `migration — pass both explicitly.`,
+    );
+    process.exit(1);
+  }
 
   console.log('Validating migration integrity...');
 


### PR DESCRIPTION
Split out of #2455, which had grown to carry two unrelated things. This is the second half: **tenant export/import/validate correctness**, nothing to do with the content-tags schema.

> **Stacked on `pu/tag-schema` (#2455), not on `master`.** These commits build on the shared `contentTagSelectionWhere` selection rule that #2455 introduces, so they do not apply to `master` on their own. **Retarget this PR to `master` once #2455 merges** — the rebase is then a no-op.

## Why this exists

Reviewing #2455 kept turning up defects in the tenant migration path, well outside its scope. Nine real bugs across eight rounds:

**Seven that FAIL a correct migration** — the validator rejecting bundles that were migrated perfectly:
- four tables compared with predicates that did not match the exporter's
- an orphaned `files` row (a blob deleted from disk, row still present) failing the whole run
- two more where the exporter and validator disagreed about path resolution

**Two that PASS an incorrect one** — far worse, because a green validation is the only thing standing between a migration and a silent data-loss incident:
- a source storage root that does not resolve (missing, a regular file, or an unreadable directory) skipped every row and reported success having compared nothing
- both storage roots defaulting to `./uploads`, so running the validator on the target host after an import compared a directory **against itself**

## What honesty about this work requires

Three of those nine were **mine** — introduced by an earlier fix in this same sequence and caught by the next round. One commit's message stated a guarantee that was simply false: it claimed an arity assertion prevented `FILE_STORAGE_PATH` from being reintroduced, but `Function.length` counts parameters before the first defaulted one, so a defaulted parameter reintroduces the bug and passes the test. That is why the final commit replaces signature checks with behaviour checks.

Each commit's message documents what the previous one got wrong. That history is deliberately preserved rather than squashed — the sequence is the evidence that this file needed its own review cycle instead of riding along on a schema PR.

## Where I disagreed with review

Review proposed the obvious generalisation: fail when *every* row was skipped. I implemented it and **two existing tests went red** — a bundle whose only blob was legitimately skipped (orphaned row, genuinely unsafe path) also skips every row, so that rule fails correct migrations. Only what is distinguishable from disk is enforced; the "right-directory-but-blobs-absent" case stays open and documented, because separating it needs `manifest.fileChecksums`.

## Validation

Every behavioural fix is mutation-checked — the mechanism broken in source, a specific test watched go red, then restored. Local: `typecheck` 17/17, `lint` 15/15, `knip` at baseline, `scripts` 347 tests.

## Not in here

[#2459](https://github.com/2witstudios/PageSpace/issues/2459) — four *pre-existing* tenant-export defects found while doing this, each of which would abort or corrupt a real migration. Verified but deliberately left alone; they predate this work and deserve their own change.
