### PR TITLE
fix(commands): scope the `/` picker to the drive the turn resolves

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -188,6 +188,16 @@ All notable user-facing changes to PageSpace are documented here. Format follows
 
 ### Fixed
 
+- **Drive commands work in an agent's own chat** — opening an AI page and typing `/` listed only the
+  built-in commands and your personal ones; the drive's own commands were missing, and since a
+  command runs from the chip you pick out of that list, they simply could not be used there. That
+  composer never said which drive it was in, so the list was built as though there were none. It now
+  scopes to the agent's drive — the same drive the command actually runs against — in the agent page,
+  in agent panes, and in the assistant. The right-sidebar assistant had a subtler version of the same
+  fault: with an agent selected it offered the commands of whatever page you were looking at, so an
+  agent borrowed from another drive showed commands that failed the moment you sent them. It now
+  offers the agent's.
+
 - **An agent you configure with tools actually gets them, or says why not** — an agent set up
   entirely through chat (`update_agent_config`) could be given the sandbox tools — `bash`,
   `readFile`, `spawn_shell`, the git commands — have all of them confirmed back on every save, and

--- a/apps/web/src/components/agents/chat/AssistantSessionChat.tsx
+++ b/apps/web/src/components/agents/chat/AssistantSessionChat.tsx
@@ -14,7 +14,7 @@
  */
 import { useAssistantSettingsStore } from '@/stores/useAssistantSettingsStore';
 import { SessionChatView } from './SessionChat';
