### PR TITLE
fix(cli): six defects an adversarial pass found in the merged #2476

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,14 +5,6 @@ All notable user-facing changes to PageSpace are documented here. Format follows
 
 ## [Unreleased]
 
-### Fixed
-
-- **The command printed after minting a key now works when you paste it.** `pagespace keys create`
-  ends by telling you how to see what the new key can do, and that line was wrong twice over: it
-  omitted the key's name, so with only a personal login it was refused outright, and a key named
-  with a space or a leading dash produced a command the shell took apart. It now names the key and
-  quotes it.
-
 ### Added
 
 - **A key can tell you what it is allowed to do** — `pagespace keys describe` reports the credential

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable user-facing changes to PageSpace are documented here. Format follows
 
 ## [Unreleased]
 
+### Fixed
+
+- **The command printed after minting a key now works when you paste it.** `pagespace keys create`
+  ends by telling you how to see what the new key can do, and that line was wrong twice over: it
+  omitted the key's name, so with only a personal login it was refused outright, and a key named
+  with a space or a leading dash produced a command the shell took apart. It now names the key and
+  quotes it.
+
 ### Added
 
 - **A key can tell you what it is allowed to do** — `pagespace keys describe` reports the credential

--- a/apps/web/src/app/api/auth/key/__tests__/route.test.ts
+++ b/apps/web/src/app/api/auth/key/__tests__/route.test.ts
@@ -236,21 +236,38 @@ describe('GET /api/auth/key', () => {
     expect(body.driveScopes.map((scope: { name: string }) => scope.name)).toEqual(['First', 'Second', 'Third']);
   });
 
