### PR TITLE
feat(tools): copy_content — move bytes the agent already has

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,7 +179,7 @@ in favor of `pagespace mcp`, part of `@pagespace/cli`; see the
 ## Core Features
 
 ### AI Agent Infrastructure
-- **80 workspace tools** for AI to manipulate content directly. The same operation registry
+- **81 workspace tools** for AI to manipulate content directly. The same operation registry
   generates every `pagespace` CLI verb, SDK method, and MCP tool, so none of the three can drift
 - **Tool permissions**: Control what each AI can do in your workspace
 - **MCP protocol support**: Connect external AI tools like Claude Desktop, Cursor, and Claude Code

--- a/apps/marketing/src/app/docs/getting-started/page.tsx
+++ b/apps/marketing/src/app/docs/getting-started/page.tsx
@@ -79,7 +79,7 @@ AI Chat pages are specialized AI conversations with custom configuration:
 1. Right-click in the file tree and select **New AI Chat**
 2. Open the agent's settings to configure:
    - **System prompt**: custom instructions for the agent's behavior
-   - **Enabled tools**: which of the 80 workspace tools the agent can call
+   - **Enabled tools**: which of the 81 workspace tools the agent can call
    - **Read-only toggle**: when on, the agent can only read and search — no writes, no trash, no task updates
    - **Web search toggle**: enables the \`web_search\` tool
    - **Provider / Model**: which AI model powers this agent

--- a/apps/web/src/components/ai/shared/chat/tool-calls/CompactToolCallRenderer.tsx
+++ b/apps/web/src/components/ai/shared/chat/tool-calls/CompactToolCallRenderer.tsx
@@ -95,6 +95,7 @@ export const TOOL_NAME_MAP: Record<string, string> = {
   'read_page': 'Read',
   'replace_lines': 'Replace',
   'insert_content': 'Insert',
+  'copy_content': 'Copy',
   'create_page': 'Create',
   'rename_page': 'Rename',
   'send_channel_message': 'Send Message',
@@ -142,6 +143,7 @@ export function useCompactToolCallDisplay(part: ToolPart, toolName: string, isEx
         return <MessageSquare className={iconClass} />;
       case 'replace_lines':
       case 'insert_content':
+      case 'copy_content':
         return <Edit className={iconClass} />;
       case 'create_page':
         return <Plus className={iconClass} />;

--- a/apps/web/src/components/ai/shared/chat/tool-calls/__tests__/registry-copy-content.test.tsx
+++ b/apps/web/src/components/ai/shared/chat/tool-calls/__tests__/registry-copy-content.test.tsx
@@ -1,0 +1,64 @@
+import { describe, it, expect } from 'vitest';
+import { isValidElement } from 'react';
+import { toolRenderers } from '../registry';
+import { RichDiffRenderer } from '../RichDiffRenderer';
+
+const render = (parsedOutput: Record<string, unknown>) =>
+  toolRenderers['copy_content']({
+    toolName: 'copy_content',
+    parsedInput: null,
+    parsedOutput,
+    output: parsedOutput,
+  } as Parameters<(typeof toolRenderers)['copy_content']>[0]);
+
+describe('copy_content renderer', () => {
+  it('given a completed page copy, should render the diff', () => {
+    const result = render({
+      success: true,
+      title: 'Doc',
+      oldContent: 'old',
+      newContent: 'new',
+    });
+    expect(isValidElement(result) && result.type).toBe(RichDiffRenderer);
+  });
+
+  it('given inserted:false, should NOT render a diff', () => {
+    // A missing insertAfter anchor rides on a success:true envelope and writes
+    // nothing, so rendering it as a completed update would report a copy that
+    // never happened.
+    const result = render({
+      success: true,
+      inserted: false,
+      title: 'Doc',
+      message: 'No line containing "NOPE" was found.',
+    });
+    expect(isValidElement(result) && result.type).not.toBe(RichDiffRenderer);
+  });
+
+  it('given inserted:false, should report the copy as unsuccessful', () => {
+    const result = render({ success: true, inserted: false, title: 'Doc' });
+    expect(isValidElement(result) && (result.props as { success?: boolean }).success).toBe(false);
+  });
+
+  it('given inserted:false alongside diff fields, should still not render a diff', () => {
+    // Defensive: the envelope must decide, not the presence of content keys.
+    const result = render({
+      success: true,
+      inserted: false,
+      oldContent: 'old',
+      newContent: 'new',
+    });
+    expect(isValidElement(result) && result.type).not.toBe(RichDiffRenderer);
+  });
+
+  it('given a file destination (no diff fields), should render the action summary as successful', () => {
+    const result = render({ success: true, path: 'export.md', message: 'Copied.' });
+    expect(isValidElement(result) && result.type).not.toBe(RichDiffRenderer);
+    expect(isValidElement(result) && (result.props as { success?: boolean }).success).toBe(true);
+  });
+
+  it('given a refusal, should report it as unsuccessful', () => {
+    const result = render({ success: false, error: 'Content mode mismatch' });
+    expect(isValidElement(result) && (result.props as { success?: boolean }).success).toBe(false);
+  });
+});

--- a/apps/web/src/components/ai/shared/chat/tool-calls/registry.tsx
+++ b/apps/web/src/components/ai/shared/chat/tool-calls/registry.tsx
@@ -395,7 +395,11 @@ export const toolRenderers: Record<string, ToolRenderer> = {
   // renders like the other line edits. A copy into a FILE has no prior content
   // to diff against, so it falls through to the action summary.
   copy_content: ({ parsedOutput }) => {
-    if (parsedOutput.success && typeof parsedOutput.oldContent === 'string' && typeof parsedOutput.newContent === 'string') {
+    // `inserted: false` rides on a success:true envelope (a missing insertAfter
+    // anchor is a no-op the agent can act on, not a fault). Nothing was written
+    // in that case, so it must not render as a completed update.
+    const copied = parsedOutput.success !== false && parsedOutput.inserted !== false;
+    if (copied && typeof parsedOutput.oldContent === 'string' && typeof parsedOutput.newContent === 'string') {
       return (
         <RichDiffRenderer
           title={(parsedOutput.title as string | undefined) || 'Document'}
@@ -409,7 +413,7 @@ export const toolRenderers: Record<string, ToolRenderer> = {
     return (
       <ActionResultRenderer
         actionType="update"
-        success={parsedOutput.success !== false}
+        success={copied}
         title={(parsedOutput.title as string | undefined) ?? (parsedOutput.path as string | undefined)}
         pageId={parsedOutput.pageId as string | undefined}
         message={parsedOutput.message as string | undefined}

--- a/apps/web/src/components/ai/shared/chat/tool-calls/registry.tsx
+++ b/apps/web/src/components/ai/shared/chat/tool-calls/registry.tsx
@@ -391,6 +391,33 @@ export const toolRenderers: Record<string, ToolRenderer> = {
   },
 
   // === PAGE WRITE TOOLS ===
+  // A copy into a page is exactly the "diff a human should review" case, so it
+  // renders like the other line edits. A copy into a FILE has no prior content
+  // to diff against, so it falls through to the action summary.
+  copy_content: ({ parsedOutput }) => {
+    if (parsedOutput.success && typeof parsedOutput.oldContent === 'string' && typeof parsedOutput.newContent === 'string') {
+      return (
+        <RichDiffRenderer
+          title={(parsedOutput.title as string | undefined) || 'Document'}
+          oldContent={parsedOutput.oldContent}
+          newContent={parsedOutput.newContent}
+          pageId={parsedOutput.pageId as string | undefined}
+          changeSummary={parsedOutput.message as string | undefined}
+        />
+      );
+    }
+    return (
+      <ActionResultRenderer
+        actionType="update"
+        success={parsedOutput.success !== false}
+        title={(parsedOutput.title as string | undefined) ?? (parsedOutput.path as string | undefined)}
+        pageId={parsedOutput.pageId as string | undefined}
+        message={parsedOutput.message as string | undefined}
+        errorMessage={parsedOutput.error as string | undefined}
+      />
+    );
+  },
+
   insert_content: ({ parsedOutput }) => {
     if (parsedOutput.success && typeof parsedOutput.oldContent === 'string' && typeof parsedOutput.newContent === 'string') {
       return (

--- a/apps/web/src/components/ai/shared/chat/tool-calls/tool-significance.ts
+++ b/apps/web/src/components/ai/shared/chat/tool-calls/tool-significance.ts
@@ -17,7 +17,7 @@ export type RunStatus = 'running' | 'error' | 'complete';
  * for a RichDiffRenderer usage per entry) so this list can't silently drift
  * from the renderers it's meant to describe.
  */
-export const DIFF_TOOL_NAMES = new Set(['replace_lines', 'insert_content', 'edit', 'write']);
+export const DIFF_TOOL_NAMES = new Set(['replace_lines', 'insert_content', 'edit', 'write', 'copy_content']);
 
 export function isDiffTool(toolName: string): boolean {
   return DIFF_TOOL_NAMES.has(toolName);

--- a/apps/web/src/lib/ai/core/__tests__/ai-tools.test.ts
+++ b/apps/web/src/lib/ai/core/__tests__/ai-tools.test.ts
@@ -21,6 +21,12 @@ vi.mock('../../tools/page-read-tools', () => ({
   },
 }));
 
+vi.mock('../../tools/copy-content-tools-runtime', () => ({
+  copyContentTools: {
+    copy_content: { name: 'copy_content', description: 'Copy content' },
+  },
+}));
+
 vi.mock('../../tools/page-write-tools', () => ({
   pageWriteTools: {
     replace_lines: { name: 'replace_lines', description: 'Replace lines' },
@@ -180,6 +186,7 @@ import { roleManagementTools } from '../../tools/role-management-tools';
 import { driveTools } from '../../tools/drive-tools';
 import { pageReadTools } from '../../tools/page-read-tools';
 import { pageWriteTools } from '../../tools/page-write-tools';
+import { copyContentTools } from '../../tools/copy-content-tools-runtime';
 import { sheetReadTools } from '../../tools/sheet-read-tools';
 import { searchTools } from '../../tools/search-tools';
 import { taskManagementTools } from '../../tools/task-management-tools';
@@ -233,6 +240,7 @@ describe('ai-tools', () => {
         ...driveTools,
         ...pageReadTools,
         ...pageWriteTools,
+        ...copyContentTools,
         ...sheetReadTools,
         ...searchTools,
         ...taskManagementTools,

--- a/apps/web/src/lib/ai/core/__tests__/inline-instructions.test.ts
+++ b/apps/web/src/lib/ai/core/__tests__/inline-instructions.test.ts
@@ -268,3 +268,39 @@ describe('SHEET bullet vs the agent allowlist', () => {
     expect(sheetLine).toContain('lineStart');
   });
 });
+
+describe('PAGE TYPES bullets — copy_content is only named to agents that hold it', () => {
+  // Every agent configured before copy_content existed has a saved
+  // enabledTools array without it. Naming a tool the agent does not hold buys
+  // an unknown-tool round trip before the model recovers — the same reason the
+  // SHEET bullet is composed rather than fixed.
+  const withoutCopy = ['read_page', 'replace_lines', 'insert_content'];
+  const withCopy = [...withoutCopy, 'copy_content'];
+
+  it('should not mention copy_content when the agent lacks it', () => {
+    expect(buildInlineInstructions(withoutCopy)).not.toContain('copy_content');
+  });
+
+  it('should mention copy_content when the agent holds it', () => {
+    expect(buildInlineInstructions(withCopy)).toContain('copy_content');
+  });
+
+  it('should still describe DOCUMENT and CODE pages either way', () => {
+    for (const tools of [withoutCopy, withCopy]) {
+      const out = buildInlineInstructions(tools);
+      expect(out).toContain('• DOCUMENT:');
+      expect(out).toContain('• CODE:');
+    }
+  });
+
+  it('should keep the slim DOCUMENT bullet when the writing-documents skill is reachable', () => {
+    // compose() takes precedence over `slim` in buildPageTypes, so the skill
+    // branch has to be reproduced inside it — this pins that it still is.
+    const out = buildInlineInstructions([...withCopy, 'load_skill']);
+    expect(out).toContain('Load the writing-documents skill');
+  });
+
+  it('should include copy_content for the undefined sentinel (admin viewer shows everything)', () => {
+    expect(buildInlineInstructions(undefined)).toContain('copy_content');
+  });
+});

--- a/apps/web/src/lib/ai/core/__tests__/stub-tools.test.ts
+++ b/apps/web/src/lib/ai/core/__tests__/stub-tools.test.ts
@@ -3,12 +3,13 @@ import { assert } from './riteway';
 import { CORE_TOOL_NAMES } from '../stub-tools';
 
 describe('CORE_TOOL_NAMES', () => {
-  it('contains exactly the 10 designated core tools', () => {
+  it('contains exactly the 11 designated core tools', () => {
     assert({
       given: 'the CORE_TOOL_NAMES set',
-      should: 'list exactly the 10 core tools',
+      should: 'list exactly the 11 core tools',
       actual: [...CORE_TOOL_NAMES].sort(),
       expected: [
+        'copy_content',
         'create_page',
         'get_page_details',
         'insert_content',

--- a/apps/web/src/lib/ai/core/ai-tools.ts
+++ b/apps/web/src/lib/ai/core/ai-tools.ts
@@ -5,6 +5,7 @@ import { roleManagementTools } from '../tools/role-management-tools';
 import { driveTools } from '../tools/drive-tools';
 import { pageReadTools } from '../tools/page-read-tools';
 import { pageWriteTools } from '../tools/page-write-tools';
+import { copyContentTools } from '../tools/copy-content-tools-runtime';
 import { sheetReadTools } from '../tools/sheet-read-tools';
 import { searchTools } from '../tools/search-tools';
 import { taskManagementTools } from '../tools/task-management-tools';
@@ -48,6 +49,11 @@ const TOOL_MODULES = {
   drives: driveTools,
   pagesRead: pageReadTools,
   pagesWrite: pageWriteTools,
+  // Registered as a WORKSPACE tool, not a sandbox one: its page->page arm
+  // touches no sandbox, and the code-execution kill-switch is default-OFF, so
+  // gating it there would hide page copying on every deployment. The per-agent
+  // sandbox switch is enforced at call time inside the file arms instead.
+  copyContent: copyContentTools,
   sheetsRead: sheetReadTools,
   search: searchTools,
   tasks: taskManagementTools,

--- a/apps/web/src/lib/ai/core/inline-instructions.ts
+++ b/apps/web/src/lib/ai/core/inline-instructions.ts
@@ -53,11 +53,11 @@ const PAGE_TYPE_BULLETS: ReadonlyArray<{
 }> = [
   { full: '• FOLDER: Container with list/icon view of children. Accepts file uploads via drag-drop.' },
   {
-    full: '• DOCUMENT: Markdown text, or rich text stored as HTML (contentMode says which; documents you create default to markdown). Write the format the page is in. Use insert_content to add lines before/after a heading or landmark, or replace_lines for precise line-range edits.',
+    full: '• DOCUMENT: Markdown text, or rich text stored as HTML (contentMode says which; documents you create default to markdown). Write the format the page is in. Use insert_content to add lines before/after a heading or landmark, or replace_lines for precise line-range edits. If the content already exists on another page or in a sandbox file, use copy_content instead of retyping it.',
     slim: '• DOCUMENT: Markdown or rich text stored as HTML (check contentMode). Load the writing-documents skill before non-trivial writing or line-range editing.',
     skill: 'writing-documents',
   },
-  { full: '• CODE: Plain-text source code with syntax highlighting. Use replace_lines for edits (raw text, no HTML processing).' },
+  { full: '• CODE: Plain-text source code with syntax highlighting. Use replace_lines for edits (raw text, no HTML processing), or copy_content to move a sandbox file in without retyping it.' },
   {
     // Composed rather than picked from fixed variants. A bullet naming a tool
     // the agent does not hold produces an unknown-tool call before the model

--- a/apps/web/src/lib/ai/core/inline-instructions.ts
+++ b/apps/web/src/lib/ai/core/inline-instructions.ts
@@ -53,11 +53,35 @@ const PAGE_TYPE_BULLETS: ReadonlyArray<{
 }> = [
   { full: '• FOLDER: Container with list/icon view of children. Accepts file uploads via drag-drop.' },
   {
-    full: '• DOCUMENT: Markdown text, or rich text stored as HTML (contentMode says which; documents you create default to markdown). Write the format the page is in. Use insert_content to add lines before/after a heading or landmark, or replace_lines for precise line-range edits. If the content already exists on another page or in a sandbox file, use copy_content instead of retyping it.',
-    slim: '• DOCUMENT: Markdown or rich text stored as HTML (check contentMode). Load the writing-documents skill before non-trivial writing or line-range editing.',
+    // Composed for the same reason the SHEET bullet is: it names tools that may
+    // be absent from a saved allowlist. Every agent configured before
+    // copy_content existed has one, and telling those agents to call it buys an
+    // unknown-tool round trip. The skill/slim branch is reproduced here because
+    // `compose` takes precedence over `slim` in buildPageTypes.
+    compose: (availableTools?: string[]) => {
+      if (skillPointerUsable(availableTools, 'writing-documents')) {
+        return '• DOCUMENT: Markdown or rich text stored as HTML (check contentMode). Load the writing-documents skill before non-trivial writing or line-range editing.';
+      }
+      const parts = [
+        '• DOCUMENT: Markdown text, or rich text stored as HTML (contentMode says which; documents you create default to markdown).',
+        'Write the format the page is in.',
+        'Use insert_content to add lines before/after a heading or landmark, or replace_lines for precise line-range edits.',
+      ];
+      if (hasAny(availableTools, ['copy_content'])) {
+        parts.push('If the content already exists on another page or in a sandbox file, use copy_content instead of retyping it.');
+      }
+      return parts.join(' ');
+    },
     skill: 'writing-documents',
   },
-  { full: '• CODE: Plain-text source code with syntax highlighting. Use replace_lines for edits (raw text, no HTML processing), or copy_content to move a sandbox file in without retyping it.' },
+  {
+    compose: (availableTools?: string[]) => {
+      const base = '• CODE: Plain-text source code with syntax highlighting. Use replace_lines for edits (raw text, no HTML processing)';
+      return hasAny(availableTools, ['copy_content'])
+        ? `${base}, or copy_content to move a sandbox file in without retyping it.`
+        : `${base}.`;
+    },
+  },
   {
     // Composed rather than picked from fixed variants. A bullet naming a tool
     // the agent does not hold produces an unknown-tool call before the model

--- a/apps/web/src/lib/ai/core/stub-tools.ts
+++ b/apps/web/src/lib/ai/core/stub-tools.ts
@@ -6,6 +6,10 @@ export const CORE_TOOL_NAMES = new Set([
   'create_page',
   'replace_lines',
   'insert_content',
+  // Core because its value is being reached for INSTEAD of a tool the model
+  // already knows: in search exposure a hidden copy_content just means the
+  // model falls back to re-transcribing the content by hand.
+  'copy_content',
   'regex_search',
   'multi_drive_search',
   // The capability loader: always upfront so the skill catalog's "call

--- a/apps/web/src/lib/ai/core/tool-filtering.ts
+++ b/apps/web/src/lib/ai/core/tool-filtering.ts
@@ -18,6 +18,11 @@ export const WRITE_TOOLS = new Set([
   'insert_content',
   'move_page',
   'edit_sheet_cells',
+  // Mutates a page or a sandbox file, so a read-only agent must not get it.
+  // Deliberately NOT in SANDBOX_TOOL_NAMES: that set is stripped wholesale when
+  // an agent's sandbox switch is off, which would also remove the page->page
+  // arm. The file arms check the switch at call time instead.
+  'copy_content',
   // Drive operations
   'create_drive',
   'rename_drive',

--- a/apps/web/src/lib/ai/skills/bodies/writing-documents.ts
+++ b/apps/web/src/lib/ai/skills/bodies/writing-documents.ts
@@ -75,6 +75,19 @@ Use it for: rewriting a section, fixing specific lines, deleting content, any ed
 
 Use it for: appending sections relative to headings or landmarks, adding items near known text — anywhere counting lines is unnecessary risk. Prefer it over \`replace_lines\` when you are adding (not changing) content.
 
+### copy_content — move content you already have, without retyping it
+
+If the content already exists somewhere the system can read — a page you read, a file you wrote in the sandbox — **do not paste it into \`replace_lines\`, \`insert_content\` or \`writeFile\`.** Call \`copy_content\` instead. The bytes move server-side, so you never emit them: copying a 500-line file costs one short tool call rather than 500 lines of output, and it is byte-exact rather than whatever you managed to retype.
+
+- \`from\`: \`{ kind: 'page', pageId, lineStart?, lineEnd? }\` or \`{ kind: 'file', path }\`. The line numbers are the ones \`read_page\` showed you.
+- \`to\`: \`{ kind: 'page', pageId, mode }\` where mode is \`replace\` (whole page), \`replaceLines\` (a range), \`insertAfter\` (an anchor, like \`insert_content\`), or \`append\`; or \`{ kind: 'file', path }\` to write a whole file.
+- It **converts nothing**. Copying raw text (a sandbox file, a markdown or CODE page) into an html-mode DOCUMENT is refused rather than silently producing literal characters. Create the destination with a matching \`contentMode\` — \`create_page\` defaults to markdown — and copy into that.
+- To copy into a NEW page: \`create_page\` first (it takes no content), then \`copy_content\` into it.
+- \`insertAfter\` reports \`inserted: false\` on a missing anchor, exactly like \`insert_content\`.
+- It refuses rather than truncating if the source is over the size limit. Narrow it with \`from.lineStart\`/\`from.lineEnd\`.
+
+Only compose content by hand when you are actually authoring it. Moving existing bytes is what this tool is for.
+
 ## Writing HTML for html-mode DOCUMENTs
 
 The rich editor's Tiptap 3 schema accepts a specific set of elements. Verified supported:

--- a/apps/web/src/lib/ai/tools/__tests__/copy-content-model-output.test.ts
+++ b/apps/web/src/lib/ai/tools/__tests__/copy-content-model-output.test.ts
@@ -1,0 +1,72 @@
+import { describe, it, expect } from 'vitest';
+import { toModelOutputForCopyContent } from '../copy-content-model-output';
+import { createCopyContentTools, type CopyContentDeps } from '../copy-content-tools';
+
+describe('toModelOutputForCopyContent', () => {
+  it('should strip the copied bytes but keep the counts', () => {
+    const out = toModelOutputForCopyContent({
+      success: true,
+      pageId: 'p1',
+      bytesCopied: 42,
+      oldContent: 'OLD-BYTES',
+      newContent: 'NEW-BYTES',
+    }) as { value: Record<string, unknown> };
+
+    expect(out.value.oldContent).toBeUndefined();
+    expect(out.value.newContent).toBeUndefined();
+    expect(out.value.bytesCopied).toBe(42);
+    expect(out.value.pageId).toBe('p1');
+  });
+
+  it('should pass a refusal through unchanged', () => {
+    const refusal = { success: false, error: 'Source is empty', message: 'nothing to copy' };
+    const out = toModelOutputForCopyContent(refusal) as { value: Record<string, unknown> };
+    expect(out.value).toEqual(refusal);
+  });
+
+  it('should tolerate a non-object output', () => {
+    expect(() => toModelOutputForCopyContent(null)).not.toThrow();
+    expect(() => toModelOutputForCopyContent('text')).not.toThrow();
+  });
+});
+
+describe('copy_content — toModelOutput is actually WIRED to the tool', () => {
+  // The suite used to call the helper directly, which pins the helper and not
+  // the tool: deleting `toModelOutput:` from the tool definition left every
+  // test green while turning the tool into a pessimization — it would have sent
+  // up to ~2 MB of copied bytes back as input tokens, which is the one thing it
+  // exists to avoid.
+  const deps = {
+    findPage: async () => ({
+      id: 'p1', title: 'Doc', type: 'DOCUMENT', contentMode: 'markdown',
+      content: 'OLD', driveId: 'd1', revision: 1,
+    }),
+    canViewPage: async () => true,
+    canEditPage: async () => true,
+    writePageContent: async () => {},
+    readSandboxFile: async () => ({ success: true as const, content: 'X', bytes: 1 }),
+    writeSandboxFile: async () => ({ success: true as const, bytesWritten: 1 }),
+    isSandboxEnabledForContext: async () => true,
+  } as unknown as CopyContentDeps;
+
+  it('the registered tool must carry a toModelOutput that strips content', async () => {
+    const tool = createCopyContentTools(deps).copy_content as {
+      execute: (a: unknown, o: unknown) => Promise<Record<string, unknown>>;
+      toModelOutput?: (arg: { output: unknown }) => { value: Record<string, unknown> };
+    };
+
+    expect(tool.toModelOutput, 'copy_content must define toModelOutput').toBeTypeOf('function');
+
+    const result = await tool.execute(
+      { from: { kind: 'page', pageId: 'p1' }, to: { kind: 'page', pageId: 'p1', mode: 'append' } },
+      { experimental_context: { userId: 'u1' } },
+    );
+    expect(result.success).toBe(true);
+    expect(typeof result.oldContent).toBe('string');
+
+    const modelFacing = JSON.stringify(tool.toModelOutput!({ output: result }));
+    expect(modelFacing).not.toContain('oldContent');
+    expect(modelFacing).not.toContain('newContent');
+    expect(modelFacing).toContain('bytesCopied');
+  });
+});

--- a/apps/web/src/lib/ai/tools/__tests__/copy-content-tools.test.ts
+++ b/apps/web/src/lib/ai/tools/__tests__/copy-content-tools.test.ts
@@ -4,6 +4,7 @@ import { describe, it, expect } from 'vitest';
 // injected fakes (production wiring lives in copy-content-tools-runtime.ts).
 import {
   createCopyContentTools,
+  copyContentInputSchema,
   MAX_COPY_BYTES,
   type CopyContentDeps,
   type CopyPageRecord,
@@ -471,5 +472,199 @@ describe('copy_content — refusals that protect content', () => {
     expect(result.success).toBe(false);
     expect(String(result.message)).toContain('File not found');
     expect(h.writes).toHaveLength(0);
+  });
+});
+
+describe('copy_content — review round 2', () => {
+  it('insertAfter into an html page should place the copy OUTSIDE the anchor element', async () => {
+    // Hand-rolling the line index nested the copy inside the anchor's <p>,
+    // producing invalid markup that Tiptap restructures on the next save —
+    // which moves every line number underneath the agent.
+    const h = harness({
+      pages: [
+        page({ id: 'src', type: 'DOCUMENT', contentMode: 'html', content: '<p>COPY</p>' }),
+        page({ id: 'dst', type: 'DOCUMENT', contentMode: 'html', content: '<p>Alpha</p><p>Beta</p>' }),
+      ],
+    });
+    const result = await run(h.deps, {
+      from: { kind: 'page', pageId: 'src' },
+      to: { kind: 'page', pageId: 'dst', mode: 'insertAfter', anchor: 'Alpha' },
+    });
+    expect(result.success).toBe(true);
+    // The copy must sit between the two paragraphs, never inside the first.
+    expect(h.writes[0].newContent).toBe('<p>\nAlpha\n</p>\n<p>\nCOPY\n</p>\n<p>\nBeta\n</p>');
+  });
+
+  it('insertAfter position:before into an html page should also respect the block boundary', async () => {
+    const h = harness({
+      pages: [
+        page({ id: 'src', type: 'DOCUMENT', contentMode: 'html', content: '<p>C</p>' }),
+        page({ id: 'dst', type: 'DOCUMENT', contentMode: 'html', content: '<p>Alpha</p>' }),
+      ],
+    });
+    await run(h.deps, {
+      from: { kind: 'page', pageId: 'src' },
+      to: { kind: 'page', pageId: 'dst', mode: 'insertAfter', anchor: 'Alpha', position: 'before' },
+    });
+    expect(h.writes[0].newContent).toBe('<p>\nC\n</p>\n<p>\nAlpha\n</p>');
+  });
+
+  it('an empty source should be refused, not used to wipe the destination', async () => {
+    // A FILE page whose text was never extracted is the realistic trigger.
+    const h = harness({
+      pages: [
+        page({ id: 'src', type: 'FILE', content: null }),
+        page({ id: 'dst', content: 'IMPORTANT\nDATA' }),
+      ],
+    });
+    const result = await run(h.deps, {
+      from: { kind: 'page', pageId: 'src' },
+      to: { kind: 'page', pageId: 'dst', mode: 'replace' },
+    });
+    expect(result.success).toBe(false);
+    expect(result.error).toBe('Source is empty');
+    expect(h.writes).toHaveLength(0);
+  });
+
+  it('an empty sandbox file should be refused too', async () => {
+    const h = harness({ file: '', pages: [page({ id: 'dst', content: 'DATA' })] });
+    const result = await run(h.deps, {
+      from: { kind: 'file', path: 'empty.txt' },
+      to: { kind: 'page', pageId: 'dst', mode: 'replace' },
+    });
+    expect(result.success).toBe(false);
+    expect(h.writes).toHaveLength(0);
+  });
+
+  it('should allow markdown into an html-mode page that actually holds markdown', async () => {
+    // The #2463 page shape: contentMode says html, the content is markdown.
+    // Refusing here sent the agent to a dead end for the tool's core use case.
+    const h = harness({
+      pages: [
+        page({ id: 'src', contentMode: 'markdown', content: '# New' }),
+        page({ id: 'dst', type: 'DOCUMENT', contentMode: 'html', content: '# already markdown\ntext' }),
+      ],
+    });
+    const result = await run(h.deps, {
+      from: { kind: 'page', pageId: 'src' },
+      to: { kind: 'page', pageId: 'dst', mode: 'replace' },
+    });
+    expect(result.success).toBe(true);
+    expect(h.writes[0].newContent).toBe('# New');
+  });
+
+  it('should still refuse markdown into a page holding real HTML', async () => {
+    const h = harness({
+      pages: [
+        page({ id: 'src', contentMode: 'markdown', content: '# New' }),
+        page({ id: 'dst', type: 'DOCUMENT', contentMode: 'html', content: '<p>real html</p>' }),
+      ],
+    });
+    const result = await run(h.deps, {
+      from: { kind: 'page', pageId: 'src' },
+      to: { kind: 'page', pageId: 'dst', mode: 'replace' },
+    });
+    expect(result.success).toBe(false);
+    expect(result.error).toBe('Content mode mismatch');
+  });
+
+  it('should refuse FOLDER and AI_CHAT destinations, whose content is structured JSON', async () => {
+    for (const type of ['FOLDER', 'AI_CHAT']) {
+      const h = harness({
+        pages: [page({ id: 'src', content: 'TEXT' }), page({ id: 'dst', type, content: '{"children":[]}' })],
+      });
+      const result = await run(h.deps, {
+        from: { kind: 'page', pageId: 'src' },
+        to: { kind: 'page', pageId: 'dst', mode: 'replace' },
+      });
+      expect(result.success, `${type} destination`).toBe(false);
+      expect(h.writes).toHaveLength(0);
+    }
+  });
+
+  it('should refuse an AI_CHAT source rather than dumping its transcript JSON', async () => {
+    const h = harness({
+      pages: [
+        page({ id: 'src', type: 'AI_CHAT', content: '{"messages":[{"secret":1}]}' }),
+        page({ id: 'dst', content: 'x' }),
+      ],
+    });
+    const result = await run(h.deps, {
+      from: { kind: 'page', pageId: 'src' },
+      to: { kind: 'page', pageId: 'dst', mode: 'replace' },
+    });
+    expect(result.success).toBe(false);
+    expect(h.writes).toHaveLength(0);
+  });
+
+  it('should report lines ADDED for an insertion, not just linesReplaced: 0', async () => {
+    const h = harness({
+      pages: [page({ id: 'src', content: 'a\nb\nc' }), page({ id: 'dst', content: 'x' })],
+    });
+    const result = await run(h.deps, {
+      from: { kind: 'page', pageId: 'src' },
+      to: { kind: 'page', pageId: 'dst', mode: 'append' },
+    });
+    expect(result.linesAdded).toBe(3);
+  });
+
+  it('should surface a content-mode warning on SUCCESS, not only on refusal', async () => {
+    const h = harness({
+      pages: [
+        page({ id: 'src', type: 'DOCUMENT', contentMode: 'html', content: '<p>X</p>' }),
+        page({ id: 'dst', type: 'DOCUMENT', contentMode: 'html', content: '<p>real html</p>' }),
+      ],
+    });
+    const result = await run(h.deps, {
+      from: { kind: 'page', pageId: 'src' },
+      to: { kind: 'page', pageId: 'dst', mode: 'append' },
+    });
+    expect(result.success).toBe(true);
+    // This destination IS html, so no warning is expected — the assertion is
+    // that the field is wired at all, checked by its absence here and its
+    // presence in the schema-mismatch case above.
+    expect(result).toHaveProperty('contentMode');
+  });
+});
+
+describe('copy_content — input schema', () => {
+  // The execute-level tests bypass zod entirely, so the schema needs its own.
+  const parse = (v: unknown) => copyContentInputSchema.safeParse(v);
+
+  it('should require to.mode for a page destination', () => {
+    expect(parse({ from: { kind: 'page' }, to: { kind: 'page' } }).success).toBe(false);
+  });
+
+  it('should reject mode on a file destination', () => {
+    expect(parse({ from: { kind: 'page' }, to: { kind: 'file', path: 'a', mode: 'replace' } }).success).toBe(false);
+  });
+
+  it('should require path for a file side', () => {
+    expect(parse({ from: { kind: 'file' }, to: { kind: 'file', path: 'a' } }).success).toBe(false);
+  });
+
+  it('should reject a line range on a file source', () => {
+    expect(parse({ from: { kind: 'file', path: 'a', lineStart: 1 }, to: { kind: 'file', path: 'b' } }).success).toBe(false);
+  });
+
+  it('should reject an inverted range on either side', () => {
+    expect(parse({ from: { kind: 'page', lineStart: 5, lineEnd: 2 }, to: { kind: 'file', path: 'b' } }).success).toBe(false);
+    expect(parse({ from: { kind: 'page' }, to: { kind: 'page', mode: 'replaceLines', startLine: 5, endLine: 2 } }).success).toBe(false);
+  });
+
+  it('should reject expectedTotalLines on modes that would ignore it', () => {
+    // Silently discarding a staleness guard on `replace` is worse than not
+    // offering one.
+    expect(parse({ from: { kind: 'page' }, to: { kind: 'page', mode: 'replace', expectedTotalLines: 10 } }).success).toBe(false);
+    expect(parse({ from: { kind: 'page' }, to: { kind: 'page', mode: 'replaceLines', startLine: 1, expectedTotalLines: 10 } }).success).toBe(true);
+  });
+
+  it('should require an anchor for insertAfter', () => {
+    expect(parse({ from: { kind: 'page' }, to: { kind: 'page', mode: 'insertAfter' } }).success).toBe(false);
+  });
+
+  it('should accept the ordinary shapes', () => {
+    expect(parse({ from: { kind: 'page', pageId: 'p', lineStart: 1, lineEnd: 4 }, to: { kind: 'page', pageId: 'q', mode: 'append' } }).success).toBe(true);
+    expect(parse({ from: { kind: 'file', path: 'a.md' }, to: { kind: 'page', pageId: 'q', mode: 'replace' } }).success).toBe(true);
   });
 });

--- a/apps/web/src/lib/ai/tools/__tests__/copy-content-tools.test.ts
+++ b/apps/web/src/lib/ai/tools/__tests__/copy-content-tools.test.ts
@@ -1,0 +1,387 @@
+import { describe, it, expect } from 'vitest';
+
+// The factory imports no DB and no sandbox driver, so it runs directly against
+// injected fakes (production wiring lives in copy-content-tools-runtime.ts).
+import {
+  createCopyContentTools,
+  MAX_COPY_BYTES,
+  type CopyContentDeps,
+  type CopyPageRecord,
+} from '../copy-content-tools';
+import { toModelOutputForCopyContent } from '../copy-content-model-output';
+
+const CONTEXT = { userId: 'u1', chatSource: { type: 'page', agentPageId: 'agent-1' } };
+
+function page(over: Partial<CopyPageRecord> = {}): CopyPageRecord {
+  return {
+    id: 'p1',
+    title: 'Doc',
+    type: 'DOCUMENT',
+    contentMode: 'markdown',
+    content: 'alpha\nbravo\ncharlie\n',
+    driveId: 'd1',
+    revision: 1,
+    ...over,
+  };
+}
+
+interface Harness {
+  deps: CopyContentDeps;
+  writes: Array<{ pageId: string; newContent: string; metadata: Record<string, unknown> }>;
+  fileWrites: Array<{ path: string; content: string }>;
+}
+
+function harness(over: Partial<CopyContentDeps> & { pages?: CopyPageRecord[]; file?: string } = {}): Harness {
+  const writes: Harness['writes'] = [];
+  const fileWrites: Harness['fileWrites'] = [];
+  const pages = over.pages ?? [page()];
+
+  const deps: CopyContentDeps = {
+    findPage: async (id) => pages.find((p) => p.id === id) ?? null,
+    canViewPage: async () => true,
+    canEditPage: async () => true,
+    writePageContent: async ({ page: p, newContent, metadata }) => {
+      writes.push({ pageId: p.id, newContent, metadata });
+    },
+    readSandboxFile: async () => ({ success: true, content: over.file ?? 'FROM FILE\n', bytes: 10 }),
+    writeSandboxFile: async ({ path, content }) => {
+      fileWrites.push({ path, content });
+      return { success: true, bytesWritten: Buffer.byteLength(content, 'utf8') };
+    },
+    isSandboxEnabledForContext: async () => true,
+    ...Object.fromEntries(Object.entries(over).filter(([k]) => !['pages', 'file'].includes(k))),
+  } as CopyContentDeps;
+
+  return { deps, writes, fileWrites };
+}
+
+function run(deps: CopyContentDeps, args: unknown, context: unknown = CONTEXT) {
+  const tools = createCopyContentTools(deps);
+  const fn = (tools.copy_content as { execute: (a: unknown, o: unknown) => Promise<Record<string, unknown>> }).execute;
+  return fn(args, { experimental_context: context });
+}
+
+describe('copy_content — byte fidelity', () => {
+  it('given a page->page whole replace, should store the source bytes exactly', async () => {
+    // Awkward on purpose: angle brackets, backticks and CRLF are what a
+    // re-transcribing model quietly reformats.
+    const tricky = 'a <p> b\r\n`code`\n\nlast';
+    const h = harness({ pages: [page({ id: 'src', content: tricky }), page({ id: 'dst', content: 'old\n' })] });
+    const result = await run(h.deps, {
+      from: { kind: 'page', pageId: 'src' },
+      to: { kind: 'page', pageId: 'dst', mode: 'replace' },
+    });
+
+    expect(result.success).toBe(true);
+    expect(h.writes).toHaveLength(1);
+    expect(h.writes[0].newContent).toBe(tricky);
+  });
+
+  it('given a file->page copy, should write the file bytes verbatim', async () => {
+    const h = harness({ file: 'line1\nline2\n', pages: [page({ id: 'dst', content: 'x\n' })] });
+    const result = await run(h.deps, {
+      from: { kind: 'file', path: 'out/report.md' },
+      to: { kind: 'page', pageId: 'dst', mode: 'replace' },
+    });
+    expect(result.success).toBe(true);
+    expect(h.writes[0].newContent).toBe('line1\nline2\n');
+  });
+
+  it('given a page->file copy, should hand the sandbox the exact bytes', async () => {
+    const h = harness({ pages: [page({ id: 'src', content: 'alpha\nbravo\n' })] });
+    await run(h.deps, {
+      from: { kind: 'page', pageId: 'src' },
+      to: { kind: 'file', path: 'export.md' },
+    });
+    expect(h.fileWrites).toEqual([{ path: 'export.md', content: 'alpha\nbravo\n' }]);
+  });
+
+  it('given a source line range, should copy exactly those lines', async () => {
+    const h = harness({
+      pages: [page({ id: 'src', content: 'l1\nl2\nl3\nl4\n' }), page({ id: 'dst', content: 'x\n' })],
+    });
+    await run(h.deps, {
+      from: { kind: 'page', pageId: 'src', lineStart: 2, lineEnd: 3 },
+      to: { kind: 'page', pageId: 'dst', mode: 'replace' },
+    });
+    expect(h.writes[0].newContent).toBe('l2\nl3');
+  });
+});
+
+describe('copy_content — destination modes', () => {
+  it('replaceLines: should change only the named range', async () => {
+    const h = harness({
+      pages: [page({ id: 'src', content: 'NEW' }), page({ id: 'dst', content: 'a\nb\nc\n' })],
+    });
+    await run(h.deps, {
+      from: { kind: 'page', pageId: 'src' },
+      to: { kind: 'page', pageId: 'dst', mode: 'replaceLines', startLine: 2, endLine: 2 },
+    });
+    expect(h.writes[0].newContent).toBe('a\nNEW\nc\n');
+  });
+
+  it('append: should add at the end without a bespoke append primitive', async () => {
+    const h = harness({
+      pages: [page({ id: 'src', content: 'TAIL' }), page({ id: 'dst', content: 'a\nb' })],
+    });
+    await run(h.deps, {
+      from: { kind: 'page', pageId: 'src' },
+      to: { kind: 'page', pageId: 'dst', mode: 'append' },
+    });
+    expect(h.writes[0].newContent).toContain('TAIL');
+    expect(h.writes[0].newContent.startsWith('a\nb')).toBe(true);
+  });
+
+  it('insertAfter: should place the copy next to the anchor line', async () => {
+    const h = harness({
+      pages: [page({ id: 'src', content: 'MID' }), page({ id: 'dst', content: 'top\nANCHOR\nbottom' })],
+    });
+    await run(h.deps, {
+      from: { kind: 'page', pageId: 'src' },
+      to: { kind: 'page', pageId: 'dst', mode: 'insertAfter', anchor: 'ANCHOR' },
+    });
+    expect(h.writes[0].newContent).toBe('top\nANCHOR\nMID\nbottom');
+  });
+
+  it('insertAfter with a missing anchor: should report inserted:false and write NOTHING', async () => {
+    const h = harness({
+      pages: [page({ id: 'src', content: 'MID' }), page({ id: 'dst', content: 'top\nbottom' })],
+    });
+    const result = await run(h.deps, {
+      from: { kind: 'page', pageId: 'src' },
+      to: { kind: 'page', pageId: 'dst', mode: 'insertAfter', anchor: 'NOPE' },
+    });
+    expect(result).toMatchObject({ success: true, inserted: false });
+    expect(h.writes).toHaveLength(0);
+  });
+
+  it('replaceLines: should honour expectedTotalLines and refuse a stale edit without writing', async () => {
+    const h = harness({
+      pages: [page({ id: 'src', content: 'NEW' }), page({ id: 'dst', content: 'a\nb\nc\n' })],
+    });
+    const result = await run(h.deps, {
+      from: { kind: 'page', pageId: 'src' },
+      to: { kind: 'page', pageId: 'dst', mode: 'replaceLines', startLine: 1, expectedTotalLines: 99 },
+    });
+    expect(result.success).toBe(false);
+    expect(result.error).toBe('Page changed since it was read');
+    expect(h.writes).toHaveLength(0);
+  });
+
+  it('replaceLines: an out-of-range line should refuse with the real line count', async () => {
+    const h = harness({
+      pages: [page({ id: 'src', content: 'NEW' }), page({ id: 'dst', content: 'a\nb\n' })],
+    });
+    const result = await run(h.deps, {
+      from: { kind: 'page', pageId: 'src' },
+      to: { kind: 'page', pageId: 'dst', mode: 'replaceLines', startLine: 50 },
+    });
+    expect(result.success).toBe(false);
+    expect(result.totalLines).toBe(3);
+    expect(h.writes).toHaveLength(0);
+  });
+});
+
+describe('copy_content — the token win', () => {
+  it('should not hand the copied bytes back to the model', async () => {
+    // If oldContent/newContent reach the model, the tool costs in input tokens
+    // exactly what it saved in output tokens and is pointless.
+    const h = harness({
+      pages: [page({ id: 'src', content: 'SECRET-PAYLOAD' }), page({ id: 'dst', content: 'x\n' })],
+    });
+    const result = await run(h.deps, {
+      from: { kind: 'page', pageId: 'src' },
+      to: { kind: 'page', pageId: 'dst', mode: 'replace' },
+    });
+
+    expect(result.oldContent).toBeTypeOf('string');
+    const modelFacing = JSON.stringify(toModelOutputForCopyContent(result));
+    expect(modelFacing).not.toContain('SECRET-PAYLOAD');
+    expect(modelFacing).toContain('bytesCopied');
+  });
+
+  it('should still carry the diff fields on the persisted result for the renderer', async () => {
+    const h = harness({ pages: [page({ id: 'src', content: 'NEW' }), page({ id: 'dst', content: 'OLD' })] });
+    const result = await run(h.deps, {
+      from: { kind: 'page', pageId: 'src' },
+      to: { kind: 'page', pageId: 'dst', mode: 'replace' },
+    });
+    expect(typeof result.oldContent).toBe('string');
+    expect(typeof result.newContent).toBe('string');
+  });
+});
+
+describe('copy_content — authorization', () => {
+  it('should refuse when the source cannot be read, without touching the destination', async () => {
+    const h = harness({
+      pages: [page({ id: 'src' }), page({ id: 'dst' })],
+      canViewPage: async () => false,
+    });
+    const result = await run(h.deps, {
+      from: { kind: 'page', pageId: 'src' },
+      to: { kind: 'page', pageId: 'dst', mode: 'replace' },
+    });
+    expect(result.success).toBe(false);
+    expect(h.writes).toHaveLength(0);
+  });
+
+  it('should refuse when the destination cannot be edited, and write nothing', async () => {
+    const h = harness({
+      pages: [page({ id: 'src' }), page({ id: 'dst' })],
+      canEditPage: async () => false,
+    });
+    const result = await run(h.deps, {
+      from: { kind: 'page', pageId: 'src' },
+      to: { kind: 'page', pageId: 'dst', mode: 'replace' },
+    });
+    expect(result.success).toBe(false);
+    expect(h.writes).toHaveLength(0);
+  });
+
+  it('given the per-agent sandbox switch off, should refuse the FILE arms', async () => {
+    // copy_content is a workspace tool, so it survives
+    // filterToolsForSandboxEnablement. Without this call-time check it would be
+    // a way around that switch.
+    const h = harness({ isSandboxEnabledForContext: async () => false });
+    const result = await run(h.deps, {
+      from: { kind: 'file', path: 'a.txt' },
+      to: { kind: 'page', pageId: 'p1', mode: 'replace' },
+    });
+    expect(result.success).toBe(false);
+    expect(String(result.message)).toContain('sandbox');
+    expect(h.writes).toHaveLength(0);
+  });
+
+  it('given the per-agent sandbox switch off, page->page should still work', async () => {
+    const h = harness({
+      pages: [page({ id: 'src', content: 'S' }), page({ id: 'dst', content: 'D' })],
+      isSandboxEnabledForContext: async () => false,
+    });
+    const result = await run(h.deps, {
+      from: { kind: 'page', pageId: 'src' },
+      to: { kind: 'page', pageId: 'dst', mode: 'replace' },
+    });
+    expect(result.success).toBe(true);
+    expect(h.writes).toHaveLength(1);
+  });
+
+  it('given the sandbox switch off, a file DESTINATION should also refuse', async () => {
+    const h = harness({ isSandboxEnabledForContext: async () => false });
+    const result = await run(h.deps, {
+      from: { kind: 'page', pageId: 'p1' },
+      to: { kind: 'file', path: 'out.txt' },
+    });
+    expect(result.success).toBe(false);
+    expect(h.fileWrites).toHaveLength(0);
+  });
+});
+
+describe('copy_content — refusals that protect content', () => {
+  it('given a raw source and an html destination, should refuse and not mutate', async () => {
+    const h = harness({
+      pages: [
+        page({ id: 'src', contentMode: 'markdown', content: '# Heading' }),
+        page({ id: 'dst', contentMode: 'html', content: '<p>hi</p>' }),
+      ],
+    });
+    const result = await run(h.deps, {
+      from: { kind: 'page', pageId: 'src' },
+      to: { kind: 'page', pageId: 'dst', mode: 'replace' },
+    });
+    expect(result.success).toBe(false);
+    expect(result.error).toBe('Content mode mismatch');
+    expect(h.writes).toHaveLength(0);
+  });
+
+  it('given a raw source and a raw destination, should copy', async () => {
+    const h = harness({
+      pages: [
+        page({ id: 'src', contentMode: 'markdown', content: '# Heading' }),
+        page({ id: 'dst', contentMode: 'markdown', content: 'old' }),
+      ],
+    });
+    const result = await run(h.deps, {
+      from: { kind: 'page', pageId: 'src' },
+      to: { kind: 'page', pageId: 'dst', mode: 'replace' },
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it('given an html source and a FILE destination, should allow it — an export has no content mode', async () => {
+    const h = harness({ pages: [page({ id: 'src', contentMode: 'html', content: '<p>hi</p>' })] });
+    const result = await run(h.deps, {
+      from: { kind: 'page', pageId: 'src' },
+      to: { kind: 'file', path: 'export.html' },
+    });
+    expect(result.success).toBe(true);
+    expect(h.fileWrites).toHaveLength(1);
+  });
+
+  it('given a SHEET source, should refuse and point at read_sheet', async () => {
+    const h = harness({ pages: [page({ id: 'src', type: 'SHEET' }), page({ id: 'dst' })] });
+    const result = await run(h.deps, {
+      from: { kind: 'page', pageId: 'src' },
+      to: { kind: 'page', pageId: 'dst', mode: 'replace' },
+    });
+    expect(result.success).toBe(false);
+    expect(String(result.message)).toContain('read_sheet');
+  });
+
+  it('given a SHEET destination, should refuse and point at edit_sheet_cells', async () => {
+    const h = harness({ pages: [page({ id: 'src' }), page({ id: 'dst', type: 'SHEET' })] });
+    const result = await run(h.deps, {
+      from: { kind: 'page', pageId: 'src' },
+      to: { kind: 'page', pageId: 'dst', mode: 'replace' },
+    });
+    expect(result.success).toBe(false);
+    expect(String(result.message)).toContain('edit_sheet_cells');
+    expect(h.writes).toHaveLength(0);
+  });
+
+  it('given a FILE-type destination page, should refuse', async () => {
+    const h = harness({ pages: [page({ id: 'src' }), page({ id: 'dst', type: 'FILE' })] });
+    const result = await run(h.deps, {
+      from: { kind: 'page', pageId: 'src' },
+      to: { kind: 'page', pageId: 'dst', mode: 'replace' },
+    });
+    expect(result.success).toBe(false);
+    expect(h.writes).toHaveLength(0);
+  });
+
+  it('given a source over the byte cap, should refuse rather than copy part of it', async () => {
+    // A half-copied document looks complete — there is no notice attached to a
+    // page to say it was cut — so this must never truncate.
+    const huge = 'x'.repeat(MAX_COPY_BYTES + 1);
+    const h = harness({ pages: [page({ id: 'src', content: huge }), page({ id: 'dst' })] });
+    const result = await run(h.deps, {
+      from: { kind: 'page', pageId: 'src' },
+      to: { kind: 'page', pageId: 'dst', mode: 'replace' },
+    });
+    expect(result.success).toBe(false);
+    expect(result.error).toBe('Source is too large to copy');
+    expect(h.writes).toHaveLength(0);
+  });
+
+  it('given a source line range past the end, should refuse with the real line count', async () => {
+    const h = harness({ pages: [page({ id: 'src', content: 'a\nb\n' }), page({ id: 'dst' })] });
+    const result = await run(h.deps, {
+      from: { kind: 'page', pageId: 'src', lineStart: 90 },
+      to: { kind: 'page', pageId: 'dst', mode: 'replace' },
+    });
+    expect(result.success).toBe(false);
+    expect(result.totalLines).toBe(3);
+  });
+
+  it('given an unreadable source file, should surface the runner error and write nothing', async () => {
+    const h = harness({
+      readSandboxFile: async () => ({ success: false, error: 'File not found.' }),
+    });
+    const result = await run(h.deps, {
+      from: { kind: 'file', path: 'missing.txt' },
+      to: { kind: 'page', pageId: 'p1', mode: 'replace' },
+    });
+    expect(result.success).toBe(false);
+    expect(String(result.message)).toContain('File not found');
+    expect(h.writes).toHaveLength(0);
+  });
+});

--- a/apps/web/src/lib/ai/tools/__tests__/copy-content-tools.test.ts
+++ b/apps/web/src/lib/ai/tools/__tests__/copy-content-tools.test.ts
@@ -182,6 +182,94 @@ describe('copy_content — destination modes', () => {
   });
 });
 
+describe('copy_content — review regressions', () => {
+  it('append into an empty page should not start with a blank line', async () => {
+    const h = harness({
+      pages: [page({ id: 'src', content: 'COPY' }), page({ id: 'dst', content: '' })],
+    });
+    await run(h.deps, {
+      from: { kind: 'page', pageId: 'src' },
+      to: { kind: 'page', pageId: 'dst', mode: 'append' },
+    });
+    expect(h.writes[0].newContent.startsWith('\n')).toBe(false);
+    expect(h.writes[0].newContent).toContain('COPY');
+  });
+
+  it('append onto content ending in a newline should not double the newline', async () => {
+    const h = harness({
+      pages: [page({ id: 'src', content: 'COPY' }), page({ id: 'dst', content: 'a\n' })],
+    });
+    await run(h.deps, {
+      from: { kind: 'page', pageId: 'src' },
+      to: { kind: 'page', pageId: 'dst', mode: 'append' },
+    });
+    expect(h.writes[0].newContent).not.toContain('\n\n');
+    expect(h.writes[0].newContent).toBe('a\nCOPY\n');
+  });
+
+  it('append onto content with no trailing newline should still separate the lines', async () => {
+    const h = harness({
+      pages: [page({ id: 'src', content: 'COPY' }), page({ id: 'dst', content: 'a\nb' })],
+    });
+    await run(h.deps, {
+      from: { kind: 'page', pageId: 'src' },
+      to: { kind: 'page', pageId: 'dst', mode: 'append' },
+    });
+    expect(h.writes[0].newContent).toBe('a\nb\nCOPY');
+  });
+
+  it('a FILE-page source is extracted plaintext, so copying it into an html page is refused', async () => {
+    // FILE rows keep the schema default contentMode 'html' while holding
+    // extracted TEXT, so trusting that default would let a .md upload through
+    // into an html document as literal characters.
+    const h = harness({
+      pages: [
+        page({ id: 'src', type: 'FILE', contentMode: 'html', content: '# Heading\n- bullet' }),
+        page({ id: 'dst', type: 'DOCUMENT', contentMode: 'html', content: '<p>hi</p>' }),
+      ],
+    });
+    const result = await run(h.deps, {
+      from: { kind: 'page', pageId: 'src' },
+      to: { kind: 'page', pageId: 'dst', mode: 'replace' },
+    });
+    expect(result.success).toBe(false);
+    expect(result.error).toBe('Content mode mismatch');
+    expect(h.writes).toHaveLength(0);
+  });
+
+  it('a FILE-page source copies cleanly into a markdown page, unmangled', async () => {
+    const h = harness({
+      pages: [
+        page({ id: 'src', type: 'FILE', contentMode: 'html', content: '# Heading\n- bullet' }),
+        page({ id: 'dst', type: 'DOCUMENT', contentMode: 'markdown', content: 'old' }),
+      ],
+    });
+    const result = await run(h.deps, {
+      from: { kind: 'page', pageId: 'src' },
+      to: { kind: 'page', pageId: 'dst', mode: 'replace' },
+    });
+    expect(result.success).toBe(true);
+    // Not line-broken as if it were HTML.
+    expect(h.writes[0].newContent).toBe('# Heading\n- bullet');
+  });
+
+  it('should not disclose a page title or type before the edit permission check', async () => {
+    // Every type refusal names the page, so the permission gate has to run
+    // first or it leaks what the page is to a caller who cannot edit it.
+    const h = harness({
+      pages: [page({ id: 'src' }), page({ id: 'dst', type: 'SHEET', title: 'Payroll 2026' })],
+      canEditPage: async () => false,
+    });
+    const result = await run(h.deps, {
+      from: { kind: 'page', pageId: 'src' },
+      to: { kind: 'page', pageId: 'dst', mode: 'replace' },
+    });
+    expect(result.success).toBe(false);
+    expect(JSON.stringify(result)).not.toContain('Payroll 2026');
+    expect(JSON.stringify(result)).not.toContain('SHEET');
+  });
+});
+
 describe('copy_content — the token win', () => {
   it('should not hand the copied bytes back to the model', async () => {
     // If oldContent/newContent reach the model, the tool costs in input tokens

--- a/apps/web/src/lib/ai/tools/__tests__/copy-content-tools.test.ts
+++ b/apps/web/src/lib/ai/tools/__tests__/copy-content-tools.test.ts
@@ -668,3 +668,207 @@ describe('copy_content — input schema', () => {
     expect(parse({ from: { kind: 'file', path: 'a.md' }, to: { kind: 'page', pageId: 'q', mode: 'replace' } }).success).toBe(true);
   });
 });
+
+describe('copy_content — content shape, one classifier for both sides', () => {
+  const doc = (id: string, contentMode: string, content: string | null, type = 'DOCUMENT') =>
+    page({ id, type, contentMode, content });
+
+  it('an HTML page should copy into a freshly created empty page', async () => {
+    // The canonical create_page -> copy_content flow. A one-sided classifier
+    // called the empty destination "raw" and the html source "html", and
+    // refused the most ordinary copy there is.
+    const h = harness({
+      pages: [doc('src', 'html', '<p>Hello</p>'), doc('dst', 'html', '')],
+    });
+    const result = await run(h.deps, {
+      from: { kind: 'page', pageId: 'src' },
+      to: { kind: 'page', pageId: 'dst', mode: 'replace' },
+    });
+    expect(result.success).toBe(true);
+    expect(h.writes).toHaveLength(1);
+  });
+
+  it('a RAW source should copy into an empty html-mode page', async () => {
+    // The discriminating case for "empty means unknown": if an empty page were
+    // classified html, this raw source would conflict and be refused — and this
+    // is exactly what create_page (which still yields html-mode rows for
+    // non-DOCUMENT types and legacy callers) followed by a file copy looks like.
+    const h = harness({ pages: [doc('src', 'markdown', '# md'), doc('dst', 'html', '')] });
+    const result = await run(h.deps, {
+      from: { kind: 'page', pageId: 'src' },
+      to: { kind: 'page', pageId: 'dst', mode: 'replace' },
+    });
+    expect(result.success).toBe(true);
+    expect(h.writes[0].newContent).toBe('# md');
+  });
+
+  it('a sandbox FILE should copy into an empty html-mode page', async () => {
+    const h = harness({ file: 'plain report text\n', pages: [doc('dst', 'html', '')] });
+    const result = await run(h.deps, {
+      from: { kind: 'file', path: 'report.md' },
+      to: { kind: 'page', pageId: 'dst', mode: 'replace' },
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it('an HTML page should copy into a page whose content is null', async () => {
+    const h = harness({ pages: [doc('src', 'html', '<p>Hi</p>'), doc('dst', 'html', null)] });
+    const result = await run(h.deps, {
+      from: { kind: 'page', pageId: 'src' },
+      to: { kind: 'page', pageId: 'dst', mode: 'replace' },
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it('two pages of the SAME shape should copy, whichever shape that is', async () => {
+    // html-mode rows holding markdown: the #2463 population. Both sides must be
+    // asked the same question, or a page cannot be copied into its own sibling.
+    const h = harness({
+      pages: [doc('src', 'html', '# Heading\ntext'), doc('dst', 'html', '# Other\ntext')],
+    });
+    const result = await run(h.deps, {
+      from: { kind: 'page', pageId: 'src' },
+      to: { kind: 'page', pageId: 'dst', mode: 'replace' },
+    });
+    expect(result.success).toBe(true);
+    expect(h.writes[0].newContent).toBe('# Heading\ntext');
+  });
+
+  it('a page should be able to append into itself', async () => {
+    const h = harness({ pages: [doc('p1', 'html', '# Heading\ntext')] });
+    const result = await run(h.deps, {
+      from: { kind: 'page', pageId: 'p1' },
+      to: { kind: 'page', pageId: 'p1', mode: 'append' },
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it('a CANVAS holding a real HTML document should reject a markdown source', async () => {
+    // looksLikeHtmlDocument keys on block tags and knows nothing of <!DOCTYPE>
+    // or <html>, so sniffing a CANVAS misreads it as raw text. CANVAS is html
+    // by type, and is classified that way rather than sniffed.
+    const h = harness({
+      pages: [
+        doc('src', 'markdown', '# md'),
+        doc('dst', 'html', '<!DOCTYPE html><html><body><p>hi</p></body></html>', 'CANVAS'),
+      ],
+    });
+    const result = await run(h.deps, {
+      from: { kind: 'page', pageId: 'src' },
+      to: { kind: 'page', pageId: 'dst', mode: 'replace' },
+    });
+    expect(result.success).toBe(false);
+    expect(result.error).toBe('Content mode mismatch');
+    expect(h.writes).toHaveLength(0);
+  });
+
+  it('a CANVAS holding a real HTML document should accept an HTML source', async () => {
+    const h = harness({
+      pages: [
+        doc('src', 'html', '<p>X</p>'),
+        doc('dst', 'html', '<!DOCTYPE html><html><body><p>hi</p></body></html>', 'CANVAS'),
+      ],
+    });
+    const result = await run(h.deps, {
+      from: { kind: 'page', pageId: 'src' },
+      to: { kind: 'page', pageId: 'dst', mode: 'replace' },
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it('should still refuse raw text into a page holding real HTML', async () => {
+    const h = harness({ pages: [doc('src', 'markdown', '# md'), doc('dst', 'html', '<p>real</p>')] });
+    const result = await run(h.deps, {
+      from: { kind: 'page', pageId: 'src' },
+      to: { kind: 'page', pageId: 'dst', mode: 'replace' },
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it('should still refuse HTML into a markdown-mode page', async () => {
+    const h = harness({ pages: [doc('src', 'html', '<p>x</p>'), doc('dst', 'markdown', '# md')] });
+    const result = await run(h.deps, {
+      from: { kind: 'page', pageId: 'src' },
+      to: { kind: 'page', pageId: 'dst', mode: 'replace' },
+    });
+    expect(result.success).toBe(false);
+  });
+});
+
+describe('copy_content — round 3 details', () => {
+  it('a whitespace-only source should be refused like an empty one', async () => {
+    const h = harness({
+      pages: [page({ id: 'src', content: '   \n  \n' }), page({ id: 'dst', content: 'IMPORTANT' })],
+    });
+    const result = await run(h.deps, {
+      from: { kind: 'page', pageId: 'src' },
+      to: { kind: 'page', pageId: 'dst', mode: 'replace' },
+    });
+    expect(result.success).toBe(false);
+    expect(result.error).toBe('Source is empty');
+    expect(h.writes).toHaveLength(0);
+  });
+
+  it('but an explicitly named blank line range should still copy', async () => {
+    // Asking for lines 2-2 of 'a\n\nb' is a deliberate selection.
+    const h = harness({
+      pages: [page({ id: 'src', content: 'a\n\nb' }), page({ id: 'dst', content: 'x' })],
+    });
+    const result = await run(h.deps, {
+      from: { kind: 'page', pageId: 'src', lineStart: 2, lineEnd: 2 },
+      to: { kind: 'page', pageId: 'dst', mode: 'replace' },
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it('should not report a negative linesAdded on a replace', async () => {
+    const h = harness({
+      pages: [page({ id: 'src', content: 'one' }), page({ id: 'dst', content: 'a\nb\nc\nd\ne' })],
+    });
+    const result = await run(h.deps, {
+      from: { kind: 'page', pageId: 'src' },
+      to: { kind: 'page', pageId: 'dst', mode: 'replace' },
+    });
+    expect(result.success).toBe(true);
+    expect(result.linesAdded).toBeUndefined();
+    expect(result.linesReplaced).toBe(5);
+  });
+
+  it('should report linesAdded on an insertion', async () => {
+    const h = harness({
+      pages: [page({ id: 'src', content: 'a\nb\nc' }), page({ id: 'dst', content: 'x' })],
+    });
+    const result = await run(h.deps, {
+      from: { kind: 'page', pageId: 'src' },
+      to: { kind: 'page', pageId: 'dst', mode: 'append' },
+    });
+    expect(result.linesAdded).toBe(3);
+  });
+});
+
+describe('copy_content — schema, round 3', () => {
+  const parse = (v: unknown) => copyContentInputSchema.safeParse(v);
+
+  it('should reject every page-only field on a file destination', () => {
+    for (const extra of [
+      { startLine: 1 },
+      { endLine: 2 },
+      { anchor: 'x' },
+      { expectedTotalLines: 5 },
+    ]) {
+      const r = parse({ from: { kind: 'page' }, to: { kind: 'file', path: 'a', ...extra } });
+      expect(r.success, JSON.stringify(extra)).toBe(false);
+    }
+  });
+
+  it('should reject expectedTotalLines: 0, which could only ever fail', () => {
+    expect(parse({
+      from: { kind: 'page' },
+      to: { kind: 'page', mode: 'replaceLines', startLine: 1, expectedTotalLines: 0 },
+    }).success).toBe(false);
+  });
+
+  it('should still accept a plain file destination', () => {
+    expect(parse({ from: { kind: 'page' }, to: { kind: 'file', path: 'a.md' } }).success).toBe(true);
+  });
+});

--- a/apps/web/src/lib/ai/tools/__tests__/copy-content-tools.test.ts
+++ b/apps/web/src/lib/ai/tools/__tests__/copy-content-tools.test.ts
@@ -10,6 +10,7 @@ import {
   type CopyPageRecord,
 } from '../copy-content-tools';
 import { toModelOutputForCopyContent } from '../copy-content-model-output';
+import { MAX_WRITE_BYTES } from '@pagespace/lib/services/sandbox/tool-runners';
 
 const CONTEXT = { userId: 'u1', chatSource: { type: 'page', agentPageId: 'agent-1' } };
 
@@ -870,5 +871,14 @@ describe('copy_content — schema, round 3', () => {
 
   it('should still accept a plain file destination', () => {
     expect(parse({ from: { kind: 'page' }, to: { kind: 'file', path: 'a.md' } }).success).toBe(true);
+  });
+});
+
+describe('copy_content — cap parity with the sandbox runner', () => {
+  it('MAX_COPY_BYTES must equal the runner MAX_WRITE_BYTES', () => {
+    // The two are hand-duplicated across a package boundary (this module must
+    // not import the sandbox package at runtime). If they drift, the tool
+    // accepts a source the runner then refuses, or refuses one it would take.
+    expect(MAX_COPY_BYTES).toBe(MAX_WRITE_BYTES);
   });
 });

--- a/apps/web/src/lib/ai/tools/copy-content-model-output.ts
+++ b/apps/web/src/lib/ai/tools/copy-content-model-output.ts
@@ -12,7 +12,7 @@ type ToolResultOutput = Awaited<ReturnType<ToolModelOutputFn>>;
  * Keys carrying copied BYTES. Present in the persisted result (the diff
  * renderer needs them) and stripped before the result reaches the model.
  */
-const BYTE_CARRYING_KEYS = ['oldContent', 'newContent', 'copiedContent'] as const;
+const BYTE_CARRYING_KEYS = ['oldContent', 'newContent'] as const;
 
 /**
  * Strip the copied bytes out of a `copy_content` result before the model sees it.
@@ -28,9 +28,9 @@ const BYTE_CARRYING_KEYS = ['oldContent', 'newContent', 'copiedContent'] as cons
  * model-facing projection is reduced — to counts and identity, which is all an
  * agent needs to decide what to do next.
  *
- * Mirrors `toModelOutputForReadPage`; kept in its own module with its own test
- * so the invariant is pinned by a test rather than by a comment someone can
- * delete.
+ * Mirrors `toModelOutputForReadPage`. `copy-content-model-output.test.ts` pins
+ * BOTH halves: that this function strips, and that the tool actually wires it
+ * up — deleting the `toModelOutput:` line used to leave every test green.
  */
 export function toModelOutputForCopyContent(output: unknown): ToolResultOutput {
   if (output === null || typeof output !== 'object') {

--- a/apps/web/src/lib/ai/tools/copy-content-model-output.ts
+++ b/apps/web/src/lib/ai/tools/copy-content-model-output.ts
@@ -1,0 +1,47 @@
+/**
+ * `ToolResultOutput` is derived from `ai`'s own public `Tool` type rather than
+ * imported by name from `@ai-sdk/provider-utils`, which only reaches this
+ * package transitively — same reasoning as `read-page-vision-output.ts`.
+ */
+import type { Tool } from 'ai';
+
+type ToolModelOutputFn = NonNullable<Tool['toModelOutput']>;
+type ToolResultOutput = Awaited<ReturnType<ToolModelOutputFn>>;
+
+/**
+ * Keys carrying copied BYTES. Present in the persisted result (the diff
+ * renderer needs them) and stripped before the result reaches the model.
+ */
+const BYTE_CARRYING_KEYS = ['oldContent', 'newContent', 'copiedContent'] as const;
+
+/**
+ * Strip the copied bytes out of a `copy_content` result before the model sees it.
+ *
+ * Without this the tool is a PESSIMIZATION, not an optimization. Its whole
+ * reason to exist is that the model never spends output tokens on content it
+ * already has; echoing that content back as tool output just moves the same
+ * bytes to the input side of the ledger, and a large copy would be clipped by
+ * the per-step result cap on its way through anyway.
+ *
+ * The bytes still ride on the PERSISTED result, because RichDiffRenderer needs
+ * `oldContent`/`newContent` to draw the diff a human reviews. Only the
+ * model-facing projection is reduced — to counts and identity, which is all an
+ * agent needs to decide what to do next.
+ *
+ * Mirrors `toModelOutputForReadPage`; kept in its own module with its own test
+ * so the invariant is pinned by a test rather than by a comment someone can
+ * delete.
+ */
+export function toModelOutputForCopyContent(output: unknown): ToolResultOutput {
+  if (output === null || typeof output !== 'object') {
+    return { type: 'json', value: output } as unknown as ToolResultOutput;
+  }
+
+  const lean: Record<string, unknown> = {};
+  for (const [key, value] of Object.entries(output as Record<string, unknown>)) {
+    if ((BYTE_CARRYING_KEYS as readonly string[]).includes(key)) continue;
+    lean[key] = value;
+  }
+
+  return { type: 'json', value: lean } as unknown as ToolResultOutput;
+}

--- a/apps/web/src/lib/ai/tools/copy-content-tools-runtime.ts
+++ b/apps/web/src/lib/ai/tools/copy-content-tools-runtime.ts
@@ -1,0 +1,137 @@
+/**
+ * Production wiring for `copy_content`.
+ *
+ * Kept separate from the factory so the factory (and its tests) never import
+ * the DB or the sandbox driver — the same split `sandbox-tools-runtime.ts` uses
+ * for `createSandboxTools`.
+ *
+ * Note which sandbox read this binds: `readSandboxFileForCopy`, NOT the
+ * `readSandboxFile` behind the `readFile` tool. That one windows by line, clips
+ * long lines and runs the injection seam, all of which are right for text going
+ * to a model and all of which would corrupt bytes going to storage.
+ */
+
+import type { Tool } from 'ai';
+import { eq } from '@pagespace/db/operators';
+import { db } from '@pagespace/db/db';
+import { pages } from '@pagespace/db/schema/core';
+import {
+  readSandboxFileForCopy,
+  writeSandboxFile,
+  DENIAL_MESSAGES,
+} from '@pagespace/lib/services/sandbox/tool-runners';
+import { pageRepository } from '@pagespace/lib/repositories/page-repository';
+import { loggers } from '@pagespace/lib/logging/logger-config';
+import { applyPageMutation } from '@/services/api/page-mutation-service';
+import { broadcastPageEvent, createPageEventPayload } from '@/lib/websocket';
+import { canActorViewPage, canActorEditPage } from './actor-permissions';
+import { buildAiMutationContext } from './page-write-tools';
+import {
+  buildRealSandboxRunDeps,
+  resolveSandboxActorContext,
+  productionSandboxGate,
+} from './sandbox-tools-runtime';
+import { createCopyContentTools, type CopyContentDeps } from './copy-content-tools';
+import type { ToolExecutionContext } from '../core/types';
+
+const copyLogger = loggers.ai.child({ module: 'copy-content-tools' });
+
+/**
+ * Resolve the actor + run the standard sandbox gate, then hand back the pieces
+ * the copy runners need. Same two-step every sandbox tool performs.
+ */
+async function openSandbox(context: ToolExecutionContext) {
+  const ctx = await resolveSandboxActorContext(context);
+  if ('error' in ctx) return { ok: false as const, error: ctx.error };
+  const decision = await productionSandboxGate(ctx);
+  if (!decision.ok) return { ok: false as const, error: decision.error };
+  return { ok: true as const, ctx };
+}
+
+/**
+ * The per-agent sandbox switch, read at CALL time.
+ *
+ * `filterToolsForSandboxEnablement` strips by tool NAME and runs once when the
+ * tool set is assembled. `copy_content` is a workspace tool (its page→page arm
+ * touches no sandbox and must work everywhere), so it is not in
+ * `SANDBOX_TOOL_NAMES` and survives that filter — which would otherwise make it
+ * a way around the switch. Checking here closes that, and only the file arms
+ * ever call it.
+ *
+ * No agent page in context (the Global Assistant, a workflow step) means there
+ * is no per-agent switch to consult, which is exactly the case where the
+ * assembly-time filter is not applied either — so the answer is yes, and the
+ * `gate` above remains the real authority.
+ */
+async function isSandboxEnabledForContext(context: ToolExecutionContext): Promise<boolean> {
+  const agentPageId = context.chatSource?.agentPageId;
+  if (!agentPageId) return true;
+  try {
+    const [row] = await db
+      .select({ sandboxEnabled: pages.sandboxEnabled })
+      .from(pages)
+      .where(eq(pages.id, agentPageId))
+      .limit(1);
+    return Boolean(row?.sandboxEnabled);
+  } catch (error) {
+    // Fail CLOSED: an unreadable switch must not read as "enabled".
+    copyLogger.warn('copy_content: could not read the agent sandbox switch; denying file access', { error });
+    return false;
+  }
+}
+
+const productionDeps: CopyContentDeps = {
+  findPage: async (pageId) => {
+    const page = await pageRepository.findById(pageId);
+    if (!page) return null;
+    return {
+      id: page.id,
+      title: page.title,
+      type: page.type,
+      contentMode: page.contentMode ?? null,
+      content: page.content ?? null,
+      driveId: page.driveId,
+      revision: typeof page.revision === 'number' ? page.revision : null,
+    };
+  },
+
+  canViewPage: (context, pageId) => canActorViewPage(context, pageId),
+  canEditPage: (context, pageId) => canActorEditPage(context, pageId),
+
+  writePageContent: async ({ page, newContent, context, metadata }) => {
+    const mutationContext = await buildAiMutationContext(context, { metadata });
+    await applyPageMutation({
+      pageId: page.id,
+      operation: 'update',
+      updates: { content: newContent },
+      updatedFields: ['content'],
+      expectedRevision: typeof page.revision === 'number' ? page.revision : undefined,
+      context: mutationContext,
+    });
+    await broadcastPageEvent(
+      createPageEventPayload(page.driveId, page.id, 'content-updated', { title: page.title })
+    );
+  },
+
+  readSandboxFile: async ({ path, context }) => {
+    const opened = await openSandbox(context);
+    if (!opened.ok) return { success: false, error: opened.error };
+    const result = await readSandboxFileForCopy({ path, ctx: opened.ctx, deps: buildRealSandboxRunDeps() });
+    return result.success
+      ? { success: true, content: result.content, bytes: result.bytes }
+      : { success: false, error: result.error ?? DENIAL_MESSAGES[result.reason] };
+  },
+
+  writeSandboxFile: async ({ path, content, context }) => {
+    const opened = await openSandbox(context);
+    if (!opened.ok) return { success: false, error: opened.error };
+    const result = await writeSandboxFile({ path, content, ctx: opened.ctx, deps: buildRealSandboxRunDeps() });
+    return result.success
+      ? { success: true, bytesWritten: result.bytesWritten }
+      : { success: false, error: result.error ?? DENIAL_MESSAGES[result.reason] };
+  },
+
+  isSandboxEnabledForContext,
+};
+
+export const copyContentTools: { copy_content: Tool } = createCopyContentTools(productionDeps);

--- a/apps/web/src/lib/ai/tools/copy-content-tools-runtime.ts
+++ b/apps/web/src/lib/ai/tools/copy-content-tools-runtime.ts
@@ -52,25 +52,37 @@ async function openSandbox(context: ToolExecutionContext) {
  * The per-agent sandbox switch, read at CALL time.
  *
  * `filterToolsForSandboxEnablement` strips by tool NAME and runs once when the
- * tool set is assembled. `copy_content` is a workspace tool (its page→page arm
+ * tool set is assembled. `copy_content` is a workspace tool (its page->page arm
  * touches no sandbox and must work everywhere), so it is not in
  * `SANDBOX_TOOL_NAMES` and survives that filter — which would otherwise make it
  * a way around the switch. Checking here closes that, and only the file arms
  * ever call it.
  *
- * No agent page in context (the Global Assistant, a workflow step) means there
- * is no per-agent switch to consult, which is exactly the case where the
- * assembly-time filter is not applied either — so the answer is yes, and the
- * `gate` above remains the real authority.
+ * WHICH agent is the acting one matters. `ask_agent` builds a nested context
+ * for the CONSULTED agent but inherits `chatSource` from the CALLER
+ * (`agent-communication-tools.ts`), so keying on `chatSource.agentPageId` alone
+ * would read the caller's switch while the consulted agent does the IO — the
+ * same "one surface answers differently from the others" contradiction that
+ * comment block warns about (#2460). `currentAgentId` is the nested context's
+ * record of who is actually running, so it wins when present.
+ *
+ * No agent page at all means the Global Assistant or a workflow step, neither of
+ * which applies the assembly-time filter either, so the answer is yes and the
+ * `gate` remains the real authority. (The page-agent CONSULT route is the one
+ * surface that applies the filter without setting `chatSource`; its file arms
+ * are unreachable regardless, because its synthetic conversation id has no
+ * session, so they fail `no_session` before touching a sandbox.)
  */
 async function isSandboxEnabledForContext(context: ToolExecutionContext): Promise<boolean> {
-  const agentPageId = context.chatSource?.agentPageId;
-  if (!agentPageId) return true;
+  const actingAgentId =
+    (context as ToolExecutionContext & { currentAgentId?: string }).currentAgentId ??
+    context.chatSource?.agentPageId;
+  if (!actingAgentId) return true;
   try {
     const [row] = await db
       .select({ sandboxEnabled: pages.sandboxEnabled })
       .from(pages)
-      .where(eq(pages.id, agentPageId))
+      .where(eq(pages.id, actingAgentId))
       .limit(1);
     return Boolean(row?.sandboxEnabled);
   } catch (error) {

--- a/apps/web/src/lib/ai/tools/copy-content-tools.ts
+++ b/apps/web/src/lib/ai/tools/copy-content-tools.ts
@@ -41,7 +41,12 @@ import { toModelOutputForCopyContent } from './copy-content-model-output';
 import { resolveOrThrowPageId } from './page-context-defaults';
 import type { ToolExecutionContext } from '../core/types';
 
-/** Mirrors MAX_WRITE_BYTES; asserted equal to the runner's cap by its test. */
+/**
+ * Mirrors `MAX_WRITE_BYTES` in the sandbox runner. Duplicated rather than
+ * imported because this module must not pull in the sandbox package; the two
+ * are pinned equal by a test, since a silent drift would mean the tool accepts
+ * a source the runner then refuses (or vice versa).
+ */
 export const MAX_COPY_BYTES = 1024 * 1024;
 
 /** Longest path this tool will accept, matching the sandbox tools. */

--- a/apps/web/src/lib/ai/tools/copy-content-tools.ts
+++ b/apps/web/src/lib/ai/tools/copy-content-tools.ts
@@ -1,0 +1,502 @@
+/**
+ * `copy_content` — move bytes the agent ALREADY has, without re-emitting them.
+ *
+ * Every other write verb takes its content as a model-emitted string, so moving
+ * a file the agent just built in the sandbox into a page costs a full
+ * re-transcription of every byte: expensive, and lossy in the way models are
+ * lossy — paraphrased prose, dropped blank lines, reflowed whitespace.
+ *
+ * This tool names a SOURCE and a DESTINATION and moves the bytes server-side.
+ * It is deliberately thin: every arm delegates to the function that already
+ * owns that operation (`replaceLines`/`insertLines` for line edits,
+ * `applyPageMutation` for the write, `readSandboxFileForCopy`/`writeSandboxFile`
+ * for the sandbox). The value is in what it does NOT do — no transcription, no
+ * conversion, no truncation.
+ *
+ * Sources are RE-READ at execute time rather than addressed by a prior tool
+ * result. That matches how this codebase already handles stale context:
+ * `tool-result-eliding.ts` drops old outputs and tells the model to call the
+ * tool again. Anything ephemeral (a command's stdout) the agent redirects to a
+ * file first, which is a thing it can already do.
+ *
+ * Everything is injected so the whole surface is unit-testable with no DB, no
+ * network and no sandbox.
+ */
+import { tool } from 'ai';
+import { z } from 'zod';
+import {
+  LineRangeError,
+  projectLines,
+  replaceLines,
+  insertLines,
+  type LineEditResult,
+} from '@/lib/editor/line-edit';
+import {
+  isRawTextPage,
+  describeContentModeMismatch,
+  serializePageContentForAI,
+} from '../core/page-serializer';
+import { isSheetType } from '@pagespace/lib/sheets/sheet';
+import { PageType } from '@pagespace/lib/utils/enums';
+import { toModelOutputForCopyContent } from './copy-content-model-output';
+import { resolveOrThrowPageId } from './page-context-defaults';
+import type { ToolExecutionContext } from '../core/types';
+
+/** Mirrors MAX_WRITE_BYTES; asserted equal to the runner's cap by its test. */
+export const MAX_COPY_BYTES = 1024 * 1024;
+
+/** Longest path this tool will accept, matching the sandbox tools. */
+export const MAX_COPY_PATH_LENGTH = 1024;
+
+/** The page shape this tool needs. A subset of the repository row. */
+export interface CopyPageRecord {
+  id: string;
+  title: string;
+  type: string;
+  contentMode: string | null;
+  content: string | null;
+  driveId: string;
+  revision?: number | null;
+}
+
+export interface CopyContentDeps {
+  /** Page reads/writes — all injected, so the factory imports no DB. */
+  findPage: (pageId: string) => Promise<CopyPageRecord | null>;
+  canViewPage: (context: ToolExecutionContext, pageId: string) => Promise<boolean>;
+  canEditPage: (context: ToolExecutionContext, pageId: string) => Promise<boolean>;
+  writePageContent: (args: {
+    page: CopyPageRecord;
+    newContent: string;
+    context: ToolExecutionContext;
+    metadata: Record<string, unknown>;
+  }) => Promise<void>;
+
+  /** Sandbox file IO. `readFile` MUST be the verbatim copy read, not readFile's. */
+  readSandboxFile: (args: {
+    path: string;
+    context: ToolExecutionContext;
+  }) => Promise<{ success: true; content: string; bytes: number } | { success: false; error: string }>;
+  writeSandboxFile: (args: {
+    path: string;
+    content: string;
+    context: ToolExecutionContext;
+  }) => Promise<{ success: true; bytesWritten: number } | { success: false; error: string }>;
+
+  /**
+   * The per-agent sandbox switch, checked AT CALL TIME.
+   *
+   * `filterToolsForSandboxEnablement` strips sandbox tools by NAME, and
+   * `pages.sandboxEnabled` is read once when the tool set is assembled. This
+   * tool is registered as a workspace tool (its page→page arm touches no
+   * sandbox and must work on every deployment), so it survives that filter —
+   * which would make it a way around the switch for an agent whose sandbox
+   * access is off. Adding it to SANDBOX_TOOL_NAMES is not an option: that would
+   * strip the page→page arm from every agent, since the switch defaults off.
+   * So the check moves here, and applies to the file arms only.
+   */
+  isSandboxEnabledForContext: (context: ToolExecutionContext) => Promise<boolean>;
+}
+
+const SIDE_KIND = z.enum(['page', 'file']);
+
+export const copyFromSchema = z
+  .object({
+    kind: SIDE_KIND.describe('"page" to copy from a workspace page, "file" from a sandbox file.'),
+    pageId: z
+      .string()
+      .optional()
+      .describe('kind=page: the source page. Omit to use the page currently in view.'),
+    path: z.string().min(1).max(MAX_COPY_PATH_LENGTH).optional().describe('kind=file: the sandbox path.'),
+    lineStart: z
+      .number()
+      .int()
+      .min(1)
+      .optional()
+      .describe(
+        'kind=page: first line to copy, 1-based. These are the SAME line numbers read_page showed you.'
+      ),
+    lineEnd: z.number().int().min(1).optional().describe('kind=page: last line to copy, inclusive.'),
+  })
+  .strict();
+
+export const copyToSchema = z
+  .object({
+    kind: SIDE_KIND.describe('"page" to write into a workspace page, "file" into a sandbox file.'),
+    pageId: z
+      .string()
+      .optional()
+      .describe('kind=page: the destination page. Omit to use the page currently in view.'),
+    path: z.string().min(1).max(MAX_COPY_PATH_LENGTH).optional().describe('kind=file: the sandbox path. Overwrites.'),
+    mode: z
+      .enum(['replace', 'replaceLines', 'insertAfter', 'append'])
+      .optional()
+      .describe(
+        'kind=page: replace = whole page; replaceLines = the startLine..endLine range; insertAfter = after the anchor line; append = at the end.'
+      ),
+    startLine: z.number().int().min(1).optional().describe('mode=replaceLines: first line to replace.'),
+    endLine: z.number().int().min(1).optional().describe('mode=replaceLines: last line, inclusive.'),
+    anchor: z
+      .string()
+      .min(1)
+      .optional()
+      .describe('mode=insertAfter: text identifying the line to insert next to.'),
+    position: z
+      .enum(['before', 'after'])
+      .optional()
+      .describe('mode=insertAfter: which side of the anchor line. Defaults to after.'),
+    expectedTotalLines: z
+      .number()
+      .int()
+      .min(0)
+      .optional()
+      .describe(
+        'mode=replaceLines: the line count you last read. The edit is refused if the page has changed since.'
+      ),
+  })
+  .strict();
+
+export const copyContentInputSchema = z
+  .object({ from: copyFromSchema, to: copyToSchema })
+  .strict()
+  .superRefine((value, ctx) => {
+    const require = (cond: boolean, path: (string | number)[], message: string) => {
+      if (!cond) ctx.addIssue({ code: z.ZodIssueCode.custom, path, message });
+    };
+
+    if (value.from.kind === 'file') {
+      require(!!value.from.path, ['from', 'path'], 'from.path is required when from.kind is "file".');
+      require(
+        value.from.lineStart === undefined && value.from.lineEnd === undefined,
+        ['from', 'lineStart'],
+        'Line ranges apply to pages, not files. Copy the whole file, or narrow it in the sandbox first.'
+      );
+    }
+    if (
+      value.from.lineStart !== undefined &&
+      value.from.lineEnd !== undefined &&
+      value.from.lineEnd < value.from.lineStart
+    ) {
+      require(false, ['from', 'lineEnd'], 'from.lineEnd must be >= from.lineStart.');
+    }
+
+    if (value.to.kind === 'file') {
+      require(!!value.to.path, ['to', 'path'], 'to.path is required when to.kind is "file".');
+      require(
+        value.to.mode === undefined,
+        ['to', 'mode'],
+        'A file destination is always a whole-file write; mode applies to pages only.'
+      );
+    } else {
+      require(!!value.to.mode, ['to', 'mode'], 'to.mode is required when to.kind is "page".');
+      if (value.to.mode === 'replaceLines') {
+        require(value.to.startLine !== undefined, ['to', 'startLine'], 'mode "replaceLines" needs startLine.');
+      }
+      if (value.to.mode === 'insertAfter') {
+        require(!!value.to.anchor, ['to', 'anchor'], 'mode "insertAfter" needs anchor.');
+      }
+    }
+  });
+
+type CopyFrom = z.infer<typeof copyFromSchema>;
+type CopyTo = z.infer<typeof copyToSchema>;
+
+interface ResolvedSource {
+  bytes: string;
+  /** How the source is described back to the caller and in activity metadata. */
+  label: string;
+  /** Whether the source text is raw (a file always is; a page depends on mode). */
+  isRawText: boolean;
+}
+
+type Refusal = { success: false; error: string; message: string; [key: string]: unknown };
+
+const refuse = (error: string, message: string, extra: Record<string, unknown> = {}): Refusal => ({
+  success: false,
+  error,
+  message,
+  ...extra,
+});
+
+/** Page types whose content is not line-addressable text. */
+function rejectNonTextPage(page: CopyPageRecord, side: 'source' | 'destination'): Refusal | null {
+  if (isSheetType(page.type as PageType)) {
+    return refuse(
+      'Sheets are not line-addressable',
+      side === 'source'
+        ? `"${page.title}" is a sheet. Its content is rows, not lines, so it cannot be copied byte-for-byte. Use read_sheet to read it.`
+        : `"${page.title}" is a sheet. Use edit_sheet_cells to write cells; a byte-for-byte copy has no meaning for rows.`,
+      { pageId: page.id, type: page.type }
+    );
+  }
+  if (page.type === PageType.CHANNEL || page.type === PageType.TASK_LIST) {
+    return refuse(
+      'Not a text page',
+      `"${page.title}" is a ${page.type}, whose content is structured records rather than text. There is nothing to copy byte-for-byte.`,
+      { pageId: page.id, type: page.type }
+    );
+  }
+  return null;
+}
+
+export function createCopyContentTools(deps: CopyContentDeps) {
+  const readContext = (options: unknown): ToolExecutionContext | undefined =>
+    (options as { experimental_context?: ToolExecutionContext })?.experimental_context;
+
+  async function resolveSource(
+    from: CopyFrom,
+    context: ToolExecutionContext
+  ): Promise<ResolvedSource | Refusal> {
+    if (from.kind === 'file') {
+      if (!(await deps.isSandboxEnabledForContext(context))) {
+        return refuse(
+          'Sandbox access is off for this agent',
+          "This agent cannot reach sandbox files. Enable sandbox access in the agent's settings, or copy from a page instead."
+        );
+      }
+      const read = await deps.readSandboxFile({ path: from.path as string, context });
+      if (!read.success) return refuse('Could not read the source file', read.error);
+      return { bytes: read.content, label: `file:${from.path}`, isRawText: true };
+    }
+
+    const pageId = resolveOrThrowPageId(from.pageId, context);
+    const page = await deps.findPage(pageId);
+    if (!page) return refuse('Source page not found', `No page with ID "${pageId}".`);
+    if (!(await deps.canViewPage(context, page.id))) {
+      return refuse('Insufficient permissions', `You do not have access to read "${page.title}".`);
+    }
+    const rejected = rejectNonTextPage(page, 'source');
+    if (rejected) return rejected;
+
+    // The SAME projection read_page shows, so a range copied from a fresh read
+    // addresses the same lines the agent saw.
+    const serialized = serializePageContentForAI(page);
+    const allLines = serialized.split('\n');
+    const totalLines = allLines.length;
+
+    if (from.lineStart === undefined && from.lineEnd === undefined) {
+      return { bytes: serialized, label: `page:${page.id}`, isRawText: isRawTextPage(page) };
+    }
+
+    const start = from.lineStart ?? 1;
+    if (start > totalLines) {
+      return refuse(
+        'Line range is past the end of the source',
+        `"${page.title}" has ${totalLines} line${totalLines === 1 ? '' : 's'}, so line ${start} does not exist.`,
+        { totalLines }
+      );
+    }
+    const end = from.lineEnd !== undefined ? Math.min(from.lineEnd, totalLines) : totalLines;
+    return {
+      bytes: allLines.slice(start - 1, end).join('\n'),
+      label: `page:${page.id} lines ${start}-${end}`,
+      isRawText: isRawTextPage(page),
+    };
+  }
+
+  async function writeToPage(
+    to: CopyTo,
+    source: ResolvedSource,
+    context: ToolExecutionContext
+  ): Promise<Record<string, unknown>> {
+    const pageId = resolveOrThrowPageId(to.pageId, context);
+    const page = await deps.findPage(pageId);
+    if (!page) return refuse('Destination page not found', `No page with ID "${pageId}".`);
+    if (page.type === PageType.FILE) {
+      return refuse(
+        'Cannot write to FILE pages',
+        'This is an uploaded file; its content is managed by the system. Create a document page instead.',
+        { pageId: page.id }
+      );
+    }
+    const rejected = rejectNonTextPage(page, 'destination');
+    if (rejected) return rejected;
+    if (!(await deps.canEditPage(context, page.id))) {
+      return refuse('Insufficient permissions', `You do not have edit access to "${page.title}".`);
+    }
+
+    // Byte-for-byte means byte-for-byte: this tool converts nothing. Raw text
+    // written into an html-mode document renders as literal characters, which
+    // is exactly the "literal garbage, not formatting" the writing-documents
+    // skill tells agents to avoid — so refuse rather than produce it.
+    const destIsRawText = isRawTextPage(page);
+    if (source.isRawText !== destIsRawText) {
+      return refuse(
+        'Content mode mismatch',
+        `The source is ${source.isRawText ? 'raw text (markdown/code/a file)' : 'HTML'} but "${page.title}" is ` +
+          `${destIsRawText ? 'a raw-text page' : 'an html-mode document'}. copy_content never converts between them — ` +
+          `writing one into the other produces literal characters, not formatting. ` +
+          `Create a page with the matching mode (create_page defaults to markdown) and copy into that.`,
+        {
+          pageId: page.id,
+          sourceIsRawText: source.isRawText,
+          destinationContentMode: page.contentMode ?? 'html',
+          ...(describeContentModeMismatch(page) ? { contentModeWarning: describeContentModeMismatch(page) } : {}),
+        }
+      );
+    }
+
+    const lineCount = projectLines(page.content, destIsRawText).length;
+    let edit: LineEditResult;
+    try {
+      switch (to.mode) {
+        case 'replace':
+          edit = replaceLines({
+            content: page.content,
+            startLine: 1,
+            endLine: lineCount,
+            replacement: source.bytes,
+            isRawText: destIsRawText,
+          });
+          break;
+        case 'replaceLines':
+          edit = replaceLines({
+            content: page.content,
+            startLine: to.startLine as number,
+            endLine: to.endLine ?? (to.startLine as number),
+            replacement: source.bytes,
+            isRawText: destIsRawText,
+            expectedTotalLines: to.expectedTotalLines,
+          });
+          break;
+        case 'append':
+          // insertLines clamps to one past the last line, so "the end" is
+          // expressible without a separate append primitive.
+          edit = insertLines({
+            content: page.content,
+            startLine: lineCount + 1,
+            insertion: source.bytes,
+            isRawText: destIsRawText,
+          });
+          break;
+        case 'insertAfter': {
+          const anchorIndex = projectLines(page.content, destIsRawText).findIndex((line) =>
+            line.includes(to.anchor as string)
+          );
+          if (anchorIndex === -1) {
+            // Mirrors insert_content: a missing anchor is a no-op the agent can
+            // act on, not a failure — and nothing is written.
+            return {
+              success: true,
+              inserted: false,
+              pageId: page.id,
+              title: page.title,
+              message: `No line containing "${to.anchor}" was found in "${page.title}". Nothing was copied.`,
+            };
+          }
+          const at = (to.position ?? 'after') === 'after' ? anchorIndex + 2 : anchorIndex + 1;
+          edit = insertLines({
+            content: page.content,
+            startLine: at,
+            insertion: source.bytes,
+            isRawText: destIsRawText,
+          });
+          break;
+        }
+        default:
+          return refuse('Unsupported mode', `Unknown destination mode "${String(to.mode)}".`);
+      }
+    } catch (error) {
+      if (error instanceof LineRangeError) {
+        return refuse(
+          error.kind === 'stale' ? 'Page changed since it was read' : 'Line number out of range',
+          error.message,
+          {
+            totalLines: lineCount,
+            suggestion: 'Read the page again and re-address the copy against the line numbers it returns.',
+            pageId: page.id,
+          }
+        );
+      }
+      throw error;
+    }
+
+    await deps.writePageContent({
+      page,
+      newContent: edit.newContent,
+      context,
+      metadata: { copiedFrom: source.label, changeType: edit.changeType, linesChanged: edit.linesReplaced },
+    });
+
+    return {
+      success: true,
+      pageId: page.id,
+      title: page.title,
+      type: page.type,
+      mode: to.mode,
+      sourceLabel: source.label,
+      bytesCopied: Buffer.byteLength(source.bytes, 'utf8'),
+      // From the edit result, never recomputed — five copies of this
+      // arithmetic disagreeing is what #2463 was.
+      linesReplaced: edit.linesReplaced,
+      newLineCount: edit.newLineCount,
+      previousLineCount: edit.previousLineCount,
+      // Stripped before the model sees them (copy-content-model-output.ts);
+      // kept here because RichDiffRenderer draws from them.
+      oldContent: edit.oldContent,
+      newContent: edit.newContent,
+      message: `Copied ${source.label} into "${page.title}" without re-transcribing it.`,
+    };
+  }
+
+  async function writeToFile(
+    to: CopyTo,
+    source: ResolvedSource,
+    context: ToolExecutionContext
+  ): Promise<Record<string, unknown>> {
+    if (!(await deps.isSandboxEnabledForContext(context))) {
+      return refuse(
+        'Sandbox access is off for this agent',
+        "This agent cannot write sandbox files. Enable sandbox access in the agent's settings, or copy into a page instead."
+      );
+    }
+    const written = await deps.writeSandboxFile({
+      path: to.path as string,
+      content: source.bytes,
+      context,
+    });
+    if (!written.success) return refuse('Could not write the destination file', written.error);
+    return {
+      success: true,
+      path: to.path,
+      sourceLabel: source.label,
+      bytesCopied: written.bytesWritten,
+      message: `Copied ${source.label} to ${to.path} without re-transcribing it.`,
+    };
+  }
+
+  return {
+    copy_content: tool({
+      description:
+        'Copy content you already have from one place to another WITHOUT retyping it: page->page, page->file, file->page, file->file. ' +
+        'The bytes move server-side, so this costs no output tokens and is byte-exact. ' +
+        'Use it instead of pasting content into replace_lines, insert_content or writeFile. ' +
+        'It never converts between formats. To copy into a new page, call create_page first (it takes no content), then copy into it.',
+      inputSchema: copyContentInputSchema,
+      toModelOutput: ({ output }) => toModelOutputForCopyContent(output),
+      execute: async ({ from, to }, options) => {
+        const context = readContext(options);
+        if (!context?.userId) throw new Error('User authentication required');
+
+        // Source first, destination second, write last. Nothing is written
+        // until BOTH sides have been authorized.
+        const source = await resolveSource(from, context);
+        if ('success' in source) return source;
+
+        const bytes = Buffer.byteLength(source.bytes, 'utf8');
+        if (bytes > MAX_COPY_BYTES) {
+          return refuse(
+            'Source is too large to copy',
+            `${source.label} is ${bytes} bytes, over the ${MAX_COPY_BYTES}-byte limit. ` +
+              `Narrow it with from.lineStart/from.lineEnd. It is NOT copied partially — a half-copied ` +
+              `document looks complete, so this refuses instead.`,
+            { sourceBytes: bytes, limit: MAX_COPY_BYTES }
+          );
+        }
+
+        return to.kind === 'page'
+          ? writeToPage(to, source, context)
+          : writeToFile(to, source, context);
+      },
+    }),
+  };
+}

--- a/apps/web/src/lib/ai/tools/copy-content-tools.ts
+++ b/apps/web/src/lib/ai/tools/copy-content-tools.ts
@@ -172,12 +172,12 @@ export const copyContentInputSchema = z
         'Line ranges apply to pages, not files. Copy the whole file, or narrow it in the sandbox first.'
       );
     }
-    if (
-      value.from.lineStart !== undefined &&
-      value.from.lineEnd !== undefined &&
-      value.from.lineEnd < value.from.lineStart
-    ) {
-      require(false, ['from', 'lineEnd'], 'from.lineEnd must be >= from.lineStart.');
+    if (value.from.lineStart !== undefined && value.from.lineEnd !== undefined) {
+      require(
+        value.from.lineEnd >= value.from.lineStart,
+        ['from', 'lineEnd'],
+        'from.lineEnd must be >= from.lineStart.'
+      );
     }
 
     if (value.to.kind === 'file') {
@@ -196,12 +196,13 @@ export const copyContentInputSchema = z
       require(!!value.to.mode, ['to', 'mode'], 'to.mode is required when to.kind is "page".');
       if (value.to.mode === 'replaceLines') {
         require(value.to.startLine !== undefined, ['to', 'startLine'], 'mode "replaceLines" needs startLine.');
-      }
-      if (value.to.mode === 'replaceLines' &&
-          value.to.startLine !== undefined &&
-          value.to.endLine !== undefined &&
-          value.to.endLine < value.to.startLine) {
-        require(false, ['to', 'endLine'], 'to.endLine must be >= to.startLine.');
+        if (value.to.startLine !== undefined && value.to.endLine !== undefined) {
+          require(
+            value.to.endLine >= value.to.startLine,
+            ['to', 'endLine'],
+            'to.endLine must be >= to.startLine.'
+          );
+        }
       }
       if (value.to.mode === 'insertAfter') {
         require(!!value.to.anchor, ['to', 'anchor'], 'mode "insertAfter" needs anchor.');
@@ -210,9 +211,9 @@ export const copyContentInputSchema = z
       // offering one — most of all on `replace`, which overwrites the whole
       // page. Only replaceLines threads it through, so only replaceLines takes
       // it.
-      if (value.to.mode !== 'replaceLines' && value.to.expectedTotalLines !== undefined) {
+      if (value.to.mode !== 'replaceLines') {
         require(
-          false,
+          value.to.expectedTotalLines === undefined,
           ['to', 'expectedTotalLines'],
           'expectedTotalLines only applies to mode "replaceLines"; it would be ignored here.'
         );
@@ -236,12 +237,20 @@ interface ResolvedSource {
 
 type Refusal = { success: false; error: string; message: string; [key: string]: unknown };
 
-const refuse = (error: string, message: string, extra: Record<string, unknown> = {}): Refusal => ({
-  success: false,
-  error,
-  message,
-  ...extra,
-});
+/**
+ * A copy that landed. The fields differ per arm — page vs file, insertion vs
+ * replace — and both the tests and RichDiffRenderer read them by name, so the
+ * shape stays open. What is pinned is what every arm owes a caller: the
+ * discriminant, and a sentence a human can read.
+ */
+type Success = { success: true; message: string; [key: string]: unknown };
+
+/** Every value the two write arms can return. */
+type CopyResult = Success | Refusal;
+
+function refuse(error: string, message: string, extra: Record<string, unknown> = {}): Refusal {
+  return { success: false, error, message, ...extra };
+}
 
 /**
  * What the bytes of a page ARE: raw text, HTML, or not yet determinable.
@@ -385,7 +394,7 @@ export function createCopyContentTools(deps: CopyContentDeps) {
     to: CopyTo,
     source: ResolvedSource,
     context: ToolExecutionContext
-  ): Promise<Record<string, unknown>> {
+  ): Promise<CopyResult> {
     const pageId = resolveOrThrowPageId(to.pageId, context);
     const page = await deps.findPage(pageId);
     if (!page) return refuse('Destination page not found', `No page with ID "${pageId}".`);
@@ -508,6 +517,11 @@ export function createCopyContentTools(deps: CopyContentDeps) {
           break;
         }
         default:
+          // Unreachable through the schema, which requires one of the four
+          // modes for a page destination. Kept because `mode` is still
+          // optional in the inferred type, so this is what keeps `edit`
+          // definitely assigned — and it is the honest answer if a future
+          // mode is added to the enum and not to this switch.
           return refuse('Unsupported mode', `Unknown destination mode "${String(to.mode)}".`);
       }
     } catch (error) {
@@ -583,7 +597,7 @@ export function createCopyContentTools(deps: CopyContentDeps) {
     to: CopyTo,
     source: ResolvedSource,
     context: ToolExecutionContext
-  ): Promise<Record<string, unknown>> {
+  ): Promise<CopyResult> {
     if (!(await deps.isSandboxEnabledForContext(context))) {
       return refuse(
         'Sandbox access is off for this agent',
@@ -638,7 +652,9 @@ export function createCopyContentTools(deps: CopyContentDeps) {
         const source = await resolveSource(from, context);
         if ('success' in source) return source;
 
-        const bytes = Buffer.byteLength(source.bytes, 'utf8');
+        // Named for the field it is reported as, and so it does not read as a
+        // sibling of `source.bytes` — which is the copied TEXT, not a count.
+        const sourceBytes = Buffer.byteLength(source.bytes, 'utf8');
         // A zero-byte source is the limit case of the truncation this tool
         // refuses to do: `replace` would empty the destination and report
         // success, with only `bytesCopied: 0` to say so. It nearly always means
@@ -652,23 +668,24 @@ export function createCopyContentTools(deps: CopyContentDeps) {
         // Unless the caller NARROWED the source explicitly — asking for lines
         // 2-2 of a document is a deliberate selection, and a blank separator
         // line is a legitimate thing to copy.
-        const deliberatelyNarrowed = from.kind === 'page' && (from.lineStart !== undefined || from.lineEnd !== undefined);
+        const deliberatelyNarrowed =
+          from.kind === 'page' && (from.lineStart !== undefined || from.lineEnd !== undefined);
         if (source.bytes.trim() === '' && !deliberatelyNarrowed) {
           return refuse(
             'Source is empty',
             `${source.label} has no content, so there is nothing to copy. Copying it would empty the destination rather than fill it. ` +
               `If the source is an uploaded file, its text may not have been extracted yet. ` +
               `To copy blank lines on purpose, name them with from.lineStart/from.lineEnd.`,
-            { sourceBytes: bytes }
+            { sourceBytes }
           );
         }
-        if (bytes > MAX_COPY_BYTES) {
+        if (sourceBytes > MAX_COPY_BYTES) {
           return refuse(
             'Source is too large to copy',
-            `${source.label} is ${bytes} bytes, over the ${MAX_COPY_BYTES}-byte limit. ` +
+            `${source.label} is ${sourceBytes} bytes, over the ${MAX_COPY_BYTES}-byte limit. ` +
               `Narrow it with from.lineStart/from.lineEnd. It is NOT copied partially — a half-copied ` +
               `document looks complete, so this refuses instead.`,
-            { sourceBytes: bytes, limit: MAX_COPY_BYTES }
+            { sourceBytes, limit: MAX_COPY_BYTES }
           );
         }
 

--- a/apps/web/src/lib/ai/tools/copy-content-tools.ts
+++ b/apps/web/src/lib/ai/tools/copy-content-tools.ts
@@ -32,7 +32,9 @@ import {
   insertLines,
   type LineEditResult,
 } from '@/lib/editor/line-edit';
+import { insertAtAnchor } from '@/lib/editor/text-edit';
 import { isRawTextPage, describeContentModeMismatch } from '../core/page-serializer';
+import { looksLikeHtmlDocument } from '@/lib/editor/line-breaks';
 import { isSheetType } from '@pagespace/lib/sheets/sheet';
 import { PageType } from '@pagespace/lib/utils/enums';
 import { toModelOutputForCopyContent } from './copy-content-model-output';
@@ -188,8 +190,25 @@ export const copyContentInputSchema = z
       if (value.to.mode === 'replaceLines') {
         require(value.to.startLine !== undefined, ['to', 'startLine'], 'mode "replaceLines" needs startLine.');
       }
+      if (value.to.mode === 'replaceLines' &&
+          value.to.startLine !== undefined &&
+          value.to.endLine !== undefined &&
+          value.to.endLine < value.to.startLine) {
+        require(false, ['to', 'endLine'], 'to.endLine must be >= to.startLine.');
+      }
       if (value.to.mode === 'insertAfter') {
         require(!!value.to.anchor, ['to', 'anchor'], 'mode "insertAfter" needs anchor.');
+      }
+      // Accepting a staleness guard and then ignoring it is worse than not
+      // offering one — most of all on `replace`, which overwrites the whole
+      // page. Only replaceLines threads it through, so only replaceLines takes
+      // it.
+      if (value.to.mode !== 'replaceLines' && value.to.expectedTotalLines !== undefined) {
+        require(
+          false,
+          ['to', 'expectedTotalLines'],
+          'expectedTotalLines only applies to mode "replaceLines"; it would be ignored here.'
+        );
       }
     }
   });
@@ -231,6 +250,38 @@ function isRawTextSource(page: CopyPageRecord): boolean {
   return page.type === PageType.FILE || isRawTextPage(page);
 }
 
+/**
+ * Whether a page's content should be treated as raw text when WRITING to it.
+ *
+ * `isRawTextPage` alone is not enough here. Everything predates content modes
+ * defaulting to html, so a large population of html-mode DOCUMENTs actually
+ * hold markdown, JSON or plain prose — the exact shape #2463 was reported
+ * against. Classifying those as HTML both refuses the copy this tool exists to
+ * perform (markdown into a page already holding markdown) AND accepts the one
+ * it should refuse (HTML into a page holding JSON).
+ *
+ * So the stored content gets a vote, using the same signal
+ * `describeContentModeMismatch` already relies on. An EMPTY page has no content
+ * to conflict with, so it accepts either.
+ */
+function isRawTextDestination(page: CopyPageRecord): boolean {
+  if (isRawTextPage(page)) return true;
+  const content = page.content ?? '';
+  if (content.trim() === '') return true;
+  return !looksLikeHtmlDocument(content);
+}
+
+/**
+ * Page types whose `content` holds structured records rather than editable
+ * text. Copying bytes into (or out of) one of these is never meaningful.
+ */
+const STRUCTURED_PAGE_TYPES: ReadonlySet<string> = new Set<string>([
+  PageType.CHANNEL,
+  PageType.TASK_LIST,
+  PageType.FOLDER,
+  PageType.AI_CHAT,
+]);
+
 /** Page types whose content is not line-addressable text. */
 function rejectNonTextPage(page: CopyPageRecord, side: 'source' | 'destination'): Refusal | null {
   if (isSheetType(page.type as PageType)) {
@@ -242,7 +293,12 @@ function rejectNonTextPage(page: CopyPageRecord, side: 'source' | 'destination')
       { pageId: page.id, type: page.type }
     );
   }
-  if (page.type === PageType.CHANNEL || page.type === PageType.TASK_LIST) {
+  // FOLDER and AI_CHAT are seeded with structured JSON by create_page
+  // (`{"children":[]}` / `{"messages":[]}`), so writing text over them destroys
+  // the page rather than editing it — and reading one dumps that raw JSON into
+  // the destination. CANVAS is deliberately absent: it genuinely is an HTML
+  // page.
+  if (STRUCTURED_PAGE_TYPES.has(page.type)) {
     return refuse(
       'Not a text page',
       `"${page.title}" is a ${page.type}, whose content is structured records rather than text. There is nothing to copy byte-for-byte.`,
@@ -334,7 +390,7 @@ export function createCopyContentTools(deps: CopyContentDeps) {
     // written into an html-mode document renders as literal characters, which
     // is exactly the "literal garbage, not formatting" the writing-documents
     // skill tells agents to avoid — so refuse rather than produce it.
-    const destIsRawText = isRawTextPage(page);
+    const destIsRawText = isRawTextDestination(page);
     if (source.isRawText !== destIsRawText) {
       return refuse(
         'Content mode mismatch',
@@ -353,6 +409,7 @@ export function createCopyContentTools(deps: CopyContentDeps) {
 
     const lineCount = projectLines(page.content, destIsRawText).length;
     let edit: LineEditResult;
+    let anchorLine: number | null = null;
     try {
       switch (to.mode) {
         case 'replace':
@@ -394,10 +451,20 @@ export function createCopyContentTools(deps: CopyContentDeps) {
           break;
         }
         case 'insertAfter': {
-          const anchorIndex = projectLines(page.content, destIsRawText).findIndex((line) =>
-            line.includes(to.anchor as string)
-          );
-          if (anchorIndex === -1) {
+          // insertAtAnchor, NOT a hand-rolled findIndex + insertLines. On an
+          // html page it snaps to the block boundary, so the copy lands outside
+          // the anchor's element instead of nested inside it — hand-rolling the
+          // index produced `<p>Alpha<p>COPY</p></p>`, invalid markup that Tiptap
+          // restructures on the next save, moving every line number underneath
+          // the agent. insert_content has always used this; so does this now.
+          const anchored = insertAtAnchor({
+            content: page.content,
+            anchor: to.anchor as string,
+            insertion: source.bytes,
+            position: to.position ?? 'after',
+            isRawText: destIsRawText,
+          });
+          if (!anchored.inserted) {
             // Mirrors insert_content: a missing anchor is a no-op the agent can
             // act on, not a failure — and nothing is written.
             return {
@@ -408,13 +475,15 @@ export function createCopyContentTools(deps: CopyContentDeps) {
               message: `No line containing "${to.anchor}" was found in "${page.title}". Nothing was copied.`,
             };
           }
-          const at = (to.position ?? 'after') === 'after' ? anchorIndex + 2 : anchorIndex + 1;
-          edit = insertLines({
-            content: page.content,
-            startLine: at,
-            insertion: source.bytes,
-            isRawText: destIsRawText,
-          });
+          edit = {
+            oldContent: anchored.oldContent,
+            newContent: anchored.newContent,
+            newLineCount: anchored.newLineCount,
+            previousLineCount: anchored.oldContent.split('\n').length,
+            linesReplaced: 0,
+            changeType: 'insertion',
+          };
+          anchorLine = anchored.anchorLine;
           break;
         }
         default:
@@ -439,22 +508,40 @@ export function createCopyContentTools(deps: CopyContentDeps) {
       page,
       newContent: edit.newContent,
       context,
-      metadata: { copiedFrom: source.label, changeType: edit.changeType, linesChanged: edit.linesReplaced },
+      metadata: {
+        copiedFrom: source.label,
+        changeType: edit.changeType,
+        linesChanged: edit.changeType === 'insertion' ? edit.newLineCount - edit.previousLineCount : edit.linesReplaced,
+      },
     });
+
+    // An insertion replaces nothing, so `linesReplaced` is 0 by construction —
+    // reporting only that for a 400-line append reads as "nothing happened".
+    // The lines ADDED is the number that describes an insertion.
+    const linesAdded = edit.newLineCount - edit.previousLineCount;
+    // Surfaced on SUCCESS, not only on the mismatch refusal: replace_lines and
+    // insert_content both attach it to the result, and a page whose stored
+    // content disagrees with its declared mode is exactly what an agent needs
+    // told after a write, not just when one is refused.
+    const contentModeWarning = describeContentModeMismatch(page);
 
     return {
       success: true,
       pageId: page.id,
       title: page.title,
       type: page.type,
+      contentMode: page.contentMode || 'html',
       mode: to.mode,
+      ...(anchorLine !== null ? { anchorLine } : {}),
       sourceLabel: source.label,
       bytesCopied: Buffer.byteLength(source.bytes, 'utf8'),
       // From the edit result, never recomputed — five copies of this
       // arithmetic disagreeing is what #2463 was.
       linesReplaced: edit.linesReplaced,
+      linesAdded,
       newLineCount: edit.newLineCount,
       previousLineCount: edit.previousLineCount,
+      ...(contentModeWarning ? { contentModeWarning } : {}),
       // Stripped before the model sees them (copy-content-model-output.ts);
       // kept here because RichDiffRenderer draws from them.
       oldContent: edit.oldContent,
@@ -502,12 +589,41 @@ export function createCopyContentTools(deps: CopyContentDeps) {
         const context = readContext(options);
         if (!context?.userId) throw new Error('User authentication required');
 
+        // Resolve BOTH page ids before doing any work. resolveOrThrowPageId
+        // throws when neither an explicit id nor a page-in-view is available,
+        // and resolving the destination lazily meant that throw landed AFTER
+        // the source had been read — provisioning a sandbox, spending machine
+        // time and writing an audit row for a copy that could never land.
+        try {
+          if (from.kind === 'page') resolveOrThrowPageId(from.pageId, context);
+          if (to.kind === 'page') resolveOrThrowPageId(to.pageId, context);
+        } catch (error) {
+          return refuse(
+            'No page specified',
+            error instanceof Error ? error.message : String(error)
+          );
+        }
+
         // Source first, destination second, write last. Nothing is written
         // until BOTH sides have been authorized.
         const source = await resolveSource(from, context);
         if ('success' in source) return source;
 
         const bytes = Buffer.byteLength(source.bytes, 'utf8');
+        // A zero-byte source is the limit case of the truncation this tool
+        // refuses to do: `replace` would empty the destination and report
+        // success, with only `bytesCopied: 0` to say so. It nearly always means
+        // the source is not what the agent thinks — an unextracted upload
+        // (image, scanned PDF, extraction still pending) or an empty file — so
+        // it is refused rather than executed.
+        if (bytes === 0) {
+          return refuse(
+            'Source is empty',
+            `${source.label} has no content, so there is nothing to copy. Copying it would empty the destination rather than fill it. ` +
+              `If the source is an uploaded file, its text may not have been extracted yet.`,
+            { sourceBytes: 0 }
+          );
+        }
         if (bytes > MAX_COPY_BYTES) {
           return refuse(
             'Source is too large to copy',

--- a/apps/web/src/lib/ai/tools/copy-content-tools.ts
+++ b/apps/web/src/lib/ai/tools/copy-content-tools.ts
@@ -146,7 +146,9 @@ export const copyToSchema = z
     expectedTotalLines: z
       .number()
       .int()
-      .min(0)
+      // A page always projects to at least one line, so 0 could only ever be a
+      // guaranteed staleness failure.
+      .min(1)
       .optional()
       .describe(
         'mode=replaceLines: the line count you last read. The edit is refused if the page has changed since.'
@@ -180,11 +182,16 @@ export const copyContentInputSchema = z
 
     if (value.to.kind === 'file') {
       require(!!value.to.path, ['to', 'path'], 'to.path is required when to.kind is "file".');
-      require(
-        value.to.mode === undefined,
-        ['to', 'mode'],
-        'A file destination is always a whole-file write; mode applies to pages only.'
-      );
+      // Every page-only field, not just `mode`. Accepting a field and then
+      // ignoring it is the thing this rule exists to prevent, so it has to
+      // cover all of them or it only pretends to.
+      for (const field of ['mode', 'startLine', 'endLine', 'anchor', 'expectedTotalLines'] as const) {
+        require(
+          value.to[field] === undefined,
+          ['to', field],
+          `to.${field} applies to page destinations only; a file destination is always a whole-file write.`
+        );
+      }
     } else {
       require(!!value.to.mode, ['to', 'mode'], 'to.mode is required when to.kind is "page".');
       if (value.to.mode === 'replaceLines') {
@@ -220,8 +227,11 @@ interface ResolvedSource {
   bytes: string;
   /** How the source is described back to the caller and in activity metadata. */
   label: string;
-  /** Whether the source text is raw (a file always is; a page depends on mode). */
-  isRawText: boolean;
+  /**
+   * What the copied bytes are. A sandbox file is always raw text; a page is
+   * classified by `contentShapeOf`.
+   */
+  shape: ContentShape;
 }
 
 type Refusal = { success: false; error: string; message: string; [key: string]: unknown };
@@ -234,41 +244,47 @@ const refuse = (error: string, message: string, extra: Record<string, unknown> =
 });
 
 /**
- * Whether a page's content is RAW TEXT rather than HTML.
+ * What the bytes of a page ARE: raw text, HTML, or not yet determinable.
  *
- * `isRawTextPage` answers this for documents and code, but a FILE page is a
- * third case it does not cover: the processor stores EXTRACTED PLAINTEXT in
- * `page.content` while the row keeps the schema default `contentMode: 'html'`.
- * Trusting that default would label a .md or .json upload as HTML and let it
- * through the compatibility check into an html-mode document, which is exactly
- * the literal-text corruption that check exists to prevent.
+ * ONE classifier, used for the source and the destination alike. Round 2 gave
+ * the two sides different rules — the destination sniffed its stored content
+ * while the source went on `contentMode` alone — and the asymmetry broke the
+ * two most ordinary copies there are: an HTML page into a freshly created
+ * (empty) page, and a page into a sibling of the very shape the sniffing was
+ * added for. Whatever the rule is, both sides have to be asked the same
+ * question.
  *
- * `describeContentModeMismatch` already states the same thing in prose — "a
- * FILE [serializes] from extracted text — neither is HTML".
+ * `unknown` is the load-bearing case. An empty page has no content to conflict
+ * with, so it is compatible with anything; treating "no evidence" as "HTML"
+ * is what refused the create_page -> copy_content flow.
+ *
+ * The content vote is DOCUMENT-only, matching `describeContentModeMismatch`
+ * exactly. Everything predates contentMode defaulting to markdown, so a large
+ * population of html-mode DOCUMENTs actually hold markdown or JSON (#2463) and
+ * their real format is only knowable by looking. Other html-typed pages are not
+ * in that population: a CANVAS genuinely is an HTML document, and
+ * `looksLikeHtmlDocument` would not recognize one anyway — it keys on block
+ * tags and knows nothing of `<!DOCTYPE>`, `<html>` or `<body>`.
  */
-function isRawTextSource(page: CopyPageRecord): boolean {
-  return page.type === PageType.FILE || isRawTextPage(page);
+type ContentShape = 'raw' | 'html' | 'unknown';
+
+function contentShapeOf(page: CopyPageRecord): ContentShape {
+  // markdown-mode documents and CODE pages: raw by declaration.
+  if (isRawTextPage(page)) return 'raw';
+  // A FILE page holds extracted PLAINTEXT while the row keeps the schema
+  // default contentMode 'html'. `describeContentModeMismatch` says the same.
+  if (page.type === PageType.FILE) return 'raw';
+  // Not a DOCUMENT, not raw-by-declaration: an html-typed page that means it.
+  if (page.type !== PageType.DOCUMENT) return 'html';
+
+  const content = page.content ?? '';
+  if (content.trim() === '') return 'unknown';
+  return looksLikeHtmlDocument(content) ? 'html' : 'raw';
 }
 
-/**
- * Whether a page's content should be treated as raw text when WRITING to it.
- *
- * `isRawTextPage` alone is not enough here. Everything predates content modes
- * defaulting to html, so a large population of html-mode DOCUMENTs actually
- * hold markdown, JSON or plain prose — the exact shape #2463 was reported
- * against. Classifying those as HTML both refuses the copy this tool exists to
- * perform (markdown into a page already holding markdown) AND accepts the one
- * it should refuse (HTML into a page holding JSON).
- *
- * So the stored content gets a vote, using the same signal
- * `describeContentModeMismatch` already relies on. An EMPTY page has no content
- * to conflict with, so it accepts either.
- */
-function isRawTextDestination(page: CopyPageRecord): boolean {
-  if (isRawTextPage(page)) return true;
-  const content = page.content ?? '';
-  if (content.trim() === '') return true;
-  return !looksLikeHtmlDocument(content);
+/** Two shapes conflict only when both are known and they differ. */
+function shapesConflict(source: ContentShape, destination: ContentShape): boolean {
+  return source !== 'unknown' && destination !== 'unknown' && source !== destination;
 }
 
 /**
@@ -325,7 +341,7 @@ export function createCopyContentTools(deps: CopyContentDeps) {
       }
       const read = await deps.readSandboxFile({ path: from.path as string, context });
       if (!read.success) return refuse('Could not read the source file', read.error);
-      return { bytes: read.content, label: `file:${from.path}`, isRawText: true };
+      return { bytes: read.content, label: `file:${from.path}`, shape: 'raw' };
     }
 
     const pageId = resolveOrThrowPageId(from.pageId, context);
@@ -339,12 +355,14 @@ export function createCopyContentTools(deps: CopyContentDeps) {
 
     // The SAME projection read_page shows, so a range copied from a fresh read
     // addresses the same lines the agent saw.
-    const serialized = canonicalizeForLineEditing(page.content, isRawTextSource(page));
+    const sourceShape = contentShapeOf(page);
+    // 'unknown' means an empty page — nothing to line-break either way.
+    const serialized = canonicalizeForLineEditing(page.content, sourceShape !== 'html');
     const allLines = serialized.split('\n');
     const totalLines = allLines.length;
 
     if (from.lineStart === undefined && from.lineEnd === undefined) {
-      return { bytes: serialized, label: `page:${page.id}`, isRawText: isRawTextSource(page) };
+      return { bytes: serialized, label: `page:${page.id}`, shape: sourceShape };
     }
 
     const start = from.lineStart ?? 1;
@@ -359,7 +377,7 @@ export function createCopyContentTools(deps: CopyContentDeps) {
     return {
       bytes: allLines.slice(start - 1, end).join('\n'),
       label: `page:${page.id} lines ${start}-${end}`,
-      isRawText: isRawTextSource(page),
+      shape: sourceShape,
     };
   }
 
@@ -390,19 +408,22 @@ export function createCopyContentTools(deps: CopyContentDeps) {
     // written into an html-mode document renders as literal characters, which
     // is exactly the "literal garbage, not formatting" the writing-documents
     // skill tells agents to avoid — so refuse rather than produce it.
-    const destIsRawText = isRawTextDestination(page);
-    if (source.isRawText !== destIsRawText) {
+    const destShape = contentShapeOf(page);
+    // The line projection follows the page's DECLARED mode, unchanged — only the
+    // compatibility gate consults the sniffed shape.
+    const destIsRawText = isRawTextPage(page);
+    if (shapesConflict(source.shape, destShape)) {
       return refuse(
         'Content mode mismatch',
-        `The source is ${source.isRawText ? 'raw text (markdown/code/a file)' : 'HTML'} but "${page.title}" is ` +
-          `${destIsRawText ? 'a raw-text page' : 'an html-mode document'}. copy_content never converts between them — ` +
+        `The source is ${source.shape === 'raw' ? 'raw text (markdown, code, or a file)' : 'HTML'} but "${page.title}" holds ` +
+          `${destShape === 'raw' ? 'raw text' : 'HTML'}. copy_content never converts between them — ` +
           `writing one into the other produces literal characters, not formatting. ` +
           `Create a page with the matching mode (create_page defaults to markdown) and copy into that.`,
         {
           pageId: page.id,
-          sourceIsRawText: source.isRawText,
+          sourceShape: source.shape,
+          destinationShape: destShape,
           destinationContentMode: page.contentMode ?? 'html',
-          ...(describeContentModeMismatch(page) ? { contentModeWarning: describeContentModeMismatch(page) } : {}),
         }
       );
     }
@@ -511,19 +532,27 @@ export function createCopyContentTools(deps: CopyContentDeps) {
       metadata: {
         copiedFrom: source.label,
         changeType: edit.changeType,
-        linesChanged: edit.changeType === 'insertion' ? edit.newLineCount - edit.previousLineCount : edit.linesReplaced,
+        // An insertion replaces nothing, so its size is the lines it ADDED.
+        linesChanged:
+          edit.changeType === 'insertion'
+            ? edit.newLineCount - edit.previousLineCount
+            : edit.linesReplaced,
       },
     });
 
     // An insertion replaces nothing, so `linesReplaced` is 0 by construction —
     // reporting only that for a 400-line append reads as "nothing happened".
-    // The lines ADDED is the number that describes an insertion.
-    const linesAdded = edit.newLineCount - edit.previousLineCount;
+    // Insertion ONLY: on a replace this delta goes negative, and a field named
+    // `linesAdded` reading -4 is a number an agent will misread. The replace
+    // modes already describe themselves with linesReplaced + newLineCount.
+    const isInsertion = edit.changeType === 'insertion';
     // Surfaced on SUCCESS, not only on the mismatch refusal: replace_lines and
     // insert_content both attach it to the result, and a page whose stored
     // content disagrees with its declared mode is exactly what an agent needs
     // told after a write, not just when one is refused.
-    const contentModeWarning = describeContentModeMismatch(page);
+    // From the content just STORED, not the pre-write row: a warning that
+    // describes the document as it used to be is worse than none.
+    const contentModeWarning = describeContentModeMismatch({ ...page, content: edit.newContent });
 
     return {
       success: true,
@@ -538,7 +567,7 @@ export function createCopyContentTools(deps: CopyContentDeps) {
       // From the edit result, never recomputed — five copies of this
       // arithmetic disagreeing is what #2463 was.
       linesReplaced: edit.linesReplaced,
-      linesAdded,
+      ...(isInsertion ? { linesAdded: edit.newLineCount - edit.previousLineCount } : {}),
       newLineCount: edit.newLineCount,
       previousLineCount: edit.previousLineCount,
       ...(contentModeWarning ? { contentModeWarning } : {}),
@@ -616,12 +645,21 @@ export function createCopyContentTools(deps: CopyContentDeps) {
         // the source is not what the agent thinks — an unextracted upload
         // (image, scanned PDF, extraction still pending) or an empty file — so
         // it is refused rather than executed.
-        if (bytes === 0) {
+        // Whitespace-only counts as empty: an unextracted upload commonly yields
+        // a lone newline or a run of spaces rather than a truly empty string,
+        // and copying that over a page is the same silent wipe.
+        //
+        // Unless the caller NARROWED the source explicitly — asking for lines
+        // 2-2 of a document is a deliberate selection, and a blank separator
+        // line is a legitimate thing to copy.
+        const deliberatelyNarrowed = from.kind === 'page' && (from.lineStart !== undefined || from.lineEnd !== undefined);
+        if (source.bytes.trim() === '' && !deliberatelyNarrowed) {
           return refuse(
             'Source is empty',
             `${source.label} has no content, so there is nothing to copy. Copying it would empty the destination rather than fill it. ` +
-              `If the source is an uploaded file, its text may not have been extracted yet.`,
-            { sourceBytes: 0 }
+              `If the source is an uploaded file, its text may not have been extracted yet. ` +
+              `To copy blank lines on purpose, name them with from.lineStart/from.lineEnd.`,
+            { sourceBytes: bytes }
           );
         }
         if (bytes > MAX_COPY_BYTES) {

--- a/apps/web/src/lib/ai/tools/copy-content-tools.ts
+++ b/apps/web/src/lib/ai/tools/copy-content-tools.ts
@@ -26,16 +26,13 @@ import { tool } from 'ai';
 import { z } from 'zod';
 import {
   LineRangeError,
+  canonicalizeForLineEditing,
   projectLines,
   replaceLines,
   insertLines,
   type LineEditResult,
 } from '@/lib/editor/line-edit';
-import {
-  isRawTextPage,
-  describeContentModeMismatch,
-  serializePageContentForAI,
-} from '../core/page-serializer';
+import { isRawTextPage, describeContentModeMismatch } from '../core/page-serializer';
 import { isSheetType } from '@pagespace/lib/sheets/sheet';
 import { PageType } from '@pagespace/lib/utils/enums';
 import { toModelOutputForCopyContent } from './copy-content-model-output';
@@ -217,6 +214,23 @@ const refuse = (error: string, message: string, extra: Record<string, unknown> =
   ...extra,
 });
 
+/**
+ * Whether a page's content is RAW TEXT rather than HTML.
+ *
+ * `isRawTextPage` answers this for documents and code, but a FILE page is a
+ * third case it does not cover: the processor stores EXTRACTED PLAINTEXT in
+ * `page.content` while the row keeps the schema default `contentMode: 'html'`.
+ * Trusting that default would label a .md or .json upload as HTML and let it
+ * through the compatibility check into an html-mode document, which is exactly
+ * the literal-text corruption that check exists to prevent.
+ *
+ * `describeContentModeMismatch` already states the same thing in prose — "a
+ * FILE [serializes] from extracted text — neither is HTML".
+ */
+function isRawTextSource(page: CopyPageRecord): boolean {
+  return page.type === PageType.FILE || isRawTextPage(page);
+}
+
 /** Page types whose content is not line-addressable text. */
 function rejectNonTextPage(page: CopyPageRecord, side: 'source' | 'destination'): Refusal | null {
   if (isSheetType(page.type as PageType)) {
@@ -269,12 +283,12 @@ export function createCopyContentTools(deps: CopyContentDeps) {
 
     // The SAME projection read_page shows, so a range copied from a fresh read
     // addresses the same lines the agent saw.
-    const serialized = serializePageContentForAI(page);
+    const serialized = canonicalizeForLineEditing(page.content, isRawTextSource(page));
     const allLines = serialized.split('\n');
     const totalLines = allLines.length;
 
     if (from.lineStart === undefined && from.lineEnd === undefined) {
-      return { bytes: serialized, label: `page:${page.id}`, isRawText: isRawTextPage(page) };
+      return { bytes: serialized, label: `page:${page.id}`, isRawText: isRawTextSource(page) };
     }
 
     const start = from.lineStart ?? 1;
@@ -289,7 +303,7 @@ export function createCopyContentTools(deps: CopyContentDeps) {
     return {
       bytes: allLines.slice(start - 1, end).join('\n'),
       label: `page:${page.id} lines ${start}-${end}`,
-      isRawText: isRawTextPage(page),
+      isRawText: isRawTextSource(page),
     };
   }
 
@@ -301,6 +315,12 @@ export function createCopyContentTools(deps: CopyContentDeps) {
     const pageId = resolveOrThrowPageId(to.pageId, context);
     const page = await deps.findPage(pageId);
     if (!page) return refuse('Destination page not found', `No page with ID "${pageId}".`);
+    // Permission FIRST: every refusal below names the page's title or type, so
+    // running them ahead of the check would tell a caller without edit access
+    // what the page is.
+    if (!(await deps.canEditPage(context, page.id))) {
+      return refuse('Insufficient permissions', 'You do not have edit access to this page.');
+    }
     if (page.type === PageType.FILE) {
       return refuse(
         'Cannot write to FILE pages',
@@ -310,10 +330,6 @@ export function createCopyContentTools(deps: CopyContentDeps) {
     }
     const rejected = rejectNonTextPage(page, 'destination');
     if (rejected) return rejected;
-    if (!(await deps.canEditPage(context, page.id))) {
-      return refuse('Insufficient permissions', `You do not have edit access to "${page.title}".`);
-    }
-
     // Byte-for-byte means byte-for-byte: this tool converts nothing. Raw text
     // written into an html-mode document renders as literal characters, which
     // is exactly the "literal garbage, not formatting" the writing-documents
@@ -358,16 +374,25 @@ export function createCopyContentTools(deps: CopyContentDeps) {
             expectedTotalLines: to.expectedTotalLines,
           });
           break;
-        case 'append':
-          // insertLines clamps to one past the last line, so "the end" is
-          // expressible without a separate append primitive.
+        case 'append': {
+          // insertLines clamps to one past the last line, so "the end" needs no
+          // separate primitive — but a trailing newline projects as a final
+          // EMPTY line, and inserting after that empty line yields a blank line
+          // between the old content and the copy ('a\n' -> 'a\n\n<copy>').
+          // Empty content is the same trap: it projects as one empty line, so
+          // a copy into an empty page would start with a blank line. Insert
+          // BEFORE that trailing empty line instead, which keeps the document's
+          // terminal newline exactly where it was.
+          const destLines = projectLines(page.content, destIsRawText);
+          const endsWithBlank = destLines[destLines.length - 1] === '';
           edit = insertLines({
             content: page.content,
-            startLine: lineCount + 1,
+            startLine: endsWithBlank ? destLines.length : destLines.length + 1,
             insertion: source.bytes,
             isRawText: destIsRawText,
           });
           break;
+        }
         case 'insertAfter': {
           const anchorIndex = projectLines(page.content, destIsRawText).findIndex((line) =>
             line.includes(to.anchor as string)

--- a/apps/web/src/lib/ai/tools/page-context-defaults.ts
+++ b/apps/web/src/lib/ai/tools/page-context-defaults.ts
@@ -19,9 +19,9 @@ export function resolveDefaultPageId(context: ToolExecutionContext | undefined):
 /**
  * Resolve an omitted `pageId` tool argument the same way across every page
  * tool that supports the default, or throw the identical, tool-agnostic
- * error message. Centralizing this keeps the 7 call sites (read_page,
- * replace_lines, rename_page, move_page, insert_content, edit_sheet_cells, read_sheet)
- * from silently drifting if the fallback or its wording ever needs to change.
+ * error message. Centralizing this keeps the call sites (read_page,
+ * replace_lines, rename_page, move_page, insert_content, edit_sheet_cells,
+ * read_sheet, copy_content) from silently drifting if the fallback or its wording ever needs to change.
  */
 export function resolveOrThrowPageId(
   pageIdArg: string | undefined,

--- a/apps/web/src/lib/ai/tools/page-write-tools.ts
+++ b/apps/web/src/lib/ai/tools/page-write-tools.ts
@@ -149,7 +149,14 @@ function logPageActivityAsync(
     });
 }
 
-async function buildAiMutationContext(
+/**
+ * Exported for `copy-content-tools-runtime.ts`: a copy into a page is a page
+ * mutation like any other and must carry the same AI-authorship metadata
+ * (actor, provider/model, agent chain). Rebuilding that shape there would let
+ * the two drift, and the drift would be invisible — activity rows would simply
+ * start disagreeing about who made the change.
+ */
+export async function buildAiMutationContext(
   context: ToolExecutionContext,
   options?: {
     metadata?: Record<string, unknown>;

--- a/apps/web/src/lib/ai/tools/tool-labels.ts
+++ b/apps/web/src/lib/ai/tools/tool-labels.ts
@@ -45,6 +45,7 @@ export const TOOL_NAME_MAP: Record<string, string> = {
   // Page write tools
   'replace_lines': 'Edit Document',
   'insert_content': 'Insert Content',
+  'copy_content': 'Copy Content',
   'create_page': 'Create Page',
   'rename_page': 'Rename Page',
   'trash_page': 'Move to Trash',

--- a/packages/lib/src/services/sandbox/__tests__/tool-runners.test.ts
+++ b/packages/lib/src/services/sandbox/__tests__/tool-runners.test.ts
@@ -1681,6 +1681,51 @@ describe('readSandboxFileForCopy', () => {
     expect(slots.released).toBe(1);
   });
 
+  it('given a binary file, should refuse rather than hand back a lossily-decoded copy', async () => {
+    // 0xFF/0xFE are not valid UTF-8. toString('utf8') turns them into U+FFFD
+    // without complaint, so a PNG would "copy" successfully and arrive corrupt.
+    const binary = Buffer.from([0x89, 0x50, 0x4e, 0x47, 0xff, 0xfe, 0x00, 0x01]);
+    const { deps } = makeDeps({
+      reconnect: async () => makeSandbox({ readFileToBuffer: async () => binary }),
+    });
+    const result = await readSandboxFileForCopy({ path: 'logo.png', ctx: makeCtx(), deps });
+    expect(result).toMatchObject({ success: false, reason: 'binary_content' });
+  });
+
+  it('given valid multi-byte UTF-8, should NOT mistake it for binary', async () => {
+    const { deps } = makeDeps({
+      reconnect: async () => makeSandbox({ readFileToBuffer: async () => Buffer.from('héllo 😀 ünïcødé') }),
+    });
+    const result = await readSandboxFileForCopy({ path: 'u.txt', ctx: makeCtx(), deps });
+    expect(result.success).toBe(true);
+    if (!result.success) return;
+    expect(result.content).toBe('héllo 😀 ünïcødé');
+  });
+
+  it('should measure the cap in BYTES, not characters', async () => {
+    // A multi-byte file whose character count sits exactly at the cap is twice
+    // that many bytes on disk, and must be refused.
+    //
+    // (Measuring the buffer rather than the decoded string is also more honest,
+    // but it is not independently observable: anything that reaches the success
+    // path round-trips, so the two lengths agree there by construction.)
+    const overCap = Buffer.from('é'.repeat(MAX_WRITE_BYTES)); // 2 bytes each
+    const { deps } = makeDeps({
+      reconnect: async () => makeSandbox({ readFileToBuffer: async () => overCap }),
+    });
+    const result = await readSandboxFileForCopy({ path: 'big.txt', ctx: makeCtx(), deps });
+    expect(result).toMatchObject({ success: false, reason: 'content_too_large' });
+  });
+
+  it('should report bytes as the file size on disk', async () => {
+    const { deps } = makeDeps({
+      reconnect: async () => makeSandbox({ readFileToBuffer: async () => Buffer.from('é') }),
+    });
+    const result = await readSandboxFileForCopy({ path: 'e.txt', ctx: makeCtx(), deps });
+    if (!result.success) return;
+    expect(result.bytes).toBe(2);
+  });
+
   it('preserves bytes exactly — CRLF, tabs, trailing newline, unicode', async () => {
     const tricky = 'a\r\n\tb\n😀\n\n';
     const { deps } = makeDeps({ reconnect: async () => fileOf(tricky) });

--- a/packages/lib/src/services/sandbox/__tests__/tool-runners.test.ts
+++ b/packages/lib/src/services/sandbox/__tests__/tool-runners.test.ts
@@ -3,6 +3,7 @@ import {
   runBashInSandbox,
   writeSandboxFile,
   readSandboxFile,
+  readSandboxFileForCopy,
   editSandboxFile,
   MAX_WRITE_BYTES,
   CHECKPOINT_TIMEOUT_MS,
@@ -12,7 +13,8 @@ import {
 import type { ExecutableSandbox, SandboxRunResult } from '../sandbox-client/types';
 import type { CodeExecutionAuditInput } from '../audit';
 import { SANDBOX_ROOT } from '../sandbox-paths';
-import { DEFAULT_READ_LINES, SANDBOX_MAX_OUTPUT_BYTES } from '../execution-policy';
+import { DEFAULT_READ_LINES, SANDBOX_MAX_OUTPUT_BYTES, MAX_LINE_BYTES } from '../execution-policy';
+import { LINE_ELISION_MARKER } from '../output-limit';
 
 const NOW = new Date('2026-06-01T12:00:00.000Z');
 
@@ -1593,5 +1595,97 @@ describe('runBashInSandbox — machine billing (Terminal Epic 3)', () => {
         workspaceId: 'shared-session-1',
       },
     ]);
+  });
+});
+
+describe('readSandboxFileForCopy', () => {
+  // This runner exists because everything readSandboxFile does to make a file
+  // safe for a MODEL corrupts bytes destined for STORAGE. Each case below pins
+  // one of those three transforms as absent.
+
+  const fileOf = (content: string) =>
+    makeSandbox({ readFileToBuffer: async () => Buffer.from(content) });
+
+  it('given a file longer than the read window, should return every line, not the first page', async () => {
+    const long = Array.from({ length: DEFAULT_READ_LINES * 2 }, (_, i) => `line ${i + 1}`).join('\n') + '\n';
+    const { deps } = makeDeps({ reconnect: async () => fileOf(long) });
+    const result = await readSandboxFileForCopy({ path: 'long.ts', ctx: makeCtx(), deps });
+    expect(result.success).toBe(true);
+    if (!result.success) return;
+    expect(result.content).toBe(long);
+  });
+
+  it('given a line longer than MAX_LINE_BYTES, should not clip it or staple on an elision marker', async () => {
+    const longLine = 'x'.repeat(MAX_LINE_BYTES * 3);
+    const { deps } = makeDeps({ reconnect: async () => fileOf(longLine) });
+    const result = await readSandboxFileForCopy({ path: 'min.js', ctx: makeCtx(), deps });
+    expect(result.success).toBe(true);
+    if (!result.success) return;
+    expect(result.content).toBe(longLine);
+    expect(result.content).not.toContain(LINE_ELISION_MARKER);
+  });
+
+  it('given a screenOutput hook, should NOT annotate — a copy is not model-visible output', async () => {
+    // readSandboxFile screens here on purpose. This path must not: the banner
+    // would land inside the user's document.
+    const { deps } = makeDeps({ screenOutput: async (t) => `[SCREENED]${t}` });
+    const result = await readSandboxFileForCopy({ path: 'a.txt', ctx: makeCtx(), deps });
+    expect(result.success).toBe(true);
+    if (!result.success) return;
+    expect(result.content).toBe('file-contents');
+    expect(result.content).not.toContain('[SCREENED]');
+  });
+
+  it('given a file over the write cap, should refuse rather than return a short copy', async () => {
+    const { deps } = makeDeps({ reconnect: async () => fileOf('y'.repeat(MAX_WRITE_BYTES + 1)) });
+    const result = await readSandboxFileForCopy({ path: 'huge.bin', ctx: makeCtx(), deps });
+    expect(result).toMatchObject({ success: false, reason: 'content_too_large' });
+  });
+
+  it('given a file exactly at the cap, should allow it', async () => {
+    const { deps } = makeDeps({ reconnect: async () => fileOf('y'.repeat(MAX_WRITE_BYTES)) });
+    const result = await readSandboxFileForCopy({ path: 'edge.bin', ctx: makeCtx(), deps });
+    expect(result.success).toBe(true);
+  });
+
+  it('given a missing file, should deny not_found', async () => {
+    const { deps } = makeDeps({ reconnect: async () => makeSandbox({ readFileToBuffer: async () => null }) });
+    const result = await readSandboxFileForCopy({ path: 'nope.txt', ctx: makeCtx(), deps });
+    expect(result).toMatchObject({ success: false, reason: 'not_found' });
+  });
+
+  it('given a traversal path, should deny path_escape before provisioning', async () => {
+    let acquired = false;
+    const { deps } = makeDeps({
+      acquireSandbox: async () => {
+        acquired = true;
+        return { ok: true, sandboxId: 'sbx-1', resumed: false, workspaceId: 'ws-1' };
+      },
+    });
+    const result = await readSandboxFileForCopy({ path: '/etc/passwd', ctx: makeCtx(), deps });
+    expect(result).toMatchObject({ success: false, reason: 'path_escape' });
+    expect(acquired).toBe(false);
+  });
+
+  it('given the kill switch off, should deny before touching a sandbox', async () => {
+    const { deps } = makeDeps({ isEnabled: () => false });
+    const result = await readSandboxFileForCopy({ path: 'a.txt', ctx: makeCtx(), deps });
+    expect(result).toMatchObject({ success: false, reason: 'kill_switch_off' });
+  });
+
+  it('given a successful copy read, should release its slot and audit', async () => {
+    const { deps, audits, slots } = makeDeps();
+    await readSandboxFileForCopy({ path: 'a.txt', ctx: makeCtx(), deps });
+    expect(audits[0]?.exitCode).toBe(0);
+    expect(audits[0]?.code).toContain('copyRead');
+    expect(slots.released).toBe(1);
+  });
+
+  it('preserves bytes exactly — CRLF, tabs, trailing newline, unicode', async () => {
+    const tricky = 'a\r\n\tb\n😀\n\n';
+    const { deps } = makeDeps({ reconnect: async () => fileOf(tricky) });
+    const result = await readSandboxFileForCopy({ path: 't.txt', ctx: makeCtx(), deps });
+    if (!result.success) return;
+    expect(result.content).toBe(tricky);
   });
 });

--- a/packages/lib/src/services/sandbox/tool-runners.ts
+++ b/packages/lib/src/services/sandbox/tool-runners.ts
@@ -372,6 +372,7 @@ export type SandboxToolDenialReason =
   | 'github_over_bash'
   | 'path_escape'
   | 'content_too_large'
+  | 'binary_content'
   | 'edit_no_match'
   | 'edit_not_unique'
   | 'no_session'
@@ -449,6 +450,8 @@ export const DENIAL_MESSAGES: Record<SandboxToolDenialReason, string> = {
     'The bash sandbox has no GitHub credentials. Use the dedicated git_*/gh_* tools for GitHub operations (e.g. git_clone, git_push, gh_pr_create) — they carry your connected GitHub auth.',
   path_escape: 'The path is invalid or escapes the sandbox root.',
   content_too_large: 'The file content is too large.',
+  binary_content:
+    'This file is not valid UTF-8 text, so it cannot be copied byte-for-byte through this tool — decoding it would silently replace the undecodable bytes. Use bash (cp/mv) to move binary files inside the sandbox.',
   edit_no_match:
     'The oldString was not found in the file. Read the file and copy the exact text to replace. '
     + 'If you read a windowed page of a long file, the text you are targeting may be in a part you have not read yet.',
@@ -1275,8 +1278,11 @@ export async function readSandboxFileForCopy({
         return fail('not_found');
       }
 
-      const content = buffer.toString('utf8');
-      const bytes = Buffer.byteLength(content, 'utf8');
+      // The cap is measured on the SOURCE BYTES, not on a decoded string: for
+      // anything that does not round-trip, the decoded form has a different
+      // length than the file on disk, and the wrong number would be the one
+      // enforced.
+      const bytes = buffer.byteLength;
       if (bytes > MAX_WRITE_BYTES) {
         await safeAudit(deps, ctx, {
           code: `copyRead ${path} (${bytes} bytes, over cap)`,
@@ -1284,6 +1290,21 @@ export async function readSandboxFileForCopy({
           durationMs,
         });
         return fail('content_too_large');
+      }
+
+      // `toString('utf8')` is LOSSY: undecodable bytes become U+FFFD, silently.
+      // A tool promising byte-exact copies must not hand back content that no
+      // longer matches the file — an image or archive would arrive corrupted
+      // and look like it copied fine. Re-encoding and comparing is the only
+      // honest check, so a non-text file is refused instead.
+      const content = buffer.toString('utf8');
+      if (Buffer.compare(Buffer.from(content, 'utf8'), buffer) !== 0) {
+        await safeAudit(deps, ctx, {
+          code: `copyRead ${path} (not utf-8)`,
+          exitCode: 1,
+          durationMs,
+        });
+        return fail('binary_content');
       }
 
       await safeAudit(deps, ctx, {

--- a/packages/lib/src/services/sandbox/tool-runners.ts
+++ b/packages/lib/src/services/sandbox/tool-runners.ts
@@ -412,6 +412,15 @@ export type ReadFileToolResult =
     }
   | { success: false; error: string; reason: SandboxToolDenialReason };
 
+/**
+ * `readSandboxFileForCopy`'s result. Deliberately NOT ReadFileToolResult: there
+ * is no `truncated`, no window and no notice, because this read either returns
+ * the file whole or fails. A partial success is not representable on purpose.
+ */
+export type ReadFileForCopyResult =
+  | { success: true; path: string; content: string; bytes: number }
+  | { success: false; error: string; reason: SandboxToolDenialReason };
+
 export type EditFileToolResult =
   | { success: true; path: string; replacements: number }
   | { success: false; error: string; reason: SandboxToolDenialReason };
@@ -1187,6 +1196,105 @@ export async function readSandboxFile({
   } finally {
     session.release();
   }
+  });
+}
+
+/**
+ * Read a sandbox file VERBATIM, for copying its bytes somewhere else.
+ *
+ * A sibling of `readSandboxFile`, not a caller of it, because everything that
+ * function does to make a file safe and affordable to put in front of a MODEL is
+ * corruption when the bytes are destined for storage:
+ *
+ *   - the line window (DEFAULT_READ_LINES) would copy the first page of a file
+ *     and call it the whole thing;
+ *   - the per-line clip (MAX_LINE_BYTES) would silently rewrite long lines and
+ *     staple LINE_ELISION_MARKER into the middle of the content;
+ *   - `deps.screenOutput` would, on a flagged file, wrap the copy in
+ *     `[UNTRUSTED TOOL OUTPUT …]` banners — text that exists to frame content
+ *     for a model, written here into a user's document.
+ *
+ * The injection seam is skipped rather than forgotten. It annotates
+ * model-visible output; these bytes are never returned to the model (the copy
+ * tool's `toModelOutput` reduces its result to counts), so there is no prompt to
+ * inject. Whatever later reads the destination applies its own seam.
+ *
+ * Refuses above MAX_WRITE_BYTES instead of truncating. A half-copied document
+ * looks complete — there is no notice attached to a page to say it was cut — so
+ * silently short content is a worse failure here than in a read.
+ */
+export async function readSandboxFileForCopy({
+  path,
+  ctx,
+  deps,
+}: {
+  path: string;
+  ctx: SandboxActorContext;
+  deps: SandboxRunDeps;
+}): Promise<ReadFileForCopyResult> {
+  if (!deps.isEnabled()) return fail('kill_switch_off');
+
+  const resolved = resolveSandboxPath(path);
+  if (!resolved) {
+    await safeAudit(deps, ctx, {
+      code: `copyRead ${path}`,
+      exitCode: null,
+      durationMs: 0,
+      anomaly: 'blocked_command',
+    });
+    return fail('path_escape');
+  }
+
+  return withMachineBilling<Extract<ReadFileForCopyResult, { success: true }>>(ctx, deps, async () => {
+    const session = await openSession(ctx, deps);
+    if (!session.ok) return fail(session.reason);
+
+    try {
+      const startedAt = deps.now();
+      let buffer: Buffer | null;
+      try {
+        buffer = await session.sandbox.readFileToBuffer({ path: resolved });
+      } catch {
+        const durationMs = deps.now().getTime() - startedAt.getTime();
+        await safeAudit(deps, ctx, {
+          code: `copyRead ${path}`,
+          exitCode: null,
+          durationMs,
+          anomaly: 'nonzero_exit',
+        });
+        return fail('execution_failed');
+      }
+      const durationMs = deps.now().getTime() - startedAt.getTime();
+      if (buffer === null) {
+        await safeAudit(deps, ctx, {
+          code: `copyRead ${path}`,
+          exitCode: 1,
+          durationMs,
+          anomaly: 'nonzero_exit',
+        });
+        return fail('not_found');
+      }
+
+      const content = buffer.toString('utf8');
+      const bytes = Buffer.byteLength(content, 'utf8');
+      if (bytes > MAX_WRITE_BYTES) {
+        await safeAudit(deps, ctx, {
+          code: `copyRead ${path} (${bytes} bytes, over cap)`,
+          exitCode: 1,
+          durationMs,
+        });
+        return fail('content_too_large');
+      }
+
+      await safeAudit(deps, ctx, {
+        code: `copyRead ${path} (${bytes} bytes)`,
+        exitCode: 0,
+        durationMs,
+      });
+      return { success: true, path, content, bytes };
+    } finally {
+      session.release();
+    }
   });
 }
 


### PR DESCRIPTION
Follows #2482. That PR fixed a read that lied about where it stopped; this one removes the reason an agent has to retype bytes it already has.

## The problem

Every write verb takes its content as a model-emitted string:

| Tool | Content arrives as |
|---|---|
| `replace_lines` / `insert_content` | `content: string` |
| `writeFile` | `content: string` |
| `editFile` | `oldString` / `newString` |
| `create_page` | *(takes no content at all)* |

So an agent that **already has** the bytes — a report it just built in the sandbox, a page it just read — must retype every one of them to move them anywhere. A 40 KB file costs roughly ten thousand output tokens to land as a page, and the model is the least reliable transcriber available: it paraphrases prose, drops blank lines, reflows whitespace. No copy primitive existed anywhere in the repo.

## The change

`copy_content` names a source and a destination and moves the bytes server-side. One tool, two sides, four paths: page→page, page→file, file→page, file→file.

```
copy_content({
  from: { kind: 'file', path: 'out/report.md' },
  to:   { kind: 'page', pageId: 'abc', mode: 'replace' }
})
```

Destination modes for a page: `replace`, `replaceLines`, `insertAfter` (anchor-based, like `insert_content`), `append`. A file destination is always a whole-file write.

It is deliberately thin — every arm delegates to whatever already owns that operation (`replaceLines`/`insertLines`/`insertAtAnchor` for the line math, `applyPageMutation` for the write, `writeSandboxFile` for the sandbox). Two things I planned to build turned out to exist already, so they aren't in the diff: `insertLines` clamps to one past the last line (so `append` needed no new primitive), and `page-serializer` already exported the content-mode helpers.

## The value is in what it does NOT do

- **Never converts.** Raw text into a page holding HTML renders as literal characters, so that combination is refused rather than performed.
- **Never truncates.** Over the size cap it refuses. A half-copied document *looks complete* — unlike a partial read, there is no notice riding along to say it was cut.
- **Never corrupts binaries.** A file that doesn't round-trip through UTF-8 is refused rather than silently decoded to U+FFFD.
- **Never wipes a destination with nothing.** An empty or whitespace-only source is refused — unless the caller named an explicit line range, which makes copying a blank line a deliberate act.
- **Never hands the bytes back to the model.** `toModelOutput` strips `oldContent`/`newContent`, which the diff renderer still gets from the persisted result. Without that, the tool would cost in input tokens exactly what it saved in output tokens.

## Three decisions worth reviewer attention

**1. Registered as a workspace tool, and the hole that opens.** The page→page arm touches no sandbox and the code-execution kill-switch is default-OFF, so registering it as a sandbox tool would hide page copying on every deployment — the mistake `ai-tools.ts` records making and reverting for the session family. But `filterToolsForSandboxEnablement` strips by **name** at assembly time, so a workspace tool survives it: an agent with `sandboxEnabled: false` could otherwise have reached files through this. The switch is therefore re-checked **at call time**, in the file arms only, and fails closed if it can't be read.

**2. `readSandboxFileForCopy` is a sibling of `readSandboxFile`, not a caller.** Since #2482, `readSandboxFile` windows by line, clips long lines, and runs the injection seam. All three are correct for text going to a model and all three are corruption for bytes going to storage — the `[UNTRUSTED TOOL OUTPUT]` banner in particular would be written into the user's document. The seam is skipped *deliberately*: it annotates model-visible output, and these bytes never reach the model.

**3. One content classifier, asked of both sides.** `contentShapeOf` returns `raw` / `html` / `unknown`. `unknown` (an empty page) is load-bearing: it accepts either, because treating "no evidence" as HTML refuses the canonical `create_page` → `copy_content` flow. The content vote is DOCUMENT-only, matching `describeContentModeMismatch` — a CANVAS is HTML by type and isn't asked to prove it, and `looksLikeHtmlDocument` wouldn't recognize one anyway (it keys on block tags, not `<!DOCTYPE>`).

Sheets are refused on both sides and pointed at `read_sheet` / `edit_sheet_cells`. FOLDER, AI_CHAT, CHANNEL and TASK_LIST are refused too — `create_page` seeds them with structured JSON, so a copy would destroy the page rather than edit it.

## Review history

Three adversarial rounds found 17 issues after the initial implementation; all are fixed, and each fix is mutation-checked. The two most serious:

- **file→file silently corrupted binaries** (`toString('utf8')` → U+FFFD), from a tool whose entire promise is byte-exactness.
- **Round 2's own content-mode fix was one-sided** and regressed the common case: an HTML page could no longer be copied into a freshly created empty page, and a page could not be copied into a sibling of the very shape the fix was written for. Round 2's test missed it by using a markdown-*mode* source. That's what round 3 unified.

Details in the PR comments.

## Testing

- 67 tool tests (9 of them schema-level — the schema previously had no coverage at all, since every test called `execute` directly), 6 renderer tests, 105 in the sandbox runner suite.
- `bunx turbo typecheck --concurrency=1`: 17/17. (Plain `bun run typecheck` intermittently reports `web#typecheck` failing here — it's a local race between `web#build` writing `.next/types` and `web#typecheck` reading them. CI's own TypeScript check is green.)
- 3008 passing across the affected web suites.
- **Every guard is mutation-checked**: reinstating any of the three transforms in the copy read, or breaking the content-shape gate, the empty-source refusal, the sandbox switch, the permission ordering, or the byte-stripping, each turns a distinct test red.

Two test files fail locally for environment reasons only (`activity-tools.test.ts` and two `*.integration.test.ts` need a provisioned test Postgres — `role "test" does not exist`). I touched none of them; CI runs them green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0178jJjAMg98jN1d6WRcyprC
