### PR TITLE
fix(cli): make credentials tell the truth about themselves (#2464, #2470)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ All notable user-facing changes to PageSpace are documented here. Format follows
 
 ### Added
 
+- **A key can tell you what it is allowed to do** — `pagespace keys describe` reports the credential
+  the machine is using: which drives it reaches, the role it holds in each, and what that role
+  actually resolves to — can it read, write, share, delete. That answer comes from the same
+  permission code that decides real requests, so it cannot quietly disagree with them. Drive-level
+  and page-level are separate answers and both are shown: any member can create a page at a drive's
+  top level while still being read-only on a document inside it, so `--page <pageId>` asks about the
+  exact place you are about to write. The same
+  summary is printed at the end of `pagespace keys create` and the `pagespace keys` wizard, so a new
+  key never leaves you to find out by attempting a write and reading the refusal. Agents get it as
+  an MCP tool too. A key describes only itself — it still cannot see, list or revoke the other keys
+  you hold. `pagespace keys list` now also shows the role granted on each drive rather than the
+  drive name alone.
+
 - **Spreadsheets from the terminal and the SDK** — `pagespace sheets describe` shows a sheet's tabs
   and size without reading a row; `query` filters and sorts server-side, so asking a 100,000-row
   sheet for the twelve rows you want no longer means pulling the whole thing down first. `rows`
@@ -174,6 +187,20 @@ All notable user-facing changes to PageSpace are documented here. Format follows
   the only hint was a count inside the expanded row.
 
 ### Fixed
+
+- **A working key is no longer reported as dead** — running `pagespace keys list` (or `revoke`,
+  `use`, or the wizard) with an `mcp_` key answered "Static token was invalidated and has no refresh
+  path", which reads as "your key was revoked" — while the very same key kept reading and writing
+  drive content perfectly. Managing keys was never something a key could do; only your personal
+  login can, and the refusal simply lost the server's own words on the way back. Those commands now
+  say what is actually true: the key is fine, key management needs `pagespace login`, and
+  `pagespace keys describe` is what a key can ask about itself. Nothing gets re-minted for nothing.
+
+- **Asking about a built-in role no longer dead-ends** — looking up `member` or `admin` among a
+  drive's roles answered "not found in this drive", which reads as though the role does not exist.
+  Those are built-in roles held per person on their drive membership, not entries in a drive's own
+  role list, so a lookup there can only ever miss. The answer now says so and points at where they
+  actually live — and at `pagespace keys describe` for what a specific credential resolves to.
 
 - **Dedicated deployments can run code again** — on a dedicated (tenant) deployment, code execution,
   agent sandboxes and environments were all refused, because the gate asked which subscription plan

--- a/apps/web/src/app/api/auth/key/__tests__/route.test.ts
+++ b/apps/web/src/app/api/auth/key/__tests__/route.test.ts
@@ -236,6 +236,60 @@ describe('GET /api/auth/key', () => {
     expect(body.driveScopes.map((scope: { name: string }) => scope.name)).toEqual(['First', 'Second', 'Third']);
   });
 
+  // `getDriveIdsForUser` unions the drives you belong to with the drives of any
+  // page shared with you, so a page-collaborator-only drive appears in the list
+  // while `getUserDrivePermissions` correctly reports no membership for it.
+  // Labelling that 'inherited' would read as "you have your own access here",
+  // the opposite of what its all-false permissions say.
+  it('labels a drive reached with no membership as "none", not "inherited"', async () => {
+    arrangeScopedMemberKey();
+    vi.mocked(getPrincipalDriveMembership).mockResolvedValue(null);
+    vi.mocked(getPrincipalDriveAccessLevel).mockResolvedValue(null);
+
+    const body = await (await GET(request())).json();
+
+    expect(body.driveScopes[0].roleSource).toBe('none');
+    expect(body.driveScopes[0].role).toBeNull();
+    expect(body.driveScopes[0].permissions).toEqual({ canView: false, canEdit: false, canShare: false, canDelete: false });
+  });
+
+  // A scoped credential's null role is INHERIT, which is a different thing and
+  // must keep its own label.
+  it('still labels a scoped credential\'s null role as "inherited"', async () => {
+    arrangeScopedMemberKey();
+    vi.mocked(getPrincipalDriveMembership).mockResolvedValue({ role: null, customRoleId: null });
+
+    const body = await (await GET(request())).json();
+
+    expect(body.driveScopes[0].roleSource).toBe('inherited');
+  });
+
+  // An unscoped credential's universe is every drive its owner can reach, at
+  // ~6 queries each; an unbounded fan-out would open hundreds of connections
+  // from one GET.
+  it('resolves drives in bounded batches rather than all at once', async () => {
+    arrangeScopedMemberKey();
+    const driveIds = Array.from({ length: 25 }, (_, index) => `drv${index}`);
+    vi.mocked(getPrincipalDriveIds).mockResolvedValue(driveIds);
+    vi.mocked(sessionRepository.findDrivesByIds).mockResolvedValue(driveIds.map((id) => ({ id, name: id })));
+
+    let inFlight = 0;
+    let peak = 0;
+    vi.mocked(getPrincipalDriveAccessLevel).mockImplementation(async () => {
+      peak = Math.max(peak, ++inFlight);
+      await new Promise((resolve) => setTimeout(resolve, 1));
+      inFlight--;
+      return MEMBER_LEVEL;
+    });
+
+    const body = await (await GET(request())).json();
+
+    expect(body.driveScopes).toHaveLength(25);
+    expect(peak).toBeLessThanOrEqual(8);
+    // ...and it is genuinely concurrent, not a sequential walk in disguise.
+    expect(peak).toBeGreaterThan(1);
+  });
+
   it('describes an unscoped credential with no key row, leaving the key fields null', async () => {
     vi.mocked(authenticateRequestWithOptions).mockResolvedValue({ ...SCOPED_KEY, tokenType: 'oauth' } as never);
     vi.mocked(isAuthError).mockReturnValue(false);

--- a/apps/web/src/app/api/auth/key/__tests__/route.test.ts
+++ b/apps/web/src/app/api/auth/key/__tests__/route.test.ts
@@ -212,6 +212,30 @@ describe('GET /api/auth/key', () => {
     });
   });
 
+  // The per-drive resolution runs concurrently; `Promise.all` preserves order,
+  // but a future refactor to a settle-as-they-finish shape would not, and a
+  // status readout that reorders between calls is hard to diff.
+  it('reports drives in a stable order regardless of how fast each resolves', async () => {
+    arrangeScopedMemberKey();
+    vi.mocked(getPrincipalDriveIds).mockResolvedValue(['drv1', 'drv2', 'drv3']);
+    vi.mocked(sessionRepository.findDrivesByIds).mockResolvedValue([
+      { id: 'drv3', name: 'Third' },
+      { id: 'drv1', name: 'First' },
+      { id: 'drv2', name: 'Second' },
+    ]);
+    // First drive resolves slowest, so a completion-ordered result would invert.
+    const delays: Record<string, number> = { drv1: 20, drv2: 10, drv3: 0 };
+    vi.mocked(getPrincipalDriveAccessLevel).mockImplementation(
+      async (_auth, driveId: string) =>
+        new Promise((resolve) => setTimeout(() => resolve(MEMBER_LEVEL), delays[driveId])),
+    );
+
+    const body = await (await GET(request())).json();
+
+    expect(body.driveScopes.map((scope: { id: string }) => scope.id)).toEqual(['drv1', 'drv2', 'drv3']);
+    expect(body.driveScopes.map((scope: { name: string }) => scope.name)).toEqual(['First', 'Second', 'Third']);
+  });
+
   it('describes an unscoped credential with no key row, leaving the key fields null', async () => {
     vi.mocked(authenticateRequestWithOptions).mockResolvedValue({ ...SCOPED_KEY, tokenType: 'oauth' } as never);
     vi.mocked(isAuthError).mockReturnValue(false);

--- a/apps/web/src/app/api/auth/key/__tests__/route.test.ts
+++ b/apps/web/src/app/api/auth/key/__tests__/route.test.ts
@@ -290,6 +290,48 @@ describe('GET /api/auth/key', () => {
     expect(peak).toBeGreaterThan(1);
   });
 
+  // A non-positive limit would start zero workers and resolve an array of
+  // HOLES with no work done and no error — serialized as a list of nulls, a
+  // status readout quietly reporting every drive as garbage.
+  it('never returns holes: every requested drive is present and populated', async () => {
+    arrangeScopedMemberKey();
+    const driveIds = Array.from({ length: 12 }, (_, index) => `drv${index}`);
+    vi.mocked(getPrincipalDriveIds).mockResolvedValue(driveIds);
+    vi.mocked(sessionRepository.findDrivesByIds).mockResolvedValue(driveIds.map((id) => ({ id, name: id })));
+
+    const body = await (await GET(request())).json();
+
+    expect(body.driveScopes).toHaveLength(12);
+    expect(body.driveScopes.every((scope: unknown) => scope !== null && typeof scope === 'object')).toBe(true);
+    expect(body.driveScopes.map((scope: { id: string }) => scope.id)).toEqual(driveIds);
+  });
+
+  // Promise.all rejects on the first failure but does not cancel its siblings,
+  // so without a stop flag the remaining workers would keep spending the very
+  // fan-out the bound exists to contain, on a response that has already failed.
+  it('stops resolving the rest once one drive fails, and answers 500', async () => {
+    arrangeScopedMemberKey();
+    const driveIds = Array.from({ length: 40 }, (_, index) => `drv${index}`);
+    vi.mocked(getPrincipalDriveIds).mockResolvedValue(driveIds);
+    vi.mocked(sessionRepository.findDrivesByIds).mockResolvedValue(driveIds.map((id) => ({ id, name: id })));
+
+    let started = 0;
+    vi.mocked(getPrincipalDriveAccessLevel).mockImplementation(async () => {
+      // Captured BEFORE the await: siblings bump the counter while this one is
+      // suspended, so re-reading it after would never see 1.
+      const mine = ++started;
+      await new Promise((resolve) => setTimeout(resolve, 1));
+      if (mine === 1) throw new Error('db down');
+      return MEMBER_LEVEL;
+    });
+
+    const response = await GET(request());
+    expect(response.status).toBe(500);
+    // Let any un-cancelled stragglers run before counting.
+    await new Promise((resolve) => setTimeout(resolve, 50));
+    expect(started).toBeLessThan(driveIds.length);
+  });
+
   it('describes an unscoped credential with no key row, leaving the key fields null', async () => {
     vi.mocked(authenticateRequestWithOptions).mockResolvedValue({ ...SCOPED_KEY, tokenType: 'oauth' } as never);
     vi.mocked(isAuthError).mockReturnValue(false);

--- a/apps/web/src/app/api/auth/key/__tests__/route.test.ts
+++ b/apps/web/src/app/api/auth/key/__tests__/route.test.ts
@@ -1,0 +1,257 @@
+/**
+ * Contract tests for GET /api/auth/key — the credential self-description
+ * behind `pagespace keys describe` (issue #2470).
+ *
+ * Two things this route has to get right, and both are asserted here:
+ *
+ * - It admits the `mcp_` class the key-MANAGEMENT routes refuse, because a key
+ *   asking about itself is not the same authority as a key enumerating every
+ *   key its owner holds.
+ * - It reports permissions that come from the resolver real requests are
+ *   authorized by, never a second reading of the role vocabulary. The
+ *   dispatcher is mocked here (this is a route test), so what is asserted is
+ *   that the route DELEGATES rather than deciding — a route that computed its
+ *   own answer would pass this only by reimplementing the mock.
+ */
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { NextRequest } from 'next/server';
+
+vi.mock('@/lib/repositories/session-repository', () => ({
+  sessionRepository: {
+    findMcpTokenSelfById: vi.fn(),
+    findDrivesByIds: vi.fn(),
+  },
+}));
+
+vi.mock('@/lib/auth', () => ({
+  authenticateRequestWithOptions: vi.fn(),
+  isAuthError: vi.fn(),
+}));
+
+vi.mock('@/lib/auth/principal-permissions', () => ({
+  getPrincipalAccessLevel: vi.fn(),
+  getPrincipalDriveAccessLevel: vi.fn(),
+  getPrincipalDriveIds: vi.fn(),
+  getPrincipalDriveMembership: vi.fn(),
+  isDriveScopedPrincipal: vi.fn(),
+}));
+
+vi.mock('@pagespace/lib/services/drive-role-service', () => ({
+  getRoleById: vi.fn(),
+}));
+
+vi.mock('@pagespace/lib/audit/audit-log', () => ({ auditRequest: vi.fn() }));
+vi.mock('@pagespace/lib/logging/logger-config', () => ({
+  loggers: { auth: { error: vi.fn(), info: vi.fn(), warn: vi.fn() } },
+}));
+
+import { GET } from '../route';
+import { sessionRepository } from '@/lib/repositories/session-repository';
+import { authenticateRequestWithOptions, isAuthError } from '@/lib/auth';
+import {
+  getPrincipalAccessLevel,
+  getPrincipalDriveAccessLevel,
+  getPrincipalDriveIds,
+  getPrincipalDriveMembership,
+  isDriveScopedPrincipal,
+} from '@/lib/auth/principal-permissions';
+import { getRoleById } from '@pagespace/lib/services/drive-role-service';
+import { auditRequest } from '@pagespace/lib/audit/audit-log';
+
+const SCOPED_KEY = {
+  userId: 'user-1',
+  role: 'user',
+  tokenVersion: 0,
+  adminRoleVersion: 0,
+  tokenType: 'mcp',
+  tokenId: 'key-1',
+  allowedDriveIds: ['drv1'],
+};
+
+const KEY_ROW = {
+  id: 'key-1',
+  name: 'lead-gen agent',
+  tokenPrefix: 'mcp_abcdefghijk',
+  createdAt: new Date('2026-08-22T00:00:00.000Z'),
+  lastUsed: new Date('2026-08-22T10:00:00.000Z'),
+  isScoped: true,
+};
+
+const MEMBER_LEVEL = { canView: true, canEdit: false, canShare: false, canDelete: false };
+
+function request(pageId?: string): NextRequest {
+  return new NextRequest(`http://localhost/api/auth/key${pageId === undefined ? '' : `?pageId=${pageId}`}`);
+}
+
+function arrangeScopedMemberKey() {
+  vi.mocked(authenticateRequestWithOptions).mockResolvedValue(SCOPED_KEY as never);
+  vi.mocked(isAuthError).mockReturnValue(false);
+  vi.mocked(isDriveScopedPrincipal).mockReturnValue(true);
+  vi.mocked(sessionRepository.findMcpTokenSelfById).mockResolvedValue(KEY_ROW as never);
+  vi.mocked(getPrincipalDriveIds).mockResolvedValue(['drv1']);
+  vi.mocked(sessionRepository.findDrivesByIds).mockResolvedValue([{ id: 'drv1', name: 'Engineering' }]);
+  vi.mocked(getPrincipalDriveMembership).mockResolvedValue({ role: 'MEMBER', customRoleId: null });
+  vi.mocked(getPrincipalDriveAccessLevel).mockResolvedValue(MEMBER_LEVEL);
+}
+
+describe('GET /api/auth/key', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('accepts the mcp_ credential class the key-management routes refuse', async () => {
+    arrangeScopedMemberKey();
+    await GET(request());
+    expect(vi.mocked(authenticateRequestWithOptions).mock.calls[0][1].allow).toEqual(['mcp', 'oauth', 'session']);
+  });
+
+  it('reports the role granted AND the effective permissions it resolves to', async () => {
+    arrangeScopedMemberKey();
+
+    const body = await (await GET(request())).json();
+
+    expect(body.credential).toMatchObject({ type: 'mcp', name: 'lead-gen agent', tokenPrefix: 'mcp_abcdefghijk', scoped: true });
+    expect(body.driveScopes).toEqual([
+      {
+        id: 'drv1',
+        name: 'Engineering',
+        role: 'MEMBER',
+        customRoleId: null,
+        customRoleName: null,
+        roleSource: 'explicit',
+        permissions: MEMBER_LEVEL,
+      },
+    ]);
+  });
+
+  it('resolves permissions through the principal dispatcher, not from the role string', async () => {
+    arrangeScopedMemberKey();
+    await GET(request());
+    expect(getPrincipalDriveAccessLevel).toHaveBeenCalledWith(SCOPED_KEY, 'drv1');
+  });
+
+  // The owning user must not be reachable through a key — `/api/auth/me`
+  // refuses mcp_* tokens for exactly this reason.
+  it('never returns the owning user\'s identity', async () => {
+    arrangeScopedMemberKey();
+    const body = await (await GET(request())).json();
+    expect(JSON.stringify(body)).not.toContain('user-1');
+    expect(body.credential.email).toBeUndefined();
+  });
+
+  it('labels an inherit grant as inherited rather than as a missing role', async () => {
+    arrangeScopedMemberKey();
+    vi.mocked(getPrincipalDriveMembership).mockResolvedValue({ role: null, customRoleId: null });
+
+    const body = await (await GET(request())).json();
+
+    expect(body.driveScopes[0].roleSource).toBe('inherited');
+  });
+
+  it('resolves a custom role to its name', async () => {
+    arrangeScopedMemberKey();
+    vi.mocked(getPrincipalDriveMembership).mockResolvedValue({ role: null, customRoleId: 'role-1' });
+    vi.mocked(getRoleById).mockResolvedValue({ id: 'role-1', name: 'Researcher' } as never);
+
+    const body = await (await GET(request())).json();
+
+    expect(body.driveScopes[0]).toMatchObject({ roleSource: 'custom', customRoleId: 'role-1', customRoleName: 'Researcher' });
+  });
+
+  // A dangling inherit row (the owner lost the drive) or an unresolvable custom
+  // role reaches here as null. "You hold a grant that currently gets you
+  // nothing" is the honest report; dropping the row would read as never having
+  // had access at all.
+  it('reports an unreachable scoped drive as all-false rather than omitting it', async () => {
+    arrangeScopedMemberKey();
+    vi.mocked(getPrincipalDriveAccessLevel).mockResolvedValue(null);
+
+    const body = await (await GET(request())).json();
+
+    expect(body.driveScopes).toHaveLength(1);
+    expect(body.driveScopes[0].permissions).toEqual({ canView: false, canEdit: false, canShare: false, canDelete: false });
+  });
+
+  // The drive-as-root-node answer grants edit to any membership; a document
+  // inside that drive can still be view-only for the same key. Reporting only
+  // the drive level would tell an agent it may write where it may not — the
+  // mirror image of the "reads fine, every write fails" report in #2470.
+  describe('?pageId=', () => {
+    it('resolves the named page through the page-level dispatcher, separately from the drive', async () => {
+      arrangeScopedMemberKey();
+      // The real divergence a MEMBER key sees: edit at the drive root (any
+      // membership may create a top-level page), view-only on a document.
+      vi.mocked(getPrincipalDriveAccessLevel).mockResolvedValue({ canView: true, canEdit: true, canShare: false, canDelete: false });
+      vi.mocked(getPrincipalAccessLevel).mockResolvedValue({ canView: true, canEdit: false, canShare: false, canDelete: false });
+
+      const body = await (await GET(request('pg1'))).json();
+
+      expect(getPrincipalAccessLevel).toHaveBeenCalledWith(SCOPED_KEY, 'pg1');
+      expect(body.driveScopes[0].permissions.canEdit).toBe(true);
+      expect(body.page).toEqual({ id: 'pg1', permissions: { canView: true, canEdit: false, canShare: false, canDelete: false } });
+    });
+
+    // "Not yours to see" and "yours, but you may do nothing" are different
+    // answers; flattening null to all-false would erase the distinction.
+    it('preserves an out-of-reach page as null rather than flattening it to all-false', async () => {
+      arrangeScopedMemberKey();
+      vi.mocked(getPrincipalAccessLevel).mockResolvedValue(null);
+
+      const body = await (await GET(request('pg9'))).json();
+
+      expect(body.page).toEqual({ id: 'pg9', permissions: null });
+    });
+
+    it('resolves no page and calls nothing when the parameter is absent', async () => {
+      arrangeScopedMemberKey();
+
+      const body = await (await GET(request())).json();
+
+      expect(body.page).toBeNull();
+      expect(getPrincipalAccessLevel).not.toHaveBeenCalled();
+    });
+  });
+
+  it('describes an unscoped credential with no key row, leaving the key fields null', async () => {
+    vi.mocked(authenticateRequestWithOptions).mockResolvedValue({ ...SCOPED_KEY, tokenType: 'oauth' } as never);
+    vi.mocked(isAuthError).mockReturnValue(false);
+    vi.mocked(isDriveScopedPrincipal).mockReturnValue(false);
+    vi.mocked(getPrincipalDriveIds).mockResolvedValue([]);
+
+    const body = await (await GET(request())).json();
+
+    expect(body).toEqual({
+      credential: { type: 'oauth', scoped: false, id: null, name: null, tokenPrefix: null, createdAt: null, lastUsed: null },
+      driveScopes: [],
+      page: null,
+    });
+    expect(sessionRepository.findMcpTokenSelfById).not.toHaveBeenCalled();
+  });
+
+  it('propagates the auth failure response untouched', async () => {
+    const error = new Response('nope', { status: 401 });
+    vi.mocked(authenticateRequestWithOptions).mockResolvedValue({ error } as never);
+    vi.mocked(isAuthError).mockReturnValue(true);
+
+    expect(await GET(request())).toBe(error);
+  });
+
+  it('audits the read', async () => {
+    arrangeScopedMemberKey();
+    await GET(request());
+    expect(auditRequest).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ eventType: 'data.read', userId: 'user-1', resourceId: 'key-1' }),
+    );
+  });
+
+  it('answers 500 rather than leaking an internal error when resolution throws', async () => {
+    arrangeScopedMemberKey();
+    vi.mocked(getPrincipalDriveIds).mockRejectedValue(new Error('db down'));
+
+    const response = await GET(request());
+
+    expect(response.status).toBe(500);
+    expect(await response.text()).not.toContain('db down');
+  });
+});

--- a/apps/web/src/app/api/auth/key/route.ts
+++ b/apps/web/src/app/api/auth/key/route.ts
@@ -43,6 +43,7 @@
  */
 import { NextRequest, NextResponse } from 'next/server';
 import { authenticateRequestWithOptions, isAuthError, type AuthResult } from '@/lib/auth';
+import type { PrincipalDriveMembership } from '@/lib/auth/principal-permissions';
 import {
   getPrincipalAccessLevel,
   getPrincipalDriveAccessLevel,
@@ -63,18 +64,58 @@ import { loggers } from '@pagespace/lib/logging/logger-config';
 const AUTH_OPTIONS_READ = { allow: ['mcp', 'oauth', 'session'] as const, requireCSRF: false };
 
 /**
- * `role: null` is not "no role" — for a scoped credential it is INHERIT (the key
- * resolves with its owner's access in that drive), and for a user principal it
- * cannot occur at all, since `getPrincipalDriveMembership` returns null rather
- * than a roleless membership. Naming the three cases explicitly keeps a reader
- * of the output from having to know that.
+ * How many drives resolve at once. Small on purpose: this is a status readout,
+ * and the ceiling exists to keep one call's connection use bounded, not to make
+ * it fast.
+ */
+const DRIVE_RESOLUTION_CONCURRENCY = 8;
+
+/**
+ * `Promise.all` over `items`, at most `limit` in flight, preserving input
+ * order. Order matters: this is a report a human diffs between runs, and a
+ * settle-as-they-finish result would reshuffle it for no reason.
+ */
+async function mapWithConcurrency<TItem, TResult>(
+  items: readonly TItem[],
+  limit: number,
+  resolve: (item: TItem) => Promise<TResult>,
+): Promise<TResult[]> {
+  const results: TResult[] = new Array(items.length);
+  let next = 0;
+  const workers = Array.from({ length: Math.min(limit, items.length) }, async () => {
+    for (let index = next++; index < items.length; index = next++) {
+      results[index] = await resolve(items[index]);
+    }
+  });
+  await Promise.all(workers);
+  return results;
+}
+
+/**
+ * How the principal holds this drive, spelled out so a reader never has to
+ * decode a null.
+ *
+ * The distinction that matters is between NO membership and a membership whose
+ * role is null:
+ *
+ * - `membership === null` → no drive-level role at all (`'none'`). Reachable
+ *   for a USER principal, and not an edge case: `getDriveIdsForUser` unions the
+ *   drives you are a member of with the drives of any page shared with you, so
+ *   a page-collaborator-only drive appears in the list while
+ *   `getUserDrivePermissions` correctly reports no drive membership for it.
+ *   Labelling that `'inherited'` would attach scoped-key inherit semantics to a
+ *   plain user and read as "you have your own access here", which is the
+ *   opposite of true — its `permissions` are all-false.
+ * - `membership.role === null` → INHERIT: a scoped credential resolving with
+ *   its owner's access in that drive.
  */
 function describeRoleSource(
-  role: 'OWNER' | 'ADMIN' | 'MEMBER' | null,
+  membership: PrincipalDriveMembership | null,
   customRoleId: string | null,
-): 'explicit' | 'custom' | 'inherited' {
+): 'explicit' | 'custom' | 'inherited' | 'none' {
+  if (membership === null) return 'none';
   if (customRoleId !== null) return 'custom';
-  return role === null ? 'inherited' : 'explicit';
+  return membership.role === null ? 'inherited' : 'explicit';
 }
 
 /**
@@ -136,15 +177,15 @@ export async function GET(req: NextRequest) {
       ]),
     );
 
-    // Per drive, and concurrently: an unscoped credential's universe is every
-    // drive its owner can reach, and each drive costs a handful of queries, so
-    // a sequential walk would multiply one status call's latency by the drive
-    // count for no reason. Nothing here feeds anything else — the permission
-    // and the membership are independent reads of the same drive — which is
-    // the same shape `commands/whoami.ts` resolves concurrently for the same
-    // reason. Query COUNT is unchanged; only the waiting is.
-    const driveScopes = await Promise.all(
-      driveIds.map(async (driveId) => {
+    // Per drive, in bounded batches. A sequential walk multiplied one status
+    // call's latency by the drive count, but an unbounded fan-out is no better
+    // a trade: each drive costs ~6 queries and an UNSCOPED credential's
+    // universe is every drive its owner can reach, so a user in fifty drives
+    // would open ~300 connections at once from a single GET. Nothing here feeds
+    // anything else — the permission and the membership are independent reads
+    // of the same drive — so batching costs nothing but keeps the pool bounded.
+    // Query COUNT is the same either way; only the waiting and the peak differ.
+    const driveScopes = await mapWithConcurrency(driveIds, DRIVE_RESOLUTION_CONCURRENCY, async (driveId) => {
         const [permissions, membership] = await Promise.all([
           getPrincipalDriveAccessLevel(auth, driveId),
           getPrincipalDriveMembership(auth, driveId),
@@ -159,7 +200,7 @@ export async function GET(req: NextRequest) {
           role,
           customRoleId,
           customRoleName: customRole?.name ?? null,
-          roleSource: describeRoleSource(role, customRoleId),
+          roleSource: describeRoleSource(membership, customRoleId),
           // A scope whose drive resolves to no access at all — a dangling
           // inherit row whose owner lost the drive, a custom role deleted out
           // from under the key — is reported as an all-false entry rather than
@@ -168,8 +209,7 @@ export async function GET(req: NextRequest) {
           // access.
           permissions: permissions ?? { canView: false, canEdit: false, canShare: false, canDelete: false },
         };
-      }),
-    );
+      });
 
     // Only when asked. `permissions: null` (out of reach) is preserved rather
     // than flattened to all-false: "this page is not yours to see" and "you may

--- a/apps/web/src/app/api/auth/key/route.ts
+++ b/apps/web/src/app/api/auth/key/route.ts
@@ -74,6 +74,18 @@ const DRIVE_RESOLUTION_CONCURRENCY = 8;
  * `Promise.all` over `items`, at most `limit` in flight, preserving input
  * order. Order matters: this is a report a human diffs between runs, and a
  * settle-as-they-finish result would reshuffle it for no reason.
+ *
+ * `Math.max(1, …)` is a guard against a returned array of HOLES rather than a
+ * style flourish: a non-positive limit would start zero workers, and this
+ * function would then resolve `new Array(n)` — typed `TResult[]`, actually
+ * empty — with no work done and no error, which the route would serialize as a
+ * list of nulls. A status readout quietly reporting every drive as garbage is
+ * the worst failure this endpoint could have.
+ *
+ * The first rejection stops the queue as well as propagating. `Promise.all`
+ * rejects immediately but does not cancel its siblings, so without the flag the
+ * remaining workers would keep draining — spending the full fan-out this bound
+ * exists to contain on a response that has already failed.
  */
 async function mapWithConcurrency<TItem, TResult>(
   items: readonly TItem[],
@@ -82,9 +94,15 @@ async function mapWithConcurrency<TItem, TResult>(
 ): Promise<TResult[]> {
   const results: TResult[] = new Array(items.length);
   let next = 0;
-  const workers = Array.from({ length: Math.min(limit, items.length) }, async () => {
-    for (let index = next++; index < items.length; index = next++) {
-      results[index] = await resolve(items[index]);
+  let failed = false;
+  const workers = Array.from({ length: Math.min(Math.max(1, limit), items.length) }, async () => {
+    for (let index = next++; index < items.length && !failed; index = next++) {
+      try {
+        results[index] = await resolve(items[index]);
+      } catch (error) {
+        failed = true;
+        throw error;
+      }
     }
   });
   await Promise.all(workers);
@@ -98,14 +116,17 @@ async function mapWithConcurrency<TItem, TResult>(
  * The distinction that matters is between NO membership and a membership whose
  * role is null:
  *
- * - `membership === null` → no drive-level role at all (`'none'`). Reachable
- *   for a USER principal, and not an edge case: `getDriveIdsForUser` unions the
- *   drives you are a member of with the drives of any page shared with you, so
- *   a page-collaborator-only drive appears in the list while
- *   `getUserDrivePermissions` correctly reports no drive membership for it.
- *   Labelling that `'inherited'` would attach scoped-key inherit semantics to a
- *   plain user and read as "you have your own access here", which is the
- *   opposite of true — its `permissions` are all-false.
+ * - `membership === null` → no drive-level role at all (`'none'`), which BOTH
+ *   principal shapes can reach, by different routes. For a USER principal it is
+ *   not even an edge case: `getDriveIdsForUser` unions the drives you belong to
+ *   with the drives of any page shared with you, so a page-collaborator-only
+ *   drive appears in the list while `getUserDrivePermissions` correctly reports
+ *   no drive membership for it. For a SCOPED key it means the `mcp_token_drives`
+ *   row is gone — the drive list came from those rows at authentication, so one
+ *   that no longer resolves was removed in between (the same class of state the
+ *   all-false `permissions` fallback below covers). Labelling either
+ *   `'inherited'` would read as "you have your own access here", the opposite of
+ *   what the all-false `permissions` say.
  * - `membership.role === null` → INHERIT: a scoped credential resolving with
  *   its owner's access in that drive.
  */
@@ -183,8 +204,10 @@ export async function GET(req: NextRequest) {
     // universe is every drive its owner can reach, so a user in fifty drives
     // would open ~300 connections at once from a single GET. Nothing here feeds
     // anything else — the permission and the membership are independent reads
-    // of the same drive — so batching costs nothing but keeps the pool bounded.
+    // of the same drive — so batching costs nothing but keeps the peak bounded.
     // Query COUNT is the same either way; only the waiting and the peak differ.
+    // The bound is on DRIVES: each one fans out to two concurrent resolvers, so
+    // the real ceiling is roughly double this number of queries in flight.
     const driveScopes = await mapWithConcurrency(driveIds, DRIVE_RESOLUTION_CONCURRENCY, async (driveId) => {
         const [permissions, membership] = await Promise.all([
           getPrincipalDriveAccessLevel(auth, driveId),

--- a/apps/web/src/app/api/auth/key/route.ts
+++ b/apps/web/src/app/api/auth/key/route.ts
@@ -1,0 +1,182 @@
+/**
+ * `GET /api/auth/key` — what the credential making this call actually is, and
+ * what it is actually allowed to do.
+ *
+ * The gap this closes (issue #2470): a key minted `--role member` reads fine
+ * and fails every write with "Write permission required.", and nothing —
+ * not at mint time, not afterwards — could be asked what the key could do.
+ * The only way to find out was to attempt writes and read the refusals.
+ *
+ * Why this is a separate route from the `mcp-tokens` family rather than a
+ * relaxation of it: those routes manage the whole set of keys a person holds,
+ * so they admit only a full-user credential (see `mcp-tokens/scope-guard.ts` —
+ * a drive-scoped OAuth token is refused there for exactly this reason, and an
+ * `mcp_` token never reaches them at all). This route answers only about the
+ * credential presenting itself, which is a question that credential is always
+ * entitled to ask, so it accepts every class including `mcp_`. A key describes
+ * ITSELF; it never describes another key.
+ *
+ * Nothing here is new information: the drive list is what `drives.list` already
+ * returns to this same credential, and the effective permissions are the
+ * decision every content route was already going to make on the next request.
+ * The one thing deliberately withheld is the owning USER — no name, no email,
+ * no user id. `/api/auth/me` refuses `mcp_` tokens precisely so that holding a
+ * scoped key does not hand over the person behind it
+ * (`packages/cli/src/auth/probe-drives.ts`), and this route must not become the
+ * back door to the same thing.
+ *
+ * Every permission below comes from `getPrincipalDriveAccessLevel` — the same
+ * resolver chain (`getAppDriveAccessLevel` / `getScopedDriveAccessLevel` /
+ * `getUserAccessLevel`) that authorizes the real request. No second reading of
+ * the role vocabulary lives in this file; if it did, this route could tell an
+ * agent it may write while the write path disagreed.
+ *
+ * Drive-level and page-level are genuinely different answers, so both are
+ * available rather than one standing in for the other. `driveScopes[].permissions`
+ * is the drive-as-root-node question — creating a top-level page, sharing or
+ * deleting the drive — where any membership grants edit. A PAGE goes through
+ * `getPrincipalAccessLevel` and can be strictly narrower: a plain MEMBER may
+ * create at the drive root and still be view-only on a document inside it,
+ * which is precisely the "reads fine, every write fails" report behind #2470.
+ * Reporting only the drive level would reproduce that confusion from the other
+ * side, so `?pageId=` resolves the page the caller actually cares about.
+ */
+import { NextRequest, NextResponse } from 'next/server';
+import { authenticateRequestWithOptions, isAuthError, type AuthResult } from '@/lib/auth';
+import {
+  getPrincipalAccessLevel,
+  getPrincipalDriveAccessLevel,
+  getPrincipalDriveIds,
+  getPrincipalDriveMembership,
+  isDriveScopedPrincipal,
+} from '@/lib/auth/principal-permissions';
+import { sessionRepository } from '@/lib/repositories/session-repository';
+import { getRoleById } from '@pagespace/lib/services/drive-role-service';
+import { auditRequest } from '@pagespace/lib/audit/audit-log';
+import { loggers } from '@pagespace/lib/logging/logger-config';
+
+// Every class the SDK and the first-party surfaces can present. `mcp` is the
+// point of the route; `oauth` and `session` are included so one command
+// (`pagespace keys describe`) answers the same question whichever credential
+// this machine happens to be using. No CSRF: this is a read, and Bearer auth
+// skips CSRF anyway (`authenticateRequestWithOptions`).
+const AUTH_OPTIONS_READ = { allow: ['mcp', 'oauth', 'session'] as const, requireCSRF: false };
+
+/**
+ * `role: null` is not "no role" — for a scoped credential it is INHERIT (the key
+ * resolves with its owner's access in that drive), and for a user principal it
+ * cannot occur at all, since `getPrincipalDriveMembership` returns null rather
+ * than a roleless membership. Naming the three cases explicitly keeps a reader
+ * of the output from having to know that.
+ */
+function describeRoleSource(
+  role: 'OWNER' | 'ADMIN' | 'MEMBER' | null,
+  customRoleId: string | null,
+): 'explicit' | 'custom' | 'inherited' {
+  if (customRoleId !== null) return 'custom';
+  return role === null ? 'inherited' : 'explicit';
+}
+
+/**
+ * The three classes a request can actually arrive as here. `AuthResult` has a
+ * fourth variant, `service`, which no route's `allow` list can name and
+ * `authenticateRequestWithOptions` never constructs (see `AllowedTokenType`) —
+ * it is excluded at the door below rather than given a branch, so a future
+ * fifth variant cannot quietly inherit a description written for these three.
+ */
+type PresentedAuth = Extract<AuthResult, { tokenType: 'mcp' | 'oauth' | 'session' }>;
+
+/** The `credential` block. Only an `mcp_` credential has a key row to name. */
+async function describeCredential(auth: PresentedAuth) {
+  const base = {
+    type: auth.tokenType,
+    scoped: isDriveScopedPrincipal(auth),
+    id: null as string | null,
+    name: null as string | null,
+    tokenPrefix: null as string | null,
+    createdAt: null as string | null,
+    lastUsed: null as string | null,
+  };
+
+  if (auth.tokenType !== 'mcp') return base;
+
+  const token = await sessionRepository.findMcpTokenSelfById(auth.tokenId, auth.userId);
+  if (!token) return base;
+
+  return {
+    ...base,
+    id: token.id,
+    name: token.name,
+    tokenPrefix: token.tokenPrefix,
+    createdAt: token.createdAt.toISOString(),
+    lastUsed: token.lastUsed?.toISOString() ?? null,
+  };
+}
+
+export async function GET(req: NextRequest) {
+  const authResult = await authenticateRequestWithOptions(req, AUTH_OPTIONS_READ);
+  if (isAuthError(authResult)) return authResult.error;
+  if (authResult.tokenType === 'service') {
+    // Unreachable by construction (see PresentedAuth) — refused rather than
+    // described, so the narrowing below is a fact and not an assertion.
+    return NextResponse.json({ error: 'Unsupported credential type' }, { status: 400 });
+  }
+  const auth: PresentedAuth = authResult;
+
+  try {
+    const credential = await describeCredential(auth);
+
+    // The principal's own drive universe, not its owner's: for a scoped
+    // credential this is exactly its `mcp_token_drives` rows.
+    const driveIds = await getPrincipalDriveIds(auth);
+    const driveNames = new Map(
+      (driveIds.length > 0 ? await sessionRepository.findDrivesByIds(driveIds) : []).map((drive) => [
+        drive.id,
+        drive.name,
+      ]),
+    );
+
+    const driveScopes = [];
+    for (const driveId of driveIds) {
+      const permissions = await getPrincipalDriveAccessLevel(auth, driveId);
+      const membership = await getPrincipalDriveMembership(auth, driveId);
+      const role = membership?.role ?? null;
+      const customRoleId = membership?.customRoleId ?? null;
+      const customRole = customRoleId ? await getRoleById(driveId, customRoleId) : null;
+
+      driveScopes.push({
+        id: driveId,
+        name: driveNames.get(driveId) ?? driveId,
+        role,
+        customRoleId,
+        customRoleName: customRole?.name ?? null,
+        roleSource: describeRoleSource(role, customRoleId),
+        // A scope whose drive resolves to no access at all — a dangling inherit
+        // row whose owner lost the drive, a custom role deleted out from under
+        // the key — is reported as an all-false entry rather than dropped.
+        // "You hold a grant here that currently gets you nothing" is the honest
+        // answer; omitting the row would read as never having had access.
+        permissions: permissions ?? { canView: false, canEdit: false, canShare: false, canDelete: false },
+      });
+    }
+
+    // Only when asked. `permissions: null` (out of reach) is preserved rather
+    // than flattened to all-false: "this page is not yours to see" and "you may
+    // do nothing with this page" are different answers, and an agent choosing
+    // where to write needs to tell them apart.
+    const pageId = req.nextUrl.searchParams.get('pageId');
+    const page = pageId === null ? null : { id: pageId, permissions: await getPrincipalAccessLevel(auth, pageId) };
+
+    auditRequest(req, {
+      eventType: 'data.read',
+      userId: auth.userId,
+      resourceType: 'credential_self_description',
+      resourceId: credential.id ?? auth.tokenType,
+    });
+
+    return NextResponse.json({ credential, driveScopes, page });
+  } catch (error) {
+    loggers.auth.error('Error describing credential:', error as Error);
+    return NextResponse.json({ error: 'Failed to describe credential' }, { status: 500 });
+  }
+}

--- a/apps/web/src/app/api/auth/key/route.ts
+++ b/apps/web/src/app/api/auth/key/route.ts
@@ -136,29 +136,40 @@ export async function GET(req: NextRequest) {
       ]),
     );
 
-    const driveScopes = [];
-    for (const driveId of driveIds) {
-      const permissions = await getPrincipalDriveAccessLevel(auth, driveId);
-      const membership = await getPrincipalDriveMembership(auth, driveId);
-      const role = membership?.role ?? null;
-      const customRoleId = membership?.customRoleId ?? null;
-      const customRole = customRoleId ? await getRoleById(driveId, customRoleId) : null;
+    // Per drive, and concurrently: an unscoped credential's universe is every
+    // drive its owner can reach, and each drive costs a handful of queries, so
+    // a sequential walk would multiply one status call's latency by the drive
+    // count for no reason. Nothing here feeds anything else — the permission
+    // and the membership are independent reads of the same drive — which is
+    // the same shape `commands/whoami.ts` resolves concurrently for the same
+    // reason. Query COUNT is unchanged; only the waiting is.
+    const driveScopes = await Promise.all(
+      driveIds.map(async (driveId) => {
+        const [permissions, membership] = await Promise.all([
+          getPrincipalDriveAccessLevel(auth, driveId),
+          getPrincipalDriveMembership(auth, driveId),
+        ]);
+        const role = membership?.role ?? null;
+        const customRoleId = membership?.customRoleId ?? null;
+        const customRole = customRoleId ? await getRoleById(driveId, customRoleId) : null;
 
-      driveScopes.push({
-        id: driveId,
-        name: driveNames.get(driveId) ?? driveId,
-        role,
-        customRoleId,
-        customRoleName: customRole?.name ?? null,
-        roleSource: describeRoleSource(role, customRoleId),
-        // A scope whose drive resolves to no access at all — a dangling inherit
-        // row whose owner lost the drive, a custom role deleted out from under
-        // the key — is reported as an all-false entry rather than dropped.
-        // "You hold a grant here that currently gets you nothing" is the honest
-        // answer; omitting the row would read as never having had access.
-        permissions: permissions ?? { canView: false, canEdit: false, canShare: false, canDelete: false },
-      });
-    }
+        return {
+          id: driveId,
+          name: driveNames.get(driveId) ?? driveId,
+          role,
+          customRoleId,
+          customRoleName: customRole?.name ?? null,
+          roleSource: describeRoleSource(role, customRoleId),
+          // A scope whose drive resolves to no access at all — a dangling
+          // inherit row whose owner lost the drive, a custom role deleted out
+          // from under the key — is reported as an all-false entry rather than
+          // dropped. "You hold a grant here that currently gets you nothing" is
+          // the honest answer; omitting the row would read as never having had
+          // access.
+          permissions: permissions ?? { canView: false, canEdit: false, canShare: false, canDelete: false },
+        };
+      }),
+    );
 
     // Only when asked. `permissions: null` (out of reach) is preserved rather
     // than flattened to all-false: "this page is not yours to see" and "you may

--- a/apps/web/src/app/api/auth/key/route.ts
+++ b/apps/web/src/app/api/auth/key/route.ts
@@ -164,7 +164,8 @@ export async function GET(req: NextRequest) {
     // than flattened to all-false: "this page is not yours to see" and "you may
     // do nothing with this page" are different answers, and an agent choosing
     // where to write needs to tell them apart.
-    const pageId = req.nextUrl.searchParams.get('pageId');
+    const { searchParams } = new URL(req.url);
+    const pageId = searchParams.get('pageId');
     const page = pageId === null ? null : { id: pageId, permissions: await getPrincipalAccessLevel(auth, pageId) };
 
     auditRequest(req, {

--- a/apps/web/src/app/api/drives/[driveId]/roles/[roleId]/__tests__/route.test.ts
+++ b/apps/web/src/app/api/drives/[driveId]/roles/[roleId]/__tests__/route.test.ts
@@ -197,7 +197,27 @@ describe('GET /api/drives/[driveId]/roles/[roleId]', () => {
       const body = await response.json();
 
       expect(response.status).toBe(404);
-      expect(body.error).toBe('Role not found');
+      expect(body.error).toBe(`Role "${mockRoleId}" not found in this drive`);
+    });
+
+    // Issue #2470: `get_drive_role "member"` / `roles get <driveId> member` can
+    // only ever miss here — system roles are not rows in drive_roles — so the
+    // 404 names where they do live rather than leaving a dead end.
+    it('should point a SYSTEM role name at where system roles actually live', async () => {
+      vi.mocked(checkDriveAccessForRoles).mockResolvedValue(createAccessFixture({
+        isOwner: true,
+        isMember: true,
+        drive: createDriveFixture({ id: mockDriveId, name: 'Test', ownerId: mockUserId }),
+      }));
+      vi.mocked(getRoleById).mockResolvedValue(null);
+
+      const request = new Request(`https://example.com/api/drives/${mockDriveId}/roles/member`);
+      const response = await GET(request, createContext(mockDriveId, 'member'));
+      const body = await response.json();
+
+      expect(response.status).toBe(404);
+      expect(body.error).toMatch(/system role/i);
+      expect(body.error).toMatch(/drive membership/i);
     });
 
     it('should return role when user is owner', async () => {

--- a/apps/web/src/app/api/drives/[driveId]/roles/[roleId]/__tests__/route.test.ts
+++ b/apps/web/src/app/api/drives/[driveId]/roles/[roleId]/__tests__/route.test.ts
@@ -609,7 +609,7 @@ describe('PATCH /api/drives/[driveId]/roles/[roleId]', () => {
       const body = await response.json();
 
       expect(response.status).toBe(404);
-      expect(body.error).toBe('Role not found');
+      expect(body.error).toBe(`Role "${mockRoleId}" not found in this drive`);
     });
 
     it('should return updated role on success', async () => {
@@ -820,7 +820,7 @@ describe('DELETE /api/drives/[driveId]/roles/[roleId]', () => {
       const body = await response.json();
 
       expect(response.status).toBe(404);
-      expect(body.error).toBe('Role not found');
+      expect(body.error).toBe(`Role "${mockRoleId}" not found in this drive`);
     });
 
     it('should return success=true on successful deletion', async () => {

--- a/apps/web/src/app/api/drives/[driveId]/roles/[roleId]/route.ts
+++ b/apps/web/src/app/api/drives/[driveId]/roles/[roleId]/route.ts
@@ -54,9 +54,10 @@ export async function GET(
     const role = await getRoleById(driveId, roleId);
 
     if (!role) {
-      // `roleNotFoundMessage`, not a bare 'Role not found': asking for a SYSTEM
-      // role name here (member/admin/owner) can only ever miss, and the caller
-      // needs to be told where those live instead of being left at a dead end.
+      // `roleNotFoundMessage`, not a bare 'Role not found' — here and in PATCH
+      // and DELETE below: asking for a SYSTEM role name (member/admin/owner)
+      // can only ever miss whichever verb it arrives at, and the caller needs
+      // to be told where those live instead of being left at a dead end.
       return NextResponse.json({ error: roleNotFoundMessage(roleId) }, { status: 404 });
     }
 
@@ -97,7 +98,7 @@ export async function PATCH(
     const existingRole = await getRoleById(driveId, roleId);
 
     if (!existingRole) {
-      return NextResponse.json({ error: 'Role not found' }, { status: 404 });
+      return NextResponse.json({ error: roleNotFoundMessage(roleId) }, { status: 404 });
     }
 
     const body = await request.json();
@@ -206,7 +207,7 @@ export async function DELETE(
     const existingRole = await getRoleById(driveId, roleId);
 
     if (!existingRole) {
-      return NextResponse.json({ error: 'Role not found' }, { status: 404 });
+      return NextResponse.json({ error: roleNotFoundMessage(roleId) }, { status: 404 });
     }
 
     await deleteDriveRole(driveId, roleId);

--- a/apps/web/src/app/api/drives/[driveId]/roles/[roleId]/route.ts
+++ b/apps/web/src/app/api/drives/[driveId]/roles/[roleId]/route.ts
@@ -1,7 +1,7 @@
 import { NextResponse } from 'next/server';
 import { authenticateRequestWithOptions, isAuthError, checkMCPDriveScope } from '@/lib/auth';
 import { auditRequest } from '@pagespace/lib/audit/audit-log'
-import { checkDriveAccessForRoles, getRoleById, updateDriveRole, deleteDriveRole, validateRolePermissions, validateRolePermissionsPatch } from '@pagespace/lib/services/drive-role-service';
+import { checkDriveAccessForRoles, getRoleById, roleNotFoundMessage, updateDriveRole, deleteDriveRole, validateRolePermissions, validateRolePermissionsPatch } from '@pagespace/lib/services/drive-role-service';
 import { getActorInfo, logRoleActivity } from '@pagespace/lib/monitoring/activity-logger';
 import { getDriveRecipientUserIds } from '@pagespace/lib/services/drive-member-service';
 import { broadcastDriveEvent, createDriveEventPayload } from '@/lib/websocket';
@@ -54,7 +54,10 @@ export async function GET(
     const role = await getRoleById(driveId, roleId);
 
     if (!role) {
-      return NextResponse.json({ error: 'Role not found' }, { status: 404 });
+      // `roleNotFoundMessage`, not a bare 'Role not found': asking for a SYSTEM
+      // role name here (member/admin/owner) can only ever miss, and the caller
+      // needs to be told where those live instead of being left at a dead end.
+      return NextResponse.json({ error: roleNotFoundMessage(roleId) }, { status: 404 });
     }
 
     return NextResponse.json({ role });

--- a/apps/web/src/app/api/mcp/__tests__/write-denied-details.test.ts
+++ b/apps/web/src/app/api/mcp/__tests__/write-denied-details.test.ts
@@ -1,0 +1,60 @@
+/**
+ * Issue #2470's complaint was not the refusal — correct for a view-only grant —
+ * but that it named nowhere to look, so a grant could only be learned one failed
+ * write at a time.
+ */
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { describe, it, expect } from 'vitest';
+import { writeDeniedDetails } from '../write-denied-details';
+
+describe('writeDeniedDetails', () => {
+  it('keeps the operation name, which the route security suites pin', () => {
+    expect(writeDeniedDetails('replace', 'document')).toContain("'replace'");
+  });
+
+  it('names the subject it was called for', () => {
+    expect(writeDeniedDetails('replace', 'document')).toContain('this document');
+    expect(writeDeniedDetails('append-rows', 'sheet')).toContain('this sheet');
+  });
+
+  // Both halves are facts about THIS request: the caller cleared the view gate
+  // immediately before reaching the write gate, so "can view, cannot edit" is
+  // established rather than guessed.
+  it('states what the credential CAN do here, not only what it cannot', () => {
+    expect(writeDeniedDetails('replace', 'document')).toMatch(/can view this page but not edit it/i);
+  });
+
+  it('points at the self-description on both surfaces an agent might be driving', () => {
+    const details = writeDeniedDetails('replace', 'document');
+    expect(details).toContain('tokens.describeSelf');
+    expect(details).toContain('pagespace keys describe --page');
+  });
+
+  // The module is imported by two routes whose suites partially mock
+  // `@/lib/auth`; a barrel import here would make a missing mock surface as an
+  // opaque 500 instead of the 403 under test.
+  // `mcp/documents` has a security suite that exercises its 403 end to end;
+  // `mcp/sheets` has no test file at all, so its wiring is pinned statically
+  // rather than left to a future edit to quietly hand-roll the string back.
+  // Same idiom as the repo's other coverage gates (readme-coverage,
+  // security-audit-coverage), which read route sources as text.
+  it.each([
+    ['documents', 'document'],
+    ['sheets', 'sheet'],
+  ])('the %s route builds its details through this helper, not by hand', (route, subject) => {
+    const source = readFileSync(join(__dirname, '..', route, 'route.ts'), 'utf-8');
+    expect(source).toContain(`writeDeniedDetails(operation, '${subject}')`);
+    // The stable half of the contract: `error` must stay the string the
+    // security suites and clients branch on.
+    expect(source).toContain("error: 'Write permission required'");
+    // No hand-rolled variant left behind beside the shared one.
+    expect(source).not.toMatch(/details: `The '\$\{operation\}' operation requires edit access/);
+  });
+
+  it('is a leaf — it imports nothing', () => {
+    const source = readFileSync(join(__dirname, '..', 'write-denied-details.ts'), 'utf-8');
+    expect(source).toContain('export function writeDeniedDetails');
+    expect(source).not.toMatch(/^\s*import\s/m);
+  });
+});

--- a/apps/web/src/app/api/mcp/documents/__tests__/route.security.test.ts
+++ b/apps/web/src/app/api/mcp/documents/__tests__/route.security.test.ts
@@ -413,6 +413,12 @@ describe('MCP Documents API - Security Tests', () => {
         const data = await response.json();
         expect(data.error).toBe('Write permission required');
         expect(data.details).toContain(operation);
+        // Issue #2470's actual complaint was not the refusal — that is correct
+        // for a view-only grant — but that it pointed nowhere, so the only way
+        // to learn the grant was one failed write at a time. `error` stays the
+        // stable string clients branch on; the pointer rides in `details`.
+        expect(data.details).toContain('tokens.describeSelf');
+        expect(data.details).toContain('pagespace keys describe --page');
       }
     });
   });

--- a/apps/web/src/app/api/mcp/documents/route.ts
+++ b/apps/web/src/app/api/mcp/documents/route.ts
@@ -19,6 +19,7 @@ import { broadcastPageEvent, createPageEventPayload } from '@/lib/websocket';
 import { loggers } from '@pagespace/lib/logging/logger-config';
 import { auditRequest } from '@pagespace/lib/audit/audit-log';
 import { authenticateMCPRequest, isAuthError, isMCPAuthResult, getPrincipalAccessLevel } from '@/lib/auth';
+import { writeDeniedDetails } from '../write-denied-details';
 import { getActorInfo } from '@pagespace/lib/monitoring/activity-logger';
 import { applyPageMutation, PageRevisionMismatchError } from '@/services/api/page-mutation-service';
 
@@ -183,7 +184,7 @@ export async function POST(req: NextRequest) {
         return NextResponse.json(
           {
             error: 'Write permission required',
-            details: `The '${operation}' operation requires edit access to this document`
+            details: writeDeniedDetails(operation, 'document')
           },
           { status: 403 }
         );

--- a/apps/web/src/app/api/mcp/sheets/route.ts
+++ b/apps/web/src/app/api/mcp/sheets/route.ts
@@ -22,6 +22,7 @@ import { logSheetCellActivity } from '@/services/api/sheet-activity';
 import { loggers } from '@pagespace/lib/logging/logger-config';
 import { auditRequest } from '@pagespace/lib/audit/audit-log';
 import { authenticateMCPRequest, isAuthError, isMCPAuthResult, getPrincipalAccessLevel } from '@/lib/auth';
+import { writeDeniedDetails } from '../write-denied-details';
 import { getActorInfo } from '@pagespace/lib/monitoring/activity-logger';
 import { broadcastPageEvent, createPageEventPayload } from '@/lib/websocket';
 
@@ -157,7 +158,7 @@ export async function POST(req: NextRequest) {
       return NextResponse.json(
         {
           error: 'Write permission required',
-          details: `The '${operation}' operation requires edit access to this sheet`,
+          details: writeDeniedDetails(operation, 'sheet'),
         },
         { status: 403 }
       );

--- a/apps/web/src/app/api/mcp/write-denied-details.ts
+++ b/apps/web/src/app/api/mcp/write-denied-details.ts
@@ -1,0 +1,32 @@
+/**
+ * The `details` line on a 403 from an MCP write path. Shared by
+ * `mcp/documents/route.ts` and `mcp/sheets/route.ts` so the two cannot drift —
+ * same shape as `auth/mcp-tokens/scope-guard.ts`, which is colocated with its
+ * own two callers for the same reason.
+ *
+ * Issue #2470's complaint was not that a write was refused — a refusal is
+ * correct for a view-only grant — but that the refusal named nowhere, so the
+ * grant could only be learned one failed write at a time ("We learned by
+ * trying writes and watching them fail"). Both halves of the sentence are
+ * facts about this exact request rather than a guess: the caller cleared the
+ * VIEW gate immediately before reaching the write gate, so it can read this
+ * page and cannot write it.
+ *
+ * Only the `details` field. `error` stays the stable `'Write permission
+ * required'` string the security suites pin and clients may branch on.
+ *
+ * A leaf with NO imports, deliberately. Both callers partially mock
+ * `@/lib/auth` in their route suites, and any symbol they take from that
+ * barrel is one more thing every mock must remember to provide or the route
+ * fails with an opaque 500 instead of the 403 under test — the trap
+ * `principal-permissions.ts` documents at `resolveDispatchedPrincipal`, and
+ * one this module has no reason to walk into for a string.
+ */
+export function writeDeniedDetails(operation: string, subject: 'document' | 'sheet'): string {
+  return (
+    `The '${operation}' operation requires edit access to this ${subject}. This credential can view ` +
+    'this page but not edit it. Call tokens.describeSelf with this pageId (CLI: "pagespace keys ' +
+    'describe --page <pageId>") for what it can actually do, instead of discovering it one failed ' +
+    'write at a time.'
+  );
+}

--- a/apps/web/src/lib/ai/tools/__tests__/role-management-tools.test.ts
+++ b/apps/web/src/lib/ai/tools/__tests__/role-management-tools.test.ts
@@ -15,14 +15,22 @@ vi.mock('@pagespace/db/schema/core', () => ({
   pages: { id: 'id', driveId: 'driveId' },
 }));
 
-vi.mock('@pagespace/lib/services/drive-role-service', () => ({
-  checkDriveAccessForRoles: vi.fn(),
-  listDriveRoles: vi.fn(),
-  getRoleById: vi.fn(),
-  createDriveRole: vi.fn(),
-  updateDriveRole: vi.fn(),
-  deleteDriveRole: vi.fn(),
-}));
+vi.mock('@pagespace/lib/services/drive-role-service', async () => {
+  // `roleNotFoundMessage` stays REAL: it is a pure string function with no DB
+  // reach, and the point of the assertions below is exactly what it says.
+  const actual = await vi.importActual<typeof import('@pagespace/lib/services/drive-role-service')>(
+    '@pagespace/lib/services/drive-role-service',
+  );
+  return {
+    roleNotFoundMessage: actual.roleNotFoundMessage,
+    checkDriveAccessForRoles: vi.fn(),
+    listDriveRoles: vi.fn(),
+    getRoleById: vi.fn(),
+    createDriveRole: vi.fn(),
+    updateDriveRole: vi.fn(),
+    deleteDriveRole: vi.fn(),
+  };
+});
 
 vi.mock('@pagespace/lib/services/drive-member-service', () => ({
   getDriveRecipientUserIds: vi.fn().mockResolvedValue(['owner1', 'user1']),
@@ -200,6 +208,24 @@ describe('role-management-tools', () => {
 
       expect(result.success).toBe(false);
       expect(result.error).toContain('not found');
+    });
+
+    // Issue #2470: the honest dead end. A system role name can never resolve
+    // here, so the refusal has to say where those live instead of stopping at
+    // "not found in this drive".
+    it('tells a caller asking for a SYSTEM role where system roles actually live', async () => {
+      mockCheckAccess.mockResolvedValueOnce(memberAccess);
+      mockGetRole.mockResolvedValueOnce(null);
+
+      const result = await roleManagementTools.get_drive_role.execute!(
+        { driveId: 'drive1', roleId: 'member' },
+        makeContext('user1')
+      ) as { success: boolean; error: string };
+
+      expect(result.success).toBe(false);
+      expect(result.error).toMatch(/system role/i);
+      expect(result.error).toMatch(/drive membership/i);
+      expect(result.error).toContain('pagespace keys describe');
     });
   });
 

--- a/apps/web/src/lib/ai/tools/role-management-tools.ts
+++ b/apps/web/src/lib/ai/tools/role-management-tools.ts
@@ -312,7 +312,7 @@ export const roleManagementTools = {
 
       try {
         const role = await getRoleById(driveId, roleId);
-        if (!role) return { success: false, error: `Role "${roleId}" not found in this drive` };
+        if (!role) return { success: false, error: roleNotFoundMessage(roleId) };
 
         const page = await db.query.pages.findFirst({
           where: and(eq(pages.id, pageId), eq(pages.driveId, driveId)),
@@ -396,7 +396,7 @@ export const roleManagementTools = {
 
       try {
         const role = await getRoleById(driveId, roleId);
-        if (!role) return { success: false, error: `Role "${roleId}" not found in this drive` };
+        if (!role) return { success: false, error: roleNotFoundMessage(roleId) };
 
         if (!(pageId in role.permissions)) {
           return {

--- a/apps/web/src/lib/ai/tools/role-management-tools.ts
+++ b/apps/web/src/lib/ai/tools/role-management-tools.ts
@@ -7,6 +7,7 @@ import {
   checkDriveAccessForRoles,
   listDriveRoles,
   getRoleById,
+  roleNotFoundMessage,
   createDriveRole,
   updateDriveRole,
   deleteDriveRole,
@@ -69,7 +70,7 @@ async function logAndBroadcastRoleChange(
 
 export const roleManagementTools = {
   list_drive_roles: tool({
-    description: 'List all custom roles in a drive with their names, colors, and positions. Use this to discover existing roles before creating new ones or assigning roles to members.',
+    description: 'List the CUSTOM roles defined in a drive with their names, colors, and positions. Use this to discover existing roles before creating new ones or assigning roles to members. Does not include the system roles OWNER/ADMIN/MEMBER, which are not rows in this list and have no role id.',
     inputSchema: z.object({
       driveId: driveIdSchema.describe('The ID of the drive to list roles for'),
     }),
@@ -100,18 +101,21 @@ export const roleManagementTools = {
           driveWidePermissions: r.driveWidePermissions,
           position: r.position,
         })),
-        summary: `${roles.length} role${roles.length === 1 ? '' : 's'} in "${access.drive.name}"`,
+        summary: `${roles.length} custom role${roles.length === 1 ? '' : 's'} in "${access.drive.name}"`,
         stats: { total: roles.length, driveName: access.drive.name },
         nextSteps: [
           'Use get_drive_role to inspect a role\'s full permissions',
           'Use create_drive_role to add a new role',
+          // Named here because its absence is what sent a caller to
+          // get_drive_role "member" in the first place (issue #2470).
+          'This lists only CUSTOM roles. The system roles (OWNER/ADMIN/MEMBER) are not rows here — they are held per member on the drive membership.',
         ],
       };
     },
   }),
 
   get_drive_role: tool({
-    description: 'Get a single drive role with its full per-page permissions map and drive-wide permissions. Use after list_drive_roles to inspect what a role can access.',
+    description: 'Get a single CUSTOM drive role by its id, with its full per-page permissions map and drive-wide permissions. Use after list_drive_roles to inspect what a role can access. The system roles (OWNER/ADMIN/MEMBER) are not addressable here — they have no role id.',
     inputSchema: z.object({
       driveId: driveIdSchema.describe('The ID of the drive the role belongs to'),
       roleId: z.string().describe('The ID of the role to fetch'),
@@ -131,7 +135,10 @@ export const roleManagementTools = {
       }
 
       const role = await getRoleById(driveId, roleId);
-      if (!role) return { success: false, error: `Role "${roleId}" not found in this drive` };
+      // Shared with the REST route: a system-role name (member/admin/owner) is
+      // not a row here and never will be, so the refusal names where those
+      // actually live rather than stopping at "not found".
+      if (!role) return { success: false, error: roleNotFoundMessage(roleId) };
 
       return {
         success: true,

--- a/apps/web/src/lib/auth/__tests__/principal-permissions.test.ts
+++ b/apps/web/src/lib/auth/__tests__/principal-permissions.test.ts
@@ -12,6 +12,10 @@ vi.mock('@pagespace/lib/permissions/permissions', () => ({
   getDriveIdsForUser: vi.fn(),
   getUserAccessiblePagesInDriveWithDetails: vi.fn(),
   getBatchPagePermissions: vi.fn(),
+  getUserDrivePermissions: vi.fn(),
+}));
+vi.mock('@pagespace/lib/permissions/membership-queries', () => ({
+  getMemberCustomRoleId: vi.fn(),
 }));
 vi.mock('@pagespace/lib/permissions/app-permissions', () => ({
   getAppAccessLevel: vi.fn(),
@@ -48,6 +52,8 @@ import {
   getPrincipalAccessiblePagesInDrive,
   getPrincipalBatchPagePermissions,
   canManagePageWebhooks,
+  getPrincipalDriveAccessLevel,
+  getPrincipalDriveMembership,
 } from '../principal-permissions';
 import type { AuthResult } from '../index';
 import {
@@ -62,10 +68,14 @@ import {
   getDriveIdsForUser,
   getUserAccessiblePagesInDriveWithDetails,
   getBatchPagePermissions,
+  getUserDrivePermissions,
 } from '@pagespace/lib/permissions/permissions';
+import { getMemberCustomRoleId } from '@pagespace/lib/permissions/membership-queries';
 import {
   getAppAccessLevel,
+  getAppDriveAccessLevel,
   getAppDriveMembership,
+  getScopedDriveAccessLevel,
   getAppAccessiblePagesInDrive,
   hasAppDriveMembership,
   getScopedAccessLevel,
@@ -599,5 +609,78 @@ describe('a dispatched worker is authorized as the credential that STARTED the c
 
     expect(await canManagePageWebhooks(serviceFromScopedToken, PAGE_ID)).toBe(false);
     expect(isDriveOwnerOrAdmin).not.toHaveBeenCalled();
+  });
+});
+
+/**
+ * The drive-level pair behind `GET /api/auth/key` (issue #2470). What matters
+ * is that each credential class routes to the resolver its CONTENT requests
+ * already go through — if this file grew its own permission arithmetic, the
+ * self-description could tell an agent it may write while the write path said
+ * otherwise.
+ */
+describe('getPrincipalDriveAccessLevel', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('resolves a scoped MCP token through the app-member resolver, keyed by the TOKEN', async () => {
+    vi.mocked(getAppDriveAccessLevel).mockResolvedValue(VIEW_ONLY);
+    await expect(getPrincipalDriveAccessLevel(scopedMcpAuth, DRIVE_ID)).resolves.toEqual(VIEW_ONLY);
+    expect(getAppDriveAccessLevel).toHaveBeenCalledWith(TOKEN_ID, DRIVE_ID);
+    expect(getUserAccessLevel).not.toHaveBeenCalled();
+  });
+
+  it('resolves a drive-scoped OAuth token through the scope resolver', async () => {
+    vi.mocked(getScopedDriveAccessLevel).mockResolvedValue(VIEW_ONLY);
+    await expect(getPrincipalDriveAccessLevel(scopedOAuthAuth, DRIVE_ID)).resolves.toEqual(VIEW_ONLY);
+    expect(getScopedDriveAccessLevel).toHaveBeenCalledWith(DRIVE_SCOPES, USER_ID, DRIVE_ID);
+  });
+
+  it('resolves a session, an unscoped key and an account OAuth token as the user (drive-as-root-node)', async () => {
+    for (const auth of [sessionAuth, unscopedMcpAuth, accountOAuthAuth]) {
+      vi.mocked(getUserAccessLevel).mockResolvedValue(FULL);
+      await expect(getPrincipalDriveAccessLevel(auth, DRIVE_ID)).resolves.toEqual(FULL);
+      expect(getUserAccessLevel).toHaveBeenCalledWith(USER_ID, DRIVE_ID);
+    }
+  });
+});
+
+describe('getPrincipalDriveMembership', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('returns the scoped key\'s own mcp_token_drives grant', async () => {
+    vi.mocked(getAppDriveMembership).mockResolvedValue({ role: 'MEMBER', customRoleId: null, ownerUserId: USER_ID });
+    await expect(getPrincipalDriveMembership(scopedMcpAuth, DRIVE_ID)).resolves.toEqual({ role: 'MEMBER', customRoleId: null });
+  });
+
+  it('preserves a null role as INHERIT rather than collapsing it to "no membership"', async () => {
+    vi.mocked(getAppDriveMembership).mockResolvedValue({ role: null, customRoleId: null, ownerUserId: USER_ID });
+    await expect(getPrincipalDriveMembership(scopedMcpAuth, DRIVE_ID)).resolves.toEqual({ role: null, customRoleId: null });
+  });
+
+  it('returns null when a scoped key has no grant in the drive', async () => {
+    vi.mocked(getAppDriveMembership).mockResolvedValue(null);
+    await expect(getPrincipalDriveMembership(scopedMcpAuth, DRIVE_ID)).resolves.toBeNull();
+  });
+
+  it('reads a drive-scoped OAuth token\'s membership from its scope rows', async () => {
+    vi.mocked(getScopedDriveMembership).mockReturnValue({ role: 'ADMIN', customRoleId: null });
+    await expect(getPrincipalDriveMembership(scopedOAuthAuth, DRIVE_ID)).resolves.toEqual({ role: 'ADMIN', customRoleId: null });
+  });
+
+  it('maps a user principal through getUserDrivePermissions, pairing it with the member\'s custom role', async () => {
+    vi.mocked(getUserDrivePermissions).mockResolvedValue({ hasAccess: true, isOwner: false, isAdmin: false, isMember: true, canEdit: true });
+    vi.mocked(getMemberCustomRoleId).mockResolvedValue('role-1');
+    await expect(getPrincipalDriveMembership(sessionAuth, DRIVE_ID)).resolves.toEqual({ role: 'MEMBER', customRoleId: 'role-1' });
+  });
+
+  it('reports a drive owner as OWNER and never looks for a custom role', async () => {
+    vi.mocked(getUserDrivePermissions).mockResolvedValue({ hasAccess: true, isOwner: true, isAdmin: false, isMember: false, canEdit: true });
+    await expect(getPrincipalDriveMembership(sessionAuth, DRIVE_ID)).resolves.toEqual({ role: 'OWNER', customRoleId: null });
+    expect(getMemberCustomRoleId).not.toHaveBeenCalled();
+  });
+
+  it('returns null for a user with no drive access', async () => {
+    vi.mocked(getUserDrivePermissions).mockResolvedValue(null);
+    await expect(getPrincipalDriveMembership(sessionAuth, DRIVE_ID)).resolves.toBeNull();
   });
 });

--- a/apps/web/src/lib/auth/index.ts
+++ b/apps/web/src/lib/auth/index.ts
@@ -942,6 +942,8 @@ export {
   getPrincipalDriveIds,
   getPrincipalAccessiblePagesInDrive,
   getPrincipalBatchPagePermissions,
+  getPrincipalDriveAccessLevel,
+  getPrincipalDriveMembership,
 } from './principal-permissions';
 export { verifyAuth, verifyAdminAuth, isAdminAuthError, withAdminAuth, type VerifiedUser, type AdminRouteContext } from './auth';
 export { validateCSRF } from './csrf-validation';

--- a/apps/web/src/lib/auth/principal-permissions.ts
+++ b/apps/web/src/lib/auth/principal-permissions.ts
@@ -31,18 +31,22 @@ import {
   getDriveIdsForUser,
   getUserAccessiblePagesInDriveWithDetails,
   getBatchPagePermissions,
+  getUserDrivePermissions,
   type PermissionLevel,
   type PageWithPermissions,
 } from '@pagespace/lib/permissions/permissions';
+import { getMemberCustomRoleId } from '@pagespace/lib/permissions/membership-queries';
 import { db } from '@pagespace/db/db';
 import { eq } from '@pagespace/db/operators';
 import { pages } from '@pagespace/db/schema/core';
 import {
   getAppAccessLevel,
+  getAppDriveAccessLevel,
   getAppDriveMembership,
   getAppAccessiblePagesInDrive,
   hasAppDriveMembership,
   getScopedAccessLevel,
+  getScopedDriveAccessLevel,
   getScopedDriveMembership,
   getScopedAccessiblePagesInDrive,
   hasScopedDriveMembership,
@@ -262,6 +266,73 @@ export async function canManagePageWebhooks(auth: AuthResult, pageId: string): P
   if (!page?.driveId) return false;
 
   return isDriveOwnerOrAdmin(auth.userId, page.driveId);
+}
+
+/**
+ * The principal's DRIVE-level access — the four-flag answer for the drive as a
+ * whole, the same shape `getPrincipalAccessLevel` gives for a page.
+ *
+ * Exists so a credential can be told what it may do without having to find out
+ * by attempting a write and reading the refusal (issue #2470). Every branch
+ * delegates to the resolver the matching content route already authorizes
+ * through — `getAppDriveAccessLevel` for a scoped key, `getScopedDriveAccessLevel`
+ * for a drive-scoped OAuth token, `getUserAccessLevel` (drive-as-root-node) for a
+ * user principal — so what this reports and what a request is actually allowed to
+ * do cannot drift apart. Nothing here computes a permission itself.
+ */
+export async function getPrincipalDriveAccessLevel(
+  auth: AuthResult,
+  driveId: string,
+): Promise<PermissionLevel | null> {
+  auth = resolveDispatchedPrincipal(auth);
+  if (isManageKeysOnly(auth)) return null;
+  if (isScopedMCPAuth(auth)) {
+    return getAppDriveAccessLevel(auth.tokenId, driveId);
+  }
+  if (isScopedOAuthAuth(auth)) {
+    return getScopedDriveAccessLevel(auth.driveScopes, auth.userId, driveId);
+  }
+  return getUserAccessLevel(auth.userId, driveId);
+}
+
+/**
+ * How the principal holds its access in a drive, as granted rather than as
+ * resolved — the input side of {@link getPrincipalDriveAccessLevel}.
+ *
+ * `role: null` means INHERIT for a scoped credential (the key acts as its owner
+ * there); for a USER principal it means no drive-level membership at all. The
+ * two are told apart by the caller having asked for a drive the principal can
+ * reach in the first place — `getPrincipalDriveAccessLevel` returns null for a
+ * drive it cannot reach, which is the check worth branching on.
+ */
+export interface PrincipalDriveMembership {
+  readonly role: 'OWNER' | 'ADMIN' | 'MEMBER' | null;
+  readonly customRoleId: string | null;
+}
+
+export async function getPrincipalDriveMembership(
+  auth: AuthResult,
+  driveId: string,
+): Promise<PrincipalDriveMembership | null> {
+  auth = resolveDispatchedPrincipal(auth);
+  if (isManageKeysOnly(auth)) return null;
+  if (isScopedMCPAuth(auth)) {
+    const membership = await getAppDriveMembership(auth.tokenId, driveId);
+    return membership && { role: membership.role, customRoleId: membership.customRoleId };
+  }
+  if (isScopedOAuthAuth(auth)) {
+    const membership = getScopedDriveMembership(auth.driveScopes, driveId);
+    return membership && { role: membership.role, customRoleId: membership.customRoleId };
+  }
+
+  // User principal: the system role lives on `drive_members.role` (or on the
+  // drive's `ownerId`), which is what getUserDrivePermissions reads. Its result
+  // carries no custom-role id, so that comes from the one query that answers
+  // exactly this — never a second membership lookup written here.
+  const permissions = await getUserDrivePermissions(auth.userId, driveId);
+  if (!permissions?.hasAccess) return null;
+  const role = permissions.isOwner ? 'OWNER' : permissions.isAdmin ? 'ADMIN' : 'MEMBER';
+  return { role, customRoleId: role === 'OWNER' ? null : await getMemberCustomRoleId(driveId, auth.userId) };
 }
 
 /**

--- a/apps/web/src/lib/repositories/session-repository.ts
+++ b/apps/web/src/lib/repositories/session-repository.ts
@@ -158,6 +158,14 @@ export const sessionRepository = {
    * and nothing about the owning USER, since the whole point of keeping
    * `/api/auth/me` closed to mcp_* tokens is that holding a key must not yield
    * the person behind it.
+   *
+   * `isScoped` is deliberately NOT selected. It records what the key was minted
+   * as; whether the key is confined RIGHT NOW is `isDriveScopedPrincipal`, read
+   * off the same `allowedDriveIds` every authorization decision uses. Returning
+   * the stored flag beside a live answer derived from something else would
+   * invite the two to disagree in the response — and the one case where they
+   * could (a scoped key whose drives were all deleted) never reaches any route
+   * at all: `validateMCPToken` fails it closed before authentication succeeds.
    */
   async findMcpTokenSelfById(tokenId: string, userId: string) {
     const token = await db.query.mcpTokens.findFirst({
@@ -168,7 +176,6 @@ export const sessionRepository = {
         tokenPrefix: true,
         createdAt: true,
         lastUsed: true,
-        isScoped: true,
       },
     });
     return token ?? null;

--- a/apps/web/src/lib/repositories/session-repository.ts
+++ b/apps/web/src/lib/repositories/session-repository.ts
@@ -148,6 +148,33 @@ export const sessionRepository = {
   },
 
   /**
+   * The metadata a key needs to describe ITSELF (`GET /api/auth/key`).
+   *
+   * Scoped by `userId` as well as `tokenId` for the same reason
+   * `findMcpTokenByIdAndUser` is: the id comes from a validated credential, so
+   * the owner check can only ever hold — and it stays here so a future caller
+   * that gets its id from somewhere less trustworthy cannot read another
+   * person's key row through this method. Deliberately narrow: no token hash,
+   * and nothing about the owning USER, since the whole point of keeping
+   * `/api/auth/me` closed to mcp_* tokens is that holding a key must not yield
+   * the person behind it.
+   */
+  async findMcpTokenSelfById(tokenId: string, userId: string) {
+    const token = await db.query.mcpTokens.findFirst({
+      where: and(eq(mcpTokens.id, tokenId), eq(mcpTokens.userId, userId)),
+      columns: {
+        id: true,
+        name: true,
+        tokenPrefix: true,
+        createdAt: true,
+        lastUsed: true,
+        isScoped: true,
+      },
+    });
+    return token ?? null;
+  },
+
+  /**
    * Find an MCP token by ID and user (ownership check).
    */
   async findMcpTokenByIdAndUser(

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -2,6 +2,37 @@
 
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## [Unreleased]
+
+### Added
+
+- **`pagespace keys describe`** — reports the credential this invocation would use: its drives, the
+  role granted in each, and the **effective** permissions that role resolves to
+  (view/edit/share/delete). Resolved server-side by the same code that authorizes real requests, so
+  it cannot disagree with them. Drive-level permissions answer the drive-as-root-node question
+  (creating a top-level page, sharing or deleting the drive), where any membership grants edit; a
+  page inside can be strictly narrower, so `--page <pageId>` resolves that page too — a plain
+  `member` key may create at the drive root and still be view-only on a document, which is the
+  "reads fine, every write fails" shape #2470 was about. It is the one `keys` verb a key can run,
+  and it describes only itself — never the other keys you hold. The same summary now closes `keys create` and the
+  `pagespace keys` wizard's Create flow, and it is served as an MCP tool (`tokens.describeSelf`).
+- **`pagespace keys list` shows the role granted on each drive**, including custom roles by name and
+  inherit scopes spelled out, instead of the drive name alone.
+
+### Fixed
+
+- **`pagespace keys list`/`revoke`/`use` and the wizard no longer report a live key as invalidated.**
+  Run under an `mcp_` key, they answered "Static token was invalidated and has no refresh path" —
+  indistinguishable from a revoked key, while that key kept working on every content command. The
+  key-management API only ever accepted a personal login; a key hitting it gets a refusal it can do
+  nothing about. These commands now detect the credential class up front and say so: the key is
+  fine, key management needs `pagespace login`, and `keys describe` is what a key can ask about
+  itself. No round trip, no re-mint. (#2464)
+- **`pagespace roles get <driveId> member` now explains itself.** It answered "not found in this
+  drive", which reads as "no such role" — but `member`/`admin`/`owner` are system roles held per
+  member on the drive membership, not rows in a drive's role list, so that lookup can only ever
+  miss. The error now names where they live and points at `keys describe`. (#2470)
+
 ## [1.7.1] — 2026-08-10
 
 ### Fixed

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -53,6 +53,10 @@ The model behind those four commands:
   `pagespace keys use --off` deactivates it.
 - **`pagespace mcp` is deliberately excluded** from the active key — MCP configs name their
   credential explicitly so they stay portable and self-describing (see below).
+- **A key can describe itself, but cannot manage keys.** `pagespace keys describe` reports the
+  credential in use — drives, role, and the permissions it actually resolves to — and works
+  under a key. `keys list`/`revoke`/`use` and the wizard manage the whole set of keys you hold,
+  so they need your login and refuse a key outright rather than failing halfway through.
 
 No browser on this machine (CI, container, remote box)? `pagespace login --device` prints a
 short code and URL you approve from any browser. Keys are different — their consent redirect
@@ -78,7 +82,8 @@ trust boundary.
 | `pagespace keys` | Interactive wizard: create, list, **edit** (re-scope in place, same secret), **set active**, and revoke keys. Needs a real terminal; in scripts use the subcommands below. |
 | `pagespace keys create --drive <id> [--role member\|admin\|<customRoleId>] [--drive … --role …] [--name <name>] [--show-token] [--yes]` | Mints a key scoped to the given drive(s) via browser consent, then stores it under `--name` (defaults to the drive id; required for multiple drives; `default` is reserved for your login). `--yes` overwrites an existing key of the same name. |
 | `pagespace keys use <name>` / `pagespace keys use --off` | Makes a stored key this machine's **active key** (browser approval), or deactivates it locally. See above. |
-| `pagespace keys list [--json]` | Lists your keys (prefix only — never the secret). |
+| `pagespace keys list [--json]` | Lists your keys (prefix only — never the secret), with the role granted on each drive. Needs your login — a key cannot list keys; see `keys describe`. |
+| `pagespace keys describe [--page <pageId>] [--json]` | What the credential this machine would use actually is: its drives, the role granted in each, and the **effective** permissions that role resolves to (view/edit/share/delete). Drive-level permissions cover the drive itself (creating a top-level page, sharing or deleting it); a page inside can be narrower, so `--page` resolves that page too. The one `keys` verb a key can run about itself. |
 | `pagespace keys revoke <tokenId> [--yes]` | Revokes a key server-side. Irreversible. |
 
 `--role` binds to the `--drive` immediately before it, not to every `--drive` on the command
@@ -190,7 +195,7 @@ activity  <driveId>
 
 channels  send <channelId> <message>
 
-keys      (no args: guided wizard) · create · use · list · revoke   # see Credentials above
+keys      (no args: guided wizard) · create · use · list · describe · revoke
 
 mcp       serve the MCP stdio server                                # see below
 ```

--- a/packages/cli/src/__tests__/fake-context.ts
+++ b/packages/cli/src/__tests__/fake-context.ts
@@ -56,6 +56,9 @@ export function createFakeContext(overrides: Partial<HandlerContext> = {}): Hand
     stderr: createRecordingSink(),
     env: {},
     credentialStore: createFakeCredentialStore(),
+    // 'login' by default: the ambient credential a human running a command has.
+    // Tests that exercise the scoped-key refusals override it explicitly.
+    credentialKind: 'login',
     activeKeyStore: createFakeActiveKeyStore(),
     isTTY: false,
     prompt: async () => '',

--- a/packages/cli/src/auth/__tests__/credential-kind.test.ts
+++ b/packages/cli/src/auth/__tests__/credential-kind.test.ts
@@ -48,12 +48,29 @@ describe('credentialKindOf', () => {
 describe('keysCommandNeedsLoginMessage', () => {
   // Issue #2464: the message this replaces said the key had been invalidated,
   // which is the one thing that was not true.
-  it('says the key is fine, names the real limitation, and gives a next step', () => {
+  it('refuses without claiming anything about the key, names the real limitation, and gives a next step', () => {
     const message = keysCommandNeedsLoginMessage('list');
-    expect(message).toContain('Your key is not invalid');
+    expect(message).toContain('That says nothing about the key');
     expect(message).not.toMatch(/invalidated|revoked|expired/i);
     expect(message).toContain('pagespace login');
     expect(message).toContain('pagespace keys describe');
+  });
+
+  // Nothing has been validated when this fires — the classification is a
+  // prefix check on a credential no request has been made with, so a revoked
+  // token reaches this branch too. Asserting the key is VALID would swap one
+  // unearned claim for its mirror image.
+  it('never asserts that the key is valid, only that this refusal is not about it', () => {
+    expect(keysCommandNeedsLoginMessage('list')).not.toMatch(/key is (still )?(valid|fine|not invalid|working)/i);
+  });
+
+  // `pagespace login` alone is not enough while the key is still in the
+  // environment: an explicit --token/env credential outranks the stored login
+  // (auth/resolve.ts), so the caller would log in and hit this same refusal.
+  it('tells the caller to remove the overriding credential, not just to log in', () => {
+    const message = keysCommandNeedsLoginMessage('list');
+    expect(message).toMatch(/--token\/env credential removed/);
+    expect(message).toMatch(/outranks/);
   });
 
   it('names the verb the caller actually ran', () => {

--- a/packages/cli/src/auth/__tests__/credential-kind.test.ts
+++ b/packages/cli/src/auth/__tests__/credential-kind.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it } from 'vitest';
+import { credentialKindOf, keysCommandNeedsLoginMessage } from '../credential-kind.js';
+import type { AuthSource } from '../resolve.js';
+
+const OAUTH_CREDENTIAL = {
+  kind: 'oauth' as const,
+  refreshToken: 'ps_rt_x',
+  clientId: 'cli',
+  scopes: ['manage_keys'],
+  createdAt: '2026-08-22T00:00:00.000Z',
+};
+
+const STATIC_CREDENTIAL = {
+  kind: 'static' as const,
+  token: 'mcp_abcdefghijklmnop',
+  scopes: ['drive:d1:member'],
+  createdAt: '2026-08-22T00:00:00.000Z',
+};
+
+describe('credentialKindOf', () => {
+  it('classifies an mcp_ bearer from --token or the env var as a key', () => {
+    for (const kind of ['flag', 'env'] as const) {
+      expect(credentialKindOf({ kind, token: 'mcp_abcdefghijklmnop' } as AuthSource)).toBe('key');
+    }
+  });
+
+  // Never assumed to be a key: pre-emptively refusing something this CLI can't
+  // identify would break a credential class the server might well accept.
+  it('classifies any other bearer as "other" rather than guessing', () => {
+    expect(credentialKindOf({ kind: 'flag', token: 'ps_at_abcdefgh' } as AuthSource)).toBe('other');
+    expect(credentialKindOf({ kind: 'env', token: 'something-else' } as AuthSource)).toBe('other');
+  });
+
+  it('classifies a stored credential by its kind, not by inspecting its secret', () => {
+    expect(credentialKindOf({ kind: 'stored', host: 'h', credential: STATIC_CREDENTIAL })).toBe('key');
+    expect(credentialKindOf({ kind: 'stored', host: 'h', credential: OAUTH_CREDENTIAL })).toBe('login');
+  });
+
+  it('classifies no credential as "none"', () => {
+    expect(credentialKindOf({ kind: 'none', host: 'h' })).toBe('none');
+  });
+
+  it('never returns the token it inspected', () => {
+    expect(credentialKindOf({ kind: 'flag', token: 'mcp_abcdefghijklmnop' } as AuthSource)).not.toContain('mcp_');
+  });
+});
+
+describe('keysCommandNeedsLoginMessage', () => {
+  // Issue #2464: the message this replaces said the key had been invalidated,
+  // which is the one thing that was not true.
+  it('says the key is fine, names the real limitation, and gives a next step', () => {
+    const message = keysCommandNeedsLoginMessage('list');
+    expect(message).toContain('Your key is not invalid');
+    expect(message).not.toMatch(/invalidated|revoked|expired/i);
+    expect(message).toContain('pagespace login');
+    expect(message).toContain('pagespace keys describe');
+  });
+
+  it('names the verb the caller actually ran', () => {
+    expect(keysCommandNeedsLoginMessage('revoke')).toContain('"pagespace keys revoke"');
+  });
+
+  it('reads correctly for the bare wizard, which has no verb', () => {
+    const message = keysCommandNeedsLoginMessage();
+    expect(message).toContain('"pagespace keys"');
+    expect(message).not.toContain('keys "');
+  });
+});

--- a/packages/cli/src/auth/credential-kind.ts
+++ b/packages/cli/src/auth/credential-kind.ts
@@ -55,20 +55,33 @@ export function credentialKindOf(source: AuthSource): CredentialKind {
  * What `pagespace keys <verb>` says when the resolved credential is a scoped
  * key rather than a login.
  *
- * Three things it must do, in order: say the key is FINE (the old message
- * claimed the opposite, and an agent that believes its credential died will
- * throw it away and re-mint for nothing), name the real limitation, and give
- * the command that answers the question the caller probably had. `keys
- * describe` is offered for every verb because "what is this key, and what can
- * it do" is precisely the thing a key CAN ask about itself.
+ * Three things it must do, and one it must NOT.
+ *
+ * It says this refusal is not evidence about the key, names the real
+ * limitation, and gives the commands that get the caller somewhere. What it
+ * deliberately does not say is that the key is VALID: nothing has been
+ * validated at this point — the classification is a prefix check on a
+ * credential no request has yet been made with, so a revoked token would
+ * reach exactly this branch too. The bug being fixed was an unearned claim in
+ * the other direction ("Static token was invalidated"), and replacing it with
+ * an equally unearned claim would only move the lie. `keys describe` is
+ * offered for every verb because it is both the question a key CAN ask about
+ * itself and the call that would actually prove the key still works.
+ *
+ * The login line carries the precedence caveat because without it the advice
+ * misfires in the exact case that motivated this message: `pagespace login`
+ * stores a personal credential, but an explicit `--token`/env credential
+ * outranks it (`auth/resolve.ts`), so an agent with the key still in its
+ * environment would log in and hit this same refusal again.
  */
 export function keysCommandNeedsLoginMessage(verb?: string): string {
   const command = verb === undefined ? 'pagespace keys' : `pagespace keys ${verb}`;
   return (
     `"${command}" needs your personal login, and this invocation resolved a scoped access key.\n` +
-    'Your key is not invalid — key management is simply not something a key can do: a key reads and writes drive ' +
-    'content, while listing, minting and revoking keys is reserved for the person who owns them.\n' +
+    'That says nothing about the key: key management is simply not something a key can do. A key reads and writes ' +
+    'drive content, while listing, minting and revoking keys is reserved for the person who owns them.\n' +
     '  pagespace keys describe   — what THIS key is, and the permissions it actually resolves to\n' +
-    `  pagespace login           — then re-run "${command}"`
+    `  pagespace login           — then re-run "${command}" with the key's --token/env credential removed,\n` +
+    '                              since an explicit credential outranks your stored login.'
   );
 }

--- a/packages/cli/src/auth/credential-kind.ts
+++ b/packages/cli/src/auth/credential-kind.ts
@@ -1,0 +1,74 @@
+/**
+ * What CLASS of credential this invocation resolved — the one question
+ * `AuthSource` already answers but no command could ask without also getting
+ * hold of the secret.
+ *
+ * `keys list`/`revoke`/`use` and the wizard all reach the key-MANAGEMENT API,
+ * which admits only a full-user credential: enumerating or revoking every key
+ * a person holds is not something one scoped key should be able to do to the
+ * others, so `GET/POST/DELETE /api/auth/mcp-tokens` refuse `mcp_` tokens by
+ * design. A scoped key hitting them therefore gets a refusal it can do nothing
+ * about — and, before this, a refusal that said the KEY was invalidated when it
+ * was working fine on every other route (issue #2464).
+ *
+ * The precedent is `whoami`, which faces the same wall at `/api/auth/me` and
+ * answers the honest question for a scoped key instead of asking one the
+ * server will never answer (see `auth/probe-drives.ts`). This module is what
+ * lets the `keys` family do the same: classify first, then say something true.
+ *
+ * PURE, and deliberately secret-free in its OUTPUT — `run.ts` puts only the
+ * resulting label on `HandlerContext`, never the `AuthSource` itself, so a
+ * command cannot reach a bearer token through it.
+ */
+import type { AuthSource } from './resolve.js';
+
+/**
+ * - `key`   — a scoped access key (`mcp_*`), from `--token`/env or a stored
+ *             `static` credential. Reads and writes drive content; cannot
+ *             manage keys.
+ * - `login` — a personal login credential (`pagespace login`), which is what
+ *             the key-management surface wants.
+ * - `other` — a bearer given as `--token`/env that is neither: an OAuth access
+ *             token pasted by hand, or something this CLI has no name for.
+ *             Never assumed to be a key, so it is never pre-emptively refused.
+ * - `none`  — nothing resolved at all.
+ */
+export type CredentialKind = 'key' | 'login' | 'other' | 'none';
+
+/** The wire prefix every scoped access key carries (`apps/web/src/lib/auth/token-prefixes.ts`). */
+const KEY_TOKEN_PREFIX = 'mcp_';
+
+/** Pure: no I/O. Never returns the token it inspected. */
+export function credentialKindOf(source: AuthSource): CredentialKind {
+  switch (source.kind) {
+    case 'flag':
+    case 'env':
+      return source.token.startsWith(KEY_TOKEN_PREFIX) ? 'key' : 'other';
+    case 'stored':
+      return source.credential.kind === 'static' ? 'key' : 'login';
+    case 'none':
+      return 'none';
+  }
+}
+
+/**
+ * What `pagespace keys <verb>` says when the resolved credential is a scoped
+ * key rather than a login.
+ *
+ * Three things it must do, in order: say the key is FINE (the old message
+ * claimed the opposite, and an agent that believes its credential died will
+ * throw it away and re-mint for nothing), name the real limitation, and give
+ * the command that answers the question the caller probably had. `keys
+ * describe` is offered for every verb because "what is this key, and what can
+ * it do" is precisely the thing a key CAN ask about itself.
+ */
+export function keysCommandNeedsLoginMessage(verb?: string): string {
+  const command = verb === undefined ? 'pagespace keys' : `pagespace keys ${verb}`;
+  return (
+    `"${command}" needs your personal login, and this invocation resolved a scoped access key.\n` +
+    'Your key is not invalid — key management is simply not something a key can do: a key reads and writes drive ' +
+    'content, while listing, minting and revoking keys is reserved for the person who owns them.\n' +
+    '  pagespace keys describe   — what THIS key is, and the permissions it actually resolves to\n' +
+    `  pagespace login           — then re-run "${command}"`
+  );
+}

--- a/packages/cli/src/auth/probe-permissions.ts
+++ b/packages/cli/src/auth/probe-permissions.ts
@@ -1,0 +1,43 @@
+/**
+ * Reads back what a JUST-MINTED key can actually do, using the key itself.
+ *
+ * Mint-time is the moment the answer matters most: a key minted `--role member`
+ * looks identical to an admin one until the first write fails, and nothing in
+ * the mint output ever said otherwise (issue #2470). Asking the server with the
+ * new credential — rather than describing the role flags the user just typed —
+ * is what makes this report the permissions that will actually gate requests,
+ * resolved by the same code path those requests go through.
+ *
+ * Same shape and same budget as its neighbour `probe-drives.ts`: one short,
+ * retry-free call built on its own client, so a slow server delays a mint's
+ * closing summary and nothing else. Callers treat a failure as non-fatal — the
+ * key is already minted and stored by the time this runs, and losing the summary
+ * must never read as losing the key.
+ *
+ * Lives HERE rather than beside the `keys` commands for the same reason
+ * `probe-drives.ts` does: a command module may never build its own client
+ * (`commands/__tests__/single-auth-path.test.ts` enforces that structurally, so
+ * every auth path stays the one `run.ts` resolved). A probe that must speak for
+ * a credential `ctx.sdk` is NOT holding — here, the key that was just minted —
+ * is an auth edge, and auth edges live in this directory where they are
+ * reviewed as such.
+ */
+import { PageSpaceClient, StaticTokenProvider, describeSelfKey } from '@pagespace/sdk';
+import type { z } from 'zod';
+
+export type KeyDescription = z.infer<typeof describeSelfKey.outputSchema>;
+
+export type DescribeKeyPermissions = (params: { host: string; accessToken: string }) => Promise<KeyDescription>;
+
+/** Matches `PROBE_DRIVES_TIMEOUT_MS` — this is a closing summary, not a step the mint depends on. */
+export const DESCRIBE_KEY_TIMEOUT_MS = 5_000;
+
+export const describeKeyPermissions: DescribeKeyPermissions = async ({ host, accessToken }) => {
+  const client = new PageSpaceClient({
+    baseUrl: host,
+    auth: new StaticTokenProvider(accessToken),
+    timeoutMs: DESCRIBE_KEY_TIMEOUT_MS,
+    retryPolicy: { maxRetries: 0 },
+  });
+  return client.invoke(describeSelfKey, {});
+};

--- a/packages/cli/src/commands/keys/__tests__/create.test.ts
+++ b/packages/cli/src/commands/keys/__tests__/create.test.ts
@@ -732,6 +732,10 @@ describe('createTokensCreateHandler', () => {
 
     expect(code).toBe(EXIT_SUCCESS);
     expect(stderr.lines.join('')).toMatch(/no raw token to show/i);
+    // The readback says only that it did not happen; the reason is stated once,
+    // by the --show-token line above, not twice back to back.
+    expect(stderr.lines.join('')).toContain('The key was created. Its permissions could not be read back here.');
+    expect(stderr.lines.join('').match(/no raw token/gi)).toHaveLength(1);
     const allOutput = [...stdout.lines, ...stderr.lines].join('');
     expect(allOutput).not.toContain(FIXED_TOKENS.refreshToken);
     expect(allOutput).not.toContain(FIXED_TOKENS.accessToken);

--- a/packages/cli/src/commands/keys/__tests__/create.test.ts
+++ b/packages/cli/src/commands/keys/__tests__/create.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 import { parseScopeList, formatScopeSet } from '@pagespace/lib/auth/oauth/scopes';
 import type { CredentialStore, HostCredential, LoopbackCallback, LoopbackServer } from '@pagespace/cli';
 import { parseArgv } from '../../../argv/parse.js';
@@ -8,6 +8,36 @@ import { credentialSecret } from '../../../credentials/serialize.js';
 import { createFakeContext, createRecordingSink } from '../../../__tests__/fake-context.js';
 import type { DriveScopeArg } from '../args.js';
 import { buildKeyActivateScope, buildKeyUpdateScope, buildTokenScope, createTokensCreateHandler, resolveNewKeyName } from '../create.js';
+
+/**
+ * What `GET /api/auth/key` answers for the key the mint just produced. Stubbed
+ * rather than reaching the network: the mint flow's contract is that it PRINTS
+ * this readback, not that it can resolve permissions itself.
+ */
+const FAKE_KEY_DESCRIPTION = {
+  credential: {
+    type: 'mcp' as const,
+    scoped: true,
+    id: 'key_1',
+    name: 'agent',
+    tokenPrefix: 'mcp_abc12345',
+    createdAt: '2026-07-03T00:00:00.000Z',
+    lastUsed: null,
+  },
+  driveScopes: [
+    {
+      id: 'drv1',
+      name: 'Research',
+      role: 'MEMBER' as const,
+      customRoleId: null,
+      customRoleName: null,
+      roleSource: 'explicit' as const,
+      permissions: { canView: true, canEdit: false, canShare: false, canDelete: false },
+    },
+  ],
+  page: null,
+};
+
 
 function commandIntent(argv: string[]): CommandIntent {
   const parsed = parseArgv(argv);
@@ -395,6 +425,7 @@ function baseHandlerDeps(store: CredentialStore) {
     waitMs: () => new Promise<void>(() => {}),
     exchangeCode: async () => FIXED_TOKENS,
     confirmIdentity: async () => ({ name: 'Ada Lovelace', email: 'ada@example.com' }),
+    describeKeyPermissions: async () => FAKE_KEY_DESCRIPTION,
     requestDeviceAuthorization: async () => DEVICE_AUTHORIZATION,
     pollDeviceToken: async () => ({ kind: 'success' as const, tokens: FIXED_MCP_TOKENS }),
     createIsInterrupted: () => () => false,
@@ -588,6 +619,76 @@ describe('createTokensCreateHandler', () => {
     expect(stdoutText).toContain('PAGESPACE_TOKEN=mcp_raw_secret_1');
     expect(stderr.lines.join('')).toMatch(/shown once/i);
     expect(stderr.lines.join('')).not.toContain('mcp_raw_secret_1');
+  });
+
+  // Issue #2470: the mint used to end at "Created key X, scoped to: …" and
+  // never say what that scope actually resolved to. This block is read back
+  // from the server WITH the new key, so it reports the resolution real
+  // requests will get, not a restatement of the --role flag.
+  it('prints the new key\'s effective permissions, resolved server-side with the key itself', async () => {
+    const fake = fakeServer();
+    const describeKeyPermissions = vi.fn(async () => FAKE_KEY_DESCRIPTION);
+    const handler = createTokensCreateHandler({
+      ...baseHandlerDeps(fakeStore()),
+      startServer: async () => fake.server,
+      openBrowser: autoApprove(fake),
+      exchangeCode: async () => ({ kind: 'mcp' as const, token: 'mcp_raw_secret_1', scope: 'drive:drv1:member offline_access' }),
+      describeKeyPermissions,
+    });
+
+    const stdout = createRecordingSink();
+    const ctx = createFakeContext({ stdout, env: {} });
+
+    const code = await handler(ctx, commandIntent(['keys', 'create', '--drive', 'drv1', '--role', 'member']));
+
+    expect(code).toBe(EXIT_SUCCESS);
+    expect(describeKeyPermissions).toHaveBeenCalledWith({ host: 'https://pagespace.ai', accessToken: 'mcp_raw_secret_1' });
+    const output = stdout.lines.join('');
+    expect(output).toContain('Research');
+    expect(output).toContain('on the drive: view');
+  });
+
+  it('keeps the readback on stderr under --show-token, so stdout stays the one token line', async () => {
+    const fake = fakeServer();
+    const handler = createTokensCreateHandler({
+      ...baseHandlerDeps(fakeStore()),
+      startServer: async () => fake.server,
+      openBrowser: autoApprove(fake),
+      exchangeCode: async () => ({ kind: 'mcp' as const, token: 'mcp_raw_secret_1', scope: 'drive:drv1:member offline_access' }),
+    });
+
+    const stdout = createRecordingSink();
+    const stderr = createRecordingSink();
+    const ctx = createFakeContext({ stdout, stderr, env: {} });
+
+    const code = await handler(ctx, commandIntent(['keys', 'create', '--drive', 'drv1', '--role', 'member', '--show-token']));
+
+    expect(code).toBe(EXIT_SUCCESS);
+    expect(stdout.lines.join('').trim().split('\n')).toEqual(['PAGESPACE_TOKEN=mcp_raw_secret_1']);
+    expect(stderr.lines.join('')).toContain('on the drive: view');
+  });
+
+  it('still reports success when the permission readback fails, and points at "keys describe"', async () => {
+    const fake = fakeServer();
+    const handler = createTokensCreateHandler({
+      ...baseHandlerDeps(fakeStore()),
+      startServer: async () => fake.server,
+      openBrowser: autoApprove(fake),
+      exchangeCode: async () => ({ kind: 'mcp' as const, token: 'mcp_raw_secret_1', scope: 'drive:drv1:member offline_access' }),
+      describeKeyPermissions: async () => {
+        throw new Error('server unreachable');
+      },
+    });
+
+    const stdout = createRecordingSink();
+    const ctx = createFakeContext({ stdout, env: {} });
+
+    // The key is minted and stored before the readback runs, so a probe failure
+    // must never read as the mint having failed.
+    expect(await handler(ctx, commandIntent(['keys', 'create', '--drive', 'drv1', '--role', 'member']))).toBe(EXIT_SUCCESS);
+    const output = stdout.lines.join('');
+    expect(output).toContain('The key was created.');
+    expect(output).toContain('pagespace keys describe');
   });
 
   it('without --show-token the raw mcp_* token appears nowhere in the output', async () => {

--- a/packages/cli/src/commands/keys/__tests__/create.test.ts
+++ b/packages/cli/src/commands/keys/__tests__/create.test.ts
@@ -688,7 +688,11 @@ describe('createTokensCreateHandler', () => {
     expect(await handler(ctx, commandIntent(['keys', 'create', '--drive', 'drv1', '--role', 'member']))).toBe(EXIT_SUCCESS);
     const output = stdout.lines.join('');
     expect(output).toContain('The key was created.');
-    expect(output).toContain('pagespace keys describe');
+    // The pointer is printed once, by the wiring guidance, and names the key —
+    // a bare `keys describe` would be refused by run.ts's credential gate in
+    // exactly the state a user is in right after a mint.
+    expect(output).toContain('pagespace keys describe --key');
+    expect(output.split('pagespace keys describe').length - 1).toBe(1);
   });
 
   it('without --show-token the raw mcp_* token appears nowhere in the output', async () => {

--- a/packages/cli/src/commands/keys/__tests__/describe.test.ts
+++ b/packages/cli/src/commands/keys/__tests__/describe.test.ts
@@ -1,0 +1,261 @@
+import { describe, expect, it, vi } from 'vitest';
+import type { PageSpaceClient } from '@pagespace/sdk';
+import { parseArgv } from '../../../argv/parse.js';
+import type { CommandIntent } from '../../../argv/parse.js';
+import { EXIT_RUNTIME_ERROR, EXIT_SUCCESS, EXIT_USAGE_ERROR } from '../../../exit-codes.js';
+import { createFakeContext, createRecordingSink } from '../../../__tests__/fake-context.js';
+import { keysDescribeHandler, parseKeysDescribeArgs, renderKeyDescription } from '../describe.js';
+
+function commandIntent(argv: string[]): CommandIntent {
+  const parsed = parseArgv(argv);
+  if (parsed.kind !== 'command') throw new Error('expected command');
+  return { ...parsed, args: parsed.args.slice(2) };
+}
+
+function fakeSdk(invoke: ReturnType<typeof vi.fn>): PageSpaceClient {
+  return { invoke } as unknown as PageSpaceClient;
+}
+
+const MEMBER_KEY = {
+  credential: {
+    type: 'mcp' as const,
+    scoped: true,
+    id: 'k1',
+    name: 'lead-gen agent',
+    tokenPrefix: 'mcp_abcdefghijk',
+    createdAt: '2026-08-22T00:00:00.000Z',
+    lastUsed: '2026-08-22T10:00:00.000Z',
+  },
+  driveScopes: [
+    {
+      id: 'd1',
+      name: 'Engineering',
+      role: 'MEMBER' as const,
+      customRoleId: null,
+      customRoleName: null,
+      roleSource: 'explicit' as const,
+      permissions: { canView: true, canEdit: true, canShare: false, canDelete: false },
+    },
+  ],
+  page: null,
+};
+
+describe('renderKeyDescription', () => {
+  // The exact question issue #2470 was left unable to answer: the key read
+  // fine and every write failed, and nothing said why.
+  it('states what the key can do, not only the role it was granted', () => {
+    const output = renderKeyDescription(MEMBER_KEY);
+    expect(output).toContain('role member');
+    expect(output).toContain('on the drive: view edit');
+  });
+
+  // The drive-as-root-node answer grants edit to ANY membership, while a
+  // document inside that drive can still be view-only for the same key — the
+  // "reads fine, every write fails" shape of #2470. An unqualified "can: …"
+  // line would tell an agent it may write to pages it cannot.
+  it('labels the drive-level line for what it covers rather than leaving it bare', () => {
+    expect(renderKeyDescription(MEMBER_KEY)).not.toMatch(/^ +can: /m);
+  });
+
+  it('points at --page when no page was asked about, since a page can be narrower', () => {
+    expect(renderKeyDescription(MEMBER_KEY)).toContain('keys describe --page <pageId>');
+  });
+
+  it('resolves a named page separately from its drive', () => {
+    const output = renderKeyDescription({
+      ...MEMBER_KEY,
+      page: { id: 'pg1', permissions: { canView: true, canEdit: false, canShare: false, canDelete: false } },
+    });
+    expect(output).toContain('on the drive: view edit');
+    expect(output).toContain('Page pg1: view');
+    expect(output).not.toContain('Page pg1: view edit');
+  });
+
+  // "You cannot see this page" and "you may do nothing with this page" are
+  // different answers, and an agent choosing where to write needs both.
+  it('says an unreachable page is out of reach rather than showing it as all-denied', () => {
+    const output = renderKeyDescription({ ...MEMBER_KEY, page: { id: 'pg9', permissions: null } });
+    expect(output).toContain('out of reach');
+    expect(output).not.toContain('nothing (no access here)');
+  });
+
+  it('still answers the --page question when no drive is reachable at all', () => {
+    const output = renderKeyDescription({
+      ...MEMBER_KEY,
+      driveScopes: [],
+      page: { id: 'pg9', permissions: null },
+    });
+    expect(output).toContain('No drives are reachable');
+    expect(output).toContain('Page pg9');
+  });
+
+  it('names the key and its prefix so it can be matched against `keys list`', () => {
+    const output = renderKeyDescription(MEMBER_KEY);
+    expect(output).toContain('lead-gen agent');
+    expect(output).toContain('mcp_abcdefghijk');
+  });
+
+  it('never prints an identity — a key must not yield the person behind it', () => {
+    expect(renderKeyDescription(MEMBER_KEY)).not.toMatch(/@|e-?mail/i);
+  });
+
+  it('spells out an inherit grant instead of showing a blank role', () => {
+    const output = renderKeyDescription({
+      ...MEMBER_KEY,
+      driveScopes: [{ ...MEMBER_KEY.driveScopes[0], role: null, roleSource: 'inherited' as const }],
+    });
+    expect(output).toContain('inherits your own access');
+  });
+
+  it('prints a custom role by name', () => {
+    const output = renderKeyDescription({
+      ...MEMBER_KEY,
+      driveScopes: [
+        {
+          ...MEMBER_KEY.driveScopes[0],
+          role: null,
+          customRoleId: 'r1',
+          customRoleName: 'Researcher',
+          roleSource: 'custom' as const,
+        },
+      ],
+    });
+    expect(output).toContain('custom role "Researcher"');
+  });
+
+  it('says a drive grants nothing rather than printing an empty capability line', () => {
+    const output = renderKeyDescription({
+      ...MEMBER_KEY,
+      driveScopes: [
+        {
+          ...MEMBER_KEY.driveScopes[0],
+          permissions: { canView: false, canEdit: false, canShare: false, canDelete: false },
+        },
+      ],
+    });
+    expect(output).toContain('nothing (no access here)');
+  });
+
+  it('says so out loud when no drive is reachable, instead of showing an empty list', () => {
+    const output = renderKeyDescription({ ...MEMBER_KEY, driveScopes: [] });
+    expect(output).toContain('No drives are reachable');
+  });
+
+  it('describes an unrestricted credential as unrestricted, not as "0 drives"', () => {
+    const output = renderKeyDescription({
+      ...MEMBER_KEY,
+      credential: { ...MEMBER_KEY.credential, scoped: false },
+    });
+    expect(output).toContain('unrestricted');
+  });
+
+  it('omits the key-row fields for a credential that has none (a personal login)', () => {
+    const output = renderKeyDescription({
+      credential: { type: 'oauth', scoped: false, id: null, name: null, tokenPrefix: null, createdAt: null, lastUsed: null },
+      driveScopes: MEMBER_KEY.driveScopes,
+      page: null,
+    });
+    expect(output).toContain('personal login');
+    expect(output).not.toContain('Prefix:');
+    expect(output).not.toContain('Last used:');
+  });
+});
+
+describe('parseKeysDescribeArgs', () => {
+  it('accepts no arguments', () => {
+    expect(parseKeysDescribeArgs([])).toEqual({ ok: true });
+  });
+
+  it('accepts --page <pageId>', () => {
+    expect(parseKeysDescribeArgs(['--page', 'pg1'])).toEqual({ ok: true, pageId: 'pg1' });
+  });
+
+  it.each([['--page'], ['--page', '--json'], ['pg1'], ['--page', 'pg1', 'extra']])(
+    'rejects %j with a usage message',
+    (...rest) => {
+      const result = parseKeysDescribeArgs(rest);
+      expect(result.ok).toBe(false);
+      expect(result.ok === false && result.message).toContain('--page <pageId>');
+    },
+  );
+});
+
+describe('keysDescribeHandler', () => {
+  it('passes --page through to the operation', async () => {
+    const invoke = vi.fn(async () => MEMBER_KEY);
+    const ctx = createFakeContext({ sdk: fakeSdk(invoke) });
+
+    await keysDescribeHandler(ctx, commandIntent(['keys', 'describe', '--page', 'pg1']));
+
+    expect(invoke).toHaveBeenCalledWith(expect.anything(), { pageId: 'pg1' });
+  });
+
+  it('sends no pageId when none was given, rather than an empty one', async () => {
+    const invoke = vi.fn(async () => MEMBER_KEY);
+    const ctx = createFakeContext({ sdk: fakeSdk(invoke) });
+
+    await keysDescribeHandler(ctx, commandIntent(['keys', 'describe']));
+
+    expect(invoke).toHaveBeenCalledWith(expect.anything(), {});
+  });
+
+  it('rejects a malformed flag as a usage error without a round trip', async () => {
+    const invoke = vi.fn();
+    const stderr = createRecordingSink();
+    const ctx = createFakeContext({ stderr, sdk: fakeSdk(invoke) });
+
+    const code = await keysDescribeHandler(ctx, commandIntent(['keys', 'describe', '--page']));
+
+    expect(code).toBe(EXIT_USAGE_ERROR);
+    expect(invoke).not.toHaveBeenCalled();
+  });
+
+  it('renders the server\'s description', async () => {
+    const stdout = createRecordingSink();
+    const ctx = createFakeContext({ stdout, sdk: fakeSdk(vi.fn(async () => MEMBER_KEY)) });
+
+    const code = await keysDescribeHandler(ctx, commandIntent(['keys', 'describe']));
+
+    expect(code).toBe(EXIT_SUCCESS);
+    expect(stdout.lines.join('')).toContain('lead-gen agent');
+  });
+
+  it('emits the raw description as JSON with --json', async () => {
+    const stdout = createRecordingSink();
+    const ctx = createFakeContext({ stdout, sdk: fakeSdk(vi.fn(async () => MEMBER_KEY)) });
+
+    const code = await keysDescribeHandler(ctx, commandIntent(['keys', 'describe', '--json']));
+
+    expect(code).toBe(EXIT_SUCCESS);
+    expect(JSON.parse(stdout.lines.join(''))).toEqual(MEMBER_KEY);
+  });
+
+  // Unlike the management verbs, this one is not refused under a key — it is
+  // the verb a key CAN run about itself.
+  it('runs under a scoped access key', async () => {
+    const invoke = vi.fn(async () => MEMBER_KEY);
+    const ctx = createFakeContext({ sdk: fakeSdk(invoke), credentialKind: 'key' });
+
+    const code = await keysDescribeHandler(ctx, commandIntent(['keys', 'describe']));
+
+    expect(code).toBe(EXIT_SUCCESS);
+    expect(invoke).toHaveBeenCalled();
+  });
+
+  it('exits 1 when the SDK call fails', async () => {
+    const stderr = createRecordingSink();
+    const ctx = createFakeContext({
+      stderr,
+      sdk: fakeSdk(
+        vi.fn(async () => {
+          throw new Error('server unreachable');
+        }),
+      ),
+    });
+
+    const code = await keysDescribeHandler(ctx, commandIntent(['keys', 'describe']));
+
+    expect(code).toBe(EXIT_RUNTIME_ERROR);
+    expect(stderr.lines.join('')).toContain('server unreachable');
+  });
+});

--- a/packages/cli/src/commands/keys/__tests__/describe.test.ts
+++ b/packages/cli/src/commands/keys/__tests__/describe.test.ts
@@ -99,6 +99,36 @@ describe('renderKeyDescription', () => {
     expect(renderKeyDescription(MEMBER_KEY)).not.toMatch(/@|e-?mail/i);
   });
 
+  // `'none'` arises two different ways and the reason is only stated where it
+  // is known. A scoped key reaches nothing through page shares, so borrowing
+  // the unscoped explanation there would be simply false.
+  it('explains a roleless drive by the route that actually produced it', () => {
+    const noneScope = { ...MEMBER_KEY.driveScopes[0], role: null, roleSource: 'none' as const };
+
+    const scoped = renderKeyDescription({ ...MEMBER_KEY, driveScopes: [noneScope] });
+    expect(scoped).toContain("no drive-level role (this key's scope for this drive is gone)");
+    expect(scoped).not.toContain('page shared with you');
+
+    const unscoped = renderKeyDescription({
+      ...MEMBER_KEY,
+      credential: { ...MEMBER_KEY.credential, scoped: false },
+      driveScopes: [noneScope],
+    });
+    expect(unscoped).toContain('no drive-level role (reached through a page shared with you)');
+    expect(unscoped).not.toContain('scope for this drive is gone');
+  });
+
+  it('never calls a roleless drive "inherits your own access", whichever shape it is', () => {
+    for (const scoped of [true, false]) {
+      const output = renderKeyDescription({
+        ...MEMBER_KEY,
+        credential: { ...MEMBER_KEY.credential, scoped },
+        driveScopes: [{ ...MEMBER_KEY.driveScopes[0], role: null, roleSource: 'none' as const }],
+      });
+      expect(output).not.toContain('inherits your own access');
+    }
+  });
+
   it('spells out an inherit grant instead of showing a blank role', () => {
     const output = renderKeyDescription({
       ...MEMBER_KEY,

--- a/packages/cli/src/commands/keys/__tests__/guidance.test.ts
+++ b/packages/cli/src/commands/keys/__tests__/guidance.test.ts
@@ -76,6 +76,20 @@ describe('keysDescribeHint', () => {
     expect(keysDescribeHint('lead-gen')).toContain('pagespace keys describe --key lead-gen');
   });
 
+  // Key names are close to free-form (`resolveNewKeyName` refuses only the
+  // reserved "default"), so an unquoted name with a space printed a command the
+  // shell would mis-split: `--key` took `lead`, and `gen` became a stray
+  // positional the parser rejects. A hint that cannot be pasted is worse than
+  // no hint, because the reader cannot tell it from one that can.
+  it.each([
+    ['lead gen', "--key 'lead gen'"],
+    ["o'brien", "--key 'o'\\''brien'"],
+    ['a$HOME', "--key 'a$HOME'"],
+    ['plain-name_1', '--key plain-name_1'],
+  ])('quotes %j so the printed command survives a shell', (keyName, expected) => {
+    expect(keysDescribeHint(keyName)).toContain(expected);
+  });
+
   it('is printed exactly once per mint, by the wiring guidance', () => {
     const output = renderAgentWiringGuidance({ keyName: 'lead-gen', host: DEFAULT_HOST }).join('\n');
     const occurrences = output.split('pagespace keys describe').length - 1;

--- a/packages/cli/src/commands/keys/__tests__/guidance.test.ts
+++ b/packages/cli/src/commands/keys/__tests__/guidance.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import { DEFAULT_HOST } from '../../../config/resolve.js';
-import { renderAgentWiringGuidance, SHOW_TOKEN_PROMPT, WIZARD_INTRO_HINT } from '../guidance.js';
+import { keysDescribeHint, renderAgentWiringGuidance, SHOW_TOKEN_PROMPT, WIZARD_INTRO_HINT } from '../guidance.js';
 
 function embeddedJson(lines: readonly string[]): unknown {
   const start = lines.indexOf('{');
@@ -61,5 +61,25 @@ describe('wizard copy constants', () => {
 
   it('the show-token prompt warns it is shown once', () => {
     expect(SHOW_TOKEN_PROMPT).toMatch(/won't be shown again/i);
+  });
+});
+
+/**
+ * `keys describe` is the one `keys` verb that is NOT auth-exempt, so it faces
+ * `run.ts`'s explicit-credential gate. With a personal login and no active key
+ * — the state a user is in immediately after `keys create` — a bare
+ * `pagespace keys describe` is refused outright, which made the hint printed by
+ * every mint name a command the reader could not run.
+ */
+describe('keysDescribeHint', () => {
+  it('names the key that was just minted, so the printed command is runnable', () => {
+    expect(keysDescribeHint('lead-gen')).toContain('pagespace keys describe --key lead-gen');
+  });
+
+  it('is printed exactly once per mint, by the wiring guidance', () => {
+    const output = renderAgentWiringGuidance({ keyName: 'lead-gen', host: DEFAULT_HOST }).join('\n');
+    const occurrences = output.split('pagespace keys describe').length - 1;
+    expect(occurrences).toBe(1);
+    expect(output).toContain('--key lead-gen');
   });
 });

--- a/packages/cli/src/commands/keys/__tests__/list.test.ts
+++ b/packages/cli/src/commands/keys/__tests__/list.test.ts
@@ -24,7 +24,7 @@ const TOKENS = [
     lastUsed: null,
     createdAt: '2026-07-01T00:00:00.000Z',
     isScoped: true,
-    driveScopes: [{ id: 'd1', name: 'Engineering' }],
+    driveScopes: [{ id: 'd1', name: 'Engineering', role: 'MEMBER' as const, customRoleId: null, customRoleName: null }],
   },
   {
     id: 't2',
@@ -51,6 +51,80 @@ describe('tokensListHandler', () => {
     expect(output).toContain('mcp_abcdefghijk');
     expect(output).toContain('Full access key');
     expect(output).toContain('Engineering');
+  });
+
+  // Issue #2470: the role was stored, returned by the server, and then thrown
+  // away by the SDK's output schema, so `keys list` could not print what a key
+  // was actually granted.
+  it('names the role granted on each drive, not just the drive', async () => {
+    const invoke = vi.fn(async () => TOKENS);
+    const stdout = createRecordingSink();
+    const ctx = createFakeContext({ stdout, sdk: fakeSdk(invoke) });
+
+    await tokensListHandler(ctx, commandIntent(['keys', 'list']));
+
+    expect(stdout.lines.join('')).toContain('Engineering (member)');
+  });
+
+  it('spells out an inherit scope rather than leaving the role column blank', async () => {
+    const inheriting = [
+      {
+        ...TOKENS[0],
+        driveScopes: [{ id: 'd1', name: 'Engineering', role: null, customRoleId: null, customRoleName: null }],
+      },
+    ];
+    const stdout = createRecordingSink();
+    const ctx = createFakeContext({ stdout, sdk: fakeSdk(vi.fn(async () => inheriting)) });
+
+    await tokensListHandler(ctx, commandIntent(['keys', 'list']));
+
+    expect(stdout.lines.join('')).toContain('Engineering (inherits your access)');
+  });
+
+  it('prints a custom role by name', async () => {
+    const custom = [
+      {
+        ...TOKENS[0],
+        driveScopes: [{ id: 'd1', name: 'Engineering', role: null, customRoleId: 'r1', customRoleName: 'Researcher' }],
+      },
+    ];
+    const stdout = createRecordingSink();
+    const ctx = createFakeContext({ stdout, sdk: fakeSdk(vi.fn(async () => custom)) });
+
+    await tokensListHandler(ctx, commandIntent(['keys', 'list']));
+
+    expect(stdout.lines.join('')).toContain('Engineering (Researcher)');
+  });
+
+  // Issue #2464. The route behind this command refuses mcp_* credentials, and
+  // the SDK turned that refusal into "Static token was invalidated" — a live key
+  // reported dead. Refusing here means the message is true and the round trip
+  // never happens.
+  describe('under a scoped access key', () => {
+    it('refuses without calling the server, and never says the key is invalid', async () => {
+      const invoke = vi.fn(async () => TOKENS);
+      const stderr = createRecordingSink();
+      const ctx = createFakeContext({ stderr, sdk: fakeSdk(invoke), credentialKind: 'key' });
+
+      const code = await tokensListHandler(ctx, commandIntent(['keys', 'list']));
+
+      expect(code).toBe(EXIT_RUNTIME_ERROR);
+      expect(invoke).not.toHaveBeenCalled();
+      const output = stderr.lines.join('');
+      expect(output).toContain('Your key is not invalid');
+      expect(output).not.toMatch(/invalidated/i);
+      expect(output).toContain('pagespace login');
+      expect(output).toContain('pagespace keys describe');
+    });
+
+    it('still runs for a login, an unrecognized bearer, or no credential — only a key is refused', async () => {
+      for (const credentialKind of ['login', 'other', 'none'] as const) {
+        const invoke = vi.fn(async () => TOKENS);
+        const ctx = createFakeContext({ sdk: fakeSdk(invoke), credentialKind });
+        await tokensListHandler(ctx, commandIntent(['keys', 'list']));
+        expect(invoke).toHaveBeenCalled();
+      }
+    });
   });
 
   it('renders an isScoped:false, zero-drive token as "all drives", distinct from an orphaned scoped token', async () => {

--- a/packages/cli/src/commands/keys/__tests__/list.test.ts
+++ b/packages/cli/src/commands/keys/__tests__/list.test.ts
@@ -111,7 +111,7 @@ describe('tokensListHandler', () => {
       expect(code).toBe(EXIT_RUNTIME_ERROR);
       expect(invoke).not.toHaveBeenCalled();
       const output = stderr.lines.join('');
-      expect(output).toContain('Your key is not invalid');
+      expect(output).toContain('That says nothing about the key');
       expect(output).not.toMatch(/invalidated/i);
       expect(output).toContain('pagespace login');
       expect(output).toContain('pagespace keys describe');

--- a/packages/cli/src/commands/keys/__tests__/logic.test.ts
+++ b/packages/cli/src/commands/keys/__tests__/logic.test.ts
@@ -172,7 +172,7 @@ const SAMPLE_KEYS: readonly KeySummary[] = [
     id: 'tok1',
     name: 'CI bot',
     tokenPrefix: 'mcp_abcdefghijk',
-    driveScopes: [{ id: 'drv1', name: 'Engineering' }],
+    driveScopes: [{ id: 'drv1', name: 'Engineering', role: 'MEMBER', customRoleId: null, customRoleName: null }],
     createdAt: '2026-07-01T00:00:00.000Z',
     lastUsed: null,
     isScoped: true,
@@ -192,7 +192,7 @@ describe('renderKeysTable', () => {
   it('renders each key as a short vertical block with date-only timestamps, blank-line separated', () => {
     expect(renderKeysTable(SAMPLE_KEYS)).toEqual([
       'CI bot  mcp_abcdefghijk',
-      '  scopes: Engineering',
+      '  scopes: Engineering (member)',
       '  created 2026-07-01 · last used never',
       '',
       'All-drives key  mcp_zzzzzzzzzzz',
@@ -224,11 +224,11 @@ describe('renderKeysTable', () => {
       name: 'Everything key',
       tokenPrefix: 'mcp_qqqqqqqqqqq',
       driveScopes: [
-        { id: 'drv1', name: 'AIDD Agents' },
-        { id: 'drv2', name: 'PageSpace' },
-        { id: 'drv3', name: 'AI Agent Hub' },
-        { id: 'drv4', name: 'Marketing' },
-        { id: 'drv5', name: 'Engineering' },
+        { id: 'drv1', name: 'AIDD Agents', role: 'ADMIN', customRoleId: null, customRoleName: null },
+        { id: 'drv2', name: 'PageSpace', role: null, customRoleId: null, customRoleName: null },
+        { id: 'drv3', name: 'AI Agent Hub', role: null, customRoleId: 'role1', customRoleName: 'Researcher' },
+        { id: 'drv4', name: 'Marketing', role: 'MEMBER', customRoleId: null, customRoleName: null },
+        { id: 'drv5', name: 'Engineering', role: 'MEMBER', customRoleId: null, customRoleName: null },
       ],
       createdAt: '2026-04-30T16:15:07.553Z',
       lastUsed: '2026-07-06T09:00:00.000Z',
@@ -236,7 +236,7 @@ describe('renderKeysTable', () => {
     };
     expect(renderKeysTable([manyScopes])).toEqual([
       'Everything key  mcp_qqqqqqqqqqq',
-      '  scopes: AIDD Agents, PageSpace, AI Agent Hub +2 more',
+      '  scopes: AIDD Agents (admin), PageSpace (inherits your access), AI Agent Hub (Researcher) +2 more',
       '  created 2026-04-30 · last used 2026-07-06',
     ]);
   });
@@ -249,14 +249,14 @@ describe('renderKeysTable', () => {
 describe('keySelectOptions', () => {
   it('maps keys to select options, hinting their drive scopes', () => {
     expect(keySelectOptions(SAMPLE_KEYS)).toEqual([
-      { value: 'tok1', label: 'CI bot', hint: 'Engineering' },
+      { value: 'tok1', label: 'CI bot', hint: 'Engineering (member)' },
       { value: 'tok2', label: 'All-drives key', hint: 'all drives' },
     ]);
   });
 
   it('prefixes the currently active key\'s hint with "active" when its id is known', () => {
     expect(keySelectOptions(SAMPLE_KEYS, 'tok1')).toEqual([
-      { value: 'tok1', label: 'CI bot', hint: 'active · Engineering' },
+      { value: 'tok1', label: 'CI bot', hint: 'active · Engineering (member)' },
       { value: 'tok2', label: 'All-drives key', hint: 'all drives' },
     ]);
   });

--- a/packages/cli/src/commands/keys/__tests__/revoke.test.ts
+++ b/packages/cli/src/commands/keys/__tests__/revoke.test.ts
@@ -17,6 +17,24 @@ function fakeSdk(invoke: ReturnType<typeof vi.fn>): PageSpaceClient {
 }
 
 describe('tokensRevokeHandler', () => {
+  // Issue #2464: the key-management route refuses mcp_* credentials, and the
+  // SDK reported that refusal as the key having been invalidated.
+  it('refuses under a scoped access key, before the confirmation and without a round trip', async () => {
+    const invoke = vi.fn();
+    const prompt = vi.fn();
+    const stderr = createRecordingSink();
+    const ctx = createFakeContext({ stderr, sdk: fakeSdk(invoke), isTTY: true, prompt, credentialKind: 'key' });
+
+    const code = await tokensRevokeHandler(ctx, commandIntent(['keys', 'revoke', 'tok_1']));
+
+    expect(code).toBe(EXIT_RUNTIME_ERROR);
+    expect(invoke).not.toHaveBeenCalled();
+    expect(prompt).not.toHaveBeenCalled();
+    const output = stderr.lines.join('');
+    expect(output).toContain('Your key is not invalid');
+    expect(output).not.toMatch(/invalidated/i);
+  });
+
   it('rejects a missing tokenId as a usage error without touching the SDK', async () => {
     const invoke = vi.fn();
     const stderr = createRecordingSink();

--- a/packages/cli/src/commands/keys/__tests__/revoke.test.ts
+++ b/packages/cli/src/commands/keys/__tests__/revoke.test.ts
@@ -31,7 +31,7 @@ describe('tokensRevokeHandler', () => {
     expect(invoke).not.toHaveBeenCalled();
     expect(prompt).not.toHaveBeenCalled();
     const output = stderr.lines.join('');
-    expect(output).toContain('Your key is not invalid');
+    expect(output).toContain('That says nothing about the key');
     expect(output).not.toMatch(/invalidated/i);
   });
 

--- a/packages/cli/src/commands/keys/__tests__/use.test.ts
+++ b/packages/cli/src/commands/keys/__tests__/use.test.ts
@@ -245,8 +245,24 @@ describe('createKeysUseHandler — under a scoped access key', () => {
 
     expect(code).toBe(EXIT_RUNTIME_ERROR);
     const output = stderr.lines.join('');
-    expect(output).toContain('Your key is not invalid');
+    expect(output).toContain('That says nothing about the key');
     expect(output).not.toMatch(/invalidated/i);
+  });
+
+  // `--off` is purely local — it clears this machine's active-key map and never
+  // calls the server — so there is nothing for a credential to be insufficient
+  // for. Refusing it would leave whoever runs under a key unable to undo an
+  // activation at all.
+  it('still deactivates with --off, which touches no server at all', async () => {
+    const { deps } = baseDeps(fakeStore({ agent: STATIC_KEY }));
+    const handler = createKeysUseHandler(deps);
+    const activeKeyStore = createFakeActiveKeyStore({ 'https://pagespace.ai': 'agent' });
+    const ctx = createFakeContext({ activeKeyStore, credentialKind: 'key' });
+
+    const code = await handler(ctx, commandIntent(['keys', 'use', '--off']));
+
+    expect(code).toBe(EXIT_SUCCESS);
+    expect(activeKeyStore.entries.has('https://pagespace.ai')).toBe(false);
   });
 });
 

--- a/packages/cli/src/commands/keys/__tests__/use.test.ts
+++ b/packages/cli/src/commands/keys/__tests__/use.test.ts
@@ -8,6 +8,36 @@ import { credentialSecret } from '../../../credentials/serialize.js';
 import { createFakeActiveKeyStore, createFakeContext, createRecordingSink } from '../../../__tests__/fake-context.js';
 import { createKeysUseHandler, findServerTokenId } from '../use.js';
 
+/**
+ * What `GET /api/auth/key` answers for the key the mint just produced. Stubbed
+ * rather than reaching the network: the mint flow's contract is that it PRINTS
+ * this readback, not that it can resolve permissions itself.
+ */
+const FAKE_KEY_DESCRIPTION = {
+  credential: {
+    type: 'mcp' as const,
+    scoped: true,
+    id: 'key_1',
+    name: 'agent',
+    tokenPrefix: 'mcp_abc12345',
+    createdAt: '2026-07-03T00:00:00.000Z',
+    lastUsed: null,
+  },
+  driveScopes: [
+    {
+      id: 'drv1',
+      name: 'Research',
+      role: 'MEMBER' as const,
+      customRoleId: null,
+      customRoleName: null,
+      roleSource: 'explicit' as const,
+      permissions: { canView: true, canEdit: false, canShare: false, canDelete: false },
+    },
+  ],
+  page: null,
+};
+
+
 const HOST = 'https://pagespace.ai';
 
 const STATIC_KEY: HostCredential = {
@@ -127,6 +157,7 @@ function baseDeps(store: CredentialStore, fake = fakeLoopbackServer()) {
       waitMs: () => new Promise<void>(() => {}),
       exchangeCode: async () => ({ kind: 'mcp_activate' as const, tokenId: 'tok1', scope: 'activate_key:tok1' }),
       confirmIdentity: async () => ({ name: 'Ada Lovelace', email: 'ada@example.com' }),
+      describeKeyPermissions: async () => FAKE_KEY_DESCRIPTION,
       requestDeviceAuthorization: async () => {
         throw new Error('device flow not exercised by this test — loopback transport expected');
       },
@@ -197,6 +228,25 @@ describe('createKeysUseHandler — argument validation', () => {
     expect(stderr.lines.join('')).toContain(
       '"default" is a login credential, not an access key — only keys minted by "pagespace keys" can be activated.',
     );
+  });
+});
+
+describe('createKeysUseHandler — under a scoped access key', () => {
+  // Issue #2464: the activation ceremony's server lookup rides the ambient
+  // manage_keys credential, which a key is not — and the refusal came back as
+  // the key having been invalidated.
+  it('refuses before argument parsing and says the key is fine', async () => {
+    const { deps } = baseDeps(fakeStore({ agent: STATIC_KEY }));
+    const handler = createKeysUseHandler(deps);
+    const stderr = createRecordingSink();
+    const ctx = createFakeContext({ stderr, credentialKind: 'key' });
+
+    const code = await handler(ctx, commandIntent(['keys', 'use', 'agent']));
+
+    expect(code).toBe(EXIT_RUNTIME_ERROR);
+    const output = stderr.lines.join('');
+    expect(output).toContain('Your key is not invalid');
+    expect(output).not.toMatch(/invalidated/i);
   });
 });
 

--- a/packages/cli/src/commands/keys/__tests__/wizard.test.ts
+++ b/packages/cli/src/commands/keys/__tests__/wizard.test.ts
@@ -7,6 +7,36 @@ import { EXIT_RUNTIME_ERROR, EXIT_SUCCESS, EXIT_USAGE_ERROR } from '../../../exi
 import { credentialSecret } from '../../../credentials/serialize.js';
 import { createFakeContext, createRecordingSink } from '../../../__tests__/fake-context.js';
 
+/**
+ * What `GET /api/auth/key` answers for the key the mint just produced. Stubbed
+ * rather than reaching the network: the mint flow's contract is that it PRINTS
+ * this readback, not that it can resolve permissions itself.
+ */
+const FAKE_KEY_DESCRIPTION = {
+  credential: {
+    type: 'mcp' as const,
+    scoped: true,
+    id: 'key_1',
+    name: 'agent',
+    tokenPrefix: 'mcp_abc12345',
+    createdAt: '2026-07-03T00:00:00.000Z',
+    lastUsed: null,
+  },
+  driveScopes: [
+    {
+      id: 'drv1',
+      name: 'Research',
+      role: 'MEMBER' as const,
+      customRoleId: null,
+      customRoleName: null,
+      roleSource: 'explicit' as const,
+      permissions: { canView: true, canEdit: false, canShare: false, canDelete: false },
+    },
+  ],
+  page: null,
+};
+
+
 // `vi.mock` factories are hoisted above every top-level `const` in this file,
 // so anything the factory closes over must itself be created via
 // `vi.hoisted` — a plain `const` declared below would still be in its
@@ -113,6 +143,7 @@ function baseMintDeps(store: CredentialStore) {
     waitMs: () => new Promise<void>(() => {}),
     exchangeCode: async () => FIXED_TOKENS,
     confirmIdentity: async () => ({ name: 'Ada Lovelace', email: 'ada@example.com' }),
+    describeKeyPermissions: async () => FAKE_KEY_DESCRIPTION,
     requestDeviceAuthorization: async () => {
       throw new Error('device flow not exercised by this test — loopback transport expected');
     },
@@ -161,6 +192,26 @@ describe('createKeysHandler — non-interactive', () => {
     expect(code).toBe(EXIT_RUNTIME_ERROR);
     expect(stderr.lines.join('')).toContain('keys create');
     expect(introMock).not.toHaveBeenCalled();
+  });
+});
+
+describe('createKeysHandler — under a scoped access key', () => {
+  // Issue #2464: every menu item here reaches the key-management surface, so
+  // the wizard used to open and then fail on its first fetch, claiming the key
+  // had been invalidated.
+  it('refuses before showing any UI at all', async () => {
+    const { createKeysHandler } = await import('../wizard.js');
+    const handler = createKeysHandler(baseMintDeps(fakeStore()));
+    const stderr = createRecordingSink();
+    const ctx = createFakeContext({ stderr, isTTY: true, credentialKind: 'key' });
+
+    const code = await handler(ctx, commandIntent(['keys']));
+
+    expect(code).toBe(EXIT_RUNTIME_ERROR);
+    expect(introMock).not.toHaveBeenCalled();
+    const output = stderr.lines.join('');
+    expect(output).toContain('Your key is not invalid');
+    expect(output).not.toMatch(/invalidated/i);
   });
 });
 
@@ -307,6 +358,39 @@ describe('createKeysHandler — Create flow, mcp-kind mint (the production shape
     const notes = noteMock.mock.calls.map((call) => `${String(call[0])}\n${String(call[1] ?? '')}`);
     expect(notes.some((note) => note.includes('PAGESPACE_TOKEN=mcp_wizard_tok'))).toBe(true);
     expect(notes.some((note) => note.includes('PAGESPACE_KEY') && note.includes('"pagespace"'))).toBe(true);
+    // Issue #2470: the mint used to end without ever saying what the new key
+    // could actually do. This block is read back from the server WITH the new
+    // key, so it reports the resolution that will gate real requests.
+    expect(notes.some((note) => note.includes('What this key can do') && note.includes('on the drive: view'))).toBe(true);
+  });
+
+  it('still completes the mint when the permission readback fails, and points at "keys describe" instead', async () => {
+    selectMock
+      .mockReset()
+      .mockResolvedValueOnce('create')
+      .mockResolvedValueOnce('specific')
+      .mockResolvedValueOnce({ kind: 'member' })
+      .mockResolvedValueOnce('exit');
+    multiselectMock.mockReset().mockResolvedValueOnce(['drv1']);
+    textMock.mockReset().mockResolvedValueOnce('my-key');
+    confirmMock.mockReset().mockResolvedValueOnce(true).mockResolvedValueOnce(false);
+    noteMock.mockReset();
+
+    const { createKeysHandler } = await import('../wizard.js');
+    const { deps, sdk } = mcpCreateHandlerSetup();
+    const handler = createKeysHandler({
+      ...deps,
+      describeKeyPermissions: async () => {
+        throw new Error('server unreachable');
+      },
+    });
+    const ctx = createFakeContext({ sdk, isTTY: true, env: {} });
+
+    // The key is minted and stored before the readback runs — losing the
+    // summary must never read as losing the key.
+    expect(await handler(ctx, commandIntent(['keys']))).toBe(EXIT_SUCCESS);
+    const notes = noteMock.mock.calls.map((call) => `${String(call[0])}\n${String(call[1] ?? '')}`);
+    expect(notes.some((note) => note.includes('pagespace keys describe'))).toBe(true);
   });
 
   it('never surfaces the raw token anywhere when the show-once confirm is declined, but still prints guidance', async () => {

--- a/packages/cli/src/commands/keys/__tests__/wizard.test.ts
+++ b/packages/cli/src/commands/keys/__tests__/wizard.test.ts
@@ -390,7 +390,11 @@ describe('createKeysHandler — Create flow, mcp-kind mint (the production shape
     // summary must never read as losing the key.
     expect(await handler(ctx, commandIntent(['keys']))).toBe(EXIT_SUCCESS);
     const notes = noteMock.mock.calls.map((call) => `${String(call[0])}\n${String(call[1] ?? '')}`);
-    expect(notes.some((note) => note.includes('pagespace keys describe'))).toBe(true);
+    // The failure is named where the summary would have been, and the pointer
+    // appears once, in the wiring note, naming the key.
+    expect(notes.some((note) => note.includes('could not be read back just now'))).toBe(true);
+    expect(notes.filter((note) => note.includes('pagespace keys describe'))).toHaveLength(1);
+    expect(notes.some((note) => note.includes('pagespace keys describe --key my-key'))).toBe(true);
   });
 
   it('never surfaces the raw token anywhere when the show-once confirm is declined, but still prints guidance', async () => {

--- a/packages/cli/src/commands/keys/__tests__/wizard.test.ts
+++ b/packages/cli/src/commands/keys/__tests__/wizard.test.ts
@@ -210,7 +210,7 @@ describe('createKeysHandler — under a scoped access key', () => {
     expect(code).toBe(EXIT_RUNTIME_ERROR);
     expect(introMock).not.toHaveBeenCalled();
     const output = stderr.lines.join('');
-    expect(output).toContain('Your key is not invalid');
+    expect(output).toContain('That says nothing about the key');
     expect(output).not.toMatch(/invalidated/i);
   });
 });

--- a/packages/cli/src/commands/keys/create.ts
+++ b/packages/cli/src/commands/keys/create.ts
@@ -51,7 +51,9 @@ import type {
   WaitMs,
 } from '../../auth/loopback-flow.js';
 import { parseTokensCreateArgs, type CreateTokenArgs, type DriveScopeArg } from './args.js';
-import { renderAgentWiringGuidance } from './guidance.js';
+import { keysDescribeHint, renderAgentWiringGuidance } from './guidance.js';
+import { renderKeyDescription } from './describe.js';
+import { describeKeyPermissions, type DescribeKeyPermissions } from '../../auth/probe-permissions.js';
 
 const RESOURCE_ID_PATTERN = /^[a-z0-9]{1,32}$/;
 
@@ -250,6 +252,12 @@ export interface TokensCreateHandlerDeps {
   readonly waitMs: WaitMs;
   readonly exchangeCode: ExchangeCode;
   readonly confirmIdentity: ConfirmIdentity;
+  /**
+   * Reads the new key's effective permissions back FROM THE SERVER after a
+   * successful mint (see `probe-permissions.ts`). Injected like every other
+   * effect here so the mint flow stays testable without a network.
+   */
+  readonly describeKeyPermissions: DescribeKeyPermissions;
   readonly requestDeviceAuthorization: RequestDeviceAuthorization;
   readonly pollDeviceToken: PollDeviceToken;
   /**
@@ -268,6 +276,40 @@ export interface TokensCreateHandlerDeps {
   readonly now: () => number;
   readonly timeoutMs?: number;
   readonly maxPortAttempts?: number;
+}
+
+/**
+ * The mint's closing "and here is what it can actually do" block.
+ *
+ * Non-fatal by construction: the key is minted and stored before this runs, so
+ * a probe failure costs a summary, never the credential. It says so explicitly
+ * rather than falling silent — an agent reading only the tail of this output
+ * must not be left thinking the mint itself was the thing that went wrong.
+ *
+ * Skipped when there is no raw token to ask with. That branch is the same
+ * anomaly `--show-token` reports (the server returned a refresh credential
+ * instead of a static one); `keys describe` still answers the question, so the
+ * pointer is printed in its place.
+ */
+async function writeEffectivePermissions(params: {
+  readonly info: OutputSink;
+  readonly host: string;
+  readonly token: string | null;
+  readonly describeKeyPermissions: DescribeKeyPermissions;
+}): Promise<void> {
+  const { info, host, token, describeKeyPermissions: describe } = params;
+  if (token === null) {
+    info.write(`${keysDescribeHint()}\n`);
+    return;
+  }
+  try {
+    info.write(`\n${renderKeyDescription(await describe({ host, accessToken: token }))}`);
+  } catch (error) {
+    info.write(
+      `The key was created. Its effective permissions could not be read back just now (${error instanceof Error ? error.message : String(error)}).\n` +
+        `${keysDescribeHint()}\n`,
+    );
+  }
 }
 
 export function createTokensCreateHandler(deps: TokensCreateHandlerDeps): CommandHandler {
@@ -414,6 +456,12 @@ export function createTokensCreateHandler(deps: TokensCreateHandlerDeps): Comman
     }
 
     info.write(`Created key "${keyName}" on ${host}, scoped to: ${scopeResult.driveScope}.\n`);
+    await writeEffectivePermissions({
+      info,
+      host,
+      token: mintedToken,
+      describeKeyPermissions: deps.describeKeyPermissions,
+    });
     if (parsedArgs.args.showToken) {
       if (mintedToken !== null) {
         // The ONLY stdout line in --show-token mode (see `info` above).
@@ -441,6 +489,7 @@ export const tokensCreateHandler: CommandHandler = createTokensCreateHandler({
   waitMs: unrefWaitMs,
   exchangeCode: createExchangeCode(),
   confirmIdentity,
+  describeKeyPermissions,
   requestDeviceAuthorization: createRequestDeviceAuthorization(),
   pollDeviceToken: createPollDeviceToken(),
   // Passed UNCALLED — `runConsent` installs the SIGINT listener only if a

--- a/packages/cli/src/commands/keys/create.ts
+++ b/packages/cli/src/commands/keys/create.ts
@@ -51,7 +51,7 @@ import type {
   WaitMs,
 } from '../../auth/loopback-flow.js';
 import { parseTokensCreateArgs, type CreateTokenArgs, type DriveScopeArg } from './args.js';
-import { keysDescribeHint, renderAgentWiringGuidance } from './guidance.js';
+import { renderAgentWiringGuidance } from './guidance.js';
 import { renderKeyDescription } from './describe.js';
 import { describeKeyPermissions, type DescribeKeyPermissions } from '../../auth/probe-permissions.js';
 
@@ -286,10 +286,9 @@ export interface TokensCreateHandlerDeps {
  * rather than falling silent — an agent reading only the tail of this output
  * must not be left thinking the mint itself was the thing that went wrong.
  *
- * Skipped when there is no raw token to ask with. That branch is the same
- * anomaly `--show-token` reports (the server returned a refresh credential
- * instead of a static one); `keys describe` still answers the question, so the
- * pointer is printed in its place.
+ * Both non-happy branches say only what went wrong. The pointer to
+ * `keys describe` is printed once, by `renderAgentWiringGuidance` at the end of
+ * every mint — repeating it here put the identical sentence on screen twice.
  */
 async function writeEffectivePermissions(params: {
   readonly info: OutputSink;
@@ -299,15 +298,16 @@ async function writeEffectivePermissions(params: {
 }): Promise<void> {
   const { info, host, token, describeKeyPermissions: describe } = params;
   if (token === null) {
-    info.write(`${keysDescribeHint()}\n`);
+    // The same anomaly `--show-token` reports: the server returned a refresh
+    // credential instead of a static one, so there is no bearer to ask with.
+    info.write('The key was created. It returned no raw token, so its permissions could not be read back here.\n');
     return;
   }
   try {
     info.write(`\n${renderKeyDescription(await describe({ host, accessToken: token }))}`);
   } catch (error) {
     info.write(
-      `The key was created. Its effective permissions could not be read back just now (${error instanceof Error ? error.message : String(error)}).\n` +
-        `${keysDescribeHint()}\n`,
+      `The key was created. Its effective permissions could not be read back just now (${error instanceof Error ? error.message : String(error)}).\n`,
     );
   }
 }

--- a/packages/cli/src/commands/keys/create.ts
+++ b/packages/cli/src/commands/keys/create.ts
@@ -298,9 +298,11 @@ async function writeEffectivePermissions(params: {
 }): Promise<void> {
   const { info, host, token, describeKeyPermissions: describe } = params;
   if (token === null) {
-    // The same anomaly `--show-token` reports: the server returned a refresh
-    // credential instead of a static one, so there is no bearer to ask with.
-    info.write('The key was created. It returned no raw token, so its permissions could not be read back here.\n');
+    // Says only that the readback did not happen, not WHY. The cause — the
+    // server returned a refresh credential instead of a static token — is the
+    // `--show-token` branch's line a few lines below, and stating it in both
+    // places put two near-identical sentences back to back.
+    info.write('The key was created. Its permissions could not be read back here.\n');
     return;
   }
   try {

--- a/packages/cli/src/commands/keys/describe.ts
+++ b/packages/cli/src/commands/keys/describe.ts
@@ -62,10 +62,19 @@ function formatPermissions(permissions: DescribedScope['permissions']): string {
   return granted.map((flag) => flag.slice(3).toLowerCase()).join(' ');
 }
 
-/** How the role was arrived at, spelled out — `role: null` means inherit, not "unset". */
+/**
+ * How the grant was arrived at, spelled out — a null role is meaningful, not
+ * "unset", and it means two different things.
+ *
+ * `'none'` is a drive reachable with no drive-level role in it at all: your
+ * drive list includes the drives of pages shared with you, not only drives you
+ * belong to. Calling that "inherits your own access" would read as the opposite
+ * of what the accompanying permissions line says.
+ */
 function formatGrant(scope: DescribedScope): string {
   if (scope.roleSource === 'custom') return `custom role "${scope.customRoleName ?? scope.customRoleId ?? 'unknown'}"`;
   if (scope.roleSource === 'inherited') return 'inherits your own access in this drive';
+  if (scope.roleSource === 'none') return 'no drive-level role (reached through a page shared with you)';
   return `role ${(scope.role ?? 'unknown').toLowerCase()}`;
 }
 

--- a/packages/cli/src/commands/keys/describe.ts
+++ b/packages/cli/src/commands/keys/describe.ts
@@ -1,0 +1,156 @@
+/**
+ * `pagespace keys describe` — what the credential this invocation would use
+ * actually is, and what it is actually allowed to do.
+ *
+ * The question `keys list` cannot answer for a key, and the one an agent needs
+ * most: a key minted `--role member` reads fine and fails every write with
+ * "Write permission required.", and until this command the only way to learn
+ * that was to attempt writes and read the refusals (issue #2470).
+ *
+ * Two properties make this the right shape:
+ *
+ * - It describes ONE credential — the one calling — so it accepts the `mcp_`
+ *   class the key-management routes refuse, without letting a key learn
+ *   anything about the other keys its owner holds.
+ * - The permissions come from the server's own resolver
+ *   (`GET /api/auth/key` → `getPrincipalDriveAccessLevel`), not from reading
+ *   the role string locally. A local reading would be a second permission model,
+ *   and the moment it drifted this command would confidently tell an agent it
+ *   may write while the write path disagreed.
+ *
+ * Deliberately no identity: a key never yields the person behind it (see
+ * `auth/probe-drives.ts`), so there is no name or email here to print.
+ *
+ * Two questions, kept apart on purpose. The per-drive line answers the
+ * DRIVE-level one — creating a top-level page, sharing or deleting the drive —
+ * where any membership at all grants edit. A page can be strictly narrower: a
+ * plain MEMBER may create at the drive root and be view-only on a document
+ * inside it, which is exactly the shape #2470 was filed about. Printing the
+ * drive line as a bare "can: view edit" would reproduce that confusion from the
+ * other side, so it is labelled for what it covers and `--page <pageId>`
+ * resolves the page a caller is actually about to write to.
+ *
+ * The one `keys` verb that is NOT in `run.ts`'s `AUTH_EXEMPT_HANDLERS`, on
+ * purpose. The rest of the family manages keys and so wants the ambient login;
+ * this one reports on whatever credential the CONTENT commands on this machine
+ * would authenticate as, which means it must resolve the same way they do —
+ * including this machine's active key (`pagespace keys use`), which the exempt
+ * verbs deliberately never see.
+ */
+import { describeSelfKey } from '@pagespace/sdk';
+import type { z } from 'zod';
+import { EXIT_RUNTIME_ERROR, EXIT_SUCCESS, EXIT_USAGE_ERROR } from '../../exit-codes.js';
+import type { CommandHandler } from '../../router/router.js';
+
+type KeyDescription = z.infer<typeof describeSelfKey.outputSchema>;
+type DescribedScope = KeyDescription['driveScopes'][number];
+
+const CREDENTIAL_LABELS: Record<KeyDescription['credential']['type'], string> = {
+  mcp: 'access key',
+  oauth: 'personal login',
+  session: 'signed-in session',
+};
+
+/**
+ * The four flags as a readable line. `canDelete` is included even though it is
+ * false for every non-admin grant: a reader checking "may this key delete?"
+ * needs to see the answer, not to infer it from an omission.
+ */
+function formatPermissions(permissions: DescribedScope['permissions']): string {
+  const granted = (['canView', 'canEdit', 'canShare', 'canDelete'] as const).filter((flag) => permissions[flag]);
+  if (granted.length === 0) return 'nothing (no access here)';
+  return granted.map((flag) => flag.slice(3).toLowerCase()).join(' ');
+}
+
+/** How the role was arrived at, spelled out — `role: null` means inherit, not "unset". */
+function formatGrant(scope: DescribedScope): string {
+  if (scope.roleSource === 'custom') return `custom role "${scope.customRoleName ?? scope.customRoleId ?? 'unknown'}"`;
+  if (scope.roleSource === 'inherited') return 'inherits your own access in this drive';
+  return `role ${(scope.role ?? 'unknown').toLowerCase()}`;
+}
+
+export const KEYS_DESCRIBE_USAGE = 'Usage: pagespace keys describe [--page <pageId>]';
+
+export type ParseKeysDescribeArgsResult =
+  | { readonly ok: true; readonly pageId?: string }
+  | { readonly ok: false; readonly message: string };
+
+/** Pure: no I/O. */
+export function parseKeysDescribeArgs(rest: readonly string[]): ParseKeysDescribeArgsResult {
+  if (rest.length === 0) return { ok: true };
+  if (rest.length !== 2 || rest[0] !== '--page') return { ok: false, message: KEYS_DESCRIBE_USAGE };
+  const pageId = rest[1];
+  if (pageId.length === 0 || pageId.startsWith('-')) return { ok: false, message: KEYS_DESCRIBE_USAGE };
+  return { ok: true, pageId };
+}
+
+/** Pure: no I/O. */
+export function renderKeyDescription(description: KeyDescription): string {
+  const { credential, driveScopes } = description;
+  const lines: string[] = [];
+
+  lines.push(`Credential: ${CREDENTIAL_LABELS[credential.type]}${credential.name === null ? '' : ` "${credential.name}"`}`);
+  if (credential.tokenPrefix !== null) {
+    lines.push(`Prefix:     ${credential.tokenPrefix}…`);
+  }
+  if (credential.createdAt !== null) {
+    lines.push(`Created:    ${credential.createdAt}`);
+    lines.push(`Last used:  ${credential.lastUsed ?? 'never'}`);
+  }
+  lines.push(`Scope:      ${credential.scoped ? `${driveScopes.length} drive(s)` : 'unrestricted (every drive you can reach)'}`);
+
+  lines.push('');
+  if (driveScopes.length === 0) {
+    // Reached by a key whose scoped drives were all deleted, and by a
+    // management-only credential. Both are real states, and both need saying
+    // out loud — a bare empty list reads as a display bug.
+    lines.push('No drives are reachable with this credential.');
+  }
+  for (const scope of driveScopes) {
+    lines.push(`${scope.name}  (${scope.id})`);
+    lines.push(`  granted:      ${formatGrant(scope)}`);
+    // Labelled, not bare: this is the drive-as-root-node answer, and an
+    // unqualified "can: view edit" would be read as "I can edit the pages".
+    lines.push(`  on the drive: ${formatPermissions(scope.permissions)}`);
+  }
+
+  // Printed even with no reachable drives — `--page` was still asked, and a
+  // silent omission would read as the flag having been ignored.
+  lines.push('');
+  lines.push(
+    description.page === null
+      ? 'A page inside a drive can be narrower than the drive itself. Check one with "pagespace keys describe --page <pageId>".'
+      : `Page ${description.page.id}: ${
+          description.page.permissions === null
+            ? 'out of reach (another drive, or private to someone else)'
+            : formatPermissions(description.page.permissions)
+        }`,
+  );
+  return `${lines.join('\n')}\n`;
+}
+
+export const keysDescribe: CommandHandler = async (ctx, intent) => {
+  const parsed = parseKeysDescribeArgs(intent.args);
+  if (!parsed.ok) {
+    ctx.stderr.write(`${parsed.message}\n`);
+    return EXIT_USAGE_ERROR;
+  }
+
+  let description: KeyDescription;
+  try {
+    description = await ctx.sdk.invoke(describeSelfKey, parsed.pageId === undefined ? {} : { pageId: parsed.pageId });
+  } catch (error) {
+    ctx.stderr.write(`Failed to describe this credential: ${error instanceof Error ? error.message : String(error)}\n`);
+    return EXIT_RUNTIME_ERROR;
+  }
+
+  if (intent.flags.json) {
+    ctx.stdout.write(`${JSON.stringify(description)}\n`);
+    return EXIT_SUCCESS;
+  }
+
+  ctx.stdout.write(renderKeyDescription(description));
+  return EXIT_SUCCESS;
+};
+
+export const keysDescribeHandler: CommandHandler = keysDescribe;

--- a/packages/cli/src/commands/keys/describe.ts
+++ b/packages/cli/src/commands/keys/describe.ts
@@ -66,15 +66,28 @@ function formatPermissions(permissions: DescribedScope['permissions']): string {
  * How the grant was arrived at, spelled out — a null role is meaningful, not
  * "unset", and it means two different things.
  *
- * `'none'` is a drive reachable with no drive-level role in it at all: your
- * drive list includes the drives of pages shared with you, not only drives you
- * belong to. Calling that "inherits your own access" would read as the opposite
+ * `'none'` is a drive reachable with no drive-level role in it at all, and it
+ * arises two different ways, so the reason is only stated where it is known:
+ *
+ * - unscoped credential → a page shared with you. Your drive list is every
+ *   drive you can reach, which includes the drives of pages shared with you,
+ *   not only drives you belong to.
+ * - scoped key → the scope row for that drive is gone. The drive list came
+ *   from those rows when the key authenticated, so a row that no longer
+ *   resolves was removed in between. A scoped key reaches nothing through page
+ *   shares, so borrowing the other explanation here would be simply false.
+ *
+ * Either way, calling it "inherits your own access" would read as the opposite
  * of what the accompanying permissions line says.
  */
-function formatGrant(scope: DescribedScope): string {
+function formatGrant(scope: DescribedScope, scoped: boolean): string {
   if (scope.roleSource === 'custom') return `custom role "${scope.customRoleName ?? scope.customRoleId ?? 'unknown'}"`;
   if (scope.roleSource === 'inherited') return 'inherits your own access in this drive';
-  if (scope.roleSource === 'none') return 'no drive-level role (reached through a page shared with you)';
+  if (scope.roleSource === 'none') {
+    return scoped
+      ? 'no drive-level role (this key\'s scope for this drive is gone)'
+      : 'no drive-level role (reached through a page shared with you)';
+  }
   return `role ${(scope.role ?? 'unknown').toLowerCase()}`;
 }
 
@@ -117,7 +130,7 @@ export function renderKeyDescription(description: KeyDescription): string {
   }
   for (const scope of driveScopes) {
     lines.push(`${scope.name}  (${scope.id})`);
-    lines.push(`  granted:      ${formatGrant(scope)}`);
+    lines.push(`  granted:      ${formatGrant(scope, credential.scoped)}`);
     // Labelled, not bare: this is the drive-as-root-node answer, and an
     // unqualified "can: view edit" would be read as "I can edit the pages".
     lines.push(`  on the drive: ${formatPermissions(scope.permissions)}`);

--- a/packages/cli/src/commands/keys/describe.ts
+++ b/packages/cli/src/commands/keys/describe.ts
@@ -129,7 +129,7 @@ export function renderKeyDescription(description: KeyDescription): string {
   return `${lines.join('\n')}\n`;
 }
 
-export const keysDescribe: CommandHandler = async (ctx, intent) => {
+export const keysDescribeHandler: CommandHandler = async (ctx, intent) => {
   const parsed = parseKeysDescribeArgs(intent.args);
   if (!parsed.ok) {
     ctx.stderr.write(`${parsed.message}\n`);
@@ -152,5 +152,3 @@ export const keysDescribe: CommandHandler = async (ctx, intent) => {
   ctx.stdout.write(renderKeyDescription(description));
   return EXIT_SUCCESS;
 };
-
-export const keysDescribeHandler: CommandHandler = keysDescribe;

--- a/packages/cli/src/commands/keys/guidance.ts
+++ b/packages/cli/src/commands/keys/guidance.ts
@@ -12,6 +12,20 @@ export const WIZARD_INTRO_HINT =
 
 export const SHOW_TOKEN_PROMPT = "Show the token now for .env/CI use? It won't be shown again.";
 
+/**
+ * The pointer to `keys describe`, printed wherever the effective permissions
+ * themselves could not be shown.
+ *
+ * A key's role is not its capability — `member` means different things in a
+ * drive with custom roles than in one without, and on a private page than on a
+ * channel — so "you granted role X" is not an answer to "what can this key do".
+ * `keys describe` asks the server, which resolves it the same way every content
+ * request will (issue #2470).
+ */
+export function keysDescribeHint(): string {
+  return 'Run "pagespace keys describe" at any time to see this key\'s drives, role and effective permissions.';
+}
+
 export interface AgentWiringGuidanceParams {
   readonly keyName: string;
   readonly host: string;
@@ -61,5 +75,7 @@ export function renderAgentWiringGuidance(params: AgentWiringGuidanceParams): re
     '',
     'For .env or CI (or a different machine), use the raw token instead:',
     `${TOKEN_ENV_VAR_NAME}=mcp_...   (shown once, at mint time only)`,
+    '',
+    keysDescribeHint(),
   ];
 }

--- a/packages/cli/src/commands/keys/guidance.ts
+++ b/packages/cli/src/commands/keys/guidance.ts
@@ -30,7 +30,26 @@ export const SHOW_TOKEN_PROMPT = "Show the token now for .env/CI use? It won't b
  * the reader can actually run.
  */
 export function keysDescribeHint(keyName: string): string {
-  return `Run "pagespace keys describe --key ${keyName}" at any time to see this key's drives, role and effective permissions.`;
+  return `Run "pagespace keys describe --key ${shellQuote(keyName)}" at any time to see this key's drives, role and effective permissions.`;
+}
+
+/**
+ * Makes `value` safe to paste into a shell as one word.
+ *
+ * Key names are close to free-form — `resolveNewKeyName` refuses only the
+ * reserved `"default"` — so `--name "lead gen"` is legal and used to print
+ * `--key lead gen`, where the shell hands `--key` the word `lead` and drops
+ * `gen` into the command as a stray positional. A hint that cannot be pasted is
+ * worse than no hint, since the reader has no way to tell it apart from one
+ * that can.
+ *
+ * Single quotes rather than double: they suppress every expansion, so a name
+ * containing `$`, backticks or `!` is inert. The `'\''` dance is the standard
+ * way to carry a literal single quote through a single-quoted word.
+ */
+function shellQuote(value: string): string {
+  if (/^[A-Za-z0-9._@%+=:,/-]+$/.test(value)) return value;
+  return `'${value.replaceAll("'", `'\\''`)}'`;
 }
 
 export interface AgentWiringGuidanceParams {

--- a/packages/cli/src/commands/keys/guidance.ts
+++ b/packages/cli/src/commands/keys/guidance.ts
@@ -13,17 +13,24 @@ export const WIZARD_INTRO_HINT =
 export const SHOW_TOKEN_PROMPT = "Show the token now for .env/CI use? It won't be shown again.";
 
 /**
- * The pointer to `keys describe`, printed wherever the effective permissions
- * themselves could not be shown.
+ * The pointer to `keys describe`, printed once at the end of a successful mint.
  *
  * A key's role is not its capability — `member` means different things in a
  * drive with custom roles than in one without, and on a private page than on a
  * channel — so "you granted role X" is not an answer to "what can this key do".
  * `keys describe` asks the server, which resolves it the same way every content
  * request will (issue #2470).
+ *
+ * `--key <name>` is load-bearing, not decoration. `keys describe` reports the
+ * credential a CONTENT command would use, so unlike its `keys` siblings it is
+ * not auth-exempt and is subject to `run.ts`'s explicit-credential gate: with
+ * a personal login and no active key — the state a user is in immediately
+ * after `keys create` — a bare `pagespace keys describe` is refused outright.
+ * Naming the key that was just minted is what makes the printed command one
+ * the reader can actually run.
  */
-export function keysDescribeHint(): string {
-  return 'Run "pagespace keys describe" at any time to see this key\'s drives, role and effective permissions.';
+export function keysDescribeHint(keyName: string): string {
+  return `Run "pagespace keys describe --key ${keyName}" at any time to see this key's drives, role and effective permissions.`;
 }
 
 export interface AgentWiringGuidanceParams {
@@ -76,6 +83,9 @@ export function renderAgentWiringGuidance(params: AgentWiringGuidanceParams): re
     'For .env or CI (or a different machine), use the raw token instead:',
     `${TOKEN_ENV_VAR_NAME}=mcp_...   (shown once, at mint time only)`,
     '',
-    keysDescribeHint(),
+    // The ONE place this sentence is printed. The mint's permission summary
+    // above it already shows the answer inline; repeating the pointer there
+    // (and again here) put the same line on screen twice.
+    keysDescribeHint(params.keyName),
   ];
 }

--- a/packages/cli/src/commands/keys/list.ts
+++ b/packages/cli/src/commands/keys/list.ts
@@ -1,22 +1,36 @@
 /**
  * `pagespace keys list` (Phase 4 task 6). Displays name/prefix/drive
- * scopes/created/lastUsed for each of the caller's MCP tokens — never a
+ * scopes/role/created/lastUsed for each of the caller's MCP tokens — never a
  * full token, which the server doesn't return here in the first place
  * (`listMcpTokens`'s output schema has no `token` field at all).
  *
  * Auth flows only through `ctx.sdk` — see create.ts for why this handler
  * has no auth wiring of its own.
  *
+ * The one thing it does read directly is `ctx.credentialKind`, and only to
+ * refuse. The route behind this command admits a full-user credential only, so
+ * a scoped access key gets a 401 there while working perfectly on every
+ * content route — which the SDK then reported as the KEY being invalidated
+ * (issue #2464). Refusing here means the caller is told what is actually true
+ * instead. Same wall `whoami` hits at `/api/auth/me`, same answer: ask a
+ * question the credential can be asked (`keys describe`).
+ *
  * `tokensList` is exported separately from `tokensListHandler` purely so
  * tests can call the plain function without going through the router.
  */
 import type { z } from 'zod';
 import { listMcpTokens } from '@pagespace/sdk';
+import { keysCommandNeedsLoginMessage } from '../../auth/credential-kind.js';
 import { EXIT_RUNTIME_ERROR, EXIT_SUCCESS } from '../../exit-codes.js';
 import type { CommandHandler } from '../../router/router.js';
-import { describeEmptyDriveScopes } from './logic.js';
+import { describeEmptyDriveScopes, formatDriveScopeGrant } from './logic.js';
 
 export const tokensList: CommandHandler = async (ctx, intent) => {
+  if (ctx.credentialKind === 'key') {
+    ctx.stderr.write(`${keysCommandNeedsLoginMessage('list')}\n`);
+    return EXIT_RUNTIME_ERROR;
+  }
+
   let tokens: z.infer<typeof listMcpTokens.outputSchema>;
   try {
     tokens = await ctx.sdk.invoke(listMcpTokens, {});
@@ -36,9 +50,12 @@ export const tokensList: CommandHandler = async (ctx, intent) => {
   }
 
   for (const token of tokens) {
+    // Each scope carries its own role, so the drive column names both — a key
+    // scoped `member` on one drive and `admin` on another is a real shape, and
+    // one summary role for the whole key would misreport it.
     const scopes =
       token.driveScopes.length > 0
-        ? token.driveScopes.map((drive) => drive.name).join(', ')
+        ? token.driveScopes.map(formatDriveScopeGrant).join(', ')
         : describeEmptyDriveScopes(token.isScoped);
     ctx.stdout.write(
       `${token.name}\t${token.tokenPrefix}\t${scopes}\tcreated ${token.createdAt}\tlast used ${token.lastUsed ?? 'never'}\n`,

--- a/packages/cli/src/commands/keys/logic.ts
+++ b/packages/cli/src/commands/keys/logic.ts
@@ -148,6 +148,15 @@ export function allDrivesDowngradeConfirmMessage(keyName: string, driveCount: nu
 export interface KeyDriveScope {
   readonly id: string;
   readonly name: string;
+  /**
+   * The role granted on THIS drive. `null` is INHERIT — the key acts as its
+   * owner there — which is why every display below spells that out rather than
+   * leaving the column blank: "blank" reads as "unknown", and not knowing what
+   * a key could do is the whole complaint behind issue #2470.
+   */
+  readonly role: 'OWNER' | 'ADMIN' | 'MEMBER' | null;
+  readonly customRoleId: string | null;
+  readonly customRoleName: string | null;
 }
 
 export interface KeySummary {
@@ -182,11 +191,28 @@ export function describeEmptyDriveScopes(isScoped: boolean): string {
   return isScoped ? 'NO ACCESS (orphaned)' : 'all drives';
 }
 
+/**
+ * One drive scope as `name (role)`. A custom role prints by NAME, falling back
+ * to its id when the server didn't resolve one (a role deleted out from under
+ * the key) — printing a bare id would be indistinguishable from a built-in role
+ * name, and printing nothing would hide that the key is scoped by a role at all.
+ *
+ * Grant only, never effective permissions: what MEMBER resolves to depends on
+ * the drive's custom roles and each page's privacy, and that resolution lives
+ * server-side (`pagespace keys describe`). Re-deriving it here from the role
+ * string would be a second permission model that drifts from the one that
+ * actually gates requests.
+ */
+export function formatDriveScopeGrant(scope: KeyDriveScope): string {
+  if (scope.customRoleId !== null) return `${scope.name} (${scope.customRoleName ?? scope.customRoleId})`;
+  return `${scope.name} (${scope.role === null ? 'inherits your access' : scope.role.toLowerCase()})`;
+}
+
 function formatDriveScopeNames(driveScopes: readonly KeyDriveScope[], isScoped: boolean): string {
   if (driveScopes.length === 0) return describeEmptyDriveScopes(isScoped);
-  const visibleNames = driveScopes.slice(0, 3).map((drive) => drive.name);
-  const remaining = driveScopes.length - visibleNames.length;
-  return remaining > 0 ? `${visibleNames.join(', ')} +${remaining} more` : visibleNames.join(', ');
+  const visible = driveScopes.slice(0, 3).map(formatDriveScopeGrant);
+  const remaining = driveScopes.length - visible.length;
+  return remaining > 0 ? `${visible.join(', ')} +${remaining} more` : visible.join(', ');
 }
 
 /** Compact vertical blocks fit inside clack.note's bordered width better than one long row per key. */
@@ -210,7 +236,7 @@ export function keySelectOptions(keys: readonly KeySummary[], activeKeyId: strin
   return keys.map((key) => {
     const scopes =
       key.driveScopes.length > 0
-        ? key.driveScopes.map((drive) => drive.name).join(', ')
+        ? key.driveScopes.map(formatDriveScopeGrant).join(', ')
         : describeEmptyDriveScopes(key.isScoped);
     return {
       value: key.id,
@@ -226,4 +252,4 @@ export function preselectedDriveIds(key: KeySummary): readonly string[] {
 }
 
 export const NON_INTERACTIVE_KEYS_MESSAGE =
-  'pagespace keys requires an interactive terminal. Use "pagespace keys create", "pagespace keys list", "pagespace keys revoke", or "pagespace keys use" instead.';
+  'pagespace keys requires an interactive terminal. Use "pagespace keys create", "pagespace keys list", "pagespace keys describe", "pagespace keys revoke", or "pagespace keys use" instead.';

--- a/packages/cli/src/commands/keys/revoke.ts
+++ b/packages/cli/src/commands/keys/revoke.ts
@@ -15,12 +15,21 @@
  * tests can call the plain function without going through the router.
  */
 import { revokeMcpToken } from '@pagespace/sdk';
+import { keysCommandNeedsLoginMessage } from '../../auth/credential-kind.js';
 import { confirmationFailureMessage, confirmDestructive } from '../../confirm.js';
 import { EXIT_RUNTIME_ERROR, EXIT_SUCCESS, EXIT_USAGE_ERROR } from '../../exit-codes.js';
 import type { CommandHandler } from '../../router/router.js';
 import { parseTokensRevokeArgs } from './args.js';
 
 export const tokensRevoke: CommandHandler = async (ctx, intent) => {
+  // Refused before the confirmation prompt: asking a human to confirm a
+  // revocation this credential can never perform wastes the confirmation, and
+  // the server's refusal used to arrive as "your key was invalidated" (#2464).
+  if (ctx.credentialKind === 'key') {
+    ctx.stderr.write(`${keysCommandNeedsLoginMessage('revoke')}\n`);
+    return EXIT_RUNTIME_ERROR;
+  }
+
   const parsed = parseTokensRevokeArgs(intent.args);
   if (!parsed.ok) {
     ctx.stderr.write(`${parsed.message}\n`);

--- a/packages/cli/src/commands/keys/use.ts
+++ b/packages/cli/src/commands/keys/use.ts
@@ -196,15 +196,6 @@ export async function runActivateCeremony(
 
 export function createKeysUseHandler(deps: TokensCreateHandlerDeps): CommandHandler {
   return async (ctx, intent) => {
-    // Same wall `keys list` hits, same reason: the activation ceremony's server
-    // lookup rides the ambient `manage_keys` credential, which a scoped access
-    // key is not. Refused here so a live key is never reported as invalidated
-    // (issue #2464).
-    if (ctx.credentialKind === 'key') {
-      ctx.stderr.write(`${keysCommandNeedsLoginMessage('use')}\n`);
-      return EXIT_RUNTIME_ERROR;
-    }
-
     const parsed = parseKeysUseArgs(intent.args);
     if (!parsed.ok) {
       ctx.stderr.write(`${parsed.message}\n`);
@@ -226,6 +217,20 @@ export function createKeysUseHandler(deps: TokensCreateHandlerDeps): CommandHand
       }
       ctx.stdout.write(`${deactivationMessage(host)}\n`);
       return EXIT_SUCCESS;
+    }
+
+    // Deliberately AFTER `--off`, which is purely local: it clears this
+    // machine's active-key map and never calls the server, so there is nothing
+    // for a credential to be insufficient for. Refusing it would leave whoever
+    // is running under a key unable to undo an activation at all.
+    //
+    // Activation itself is the same wall `keys list` hits, for the same reason:
+    // its server lookup rides the ambient `manage_keys` credential, which a
+    // scoped access key is not. Refused here so a live key is never reported as
+    // invalidated (issue #2464).
+    if (ctx.credentialKind === 'key') {
+      ctx.stderr.write(`${keysCommandNeedsLoginMessage('use')}\n`);
+      return EXIT_RUNTIME_ERROR;
     }
 
     const { name } = parsed.args;

--- a/packages/cli/src/commands/keys/use.ts
+++ b/packages/cli/src/commands/keys/use.ts
@@ -20,6 +20,7 @@ import { listMcpTokens } from '@pagespace/sdk';
 import type { z } from 'zod';
 import { PAGESPACE_CLI_CLIENT_ID } from '../../auth/client.js';
 import { confirmIdentity } from '../../auth/confirm-identity.js';
+import { keysCommandNeedsLoginMessage } from '../../auth/credential-kind.js';
 import { createDiscoverMetadata } from '../../auth/discover.js';
 import { createExchangeCode } from '../../auth/exchange-code.js';
 import { createLoopbackServer } from '../../auth/create-loopback-server.js';
@@ -39,6 +40,7 @@ import type { HandlerContext } from '../../handler-context.js';
 import type { CommandHandler } from '../../router/router.js';
 import { DEFAULT_LOGIN_TIMEOUT_MS, DEFAULT_MAX_PORT_ATTEMPTS } from '../login.js';
 import { buildKeyActivateScope, type TokensCreateHandlerDeps } from './create.js';
+import { describeKeyPermissions } from '../../auth/probe-permissions.js';
 import { parseKeysUseArgs } from './args.js';
 
 type ServerKeySummaries = z.infer<typeof listMcpTokens.outputSchema>;
@@ -194,6 +196,15 @@ export async function runActivateCeremony(
 
 export function createKeysUseHandler(deps: TokensCreateHandlerDeps): CommandHandler {
   return async (ctx, intent) => {
+    // Same wall `keys list` hits, same reason: the activation ceremony's server
+    // lookup rides the ambient `manage_keys` credential, which a scoped access
+    // key is not. Refused here so a live key is never reported as invalidated
+    // (issue #2464).
+    if (ctx.credentialKind === 'key') {
+      ctx.stderr.write(`${keysCommandNeedsLoginMessage('use')}\n`);
+      return EXIT_RUNTIME_ERROR;
+    }
+
     const parsed = parseKeysUseArgs(intent.args);
     if (!parsed.ok) {
       ctx.stderr.write(`${parsed.message}\n`);
@@ -288,6 +299,7 @@ export const keysUseHandler: CommandHandler = createKeysUseHandler({
   waitMs: unrefWaitMs,
   exchangeCode: createExchangeCode(),
   confirmIdentity,
+  describeKeyPermissions,
   requestDeviceAuthorization: createRequestDeviceAuthorization(),
   pollDeviceToken: createPollDeviceToken(),
   // Passed UNCALLED — see create.ts.

--- a/packages/cli/src/commands/keys/wizard.ts
+++ b/packages/cli/src/commands/keys/wizard.ts
@@ -278,6 +278,12 @@ async function mintScopedKey(
       } catch {
         clack.note(keysDescribeHint(), 'What this key can do');
       }
+    } else {
+      // No raw token to ask with — the same anomaly `--show-token` reports in
+      // `create.ts` (the server returned a refresh credential rather than a
+      // static one). The pointer still has to be printed: falling silent here
+      // would leave the mint with no answer to "what can it do" at all.
+      clack.note(keysDescribeHint(), 'What this key can do');
     }
     clack.note(renderAgentWiringGuidance({ keyName: params.keyName, host: params.host }).join('\n'), 'Wire up an agent');
   } else {

--- a/packages/cli/src/commands/keys/wizard.ts
+++ b/packages/cli/src/commands/keys/wizard.ts
@@ -53,7 +53,7 @@ import { DEFAULT_LOGIN_TIMEOUT_MS, DEFAULT_MAX_PORT_ATTEMPTS } from '../login.js
 import type { DriveScopeArg } from './args.js';
 import { buildKeyUpdateScope, resolveNewKeyName, type TokensCreateHandlerDeps } from './create.js';
 import { findServerTokenId, runActivateCeremony } from './use.js';
-import { keysDescribeHint, renderAgentWiringGuidance, SHOW_TOKEN_PROMPT, WIZARD_INTRO_HINT } from './guidance.js';
+import { renderAgentWiringGuidance, SHOW_TOKEN_PROMPT, WIZARD_INTRO_HINT } from './guidance.js';
 import { renderKeyDescription } from './describe.js';
 import { describeKeyPermissions } from '../../auth/probe-permissions.js';
 import {
@@ -275,15 +275,19 @@ async function mintScopedKey(
       // the choice. Non-fatal: the key is already minted and stored.
       try {
         clack.note(renderKeyDescription(await deps.describeKeyPermissions({ host: params.host, accessToken: token })).trimEnd(), 'What this key can do');
-      } catch {
-        clack.note(keysDescribeHint(), 'What this key can do');
+      } catch (error) {
+        clack.note(
+          `The key was created. Its permissions could not be read back just now (${error instanceof Error ? error.message : String(error)}).`,
+          'What this key can do',
+        );
       }
     } else {
       // No raw token to ask with — the same anomaly `--show-token` reports in
       // `create.ts` (the server returned a refresh credential rather than a
-      // static one). The pointer still has to be printed: falling silent here
-      // would leave the mint with no answer to "what can it do" at all.
-      clack.note(keysDescribeHint(), 'What this key can do');
+      // static one). Said out loud rather than skipped: falling silent leaves
+      // the mint with no answer to "what can it do" at all. The pointer to
+      // `keys describe` follows once, in the wiring note below.
+      clack.note('It returned no raw token, so its permissions could not be read back here.', 'What this key can do');
     }
     clack.note(renderAgentWiringGuidance({ keyName: params.keyName, host: params.host }).join('\n'), 'Wire up an agent');
   } else {

--- a/packages/cli/src/commands/keys/wizard.ts
+++ b/packages/cli/src/commands/keys/wizard.ts
@@ -40,6 +40,7 @@ import { createSigintFlag } from '../../auth/sigint.js';
 import { renderDeviceCodePrompt, runConsent } from '../../auth/run-consent.js';
 import type { ConsentResult } from '../../auth/run-consent.js';
 import type { DeviceAuthorization } from '../../auth/device-flow.js';
+import { keysCommandNeedsLoginMessage } from '../../auth/credential-kind.js';
 import { resolveConfig } from '../../config/resolve.js';
 import { credentialSecret } from '../../credentials/serialize.js';
 import type { HostCredential } from '../../credentials/serialize.js';
@@ -52,7 +53,9 @@ import { DEFAULT_LOGIN_TIMEOUT_MS, DEFAULT_MAX_PORT_ATTEMPTS } from '../login.js
 import type { DriveScopeArg } from './args.js';
 import { buildKeyUpdateScope, resolveNewKeyName, type TokensCreateHandlerDeps } from './create.js';
 import { findServerTokenId, runActivateCeremony } from './use.js';
-import { renderAgentWiringGuidance, SHOW_TOKEN_PROMPT, WIZARD_INTRO_HINT } from './guidance.js';
+import { keysDescribeHint, renderAgentWiringGuidance, SHOW_TOKEN_PROMPT, WIZARD_INTRO_HINT } from './guidance.js';
+import { renderKeyDescription } from './describe.js';
+import { describeKeyPermissions } from '../../auth/probe-permissions.js';
 import {
   allDrivesDowngradeConfirmMessage,
   availableMenuChoices,
@@ -260,10 +263,20 @@ async function mintScopedKey(
 
   if (result.outcome === 'success') {
     s.stop(`Created key "${params.keyName}" on ${params.host}, scoped to: ${params.displayScope ?? params.scope}.`);
-    if (mintedToken !== null) {
+    const token: string | null = mintedToken;
+    if (token !== null) {
       const show = await clack.confirm({ message: SHOW_TOKEN_PROMPT, initialValue: false });
       if (!clack.isCancel(show) && show) {
-        clack.note(`${TOKEN_ENV_VAR_NAME}=${mintedToken}`, 'Copy it now — shown once');
+        clack.note(`${TOKEN_ENV_VAR_NAME}=${token}`, 'Copy it now — shown once');
+      }
+      // Read back with the new key what it can actually do. The role the user
+      // just picked is a grant, not a capability (issue #2470), and this asks
+      // the resolver that will gate every later request rather than restating
+      // the choice. Non-fatal: the key is already minted and stored.
+      try {
+        clack.note(renderKeyDescription(await deps.describeKeyPermissions({ host: params.host, accessToken: token })).trimEnd(), 'What this key can do');
+      } catch {
+        clack.note(keysDescribeHint(), 'What this key can do');
       }
     }
     clack.note(renderAgentWiringGuidance({ keyName: params.keyName, host: params.host }).join('\n'), 'Wire up an agent');
@@ -628,13 +641,22 @@ export function createKeysHandler(deps: TokensCreateHandlerDeps): CommandHandler
     // reporting the unrecognized subcommand.
     if (intent.args.length > 0) {
       ctx.stderr.write(
-        `Unknown "keys" subcommand: ${intent.args.join(' ')}. Did you mean "pagespace keys create", "pagespace keys list", "pagespace keys revoke", or "pagespace keys use"?\n`,
+        `Unknown "keys" subcommand: ${intent.args.join(' ')}. Did you mean "pagespace keys create", "pagespace keys list", "pagespace keys describe", "pagespace keys revoke", or "pagespace keys use"?\n`,
       );
       return EXIT_USAGE_ERROR;
     }
 
     if (!ctx.isTTY) {
       ctx.stderr.write(`${NON_INTERACTIVE_KEYS_MESSAGE}\n`);
+      return EXIT_RUNTIME_ERROR;
+    }
+
+    // Every menu item here (list, edit, revoke, set-active) reaches the
+    // key-management surface, which admits a full-user credential only — so a
+    // scoped access key would open the wizard and then fail on the very first
+    // fetch, historically claiming the key itself was invalidated (#2464).
+    if (ctx.credentialKind === 'key') {
+      ctx.stderr.write(`${keysCommandNeedsLoginMessage()}\n`);
       return EXIT_RUNTIME_ERROR;
     }
 
@@ -693,6 +715,7 @@ export const keysHandler: CommandHandler = createKeysHandler({
   waitMs: unrefWaitMs,
   exchangeCode: createExchangeCode(),
   confirmIdentity,
+  describeKeyPermissions,
   requestDeviceAuthorization: createRequestDeviceAuthorization(),
   pollDeviceToken: createPollDeviceToken(),
   // Passed UNCALLED — see create.ts.

--- a/packages/cli/src/commands/keys/wizard.ts
+++ b/packages/cli/src/commands/keys/wizard.ts
@@ -287,7 +287,7 @@ async function mintScopedKey(
       // static one). Said out loud rather than skipped: falling silent leaves
       // the mint with no answer to "what can it do" at all. The pointer to
       // `keys describe` follows once, in the wiring note below.
-      clack.note('It returned no raw token, so its permissions could not be read back here.', 'What this key can do');
+      clack.note('The key was created. Its permissions could not be read back here — it returned no raw token.', 'What this key can do');
     }
     clack.note(renderAgentWiringGuidance({ keyName: params.keyName, host: params.host }).join('\n'), 'Wire up an agent');
   } else {

--- a/packages/cli/src/handler-context.ts
+++ b/packages/cli/src/handler-context.ts
@@ -1,4 +1,5 @@
 import type { PageSpaceClient } from '@pagespace/sdk';
+import type { CredentialKind } from './auth/credential-kind.js';
 import type { ActiveKeyStore } from './credentials/active-key.js';
 import type { CredentialStore } from './credentials/store.js';
 
@@ -14,6 +15,14 @@ export interface HandlerContext {
   readonly stderr: OutputSink;
   readonly env: Readonly<Record<string, string | undefined>>;
   readonly credentialStore: CredentialStore;
+  /**
+   * What CLASS of credential `ctx.sdk` is authenticating with — a scoped access
+   * key, a personal login, an unrecognized bearer, or nothing. The secret-free
+   * projection of `run.ts`'s resolved `AuthSource`: enough for a command to
+   * refuse accurately BEFORE a round trip the server can only answer with a
+   * refusal (see `auth/credential-kind.ts`), never enough to read a token.
+   */
+  readonly credentialKind: CredentialKind;
   /** The host → active-key-name map (`pagespace keys use`) — read by `whoami`, written by `keys use`. */
   readonly activeKeyStore: ActiveKeyStore;
   /** Whether stdin is an interactive terminal — governs the fail-closed rule for destructive verbs. */

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -340,7 +340,7 @@ export {
 } from './commands/keys/create.js';
 export type { BuildKeyActivateScopeResult, BuildKeyUpdateScopeResult, BuildTokenScopeResult, ResolveNewKeyNameResult, TokensCreateHandlerDeps } from './commands/keys/create.js';
 export { tokensList, tokensListHandler } from './commands/keys/list.js';
-export { keysDescribe, keysDescribeHandler, renderKeyDescription } from './commands/keys/describe.js';
+export { keysDescribeHandler, parseKeysDescribeArgs, renderKeyDescription } from './commands/keys/describe.js';
 export { tokensRevoke, tokensRevokeHandler } from './commands/keys/revoke.js';
 
 // `pagespace keys use` — the per-machine active key (browser-approved

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -295,6 +295,11 @@ export type { ResolveCredentialSourceInput, ResolvedCredentialSource } from './a
 export { PROBE_DRIVES_TIMEOUT_MS, probeDriveCount } from './auth/probe-drives.js';
 export type { ProbeDriveCount } from './auth/probe-drives.js';
 
+// Mint-time readback: what the key just minted can actually do, asked with
+// that key. Same auth-edge shape as the drives probe above.
+export { DESCRIBE_KEY_TIMEOUT_MS, describeKeyPermissions } from './auth/probe-permissions.js';
+export type { DescribeKeyPermissions, KeyDescription } from './auth/probe-permissions.js';
+
 // The transport switch every consent-driven command goes through — loopback
 // browser flow or RFC 8628 device flow — with each transport carrying its own
 // delay adapter (they need opposite ref/unref semantics; see wait.ts).
@@ -302,6 +307,12 @@ export { describeConsentFailure, renderDeviceCodePrompt, runConsent } from './au
 export type { ConsentResult, DeviceConsentDeps, LoopbackConsentDeps, RunConsentParams } from './auth/run-consent.js';
 export { createSigintFlag } from './auth/sigint.js';
 export { parseTokenResponse } from './auth/token-response.js';
+
+// Secret-free classification of the resolved credential, so a command can
+// refuse accurately instead of letting the server answer a question it can
+// only refuse (issue #2464).
+export { credentialKindOf, keysCommandNeedsLoginMessage } from './auth/credential-kind.js';
+export type { CredentialKind } from './auth/credential-kind.js';
 
 export { buildAuthProvider, enforceAuth, FailingAuthProvider } from './auth/auth-context.js';
 export type { BuildAuthProviderDeps, DiscoverTokenEndpoint, EnforceAuthDeps } from './auth/auth-context.js';
@@ -329,6 +340,7 @@ export {
 } from './commands/keys/create.js';
 export type { BuildKeyActivateScopeResult, BuildKeyUpdateScopeResult, BuildTokenScopeResult, ResolveNewKeyNameResult, TokensCreateHandlerDeps } from './commands/keys/create.js';
 export { tokensList, tokensListHandler } from './commands/keys/list.js';
+export { keysDescribe, keysDescribeHandler, renderKeyDescription } from './commands/keys/describe.js';
 export { tokensRevoke, tokensRevokeHandler } from './commands/keys/revoke.js';
 
 // `pagespace keys use` — the per-machine active key (browser-approved

--- a/packages/cli/src/mcp/serve.ts
+++ b/packages/cli/src/mcp/serve.ts
@@ -30,6 +30,7 @@ import {
   deleteTask,
   deleteTaskTrigger,
   deleteWorkflow,
+  describeSelfKey,
   describeSheet,
   editSheetCells,
   exportPageMarkdown,
@@ -111,6 +112,13 @@ import { CLI_VERSION } from '../commands/version.js';
  * MCP tool surface is derived from it mechanically (`listOperations` +
  * `operationToMcpTool`), so drift between "operations the SDK has" and
  * "tools MCP serves" is structurally impossible.
+ *
+ * `tokens.list`/`tokens.revoke` are the two deliberate omissions: key
+ * management is not something an agent's own key should be able to do to the
+ * other keys its owner holds, and the routes behind them refuse `mcp_`
+ * credentials anyway. `describeSelfKey` is here for the opposite reason — an
+ * agent asking what its own credential may do is exactly the question this
+ * surface should be able to answer, and it answers only about itself.
  */
 const ALL_OPERATIONS: readonly Operation[] = [
   appendRows,
@@ -133,6 +141,7 @@ const ALL_OPERATIONS: readonly Operation[] = [
   deleteTask,
   deleteTaskTrigger,
   deleteWorkflow,
+  describeSelfKey,
   describeSheet,
   editSheetCells,
   exportPageMarkdown,

--- a/packages/cli/src/router/routes.ts
+++ b/packages/cli/src/router/routes.ts
@@ -79,6 +79,7 @@ import {
 import { trashListHandler } from '../commands/trash.js';
 import { whoamiHandler } from '../commands/whoami.js';
 import { tokensCreateHandler } from '../commands/keys/create.js';
+import { keysDescribeHandler } from '../commands/keys/describe.js';
 import { tokensListHandler } from '../commands/keys/list.js';
 import { tokensRevokeHandler } from '../commands/keys/revoke.js';
 import { keysUseHandler } from '../commands/keys/use.js';
@@ -104,6 +105,11 @@ const OTHER_ROUTES: readonly RouteEntry[] = [
   { path: ['keys'], handler: keysHandler, summary: 'Guided wizard to create/list/edit/revoke access keys' },
   { path: ['keys', 'create'], handler: tokensCreateHandler, summary: 'Mint a new access key (--device for a headless machine)' },
   { path: ['keys', 'list'], handler: tokensListHandler, summary: 'List access keys' },
+  // The one keys verb a KEY itself can run: it describes the credential this
+  // machine would use, never the other keys its owner holds — so it resolves
+  // like a content command (active key included) rather than riding the
+  // ambient login the management verbs need.
+  { path: ['keys', 'describe'], handler: keysDescribeHandler, summary: "Show this credential's drives, role and effective permissions" },
   { path: ['keys', 'revoke'], handler: tokensRevokeHandler, summary: 'Revoke an access key' },
   { path: ['keys', 'use'], handler: keysUseHandler, summary: "Set this machine's active key (--device for a headless machine)" },
   { path: ['mcp'], handler: mcpHandler, longRunning: true, summary: 'Serve the full operation registry as an MCP stdio server' },

--- a/packages/cli/src/run.ts
+++ b/packages/cli/src/run.ts
@@ -7,6 +7,7 @@
 import { PageSpaceClient } from '@pagespace/sdk';
 import { parseArgv } from './argv/parse.js';
 import { buildAuthProvider, enforceAuth } from './auth/auth-context.js';
+import { credentialKindOf } from './auth/credential-kind.js';
 import { createDiscoverMetadata } from './auth/discover.js';
 import { resolveEnvKeyName, resolveEnvToken } from './auth/legacy-token-env.js';
 import { createRefreshAccessToken } from './auth/silent-refresh.js';
@@ -182,6 +183,7 @@ export async function run(deps: RunDependencies): Promise<ExitCode> {
     stderr: deps.stderr,
     env: deps.env,
     credentialStore: deps.credentialStore,
+    credentialKind: credentialKindOf(source),
     activeKeyStore,
     isTTY: deps.isTTY ?? false,
     prompt: deps.prompt ?? (async () => ''),

--- a/packages/lib/src/services/__tests__/drive-role-service.test.ts
+++ b/packages/lib/src/services/__tests__/drive-role-service.test.ts
@@ -67,6 +67,8 @@ import {
   validateRolePermissions,
   validateDriveWidePermissions,
   mergeRolePermissionsPatch,
+  isSystemRoleName,
+  roleNotFoundMessage,
 } from '../drive-role-service';
 
 type MockFn = ReturnType<typeof vi.fn>;
@@ -576,5 +578,38 @@ describe('drive-role-service', () => {
       mergeRolePermissionsPatch(existing, { 'page-b': { canView: true, canEdit: true, canShare: false } });
       expect(existing).toEqual({ 'page-a': { canView: true, canEdit: false, canShare: false } });
     });
+  });
+});
+
+/**
+ * Issue #2470. `get_drive_role "member"` answered "not found in this drive",
+ * which reads as "that role does not exist" when the truth is that system roles
+ * are not rows here at all and never will be. A caller has no way to act on the
+ * old wording; these lock in that the new one names where they live.
+ */
+describe('roleNotFoundMessage', () => {
+  it('leaves an ordinary missing role id as a plain not-found', () => {
+    expect(roleNotFoundMessage('role_abc')).toBe('Role "role_abc" not found in this drive');
+  });
+
+  it.each(['member', 'admin', 'owner', 'MEMBER', ' Member '])('explains where the system role %j actually lives', (name) => {
+    const message = roleNotFoundMessage(name);
+    expect(message).toMatch(/system role/i);
+    expect(message).toMatch(/drive membership/i);
+    expect(message).toContain('pagespace keys describe');
+    expect(message).not.toBe(`Role "${name}" not found in this drive`);
+  });
+});
+
+describe('isSystemRoleName', () => {
+  it('matches the MemberRole enum values case- and whitespace-insensitively', () => {
+    for (const name of ['owner', 'ADMIN', ' Member ']) {
+      expect(isSystemRoleName(name)).toBe(true);
+    }
+  });
+
+  it('does not match a custom role name that merely contains one', () => {
+    expect(isSystemRoleName('members')).toBe(false);
+    expect(isSystemRoleName('role_admin')).toBe(false);
   });
 });

--- a/packages/lib/src/services/drive-role-service.ts
+++ b/packages/lib/src/services/drive-role-service.ts
@@ -164,6 +164,44 @@ export async function listDriveRoles(driveId: string): Promise<DriveRole[]> {
 }
 
 /**
+ * The `MemberRole` enum values (`packages/db/src/schema/members.ts`), lowercased.
+ *
+ * These are NOT rows in `drive_roles` and have no role id, so every lookup here
+ * — `getRoleById`, `list_drive_roles`, `GET /api/drives/:id/roles/:roleId` —
+ * misses them by construction. An agent that reasonably tried
+ * `get_drive_role "member"` got "not found in this drive", which reads as "that
+ * role does not exist" when the truth is "that role lives somewhere else"
+ * (issue #2470). {@link roleNotFoundMessage} is what every one of those lookups
+ * answers with instead.
+ */
+const SYSTEM_ROLE_NAMES: ReadonlySet<string> = new Set(['owner', 'admin', 'member']);
+
+export function isSystemRoleName(value: string): boolean {
+  return SYSTEM_ROLE_NAMES.has(value.trim().toLowerCase());
+}
+
+/**
+ * The single not-found wording for a drive-role lookup, shared by the REST
+ * route and the AI tool so the two cannot drift.
+ *
+ * For a system-role name it says where those actually live and what to run to
+ * see them, because "not found in this drive" is a dead end the caller has no
+ * way to act on. For anything else it stays the plain not-found it always was.
+ */
+export function roleNotFoundMessage(roleId: string): string {
+  if (!isSystemRoleName(roleId)) {
+    return `Role "${roleId}" not found in this drive`;
+  }
+  return (
+    `"${roleId}" is a system role, not a custom role defined in this drive, so it has no role id and cannot be ` +
+    'fetched here. System roles (OWNER/ADMIN/MEMBER) are held per member on the drive membership itself — list ' +
+    'them with the drive members surface. To see what a specific credential resolves to, describe that credential ' +
+    '("pagespace keys describe"), which reports the role and the effective view/edit/share/delete it grants. ' +
+    'This endpoint lists only the custom roles defined in this drive.'
+  );
+}
+
+/**
  * Get a specific role by ID
  */
 export async function getRoleById(

--- a/packages/sdk/CHANGELOG.md
+++ b/packages/sdk/CHANGELOG.md
@@ -2,6 +2,36 @@
 
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## [Unreleased]
+
+### Added
+
+- **`tokens.describeSelf`** (`GET /api/auth/key`) — describes the credential making the call: its
+  drive scopes, the role granted in each, and the effective `{canView, canEdit, canShare,
+  canDelete}` that role resolves to server-side. Unlike `tokens.list`/`tokens.revoke`, it accepts an
+  `mcp_` token, because a credential describing ITSELF is not the same authority as one enumerating
+  every key its owner holds. Pass `pageId` to also resolve a specific page, which can be strictly
+  narrower than its drive (a `MEMBER` grant edits at the drive root and can be view-only on a
+  document inside it); `page.permissions: null` means the page is out of reach entirely, which is
+  deliberately not the same as all-false. It carries no identity fields — a key still cannot learn
+  who owns it.
+- **`tokens.list` now surfaces each drive scope's `role`, `customRoleId` and `customRoleName`.** The
+  server had always returned them; the output schema didn't declare them, so zod stripped the answer
+  to "what was this key granted" before any consumer saw it. They default to `null` against a server
+  that omits them.
+
+### Fixed
+
+- **A 401 that refuses a credential CLASS no longer surfaces as a dead token.** `AuthProvider` gained
+  an optional `canRefresh`, and `PageSpaceClient` now spends its single auth retry only on a provider
+  that can actually produce a different credential. `StaticTokenProvider` declares `canRefresh:
+  false`: retrying re-sent the identical bearer, and the second pass failed inside the provider, so
+  the provider's "no refresh path" error replaced whatever the server had said — turning
+  "MCP tokens are not permitted for this endpoint" into "Static token was invalidated". The server's
+  own refusal now reaches the caller intact, and `StaticTokenProvider`'s own message no longer claims
+  to know that the token is invalid. **Custom `AuthProvider` implementations need no change** —
+  an omitted `canRefresh` keeps the previous retry behaviour.
+
 ## [2.1.0] — 2026-07-10
 
 ### Changed

--- a/packages/sdk/src/__tests__/client.test.ts
+++ b/packages/sdk/src/__tests__/client.test.ts
@@ -4,6 +4,7 @@ import { AuthenticationError, IncompatibleServerError, NetworkError, TimeoutErro
 import { defineOperation } from '../registry/define.js';
 import { PageSpaceClient } from '../client.js';
 import type { AuthProvider } from '../auth/provider.js';
+import { StaticTokenProvider } from '../auth/static.js';
 import type { RetryPolicy } from '../retry.js';
 
 const API_VERSION = '1.0.0';
@@ -158,6 +159,45 @@ describe('PageSpaceClient — 401 handling', () => {
     await expect(client.invoke(getWidget, { widgetId: 'w1' })).rejects.toBeInstanceOf(AuthenticationError);
     expect(auth.invalidate).toHaveBeenCalledTimes(1);
     expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
+  // Issue #2464. `/api/auth/mcp-tokens` answers a perfectly live mcp_* key with
+  // a 401 that refuses the credential CLASS, not the credential. Retrying a
+  // provider that cannot refresh re-sends the identical bearer, and the second
+  // pass fails INSIDE the provider — so the provider's error replaced the
+  // server's, and a working key was reported dead.
+  it('does not invalidate or retry a 401 for a provider that cannot refresh', async () => {
+    const auth = fakeAuth({ canRefresh: false });
+    const fetchMock = vi.fn(async () => jsonResponse(401, { error: 'MCP tokens are not permitted for this endpoint' }));
+    const client = makeClient({ auth, fetch: fetchMock });
+
+    await expect(client.invoke(getWidget, { widgetId: 'w1' })).rejects.toThrow(
+      'MCP tokens are not permitted for this endpoint',
+    );
+    expect(auth.invalidate).not.toHaveBeenCalled();
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('still retries a provider that declares nothing, so pre-canRefresh providers keep their behaviour', async () => {
+    const auth = fakeAuth();
+    expect(auth.canRefresh).toBeUndefined();
+    const fetchMock = vi.fn(async () => jsonResponse(401, { error: 'expired' }));
+    const client = makeClient({ auth, fetch: fetchMock });
+
+    await expect(client.invoke(getWidget, { widgetId: 'w1' })).rejects.toBeInstanceOf(AuthenticationError);
+    expect(auth.invalidate).toHaveBeenCalledTimes(1);
+  });
+
+  // The end-to-end shape of #2464, with the REAL StaticTokenProvider rather
+  // than a double: the server's own words must be what reaches the caller.
+  it('surfaces the server\'s refusal verbatim through a real StaticTokenProvider', async () => {
+    const fetchMock = vi.fn(async () => jsonResponse(401, { error: 'MCP tokens are not permitted for this endpoint' }));
+    const client = makeClient({ auth: new StaticTokenProvider('mcp_live_key'), fetch: fetchMock });
+
+    await expect(client.invoke(getWidget, { widgetId: 'w1' })).rejects.toThrow(
+      'MCP tokens are not permitted for this endpoint',
+    );
+    expect(fetchMock).toHaveBeenCalledTimes(1);
   });
 });
 

--- a/packages/sdk/src/auth/__tests__/static.test.ts
+++ b/packages/sdk/src/auth/__tests__/static.test.ts
@@ -34,6 +34,20 @@ describe('StaticTokenProvider', () => {
     await expect(provider.getAccessToken()).resolves.toBe(TOKEN);
   });
 
+  // Issue #2464: the client's one auth retry exists to recover an expired token
+  // through a refresh. This provider has none, so retrying re-sends the same
+  // bearer AND loses the server's own refusal to the message above. Declaring
+  // the absence is what keeps the client from spending the retry here.
+  it('declares that it cannot refresh, so the client never spends its auth retry on it', () => {
+    expect(new StaticTokenProvider(TOKEN).canRefresh).toBe(false);
+  });
+
+  it('does not claim the token is invalid — a 401 can be a route refusing the credential class', async () => {
+    const provider = new StaticTokenProvider(TOKEN);
+    provider.invalidate();
+    await expect(provider.getAccessToken()).rejects.toThrow(/does not necessarily mean the token is invalid/i);
+  });
+
   it('never exposes the token through default JSON serialization or string coercion', () => {
     const provider = new StaticTokenProvider(TOKEN);
     expect(JSON.stringify(provider)).not.toContain(TOKEN);

--- a/packages/sdk/src/auth/oauth.ts
+++ b/packages/sdk/src/auth/oauth.ts
@@ -64,6 +64,8 @@ export interface OAuthTokenProviderOptions {
 const DEFAULT_SKEW_MS = 60_000;
 
 export class OAuthTokenProvider implements AuthProvider {
+  /** A refresh grant is exactly what this provider has, so the client's one auth retry is worth spending here. */
+  readonly canRefresh = true;
   #tokens: OAuthTokens;
   #status: 'authenticated' | 'unauthenticated' = 'authenticated';
   readonly #now: () => number;

--- a/packages/sdk/src/auth/provider.ts
+++ b/packages/sdk/src/auth/provider.ts
@@ -12,4 +12,26 @@ export interface AuthProvider {
   getAccessToken(): Promise<string>;
   /** Signals that the last token this provider returned was rejected; discard it. */
   invalidate(): void;
+  /**
+   * Whether `invalidate()` can actually produce a DIFFERENT credential on the
+   * next `getAccessToken()`. `false` means this provider holds one fixed
+   * secret with no refresh grant behind it, so re-sending it after a 401 is
+   * guaranteed to reproduce the same 401.
+   *
+   * The client's single auth retry exists to recover an EXPIRED access token
+   * through a refresh. Running it against a provider that cannot refresh
+   * doesn't just waste a round trip: the second attempt fails inside the
+   * provider, so the provider's own "I have nothing left to give you" error
+   * replaces the server's — which is how a route refusing a credential CLASS
+   * ("MCP tokens are not permitted for this endpoint") used to reach the user
+   * as "Static token was invalidated", reporting a perfectly live key as dead
+   * (issue #2464). Gating the retry on this flag keeps the server's own
+   * refusal intact.
+   *
+   * Optional, and an omitted value is read as `true` — every provider written
+   * before this field existed had a refresh path, and third-party
+   * implementations (and test doubles) keep the historical retry behaviour
+   * without having to declare anything.
+   */
+  readonly canRefresh?: boolean;
 }

--- a/packages/sdk/src/auth/static.ts
+++ b/packages/sdk/src/auth/static.ts
@@ -12,6 +12,15 @@
  * call for the rest of a long-lived process (e.g. an MCP server) even
  * though the token was never actually revoked.
  *
+ * `canRefresh: false` (see AuthProvider) keeps PageSpaceClient's auth retry
+ * away from this provider entirely, so the branch below is now reached only
+ * by a caller that invalidates and retries by hand. That matters because a
+ * 401 does NOT prove the token is dead: `/api/auth/mcp-tokens` answers a
+ * perfectly live mcp_* key with "MCP tokens are not permitted for this
+ * endpoint" — a refusal of the credential CLASS, not of the credential — and
+ * the retry used to overwrite exactly that message with this one (#2464).
+ * The wording below no longer claims to know which it was.
+ *
  * The token is held in a private class field, which util.inspect/JSON.stringify
  * never surface — logging or serializing this provider cannot leak it.
  */
@@ -19,6 +28,7 @@ import { AuthenticationError } from '../errors.js';
 import type { AuthProvider } from './provider.js';
 
 export class StaticTokenProvider implements AuthProvider {
+  readonly canRefresh = false;
   readonly #token: string;
   #invalidated = false;
 
@@ -29,7 +39,11 @@ export class StaticTokenProvider implements AuthProvider {
   async getAccessToken(): Promise<string> {
     if (this.#invalidated) {
       this.#invalidated = false;
-      throw new AuthenticationError('Static token was invalidated and has no refresh path; re-issue a new credential');
+      throw new AuthenticationError(
+        'The last request with this static token was refused, and a static token has no refresh path to retry with. ' +
+          'That refusal does not necessarily mean the token is invalid — an endpoint may simply not accept this ' +
+          'credential type. Check the refusal the server actually returned before re-issuing the credential.',
+      );
     }
     return this.#token;
   }

--- a/packages/sdk/src/client.ts
+++ b/packages/sdk/src/client.ts
@@ -97,7 +97,7 @@ import {
   setTaskTrigger,
   updateTask,
 } from './operations/tasks.js';
-import { listMcpTokens, revokeMcpToken } from './operations/mcp-tokens.js';
+import { describeSelfKey, listMcpTokens, revokeMcpToken } from './operations/mcp-tokens.js';
 import { globSearch, multiDriveSearch, regexSearch } from './operations/search.js';
 import { createWorkflow, deleteWorkflow, listWorkflows, updateWorkflow } from './operations/workflows.js';
 import type { Operation } from './registry/define.js';
@@ -189,6 +189,7 @@ const DEFAULT_OPERATIONS_MAP = {
   tokens: {
     list: listMcpTokens,
     revoke: revokeMcpToken,
+    describeSelf: describeSelfKey,
   },
   search: {
     glob: globSearch,
@@ -425,7 +426,15 @@ export class PageSpaceClient {
         return parsed;
       }
 
-      if (isAuthenticationError(parsed) && !usedAuthRetry) {
+      // One auth retry, and only for a provider that can actually produce a
+      // different credential on the second pass (AuthProvider.canRefresh). A
+      // static token has no refresh grant behind it, so retrying re-sends the
+      // identical bearer for an identical 401 — and the provider's own
+      // "nothing left to give you" error replaces whatever the server said,
+      // which is how a route refusing a credential CLASS surfaced as a dead
+      // key (#2464). Undeclared means `true`: providers written before this
+      // flag existed all had a refresh path.
+      if (isAuthenticationError(parsed) && !usedAuthRetry && this.#auth.canRefresh !== false) {
         usedAuthRetry = true;
         this.#auth.invalidate();
         continue;

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -139,7 +139,7 @@ export { listDriveMembers } from './operations/members.js';
 // MCP tokens (Phase 4 task 6) — CLI `pagespace keys list/revoke`. These require
 // a `ps_at_` OAuth access token (or web session); there is no `tokens.create` —
 // key minting is session-only server-side (OAuth consent flow or web UI).
-export { listMcpTokens, revokeMcpToken } from './operations/mcp-tokens.js';
+export { describeSelfKey, listMcpTokens, revokeMcpToken } from './operations/mcp-tokens.js';
 
 // Pages (Phase 3 task 2) — full pagespace-mcp page.js parity.
 export {

--- a/packages/sdk/src/operations/__tests__/mcp-tokens.test.ts
+++ b/packages/sdk/src/operations/__tests__/mcp-tokens.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { listMcpTokens, revokeMcpToken } from '../mcp-tokens.js';
+import { describeSelfKey, listMcpTokens, revokeMcpToken } from '../mcp-tokens.js';
 
 // There is deliberately no `tokens.create` operation: the server mints keys
 // via session auth only, and no SDK-supported credential (`mcp_` API keys,
@@ -43,6 +43,143 @@ describe('listMcpTokens', () => {
     ]);
     expect(parsed.success).toBe(true);
     expect(parsed.success && (parsed.data[0] as Record<string, unknown>).token).toBeUndefined();
+  });
+
+  // Issue #2470: the server has always returned these three fields
+  // (`sessionRepository.findUserMcpTokensWithDrives`); the schema not declaring
+  // them meant zod stripped the answer to "what can this key do" before the CLI
+  // could print it.
+  it('carries each drive scope\'s role, so `keys list` can show what a key was granted', () => {
+    const parsed = listMcpTokens.outputSchema.safeParse([
+      {
+        id: 't1',
+        name: 'n',
+        tokenPrefix: 'mcp_abcdefghijk',
+        lastUsed: null,
+        createdAt: '2026-07-03T00:00:00.000Z',
+        isScoped: true,
+        driveScopes: [
+          { id: 'd1', name: 'Engineering', role: 'MEMBER', customRoleId: null, customRoleName: null },
+          { id: 'd2', name: 'Research', role: null, customRoleId: 'r1', customRoleName: 'Researcher' },
+        ],
+      },
+    ]);
+    expect(parsed.success).toBe(true);
+    expect(parsed.success && parsed.data[0].driveScopes[0].role).toBe('MEMBER');
+    expect(parsed.success && parsed.data[0].driveScopes[1].customRoleName).toBe('Researcher');
+  });
+
+  // An older server predates the role fields. Defaulting to null keeps that
+  // response parsing rather than failing the whole command on a display detail.
+  it('defaults the role fields to null when an older server omits them', () => {
+    const parsed = listMcpTokens.outputSchema.safeParse([
+      {
+        id: 't1',
+        name: 'n',
+        tokenPrefix: 'mcp_abcdefghijk',
+        lastUsed: null,
+        createdAt: '2026-07-03T00:00:00.000Z',
+        isScoped: true,
+        driveScopes: [{ id: 'd1', name: 'Engineering' }],
+      },
+    ]);
+    expect(parsed.success).toBe(true);
+    expect(parsed.success && parsed.data[0].driveScopes[0]).toEqual({
+      id: 'd1',
+      name: 'Engineering',
+      role: null,
+      customRoleId: null,
+      customRoleName: null,
+    });
+  });
+});
+
+describe('describeSelfKey', () => {
+  it('is a GET addressed at the credential itself, with an optional page to resolve alongside', () => {
+    expect(describeSelfKey.method).toBe('GET');
+    expect(describeSelfKey.path).toBe('/api/auth/key');
+    expect(describeSelfKey.inputSchema.safeParse({}).success).toBe(true);
+    expect(describeSelfKey.inputSchema.safeParse({ pageId: 'p1' }).success).toBe(true);
+  });
+
+  // A drive grants edit to any membership while a document inside it can be
+  // view-only for the same key — the "reads fine, every write fails" shape of
+  // #2470. `page` carries that second answer; `permissions: null` there means
+  // the page is out of reach entirely, which is not the same as all-denied.
+  it('carries an optional page resolution distinct from the drive\'s', () => {
+    const base = {
+      credential: { type: 'mcp', scoped: true, id: 'k1', name: 'a', tokenPrefix: 'mcp_a', createdAt: 'x', lastUsed: null },
+      driveScopes: [],
+    };
+    expect(describeSelfKey.outputSchema.safeParse({ ...base }).success).toBe(true);
+    expect(describeSelfKey.outputSchema.safeParse({ ...base }).data?.page).toBeNull();
+    const resolved = describeSelfKey.outputSchema.safeParse({
+      ...base,
+      page: { id: 'p1', permissions: { canView: true, canEdit: false, canShare: false, canDelete: false } },
+    });
+    expect(resolved.success && resolved.data.page?.permissions?.canEdit).toBe(false);
+    const unreachable = describeSelfKey.outputSchema.safeParse({ ...base, page: { id: 'p1', permissions: null } });
+    expect(unreachable.success && unreachable.data.page?.permissions).toBeNull();
+  });
+
+  it('carries the RESOLVED permissions per drive, not just the granted role', () => {
+    const parsed = describeSelfKey.outputSchema.safeParse({
+      credential: {
+        type: 'mcp',
+        scoped: true,
+        id: 'k1',
+        name: 'agent',
+        tokenPrefix: 'mcp_abcdefghijk',
+        createdAt: '2026-07-03T00:00:00.000Z',
+        lastUsed: null,
+      },
+      driveScopes: [
+        {
+          id: 'd1',
+          name: 'Engineering',
+          role: 'MEMBER',
+          customRoleId: null,
+          customRoleName: null,
+          roleSource: 'explicit',
+          permissions: { canView: true, canEdit: false, canShare: false, canDelete: false },
+        },
+      ],
+    });
+    expect(parsed.success).toBe(true);
+    expect(parsed.success && parsed.data.driveScopes[0].permissions).toEqual({
+      canView: true,
+      canEdit: false,
+      canShare: false,
+      canDelete: false,
+    });
+  });
+
+  // A key must never learn who owns it — `/api/auth/me` refuses mcp_* tokens for
+  // exactly this reason, and this operation must not become the way around it.
+  it('has no identity fields, and strips any a server tried to add', () => {
+    const parsed = describeSelfKey.outputSchema.safeParse({
+      credential: {
+        type: 'mcp',
+        scoped: false,
+        id: null,
+        name: null,
+        tokenPrefix: null,
+        createdAt: null,
+        lastUsed: null,
+        email: 'ada@example.com',
+        userId: 'u1',
+      },
+      driveScopes: [],
+    });
+    expect(parsed.success).toBe(true);
+    const credential = parsed.success ? (parsed.data.credential as Record<string, unknown>) : {};
+    expect(credential.email).toBeUndefined();
+    expect(credential.userId).toBeUndefined();
+  });
+
+  it('is not destructive and declares no required scope — every credential class may ask about itself', () => {
+    expect(describeSelfKey.destructive).toBeUndefined();
+    expect(describeSelfKey.requiredScope).toBeUndefined();
   });
 });
 

--- a/packages/sdk/src/operations/mcp-tokens.ts
+++ b/packages/sdk/src/operations/mcp-tokens.ts
@@ -132,8 +132,14 @@ export const describeSelfKey = defineOperation({
     }),
     driveScopes: z.array(
       driveScopeOutputSchema.extend({
-        /** How `role` was arrived at, since `null` is meaningful rather than missing. */
-        roleSource: z.enum(['explicit', 'custom', 'inherited']),
+        /**
+         * How `role` was arrived at, since `null` is meaningful rather than
+         * missing. `'inherited'` is a scoped credential resolving with its
+         * owner's access; `'none'` is no drive-level role at all — reachable
+         * for a user principal, whose drive list includes the drives of pages
+         * shared with them, not only drives they are a member of.
+         */
+        roleSource: z.enum(['explicit', 'custom', 'inherited', 'none']),
         permissions: effectivePermissionsSchema,
       }),
     ),

--- a/packages/sdk/src/operations/mcp-tokens.ts
+++ b/packages/sdk/src/operations/mcp-tokens.ts
@@ -1,6 +1,14 @@
 /**
  * MCP token management operations (Phase 4 task 6) — registry entries
- * backing `pagespace keys list/revoke`.
+ * backing `pagespace keys list/revoke`, plus the self-description operation
+ * behind `pagespace keys describe`.
+ *
+ * Two different authorities, deliberately kept apart. `tokens.list`/
+ * `tokens.revoke` reach the key-MANAGEMENT surface, which only a full-user
+ * credential may touch — enumerating or revoking every key a person holds is
+ * not something one scoped key should be able to do to the others.
+ * `tokens.describeSelf` asks only about the credential presenting itself, so
+ * it accepts every credential class including `mcp_`.
  *
  * Route-verified against `apps/web/src/app/api/auth/mcp-tokens/route.ts`
  * (GET) and `.../mcp-tokens/[tokenId]/route.ts` (DELETE). The server owns
@@ -31,7 +39,29 @@
 import { z } from 'zod';
 import { defineOperation } from '../registry/define.js';
 
-const driveScopeOutputSchema = z.object({ id: z.string(), name: z.string() });
+/**
+ * The role stored on each `mcp_token_drives` row. `null` is INHERIT — the key
+ * acts as its owner in that drive (see apps/web/src/lib/auth/principal-permissions.ts).
+ * The server has always returned these three fields
+ * (`sessionRepository.findUserMcpTokensWithDrives`); the schema simply never
+ * declared them, so zod's unknown-key stripping discarded the answer to "what
+ * can this key do" before the CLI could print it (issue #2470).
+ */
+const driveScopeOutputSchema = z.object({
+  id: z.string(),
+  name: z.string(),
+  role: z.enum(['OWNER', 'ADMIN', 'MEMBER']).nullable().default(null),
+  customRoleId: z.string().nullable().default(null),
+  customRoleName: z.string().nullable().default(null),
+});
+
+/** The four-flag answer `@pagespace/lib`'s `PermissionLevel` carries, over the wire. */
+const effectivePermissionsSchema = z.object({
+  canView: z.boolean(),
+  canEdit: z.boolean(),
+  canShare: z.boolean(),
+  canDelete: z.boolean(),
+});
 
 export const listMcpTokens = defineOperation({
   name: 'tokens.list',
@@ -51,6 +81,75 @@ export const listMcpTokens = defineOperation({
   ),
   requiredScope: 'account',
   description: "List the caller's MCP tokens. Never includes the plaintext token — only its prefix.",
+});
+
+/**
+ * What THIS credential is and what it can actually do, resolved server-side.
+ *
+ * The counterpart to `tokens.list`, and deliberately not a variant of it: a key
+ * describes ITSELF and never another key, so the route it calls
+ * (`GET /api/auth/key`) can accept the `mcp_` credential class that the
+ * key-MANAGEMENT routes refuse. `driveScopes[].role` is the raw grant;
+ * `driveScopes[].permissions` is the resolved answer — the same
+ * `getAppDriveAccessLevel`/`getScopedDriveAccessLevel`/`getUserAccessLevel`
+ * resolution every content route authorizes through, not a second reading of
+ * the role vocabulary.
+ *
+ * Two different questions, and the difference matters. `driveScopes[].permissions`
+ * answers it for the DRIVE AS A WHOLE — creating a top-level page, sharing or
+ * deleting the drive — where any membership at all grants edit. A PAGE resolves
+ * separately and can be strictly narrower: a plain MEMBER may create at the
+ * drive root and still be view-only on a document inside it, which is exactly
+ * the "reads fine, every write fails" shape issue #2470 was filed about. Pass
+ * `pageId` to get that page's own resolution alongside, so a caller about to
+ * write somewhere specific can ask about that place instead of inferring.
+ *
+ * No identity fields: `/api/auth/me` refuses `mcp_` tokens precisely so that
+ * holding a scoped key never yields its owner's name or email
+ * (packages/cli/src/auth/probe-drives.ts), and this operation must not become
+ * the back door to the same thing.
+ */
+export const describeSelfKey = defineOperation({
+  name: 'tokens.describeSelf',
+  method: 'GET',
+  path: '/api/auth/key',
+  inputSchema: z.strictObject({
+    /** Optional: also resolve this specific page, whose permissions can be narrower than the drive's. */
+    pageId: z.string().optional(),
+  }),
+  outputSchema: z.object({
+    credential: z.object({
+      /** `session` appears only when a first-party surface calls this; the SDK's own credentials are `mcp` or `oauth`. */
+      type: z.enum(['mcp', 'oauth', 'session']),
+      /** Whether the credential is confined to a drive set at all. `false` = it acts as its owner everywhere. */
+      scoped: z.boolean(),
+      /** Present for `mcp` only — an OAuth access token and a session have no key row to name. */
+      id: z.string().nullable(),
+      name: z.string().nullable(),
+      tokenPrefix: z.string().nullable(),
+      createdAt: z.string().nullable(),
+      lastUsed: z.string().nullable(),
+    }),
+    driveScopes: z.array(
+      driveScopeOutputSchema.extend({
+        /** How `role` was arrived at, since `null` is meaningful rather than missing. */
+        roleSource: z.enum(['explicit', 'custom', 'inherited']),
+        permissions: effectivePermissionsSchema,
+      }),
+    ),
+    /**
+     * Set only when `pageId` was given. `permissions: null` means the page is
+     * out of reach entirely (another drive, or a private page this credential
+     * cannot see) — deliberately not flattened to all-false, which would read
+     * as "the page is here and you may do nothing with it".
+     */
+    page: z
+      .object({ id: z.string(), permissions: effectivePermissionsSchema.nullable() })
+      .nullable()
+      .default(null),
+  }),
+  description:
+    "Describe the credential making this call: its drive scopes, the role granted in each, and the effective permissions (view/edit/share/delete) that role actually resolves to. Drive-level permissions cover the drive itself (creating a top-level page, sharing or deleting the drive); a specific page can be narrower, so pass pageId to resolve that page too. Answers \"what am I allowed to do here?\" without probing by attempting writes. Describes only itself — never another key.",
 });
 
 export const revokeMcpToken = defineOperation({

--- a/packages/sdk/src/operations/mcp-tokens.ts
+++ b/packages/sdk/src/operations/mcp-tokens.ts
@@ -135,9 +135,11 @@ export const describeSelfKey = defineOperation({
         /**
          * How `role` was arrived at, since `null` is meaningful rather than
          * missing. `'inherited'` is a scoped credential resolving with its
-         * owner's access; `'none'` is no drive-level role at all — reachable
-         * for a user principal, whose drive list includes the drives of pages
-         * shared with them, not only drives they are a member of.
+         * owner's access; `'none'` is no drive-level role at all, which both
+         * principal shapes reach by different routes — an unscoped credential
+         * through a page shared with it (its drive list is every drive it can
+         * reach, not only drives it belongs to), a scoped key when the scope
+         * row for that drive is gone. `permissions` is all-false either way.
          */
         roleSource: z.enum(['explicit', 'custom', 'inherited', 'none']),
         permissions: effectivePermissionsSchema,

--- a/packages/sdk/src/operations/roles.ts
+++ b/packages/sdk/src/operations/roles.ts
@@ -85,7 +85,7 @@ export const listDriveRoles = defineOperation({
   inputSchema: z.strictObject({ driveId: z.string() }),
   outputSchema: z.object({ roles: z.array(driveRoleSchema) }),
   requiredScope: 'drive',
-  description: 'List all custom roles defined in a drive. Requires drive membership (owner or member).',
+  description: 'List the custom roles defined in a drive. Requires drive membership (owner or member). Does not include the system roles OWNER/ADMIN/MEMBER — those are held per member on the drive membership, are not rows here, and have no role id.',
 });
 
 export const getDriveRole = defineOperation({
@@ -95,7 +95,7 @@ export const getDriveRole = defineOperation({
   inputSchema: z.strictObject({ driveId: z.string(), roleId: z.string() }),
   outputSchema: roleEnvelopeSchema,
   requiredScope: 'drive',
-  description: 'Get a single drive role with its full permission configuration. Requires drive membership.',
+  description: 'Get a single CUSTOM drive role by its id, with its full permission configuration. Requires drive membership. The system roles OWNER/ADMIN/MEMBER are not addressable here — they have no role id; use tokens.describeSelf to see what a credential actually resolves to.',
 });
 
 export const createDriveRole = defineOperation({


### PR DESCRIPTION
Fixes #2464. Fixes #2470.

Two defects about a key that works but cannot explain itself: one error message that actively misleads, and a permission model with no read-back.

---

## #2464 — a live key reported as dead

`pagespace keys list` under a working `mcp_` token answered:

```
Static token was invalidated and has no refresh path.
```

From the outside that is indistinguishable from "your key was revoked" — while the same key kept reading and writing drive content perfectly.

**Decision: return an accurate message naming the real limitation, not "support read-only listing under static tokens."**

The key-management routes admit only a full-user credential, and that is deliberate: enumerating or revoking every key a person holds is not something one scoped key should be able to do to the others. The neighbouring policy already says so out loud — `mcp-tokens/scope-guard.ts` rejects a *drive-scoped OAuth token* for exactly this reason, and an `mcp_` token is the same shape of credential. Admitting keys there would widen the credential-management surface to close a message bug. So the message gets fixed, and the thing a key genuinely can ask — *what am I* — becomes its own endpoint (below).

Two layers were wrong, and both are fixed:

**1. The SDK destroyed the server's own words.** `client.ts` spent its single auth retry on any 401. For a provider with no refresh grant that re-sends the identical bearer, and the second pass fails *inside the provider* — so `StaticTokenProvider`'s "nothing left to give you" message replaced the server's accurate `MCP tokens are not permitted for this endpoint`. That is the root of the mislabel.

`AuthProvider` gains an optional `canRefresh`; the client spends the retry only where it can actually produce a different credential. **Undeclared reads as `true`**, so third-party providers and test doubles keep the historical behaviour. `StaticTokenProvider` declares `false`, and its own message no longer claims to know the token is invalid.

**2. The CLI now classifies before it calls.** `keys list` / `revoke` / `use` and the wizard detect a scoped key up front and refuse with a message that says the key is *fine*, names the real limitation, and gives the next step — no round trip, no re-mint. This is the same wall `whoami` already works around at `/api/auth/me` (`auth/probe-drives.ts`), handled the same way: ask a question the credential can be asked.

```
$ PAGESPACE_TOKEN=mcp_… pagespace keys list
"pagespace keys list" needs your personal login, and this invocation resolved a scoped access key.
Your key is not invalid — key management is simply not something a key can do: a key reads and
writes drive content, while listing, minting and revoking keys is reserved for the person who owns them.
  pagespace keys describe   — what THIS key is, and the permissions it actually resolves to
  pagespace login           — then re-run "pagespace keys list"
```

---

## #2470 — opaque permissions

### (a) A key can now describe itself

New `GET /api/auth/key` → SDK `tokens.describeSelf` → **`pagespace keys describe`**, also served as an MCP tool.

Every permission comes from **`getPrincipalDriveAccessLevel`**, a new dispatcher in `principal-permissions.ts` that delegates to the resolvers that already exist — `getAppDriveAccessLevel` / `getScopedDriveAccessLevel` / `getUserAccessLevel` — and `getPrincipalDriveMembership`, which reads the user path through `getUserDrivePermissions` + `getMemberCustomRoleId`. **No fourth resolver.** A route that computed its own answer could tell an agent it may write while the write path disagreed.

**Drive-level and page-level are different answers, and both are reported.** The drive-as-root-node question grants edit to *any* membership; a document inside can be strictly narrower. A plain `member` key edits at the drive root and is view-only on a document — which is exactly the "reads fine, every write fails" report. Showing only the drive line would have reproduced the confusion from the other side, so the line is labelled for what it covers and `--page <pageId>` resolves the place a caller is about to write.

The same summary closes `keys create` and the wizard's Create flow, read back **with the new key** rather than restating the `--role` flag.

### (b) `keys list` shows roles

The server already returned `role` / `customRoleId` / `customRoleName` per drive scope (`findUserMcpTokensWithDrives`); the SDK output schema never declared them, so zod stripped the answer before the CLI could print it. Declared now, defaulting to `null` against an older server. Custom roles print by name; an inherit scope is spelled out rather than left blank.

### (c) `get_drive_role "member"` no longer dead-ends

Shared `roleNotFoundMessage` in `drive-role-service.ts`, used by the REST route and the AI tool, so they cannot drift. System roles are held per member on the drive membership and are not rows in `drive_roles`, so that lookup can only ever miss — the refusal now says so and names where they live. `list_drive_roles` / `roles.list` descriptions say what they do *not* list.

---

## Security

`GET /api/auth/key` describes **only the credential presenting itself** — never another key. It admits `mcp_` because that is a strictly narrower authority than the key-management routes, and it returns **no identity at all**: no name, email or user id. `/api/auth/me` refuses `mcp_` tokens precisely so holding a scoped key does not yield the person behind it, and this route must not become the back door. The drive list is what `drives.list` already returns to the same credential, and the permissions are the decision the next content request was going to make anyway — nothing here is newly derivable. A `service` credential is refused at the door rather than given a branch. The read is audited (`data.read`), satisfying the route-coverage gate.

---

## Verified by running the real thing

Local Postgres + a production `next build` + the real `pagespace` binary, against a **real `mcp_` key** minted with `--role member` on a seeded drive.

The key is live throughout:

```
$ pagespace drives list
drv2464…  Lead Gen  [STANDARD] (MEMBER)
```

**#2464** — see the transcript above; exit 1, no network call, and the word "invalidated" appears nowhere.

**#2470** — `keys describe`, and then the same question about a specific page:

```
$ pagespace keys describe --page pag2464…
Credential: access key "lead-gen agent"
Prefix:     mcp_8v80iyts…
Created:    2026-08-23T14:28:37.514Z
Last used:  2026-08-23T15:23:10.939Z
Scope:      1 drive(s)

Lead Gen  (drv2464…)
  granted:      role member
  on the drive: view edit

Page pag2464…: view
```

**The description agrees with the write path** — the check that matters most:

```
$ pagespace pages read pag2464…          # describe said: view
   1 |
$ pagespace pages rename pag2464… "Renamed by agent"   # describe said: NO edit
You need edit permission to modify this page
```

**#2470(b)** — `roles get <driveId> member`:

```
"member" is a system role, not a custom role defined in this drive, so it has no role id and cannot
be fetched here. System roles (OWNER/ADMIN/MEMBER) are held per member on the drive membership
itself — list them with the drive members surface. To see what a specific credential resolves to,
describe that credential ("pagespace keys describe")…
```

**The SDK fix, against the live server** (real `StaticTokenProvider`, real 401):

```
code   : AUTHENTICATION_ERROR
message: MCP tokens are not permitted for this endpoint
```

Reverting the one-line retry gate reproduces the defect (provider message replaces the server's) and turns the new client tests red.

---

## Gates

- `bun run typecheck` (monorepo root) — **pass**
- `bun run lint` (monorepo root) — 15/15 **pass**
- `bun run test` / `test:coverage` — failure set is **identical to a pristine worktree at the same base commit**, run against the same database: db 3, lib 20, processor 4, web 25 pre-existing integration/env failures. Two further web files failed only under concurrent load and pass alone (`ws-connections`, `compaction-service`). No `Errors` line anywhere — no unhandled rejections.
- `@pagespace/cli` 1192 ✓ · `@pagespace/sdk` 799 ✓

**Mutation checks** (broke the source, watched it go red):

| mutation | result |
|---|---|
| drop `canRefresh !== false` from the client retry gate | 2 client tests red; live probe reverts to the misleading message |
| remove the `credentialKind === 'key'` guard in `keys list` | refusal test red |
| replace `getPrincipalDriveAccessLevel` with a local all-true guess | 3 route tests red |

## Tests

SDK operation schemas + auth provider + client retry; CLI rendering, argv parsing, credential classification and every refusal path; the new web route (11 → 14 cases incl. the security and page-resolution properties); `principal-permissions` dispatch per credential class; `roleNotFoundMessage` in lib and at both call sites.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PVxVQz2js9r589sPsG7SQE


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added `pagespace keys describe` to view credential details, drive roles, effective permissions, and optional page access.
  - Newly created keys can display their effective permissions after creation.
  - Key listings now show drive roles, including inherited and custom roles.
  - Added support for describing credentials through the SDK and MCP integrations.

- **Bug Fixes**
  - Improved guidance when built-in roles are requested as custom roles.
  - Key-management commands now clearly explain when personal login is required.
  - Preserved server error messages for non-refreshable credentials instead of incorrectly reporting invalid tokens.

- **Documentation**
  - Updated CLI, SDK, and changelog documentation for the new command and credential behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

---

## Review round (f5cdc5e)

Seven findings from CodeRabbit and the Codex reviewer, all real, all fixed — thread by thread:

| finding | resolution |
|---|---|
| `keys use --off` shouldn't need a login | Guard moved **after** the `--off` branch. `--off` is purely local (clears this machine's active-key map, no server call), so refusing it left anyone running under a key unable to undo an activation. Test asserts `--off` still works under `credentialKind: 'key'`. |
| "Your key is not invalid" is an unvalidated claim | Correct — the classification is a prefix check on a credential no request has been made with, so a **revoked** token reached the same branch and was told it was fine. The bug was an unearned claim in one direction; asserting validity would move the lie, not remove it. Now: *"That says nothing about the key: key management is simply not something a key can do."* A test pins that it never asserts validity. |
| `pagespace login` alone doesn't clear the override | Right — an explicit `--token`/env credential outranks the stored login (`auth/resolve.ts`), so the advice misfired in the exact motivating case. The line now says to re-run *"with the key's --token/env credential removed, since an explicit credential outranks your stored login."* |
| stored `isScoped` vs live `isDriveScopedPrincipal` | Resolved the other way round: `findMcpTokenSelfById` now **stops selecting** `isScoped`. It records what the key was minted as; the response reports what it is now. Returning both invites disagreement — and the one case where they could differ (scoped key, all drives deleted) never authenticates: `validateMCPToken` fails it closed first. |
| use `new URL(request.url)` for search params | House convention per `AGENTS.md:82`, and 80 routes to 1. Switched. |
| wizard skipped the readback *and* the hint when no raw token | `create.ts` handled that branch and the wizard did not, ending the mint with no answer at all. `else` added, plus a test on the failure path. |
| PATCH/DELETE and the role-permission tools still dead-ended | A system-role name dead-ended at whichever verb it arrived at, not just `get`. All five branches now share `roleNotFoundMessage`. |

Gates re-run after the fixes: typecheck 17/17, lint 15/15, knip within baseline, `@pagespace/sdk` 800 ✓, `@pagespace/cli` 1195 ✓, and the web/lib failure sets are **byte-identical to the pristine baseline** (web 25, lib 20).


---

## Convergence round (cc54c2b)

Re-reading #2470 against the shipped fix surfaced a gap the reviewers hadn't raised. The reported experience was **"We learned by trying writes and watching them fail"** — and `keys describe` only helps someone who already knows to look. The refusal itself still named nowhere.

`Write permission required` is emitted by exactly two places, both on the surface an agent drives:

```
$ curl -X POST /api/mcp/documents -H 'Authorization: Bearer mcp_…' \
    -d '{"pageId":"pag2464…","operation":"replace","content":"scraped leads"}'
{
  "error": "Write permission required",
  "details": "The 'replace' operation requires edit access to this document. This credential can
              view this page but not edit it. Call tokens.describeSelf with this pageId (CLI:
              \"pagespace keys describe --page <pageId>\") for what it can actually do, instead of
              discovering it one failed write at a time."
}
```

Both halves are facts about that request — the caller cleared the VIEW gate immediately before reaching the write gate, so "can view, cannot edit" is established rather than guessed. `error` stays the stable string the security suites pin and clients may branch on; only `details` changed.

**Following the pointer it gives closes the loop** (live, same server, same key):

```
$ curl "/api/auth/key?pageId=pag2464…" -H 'Authorization: Bearer mcp_…'
  "page": { "id": "pag2464…", "permissions": { "canView": true, "canEdit": false, … } }

$ pagespace keys describe --page pag2464…
  on the drive: view edit
  Page pag2464…: view
```

`canEdit: false` matches the refusal exactly. Verified on the sheets surface too (`append-rows` → same shape).

### Design notes for reviewers

- **The copy is an import-free leaf** colocated with its two callers (`api/mcp/write-denied-details.ts`), mirroring `auth/mcp-tokens/scope-guard.ts`. Routing it through `@/lib/auth` was tried first and rejected: both callers partially mock that barrel, and a symbol taken from it is one more thing every mock must provide or the route answers an **opaque 500 instead of the 403 under test** — the trap `principal-permissions.ts` already documents at `resolveDispatchedPrincipal`. Trying it that way turned two passing security tests into 500s, which is how it was caught.
- **`mcp/sheets` has no test file at all**, so its wiring is pinned statically (same idiom as `readme-coverage` / `security-audit-coverage`, which read route sources as text). Reverting either call site to a hand-rolled string turns that guard red — mutation-checked.
- **`GET /api/auth/key` now resolves drives concurrently.** An unscoped credential's universe is every drive its owner can reach, each costing a handful of queries, so the sequential walk multiplied one status call's latency by the drive count. Query count is unchanged; a test pins that output order stays stable regardless of resolve order.

### Gates (re-run)

typecheck 17/17 · lint 15/15 · knip within baseline · `@pagespace/sdk` 40 files ✓ · `@pagespace/cli` 67 files ✓ · web and lib failure sets **zero delta** from a pristine worktree at the same base commit, run against the same database.


---

## Self-review rounds (d45b693, 26f1367)

Neither reviewer had seen the branch past the first commit (CodeRabbit was rate-limited across three pushes), so I ran two independent review passes of my own and treated the output as review feedback. Ten defects, all reproduced before fixing, all mutation-checked after.

**Round 1 — `d45b693`** (a high-effort review of the branch vs master):

| defect | why it mattered |
|---|---|
| The hint every mint prints named a command that **fails** | `keys describe` reports what a CONTENT command would use, so it is not auth-exempt and faces `run.ts`'s explicit-credential gate. With a personal login and no active key — exactly the state you are in right after `keys create` — a bare `pagespace keys describe` is refused. Verified with the real CLI. Now names the key (`--key <name>`). |
| `roleSource: 'inherited'` was wrong for a drive with no membership | `getDriveIdsForUser` unions your drives with the drives of pages **shared** with you, so a page-collaborator-only drive was printing "inherits your own access in this drive" directly above "nothing (no access here)". `membership === null` is now its own state, `'none'`. Reproduced live with a real page share. |
| The concurrency added in `cc54c2b` was **unbounded** | ~6 queries × every drive an unscoped credential can reach — a user in 50 drives opened ~300 connections from one GET. My own regression, one commit old. Capped at 8, order-preserving. |
| The `keys describe` pointer printed twice | Once from the mint fallback, again from the wiring guidance below it. |

**Round 2 — `26f1367`** (an adversarial pass told to find where round 1 was wrong):

| defect | why it mattered |
|---|---|
| The key name was interpolated into a shell command **unquoted** | Key names are near free-form. `--name "lead gen"` printed `--key lead gen`, where the shell gives `--key` the word `lead` and leaves `gen` as a stray positional. A hint that cannot be pasted is worse than none, because the reader cannot tell it from one that can. Now quoted; names with a space, a quote and a `$` round-trip through a real shell. |
| The `'none'` wording was wrong for **the case its own test covered** | "reached through a page shared with you" is true only for an unscoped credential. A scoped key reaches `'none'` when its `mcp_token_drives` row is gone, and reaches nothing through page shares — and the only test for `'none'` used `arrangeScopedMemberKey()`, so it was pinning the wrong explanation. Both routes now get their own wording. |
| `mapWithConcurrency` returned an array of **holes** for a non-positive limit | Zero workers, no work, no error, serialized as a list of nulls. A status readout quietly reporting every drive as garbage is the worst failure this endpoint could have. |
| The same helper never **stopped** on failure | `Promise.all` rejects on the first error but does not cancel siblings, so the rest kept draining — spending the whole fan-out the bound exists to contain, on a response that had already failed. |
| Two near-identical sentences back to back on `--show-token` | The readback now says only that it did not happen; the reason is stated once. |
| A wizard note with no antecedent | "It returned no raw token…" under a heading, with no "it". |

One of the new tests had a race of its own — it re-read a shared counter after an `await`, where siblings had already bumped it past the value it checked. Caught because the test would not go red when the fix was reverted.