-import { useAssistantSessionChat } from './useAssistantSessionChat';
+import { useAssistantContextRef, useAssistantSessionChat } from './useAssistantSessionChat';
 
 export default function AssistantSessionChat({
   sessionId,
@@ -33,6 +33,10 @@ export default function AssistantSessionChat({
 }) {
   const chat = useAssistantSessionChat({ conversationId, driveId });
   const currentModel = useAssistantSettingsStore((state) => state.currentModel);
+  // Same ref the turn itself ships, so the `/` picker scopes to exactly the
+  // drive `global-chat-turn` will resolve — including the case this session
+  // has no drive of its own but the pathname stands in one.
+  const contextRef = useAssistantContextRef(driveId);
 
   return (
     <SessionChatView
@@ -41,6 +45,7 @@ export default function AssistantSessionChat({
       chat={chat}
       name="Global Assistant"
       visionModel={currentModel || ''}
+      commandDriveId={contextRef.driveId ?? null}
       context={context}
       isReadOnly={isReadOnly}
     />

--- a/apps/web/src/components/agents/chat/SessionChat.tsx
+++ b/apps/web/src/components/agents/chat/SessionChat.tsx
@@ -60,6 +60,11 @@ export default function SessionChat({
       sessionId={sessionId}
       conversationId={conversationId}
       chat={chat}
+      // The AGENT's own drive — deliberately not the pane-hosting session's,
+      // which can legitimately be a different one. The server resolves this
+      // turn's command chips against the agent page's `page.driveId`, so any
+      // other scope would offer commands that fail as `not_found` on send.
+      commandDriveId={agent.driveId}
       name={agent.title}
       visionModel={agent.aiModel || ''}
       context={context}
@@ -85,6 +90,15 @@ export interface SessionChatViewProps {
   name: string;
   /** The model whose vision capability gates image attachment — '' = none. */
   visionModel: string;
+  /**
+   * Drive scope for the `/` command picker — the drive whose commands the
+   * SERVER will resolve this conversation's chips against. `null` when the
+   * turn resolves no drive at all (a driveless global-assistant session on a
+   * non-drive route), which is correct: picker and execution then agree that
+   * there are none. Required, not optional, so a future caller of this shared
+   * view cannot silently reintroduce the unscoped-picker bug.
+   */
+  commandDriveId: string | null;
   context: 'page' | 'console';
   isReadOnly?: boolean;
 }
@@ -95,6 +109,7 @@ export function SessionChatView({
   chat,
   name,
   visionModel,
+  commandDriveId,
   context,
   isReadOnly = false,
 }: SessionChatViewProps) {
@@ -216,6 +231,7 @@ export function SessionChatView({
           hideModelSelector
           variant={context === 'console' ? 'sidebar' : 'main'}
           hasVision={hasVisionCapability(visionModel)}
+          commandDriveId={commandDriveId ?? undefined}
           remoteStreamingUser={remoteStreamingUser}
         />
       </div>

--- a/apps/web/src/components/agents/chat/__tests__/SessionChat.test.tsx
+++ b/apps/web/src/components/agents/chat/__tests__/SessionChat.test.tsx
@@ -38,12 +38,14 @@ vi.mock('@/components/ai/chat/input', () => ({
     onSend,
     disabled,
     placeholder,
+    commandDriveId,
   }: {
     value: string;
     onChange: (v: string) => void;
     onSend: () => void;
     disabled?: boolean;
     placeholder?: string;
+    commandDriveId?: string;
   }) => (
     <div>
       <input
@@ -51,6 +53,7 @@ vi.mock('@/components/ai/chat/input', () => ({
         value={value}
         placeholder={placeholder}
         disabled={disabled}
+        data-command-drive-id={commandDriveId ?? 'none'}
         onChange={(e) => onChange(e.target.value)}
       />
       <button data-testid="chat-send" onClick={onSend}>
@@ -64,12 +67,32 @@ vi.mock('@/components/ai/shared/chat', () => ({
   UndoAiChangesDialog: () => null,
 }));
 
+const assistantChatState = vi.hoisted(() => ({
+  current: {} as Record<string, unknown>,
+}));
+
+vi.mock('../useAssistantSessionChat', () => ({
+  useAssistantSessionChat: vi.fn(() => assistantChatState.current),
+  // The session's own drive when it has one, else whatever the pathname
+  // resolves to — the same fallback the real hook feeds into `contextRef`.
+  useAssistantContextRef: vi.fn((driveId: string | null) => ({
+    routeType: 'drive',
+    driveId: driveId ?? 'drive-from-pathname',
+  })),
+}));
+
+vi.mock('@/stores/useAssistantSettingsStore', () => ({
+  useAssistantSettingsStore: (selector: (s: unknown) => unknown) =>
+    selector({ currentModel: 'claude-sonnet-5' }),
+}));
+
 vi.mock('@/components/ai/shared/chat/ChatErrorBanner', () => ({
   ChatErrorBanner: ({ cause }: { cause: unknown }) =>
     cause ? <div data-testid="chat-error-banner" /> : null,
 }));
 
 import SessionChat from '../SessionChat';
+import AssistantSessionChat from '../AssistantSessionChat';
 
 function agentFixture(): AgentInfo {
   return {
@@ -109,9 +132,26 @@ function baseChatState(overrides: Record<string, unknown> = {}) {
 
 beforeEach(() => {
   chatState.current = baseChatState();
+  assistantChatState.current = baseChatState();
 });
 
 describe('SessionChat', () => {
+  // Regression: the composer rendered with no command drive at all, so `/`
+  // listed only built-ins + personal commands — `loadAvailableCommands` skips
+  // the drive query entirely when driveId is null, and a command the picker
+  // never offers can never be inserted as a chip, which is the only way one
+  // executes. The scope MUST be the agent page's own drive, because that is
+  // what the server resolves chips against (page-chat-turn's `page.driveId`);
+  // a session's drive can legitimately differ and would offer commands that
+  // then fail as not_found.
+  it("scopes the command picker to the agent's drive", () => {
+    render(<SessionChat agent={agentFixture()} conversationId="conv-1" context="page" />);
+    expect(screen.getByTestId('chat-input')).toHaveAttribute(
+      'data-command-drive-id',
+      'drive-1'
+    );
+  });
+
   it("renders the full messages area (ChatMessagesArea) in 'page' context", () => {
     render(<SessionChat agent={agentFixture()} conversationId="conv-1" context="page" />);
     expect(screen.getByTestId('chat-messages-area')).toBeInTheDocument();
@@ -193,5 +233,41 @@ describe('SessionChat', () => {
     chatState.current = baseChatState({ errorCause: { message: 'boom' } });
     render(<SessionChat agent={agentFixture()} conversationId="conv-1" context="page" />);
     expect(screen.getByTestId('chat-error-banner')).toBeInTheDocument();
+  });
+});
+
+describe('AssistantSessionChat — command picker scope', () => {
+  // The global assistant's execution scope is not its `driveId` prop but the
+  // contextRef it ships, which `global-chat-turn` resolves into the drive it
+  // scopes commands to. Routing the picker through the SAME ref is what keeps
+  // the two from disagreeing.
+  it("uses the session's own drive when it has one", () => {
+    render(
+      <AssistantSessionChat
+        sessionId="sess-1"
+        conversationId="conv-1"
+        driveId="drive-2"
+        context="page"
+      />
+    );
+    expect(screen.getByTestId('chat-input')).toHaveAttribute(
+      'data-command-drive-id',
+      'drive-2'
+    );
+  });
+
+  it('falls back to the pathname-derived drive for a driveless session, rather than dropping drive commands the server would have run', () => {
+    render(
+      <AssistantSessionChat
+        sessionId="sess-1"
+        conversationId="conv-1"
+        driveId={null}
+        context="page"
+      />
+    );
+    expect(screen.getByTestId('chat-input')).toHaveAttribute(
+      'data-command-drive-id',
+      'drive-from-pathname'
+    );
   });
 });

--- a/apps/web/src/components/agents/chat/useAssistantSessionChat.ts
+++ b/apps/web/src/components/agents/chat/useAssistantSessionChat.ts
@@ -61,6 +61,25 @@ import { useConversationSubscription } from '@/hooks/useConversationSubscription
 import { useAssistantSettingsStore } from '@/stores/useAssistantSettingsStore';
 import type { UseAgentSessionChatReturn } from './useAgentSessionChat';
 
+/**
+ * The context ref an assistant session sends — and therefore the drive the
+ * SERVER scopes that turn to (`global-chat-turn` reads
+ * `locationContext?.currentDrive?.id`). Exported so the composer can scope its
+ * `/` command picker to the exact same drive: the picker and the execution it
+ * feeds must never disagree about which drive's commands exist.
+ *
+ * The session's own drive wins over the pathname because the Agents console
+ * never navigates as panes are clicked, so pathname parsing cannot see it.
+ */
+export function useAssistantContextRef(driveId: string | null): ContextRef {
+  const pathname = usePathname();
+  const drives = useDriveStore((state) => state.drives);
+  return useMemo(
+    () => (driveId ? { routeType: 'drive', driveId } : buildContextRef(pathname, drives)),
+    [driveId, pathname, drives],
+  );
+}
+
 export function useAssistantSessionChat({
   conversationId,
   driveId,
@@ -78,9 +97,8 @@ export function useAssistantSessionChat({
    */
   driveId: string | null;
 }): UseAgentSessionChatReturn {
-  const pathname = usePathname();
   const { user } = useAuth();
-  const drives = useDriveStore((state) => state.drives);
+  const contextRef = useAssistantContextRef(driveId);
 
   // The user's one global channel — every assistant stream, whichever surface
   // started it, broadcasts here. Null until auth resolves; every consumer
@@ -172,7 +190,6 @@ export function useAssistantSessionChat({
   // Shared by handleSend and the ask_user answer path (submitting an answer
   // re-invokes the chat with the same per-request body a fresh send would use).
   const buildBody = useCallback(() => {
-    const contextRef: ContextRef = driveId ? { routeType: 'drive', driveId } : buildContextRef(pathname, drives);
     return buildGlobalChatRequestBody({
       conversationId,
       isReadOnly: !writeMode,
@@ -185,9 +202,7 @@ export function useAssistantSessionChat({
     });
   }, [
     conversationId,
-    driveId,
-    pathname,
-    drives,
+    contextRef,
     writeMode,
     webSearchEnabled,
     imageGenEnabled,

--- a/apps/web/src/components/ai/chat/input/ChatInput.tsx
+++ b/apps/web/src/components/ai/chat/input/ChatInput.tsx
@@ -33,6 +33,13 @@ export interface ChatInputProps {
   placeholder?: string;
   /** Drive ID for mention suggestions */
   driveId?: string;
+  /**
+   * Drive scope for the `/` command picker — defaults to `driveId`. Set it
+   * when the two differ (an agent conversation scopes commands to the AGENT's
+   * drive while mentions stay on the route's), and see `ChatTextareaProps`
+   * for the invariant it must satisfy.
+   */
+  commandDriveId?: string;
   /** Enable cross-drive mention search */
   crossDrive?: boolean;
   /** Hide the model/provider selector in footer (for compact layouts) */
@@ -109,6 +116,7 @@ export const ChatInput = forwardRef<ChatInputRef, ChatInputProps>(
       disabled = false,
       placeholder = 'Type your message...',
       driveId,
+      commandDriveId,
       crossDrive = false,
       hideModelSelector = false,
       variant = 'main',
@@ -261,6 +269,7 @@ export const ChatInput = forwardRef<ChatInputRef, ChatInputProps>(
             onSend={handleSend}
             placeholder={placeholder}
             driveId={driveId}
+            commandDriveId={commandDriveId}
             crossDrive={crossDrive}
             disabled={effectiveDisabled}
             variant={variant}

--- a/apps/web/src/components/ai/chat/input/ChatTextarea.tsx
+++ b/apps/web/src/components/ai/chat/input/ChatTextarea.tsx
@@ -35,6 +35,15 @@ export interface ChatTextareaProps {
   placeholder?: string;
   /** Drive ID for mention suggestions */
   driveId?: string;
+  /**
+   * Drive scope for the `/` command picker, when it differs from the mention
+   * picker's `driveId` (defaults to it). MUST be the drive the server resolves
+   * this surface's command chips against — `page.driveId` for an agent turn
+   * (`page-chat-turn.ts`), the location context's drive for a global-assistant
+   * one (`global-chat-turn.ts`). Offering a scope the server won't use hands
+   * the user commands that fail as `not_found` the moment they're sent.
+   */
+  commandDriveId?: string;
   /** Enable cross-drive mention search */
   crossDrive?: boolean;
   /** Whether the input is disabled */
@@ -69,6 +78,7 @@ const ChatTextareaInner = forwardRef<ChatTextareaRef, ChatTextareaProps>(
       canSendEmpty = false,
       placeholder = 'Type your message...',
       driveId,
+      commandDriveId,
       crossDrive = false,
       disabled = false,
       variant = 'main',
@@ -113,7 +123,7 @@ const ChatTextareaInner = forwardRef<ChatTextareaRef, ChatTextareaProps>(
     const command = useCommandSuggestion({
       inputRef: textareaRef,
       enabled: !disabled,
-      driveId,
+      driveId: commandDriveId ?? driveId,
       popupPlacement,
       getTokens,
       enterSelects: enterToSend,

--- a/apps/web/src/components/ai/chat/input/__tests__/ChatInput.remoteStreamingUser.test.tsx
+++ b/apps/web/src/components/ai/chat/input/__tests__/ChatInput.remoteStreamingUser.test.tsx
@@ -33,8 +33,22 @@ vi.mock('@/hooks/useMobileKeyboard', () => ({
 }));
 
 vi.mock('../ChatTextarea', () => ({
-  ChatTextarea: ({ disabled, value }: { disabled?: boolean; value: string }) => (
-    <textarea data-testid="chat-textarea" disabled={disabled} value={value} readOnly />
+  ChatTextarea: ({
+    disabled,
+    value,
+    commandDriveId,
+  }: {
+    disabled?: boolean;
+    value: string;
+    commandDriveId?: string;
+  }) => (
+    <textarea
+      data-testid="chat-textarea"
+      disabled={disabled}
+      value={value}
+      data-command-drive-id={commandDriveId ?? 'none'}
+      readOnly
+    />
   ),
 }));
 
@@ -123,6 +137,23 @@ describe('ChatInput — remoteStreamingUser lock', () => {
     const actions = screen.getByTestId('input-actions');
     expect(actions.getAttribute('data-streaming')).toBe('false');
     expect(actions.getAttribute('data-disabled')).toBe('true');
+  });
+
+  // The command picker's drive scope is decided in ChatTextarea, so ChatInput's
+  // only job is to hand the prop over intact — an easy hop to drop, and one no
+  // surface-level suite can catch (they all mock ChatInput away).
+  it('forwards commandDriveId to the textarea, and omits it cleanly when unset', () => {
+    const { rerender } = render(<ChatInput {...baseProps} commandDriveId="agent-drive" />);
+    expect(screen.getByTestId('chat-textarea')).toHaveAttribute(
+      'data-command-drive-id',
+      'agent-drive'
+    );
+
+    rerender(<ChatInput {...baseProps} />);
+    expect(screen.getByTestId('chat-textarea')).toHaveAttribute(
+      'data-command-drive-id',
+      'none'
+    );
   });
 
   it('given remoteStreamingUser is null, behaves identically to the prop being omitted', () => {

--- a/apps/web/src/components/ai/chat/input/__tests__/ChatTextarea.commandDriveId.test.tsx
+++ b/apps/web/src/components/ai/chat/input/__tests__/ChatTextarea.commandDriveId.test.tsx
@@ -1,0 +1,108 @@
+/**
+ * The composer's command-picker drive scope.
+ *
+ * `useCommandSuggestion` turns whatever `driveId` it is handed into the
+ * `/api/commands/suggest?driveId=` query, and with none the route skips the
+ * drive-commands query outright — so an unscoped composer can only ever offer
+ * built-ins plus personal commands. This suite guards the wiring that decides
+ * that scope, which the surface-level suites cannot: they mock `ChatInput`
+ * away, so removing `commandDriveId ?? driveId` here leaves them green.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render } from '@testing-library/react';
+import React from 'react';
+
+const captured = vi.hoisted(() => ({
+  command: undefined as { driveId?: string } | undefined,
+  mention: undefined as { driveId?: string; crossDrive?: boolean } | undefined,
+}));
+
+vi.mock('@/hooks/useCommandSuggestion', () => ({
+  useCommandSuggestion: (props: { driveId?: string }) => {
+    captured.command = props;
+    return {
+      isOpen: false,
+      position: null,
+      items: [],
+      hasAnyCommands: false,
+      loading: false,
+      loadFailed: false,
+      query: '',
+      selectedIndex: 0,
+      handleInput: vi.fn(),
+      handleKeyDown: vi.fn(),
+      handleCompositionStart: vi.fn(),
+      handleCompositionEnd: vi.fn(),
+      syncDisplayText: vi.fn(),
+      actions: {
+        select: vi.fn(),
+        setSelectedIndex: vi.fn(),
+        close: vi.fn(),
+        dismiss: vi.fn(),
+      },
+    };
+  },
+}));
+
+vi.mock('@/hooks/useSuggestion', () => ({
+  useSuggestion: (props: { driveId?: string; crossDrive?: boolean }) => {
+    captured.mention = props;
+    return {
+      query: '',
+      handleKeyDown: vi.fn(),
+      handleValueChange: vi.fn(),
+      actions: { selectSuggestion: vi.fn(), close: vi.fn() },
+    };
+  },
+}));
+
+vi.mock('@/components/mentions/MentionPickerPortal', () => ({
+  MentionPickerPortal: () => null,
+}));
+
+vi.mock('@/components/commands/CommandPickerPortal', () => ({
+  CommandPickerPortal: () => null,
+}));
+
+import { ChatTextarea } from '../ChatTextarea';
+
+const baseProps = {
+  value: '',
+  onChange: vi.fn(),
+  onSend: vi.fn(),
+};
+
+beforeEach(() => {
+  captured.command = undefined;
+  captured.mention = undefined;
+});
+
+describe('ChatTextarea — command picker drive scope', () => {
+  it('scopes the command picker to commandDriveId when it differs from the mention drive', () => {
+    render(<ChatTextarea {...baseProps} driveId="route-drive" commandDriveId="agent-drive" />);
+    expect(captured.command?.driveId).toBe('agent-drive');
+  });
+
+  it('leaves mention search on its own driveId — command scope must not move it', () => {
+    render(
+      <ChatTextarea
+        {...baseProps}
+        driveId="route-drive"
+        commandDriveId="agent-drive"
+        crossDrive
+      />
+    );
+    expect(captured.mention?.driveId).toBe('route-drive');
+    expect(captured.mention?.crossDrive).toBe(true);
+  });
+
+  it('falls back to driveId when commandDriveId is omitted, so existing callers are unchanged', () => {
+    render(<ChatTextarea {...baseProps} driveId="route-drive" />);
+    expect(captured.command?.driveId).toBe('route-drive');
+  });
+
+  it('passes undefined when neither is given, which the suggest route reads as "no drive"', () => {
+    render(<ChatTextarea {...baseProps} />);
+    expect(captured.command?.driveId).toBeUndefined();
+  });
+});

--- a/apps/web/src/components/layout/right-sidebar/ai-assistant/SidebarChatTab.tsx
+++ b/apps/web/src/components/layout/right-sidebar/ai-assistant/SidebarChatTab.tsx
@@ -54,6 +54,7 @@ import { useEditingStore } from '@/stores/useEditingStore';
 import { ChatErrorBanner } from '@/components/ai/shared/chat/ChatErrorBanner';
 import { selectMessagesAreaMode } from '@/lib/ai/streams/selectMessagesAreaMode';
 import { canResumeRecovery } from '@/lib/ai/streams/canResumeRecovery';
+import { commandDriveIdFor } from '@/lib/commands/command-scope';
 
 // Threshold for enabling virtualization in sidebar (lower than main chat due to compact items)
 const SIDEBAR_VIRTUALIZATION_THRESHOLD = 30;
@@ -989,6 +990,13 @@ const SidebarChatTab: React.FC = () => {
           isStopping={isStopping}
           placeholder={`Ask about ${contextLabel ?? 'your workspace'}...`}
           driveId={locationContext?.currentDrive?.id}
+          // Commands scope to the SELECTED AGENT's drive, not the route's:
+          // an agent reached from another drive still has its chips resolved
+          // against its own `page.driveId` server-side, so scoping the picker
+          // to wherever the user happens to be standing offers commands that
+          // come back `not_found`. Mirrors GlobalAssistantView. Mention search
+          // (`driveId`/`crossDrive` above) is deliberately left as it was.
+          commandDriveId={commandDriveIdFor(selectedAgent, locationContext?.currentDrive?.id)}
           crossDrive={true}
           hideModelSelector={true}
           variant="sidebar"

--- a/apps/web/src/lib/commands/__tests__/command-scope.test.ts
+++ b/apps/web/src/lib/commands/__tests__/command-scope.test.ts
@@ -1,0 +1,26 @@
+import { describe, it, expect } from 'vitest';
+import { commandDriveIdFor } from '../command-scope';
+
+describe('commandDriveIdFor', () => {
+  it("prefers the selected agent's own drive over wherever the user is standing", () => {
+    // The regression this exists for: an agent borrowed into another drive
+    // still has its chips resolved against its own page.driveId server-side,
+    // so scoping to the route offers commands that fail as not_found.
+    expect(commandDriveIdFor({ driveId: 'agent-drive' }, 'route-drive')).toBe('agent-drive');
+  });
+
+  it("uses the agent's drive even when the route resolves to no drive at all", () => {
+    expect(commandDriveIdFor({ driveId: 'agent-drive' }, undefined)).toBe('agent-drive');
+    expect(commandDriveIdFor({ driveId: 'agent-drive' }, null)).toBe('agent-drive');
+  });
+
+  it('falls back to the location drive in assistant mode, which is what that turn scopes to', () => {
+    expect(commandDriveIdFor(null, 'route-drive')).toBe('route-drive');
+    expect(commandDriveIdFor(undefined, 'route-drive')).toBe('route-drive');
+  });
+
+  it('normalises "no drive" to undefined, the shape the composer prop expects', () => {
+    expect(commandDriveIdFor(null, null)).toBeUndefined();
+    expect(commandDriveIdFor(undefined, undefined)).toBeUndefined();
+  });
+});

--- a/apps/web/src/lib/commands/command-scope.ts
+++ b/apps/web/src/lib/commands/command-scope.ts
@@ -1,0 +1,27 @@
+/**
+ * Which drive's commands a composer should offer (Universal Commands).
+ *
+ * The picker and the server must agree on this, or the picker hands the user
+ * commands that come back `not_found` the moment the message is sent: a chip
+ * is resolved against the drive the TURN resolves, never the drive the
+ * composer happened to be scoped to.
+ *
+ * For a dual-mode surface (an agent selector over an otherwise
+ * location-scoped assistant) those are two different drives:
+ *
+ * - agent mode  — `page-chat-turn` resolves chips with the AGENT PAGE's own
+ *   `page.driveId`. An agent reached from another drive (via
+ *   `drive_agent_members`) keeps its own drive; where the user is standing is
+ *   irrelevant.
+ * - assistant mode — `global-chat-turn` resolves them with the location
+ *   context's drive, i.e. the route the user is on.
+ *
+ * Pure, and deliberately shared: the two surfaces that make this choice had
+ * drifted apart, which is the whole reason drive commands went missing.
+ */
+export function commandDriveIdFor(
+  selectedAgent: { driveId: string } | null | undefined,
+  locationDriveId: string | null | undefined
+): string | undefined {
+  return selectedAgent?.driveId ?? locationDriveId ?? undefined;
+}


### PR DESCRIPTION
## The bug

Open an AI page, type `/`, and the drive's own commands are missing — only built-ins and your personal ones appear. A command runs from the chip you pick out of that list, so a command that is never listed is a command that cannot be used.

## Root cause

`SessionChat` renders `<ChatInput>` with **no drive scope at all**. That prop is what becomes `/api/commands/suggest?driveId=`, and `loadAvailableCommands` skips the drive-commands query outright when the drive is null (`apps/web/src/lib/commands/available-commands.ts`). One view backs every agent-session surface — the open `AI_CHAT` page, the panes grid, and the pane assistant — so all three were unscoped.

**The server was already correct.** `page-chat-turn` resolves chips with the agent page's `page.driveId`; nothing under `app/api/commands/`, `available-commands.ts`, or either chat-turn file is touched here. This is purely the composer failing to say where it is.

The UX spec is explicit that this should not vary by surface — universal-commands-ux.md §1.2: *"any AI-capable input … should offer the same picker with identical behavior."*

### A second instance, same class

The right-sidebar assistant scoped commands to the **route's** drive even with an agent selected, while the server scoped them to the **agent's**. An agent reached from another drive (via `drive_agent_members`) therefore offered commands that came back `not_found` on send. `GlobalAssistantView` already had the correct branch; `SidebarChatTab` had drifted from it — which is what produced this bug class in the first place, so the choice now lives in one shared `commandDriveIdFor`.

## Approach

Command scope gets its **own** prop rather than overloading `driveId`, which also drives mention search. Mention behaviour is unchanged on every surface.

- `ChatTextarea` / `ChatInput` — new `commandDriveId?: string`, defaulting to `driveId`, so existing callers are unchanged by construction.
- `SessionChatView.commandDriveId` is **required, not optional** — a future caller of the shared view cannot silently reintroduce the unscoped picker.
- The agent branch passes `agent.driveId` deliberately, **not** the pane-hosting session's drive, which can legitimately differ (`AgentPageView`); the server scopes to `page.driveId`.
- The assistant branch reads the same `contextRef` the turn itself ships, hoisted into `useAssistantContextRef` so the picker and the request cannot drift.

**Invariant established:** the drive the picker scopes to must equal the drive the server resolves chips against. Anything else offers commands that fail on use.

## Verification

46 tests across 7 suites. Red-first confirmed (`none` vs `drive-1`), then **each hop mutated individually and confirmed to fail**:

| Mutation | Caught by |
|---|---|
| drop `agent.driveId` | `SessionChat.test.tsx` |
| drop `commandDriveId ?? driveId` at the hook call | `ChatTextarea.commandDriveId.test.tsx` (new) |
| drop the `ChatInput → ChatTextarea` forward | `ChatInput.remoteStreamingUser.test.tsx` |
| assistant fallback → raw `driveId` | `SessionChat.test.tsx` |

The first mutation check is why two of those suites are new: the surface-level suite mocks `ChatInput` away, so it passed three of the four mutations. It would have named a mechanism it did not guard.

`commandDriveIdFor` is a real shared function with its own unit test, rather than a re-implementation mirrored inside a test file — the pattern the existing `SidebarChatTab` suite uses, which guards nothing.

Rebased onto current `master` (was 64 behind) and re-run green on the fresh base.

## Not done

- **`typecheck` was not run locally** — eight `pu` agents were running at load ~5–7, so the no-local-builds rule applied. `eslint` is clean on all changed files, and both `SessionChatView` call sites were statically confirmed to pass the now-required prop. **CI is the gate for types here.**
- **The `@` mention picker is still dead on these same surfaces** — `useSuggestionCore` short-circuits to zero results when `crossDrive` and `driveId` are both absent, which is exactly their state, so `@` returns nothing there today. Deliberately left out to keep this change strictly command-scoped; it is a one-line addition (`driveId={agent.driveId}`) whenever wanted.

## Manual check

Create a drive command in the drive owning an `AI_CHAT` page → open that page → `/` → the command appears with its drive badge, inserts as a chip, and on send produces a `data-command-execution` indicator rather than "could not be loaded". Repeat in the right sidebar with that agent selected while standing on a page in a *different* drive.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019EeD7zUSKrRe5jVF4Vo5w6


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Drive commands are now available and correctly scoped in agent chats, panes, and the assistant.
  * Command suggestions use the selected agent’s drive, with a fallback to the current drive when no agent is selected.

* **Bug Fixes**
  * Prevented commands from resolving against an unrelated page or drive context.
  * Preserved separate drive behavior for mentions and command suggestions.

* **Tests**
  * Added coverage for agent, assistant, fallback, and command forwarding scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->