### PR TITLE
chore(release): @pagespace/sdk@2.2.0, @pagespace/cli@1.8.0

### DIFF
--- a/apps/marketing/src/app/docs/features/cli/page.tsx
+++ b/apps/marketing/src/app/docs/features/cli/page.tsx
@@ -27,7 +27,7 @@ Or run it without installing:
 npx -y -p @pagespace/cli pagespace <command>
 \`\`\`
 
-The current version is **1.6.1**. Installing gives you two binaries: \`pagespace\` (the CLI) and \`pagespace-mcp\` (the MCP server).
+The current version is **1.8.0**. Installing gives you two binaries: \`pagespace\` (the CLI) and \`pagespace-mcp\` (the MCP server).
 
 ## Sign in
 
@@ -97,6 +97,30 @@ pagespace pages trash <pageId> --yes
 
 Page types are \`FOLDER\`, \`DOCUMENT\`, \`CHANNEL\`, \`AI_CHAT\`, \`CANVAS\`, \`FILE\`, \`SHEET\`, \`TASK_LIST\`, and \`CODE\`.
 
+**Sheets** — a spreadsheet as rows you can query, not a file you download.
+
+\`\`\`bash
+# tabs, rows, columns — without reading a row
+pagespace sheets describe <pageId>
+
+# filter and sort server-side; --where takes JSON
+pagespace sheets query <pageId> --where '{"column":"C","op":"eq","value":"open"}' \
+  --select A,C,F --order-by F:desc --limit 20 --json
+
+# walk a tab by position
+pagespace sheets rows <pageId> --from-row 0 --limit 50 --json
+
+# payloads come from --json-input or stdin
+echo '[{"A":"widget","B":"12"}]' | pagespace sheets append <pageId>
+pagespace sheets update-cells <pageId> --json-input '[{"address":"A1","value":"Hello"}]'
+
+pagespace sheets delete-rows <pageId> --from-row 10 --count 5 --yes
+\`\`\`
+
+\`--where\` also nests: \`{"and":[{"column":"C","op":"eq","value":"open"},{"column":"F","op":"gt","value":1000}]}\`. Every verb takes \`--tab <n>\` for a sheet with more than one tab.
+
+Filters match the values you **see** — a formula column compares as its result, not its \`=\` text. \`delete-rows\` is the one irreversible verb, so it confirms first; \`--yes\` skips the prompt, and with no TTY and no \`--yes\` it refuses rather than assuming consent.
+
 **Search**
 
 \`\`\`bash
@@ -123,7 +147,7 @@ pagespace agents ask <agentPageId> "Follow up" --conversation-id <convId>
 pagespace agents config <agentPageId> --set model=gpt-4o
 \`\`\`
 
-Also available: \`pagespace channels send\`, \`pagespace activity\`, \`pagespace trash list\`, \`pagespace sheets edit-cells\`, and \`pagespace models list\`.
+Also available: \`pagespace channels send\`, \`pagespace activity\`, \`pagespace trash list\`, \`pagespace sheets edit-cells\` (the older single-tab form), \`pagespace keys describe\` (what the active credential can actually do), and \`pagespace models list\`.
 
 Because \`--json\` is clean on stdout, commands compose:
 

--- a/apps/marketing/src/app/docs/features/sdk/page.tsx
+++ b/apps/marketing/src/app/docs/features/sdk/page.tsx
@@ -21,7 +21,7 @@ It's the same client the [\`pagespace\` CLI](/docs/features/cli) and the \`pages
 npm install @pagespace/sdk
 \`\`\`
 
-ESM only, with a single runtime dependency (\`zod\`). The current version is **2.1.0**.
+ESM only, with a single runtime dependency (\`zod\`). The current version is **2.2.0**.
 
 ## Quickstart
 
@@ -84,6 +84,7 @@ Every operation hangs off a namespace on the client. Inputs and outputs are sche
 | \`drives\` | \`list\`, \`create\`, \`rename\`, \`updateContext\`, \`setHomePage\`, \`trash\`, \`restore\` |
 | \`pages\` | \`list\`, \`listTrash\`, \`create\`, \`details\`, \`rename\`, \`move\`, \`trash\`, \`restore\` — plus content editing: \`read\`, \`replaceLines\`, \`insertLines\`, \`deleteLines\`, \`editCells\` |
 | \`tasks\` | \`create\`, \`update\`, \`delete\`, \`reorder\`, \`getAssigned\`, \`createStatus\`, \`setTrigger\`, \`deleteTrigger\` |
+| \`sheets\` | \`describe\`, \`queryRows\`, \`getRows\`, \`appendRows\`, \`updateCells\`, \`deleteRows\` — a spreadsheet as queryable rows |
 | \`search\` | \`regex\`, \`glob\`, \`multiDrive\` |
 | \`agents\` | \`list\`, \`listMultiDrive\`, \`ask\`, \`updateConfig\`, \`listModels\` |
 | \`conversations\` | \`list\`, \`read\` — full transcripts of an agent's conversations |
@@ -96,7 +97,7 @@ Every operation hangs off a namespace on the client. Inputs and outputs are sche
 | \`workflows\` | \`list\`, \`create\`, \`update\`, \`delete\` |
 | \`activity\` | \`get\` — a drive's activity feed |
 | \`export\` | \`pageMarkdown\`, \`sheetCsv\` |
-| \`tokens\` | \`list\`, \`revoke\` — API keys (OAuth only) |
+| \`tokens\` | \`list\`, \`revoke\` — API keys (OAuth only); \`describeSelf\` — what the calling credential can do |
 
 Reading and writing document content lives on \`pages\`, not a separate namespace:
 
@@ -111,6 +112,26 @@ await client.pages.deleteLines({ pageId, startLine: 10, endLine: 12 });
 // Sheet cells
 await client.pages.editCells({ pageId, cells: [{ address: 'A1', value: 'Hello' }] });
 \`\`\`
+
+### Spreadsheets as data
+
+A sheet with 100,000 rows is not something you want to download to find twelve. \`sheets\` filters, sorts and pages server-side:
+
+\`\`\`typescript
+const { rows, total } = await client.sheets.queryRows({
+  pageId,
+  where: { and: [
+    { column: 'C', op: 'eq', value: 'open' },
+    { column: 'F', op: 'gt', value: 1000 },
+  ]},
+  orderBy: [{ column: 'F', direction: 'desc' }],
+  limit: 20,
+});
+
+console.log(\`showing \${rows.length} of \${total}\`);
+\`\`\`
+
+Filters match the values you **see**: a formula column compares as its result, not its \`=\` text. Every cell carries both — \`raw\` is what was authored, \`value\` what it evaluates to.
 
 Need an endpoint the SDK doesn't wrap? \`defineOperation\` lets you declare one with its own Zod schemas and call it through \`client.invoke\`, keeping the same typing, auth, and retry behaviour.
 

--- a/bun.lock
+++ b/bun.lock
@@ -442,7 +442,7 @@
     },
     "packages/cli": {
       "name": "@pagespace/cli",
-      "version": "1.7.1",
+      "version": "1.8.0",
       "bin": {
         "pagespace": "./dist/bin.js",
         "pagespace-mcp": "./dist/bin-pagespace-mcp.js",
@@ -519,7 +519,7 @@
     },
     "packages/sdk": {
       "name": "@pagespace/sdk",
-      "version": "2.1.0",
+      "version": "2.2.0",
       "dependencies": {
         "zod": "^4.1.8",
       },

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -4,7 +4,25 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+## [1.8.0] — 2026-08-23
+
 ### Added
+
+- **`pagespace sheets` — seven verbs that treat a spreadsheet as data.** `describe` shows a sheet's
+  tabs, row and column counts without reading a row. `query` filters and sorts **server-side**, so
+  asking a 100,000-row sheet for the twelve rows you want no longer means pulling the whole thing
+  down first. `rows` walks a tab in order, `append` adds rows, `update-cells` writes by A1 address
+  (and, unlike the older `edit-cells`, can reach a tab other than the first), and `delete-rows`
+  removes a range.
+
+  Filters match **the values you see**: a formula column compares as its result, not its `=` text.
+
+  `delete-rows` is the one irreversible verb, so it confirms before acting. `--yes` skips the
+  prompt; with no TTY and no `--yes` it fails closed rather than assuming consent — a script that
+  never meant to delete cannot delete by omission.
+
+  All seven honour `--json` for scripting, and the same six operations are served as MCP tools, so
+  an agent gets them without shelling out.
 
 - **`pagespace keys describe`** — reports the credential this invocation would use: its drives, the
   role granted in each, and the **effective** permissions that role resolves to

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pagespace/cli",
-  "version": "1.7.1",
+  "version": "1.8.0",
   "description": "pagespace — the official CLI for PageSpace: browser-based login, drive/page/task management, and a `pagespace mcp` stdio server for coding agents.",
   "license": "MIT",
   "repository": {
@@ -41,7 +41,7 @@
     "@clack/prompts": "^1.7.0",
     "@modelcontextprotocol/sdk": "^1.29.0",
     "@napi-rs/keyring": "^1.3.0",
-    "@pagespace/sdk": "^2.0.0",
+    "@pagespace/sdk": "^2.2.0",
     "zod": "^4.1.8"
   },
   "devDependencies": {

--- a/packages/cli/src/commands/version.ts
+++ b/packages/cli/src/commands/version.ts
@@ -7,7 +7,7 @@ import type { CommandHandler } from '../router/router.js';
  * guarded by `commands/__tests__/version.test.ts`, which reads package.json
  * directly, so bumping one without the other fails the suite.
  */
-export const CLI_VERSION = '1.7.1';
+export const CLI_VERSION = '1.8.0';
 
 export const versionHandler: CommandHandler = async (ctx, intent) => {
   if (intent.flags.json) {

--- a/packages/sdk/CHANGELOG.md
+++ b/packages/sdk/CHANGELOG.md
@@ -4,7 +4,35 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+## [2.2.0] — 2026-08-23
+
 ### Added
+
+- **`client.sheets` — a spreadsheet is queryable data, not a document you download.** Six operations
+  over `POST /api/mcp/sheets`: `queryRows` (filter with nested `and`/`or`/`not`, project with
+  `select`, sort with `orderBy`, page with `limit`/`offset`), `getRows` (positional paging by row
+  index), `describe` (tabs, row and column counts, frozen rows — without reading a row),
+  `appendRows`, `updateCells` (A1 addresses, and unlike the older `documents.editSheetCells` it can
+  reach a tab other than the first) and `deleteRows`. Asking a 100,000-row sheet for twelve matching
+  rows now transfers twelve rows.
+
+  Filters compare against the **computed** value, so a formula column matches on its result rather
+  than its `=` text. Every cell carries both: `raw` is what was authored, `value` what it evaluates
+  to. `SheetWhereInput` is exported for building filters in typed code.
+
+  `queryRows` returns `total` — the full match count, not the page size — so a caller can report
+  "20 of 4,312" without a second request. `getRows` returns `nextFromRow`, a **position**, not a
+  count: advancing by `rows.length` loops forever on a sparse tab, following `nextFromRow`
+  terminates.
+
+  `describe` deliberately takes no `tabIndex`. The route resolves the tab before dispatch, so
+  passing one 409s before `describe` runs — precisely for the caller who does not yet know which
+  tabs exist. `deleteRows` requires both `fromRow` and `count`; neither is defaulted, because a
+  wrong guess destroys data.
+
+- **`documents.editSheetCells` now reports `recomputed`** in its `stats` — how many dependent cells
+  were recalculated. The server had always returned it; the output schema didn't declare it, so zod
+  stripped it before any consumer saw it.
 
 - **`tokens.describeSelf`** (`GET /api/auth/key`) — describes the credential making the call: its
   drive scopes, the role granted in each, and the effective `{canView, canEdit, canShare,
@@ -19,6 +47,26 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   server had always returned them; the output schema didn't declare them, so zod stripped the answer
   to "what was this key granted" before any consumer saw it. They default to `null` against a server
   that omits them.
+
+### Removed
+
+- **`'MACHINE'` is no longer an accepted page type.** `pageTypeSchema` — and therefore
+  `pages.create`, `pages.list`, search filters and the `type` on every page response — no longer
+  accepts or emits it. 2.1.0 renamed `'TERMINAL'` to `'MACHINE'`; this removes the type outright,
+  because the feature it named was deleted server-side. A call passing `'MACHINE'` now fails
+  client-side in schema validation rather than server-side as an unknown type. **This is a narrowing
+  of accepted input in a minor release**, which strict semver would call breaking; it is shipped as
+  a minor because the endpoint rejects the value either way and there is no migration to perform.
+
+### Changed
+
+- **Calendar timezone resolution is documented as it actually behaves.** Omitting `timezone` is not
+  the same as sending `"UTC"`: the server resolves an absent field against the caller's profile
+  timezone and only then falls back to UTC, matching `tasks.create`/`tasks.setTrigger`.
+  `calendar.create` stores the resolved zone on the event, so a later `update` that omits `timezone`
+  reinterprets against the event's own zone rather than the editor's. `startDate`/`endDate` on
+  `calendar.list` are absolute instants and are never reinterpreted. No SDK code changed; the
+  previous documentation described behaviour that did not match the server.
 
 ### Fixed
 

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pagespace/sdk",
-  "version": "2.1.0",
+  "version": "2.2.0",
   "description": "Typed TypeScript/JavaScript client SDK for the PageSpace API — drives, pages, tasks, roles, search, agents, and more.",
   "keywords": [
     "pagespace",

--- a/packages/sdk/src/version.ts
+++ b/packages/sdk/src/version.ts
@@ -5,7 +5,7 @@ import type { CompatibilityResult } from './errors.js';
  * guarded by `__tests__/version.test.ts`, which reads package.json directly,
  * so bumping one without the other fails the suite.
  */
-export const SDK_VERSION = '2.1.0';
+export const SDK_VERSION = '2.2.0';
 
 /**
  * The SDK's compiled-in floor for the server's API_CONTRACT_VERSION (ADR 0001


### PR DESCRIPTION
## Why

The sheets row API landed in #2458 and #2471, but **neither package was version-bumped**. npm still
serves `@pagespace/sdk@2.1.0` and `@pagespace/cli@1.7.1` — byte-identical versions to what is on
master. Two consequences:

- `npm publish` would fail 403 over the existing version.
- Nobody installing from npm can reach `client.sheets` or the seven `pagespace sheets` verbs.

## What

| | from | to |
|---|---|---|
| `packages/sdk/package.json` | 2.1.0 | **2.2.0** |
| `packages/sdk/src/version.ts` (`SDK_VERSION`) | 2.1.0 | **2.2.0** |
| `packages/cli/package.json` | 1.7.1 | **1.8.0** |
| `packages/cli/src/commands/version.ts` (`CLI_VERSION`) | 1.7.1 | **1.8.0** |
| cli → sdk dependency pin | `^2.0.0` | **`^2.2.0`** |

Four version sites rather than two: both packages keep the version as a source constant as well, each
with its own drift guard test. `CLI_VERSION` has been left behind by its own release commit before
(bc8fea247), which is what those guards exist to catch.

**The pin move is the load-bearing one.** `^2.0.0` would resolve 2.2.0 on a clean install, but it also
permits 2.1.0 — so someone upgrading only the CLI could land 1.8.0 against an SDK with no `sheets`
namespace, and every new verb would throw at runtime.

## Why minor and not major

The SDK's `index.ts` diff since 2.1.0 is purely additive. Two symbols were removed in that range —
`extractPathParamNames`, and `MACHINE` from a page-type list — but neither is re-exported from
`index.ts`, and `exports` only exposes `"."`, so no npm consumer can import them.

One honest caveat: `MACHINE` is no longer accepted by the create/search input schemas, which is a
narrowing of accepted runtime input. Strict semver could call that breaking. The MACHINE feature was
deleted server-side in the same range (623e632e7), so such a call fails either way — a major bump
would signal a migration that does not exist.

## Validation

- `@pagespace/sdk` — 788 tests, 40 files
- `@pagespace/cli` — 1140 tests, 65 files (both include the version drift guards)
- `bun run typecheck` — 17/17
- `npm pack --dry-run` on both: SDK ships `dist/operations/sheets.*` and exports the six ops from
  `dist/index.d.ts`; CLI ships `dist/commands/sheets.*` with the row ops on the MCP surface

## Publishing order after merge

SDK first — the CLI's `^2.2.0` pin cannot resolve until it exists:

```
cd packages/sdk && npm publish
cd packages/cli && npm publish
```

No release workflow exists in this repo; publishing is manual.