-  // `getDriveIdsForUser` unions the drives you belong to with the drives of any
-  // page shared with you, so a page-collaborator-only drive appears in the list
-  // while `getUserDrivePermissions` correctly reports no membership for it.
-  // Labelling that 'inherited' would read as "you have your own access here",
-  // the opposite of what its all-false permissions say.
-  it('labels a drive reached with no membership as "none", not "inherited"', async () => {
+  // Both principal shapes reach "no drive-level role", by different routes, and
+  // both must be labelled 'none' rather than 'inherited' — the latter reads as
+  // "you have your own access here", the opposite of the all-false permissions
+  // alongside it. Arranged separately because an earlier version of this test
+  // described the USER route while arranging the SCOPED one.
+  it('labels an UNSCOPED credential\'s roleless drive as "none" (a page shared with it)', async () => {
+    vi.mocked(authenticateRequestWithOptions).mockResolvedValue({ ...SCOPED_KEY, allowedDriveIds: [] } as never);
+    vi.mocked(isAuthError).mockReturnValue(false);
+    vi.mocked(isDriveScopedPrincipal).mockReturnValue(false);
+    vi.mocked(sessionRepository.findMcpTokenSelfById).mockResolvedValue(KEY_ROW as never);
+    vi.mocked(getPrincipalDriveIds).mockResolvedValue(['drv1']);
+    vi.mocked(sessionRepository.findDrivesByIds).mockResolvedValue([{ id: 'drv1', name: 'Engineering' }]);
+    vi.mocked(getPrincipalDriveMembership).mockResolvedValue(null);
+    vi.mocked(getPrincipalDriveAccessLevel).mockResolvedValue(null);
+
+    const body = await (await GET(request())).json();
+
+    expect(body.credential.scoped).toBe(false);
+    expect(body.driveScopes[0].roleSource).toBe('none');
+    expect(body.driveScopes[0].role).toBeNull();
+    expect(body.driveScopes[0].permissions).toEqual({ canView: false, canEdit: false, canShare: false, canDelete: false });
+  });
+
+  it('labels a SCOPED key\'s roleless drive as "none" (its scope row is gone)', async () => {
     arrangeScopedMemberKey();
     vi.mocked(getPrincipalDriveMembership).mockResolvedValue(null);
     vi.mocked(getPrincipalDriveAccessLevel).mockResolvedValue(null);
 
     const body = await (await GET(request())).json();
 
+    expect(body.credential.scoped).toBe(true);
     expect(body.driveScopes[0].roleSource).toBe('none');
-    expect(body.driveScopes[0].role).toBeNull();
-    expect(body.driveScopes[0].permissions).toEqual({ canView: false, canEdit: false, canShare: false, canDelete: false });
   });
 
   // A scoped credential's null role is INHERIT, which is a different thing and
@@ -329,7 +346,9 @@ describe('GET /api/auth/key', () => {
     expect(response.status).toBe(500);
     // Let any un-cancelled stragglers run before counting.
     await new Promise((resolve) => setTimeout(resolve, 50));
-    expect(started).toBeLessThan(driveIds.length);
+    // Exactly the batch that was in flight when the first failed — 8, not
+    // "fewer than 40", which would have passed at 39 and proven nothing.
+    expect(started).toBe(8);
   });
 
   it('describes an unscoped credential with no key row, leaving the key fields null', async () => {

--- a/apps/web/src/app/api/auth/key/route.ts
+++ b/apps/web/src/app/api/auth/key/route.ts
@@ -51,6 +51,7 @@ import {
   getPrincipalDriveMembership,
   isDriveScopedPrincipal,
 } from '@/lib/auth/principal-permissions';
+import { mapWithConcurrency } from '@/lib/map-with-concurrency';
 import { sessionRepository } from '@/lib/repositories/session-repository';
 import { getRoleById } from '@pagespace/lib/services/drive-role-service';
 import { auditRequest } from '@pagespace/lib/audit/audit-log';
@@ -69,45 +70,6 @@ const AUTH_OPTIONS_READ = { allow: ['mcp', 'oauth', 'session'] as const, require
  * it fast.
  */
 const DRIVE_RESOLUTION_CONCURRENCY = 8;
-
-/**
- * `Promise.all` over `items`, at most `limit` in flight, preserving input
- * order. Order matters: this is a report a human diffs between runs, and a
- * settle-as-they-finish result would reshuffle it for no reason.
- *
- * `Math.max(1, …)` is a guard against a returned array of HOLES rather than a
- * style flourish: a non-positive limit would start zero workers, and this
- * function would then resolve `new Array(n)` — typed `TResult[]`, actually
- * empty — with no work done and no error, which the route would serialize as a
- * list of nulls. A status readout quietly reporting every drive as garbage is
- * the worst failure this endpoint could have.
- *
- * The first rejection stops the queue as well as propagating. `Promise.all`
- * rejects immediately but does not cancel its siblings, so without the flag the
- * remaining workers would keep draining — spending the full fan-out this bound
- * exists to contain on a response that has already failed.
- */
-async function mapWithConcurrency<TItem, TResult>(
-  items: readonly TItem[],
-  limit: number,
-  resolve: (item: TItem) => Promise<TResult>,
-): Promise<TResult[]> {
-  const results: TResult[] = new Array(items.length);
-  let next = 0;
-  let failed = false;
-  const workers = Array.from({ length: Math.min(Math.max(1, limit), items.length) }, async () => {
-    for (let index = next++; index < items.length && !failed; index = next++) {
-      try {
-        results[index] = await resolve(items[index]);
-      } catch (error) {
-        failed = true;
-        throw error;
-      }
-    }
-  });
-  await Promise.all(workers);
-  return results;
-}
 
 /**
  * How the principal holds this drive, spelled out so a reader never has to

--- a/apps/web/src/app/api/auth/key/route.ts
+++ b/apps/web/src/app/api/auth/key/route.ts
@@ -171,30 +171,30 @@ export async function GET(req: NextRequest) {
     // The bound is on DRIVES: each one fans out to two concurrent resolvers, so
     // the real ceiling is roughly double this number of queries in flight.
     const driveScopes = await mapWithConcurrency(driveIds, DRIVE_RESOLUTION_CONCURRENCY, async (driveId) => {
-        const [permissions, membership] = await Promise.all([
-          getPrincipalDriveAccessLevel(auth, driveId),
-          getPrincipalDriveMembership(auth, driveId),
-        ]);
-        const role = membership?.role ?? null;
-        const customRoleId = membership?.customRoleId ?? null;
-        const customRole = customRoleId ? await getRoleById(driveId, customRoleId) : null;
+      const [permissions, membership] = await Promise.all([
+        getPrincipalDriveAccessLevel(auth, driveId),
+        getPrincipalDriveMembership(auth, driveId),
+      ]);
+      const role = membership?.role ?? null;
+      const customRoleId = membership?.customRoleId ?? null;
+      const customRole = customRoleId ? await getRoleById(driveId, customRoleId) : null;
 
-        return {
-          id: driveId,
-          name: driveNames.get(driveId) ?? driveId,
-          role,
-          customRoleId,
-          customRoleName: customRole?.name ?? null,
-          roleSource: describeRoleSource(membership, customRoleId),
-          // A scope whose drive resolves to no access at all — a dangling
-          // inherit row whose owner lost the drive, a custom role deleted out
-          // from under the key — is reported as an all-false entry rather than
-          // dropped. "You hold a grant here that currently gets you nothing" is
-          // the honest answer; omitting the row would read as never having had
-          // access.
-          permissions: permissions ?? { canView: false, canEdit: false, canShare: false, canDelete: false },
-        };
-      });
+      return {
+        id: driveId,
+        name: driveNames.get(driveId) ?? driveId,
+        role,
+        customRoleId,
+        customRoleName: customRole?.name ?? null,
+        roleSource: describeRoleSource(membership, customRoleId),
+        // A scope whose drive resolves to no access at all — a dangling
+        // inherit row whose owner lost the drive, a custom role deleted out
+        // from under the key — is reported as an all-false entry rather than
+        // dropped. "You hold a grant here that currently gets you nothing" is
+        // the honest answer; omitting the row would read as never having had
+        // access.
+        permissions: permissions ?? { canView: false, canEdit: false, canShare: false, canDelete: false },
+      };
+    });
 
     // Only when asked. `permissions: null` (out of reach) is preserved rather
     // than flattened to all-false: "this page is not yours to see" and "you may

--- a/apps/web/src/app/api/mcp/__tests__/write-denied-details.test.ts
+++ b/apps/web/src/app/api/mcp/__tests__/write-denied-details.test.ts
@@ -31,6 +31,14 @@ describe('writeDeniedDetails', () => {
     expect(details).toContain('pagespace keys describe --page');
   });
 
+  // `keys describe` reports on a CONTENT credential, so unlike its `keys`
+  // siblings it faces the CLI's explicit-credential gate — run bare under a
+  // personal login it is refused. Naming a command the reader cannot run is
+  // the failure this whole message exists to prevent.
+  it('says the CLI form needs this same credential, not a bare invocation', () => {
+    expect(writeDeniedDetails('replace', 'document')).toMatch(/same credential/i);
+  });
+
   // The module is imported by two routes whose suites partially mock
   // `@/lib/auth`; a barrel import here would make a missing mock surface as an
   // opaque 500 instead of the 403 under test.

--- a/apps/web/src/app/api/mcp/write-denied-details.ts
+++ b/apps/web/src/app/api/mcp/write-denied-details.ts
@@ -12,6 +12,12 @@
  * VIEW gate immediately before reaching the write gate, so it can read this
  * page and cannot write it.
  *
+ * "with this same credential" is load-bearing, not filler. `keys describe`
+ * reports on a CONTENT credential, so unlike its `keys` siblings it is subject
+ * to the CLI's explicit-credential gate: run bare, under nothing but a personal
+ * login, it is refused. Naming a command the reader cannot run is the failure
+ * this message exists to prevent, one level up.
+ *
  * Only the `details` field. `error` stays the stable `'Write permission
  * required'` string the security suites pin and clients may branch on.
  *
@@ -25,8 +31,8 @@
 export function writeDeniedDetails(operation: string, subject: 'document' | 'sheet'): string {
   return (
     `The '${operation}' operation requires edit access to this ${subject}. This credential can view ` +
-    'this page but not edit it. Call tokens.describeSelf with this pageId (CLI: "pagespace keys ' +
-    'describe --page <pageId>") for what it can actually do, instead of discovering it one failed ' +
-    'write at a time.'
+    'this page but not edit it. Call tokens.describeSelf with this pageId — or, with this same ' +
+    'credential, "pagespace keys describe --page <pageId>" — for what it can actually do, instead ' +
+    'of discovering it one failed write at a time.'
   );
 }

--- a/apps/web/src/lib/__tests__/map-with-concurrency.test.ts
+++ b/apps/web/src/lib/__tests__/map-with-concurrency.test.ts
@@ -5,30 +5,9 @@
  * deleted with every route test still green.
  */
 import { describe, it, expect, vi } from 'vitest';
-import { mapWithConcurrency, resolveWorkerCount } from '../map-with-concurrency';
+import { mapWithConcurrency } from '../map-with-concurrency';
 
 const double = async (n: number) => n * 2;
-
-describe('resolveWorkerCount', () => {
-  it('honours a sane limit, capped by the item count', () => {
-    expect(resolveWorkerCount(8, 25)).toBe(8);
-    expect(resolveWorkerCount(8, 3)).toBe(3);
-  });
-
-  it('does nothing for no items', () => {
-    expect(resolveWorkerCount(8, 0)).toBe(0);
-  });
-
-  // Zero workers would resolve `new Array(n)` — typed as results, actually a
-  // row of holes — with no work done and no error, which a caller serializes
-  // as every item being null.
-  it.each([0, -1, Number.NaN, Number.POSITIVE_INFINITY, 0.5])(
-    'never starts zero workers for limit %p when there is work',
-    (limit) => {
-      expect(resolveWorkerCount(limit, 5)).toBeGreaterThanOrEqual(1);
-    },
-  );
-});
 
 describe('mapWithConcurrency', () => {
   it('maps every item, in input order', async () => {
@@ -50,13 +29,22 @@ describe('mapWithConcurrency', () => {
     expect(result).toEqual(delays);
   });
 
-  it.each([0, -1, Number.NaN])('returns no holes for limit %p', async (limit) => {
-    const result = await mapWithConcurrency([1, 2, 3], limit, double);
-    expect(result).toEqual([2, 4, 6]);
-    // `toEqual` alone passes on a hole array against [undefined,...]; this is
-    // the assertion that actually distinguishes them.
-    expect(Object.keys(result)).toHaveLength(3);
-  });
+  // A non-positive — or non-finite — limit would start zero workers and resolve
+  // `new Array(n)`: typed as results, actually a row of holes, with no work done
+  // and no error. A caller serializing that reports every item as null.
+  // Exercised through the real entry point because the guard itself is private.
+  it.each([0, -1, Number.NaN, Number.POSITIVE_INFINITY, 0.5])(
+    'does the work and returns no holes for limit %p',
+    async (limit) => {
+      const resolve = vi.fn(double);
+      const result = await mapWithConcurrency([1, 2, 3], limit, resolve);
+      expect(resolve).toHaveBeenCalledTimes(3);
+      expect(result).toEqual([2, 4, 6]);
+      // `toEqual` alone passes on a hole array against [undefined, ...]; this is
+      // the assertion that actually distinguishes them.
+      expect(Object.keys(result)).toHaveLength(3);
+    },
+  );
 
   it('holds concurrency at the limit', async () => {
     let inFlight = 0;

--- a/apps/web/src/lib/__tests__/map-with-concurrency.test.ts
+++ b/apps/web/src/lib/__tests__/map-with-concurrency.test.ts
@@ -29,22 +29,54 @@ describe('mapWithConcurrency', () => {
     expect(result).toEqual(delays);
   });
 
-  // A non-positive — or non-finite — limit would start zero workers and resolve
-  // `new Array(n)`: typed as results, actually a row of holes, with no work done
-  // and no error. A caller serializing that reports every item as null.
-  // Exercised through the real entry point because the guard itself is private.
-  it.each([0, -1, Number.NaN, Number.POSITIVE_INFINITY, 0.5])(
-    'does the work and returns no holes for limit %p',
-    async (limit) => {
-      const resolve = vi.fn(double);
-      const result = await mapWithConcurrency([1, 2, 3], limit, resolve);
-      expect(resolve).toHaveBeenCalledTimes(3);
-      expect(result).toEqual([2, 4, 6]);
-      // `toEqual` alone passes on a hole array against [undefined, ...]; this is
-      // the assertion that actually distinguishes them.
-      expect(Object.keys(result)).toHaveLength(3);
-    },
-  );
+  // A limit that resolves to zero workers would return `new Array(n)`: typed as
+  // results, actually a row of holes, with no work done and no error. A caller
+  // serializing that reports every item as null. Exercised through the real
+  // entry point because the guard itself is private.
+  //
+  // `0`/`-1`/`0.5` are the rows that pin `Math.max(1, …)`; `NaN` is the row that
+  // pins the `Number.isFinite` branch (without it, `Math.min(NaN, 3)` is `NaN`
+  // and `Array.from({length: NaN})` is empty). They fail for different reasons,
+  // which is why both guards are listed.
+  it.each([0, -1, 0.5, Number.NaN])('does the work and returns no holes for limit %p', async (limit) => {
+    const resolve = vi.fn(double);
+    const result = await mapWithConcurrency([1, 2, 3], limit, resolve);
+    expect(resolve).toHaveBeenCalledTimes(3);
+    expect(result).toEqual([2, 4, 6]);
+    // `toEqual` alone passes on a hole array against [undefined, ...]; this is
+    // the assertion that actually distinguishes them.
+    expect(Object.keys(result)).toHaveLength(3);
+  });
+
+  // A garbage limit falls back to SERIAL — the slowest correct answer, never a
+  // wrong one. Asserting the concurrency, not just the results, is what stops
+  // `NaN` from silently becoming "unbounded".
+  it('runs serially for a NaN limit rather than guessing a width', async () => {
+    let peak = 0;
+    let inFlight = 0;
+    await mapWithConcurrency([1, 2, 3, 4], Number.NaN, async (n) => {
+      peak = Math.max(peak, ++inFlight);
+      await new Promise((done) => setTimeout(done, 1));
+      inFlight--;
+      return n;
+    });
+    expect(peak).toBe(1);
+  });
+
+  // `Infinity` is an intent — "no ceiling" — not a bug, so it means one worker
+  // per item. It used to collapse to a single serial worker, which is the
+  // opposite of what the caller asked for.
+  it('treats an Infinity limit as unbounded, not as serial', async () => {
+    let peak = 0;
+    let inFlight = 0;
+    await mapWithConcurrency([1, 2, 3, 4, 5], Number.POSITIVE_INFINITY, async (n) => {
+      peak = Math.max(peak, ++inFlight);
+      await new Promise((done) => setTimeout(done, 1));
+      inFlight--;
+      return n;
+    });
+    expect(peak).toBe(5);
+  });
 
   it('holds concurrency at the limit', async () => {
     let inFlight = 0;
@@ -72,22 +104,6 @@ describe('mapWithConcurrency', () => {
     // The four workers in flight when the first failed are the only ones that
     // ever claimed an index; the remaining 36 items are never started.
     expect(started).toBe(4);
-  });
-
-  it('does not raise an unhandled rejection when several workers fail at once', async () => {
-    const unhandled = vi.fn();
-    process.on('unhandledRejection', unhandled);
-    try {
-      await expect(
-        mapWithConcurrency([1, 2, 3, 4], 4, async () => {
-          throw new Error('all fail');
-        }),
-      ).rejects.toThrow('all fail');
-      await new Promise((done) => setTimeout(done, 20));
-      expect(unhandled).not.toHaveBeenCalled();
-    } finally {
-      process.off('unhandledRejection', unhandled);
-    }
   });
 
   it('catches a resolver that throws synchronously', async () => {

--- a/apps/web/src/lib/__tests__/map-with-concurrency.test.ts
+++ b/apps/web/src/lib/__tests__/map-with-concurrency.test.ts
@@ -1,0 +1,112 @@
+/**
+ * These edge cases had no coverage while this lived as a private helper inside
+ * the route: the caller passes a hardcoded limit, so no test could reach a
+ * non-positive one, and the guard meant to prevent a hole-filled array could be
+ * deleted with every route test still green.
+ */
+import { describe, it, expect, vi } from 'vitest';
+import { mapWithConcurrency, resolveWorkerCount } from '../map-with-concurrency';
+
+const double = async (n: number) => n * 2;
+
+describe('resolveWorkerCount', () => {
+  it('honours a sane limit, capped by the item count', () => {
+    expect(resolveWorkerCount(8, 25)).toBe(8);
+    expect(resolveWorkerCount(8, 3)).toBe(3);
+  });
+
+  it('does nothing for no items', () => {
+    expect(resolveWorkerCount(8, 0)).toBe(0);
+  });
+
+  // Zero workers would resolve `new Array(n)` — typed as results, actually a
+  // row of holes — with no work done and no error, which a caller serializes
+  // as every item being null.
+  it.each([0, -1, Number.NaN, Number.POSITIVE_INFINITY, 0.5])(
+    'never starts zero workers for limit %p when there is work',
+    (limit) => {
+      expect(resolveWorkerCount(limit, 5)).toBeGreaterThanOrEqual(1);
+    },
+  );
+});
+
+describe('mapWithConcurrency', () => {
+  it('maps every item, in input order', async () => {
+    await expect(mapWithConcurrency([1, 2, 3, 4, 5], 2, double)).resolves.toEqual([2, 4, 6, 8, 10]);
+  });
+
+  it('returns [] for no items without calling the resolver', async () => {
+    const resolve = vi.fn(double);
+    await expect(mapWithConcurrency([], 4, resolve)).resolves.toEqual([]);
+    expect(resolve).not.toHaveBeenCalled();
+  });
+
+  it('preserves order even when later items finish first', async () => {
+    const delays = [30, 20, 10, 0];
+    const result = await mapWithConcurrency(delays, 4, async (delay) => {
+      await new Promise((done) => setTimeout(done, delay));
+      return delay;
+    });
+    expect(result).toEqual(delays);
+  });
+
+  it.each([0, -1, Number.NaN])('returns no holes for limit %p', async (limit) => {
+    const result = await mapWithConcurrency([1, 2, 3], limit, double);
+    expect(result).toEqual([2, 4, 6]);
+    // `toEqual` alone passes on a hole array against [undefined,...]; this is
+    // the assertion that actually distinguishes them.
+    expect(Object.keys(result)).toHaveLength(3);
+  });
+
+  it('holds concurrency at the limit', async () => {
+    let inFlight = 0;
+    let peak = 0;
+    await mapWithConcurrency(Array.from({ length: 30 }, (_, i) => i), 4, async (n) => {
+      peak = Math.max(peak, ++inFlight);
+      await new Promise((done) => setTimeout(done, 1));
+      inFlight--;
+      return n;
+    });
+    expect(peak).toBe(4);
+  });
+
+  it('propagates the first rejection and stops claiming new work', async () => {
+    let started = 0;
+    const attempt = mapWithConcurrency(Array.from({ length: 40 }, (_, i) => i), 4, async (n) => {
+      const mine = ++started;
+      await new Promise((done) => setTimeout(done, 1));
+      if (mine === 1) throw new Error('boom');
+      return n;
+    });
+
+    await expect(attempt).rejects.toThrow('boom');
+    await new Promise((done) => setTimeout(done, 50));
+    // The four workers in flight when the first failed are the only ones that
+    // ever claimed an index; the remaining 36 items are never started.
+    expect(started).toBe(4);
+  });
+
+  it('does not raise an unhandled rejection when several workers fail at once', async () => {
+    const unhandled = vi.fn();
+    process.on('unhandledRejection', unhandled);
+    try {
+      await expect(
+        mapWithConcurrency([1, 2, 3, 4], 4, async () => {
+          throw new Error('all fail');
+        }),
+      ).rejects.toThrow('all fail');
+      await new Promise((done) => setTimeout(done, 20));
+      expect(unhandled).not.toHaveBeenCalled();
+    } finally {
+      process.off('unhandledRejection', unhandled);
+    }
+  });
+
+  it('catches a resolver that throws synchronously', async () => {
+    await expect(
+      mapWithConcurrency([1], 2, () => {
+        throw new Error('sync boom');
+      }),
+    ).rejects.toThrow('sync boom');
+  });
+});

--- a/apps/web/src/lib/map-with-concurrency.ts
+++ b/apps/web/src/lib/map-with-concurrency.ts
@@ -28,8 +28,10 @@
  * remaining workers keep draining — spending the whole fan-out the limit exists
  * to contain on a result that has already failed. `failed` is set synchronously
  * in `catch` before the rethrow, so no worker can claim a new index afterwards;
- * a worker already suspended mid-await still completes the index it claimed, so
- * the claimed prefix is never left holed.
+ * a worker already suspended mid-await still completes the index it claimed.
+ * The index that FAILED is of course left unwritten, which is why a rejection
+ * must propagate rather than be swallowed — the array is never returned in that
+ * state, and there is no path where `Promise.all` resolves over a hole.
  */
 function resolveWorkerCount(limit: number, itemCount: number): number {
   // `Infinity` means "no ceiling", so it resolves to one worker per item.

--- a/apps/web/src/lib/map-with-concurrency.ts
+++ b/apps/web/src/lib/map-with-concurrency.ts
@@ -10,10 +10,12 @@
  * non-positive one, and the guard that was supposed to prevent a hole-filled
  * array could be deleted with every test still green.
  *
- * `resolveWorkerCount` is the whole subtlety. It stays module-private and is
- * exercised through `mapWithConcurrency` rather than directly: knip ignores
- * `src/**/__tests__/**`, so an export whose only consumer is a test counts as
- * dead code and fails the unused-code gate. Going through the real entry point
+ * `resolveWorkerCount` carries the whole subtlety. It stays module-private and is
+ * exercised through `mapWithConcurrency` rather than directly: knip ignores this
+ * app's `__tests__` directories, so an export whose only consumer is a test
+ * counts as dead code and fails the unused-code gate. (Spelling that ignore
+ * pattern out as a glob here would end this comment early — it contains the
+ * close-comment sequence.) Going through the real entry point
  * is the better test anyway — the edge cases below still turn red if the guard
  * is removed. A non-positive — or non-finite —
  * limit would start zero workers, and this function would then resolve
@@ -30,9 +32,16 @@
  * the claimed prefix is never left holed.
  */
 function resolveWorkerCount(limit: number, itemCount: number): number {
-  if (itemCount === 0) return 0;
-  const requested = Number.isFinite(limit) ? Math.floor(limit) : 1;
-  return Math.min(Math.max(1, requested), itemCount);
+  // `Infinity` means "no ceiling", so it resolves to one worker per item.
+  // Anything else non-finite (`NaN`) is a caller bug rather than an intent, and
+  // falls back to serial — the slowest correct answer, never a wrong one.
+  if (!Number.isFinite(limit)) return limit === Number.POSITIVE_INFINITY ? itemCount : Math.min(1, itemCount);
+  // The `Math.min` is an allocation guard with NO observable behaviour: extra
+  // workers past `itemCount` would immediately see `index >= items.length` and
+  // exit, so results and call counts are identical either way. Deliberately
+  // untested for that reason — there is nothing a test could assert that would
+  // distinguish it, and a test that cannot fail is worse than none.
+  return Math.min(Math.max(1, Math.floor(limit)), itemCount);
 }
 
 export async function mapWithConcurrency<TItem, TResult>(

--- a/apps/web/src/lib/map-with-concurrency.ts
+++ b/apps/web/src/lib/map-with-concurrency.ts
@@ -10,7 +10,12 @@
  * non-positive one, and the guard that was supposed to prevent a hole-filled
  * array could be deleted with every test still green.
  *
- * `resolveWorkerCount` is the whole subtlety. A non-positive — or non-finite —
+ * `resolveWorkerCount` is the whole subtlety. It stays module-private and is
+ * exercised through `mapWithConcurrency` rather than directly: knip ignores
+ * `src/**/__tests__/**`, so an export whose only consumer is a test counts as
+ * dead code and fails the unused-code gate. Going through the real entry point
+ * is the better test anyway — the edge cases below still turn red if the guard
+ * is removed. A non-positive — or non-finite —
  * limit would start zero workers, and this function would then resolve
  * `new Array(n)`: typed `TResult[]`, actually a row of holes, with no work done
  * and no error raised. A caller serializing that reports every item as null,
@@ -24,7 +29,7 @@
  * a worker already suspended mid-await still completes the index it claimed, so
  * the claimed prefix is never left holed.
  */
-export function resolveWorkerCount(limit: number, itemCount: number): number {
+function resolveWorkerCount(limit: number, itemCount: number): number {
   if (itemCount === 0) return 0;
   const requested = Number.isFinite(limit) ? Math.floor(limit) : 1;
   return Math.min(Math.max(1, requested), itemCount);

--- a/apps/web/src/lib/map-with-concurrency.ts
+++ b/apps/web/src/lib/map-with-concurrency.ts
@@ -1,0 +1,53 @@
+/**
+ * `Promise.all` over `items`, at most `limit` in flight, preserving input order.
+ *
+ * Order matters wherever this is used for a report a human diffs between runs:
+ * a settle-as-they-finish result would reshuffle it for no reason.
+ *
+ * Lives in its own module rather than beside its caller so the edge cases below
+ * can be tested directly. They were not, when this was a private helper inside
+ * a route: the caller passes a hardcoded limit, so no test could reach a
+ * non-positive one, and the guard that was supposed to prevent a hole-filled
+ * array could be deleted with every test still green.
+ *
+ * `resolveWorkerCount` is the whole subtlety. A non-positive — or non-finite —
+ * limit would start zero workers, and this function would then resolve
+ * `new Array(n)`: typed `TResult[]`, actually a row of holes, with no work done
+ * and no error raised. A caller serializing that reports every item as null,
+ * which is a far worse failure than being slow.
+ *
+ * The first rejection stops the queue as well as propagating. `Promise.all`
+ * rejects immediately but does not cancel its siblings, so without the flag the
+ * remaining workers keep draining — spending the whole fan-out the limit exists
+ * to contain on a result that has already failed. `failed` is set synchronously
+ * in `catch` before the rethrow, so no worker can claim a new index afterwards;
+ * a worker already suspended mid-await still completes the index it claimed, so
+ * the claimed prefix is never left holed.
+ */
+export function resolveWorkerCount(limit: number, itemCount: number): number {
+  if (itemCount === 0) return 0;
+  const requested = Number.isFinite(limit) ? Math.floor(limit) : 1;
+  return Math.min(Math.max(1, requested), itemCount);
+}
+
+export async function mapWithConcurrency<TItem, TResult>(
+  items: readonly TItem[],
+  limit: number,
+  resolve: (item: TItem) => Promise<TResult>,
+): Promise<TResult[]> {
+  const results: TResult[] = new Array(items.length);
+  let next = 0;
+  let failed = false;
+  const workers = Array.from({ length: resolveWorkerCount(limit, items.length) }, async () => {
+    for (let index = next++; index < items.length && !failed; index = next++) {
+      try {
+        results[index] = await resolve(items[index]);
+      } catch (error) {
+        failed = true;
+        throw error;
+      }
+    }
+  });
+  await Promise.all(workers);
+  return results;
+}

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -6,17 +6,6 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Fixed
 
-- **The `keys describe` hint printed after a mint is now runnable.** It omitted `--key`, so with a
-  personal login and no active key — the state you are in right after `keys create` — the printed
-  command hit `run.ts`'s explicit-credential gate and was refused. It also interpolated the key name
-  into a shell command unquoted, so `--name "lead gen"` printed `--key lead gen`. It now emits
-  `--key=<name>`, shell-quoted: the equals form is required because a name beginning with `-`
-  survives quote-stripping as an argv word `parseArgv` rejects as a flag value.
-- **The mint no longer swallows why a permission readback was skipped.** When the server returns a
-  refresh credential instead of a static token there is no bearer to ask with; without
-  `--show-token` that path had stopped saying so.
-- **`keys describe`'s usage line and the README** now state that it needs a content credential
-  named — it is the one `keys` verb that reports on one.
 - **`keys create --name ""` is refused instead of minting an unusable key.** A blank name arrived as
   an empty string rather than as "absent", so the key was stored under `""` — and `--key`, the key
   env var and `keys use` all treat a blank name as no name, so nothing could ever select it again.
@@ -33,6 +22,9 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   "reads fine, every write fails" shape #2470 was about. It is the one `keys` verb a key can run,
   and it describes only itself — never the other keys you hold. The same summary now closes `keys create` and the
   `pagespace keys` wizard's Create flow, and it is served as an MCP tool (`tokens.describeSelf`).
+  Unlike its `keys` siblings it reports on a *content* credential, so it needs one named —
+  `--key=<name>`, `--token`, the env vars, or an active key — which is what the hint printed after a
+  mint now gives you, shell-quoted so a key named with a space or a leading dash still pastes.
 - **`pagespace keys list` shows the role granted on each drive**, including custom roles by name and
   inherit scopes spelled out, instead of the drive name alone.
 

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -20,6 +20,10 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   returns a refresh credential instead of a static token there is no bearer to ask with; 1.8.0 said
   the readback had failed but not that. (The `pagespace keys` wizard already gave the reason — the
   two surfaces now match.)
+- **The `logout` command suggested when a key name is already taken is pasteable too.** It printed
+  `--key <name>` space-separated with the name interpolated, so a key called `-prod` produced a
+  command the parser rejects and `lead gen` one that logs out of the wrong key. Same fix as the
+  post-mint hint, which is where the hole was first found.
 - **`keys describe`'s usage line and the README** now say it needs a content credential named — it
   is the one `keys` verb that reports on one rather than managing keys, and the README's summary
   paragraph previously said the opposite.

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -14,10 +14,12 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - **`keys create` refuses a blank or whitespace-padded `--name` instead of minting an unfindable
   key.** A key is stored under its name verbatim, but every lookup trims first — so `--name "  x  "`
   wrote the store under `"  x  "` while `--key` resolved `"x"` and missed, and `--name ""` wrote a
-  key no lookup could ever produce. Both are now refused at mint, with the trimmed form suggested.
-- **A mint that returns no raw token says so.** When the server returns a refresh credential instead
-  of a static token there is no bearer to read the new key's permissions back with; without
-  `--show-token` that path printed nothing about why the summary was missing.
+  key no lookup could ever produce. A padded name is now refused with the trimmed spelling
+  suggested; a blank or all-whitespace one is refused as blank.
+- **`keys create` now says WHY it could not read a new key's permissions back.** When the server
+  returns a refresh credential instead of a static token there is no bearer to ask with; 1.8.0 said
+  the readback had failed but not that. (The `pagespace keys` wizard already gave the reason — the
+  two surfaces now match.)
 - **`keys describe`'s usage line and the README** now say it needs a content credential named — it
   is the one `keys` verb that reports on one rather than managing keys, and the README's summary
   paragraph previously said the opposite.

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -6,9 +6,10 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Fixed
 
-- **`keys create --name ""` is refused instead of minting an unusable key.** A blank name arrived as
-  an empty string rather than as "absent", so the key was stored under `""` — and `--key`, the key
-  env var and `keys use` all treat a blank name as no name, so nothing could ever select it again.
+- **`keys create` refuses a blank or whitespace-padded `--name` instead of minting an unfindable
+  key.** A key is stored under its name verbatim, but every lookup trims first — so `--name "  x  "`
+  wrote the store under `"  x  "` while `--key` resolved `"x"` and missed, and `--name ""` wrote a
+  key no lookup could ever produce. Both are now refused at mint, with the trimmed form suggested.
 
 ### Added
 

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -20,6 +20,11 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   returns a refresh credential instead of a static token there is no bearer to ask with; 1.8.0 said
   the readback had failed but not that. (The `pagespace keys` wizard already gave the reason — the
   two surfaces now match.)
+- **`pagespace login --key <name>` no longer suggests a command that would revoke your personal
+  login.** When a NAMED key was the credential already stored, the message named that key but
+  suggested a bare `pagespace logout --host <host>` — and `logout` resolves its own key name, so it
+  landed on `default`, revoking that refresh token server-side and deleting it. The suggestion now
+  names the same key the message is about. `login --device` printed the same line.
 - **The `logout` command suggested when a key name is already taken is pasteable too.** It printed
   `--key <name>` space-separated with the name interpolated, so a key called `-prod` produced a
   command the parser rejects and `lead gen` one that logs out of the wrong key. Same fix as the

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -17,6 +17,9 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   `--show-token` that path had stopped saying so.
 - **`keys describe`'s usage line and the README** now state that it needs a content credential
   named — it is the one `keys` verb that reports on one.
+- **`keys create --name ""` is refused instead of minting an unusable key.** A blank name arrived as
+  an empty string rather than as "absent", so the key was stored under `""` — and `--key`, the key
+  env var and `keys use` all treat a blank name as no name, so nothing could ever select it again.
 
 ### Added
 

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -4,6 +4,20 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Fixed
+
+- **The `keys describe` hint printed after a mint is now runnable.** It omitted `--key`, so with a
+  personal login and no active key — the state you are in right after `keys create` — the printed
+  command hit `run.ts`'s explicit-credential gate and was refused. It also interpolated the key name
+  into a shell command unquoted, so `--name "lead gen"` printed `--key lead gen`. It now emits
+  `--key=<name>`, shell-quoted: the equals form is required because a name beginning with `-`
+  survives quote-stripping as an argv word `parseArgv` rejects as a flag value.
+- **The mint no longer swallows why a permission readback was skipped.** When the server returns a
+  refresh credential instead of a static token there is no bearer to ask with; without
+  `--show-token` that path had stopped saying so.
+- **`keys describe`'s usage line and the README** now state that it needs a content credential
+  named — it is the one `keys` verb that reports on one.
+
 ### Added
 
 - **`pagespace keys describe`** — reports the credential this invocation would use: its drives, the

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -55,8 +55,11 @@ The model behind those four commands:
   credential explicitly so they stay portable and self-describing (see below).
 - **A key can describe itself, but cannot manage keys.** `pagespace keys describe` reports the
   credential in use — drives, role, and the permissions it actually resolves to — and works
-  under a key. `keys list`/`revoke`/`use` and the wizard manage the whole set of keys you hold,
-  so they need your login and refuse a key outright rather than failing halfway through.
+  under a key. Because it reports on a *content* credential rather than managing keys, it is the
+  one `keys` verb that follows the content-command rule above: name the credential
+  (`--key=<name>`, `--token`, the env vars, or an active key). `keys list`/`revoke`/`use` and the
+  wizard manage the whole set of keys you hold, so they need your login instead, and refuse a key
+  outright rather than failing halfway through.
 
 No browser on this machine (CI, container, remote box)? `pagespace login --device` prints a
 short code and URL you approve from any browser. Keys are different — their consent redirect
@@ -83,7 +86,7 @@ trust boundary.
 | `pagespace keys create --drive <id> [--role member\|admin\|<customRoleId>] [--drive … --role …] [--name <name>] [--show-token] [--yes]` | Mints a key scoped to the given drive(s) via browser consent, then stores it under `--name` (defaults to the drive id; required for multiple drives; `default` is reserved for your login). `--yes` overwrites an existing key of the same name. |
 | `pagespace keys use <name>` / `pagespace keys use --off` | Makes a stored key this machine's **active key** (browser approval), or deactivates it locally. See above. |
 | `pagespace keys list [--json]` | Lists your keys (prefix only — never the secret), with the role granted on each drive. Needs your login — a key cannot list keys; see `keys describe`. |
-| `pagespace keys describe [--page <pageId>] [--json]` | What the credential this machine would use actually is: its drives, the role granted in each, and the **effective** permissions that role resolves to (view/edit/share/delete). Drive-level permissions cover the drive itself (creating a top-level page, sharing or deleting it); a page inside can be narrower, so `--page` resolves that page too. The one `keys` verb a key can run about itself. |
+| `pagespace keys describe [--page <pageId>] [--json]` | What the credential this machine would use actually is: its drives, the role granted in each, and the **effective** permissions that role resolves to (view/edit/share/delete). Drive-level permissions cover the drive itself (creating a top-level page, sharing or deleting it); a page inside can be narrower, so `--page` resolves that page too. The one `keys` verb a key can run about itself — and, unlike its siblings, it reports on a **content** credential, so it needs one named: `--key=<name>`, `--token`, the env vars, or an active key. A bare `pagespace keys describe` with only a personal login is refused, like any other content command. |
 | `pagespace keys revoke <tokenId> [--yes]` | Revokes a key server-side. Irreversible. |
 
 `--role` binds to the `--drive` immediately before it, not to every `--drive` on the command

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -95,9 +95,14 @@ all — it's scoped to *whatever role you personally hold on drive `a` at reques
 changes if your own membership does. Give every drive its own `--role` when you want a fixed
 grant: `--drive a --role admin --drive b --role admin`.
 
-None of these need `--key`/`--token`: a plain `pagespace login` is enough to drive them all
-(`keys create` brings its own browser consent). Everything else — the content commands — needs
-a credential, resolved as described next.
+A plain `pagespace login` is enough to drive these — with one exception. `keys create`, `list`,
+`revoke`, `use` and the wizard all *manage* keys, so they need your login and nothing else
+(`keys create` brings its own browser consent). **`keys describe` is the exception**: it reports on
+a *content* credential rather than managing keys, so it needs one named — `--key=<name>`,
+`--token`, the env vars, or an active key — exactly like the content commands below. A bare
+`pagespace keys describe` with only a login is refused.
+
+Everything else — the content commands — needs a credential, resolved as described next.
 
 ### How commands find a credential
 

--- a/packages/cli/src/commands/__tests__/login-device.test.ts
+++ b/packages/cli/src/commands/__tests__/login-device.test.ts
@@ -147,6 +147,34 @@ describe('createLoginDeviceHandler', () => {
     expect(stderr.lines.join('')).not.toContain('ps_rt_existing');
   });
 
+
+  // `logout` REVOKES the refresh token server-side before deleting it, and it
+  // resolves its own key name — so a bare `logout --host X` suggested while a
+  // NAMED key is the blocker would revoke the personal login instead. The
+  // suggestion has to name the same key the sentence is about.
+  it('suggests a logout that names the blocking key, not one that revokes the default credential', async () => {
+    const store = fakeStore();
+    // Stored under the NAMED key, which is what makes it the blocker here.
+    await store.set(
+      'https://pagespace.ai',
+      { kind: 'oauth', refreshToken: 'ps_rt_existing', clientId: 'pagespace-cli', scopes: ['account'], createdAt: '2026-01-01T00:00:00.000Z' },
+      'ci bot',
+    );
+    const handler = createLoginDeviceHandler(baseHandlerDeps(store));
+
+    const stderr = createRecordingSink();
+    const ctx = createFakeContext({ stderr, env: {} });
+
+    const code = await handler(ctx, commandIntent(['login', '--key', 'ci bot']));
+
+    expect(code).toBe(EXIT_RUNTIME_ERROR);
+    const output = stderr.lines.join('');
+    expect(output).toContain(`(key "ci bot")`);
+    // Names the key, and is quoted so it survives being pasted.
+    expect(output).toContain(`--key='ci bot'`);
+    expect(output).not.toMatch(/logout --host=\S+" first/);
+  });
+
   it('overwrites an existing stored credential when --yes is passed', async () => {
     const store = fakeStore(
       new Map([['https://pagespace.ai', { kind: 'oauth', refreshToken: 'ps_rt_existing', clientId: 'pagespace-cli', scopes: ['account'], createdAt: '2026-01-01T00:00:00.000Z' }]]),

--- a/packages/cli/src/commands/__tests__/login.test.ts
+++ b/packages/cli/src/commands/__tests__/login.test.ts
@@ -196,6 +196,34 @@ describe('createLoginHandler', () => {
     expect(stderr.lines.join('')).not.toContain('ps_rt_existing');
   });
 
+
+  // `logout` REVOKES the refresh token server-side before deleting it, and it
+  // resolves its own key name — so a bare `logout --host X` suggested while a
+  // NAMED key is the blocker would revoke the personal login instead. The
+  // suggestion has to name the same key the sentence is about.
+  it('suggests a logout that names the blocking key, not one that revokes the default credential', async () => {
+    const store = fakeStore();
+    // Stored under the NAMED key, which is what makes it the blocker here.
+    await store.set(
+      'https://pagespace.ai',
+      { kind: 'oauth', refreshToken: 'ps_rt_existing', clientId: 'pagespace-cli', scopes: ['account'], createdAt: '2026-01-01T00:00:00.000Z' },
+      'ci bot',
+    );
+    const handler = createLoginHandler(baseHandlerDeps(store));
+
+    const stderr = createRecordingSink();
+    const ctx = createFakeContext({ stderr, env: {} });
+
+    const code = await handler(ctx, commandIntent(['login', '--key', 'ci bot']));
+
+    expect(code).toBe(EXIT_RUNTIME_ERROR);
+    const output = stderr.lines.join('');
+    expect(output).toContain(`(key "ci bot")`);
+    // Names the key, and is quoted so it survives being pasted.
+    expect(output).toContain(`--key='ci bot'`);
+    expect(output).not.toMatch(/logout --host=\S+" first/);
+  });
+
   it('overwrites an existing stored credential when --yes is passed', async () => {
     const store = fakeStore(
       new Map([['https://pagespace.ai', { kind: 'oauth', refreshToken: 'ps_rt_existing', clientId: 'pagespace-cli', scopes: ['account'], createdAt: '2026-01-01T00:00:00.000Z' }]]),

--- a/packages/cli/src/commands/keys/__tests__/create.test.ts
+++ b/packages/cli/src/commands/keys/__tests__/create.test.ts
@@ -695,6 +695,24 @@ describe('createTokensCreateHandler', () => {
     expect(output.split('pagespace keys describe').length - 1).toBe(1);
   });
 
+  // The cause has to be stated here rather than deferred to the --show-token
+  // branch, which does not run on this path: deferring left a bare "could not
+  // be read back" with nothing for the reader to act on.
+  it('names WHY the readback did not happen even without --show-token', async () => {
+    const fake = fakeServer();
+    const handler = createTokensCreateHandler({
+      ...baseHandlerDeps(fakeStore()),
+      startServer: async () => fake.server,
+      openBrowser: autoApprove(fake),
+    });
+
+    const stdout = createRecordingSink();
+    const ctx = createFakeContext({ stdout, env: {} });
+
+    expect(await handler(ctx, commandIntent(['keys', 'create', '--drive', 'drv1', '--role', 'member']))).toBe(EXIT_SUCCESS);
+    expect(stdout.lines.join('')).toContain('Its permissions could not be read back here — it returned no raw token.');
+  });
+
   it('without --show-token the raw mcp_* token appears nowhere in the output', async () => {
     const store = fakeStore();
     const fake = fakeServer();
@@ -732,10 +750,7 @@ describe('createTokensCreateHandler', () => {
 
     expect(code).toBe(EXIT_SUCCESS);
     expect(stderr.lines.join('')).toMatch(/no raw token to show/i);
-    // The readback says only that it did not happen; the reason is stated once,
-    // by the --show-token line above, not twice back to back.
-    expect(stderr.lines.join('')).toContain('The key was created. Its permissions could not be read back here.');
-    expect(stderr.lines.join('').match(/no raw token/gi)).toHaveLength(1);
+    expect(stderr.lines.join('')).toContain('Its permissions could not be read back here — it returned no raw token.');
     const allOutput = [...stdout.lines, ...stderr.lines].join('');
     expect(allOutput).not.toContain(FIXED_TOKENS.refreshToken);
     expect(allOutput).not.toContain(FIXED_TOKENS.accessToken);

--- a/packages/cli/src/commands/keys/__tests__/create.test.ts
+++ b/packages/cli/src/commands/keys/__tests__/create.test.ts
@@ -295,6 +295,16 @@ describe('resolveNewKeyName', () => {
     });
   });
 
+  // `--name ""` arrives as an empty STRING, not as absent — `??` only falls
+  // through on null/undefined — so it used to mint a key the keychain stores
+  // under "", which `--key=`, the key env var and `keys use` all refuse
+  // (blank reads as absent). Nothing could ever name it again.
+  it.each([[''], ['   '], ['\t']])('rejects a blank --name (%j), which would mint an unusable key', (name) => {
+    const result = resolveNewKeyName({ name, drives: [{ id: 'drv1', role: null }] });
+    expect(result.ok).toBe(false);
+    expect(result.ok === false && result.message).toContain('must not be blank');
+  });
+
   it('rejects "default" as an explicit --name — that slot is reserved for "pagespace login", and says so in key vocabulary', () => {
     const result = resolveNewKeyName({ name: 'default', drives: [{ id: 'drv1', role: null }] });
     expect(result.ok).toBe(false);

--- a/packages/cli/src/commands/keys/__tests__/create.test.ts
+++ b/packages/cli/src/commands/keys/__tests__/create.test.ts
@@ -302,7 +302,26 @@ describe('resolveNewKeyName', () => {
   it.each([[''], ['   '], ['\t']])('rejects a blank --name (%j), which would mint an unusable key', (name) => {
     const result = resolveNewKeyName({ name, drives: [{ id: 'drv1', role: null }] });
     expect(result.ok).toBe(false);
-    expect(result.ok === false && result.message).toContain('must not be blank');
+    expect(result.ok === false && result.message).toMatch(/must not be blank|whitespace/);
+  });
+
+  // The same failure short of its limit: a key is STORED under its name
+  // verbatim but every lookup trims first, so `--name "  x  "` writes the store
+  // under "  x  " while `--key` resolves "x" and misses. Trimming to decide and
+  // storing untrimmed is what created the mismatch.
+  it.each([['  x  '], ['x '], [' x'], ['\tx']])('rejects a whitespace-padded --name (%j)', (name) => {
+    const result = resolveNewKeyName({ name, drives: [{ id: 'drv1', role: null }] });
+    expect(result.ok).toBe(false);
+    expect(result.ok === false && result.message).toMatch(/whitespace/);
+    // Names the usable form rather than leaving the caller to guess.
+    expect(result.ok === false && result.message).toContain(`"${name.trim()}"`);
+  });
+
+  it('still accepts a name with INTERNAL spaces, which look up fine', () => {
+    expect(resolveNewKeyName({ name: 'lead gen', drives: [{ id: 'drv1', role: null }] })).toEqual({
+      ok: true,
+      name: 'lead gen',
+    });
   });
 
   it('rejects "default" as an explicit --name — that slot is reserved for "pagespace login", and says so in key vocabulary', () => {

--- a/packages/cli/src/commands/keys/__tests__/create.test.ts
+++ b/packages/cli/src/commands/keys/__tests__/create.test.ts
@@ -329,6 +329,35 @@ describe('resolveNewKeyName', () => {
     });
   });
 
+  // The padding branch is the only rejection that SUGGESTS a replacement, so
+  // every name whose trimmed form is ALSO invalid has to be caught before it.
+  // Two such names exist — "   " trims to "" (blank) and "  default  " trims to
+  // "default" (reserved) — and both used to be told to use the very thing the
+  // next guard refuses.
+  it('rejects a padded reserved name as reserved, not with advice to use the reserved name', () => {
+    const result = resolveNewKeyName({ name: '  default  ', drives: [{ id: 'drv1', role: null }] });
+    expect(result.ok).toBe(false);
+    expect(result.ok === false && result.message).toContain('is reserved');
+    expect(result.ok === false && result.message).not.toMatch(/Use "default"/);
+  });
+
+  // The invariant that makes this class of bug impossible rather than merely
+  // absent: whenever a rejection names a replacement, that replacement must
+  // itself be accepted.
+  it.each([['  x  '], [' lead gen '], ['\tci-bot\t']])(
+    'only ever suggests a name that is itself valid (%j)',
+    (name) => {
+      const result = resolveNewKeyName({ name, drives: [{ id: 'drv1', role: null }] });
+      expect(result.ok).toBe(false);
+      const suggested = result.ok === false && result.message.match(/Use "(.*)"\.$/)?.[1];
+      expect(suggested).toBeTruthy();
+      expect(resolveNewKeyName({ name: suggested as string, drives: [{ id: 'drv1', role: null }] })).toEqual({
+        ok: true,
+        name: suggested,
+      });
+    },
+  );
+
   it('rejects "default" as an explicit --name — that slot is reserved for "pagespace login", and says so in key vocabulary', () => {
     const result = resolveNewKeyName({ name: 'default', drives: [{ id: 'drv1', role: null }] });
     expect(result.ok).toBe(false);

--- a/packages/cli/src/commands/keys/__tests__/create.test.ts
+++ b/packages/cli/src/commands/keys/__tests__/create.test.ts
@@ -882,6 +882,9 @@ describe('createTokensCreateHandler', () => {
     const output = stderr.lines.join('');
     expect(output).toContain(`--key='-prod key'`);
     expect(output).not.toContain('--key -prod key');
+    // Both halves of the suggested command, not just the one that motivated it.
+    expect(output).toContain('--host=https://pagespace.ai');
+    expect(output).not.toContain('--host https://pagespace.ai');
   });
 
   it('overwrites an existing stored key when --yes is passed', async () => {

--- a/packages/cli/src/commands/keys/__tests__/create.test.ts
+++ b/packages/cli/src/commands/keys/__tests__/create.test.ts
@@ -828,6 +828,33 @@ describe('createTokensCreateHandler', () => {
     expect(stderr.lines.join('')).not.toContain('ps_rt_existing');
   });
 
+  // The other command this CLI prints with a key name in it. A name like
+  // `-prod` made the suggested logout unpasteable in exactly the way the
+  // post-mint hint was — `--key` takes the next word, or rejects a value
+  // starting with `-` outright.
+  it('suggests a logout command that survives an awkward key name', async () => {
+    const store = fakeStore();
+    await store.set(
+      'https://pagespace.ai',
+      { kind: 'static', token: 'mcp_existing', scopes: ['drive:drv1:member'], createdAt: '2026-01-01T00:00:00.000Z' },
+      '-prod key',
+    );
+    const handler = createTokensCreateHandler(baseHandlerDeps(store));
+
+    const stderr = createRecordingSink();
+    const ctx = createFakeContext({ stderr, env: {} });
+
+    const code = await handler(
+      ctx,
+      commandIntent(['keys', 'create', '--drive', 'drv1', '--role', 'member', '--name', '-prod key']),
+    );
+
+    expect(code).toBe(EXIT_RUNTIME_ERROR);
+    const output = stderr.lines.join('');
+    expect(output).toContain(`--key='-prod key'`);
+    expect(output).not.toContain('--key -prod key');
+  });
+
   it('overwrites an existing stored key when --yes is passed', async () => {
     const store = fakeStore();
     await store.set(

--- a/packages/cli/src/commands/keys/__tests__/create.test.ts
+++ b/packages/cli/src/commands/keys/__tests__/create.test.ts
@@ -299,10 +299,15 @@ describe('resolveNewKeyName', () => {
   // through on null/undefined — so it used to mint a key the keychain stores
   // under "", which `--key=`, the key env var and `keys use` all refuse
   // (blank reads as absent). Nothing could ever name it again.
-  it.each([[''], ['   '], ['\t']])('rejects a blank --name (%j), which would mint an unusable key', (name) => {
+  // Asserted as the BLANK message specifically, not "blank or whitespace". An
+  // all-whitespace name satisfies both guards, and when the padding guard won
+  // the race the advice became `Use ""` — the empty name the other guard
+  // rejects. A regex accepting either message hid that entirely.
+  it.each([[''], ['   '], ['\t'], ['\n ']])('rejects a blank-or-whitespace --name (%j) as blank', (name) => {
     const result = resolveNewKeyName({ name, drives: [{ id: 'drv1', role: null }] });
     expect(result.ok).toBe(false);
-    expect(result.ok === false && result.message).toMatch(/must not be blank|whitespace/);
+    expect(result.ok === false && result.message).toContain('must not be blank');
+    expect(result.ok === false && result.message).not.toMatch(/Use ""/);
   });
 
   // The same failure short of its limit: a key is STORED under its name

--- a/packages/cli/src/commands/keys/__tests__/describe.test.ts
+++ b/packages/cli/src/commands/keys/__tests__/describe.test.ts
@@ -208,6 +208,15 @@ describe('parseKeysDescribeArgs', () => {
       expect(result.ok === false && result.message).toContain('--page <pageId>');
     },
   );
+
+  // The usage line is the one place a reader learns that this verb, alone among
+  // its `keys` siblings, needs a content credential named — pinned so it cannot
+  // drift back to a bare synopsis.
+  it('tells the reader it needs a credential named, which its siblings do not', () => {
+    const result = parseKeysDescribeArgs(['--page']);
+    expect(result.ok === false && result.message).toContain('--key=<name>');
+    expect(result.ok === false && result.message).toMatch(/content credential/i);
+  });
 });
 
 describe('keysDescribeHandler', () => {

--- a/packages/cli/src/commands/keys/__tests__/guidance.test.ts
+++ b/packages/cli/src/commands/keys/__tests__/guidance.test.ts
@@ -73,7 +73,7 @@ describe('wizard copy constants', () => {
  */
 describe('keysDescribeHint', () => {
   it('names the key that was just minted, so the printed command is runnable', () => {
-    expect(keysDescribeHint('lead-gen')).toContain('pagespace keys describe --key=lead-gen');
+    expect(keysDescribeHint('lead-gen', DEFAULT_HOST)).toContain('pagespace keys describe --key=lead-gen');
   });
 
   // Key names are close to free-form (`resolveNewKeyName` refuses only the
@@ -95,7 +95,18 @@ describe('keysDescribeHint', () => {
     ['-prod', '--key=-prod'],
     ['--json', '--key=--json'],
   ])('prints %j as a word a shell hands back intact', (keyName, expected) => {
-    expect(keysDescribeHint(keyName)).toContain(expected);
+    expect(keysDescribeHint(keyName, DEFAULT_HOST)).toContain(expected);
+  });
+
+  // The key is stored under the host it was minted against, and the credential
+  // store is keyed by host — so a hint that omits --host resolves against the
+  // default and misses a key minted anywhere else. Same reason the MCP config
+  // block carries PAGESPACE_API_URL.
+  it('carries --host for a non-default host, and omits it for the default', () => {
+    expect(keysDescribeHint('k', 'https://tenant.example.com')).toContain(
+      '--key=k --host=https://tenant.example.com',
+    );
+    expect(keysDescribeHint('k', DEFAULT_HOST)).not.toContain('--host');
   });
 
   it('is printed exactly once per mint, by the wiring guidance', () => {

--- a/packages/cli/src/commands/keys/__tests__/guidance.test.ts
+++ b/packages/cli/src/commands/keys/__tests__/guidance.test.ts
@@ -73,7 +73,7 @@ describe('wizard copy constants', () => {
  */
 describe('keysDescribeHint', () => {
   it('names the key that was just minted, so the printed command is runnable', () => {
-    expect(keysDescribeHint('lead-gen')).toContain('pagespace keys describe --key lead-gen');
+    expect(keysDescribeHint('lead-gen')).toContain('pagespace keys describe --key=lead-gen');
   });
 
   // Key names are close to free-form (`resolveNewKeyName` refuses only the
@@ -81,12 +81,20 @@ describe('keysDescribeHint', () => {
   // shell would mis-split: `--key` took `lead`, and `gen` became a stray
   // positional the parser rejects. A hint that cannot be pasted is worse than
   // no hint, because the reader cannot tell it from one that can.
+  // Quoting alone is not enough: a name starting with `-` survives
+  // quote-stripping as the argv word `-prod`, and `parseArgv` rejects a
+  // space-separated flag value beginning with `-`. The equals-joined form is
+  // what `parse.ts` documents for exactly that ambiguity, so the hint uses it
+  // unconditionally — a plain name is unquoted, but still `--key=`.
   it.each([
-    ['lead gen', "--key 'lead gen'"],
-    ["o'brien", "--key 'o'\\''brien'"],
-    ['a$HOME', "--key 'a$HOME'"],
-    ['plain-name_1', '--key plain-name_1'],
-  ])('quotes %j so the printed command survives a shell', (keyName, expected) => {
+    ['lead gen', "--key='lead gen'"],
+    ["o'brien", "--key='o'\\''brien'"],
+    ['a$HOME', "--key='a$HOME'"],
+    ['~x', "--key='~x'"],
+    ['plain-name_1', '--key=plain-name_1'],
+    ['-prod', '--key=-prod'],
+    ['--json', '--key=--json'],
+  ])('prints %j as a word a shell hands back intact', (keyName, expected) => {
     expect(keysDescribeHint(keyName)).toContain(expected);
   });
 
@@ -94,6 +102,6 @@ describe('keysDescribeHint', () => {
     const output = renderAgentWiringGuidance({ keyName: 'lead-gen', host: DEFAULT_HOST }).join('\n');
     const occurrences = output.split('pagespace keys describe').length - 1;
     expect(occurrences).toBe(1);
-    expect(output).toContain('--key lead-gen');
+    expect(output).toContain('--key=lead-gen');
   });
 });

--- a/packages/cli/src/commands/keys/__tests__/guidance.test.ts
+++ b/packages/cli/src/commands/keys/__tests__/guidance.test.ts
@@ -77,7 +77,8 @@ describe('keysDescribeHint', () => {
   });
 
   // Key names are close to free-form (`resolveNewKeyName` refuses only the
-  // reserved "default"), so an unquoted name with a space printed a command the
+  // reserved "default" and names no lookup could produce — blank or padded), so
+  // an unquoted name with a space printed a command the
   // shell would mis-split: `--key` took `lead`, and `gen` became a stray
   // positional the parser rejects. A hint that cannot be pasted is worse than
   // no hint, because the reader cannot tell it from one that can.

--- a/packages/cli/src/commands/keys/__tests__/wizard.test.ts
+++ b/packages/cli/src/commands/keys/__tests__/wizard.test.ts
@@ -364,6 +364,32 @@ describe('createKeysHandler — Create flow, mcp-kind mint (the production shape
     expect(notes.some((note) => note.includes('What this key can do') && note.includes('on the drive: view'))).toBe(true);
   });
 
+  // The no-raw-token branch had no test at all, so its copy could drift from
+  // create.ts's (and did — one surface kept the reason, the other dropped it).
+  it('says the key was created and why its permissions are missing when no raw token comes back', async () => {
+    selectMock
+      .mockReset()
+      .mockResolvedValueOnce('create')
+      .mockResolvedValueOnce('specific')
+      .mockResolvedValueOnce({ kind: 'member' })
+      .mockResolvedValueOnce('exit');
+    multiselectMock.mockReset().mockResolvedValueOnce(['drv1']);
+    textMock.mockReset().mockResolvedValueOnce('my-key');
+    confirmMock.mockReset().mockResolvedValueOnce(true);
+    noteMock.mockReset();
+
+    const { createKeysHandler } = await import('../wizard.js');
+    const { deps, sdk } = mcpCreateHandlerSetup();
+    // An oauth-kind exchange yields no static token, so onMintedStaticToken
+    // never fires — the same anomaly `--show-token` reports in create.ts.
+    const handler = createKeysHandler({ ...deps, exchangeCode: async () => FIXED_TOKENS });
+    const ctx = createFakeContext({ sdk, isTTY: true, env: {} });
+
+    expect(await handler(ctx, commandIntent(['keys']))).toBe(EXIT_SUCCESS);
+    const notes = noteMock.mock.calls.map((call) => `${String(call[0])}\n${String(call[1] ?? '')}`);
+    expect(notes.some((note) => note.includes('The key was created. Its permissions could not be read back here — it returned no raw token.'))).toBe(true);
+  });
+
   it('still completes the mint when the permission readback fails, and points at "keys describe" instead', async () => {
     selectMock
       .mockReset()
@@ -394,7 +420,7 @@ describe('createKeysHandler — Create flow, mcp-kind mint (the production shape
     // appears once, in the wiring note, naming the key.
     expect(notes.some((note) => note.includes('could not be read back just now'))).toBe(true);
     expect(notes.filter((note) => note.includes('pagespace keys describe'))).toHaveLength(1);
-    expect(notes.some((note) => note.includes('pagespace keys describe --key my-key'))).toBe(true);
+    expect(notes.some((note) => note.includes('pagespace keys describe --key=my-key'))).toBe(true);
   });
 
   it('never surfaces the raw token anywhere when the show-once confirm is declined, but still prints guidance', async () => {

--- a/packages/cli/src/commands/keys/create.ts
+++ b/packages/cli/src/commands/keys/create.ts
@@ -247,16 +247,20 @@ export function resolveNewKeyName({
   //
   // Only reachable through the flag path — `wizard.ts` trims before it gets
   // here.
+  // Blank FIRST, deliberately. An all-whitespace name satisfies both
+  // conditions, and taking the padding branch made the message suggest the
+  // trimmed form — which for "   " is the empty string the next guard rejects,
+  // i.e. advice to do the one other thing that cannot work.
+  if (resolvedName.trim().length === 0) {
+    return {
+      ok: false,
+      message: '--name must not be blank: a key is selected by its name, so an unnamed key could never be used.',
+    };
+  }
   if (resolvedName !== resolvedName.trim()) {
     return {
       ok: false,
       message: `--name "${resolvedName}" has leading or trailing whitespace: keys are looked up by their trimmed name, so this one could be created and never found again. Use "${resolvedName.trim()}".`,
-    };
-  }
-  if (resolvedName.length === 0) {
-    return {
-      ok: false,
-      message: '--name must not be blank: a key is selected by its name, so an unnamed key could never be used.',
     };
   }
   if (resolvedName === DEFAULT_PROFILE_NAME) {

--- a/packages/cli/src/commands/keys/create.ts
+++ b/packages/cli/src/commands/keys/create.ts
@@ -336,7 +336,7 @@ async function writeEffectivePermissions(params: {
     info.write(`\n${renderKeyDescription(await describe({ host, accessToken: token }))}`);
   } catch (error) {
     info.write(
-      `The key was created. Its effective permissions could not be read back just now (${error instanceof Error ? error.message : String(error)}).\n`,
+      `The key was created. Its permissions could not be read back just now (${error instanceof Error ? error.message : String(error)}).\n`,
     );
   }
 }

--- a/packages/cli/src/commands/keys/create.ts
+++ b/packages/cli/src/commands/keys/create.ts
@@ -234,6 +234,20 @@ export function resolveNewKeyName({
     };
   }
   const resolvedName = name ?? drives[0].id;
+  // `--name ""` reaches here as an empty string, not as "absent": `??` only
+  // falls through on null/undefined. A key is selected BY its name everywhere
+  // it is used — `--key=<name>`, the key env var, `keys use <name>` — and a
+  // blank one is refused by all three (`presentToken` treats blank as absent),
+  // so minting it produces a credential in the keychain that nothing can ever
+  // name again. Refused loudly rather than silently renamed after the drive:
+  // an explicit blank `--name` is a mistake, and quietly picking a different
+  // name would hide it.
+  if (resolvedName.trim().length === 0) {
+    return {
+      ok: false,
+      message: '--name must not be blank: a key is selected by its name, so an unnamed key could never be used.',
+    };
+  }
   if (resolvedName === DEFAULT_PROFILE_NAME) {
     return {
       ok: false,

--- a/packages/cli/src/commands/keys/create.ts
+++ b/packages/cli/src/commands/keys/create.ts
@@ -298,11 +298,13 @@ async function writeEffectivePermissions(params: {
 }): Promise<void> {
   const { info, host, token, describeKeyPermissions: describe } = params;
   if (token === null) {
-    // Says only that the readback did not happen, not WHY. The cause — the
-    // server returned a refresh credential instead of a static token — is the
-    // `--show-token` branch's line a few lines below, and stating it in both
-    // places put two near-identical sentences back to back.
-    info.write('The key was created. Its permissions could not be read back here.\n');
+    // The cause belongs HERE, not deferred to the `--show-token` branch below:
+    // that line only runs when `--show-token` was passed, so on the ordinary
+    // path deferring left a bare "could not be read back" with nothing to act
+    // on. The two lines do sit next to each other under `--show-token`, but
+    // they answer different questions — this one is about the permissions, that
+    // one is about the token you asked to see.
+    info.write('The key was created. Its permissions could not be read back here — it returned no raw token.\n');
     return;
   }
   try {

--- a/packages/cli/src/commands/keys/create.ts
+++ b/packages/cli/src/commands/keys/create.ts
@@ -51,7 +51,8 @@ import type {
   WaitMs,
 } from '../../auth/loopback-flow.js';
 import { parseTokensCreateArgs, type CreateTokenArgs, type DriveScopeArg } from './args.js';
-import { renderAgentWiringGuidance, shellQuote } from './guidance.js';
+import { renderAgentWiringGuidance } from './guidance.js';
+import { shellQuote } from '../../shell-quote.js';
 import { renderKeyDescription } from './describe.js';
 import { describeKeyPermissions, type DescribeKeyPermissions } from '../../auth/probe-permissions.js';
 

--- a/packages/cli/src/commands/keys/create.ts
+++ b/packages/cli/src/commands/keys/create.ts
@@ -247,26 +247,31 @@ export function resolveNewKeyName({
   //
   // Only reachable through the flag path — `wizard.ts` trims before it gets
   // here.
-  // Blank FIRST, deliberately. An all-whitespace name satisfies both
-  // conditions, and taking the padding branch made the message suggest the
-  // trimmed form — which for "   " is the empty string the next guard rejects,
-  // i.e. advice to do the one other thing that cannot work.
-  if (resolvedName.trim().length === 0) {
+  // ORDER IS THE POINT HERE. The padding branch is the only one that SUGGESTS
+  // a replacement, so every rejection whose trimmed form is also invalid has to
+  // be caught before it — otherwise the advice names something the very next
+  // guard refuses. Both such cases exist and both were live:
+  //   "   "         → trims to "", which the blank rule rejects
+  //   "  default  " → trims to "default", which the reserved rule rejects
+  // So: blank, then reserved (tested against the TRIMMED name, since that is
+  // what the store would be keyed on), then padding.
+  const trimmedName = resolvedName.trim();
+  if (trimmedName.length === 0) {
     return {
       ok: false,
       message: '--name must not be blank: a key is selected by its name, so an unnamed key could never be used.',
     };
   }
-  if (resolvedName !== resolvedName.trim()) {
+  if (trimmedName === DEFAULT_PROFILE_NAME) {
     return {
       ok: false,
-      message: `--name "${resolvedName}" has leading or trailing whitespace: keys are looked up by their trimmed name, so this one could be created and never found again. Use "${resolvedName.trim()}".`,
+      message: `--name "${resolvedName}" is reserved for the personal credential stored by "pagespace login". Choose another key name.`,
     };
   }
-  if (resolvedName === DEFAULT_PROFILE_NAME) {
+  if (resolvedName !== trimmedName) {
     return {
       ok: false,
-      message: `--name "${DEFAULT_PROFILE_NAME}" is reserved for the personal credential stored by "pagespace login". Choose another key name.`,
+      message: `--name "${resolvedName}" has leading or trailing whitespace: keys are looked up by their trimmed name, so this one could be created and never found again. Use "${trimmedName}".`,
     };
   }
   return { ok: true, name: resolvedName };

--- a/packages/cli/src/commands/keys/create.ts
+++ b/packages/cli/src/commands/keys/create.ts
@@ -51,7 +51,7 @@ import type {
   WaitMs,
 } from '../../auth/loopback-flow.js';
 import { parseTokensCreateArgs, type CreateTokenArgs, type DriveScopeArg } from './args.js';
-import { renderAgentWiringGuidance } from './guidance.js';
+import { renderAgentWiringGuidance, shellQuote } from './guidance.js';
 import { renderKeyDescription } from './describe.js';
 import { describeKeyPermissions, type DescribeKeyPermissions } from '../../auth/probe-permissions.js';
 
@@ -421,7 +421,11 @@ export function createTokensCreateHandler(deps: TokensCreateHandlerDeps): Comman
     const existing = await store.get(host, keyName);
     if (existing && !intent.flags.yes) {
       ctx.stderr.write(
-        `A stored credential for ${host} (key "${keyName}") already exists. Re-run with --yes to overwrite it, or "pagespace logout --host ${host} --key ${keyName}" first.\n`,
+        // Equals-joined and quoted for the same reason the post-mint hint is
+        // (see `guidance.ts`'s `shellQuote`): this suggests a command with a
+        // key name in it, and a name like `-prod` or `lead gen` made it
+        // unpasteable — `--key` would take the next word, or none at all.
+        `A stored credential for ${host} (key "${keyName}") already exists. Re-run with --yes to overwrite it, or "pagespace logout --host=${shellQuote(host)} --key=${shellQuote(keyName)}" first.\n`,
       );
       return EXIT_RUNTIME_ERROR;
     }

--- a/packages/cli/src/commands/keys/create.ts
+++ b/packages/cli/src/commands/keys/create.ts
@@ -234,15 +234,26 @@ export function resolveNewKeyName({
     };
   }
   const resolvedName = name ?? drives[0].id;
-  // `--name ""` reaches here as an empty string, not as "absent": `??` only
-  // falls through on null/undefined. A key is selected BY its name everywhere
-  // it is used — `--key=<name>`, the key env var, `keys use <name>` — and a
-  // blank one is refused by all three (`presentToken` treats blank as absent),
-  // so minting it produces a credential in the keychain that nothing can ever
-  // name again. Refused loudly rather than silently renamed after the drive:
-  // an explicit blank `--name` is a mistake, and quietly picking a different
-  // name would hide it.
-  if (resolvedName.trim().length === 0) {
+  // A key is stored under its name VERBATIM, but every lookup trims first
+  // (`auth/resolve.ts`'s `presentToken`/`resolveKeyName`). So any name that is
+  // not equal to its own trimmed form can be minted and then never found
+  // again: `--name "  x  "` writes the store under `"  x  "` while `--key`
+  // resolves `"x"` and misses. A fully blank name is the same failure at its
+  // limit — it trims to nothing, so no lookup can ever produce it.
+  //
+  // Both are refused rather than silently trimmed: an explicit `--name` with
+  // padding is a typo, and quietly storing something other than what was asked
+  // for is how the mismatch got created in the first place.
+  //
+  // Only reachable through the flag path — `wizard.ts` trims before it gets
+  // here.
+  if (resolvedName !== resolvedName.trim()) {
+    return {
+      ok: false,
+      message: `--name "${resolvedName}" has leading or trailing whitespace: keys are looked up by their trimmed name, so this one could be created and never found again. Use "${resolvedName.trim()}".`,
+    };
+  }
+  if (resolvedName.length === 0) {
     return {
       ok: false,
       message: '--name must not be blank: a key is selected by its name, so an unnamed key could never be used.',

--- a/packages/cli/src/commands/keys/describe.ts
+++ b/packages/cli/src/commands/keys/describe.ts
@@ -91,7 +91,9 @@ function formatGrant(scope: DescribedScope, scoped: boolean): string {
   return `role ${(scope.role ?? 'unknown').toLowerCase()}`;
 }
 
-export const KEYS_DESCRIBE_USAGE = 'Usage: pagespace keys describe [--page <pageId>]';
+export const KEYS_DESCRIBE_USAGE =
+  'Usage: pagespace keys describe [--page <pageId>]\n' +
+  '  Needs a content credential named: --key=<name>, --token, the env vars, or an active key.';
 
 export type ParseKeysDescribeArgsResult =
   | { readonly ok: true; readonly pageId?: string }

--- a/packages/cli/src/commands/keys/guidance.ts
+++ b/packages/cli/src/commands/keys/guidance.ts
@@ -61,8 +61,12 @@ export function keysDescribeHint(keyName: string, host: string): string {
  * — so `--key '-prod'` is a usage error no amount of quoting can rescue.
  * `--key=-prod` is exactly the ambiguity the equals form exists to resolve
  * (see `parse.ts`, which documents it for `--host=-looks-like-a-flag`).
+ *
+ * Exported because the hint is not the only command this CLI prints with a key
+ * name in it — `keys create`'s "already exists" message suggests a `logout`
+ * command the same way, and had the same hole.
  */
-function shellQuote(value: string): string {
+export function shellQuote(value: string): string {
   if (/^[A-Za-z0-9._@%+=:,/-]+$/.test(value)) return value;
   return `'${value.replaceAll("'", `'\\''`)}'`;
 }

--- a/packages/cli/src/commands/keys/guidance.ts
+++ b/packages/cli/src/commands/keys/guidance.ts
@@ -6,6 +6,7 @@
  */
 import { KEY_ENV_VAR_NAME, TOKEN_ENV_VAR_NAME } from '../../auth/resolve.js';
 import { DEFAULT_HOST } from '../../config/resolve.js';
+import { shellQuote } from '../../shell-quote.js';
 
 export const WIZARD_INTRO_HINT =
   'Keys are scoped credentials your agents use to access specific drives. Each key is saved locally as a named credential in your OS keychain.';
@@ -39,37 +40,6 @@ export function keysDescribeHint(keyName: string, host: string): string {
   return `Run "pagespace keys describe --key=${shellQuote(keyName)}${hostFlag}" at any time to see this key's drives, role and effective permissions.`;
 }
 
-/**
- * Makes `value` safe to paste into a shell as one word.
- *
- * Key names are close to free-form — `resolveNewKeyName` refuses only the
- * reserved `"default"` and names that cannot be looked up (blank, or padded
- * with whitespace) — so `--name "lead gen"` is legal and printing it bare
- * gave `--key lead gen`, where the shell hands `--key` the word `lead` and
- * drops `gen` into the command as a stray positional. A hint that cannot be
- * pasted is worse than no hint, since the reader has no way to tell it apart
- * from one that can.
- *
- * Single quotes rather than double: they suppress every expansion, so a name
- * containing `$`, backticks or `!` is inert. The `'\''` dance is the standard
- * way to carry a literal single quote through a single-quoted word.
- *
- * Quoting alone is NOT enough, which is why the caller emits the equals-joined
- * `--key=<quoted>` form. A name beginning with `-` (`--name -prod` is legal and
- * mints fine) survives quote-stripping as the argv word `-prod`, and
- * `argv/parse.ts` rejects a space-separated flag value that starts with `-`
- * — so `--key '-prod'` is a usage error no amount of quoting can rescue.
- * `--key=-prod` is exactly the ambiguity the equals form exists to resolve
- * (see `parse.ts`, which documents it for `--host=-looks-like-a-flag`).
- *
- * Exported because the hint is not the only command this CLI prints with a key
- * name in it — `keys create`'s "already exists" message suggests a `logout`
- * command the same way, and had the same hole.
- */
-export function shellQuote(value: string): string {
-  if (/^[A-Za-z0-9._@%+=:,/-]+$/.test(value)) return value;
-  return `'${value.replaceAll("'", `'\\''`)}'`;
-}
 
 export interface AgentWiringGuidanceParams {
   readonly keyName: string;

--- a/packages/cli/src/commands/keys/guidance.ts
+++ b/packages/cli/src/commands/keys/guidance.ts
@@ -30,22 +30,30 @@ export const SHOW_TOKEN_PROMPT = "Show the token now for .env/CI use? It won't b
  * the reader can actually run.
  */
 export function keysDescribeHint(keyName: string): string {
-  return `Run "pagespace keys describe --key ${shellQuote(keyName)}" at any time to see this key's drives, role and effective permissions.`;
+  return `Run "pagespace keys describe --key=${shellQuote(keyName)}" at any time to see this key's drives, role and effective permissions.`;
 }
 
 /**
  * Makes `value` safe to paste into a shell as one word.
  *
  * Key names are close to free-form — `resolveNewKeyName` refuses only the
- * reserved `"default"` — so `--name "lead gen"` is legal and used to print
- * `--key lead gen`, where the shell hands `--key` the word `lead` and drops
- * `gen` into the command as a stray positional. A hint that cannot be pasted is
- * worse than no hint, since the reader has no way to tell it apart from one
- * that can.
+ * reserved `"default"` — so `--name "lead gen"` is legal and printing it bare
+ * gave `--key lead gen`, where the shell hands `--key` the word `lead` and
+ * drops `gen` into the command as a stray positional. A hint that cannot be
+ * pasted is worse than no hint, since the reader has no way to tell it apart
+ * from one that can.
  *
  * Single quotes rather than double: they suppress every expansion, so a name
  * containing `$`, backticks or `!` is inert. The `'\''` dance is the standard
  * way to carry a literal single quote through a single-quoted word.
+ *
+ * Quoting alone is NOT enough, which is why the caller emits the equals-joined
+ * `--key=<quoted>` form. A name beginning with `-` (`--name -prod` is legal and
+ * mints fine) survives quote-stripping as the argv word `-prod`, and
+ * `argv/parse.ts` rejects a space-separated flag value that starts with `-`
+ * — so `--key '-prod'` is a usage error no amount of quoting can rescue.
+ * `--key=-prod` is exactly the ambiguity the equals form exists to resolve
+ * (see `parse.ts`, which documents it for `--host=-looks-like-a-flag`).
  */
 function shellQuote(value: string): string {
   if (/^[A-Za-z0-9._@%+=:,/-]+$/.test(value)) return value;

--- a/packages/cli/src/commands/keys/guidance.ts
+++ b/packages/cli/src/commands/keys/guidance.ts
@@ -29,8 +29,14 @@ export const SHOW_TOKEN_PROMPT = "Show the token now for .env/CI use? It won't b
  * Naming the key that was just minted is what makes the printed command one
  * the reader can actually run.
  */
-export function keysDescribeHint(keyName: string): string {
-  return `Run "pagespace keys describe --key=${shellQuote(keyName)}" at any time to see this key's drives, role and effective permissions.`;
+export function keysDescribeHint(keyName: string, host: string): string {
+  // `--host` for the same reason the MCP config block below carries
+  // PAGESPACE_API_URL: the key was stored under THIS host, and the credential
+  // store is keyed by host, so a command that omits it resolves against the
+  // default and misses a key minted anywhere else. Omitted for the default
+  // host, where it would be noise.
+  const hostFlag = host === DEFAULT_HOST ? '' : ` --host=${shellQuote(host)}`;
+  return `Run "pagespace keys describe --key=${shellQuote(keyName)}${hostFlag}" at any time to see this key's drives, role and effective permissions.`;
 }
 
 /**
@@ -113,6 +119,6 @@ export function renderAgentWiringGuidance(params: AgentWiringGuidanceParams): re
     // The ONE place this sentence is printed. The mint's permission summary
     // above it already shows the answer inline; repeating the pointer there
     // (and again here) put the same line on screen twice.
-    keysDescribeHint(params.keyName),
+    keysDescribeHint(params.keyName, params.host),
   ];
 }

--- a/packages/cli/src/commands/keys/guidance.ts
+++ b/packages/cli/src/commands/keys/guidance.ts
@@ -21,7 +21,7 @@ export const SHOW_TOKEN_PROMPT = "Show the token now for .env/CI use? It won't b
  * `keys describe` asks the server, which resolves it the same way every content
  * request will (issue #2470).
  *
- * `--key <name>` is load-bearing, not decoration. `keys describe` reports the
+ * `--key=<name>` is load-bearing, not decoration. `keys describe` reports the
  * credential a CONTENT command would use, so unlike its `keys` siblings it is
  * not auth-exempt and is subject to `run.ts`'s explicit-credential gate: with
  * a personal login and no active key — the state a user is in immediately
@@ -43,7 +43,8 @@ export function keysDescribeHint(keyName: string, host: string): string {
  * Makes `value` safe to paste into a shell as one word.
  *
  * Key names are close to free-form — `resolveNewKeyName` refuses only the
- * reserved `"default"` — so `--name "lead gen"` is legal and printing it bare
+ * reserved `"default"` and names that cannot be looked up (blank, or padded
+ * with whitespace) — so `--name "lead gen"` is legal and printing it bare
  * gave `--key lead gen`, where the shell hands `--key` the word `lead` and
  * drops `gen` into the command as a stray positional. A hint that cannot be
  * pasted is worse than no hint, since the reader has no way to tell it apart

--- a/packages/cli/src/commands/login-device.ts
+++ b/packages/cli/src/commands/login-device.ts
@@ -29,6 +29,7 @@ import { runDeviceLogin } from '../auth/device-flow.js';
 import type { DeviceAuthorization, PollDeviceToken, RequestDeviceAuthorization } from '../auth/device-flow.js';
 import type { ConfirmIdentity, DiscoverMetadata, WaitMs } from '../auth/loopback-flow.js';
 import { DEFAULT_LOGIN_SCOPE } from './login.js';
+import { shellQuote } from '../shell-quote.js';
 
 export interface LoginDeviceHandlerDeps {
   readonly createCredentialStore: () => CredentialStore;
@@ -68,7 +69,14 @@ export function createLoginDeviceHandler(deps: LoginDeviceHandlerDeps): CommandH
     if (existing && !intent.flags.yes) {
       const keyNote = keyName === DEFAULT_PROFILE_NAME ? '' : ` (key "${keyName}")`;
       ctx.stderr.write(
-        `A stored credential for ${host}${keyNote} already exists. Re-run with --yes to overwrite it, or "pagespace logout --host ${host}" first.\n`,
+        // The suggested logout must name the SAME key this message is about.
+        // Without `--key`, `logout` resolves the name independently and lands
+        // on `default` — and logout is destructive: it revokes the refresh
+        // token server-side before deleting it. So telling someone blocked by
+        // key "ci" to run a bare logout was telling them to revoke their
+        // personal login. Quoted and equals-joined for the same reason
+        // `keys create` is (see `shell-quote.ts`).
+        `A stored credential for ${host}${keyNote} already exists. Re-run with --yes to overwrite it, or "pagespace logout --host=${shellQuote(host)}${keyName === DEFAULT_PROFILE_NAME ? '' : ` --key=${shellQuote(keyName)}`}" first.\n`,
       );
       return EXIT_RUNTIME_ERROR;
     }

--- a/packages/cli/src/commands/login.ts
+++ b/packages/cli/src/commands/login.ts
@@ -27,6 +27,7 @@ import { unrefWaitMs } from '../auth/wait.js';
 import { runLoopbackLogin } from '../auth/loopback-flow.js';
 import { resolveEnvKeyName } from '../auth/legacy-token-env.js';
 import { resolveKeyName } from '../auth/resolve.js';
+import { shellQuote } from '../shell-quote.js';
 import type {
   ConfirmIdentity,
   DiscoverMetadata,
@@ -74,7 +75,14 @@ export function createLoginHandler(deps: LoginHandlerDeps): CommandHandler {
     if (existing && !intent.flags.yes) {
       const keyNote = keyName === DEFAULT_PROFILE_NAME ? '' : ` (key "${keyName}")`;
       ctx.stderr.write(
-        `A stored credential for ${host}${keyNote} already exists. Re-run with --yes to overwrite it, or "pagespace logout --host ${host}" first.\n`,
+        // The suggested logout must name the SAME key this message is about.
+        // Without `--key`, `logout` resolves the name independently and lands
+        // on `default` — and logout is destructive: it revokes the refresh
+        // token server-side before deleting it. So telling someone blocked by
+        // key "ci" to run a bare logout was telling them to revoke their
+        // personal login. Quoted and equals-joined for the same reason
+        // `keys create` is (see `shell-quote.ts`).
+        `A stored credential for ${host}${keyNote} already exists. Re-run with --yes to overwrite it, or "pagespace logout --host=${shellQuote(host)}${keyName === DEFAULT_PROFILE_NAME ? '' : ` --key=${shellQuote(keyName)}`}" first.\n`,
       );
       return EXIT_RUNTIME_ERROR;
     }

--- a/packages/cli/src/shell-quote.ts
+++ b/packages/cli/src/shell-quote.ts
@@ -1,0 +1,32 @@
+/**
+ * Makes `value` safe to paste into a shell as one word.
+ *
+ * Key names are close to free-form — `resolveNewKeyName` refuses only the
+ * reserved `"default"` and names that cannot be looked up (blank, or padded
+ * with whitespace) — so `--name "lead gen"` is legal and printing it bare
+ * gave `--key lead gen`, where the shell hands `--key` the word `lead` and
+ * drops `gen` into the command as a stray positional. A hint that cannot be
+ * pasted is worse than no hint, since the reader has no way to tell it apart
+ * from one that can.
+ *
+ * Single quotes rather than double: they suppress every expansion, so a name
+ * containing `$`, backticks or `!` is inert. The `'\''` dance is the standard
+ * way to carry a literal single quote through a single-quoted word.
+ *
+ * Quoting alone is NOT enough, which is why the caller emits the equals-joined
+ * `--key=<quoted>` form. A name beginning with `-` (`--name -prod` is legal and
+ * mints fine) survives quote-stripping as the argv word `-prod`, and
+ * `argv/parse.ts` rejects a space-separated flag value that starts with `-`
+ * — so `--key '-prod'` is a usage error no amount of quoting can rescue.
+ * `--key=-prod` is exactly the ambiguity the equals form exists to resolve
+ * (see `parse.ts`, which documents it for `--host=-looks-like-a-flag`).
+ *
+ * Four callers across two command families now: the post-mint hint, and the
+ * three "a credential already exists" messages that suggest a `logout`. Living
+ * in its own leaf keeps `commands/login.ts` from importing out of
+ * `commands/keys/`.
+ */
+export function shellQuote(value: string): string {
+  if (/^[A-Za-z0-9._@%+=:,/-]+$/.test(value)) return value;
+  return `'${value.replaceAll("'", `'\\''`)}'`;
+}

--- a/packages/lib/src/services/__tests__/drive-role-service.test.ts
+++ b/packages/lib/src/services/__tests__/drive-role-service.test.ts
@@ -597,6 +597,10 @@ describe('roleNotFoundMessage', () => {
     expect(message).toMatch(/system role/i);
     expect(message).toMatch(/drive membership/i);
     expect(message).toContain('pagespace keys describe');
+    // Same reason as the MCP write refusal: `keys describe` needs a content
+    // credential named, so pointing at a bare invocation would send the reader
+    // into a second refusal.
+    expect(message).toMatch(/with that credential in hand/i);
     expect(message).not.toBe(`Role "${name}" not found in this drive`);
   });
 });

--- a/packages/lib/src/services/drive-role-service.ts
+++ b/packages/lib/src/services/drive-role-service.ts
@@ -196,7 +196,8 @@ export function roleNotFoundMessage(roleId: string): string {
     `"${roleId}" is a system role, not a custom role defined in this drive, so it has no role id and cannot be ` +
     'fetched here. System roles (OWNER/ADMIN/MEMBER) are held per member on the drive membership itself — list ' +
     'them with the drive members surface. To see what a specific credential resolves to, describe that credential ' +
-    '("pagespace keys describe"), which reports the role and the effective view/edit/share/delete it grants. ' +
+    '(with that credential in hand: "pagespace keys describe"), which reports the role and the effective ' +
+    'view/edit/share/delete it grants. ' +
     'This endpoint lists only the custom roles defined in this drive.'
   );
 }


### PR DESCRIPTION
Follow-up to #2476, which merged while a review I had commissioned was still running. It came back with six findings against the code that landed. Four are real defects — **two of them mine from that branch** — and two are test-quality problems.

None of these came from a reviewer. All six reproduce.

## The defects

**1. The `keys describe` hint is still unrunnable for a whole class of key names.**

#2476 fixed this for names with spaces by shell-quoting. That was incomplete: `-prod` passes the allowlist, and quoting cannot save it — the shell strips quotes either way, so argv gets the word `-prod`, and `argv/parse.ts` rejects a space-separated flag value beginning with `-`.

```
parseArgv(['keys','describe','--key','-prod'])  -> usage-error: Flag --key requires a value.
parseArgv(['keys','describe','--key=-prod'])    -> command, key="-prod"
```

Reachable: `resolveNewKeyName` refuses only the reserved `"default"`, and `--name` takes the next token with no `-` guard, so `keys create --name -prod` mints it. The hint now emits the equals-joined `--key=<quoted>` form, which `parse.ts` documents for exactly this ambiguity. Eight name classes round-trip through **real bash into the real parser**:

```
"lead-gen" => --key=lead-gen        "-prod"  => --key=-prod
"lead gen" => --key='lead gen'      "--json" => --key=--json
"o'brien"  => --key='o'\''brien'    "a$HOME" => --key='a$HOME'
"~x"       => --key='~x'            "a b c"  => --key='a b c'
```

**2. A regression I introduced in `26f1367`.** De-duplicating the mint output moved the *reason* a permission readback was skipped onto the `--show-token` branch — which doesn't run on the ordinary path. Without the flag the user got a bare "could not be read back" with nothing to act on. The cause is back where it belongs, and the new test covers the path *without* the flag (the only existing test used `--show-token`, which is why nothing caught it).

**3. "Each fix is mutation-checked" was false in `26f1367`.** The `Math.max(1, …)` worker-count guard had **zero** coverage: `mapWithConcurrency` was private to the route and the limit is a hardcoded `8`, so no test could reach a non-positive one — deleting the guard left every test green. It is now `apps/web/src/lib/map-with-concurrency.ts` with 17 direct tests, and removing the guard turns four of them red.

The guard was also incomplete. `Math.max(1, NaN)` is `NaN`:

```
limit 0    => [2,4,6]            holes []
limit -1   => [2,4,6]            holes []
limit NaN  => [null,null,null]   holes [0,1,2]   <-- the exact failure the doc claimed to prevent
```

**4. The route-side `'none'` test had the same mismatch #2476 fixed CLI-side** — it described the user-principal route while arranging the scoped one. Split into two tests that arrange what they describe.

**5.** The wizard's no-raw-token copy had no test, so it had already drifted from `create.ts`'s. **6.** The stop-on-failure test asserted `toBeLessThan(40)` where the value is deterministically `8` — it would have passed at 39.

## Also

Documents, in the README and the usage line, that `keys describe` needs a content credential named (`--key=<name>`, `--token`, env, or an active key). It is the one `keys` verb that reports on a *content* credential rather than managing keys, so it follows the content-command rule — and nothing said so.

## Validation

Narrowest suites only: `@pagespace/cli` **1208/1208**, plus the web route and the new helper suite individually. **The monorepo gates are deliberately left to CI** — several agents share this machine and concurrent turbo/Next builds take it down, so CI is the authority here rather than a local run.

**On mutation-checking — being precise, since finding 3 above is exactly the cost of not being.**

- The `Math.max(1, …)` worker-count guard: **mutation-checked**. Reverting `resolveWorkerCount` to
  `Math.min(requested, itemCount)` turns 4 of the 17 helper tests red. This is the one that had no
  coverage before, so it is the one that needed proving.
- The other five are covered by assertions that name the exact new string or shape
  (`--key=-prod`, the restored cause on the no-flag path, the two split `'none'` arrangements, the
  wizard copy, `toBe(8)`), so a revert cannot pass them — but I did **not** run each revert. I am
  not repeating the claim I just came here to correct.

The `--key=` change has something stronger than a mutation check anyway: 8 name classes were pasted
through a real `bash` and fed to the real `parseArgv`, and every one came back byte-exact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PVxVQz2js9r589sPsG7SQE



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Improvements**
  - Improved CLI guidance for describing credentials, including required content credentials and clearer, pasteable command examples.
  - Added shell-safe handling for credential names and host-specific command hints.
  - Clarified write-denial and system-role error messages to recommend using the relevant credential.
  - Credential creation now rejects blank or whitespace-padded names.
  - Improved feedback when permissions cannot be read back, including whether a raw token was returned.
- **Documentation**
  - Updated CLI documentation and changelog with credential usage requirements and authentication details.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

---

## Later rounds

**Merged master (CLI 1.8.0).** #2479 cut the release that shipped `keys describe` while this branch was open, which **inverted the changelog reasoning**: these stopped being fixes to unreleased work and became fixes to a released version, so they now sit under a fresh `Unreleased → Fixed` written from the 1.8.0 user's point of view. Two things the auto-merge got wrong and are corrected: it carried a sentence of mine **into the shipped 1.8.0 section** describing behaviour 1.8.0 doesn't have (everything from that heading down is now byte-identical to master), and the entries narrated my commit sequence rather than the user's experience. The root changelog is deliberately untouched — it still lists the feature under Unreleased, so a `Fixed` entry there would recreate the problem.

**A third adversarial pass found seven more**, including one that mattered a lot:

- **`map-with-concurrency.ts` did not compile.** Its doc comment contained the glob `src/**/__tests__/**`, and `**/` contains the close-comment sequence — so the comment ended mid-sentence, `__tests__` became live code, and the file threw `ReferenceError` with **0 tests collected**. I had previously "verified" that file by reading it and checking brace balance, which proved nothing. Caught by running it.
- **The blank-`--name` guard missed the case adjacent to the one it fixed.** Keys are *stored* verbatim but every lookup *trims*, so `--name "  x  "` wrote the store under `"  x  "` while `--key` resolved `"x"` and missed — the same unfindable key the guard's own comment claimed to prevent.
- **A comment (and changelog line) claimed three commands refuse a blank name; it's two** — `parseKeysUseArgs` accepts `''`.
- **`Infinity` resolved to one worker**, the opposite of "no ceiling".
- **Two of five parameterized rows could never fail** — `Number.isFinite` short-circuits first, so `NaN`/`Infinity` were green with *or* without the `Math.max` guard. Split by which guard each pins; both mutations now verified red (3 red / 2 red).
- **The "no unhandled rejection" test asserted a property of `Promise.all`**, not of this module. Deleted.
- **The hint still failed against a non-default host** — keys are stored per host, so `--key=k` resolved against the default and missed.

### Verification

Every source file the branch touches is now exercised by a passing test — the sweep that would have caught the comment bug, and now the thing I run instead of reading a file and declaring it fine:

| file | suite |
|---|---|
| `auth/key/route.ts` | 21 ✓ |
| `write-denied-details.ts` | 8 ✓ |
| `map-with-concurrency.ts` | 12 ✓ |
| `keys/{create,describe,guidance}.ts` | 122 ✓ |
| `drive-role-service.ts` | 60 ✓ |

Plus `@pagespace/cli` typecheck clean and the knip ratchet within baseline. All run one at a time, only while no other agent had a build going — this machine runs ~10 agents and concurrent monorepo builds take it down, so **CI is the gate here** and local runs are kept to the narrowest thing that answers the question.


---

## A scope call I got wrong, then reversed

Sweeping for this PR's own pattern turned up `login.ts:77` / `login-device.ts:71`, which print a `logout` suggestion that **omits `--key`** while the same sentence names a non-default key. I first judged this out of scope — different command family — and documented it here instead of fixing it.

That was wrong, and a later adversarial pass showed why. I had it filed as "suggests the wrong key". It is worse than that: **`logout` revokes the refresh token server-side** (`logout.ts:87`) before deleting it, and it resolves its own key name, so it lands on `default`. A user blocked by key `ci` was being told to run a command that **revokes their personal login**.

Severity decides scope, not which directory the file lives in. Fixed in both files, with a test in each that dies if the `--key` is dropped again.

`shellQuote` moved to its own leaf (`src/shell-quote.ts`) so `commands/login` does not import out of `commands/keys/` — it now has four callers across two command families.
