### PR TITLE
feat(app-hosting): awake-seconds metering and credit drain (ships dark)

### DIFF
--- a/apps/web/src/app/api/cron/meter-published-apps/route.ts
+++ b/apps/web/src/app/api/cron/meter-published-apps/route.ts
@@ -1,0 +1,148 @@
+import {
+  defaultAwakeMeterDeps,
+  meterAwakePublishedAppsSerialized,
+} from '@pagespace/lib/services/app-hosting/awake-meter';
+import * as Sentry from '@sentry/nextjs';
+import { audit } from '@pagespace/lib/audit/audit-log';
+import { loggers } from '@pagespace/lib/logging/logger-config';
+import { NextResponse } from 'next/server';
+import { validateSignedCronRequest } from '@/lib/auth/cron-auth';
+
+/**
+ * Cron endpoint that HEARTBEAT-SETTLES every awake published app.
+ *
+ * A published app's machine runs with `autostop: "off"` so that every awake
+ * boundary is an API call we made — but a machine can stay up for weeks between
+ * those boundaries, and settling only at stop would leave the whole of that time
+ * as an unbilled liability riding on one process not crashing. This tick bounds
+ * that exposure to the cadence, exactly as the realtime shell handler settles a
+ * live PTY rather than waiting for hangup. It also RE-GATES: the settle consumes
+ * the wake's hold, so each tick re-holds, and a payer who has run out of credits
+ * has their app stopped and parked instead of staying awake for free.
+ *
+ * SHIPS DARK. `APP_HOSTING_ENABLED` unset makes the meter report `disabled` and
+ * read nothing — and, critically, that is reported as a green 200. A dark feature
+ * must never redden a live cron.
+ *
+ * WHAT IS LOUD. Only conditions that mean real money went wrong on a feature that
+ * is actually running: a row source that could not be read at all (nothing was
+ * metered), and `settledButUnadvanced` (money moved and the window did not close,
+ * so the same span WILL be billed again next tick — a genuine double-bill in
+ * progress). `failed`, `unresolvedPayer` and `skipped` are per-row and
+ * self-correcting: the window stays open and the next tick bills it in full, so
+ * they are counted and audited rather than alerted on.
+ *
+ * As with the storage reconcile, the Sentry capture is what actually reaches a
+ * human — the docker cron invokes this through `curl -sS` without `-f`, so an
+ * HTTP 500 exits 0 and its body just lands in a log. The status code stays the
+ * honest answer for a caller that checks one.
+ *
+ * CONCURRENCY: `meterAwakePublishedAppsSerialized` holds a Postgres advisory
+ * try-lock for the whole run, so a second container, a manual trigger or an API
+ * invocation racing the schedule is a clean no-op rather than a double-bill —
+ * `trackUsage` and the watermark advance are two separate un-transactioned writes.
+ *
+ * Authentication: HMAC-signed request with X-Cron-Timestamp, X-Cron-Nonce,
+ * X-Cron-Signature headers.
+ */
+export async function GET(request: Request) {
+  const authError = validateSignedCronRequest(request);
+  if (authError) {
+    return authError;
+  }
+
+  try {
+    const run = await meterAwakePublishedAppsSerialized(defaultAwakeMeterDeps);
+
+    if (run.outcome === 'lock_busy') {
+      console.log('[Cron] Published-app awake meter: skipped — advisory lock held by another run');
+      return NextResponse.json({ success: true, outcome: 'lock_busy', timestamp: new Date().toISOString() });
+    }
+
+    if (run.outcome === 'disabled') {
+      // Not a failure and not an anomaly: APP_HOSTING_ENABLED is off, which is
+      // the default everywhere. Reported green so the cron stays quiet until the
+      // feature is switched on.
+      return NextResponse.json({ success: true, outcome: 'disabled', timestamp: new Date().toISOString() });
+    }
+
+    console.log(
+      `[Cron] Published-app awake meter: processed ${run.processed}, settled ${run.settled}, repaired ${run.repaired}, stamped ${run.stamped}, skipped ${run.skipped}, unresolvedPayer ${run.unresolvedPayer}, parked ${run.parked}, failed ${run.failed}, clamped ${run.clamped}, superseded ${run.watermarkSuperseded}, settledButUnadvanced ${run.settledButUnadvanced}, awakeSeconds ${run.totalAwakeSeconds.toFixed(1)}`,
+    );
+
+    audit({
+      eventType: 'data.write',
+      resourceType: 'cron_job',
+      resourceId: 'meter_published_apps',
+      details: {
+        processed: run.processed,
+        settled: run.settled,
+        // A window closed at a mirrored stop boundary — a stop whose status write
+        // was lost, repaired from the event mirror instead of billing a stopped
+        // machine until the weekly reconcile noticed.
+        repaired: run.repaired,
+        // A `running` row that carried no window. Its clock was started at NOW and
+        // nothing was billed for the unknown span; a count that stays above zero
+        // means machines are being started outside the wake seam.
+        stamped: run.stamped,
+        skipped: run.skipped,
+        unresolvedPayer: run.unresolvedPayer,
+        parked: run.parked,
+        failed: run.failed,
+        // Expected to be ZERO in steady state: a settle whose span exceeded a day
+        // and was shortened, which forgives revenue.
+        clamped: run.clamped,
+        watermarkSuperseded: run.watermarkSuperseded,
+        settledButUnadvanced: run.settledButUnadvanced,
+        totalAwakeSeconds: run.totalAwakeSeconds,
+        sourceFailed: run.sourceFailed,
+      },
+    });
+
+    const alertReason = run.sourceFailed
+      ? 'could not read its row source — no app was metered this tick'
+      : run.settledButUnadvanced > 0
+        ? `settled ${run.settledButUnadvanced} app(s) whose watermark did not advance — those windows will be billed again next tick`
+        : null;
+
+    if (alertReason) {
+      Sentry.captureException(new Error(`Published-app awake meter ${alertReason}`), {
+        level: 'error',
+        // Fingerprinted on the CAUSE, never the message: the message carries
+        // changing counts and would open a fresh issue per tick.
+        fingerprint: [run.sourceFailed ? 'awake-meter-source-unreadable' : 'awake-meter-settled-unadvanced'],
+        tags: {
+          check: 'published_app_awake_meter',
+          reason: run.sourceFailed ? 'source_unreadable' : 'settled_but_unadvanced',
+        },
+        extra: {
+          processed: run.processed,
+          settled: run.settled,
+          failed: run.failed,
+          settledButUnadvanced: run.settledButUnadvanced,
+          totalAwakeSeconds: run.totalAwakeSeconds,
+        },
+      });
+      // Deliberately not awaiting `Sentry.flush` — a long-lived container drains
+      // its own transport, and awaiting would add the flush timeout to every
+      // failing tick for no guarantee this endpoint could act on.
+      loggers.system.error(`[Cron] Published-app awake meter FAILED: ${alertReason}`);
+      return NextResponse.json(
+        { success: false, error: `published-app awake meter ${alertReason}`, ...run, timestamp: new Date().toISOString() },
+        { status: 500 },
+      );
+    }
+
+    return NextResponse.json({ success: true, ...run, timestamp: new Date().toISOString() });
+  } catch (error) {
+    loggers.system.error('[Cron] Error metering published-app awake seconds', error as Error);
+    return NextResponse.json(
+      { success: false, error: error instanceof Error ? error.message : 'Unknown error' },
+      { status: 500 },
+    );
+  }
+}
+
+export async function POST(request: Request) {
+  return GET(request);
+}

--- a/apps/web/src/app/api/cron/reconcile-app-awake-seconds/route.ts
+++ b/apps/web/src/app/api/cron/reconcile-app-awake-seconds/route.ts
@@ -1,0 +1,113 @@
+import {
+  defaultAwakeReconcileDeps,
+  reconcileAwakeSecondsSerialized,
+} from '@pagespace/lib/services/app-hosting/awake-reconcile';
+import * as Sentry from '@sentry/nextjs';
+import { audit } from '@pagespace/lib/audit/audit-log';
+import { loggers } from '@pagespace/lib/logging/logger-config';
+import { NextResponse } from 'next/server';
+import { validateSignedCronRequest } from '@/lib/auth/cron-auth';
+
+/**
+ * WEEKLY cron that checks what we billed for published-app awake time against
+ * Fly's managed Prometheus — the only independent record that a machine was up.
+ *
+ * Fly has no billing API, and its own machine event log holds only the last 20
+ * entries with no pagination, so awake-seconds history is NOT rebuildable after
+ * the fact: our own start/stop calls are the primary record and the local event
+ * mirror is where they are kept. Managed Prometheus retains roughly 15 days, which
+ * is what fixes this cadence — weekly leaves a full window of slack for one missed
+ * run, where monthly would routinely ask about samples that no longer exist.
+ *
+ * IT COMPARES AND ALERTS; IT MOVES NO MONEY. A scraped gauge is not evidence of a
+ * charge, and auto-adjusting a customer's ledger from one would let a metrics
+ * artifact issue refunds and back-charges nobody reviewed. What it produces is a
+ * named, DIRECTIONAL signal — `over_billed` (a customer paid for time Fly did not
+ * see: the serious direction) versus `under_billed` (a boundary we never recorded:
+ * our own loss) — while the window is still open for a human to act on.
+ *
+ * SHIPS DARK, TWICE OVER. `APP_HOSTING_ENABLED` off reports `disabled`; no
+ * Prometheus org slug or token reports `unconfigured`. Both are green 200s: a dark
+ * or unconfigured feature must never redden a cron.
+ *
+ * Authentication: HMAC-signed request with X-Cron-Timestamp, X-Cron-Nonce,
+ * X-Cron-Signature headers.
+ */
+export async function GET(request: Request) {
+  const authError = validateSignedCronRequest(request);
+  if (authError) {
+    return authError;
+  }
+
+  try {
+    const run = await reconcileAwakeSecondsSerialized(defaultAwakeReconcileDeps);
+
+    if (run.outcome === 'lock_busy') {
+      console.log('[Cron] Published-app awake reconcile: skipped — advisory lock held by another run');
+      return NextResponse.json({ success: true, outcome: 'lock_busy', timestamp: new Date().toISOString() });
+    }
+    if (run.outcome === 'disabled' || run.outcome === 'unconfigured') {
+      console.log(`[Cron] Published-app awake reconcile: ${run.outcome}`);
+      return NextResponse.json({ success: true, outcome: run.outcome, timestamp: new Date().toISOString() });
+    }
+
+    console.log(
+      `[Cron] Published-app awake reconcile: processed ${run.processed}, compared ${run.compared}, noSeries ${run.noSeries}, failed ${run.failed}, drifted ${run.drifted} (window ${run.windowDays}d)`,
+    );
+
+    audit({
+      eventType: 'data.read',
+      resourceType: 'cron_job',
+      resourceId: 'reconcile_app_awake_seconds',
+      details: {
+        processed: run.processed,
+        compared: run.compared,
+        // No `fly_instance_up` series at all — never woken, or aged out of
+        // retention. Ordinary, and not a fault.
+        noSeries: run.noSeries,
+        failed: run.failed,
+        drifted: run.drifted,
+        windowDays: run.windowDays,
+        // Worst first, over-billed ahead of under-billed. Capped for reporting;
+        // `drifted` is the true count.
+        reports: run.reports,
+      },
+    });
+
+    if (run.drifted > 0) {
+      // A WARNING, not an error, and deliberately so: drift is a finding for a
+      // human to read, not an incident to page on. The two directions are split
+      // into separate fingerprints because they are different problems with
+      // different owners — one is a possible refund, the other is our own
+      // unrecorded boundary.
+      const overBilled = run.reports.filter((report) => report.drift.direction === 'over_billed').length;
+      Sentry.captureMessage(
+        `Published-app awake reconcile found ${run.drifted} app(s) whose billed awake time disagrees with fly_instance_up`,
+        {
+          level: overBilled > 0 ? 'error' : 'warning',
+          fingerprint: [overBilled > 0 ? 'awake-reconcile-over-billed' : 'awake-reconcile-under-billed'],
+          tags: {
+            check: 'published_app_awake_reconcile',
+            reason: overBilled > 0 ? 'over_billed' : 'under_billed',
+          },
+          extra: { drifted: run.drifted, overBilled, compared: run.compared, reports: run.reports },
+        },
+      );
+    }
+
+    // Returned green even with drift: the run itself succeeded, and it did exactly
+    // what it exists to do. Failing the endpoint would make a finding look like an
+    // outage of the finder.
+    return NextResponse.json({ success: true, ...run, timestamp: new Date().toISOString() });
+  } catch (error) {
+    loggers.system.error('[Cron] Error reconciling published-app awake seconds', error as Error);
+    return NextResponse.json(
+      { success: false, error: error instanceof Error ? error.message : 'Unknown error' },
+      { status: 500 },
+    );
+  }
+}
+
+export async function POST(request: Request) {
+  return GET(request);
+}

--- a/apps/web/src/app/api/cron/reconcile-machine-storage/__tests__/route.test.ts
+++ b/apps/web/src/app/api/cron/reconcile-machine-storage/__tests__/route.test.ts
@@ -76,10 +76,11 @@ describe('/api/cron/reconcile-machine-storage', () => {
       // Two of the three rows had a positive accrual; the never-measured one
       // priced to $0 and is not billable.
       billableRows: 2,
-      billingByKind: { session: { billable: 1, charged: 1, skipped: 0, failed: 0 }, env: { billable: 1, charged: 1, skipped: 0, failed: 0 } },
+      billingByKind: { session: { billable: 1, charged: 1, skipped: 0, failed: 0 }, env: { billable: 1, charged: 1, skipped: 0, failed: 0 }, hosting: { billable: 0, charged: 0, skipped: 0, failed: 0 } },
       measurementHealth: {
         session: { live: 2, neverMeasured: 1, stale: 0 },
         env: { live: 1, neverMeasured: 0, stale: 0 },
+        hosting: { live: 0, neverMeasured: 0, stale: 0 },
       },
       failedSources: [],
       totalCostDollars: 0.001234,
@@ -126,6 +127,7 @@ describe('/api/cron/reconcile-machine-storage', () => {
           measurementHealth: {
             session: { live: 2, neverMeasured: 1, stale: 0 },
             env: { live: 1, neverMeasured: 0, stale: 0 },
+            hosting: { live: 0, neverMeasured: 0, stale: 0 },
           },
           failedSources: [],
         }),
@@ -143,10 +145,11 @@ describe('/api/cron/reconcile-machine-storage', () => {
       watermarkSuperseded: 0,
       spanClamped: 0,
       billableRows: 2,
-      billingByKind: { session: { billable: 1, charged: 1, skipped: 0, failed: 0 }, env: { billable: 1, charged: 1, skipped: 0, failed: 0 } },
+      billingByKind: { session: { billable: 1, charged: 1, skipped: 0, failed: 0 }, env: { billable: 1, charged: 1, skipped: 0, failed: 0 }, hosting: { billable: 0, charged: 0, skipped: 0, failed: 0 } },
       measurementHealth: {
         session: { live: 2, neverMeasured: 1, stale: 0 },
         env: { live: 1, neverMeasured: 0, stale: 0 },
+        hosting: { live: 0, neverMeasured: 0, stale: 0 },
       },
       failedSources: [],
     });
@@ -170,12 +173,13 @@ describe('/api/cron/reconcile-machine-storage', () => {
       watermarkSuperseded: 0,
       spanClamped: 0,
       billableRows: 0,
-      billingByKind: { session: { billable: 0, charged: 0, skipped: 0, failed: 0 }, env: { billable: 0, charged: 0, skipped: 0, failed: 0 } },
+      billingByKind: { session: { billable: 0, charged: 0, skipped: 0, failed: 0 }, env: { billable: 0, charged: 0, skipped: 0, failed: 0 }, hosting: { billable: 0, charged: 0, skipped: 0, failed: 0 } },
       measurementHealth: {
         session: { live: 2, neverMeasured: 1, stale: 0 },
         // The env LIST threw, so `listSource` yielded no rows and every env
         // counter is necessarily zero.
         env: { live: 0, neverMeasured: 0, stale: 0 },
+        hosting: { live: 0, neverMeasured: 0, stale: 0 },
       },
       failedSources: ['env'],
       totalCostDollars: 0.001234,
@@ -211,10 +215,11 @@ describe('/api/cron/reconcile-machine-storage', () => {
       watermarkSuperseded: 0,
       spanClamped: 0,
       billableRows: 0,
-      billingByKind: { session: { billable: 0, charged: 0, skipped: 0, failed: 0 }, env: { billable: 0, charged: 0, skipped: 0, failed: 0 } },
+      billingByKind: { session: { billable: 0, charged: 0, skipped: 0, failed: 0 }, env: { billable: 0, charged: 0, skipped: 0, failed: 0 }, hosting: { billable: 0, charged: 0, skipped: 0, failed: 0 } },
       measurementHealth: {
         session: { live: 0, neverMeasured: 0, stale: 0 },
         env: { live: 0, neverMeasured: 0, stale: 0 },
+        hosting: { live: 0, neverMeasured: 0, stale: 0 },
       },
       failedSources: ['session'],
       totalCostDollars: 0,
@@ -248,10 +253,11 @@ describe('/api/cron/reconcile-machine-storage', () => {
       watermarkSuperseded: 0,
       spanClamped: 0,
       billableRows: 3,
-      billingByKind: { session: { billable: 3, charged: 0, skipped: 3, failed: 0 }, env: { billable: 0, charged: 0, skipped: 0, failed: 0 } },
+      billingByKind: { session: { billable: 3, charged: 0, skipped: 3, failed: 0 }, env: { billable: 0, charged: 0, skipped: 0, failed: 0 }, hosting: { billable: 0, charged: 0, skipped: 0, failed: 0 } },
       measurementHealth: {
         session: { live: 3, neverMeasured: 0, stale: 0 },
         env: { live: 0, neverMeasured: 0, stale: 0 },
+        hosting: { live: 0, neverMeasured: 0, stale: 0 },
       },
       failedSources: [],
       totalCostDollars: 0,
@@ -283,10 +289,11 @@ describe('/api/cron/reconcile-machine-storage', () => {
       // All four HAD something to charge — that is what makes "every row failed"
       // evidence of a broken meter rather than a tick with nothing to do.
       billableRows: 4,
-      billingByKind: { session: { billable: 4, charged: 0, skipped: 0, failed: 4 }, env: { billable: 0, charged: 0, skipped: 0, failed: 0 } },
+      billingByKind: { session: { billable: 4, charged: 0, skipped: 0, failed: 4 }, env: { billable: 0, charged: 0, skipped: 0, failed: 0 }, hosting: { billable: 0, charged: 0, skipped: 0, failed: 0 } },
       measurementHealth: {
         session: { live: 2, neverMeasured: 0, stale: 0 },
         env: { live: 2, neverMeasured: 0, stale: 0 },
+        hosting: { live: 0, neverMeasured: 0, stale: 0 },
       },
       failedSources: [],
       totalCostDollars: 0,
@@ -322,10 +329,11 @@ describe('/api/cron/reconcile-machine-storage', () => {
       spanClamped: 0,
       // Twenty sessions had charges to make; the twenty-first row is the $0 env.
       billableRows: 20,
-      billingByKind: { session: { billable: 20, charged: 0, skipped: 20, failed: 0 }, env: { billable: 0, charged: 0, skipped: 0, failed: 0 } },
+      billingByKind: { session: { billable: 20, charged: 0, skipped: 20, failed: 0 }, env: { billable: 0, charged: 0, skipped: 0, failed: 0 }, hosting: { billable: 0, charged: 0, skipped: 0, failed: 0 } },
       measurementHealth: {
         session: { live: 20, neverMeasured: 0, stale: 0 },
         env: { live: 1, neverMeasured: 1, stale: 0 },
+        hosting: { live: 0, neverMeasured: 0, stale: 0 },
       },
       failedSources: [],
       totalCostDollars: 0,
@@ -356,10 +364,11 @@ describe('/api/cron/reconcile-machine-storage', () => {
       spanClamped: 0,
       billableRows: 12,
       // Ten sessions had charges to make and none landed; the two envs did.
-      billingByKind: { session: { billable: 10, charged: 0, skipped: 10, failed: 0 }, env: { billable: 2, charged: 2, skipped: 0, failed: 0 } },
+      billingByKind: { session: { billable: 10, charged: 0, skipped: 10, failed: 0 }, env: { billable: 2, charged: 2, skipped: 0, failed: 0 }, hosting: { billable: 0, charged: 0, skipped: 0, failed: 0 } },
       measurementHealth: {
         session: { live: 10, neverMeasured: 0, stale: 0 },
         env: { live: 2, neverMeasured: 0, stale: 0 },
+        hosting: { live: 0, neverMeasured: 0, stale: 0 },
       },
       failedSources: [],
       totalCostDollars: 0.02,
@@ -393,10 +402,12 @@ describe('/api/cron/reconcile-machine-storage', () => {
       billingByKind: {
         session: { billable: 3, charged: 0, skipped: 0, failed: 3 },
         env: { billable: 40, charged: 0, skipped: 40, failed: 0 },
+        hosting: { billable: 0, charged: 0, skipped: 0, failed: 0 },
       },
       measurementHealth: {
         session: { live: 3, neverMeasured: 0, stale: 0 },
         env: { live: 40, neverMeasured: 0, stale: 0 },
+        hosting: { live: 0, neverMeasured: 0, stale: 0 },
       },
       failedSources: [],
       totalCostDollars: 0,
@@ -425,10 +436,11 @@ describe('/api/cron/reconcile-machine-storage', () => {
       watermarkSuperseded: 0,
       spanClamped: 0,
       billableRows: 4,
-      billingByKind: { session: { billable: 4, charged: 1, skipped: 0, failed: 0 }, env: { billable: 0, charged: 0, skipped: 0, failed: 0 } },
+      billingByKind: { session: { billable: 4, charged: 1, skipped: 0, failed: 0 }, env: { billable: 0, charged: 0, skipped: 0, failed: 0 }, hosting: { billable: 0, charged: 0, skipped: 0, failed: 0 } },
       measurementHealth: {
         session: { live: 2, neverMeasured: 0, stale: 0 },
         env: { live: 2, neverMeasured: 0, stale: 0 },
+        hosting: { live: 0, neverMeasured: 0, stale: 0 },
       },
       failedSources: [],
       totalCostDollars: 0.5,
@@ -457,10 +469,11 @@ describe('/api/cron/reconcile-machine-storage', () => {
       watermarkSuperseded: 0,
       spanClamped: 0,
       billableRows: 0,
-      billingByKind: { session: { billable: 0, charged: 0, skipped: 0, failed: 0 }, env: { billable: 0, charged: 0, skipped: 0, failed: 0 } },
+      billingByKind: { session: { billable: 0, charged: 0, skipped: 0, failed: 0 }, env: { billable: 0, charged: 0, skipped: 0, failed: 0 }, hosting: { billable: 0, charged: 0, skipped: 0, failed: 0 } },
       measurementHealth: {
         session: { live: 1, neverMeasured: 0, stale: 0 },
         env: { live: 0, neverMeasured: 0, stale: 0 },
+        hosting: { live: 0, neverMeasured: 0, stale: 0 },
       },
       failedSources: [],
       totalCostDollars: 0,
@@ -485,10 +498,11 @@ describe('/api/cron/reconcile-machine-storage', () => {
       watermarkSuperseded: 0,
       spanClamped: 0,
       billableRows: 0,
-      billingByKind: { session: { billable: 0, charged: 0, skipped: 0, failed: 0 }, env: { billable: 0, charged: 0, skipped: 0, failed: 0 } },
+      billingByKind: { session: { billable: 0, charged: 0, skipped: 0, failed: 0 }, env: { billable: 0, charged: 0, skipped: 0, failed: 0 }, hosting: { billable: 0, charged: 0, skipped: 0, failed: 0 } },
       measurementHealth: {
         session: { live: 0, neverMeasured: 0, stale: 0 },
         env: { live: 0, neverMeasured: 0, stale: 0 },
+        hosting: { live: 0, neverMeasured: 0, stale: 0 },
       },
       failedSources: [],
       totalCostDollars: 0,
@@ -517,10 +531,11 @@ describe('/api/cron/reconcile-machine-storage', () => {
       watermarkSuperseded: 0,
       spanClamped: 0,
       billableRows: 3,
-      billingByKind: { session: { billable: 0, charged: 0, skipped: 0, failed: 0 }, env: { billable: 3, charged: 0, skipped: 0, failed: 0 } },
+      billingByKind: { session: { billable: 0, charged: 0, skipped: 0, failed: 0 }, env: { billable: 3, charged: 0, skipped: 0, failed: 0 }, hosting: { billable: 0, charged: 0, skipped: 0, failed: 0 } },
       measurementHealth: {
         session: { live: 0, neverMeasured: 0, stale: 0 },
         env: { live: 3, neverMeasured: 0, stale: 0 },
+        hosting: { live: 0, neverMeasured: 0, stale: 0 },
       },
       failedSources: [],
       totalCostDollars: 0,
@@ -548,10 +563,11 @@ describe('/api/cron/reconcile-machine-storage', () => {
       watermarkSuperseded: 0,
       spanClamped: 0,
       billableRows: 0,
-      billingByKind: { session: { billable: 0, charged: 0, skipped: 0, failed: 0 }, env: { billable: 0, charged: 0, skipped: 0, failed: 0 } },
+      billingByKind: { session: { billable: 0, charged: 0, skipped: 0, failed: 0 }, env: { billable: 0, charged: 0, skipped: 0, failed: 0 }, hosting: { billable: 0, charged: 0, skipped: 0, failed: 0 } },
       measurementHealth: {
         session: { live: 0, neverMeasured: 0, stale: 0 },
         env: { live: 3, neverMeasured: 0, stale: 0 },
+        hosting: { live: 0, neverMeasured: 0, stale: 0 },
       },
       failedSources: [],
       totalCostDollars: 0,

--- a/apps/web/src/app/api/cron/reconcile-machine-storage/route.ts
+++ b/apps/web/src/app/api/cron/reconcile-machine-storage/route.ts
@@ -17,13 +17,13 @@ import { validateSignedCronRequest } from '@/lib/auth/cron-auth';
  * footprint. It NEVER wakes a sprite to measure; a never-measured row bills a
  * conservative 0 for that window.
  *
- * TWO persistence units, ONE meter and ONE schedule: agent SESSIONS (billed to
+ * THREE persistence units, ONE meter and ONE schedule: agent SESSIONS (billed to
  * the session's drive owner, or to its own owner for a global-assistant
- * session) and drive ENVIRONMENTS (billed to the DRIVE OWNER, with no
- * fallback — an unresolvable drive skips the cycle rather than misattributing
- * a charge). Envs joined as a row source deliberately, rather than as a second
- * cron: the counters below aggregate both, and there is exactly one advisory
- * lock standing between a rolling deploy and a double-bill.
+ * session), drive ENVIRONMENTS, and published-app ROOTFS (both billed to the
+ * DRIVE OWNER, with no fallback — an unresolvable drive skips the cycle rather
+ * than misattributing a charge). Each joined as a row source deliberately, rather
+ * than as another cron: the counters below aggregate all three, and there is
+ * exactly one advisory lock standing between a rolling deploy and a double-bill.
  *
  * A tick that accomplished nothing it should have raises a SENTRY alert and
  * fails this endpoint (500, after the work that succeeded is reported) — left
@@ -32,10 +32,11 @@ import { validateSignedCronRequest } from '@/lib/auth/cron-auth';
  * unreadable unit never stops the other's billing; what changes here is only how
  * the tick is reported.
  *
- * Severity is split by whether the unit is LIVE. Envs ship dark, so an
- * unreadable `drive_envs` is captured as a warning and the tick still succeeds —
- * a dark feature must not redden a cron that is metering real sessions
- * correctly. The session source, and a whole-tick billing wipeout, are loud.
+ * Severity is split by whether the unit is LIVE. Envs and published apps both
+ * ship dark, so an unreadable `drive_envs` or `published_apps` is captured as a
+ * warning and the tick still succeeds — a dark feature must not redden a cron that
+ * is metering real sessions correctly. The session source, and a whole-tick
+ * billing wipeout, are loud.
  *
  * The Sentry call is the part that actually alerts, and it is not belt-and-braces:
  * the docker cron invokes this through `cron-curl`, which runs `curl -sS`
@@ -84,7 +85,7 @@ export async function GET(request: Request) {
     }
 
     console.log(
-      `[Cron] Terminal storage reconcile: processed ${run.processed}, charged ${run.charged}, skipped ${run.skipped}, failed ${run.failed}, chargedButUnadvanced ${run.chargedButUnadvanced}, stale ${run.staleMeasurements}, superseded ${run.watermarkSuperseded}, spanClamped ${run.spanClamped}, billable ${run.billableRows}, neverMeasured ${run.neverMeasured} (sessions ${run.measurementHealth.session.neverMeasured}/${run.measurementHealth.session.live}, envs ${run.measurementHealth.env.neverMeasured}/${run.measurementHealth.env.live}), failedSources [${run.failedSources.join(', ')}], total $${run.totalCostDollars.toFixed(6)}`,
+      `[Cron] Terminal storage reconcile: processed ${run.processed}, charged ${run.charged}, skipped ${run.skipped}, failed ${run.failed}, chargedButUnadvanced ${run.chargedButUnadvanced}, stale ${run.staleMeasurements}, superseded ${run.watermarkSuperseded}, spanClamped ${run.spanClamped}, billable ${run.billableRows}, neverMeasured ${run.neverMeasured} (sessions ${run.measurementHealth.session.neverMeasured}/${run.measurementHealth.session.live}, envs ${run.measurementHealth.env.neverMeasured}/${run.measurementHealth.env.live}, hosting ${run.measurementHealth.hosting.neverMeasured}/${run.measurementHealth.hosting.live}), failedSources [${run.failedSources.join(', ')}], total $${run.totalCostDollars.toFixed(6)}`,
     );
 
     audit({
@@ -149,6 +150,10 @@ export async function GET(request: Request) {
     // fault is discoverable without being an incident. When envs become
     // user-visible this distinction goes away and the env source joins the loud
     // set; the `LOUD_SOURCES` list below is the one line that changes.
+    //
+    // Published-app rootfs is the same case for the same reason — dark behind
+    // APP_HOSTING_ENABLED, nothing provisions one yet — and joins the loud set on
+    // that same line when hosting launches.
     //
     // What IS loud: the SESSION source failing (real money, live feature), and a
     // tick where every row of more than one failed to bill. That `> 1` is the

--- a/apps/web/src/lib/subscription/usage-breakdown.ts
+++ b/apps/web/src/lib/subscription/usage-breakdown.ts
@@ -213,6 +213,15 @@ export function aggregateUsageBreakdown(
       eb.calls += 1;
       environmentBuckets.set(envKey, eb);
     } else if (source === 'terminal') {
+      // NOTE: published-app rows (`published-app-awake` runtime and
+      // `published-app-storage` rootfs) land HERE, in the unattributed-agent
+      // line, for exactly the reason env rows used to: `source: 'terminal'`, no
+      // `pageId`, and an id on `sessionId` that addresses a different table. It
+      // is the same deferred gap, ratified the same way — hosting has no user
+      // -visible surface yet and bills nothing today, and the honest fix is a
+      // first-class subject discriminator on the usage row rather than a second
+      // model-string special case here. A published-apps section lands with the
+      // hosting UI, alongside the environments one above.
       agentSessionMillicents += charge;
       // Rows without a resolvable page (pre-attribution history, or a session
       // with no backing page e.g. the global assistant) collapse into one

--- a/docker/cron/crontab
+++ b/docker/cron/crontab
@@ -140,3 +140,30 @@
 # this window (an orphan reaped mid-tick on any OTHER minute) remains an
 # accepted residual risk — see findStorageDriftCandidates's doc.
 5,20,35,50 * * * * flock -n /run/reconcile-storage.lock cron-curl GET __WEB_URL__/api/cron/reconcile-storage >> /var/log/cron/reconcile-storage.log 2>&1 || echo "$(date -u) tick skipped (lock held) or request failed" >> /var/log/cron/reconcile-storage.log
+
+# Published-app awake meter - Every 10 minutes
+# Heartbeat-settles awake-seconds for every published app whose machine is up, and
+# re-holds against the payer's balance on each tick. A published app's machine runs
+# with autostop off so that every awake boundary is an API call we made — but it can
+# stay up for weeks between those boundaries, and settling only at stop would leave
+# the whole of that time riding on one process not crashing. Ten minutes matches the
+# realtime shell handler's settle cadence and bounds the loss to one tick.
+# The re-hold is also what makes the credit gate keep binding on a long-lived app:
+# a payer who runs out mid-window has their machine stopped and PARKED rather than
+# staying awake for free (parking on the DAILY CAP stays with the idle reaper).
+# The route holds a Postgres advisory lock across ALL callers — trackUsage and the
+# watermark advance are two separate un-transactioned writes, so overlapping runs
+# could double-bill; flock -n is this container's own defense in depth.
+# Dark until APP_HOSTING_ENABLED=true, when it reports `disabled` and reads nothing.
+*/10 * * * * flock -n /run/meter-published-apps.lock cron-curl GET __WEB_URL__/api/cron/meter-published-apps >> /var/log/cron/meter-published-apps.log 2>&1 || echo "$(date -u) tick skipped (lock held) or request failed" >> /var/log/cron/meter-published-apps.log
+
+# Published-app awake-seconds reconcile - Weekly on Mondays at 3:30am UTC
+# Compares the awake-seconds implied by our own mirrored start/stop boundaries
+# against Fly's managed Prometheus (fly_instance_up), which retains ~15 days. That
+# retention is what fixes the cadence: weekly leaves a full window of slack for one
+# missed run, where monthly would routinely ask about samples that no longer exist.
+# Fly's own machine event log keeps only the last 20 entries, so awake history is
+# NOT rebuildable after the fact — published_app_machine_events is the record, and
+# this is the check on it. It COMPARES AND ALERTS; it never moves money (a scraped
+# gauge is not evidence of a charge). Inert with no FLY_PROMETHEUS_ORG_SLUG.
+30 3 * * 1 flock -n /run/reconcile-app-awake-seconds.lock cron-curl GET __WEB_URL__/api/cron/reconcile-app-awake-seconds >> /var/log/cron/reconcile-app-awake-seconds.log 2>&1 || echo "$(date -u) tick skipped (lock held) or request failed" >> /var/log/cron/reconcile-app-awake-seconds.log

--- a/packages/db/drizzle/0274_swift_reaper.sql
+++ b/packages/db/drizzle/0274_swift_reaper.sql
@@ -1,0 +1,38 @@
+CREATE TABLE "published_app_machine_events" (
+	"id" text PRIMARY KEY NOT NULL,
+	"publishedAppId" text NOT NULL,
+	"flyAppName" text NOT NULL,
+	"machineId" text NOT NULL,
+	"origin" text NOT NULL,
+	"action" text NOT NULL,
+	"flyEventId" text,
+	"flyEventType" text,
+	"flyEventStatus" text,
+	"occurredAt" timestamp with time zone NOT NULL,
+	"recordedAt" timestamp with time zone DEFAULT now() NOT NULL,
+	CONSTRAINT "published_app_machine_events_origin_allowed" CHECK ("published_app_machine_events"."origin" IN ('orchestrator', 'fly')),
+	CONSTRAINT "published_app_machine_events_action_allowed" CHECK ("published_app_machine_events"."action" IN ('start', 'stop')),
+	CONSTRAINT "published_app_machine_events_fly_event_id_coherent" CHECK (("published_app_machine_events"."origin" = 'fly') = ("published_app_machine_events"."flyEventId" IS NOT NULL))
+);
+--> statement-breakpoint
+ALTER TABLE "published_apps" ADD COLUMN "imageSizeMeasuredAt" timestamp with time zone;--> statement-breakpoint
+ALTER TABLE "published_apps" ADD COLUMN "awakeBilledThrough" timestamp with time zone;--> statement-breakpoint
+ALTER TABLE "published_apps" ADD COLUMN "awakeHoldId" text;--> statement-breakpoint
+ALTER TABLE "published_apps" ADD COLUMN "storageLastBilledAt" timestamp with time zone DEFAULT now() NOT NULL;--> statement-breakpoint
+ALTER TABLE "published_app_machine_events" ADD CONSTRAINT "published_app_machine_events_publishedAppId_published_apps_id_fk" FOREIGN KEY ("publishedAppId") REFERENCES "public"."published_apps"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+CREATE INDEX "published_app_machine_events_app_idx" ON "published_app_machine_events" USING btree ("publishedAppId","occurredAt");--> statement-breakpoint
+CREATE UNIQUE INDEX "published_app_machine_events_fly_event_unique" ON "published_app_machine_events" USING btree ("machineId","flyEventId") WHERE "flyEventId" IS NOT NULL;--> statement-breakpoint
+-- Hand-added backfill (the only hand-added content in this file). Postgres
+-- validates a CHECK against every existing row the moment it is added, and a row
+-- built before this migration already carries an `imageSizeBytes` while the column
+-- beside it is necessarily NULL — so without this UPDATE the constraint below
+-- fails on any deployment that has ever built a published app, and the migration
+-- one-shot blocks the whole release. Dated from `updatedAt`, the closest record
+-- this schema keeps of when that size was written; the storage meter reads the
+-- age as measurement staleness, which for a legacy size is exactly true.
+-- It cannot be a separate migration: `runMigrations` applies every pending entry
+-- in ONE invocation, so a backfill registered after this file would still run
+-- after the constraint it exists to satisfy.
+UPDATE "published_apps" SET "imageSizeMeasuredAt" = "updatedAt" WHERE "imageSizeBytes" IS NOT NULL AND "imageSizeMeasuredAt" IS NULL;--> statement-breakpoint
+ALTER TABLE "published_apps" ADD CONSTRAINT "published_apps_image_size_measured_coherent" CHECK (("published_apps"."imageSizeBytes" IS NULL) = ("published_apps"."imageSizeMeasuredAt" IS NULL));--> statement-breakpoint
+ALTER TABLE "published_apps" ADD CONSTRAINT "published_apps_awake_window_needs_wake" CHECK ("published_apps"."awakeBilledThrough" IS NULL OR "published_apps"."lastWakeAt" IS NOT NULL);

--- a/packages/db/drizzle/meta/0274_snapshot.json
+++ b/packages/db/drizzle/meta/0274_snapshot.json
@@ -1,0 +1,23231 @@
+{
+  "id": "66ad2306-8aed-4236-96be-3ec6525b63fe",
+  "prevId": "0f9669ac-2e27-4f85-b8a9-871465b2918f",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.device_tokens": {
+      "name": "device_tokens",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tokenHash": {
+          "name": "tokenHash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tokenPrefix": {
+          "name": "tokenPrefix",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expiresAt": {
+          "name": "expiresAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "lastUsedAt": {
+          "name": "lastUsedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deviceId": {
+          "name": "deviceId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "platform": {
+          "name": "platform",
+          "type": "PlatformType",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "deviceName": {
+          "name": "deviceName",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tokenVersion": {
+          "name": "tokenVersion",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "userAgent": {
+          "name": "userAgent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ipAddress": {
+          "name": "ipAddress",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lastIpAddress": {
+          "name": "lastIpAddress",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "location": {
+          "name": "location",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "trustScore": {
+          "name": "trustScore",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "suspiciousActivityCount": {
+          "name": "suspiciousActivityCount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "revokedAt": {
+          "name": "revokedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revokedReason": {
+          "name": "revokedReason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "replacedByTokenId": {
+          "name": "replacedByTokenId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "device_tokens_user_id_idx": {
+          "name": "device_tokens_user_id_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "device_tokens_token_hash_idx": {
+          "name": "device_tokens_token_hash_idx",
+          "columns": [
+            {
+              "expression": "tokenHash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "device_tokens_device_id_idx": {
+          "name": "device_tokens_device_id_idx",
+          "columns": [
+            {
+              "expression": "deviceId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "device_tokens_expires_at_idx": {
+          "name": "device_tokens_expires_at_idx",
+          "columns": [
+            {
+              "expression": "expiresAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "device_tokens_active_device_idx": {
+          "name": "device_tokens_active_device_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deviceId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "platform",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"device_tokens\".\"revokedAt\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "device_tokens_userId_users_id_fk": {
+          "name": "device_tokens_userId_users_id_fk",
+          "tableFrom": "device_tokens",
+          "tableTo": "users",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "device_tokens_tokenHash_unique": {
+          "name": "device_tokens_tokenHash_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "tokenHash"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.email_unsubscribe_tokens": {
+      "name": "email_unsubscribe_tokens",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_prefix": {
+          "name": "token_prefix",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "notification_type": {
+          "name": "notification_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "used_at": {
+          "name": "used_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "email_unsubscribe_tokens_token_hash_idx": {
+          "name": "email_unsubscribe_tokens_token_hash_idx",
+          "columns": [
+            {
+              "expression": "token_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "email_unsubscribe_tokens_user_id_idx": {
+          "name": "email_unsubscribe_tokens_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "email_unsubscribe_tokens_expires_at_idx": {
+          "name": "email_unsubscribe_tokens_expires_at_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "email_unsubscribe_tokens_user_id_users_id_fk": {
+          "name": "email_unsubscribe_tokens_user_id_users_id_fk",
+          "tableFrom": "email_unsubscribe_tokens",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "email_unsubscribe_tokens_token_hash_unique": {
+          "name": "email_unsubscribe_tokens_token_hash_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token_hash"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.mcp_tokens": {
+      "name": "mcp_tokens",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tokenHash": {
+          "name": "tokenHash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tokenPrefix": {
+          "name": "tokenPrefix",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "isScoped": {
+          "name": "isScoped",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "lastUsed": {
+          "name": "lastUsed",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "revokedAt": {
+          "name": "revokedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "mcp_tokens_user_id_idx": {
+          "name": "mcp_tokens_user_id_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "mcp_tokens_token_hash_idx": {
+          "name": "mcp_tokens_token_hash_idx",
+          "columns": [
+            {
+              "expression": "tokenHash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "mcp_tokens_userId_users_id_fk": {
+          "name": "mcp_tokens_userId_users_id_fk",
+          "tableFrom": "mcp_tokens",
+          "tableTo": "users",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "mcp_tokens_tokenHash_unique": {
+          "name": "mcp_tokens_tokenHash_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "tokenHash"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.passkeys": {
+      "name": "passkeys",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "credential_id": {
+          "name": "credential_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "public_key": {
+          "name": "public_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "counter": {
+          "name": "counter",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "device_type": {
+          "name": "device_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "transports": {
+          "name": "transports",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "backed_up": {
+          "name": "backed_up",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "passkeys_user_id_idx": {
+          "name": "passkeys_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "passkeys_credential_id_idx": {
+          "name": "passkeys_credential_id_idx",
+          "columns": [
+            {
+              "expression": "credential_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "passkeys_user_id_users_id_fk": {
+          "name": "passkeys_user_id_users_id_fk",
+          "tableFrom": "passkeys",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "passkeys_credential_id_unique": {
+          "name": "passkeys_credential_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "credential_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.socket_tokens": {
+      "name": "socket_tokens",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tokenHash": {
+          "name": "tokenHash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expiresAt": {
+          "name": "expiresAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "socket_tokens_user_id_idx": {
+          "name": "socket_tokens_user_id_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "socket_tokens_token_hash_idx": {
+          "name": "socket_tokens_token_hash_idx",
+          "columns": [
+            {
+              "expression": "tokenHash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "socket_tokens_expires_at_idx": {
+          "name": "socket_tokens_expires_at_idx",
+          "columns": [
+            {
+              "expression": "expiresAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "socket_tokens_userId_users_id_fk": {
+          "name": "socket_tokens_userId_users_id_fk",
+          "tableFrom": "socket_tokens",
+          "tableTo": "users",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "socket_tokens_tokenHash_unique": {
+          "name": "socket_tokens_tokenHash_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "tokenHash"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "emailBidx": {
+          "name": "emailBidx",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "emailVerified": {
+          "name": "emailVerified",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "googleId": {
+          "name": "googleId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "appleId": {
+          "name": "appleId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider": {
+          "name": "provider",
+          "type": "AuthProvider",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'email'"
+        },
+        "tokenVersion": {
+          "name": "tokenVersion",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "role": {
+          "name": "role",
+          "type": "UserRole",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'user'"
+        },
+        "adminRoleVersion": {
+          "name": "adminRoleVersion",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "currentAiProvider": {
+          "name": "currentAiProvider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'openai'"
+        },
+        "currentAiModel": {
+          "name": "currentAiModel",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'openai/gpt-5.6-luna'"
+        },
+        "imageGenerationModel": {
+          "name": "imageGenerationModel",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "storageUsedBytes": {
+          "name": "storageUsedBytes",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "activeUploads": {
+          "name": "activeUploads",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "lastStorageCalculated": {
+          "name": "lastStorageCalculated",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stripeCustomerId": {
+          "name": "stripeCustomerId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "subscriptionTier": {
+          "name": "subscriptionTier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'free'"
+        },
+        "tosAcceptedAt": {
+          "name": "tosAcceptedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "failedLoginAttempts": {
+          "name": "failedLoginAttempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "lockedUntil": {
+          "name": "lockedUntil",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "suspendedAt": {
+          "name": "suspendedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "suspendedReason": {
+          "name": "suspendedReason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "timezone": {
+          "name": "timezone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "starterSkillsInstalledAt": {
+          "name": "starterSkillsInstalledAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "users_email_bidx_idx": {
+          "name": "users_email_bidx_idx",
+          "columns": [
+            {
+              "expression": "emailBidx",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        },
+        "users_googleId_unique": {
+          "name": "users_googleId_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "googleId"
+          ]
+        },
+        "users_appleId_unique": {
+          "name": "users_appleId_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "appleId"
+          ]
+        },
+        "users_stripeCustomerId_unique": {
+          "name": "users_stripeCustomerId_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "stripeCustomerId"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.verification_tokens": {
+      "name": "verification_tokens",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tokenHash": {
+          "name": "tokenHash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tokenPrefix": {
+          "name": "tokenPrefix",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expiresAt": {
+          "name": "expiresAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "usedAt": {
+          "name": "usedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "verification_tokens_user_id_idx": {
+          "name": "verification_tokens_user_id_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "verification_tokens_token_hash_idx": {
+          "name": "verification_tokens_token_hash_idx",
+          "columns": [
+            {
+              "expression": "tokenHash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "verification_tokens_type_idx": {
+          "name": "verification_tokens_type_idx",
+          "columns": [
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "verification_tokens_userId_users_id_fk": {
+          "name": "verification_tokens_userId_users_id_fk",
+          "tableFrom": "verification_tokens",
+          "tableTo": "users",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "verification_tokens_tokenHash_unique": {
+          "name": "verification_tokens_tokenHash_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "tokenHash"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sessions": {
+      "name": "sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_prefix": {
+          "name": "token_prefix",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "device_id": {
+          "name": "device_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "ARRAY[]::text[]"
+        },
+        "resource_type": {
+          "name": "resource_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resource_id": {
+          "name": "resource_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "drive_id": {
+          "name": "drive_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "token_version": {
+          "name": "token_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "admin_role_version": {
+          "name": "admin_role_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_by_service": {
+          "name": "created_by_service",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by_ip": {
+          "name": "created_by_ip",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_used_ip": {
+          "name": "last_used_ip",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revoked_reason": {
+          "name": "revoked_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "sessions_user_id_idx": {
+          "name": "sessions_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sessions_expires_at_idx": {
+          "name": "sessions_expires_at_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sessions_user_active_idx": {
+          "name": "sessions_user_active_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "revoked_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sessions_user_device_idx": {
+          "name": "sessions_user_device_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "device_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "sessions_user_id_users_id_fk": {
+          "name": "sessions_user_id_users_id_fk",
+          "tableFrom": "sessions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "sessions_token_hash_unique": {
+          "name": "sessions_token_hash_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token_hash"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.drives": {
+      "name": "drives",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ownerId": {
+          "name": "ownerId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "DriveKind",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'STANDARD'"
+        },
+        "isTrashed": {
+          "name": "isTrashed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "trashedAt": {
+          "name": "trashedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "drivePrompt": {
+          "name": "drivePrompt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "publishSubdomain": {
+          "name": "publishSubdomain",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "homePageId": {
+          "name": "homePageId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "publish_default_og_image_url": {
+          "name": "publish_default_og_image_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "not_found_page_id": {
+          "name": "not_found_page_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "publish_favicon_url": {
+          "name": "publish_favicon_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "drives_owner_id_idx": {
+          "name": "drives_owner_id_idx",
+          "columns": [
+            {
+              "expression": "ownerId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "drives_owner_id_slug_key": {
+          "name": "drives_owner_id_slug_key",
+          "columns": [
+            {
+              "expression": "ownerId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "drives_owner_home_unique": {
+          "name": "drives_owner_home_unique",
+          "columns": [
+            {
+              "expression": "ownerId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"drives\".\"kind\" = 'HOME'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "drives_ownerId_users_id_fk": {
+          "name": "drives_ownerId_users_id_fk",
+          "tableFrom": "drives",
+          "tableTo": "users",
+          "columnsFrom": [
+            "ownerId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "drives_homePageId_pages_id_fk": {
+          "name": "drives_homePageId_pages_id_fk",
+          "tableFrom": "drives",
+          "tableTo": "pages",
+          "columnsFrom": [
+            "homePageId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "drives_not_found_page_id_pages_id_fk": {
+          "name": "drives_not_found_page_id_pages_id_fk",
+          "tableFrom": "drives",
+          "tableTo": "pages",
+          "columnsFrom": [
+            "not_found_page_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "drives_publishSubdomain_unique": {
+          "name": "drives_publishSubdomain_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "publishSubdomain"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.favorites": {
+      "name": "favorites",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "itemType": {
+          "name": "itemType",
+          "type": "FavoriteItemType",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'page'"
+        },
+        "pageId": {
+          "name": "pageId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "driveId": {
+          "name": "driveId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "favorites_user_id_page_id_key": {
+          "name": "favorites_user_id_page_id_key",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "pageId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "favorites_user_id_drive_id_key": {
+          "name": "favorites_user_id_drive_id_key",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "driveId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "favorites_user_id_position_idx": {
+          "name": "favorites_user_id_position_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "position",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "favorites_userId_users_id_fk": {
+          "name": "favorites_userId_users_id_fk",
+          "tableFrom": "favorites",
+          "tableTo": "users",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "favorites_pageId_pages_id_fk": {
+          "name": "favorites_pageId_pages_id_fk",
+          "tableFrom": "favorites",
+          "tableTo": "pages",
+          "columnsFrom": [
+            "pageId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "favorites_driveId_drives_id_fk": {
+          "name": "favorites_driveId_drives_id_fk",
+          "tableFrom": "favorites",
+          "tableTo": "drives",
+          "columnsFrom": [
+            "driveId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "favorites_item_type_consistency_chk": {
+          "name": "favorites_item_type_consistency_chk",
+          "value": "((\"itemType\" = 'page' AND \"pageId\" IS NOT NULL AND \"driveId\" IS NULL) OR (\"itemType\" = 'drive' AND \"driveId\" IS NOT NULL AND \"pageId\" IS NULL))"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.mentions": {
+      "name": "mentions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "sourcePageId": {
+          "name": "sourcePageId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "targetPageId": {
+          "name": "targetPageId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "mentions_source_page_id_target_page_id_key": {
+          "name": "mentions_source_page_id_target_page_id_key",
+          "columns": [
+            {
+              "expression": "sourcePageId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "targetPageId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "mentions_source_page_id_idx": {
+          "name": "mentions_source_page_id_idx",
+          "columns": [
+            {
+              "expression": "sourcePageId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "mentions_target_page_id_idx": {
+          "name": "mentions_target_page_id_idx",
+          "columns": [
+            {
+              "expression": "targetPageId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "mentions_sourcePageId_pages_id_fk": {
+          "name": "mentions_sourcePageId_pages_id_fk",
+          "tableFrom": "mentions",
+          "tableTo": "pages",
+          "columnsFrom": [
+            "sourcePageId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "mentions_targetPageId_pages_id_fk": {
+          "name": "mentions_targetPageId_pages_id_fk",
+          "tableFrom": "mentions",
+          "tableTo": "pages",
+          "columnsFrom": [
+            "targetPageId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.pages": {
+      "name": "pages",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "PageType",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "contentMode": {
+          "name": "contentMode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'html'"
+        },
+        "isPaginated": {
+          "name": "isPaginated",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "position": {
+          "name": "position",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "isTrashed": {
+          "name": "isTrashed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "aiProvider": {
+          "name": "aiProvider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "aiModel": {
+          "name": "aiModel",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "systemPrompt": {
+          "name": "systemPrompt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "enabledTools": {
+          "name": "enabledTools",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "includeDrivePrompt": {
+          "name": "includeDrivePrompt",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "agentDefinition": {
+          "name": "agentDefinition",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "visibleToGlobalAssistant": {
+          "name": "visibleToGlobalAssistant",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "includePageTree": {
+          "name": "includePageTree",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "pageTreeScope": {
+          "name": "pageTreeScope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'children'"
+        },
+        "toolExposureMode": {
+          "name": "toolExposureMode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'upfront'"
+        },
+        "sandboxEnabled": {
+          "name": "sandboxEnabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "userScopedAccess": {
+          "name": "userScopedAccess",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "siteMode": {
+          "name": "siteMode",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "fileSize": {
+          "name": "fileSize",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mimeType": {
+          "name": "mimeType",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "originalFileName": {
+          "name": "originalFileName",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "filePath": {
+          "name": "filePath",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "fileMetadata": {
+          "name": "fileMetadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "processingStatus": {
+          "name": "processingStatus",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'pending'"
+        },
+        "processingError": {
+          "name": "processingError",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "processedAt": {
+          "name": "processedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "extractionMethod": {
+          "name": "extractionMethod",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "extractionMetadata": {
+          "name": "extractionMetadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "contentHash": {
+          "name": "contentHash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "excludeFromSearch": {
+          "name": "excludeFromSearch",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "isPrivate": {
+          "name": "isPrivate",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "createdBy": {
+          "name": "createdBy",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "trashedAt": {
+          "name": "trashedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revision": {
+          "name": "revision",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "stateHash": {
+          "name": "stateHash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "driveId": {
+          "name": "driveId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "parentId": {
+          "name": "parentId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "originalParentId": {
+          "name": "originalParentId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "pages_drive_id_idx": {
+          "name": "pages_drive_id_idx",
+          "columns": [
+            {
+              "expression": "driveId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "pages_parent_id_idx": {
+          "name": "pages_parent_id_idx",
+          "columns": [
+            {
+              "expression": "parentId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "pages_parent_id_position_idx": {
+          "name": "pages_parent_id_position_idx",
+          "columns": [
+            {
+              "expression": "parentId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "position",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "pages_drive_id_is_trashed_type_idx": {
+          "name": "pages_drive_id_is_trashed_type_idx",
+          "columns": [
+            {
+              "expression": "driveId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "isTrashed",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "pages_createdBy_users_id_fk": {
+          "name": "pages_createdBy_users_id_fk",
+          "tableFrom": "pages",
+          "tableTo": "users",
+          "columnsFrom": [
+            "createdBy"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "pages_driveId_drives_id_fk": {
+          "name": "pages_driveId_drives_id_fk",
+          "tableFrom": "pages",
+          "tableTo": "drives",
+          "columnsFrom": [
+            "driveId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.storage_events": {
+      "name": "storage_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pageId": {
+          "name": "pageId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "eventType": {
+          "name": "eventType",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sizeDelta": {
+          "name": "sizeDelta",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "totalSizeAfter": {
+          "name": "totalSizeAfter",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "storage_events_user_id_idx": {
+          "name": "storage_events_user_id_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "storage_events_created_at_idx": {
+          "name": "storage_events_created_at_idx",
+          "columns": [
+            {
+              "expression": "createdAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "storage_events_userId_users_id_fk": {
+          "name": "storage_events_userId_users_id_fk",
+          "tableFrom": "storage_events",
+          "tableTo": "users",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "storage_events_pageId_pages_id_fk": {
+          "name": "storage_events_pageId_pages_id_fk",
+          "tableFrom": "storage_events",
+          "tableTo": "pages",
+          "columnsFrom": [
+            "pageId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.tags": {
+      "name": "tags",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "driveId": {
+          "name": "driveId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "normalizedKey": {
+          "name": "normalizedKey",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "color": {
+          "name": "color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdBy": {
+          "name": "createdBy",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "tags_drive_id_idx": {
+          "name": "tags_drive_id_idx",
+          "columns": [
+            {
+              "expression": "driveId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "tags_driveId_drives_id_fk": {
+          "name": "tags_driveId_drives_id_fk",
+          "tableFrom": "tags",
+          "tableTo": "drives",
+          "columnsFrom": [
+            "driveId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "tags_createdBy_users_id_fk": {
+          "name": "tags_createdBy_users_id_fk",
+          "tableFrom": "tags",
+          "tableTo": "users",
+          "columnsFrom": [
+            "createdBy"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "tags_drive_id_normalized_key_key": {
+          "name": "tags_drive_id_normalized_key_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "driveId",
+            "normalizedKey"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_mentions": {
+      "name": "user_mentions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "sourcePageId": {
+          "name": "sourcePageId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "targetUserId": {
+          "name": "targetUserId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "mentionedByUserId": {
+          "name": "mentionedByUserId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "user_mentions_source_page_id_target_user_id_key": {
+          "name": "user_mentions_source_page_id_target_user_id_key",
+          "columns": [
+            {
+              "expression": "sourcePageId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "targetUserId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_mentions_source_page_id_idx": {
+          "name": "user_mentions_source_page_id_idx",
+          "columns": [
+            {
+              "expression": "sourcePageId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_mentions_target_user_id_idx": {
+          "name": "user_mentions_target_user_id_idx",
+          "columns": [
+            {
+              "expression": "targetUserId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_mentions_sourcePageId_pages_id_fk": {
+          "name": "user_mentions_sourcePageId_pages_id_fk",
+          "tableFrom": "user_mentions",
+          "tableTo": "pages",
+          "columnsFrom": [
+            "sourcePageId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "user_mentions_targetUserId_users_id_fk": {
+          "name": "user_mentions_targetUserId_users_id_fk",
+          "tableFrom": "user_mentions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "targetUserId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "user_mentions_mentionedByUserId_users_id_fk": {
+          "name": "user_mentions_mentionedByUserId_users_id_fk",
+          "tableFrom": "user_mentions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "mentionedByUserId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.drive_agent_members": {
+      "name": "drive_agent_members",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "driveId": {
+          "name": "driveId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agentPageId": {
+          "name": "agentPageId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "MemberRole",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'MEMBER'"
+        },
+        "customRoleId": {
+          "name": "customRoleId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "includeContext": {
+          "name": "includeContext",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "addedBy": {
+          "name": "addedBy",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "addedAt": {
+          "name": "addedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "drive_agent_members_drive_id_idx": {
+          "name": "drive_agent_members_drive_id_idx",
+          "columns": [
+            {
+              "expression": "driveId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "drive_agent_members_agent_page_id_idx": {
+          "name": "drive_agent_members_agent_page_id_idx",
+          "columns": [
+            {
+              "expression": "agentPageId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "drive_agent_members_driveId_drives_id_fk": {
+          "name": "drive_agent_members_driveId_drives_id_fk",
+          "tableFrom": "drive_agent_members",
+          "tableTo": "drives",
+          "columnsFrom": [
+            "driveId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "drive_agent_members_agentPageId_pages_id_fk": {
+          "name": "drive_agent_members_agentPageId_pages_id_fk",
+          "tableFrom": "drive_agent_members",
+          "tableTo": "pages",
+          "columnsFrom": [
+            "agentPageId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "drive_agent_members_customRoleId_drive_roles_id_fk": {
+          "name": "drive_agent_members_customRoleId_drive_roles_id_fk",
+          "tableFrom": "drive_agent_members",
+          "tableTo": "drive_roles",
+          "columnsFrom": [
+            "customRoleId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "drive_agent_members_addedBy_users_id_fk": {
+          "name": "drive_agent_members_addedBy_users_id_fk",
+          "tableFrom": "drive_agent_members",
+          "tableTo": "users",
+          "columnsFrom": [
+            "addedBy"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "drive_agent_members_drive_agent_key": {
+          "name": "drive_agent_members_drive_agent_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "driveId",
+            "agentPageId"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.drive_members": {
+      "name": "drive_members",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "driveId": {
+          "name": "driveId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "MemberRole",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'MEMBER'"
+        },
+        "customRoleId": {
+          "name": "customRoleId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "invitedBy": {
+          "name": "invitedBy",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "invitedAt": {
+          "name": "invitedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "acceptedAt": {
+          "name": "acceptedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lastAccessedAt": {
+          "name": "lastAccessedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "drive_members_drive_id_idx": {
+          "name": "drive_members_drive_id_idx",
+          "columns": [
+            {
+              "expression": "driveId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "drive_members_user_id_idx": {
+          "name": "drive_members_user_id_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "drive_members_role_idx": {
+          "name": "drive_members_role_idx",
+          "columns": [
+            {
+              "expression": "role",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "drive_members_custom_role_id_idx": {
+          "name": "drive_members_custom_role_id_idx",
+          "columns": [
+            {
+              "expression": "customRoleId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "drive_members_driveId_drives_id_fk": {
+          "name": "drive_members_driveId_drives_id_fk",
+          "tableFrom": "drive_members",
+          "tableTo": "drives",
+          "columnsFrom": [
+            "driveId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "drive_members_userId_users_id_fk": {
+          "name": "drive_members_userId_users_id_fk",
+          "tableFrom": "drive_members",
+          "tableTo": "users",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "drive_members_customRoleId_drive_roles_id_fk": {
+          "name": "drive_members_customRoleId_drive_roles_id_fk",
+          "tableFrom": "drive_members",
+          "tableTo": "drive_roles",
+          "columnsFrom": [
+            "customRoleId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "drive_members_invitedBy_users_id_fk": {
+          "name": "drive_members_invitedBy_users_id_fk",
+          "tableFrom": "drive_members",
+          "tableTo": "users",
+          "columnsFrom": [
+            "invitedBy"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "drive_members_drive_user_key": {
+          "name": "drive_members_drive_user_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "driveId",
+            "userId"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.drive_roles": {
+      "name": "drive_roles",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "driveId": {
+          "name": "driveId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "color": {
+          "name": "color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "isDefault": {
+          "name": "isDefault",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "permissions": {
+          "name": "permissions",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "drive_wide_permissions": {
+          "name": "drive_wide_permissions",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "NULL"
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "drive_roles_drive_id_idx": {
+          "name": "drive_roles_drive_id_idx",
+          "columns": [
+            {
+              "expression": "driveId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "drive_roles_position_idx": {
+          "name": "drive_roles_position_idx",
+          "columns": [
+            {
+              "expression": "position",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "drive_roles_driveId_drives_id_fk": {
+          "name": "drive_roles_driveId_drives_id_fk",
+          "tableFrom": "drive_roles",
+          "tableTo": "drives",
+          "columnsFrom": [
+            "driveId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "drive_roles_drive_name_key": {
+          "name": "drive_roles_drive_name_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "driveId",
+            "name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.mcp_token_drives": {
+      "name": "mcp_token_drives",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "tokenId": {
+          "name": "tokenId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "driveId": {
+          "name": "driveId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "MemberRole",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "customRoleId": {
+          "name": "customRoleId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "addedBy": {
+          "name": "addedBy",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "mcp_token_drives_token_id_idx": {
+          "name": "mcp_token_drives_token_id_idx",
+          "columns": [
+            {
+              "expression": "tokenId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "mcp_token_drives_drive_id_idx": {
+          "name": "mcp_token_drives_drive_id_idx",
+          "columns": [
+            {
+              "expression": "driveId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "mcp_token_drives_token_drive_unique": {
+          "name": "mcp_token_drives_token_drive_unique",
+          "columns": [
+            {
+              "expression": "tokenId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "driveId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "mcp_token_drives_tokenId_mcp_tokens_id_fk": {
+          "name": "mcp_token_drives_tokenId_mcp_tokens_id_fk",
+          "tableFrom": "mcp_token_drives",
+          "tableTo": "mcp_tokens",
+          "columnsFrom": [
+            "tokenId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "mcp_token_drives_driveId_drives_id_fk": {
+          "name": "mcp_token_drives_driveId_drives_id_fk",
+          "tableFrom": "mcp_token_drives",
+          "tableTo": "drives",
+          "columnsFrom": [
+            "driveId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "mcp_token_drives_customRoleId_drive_roles_id_fk": {
+          "name": "mcp_token_drives_customRoleId_drive_roles_id_fk",
+          "tableFrom": "mcp_token_drives",
+          "tableTo": "drive_roles",
+          "columnsFrom": [
+            "customRoleId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "mcp_token_drives_addedBy_users_id_fk": {
+          "name": "mcp_token_drives_addedBy_users_id_fk",
+          "tableFrom": "mcp_token_drives",
+          "tableTo": "users",
+          "columnsFrom": [
+            "addedBy"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.page_permissions": {
+      "name": "page_permissions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "pageId": {
+          "name": "pageId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "canView": {
+          "name": "canView",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "canEdit": {
+          "name": "canEdit",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "canShare": {
+          "name": "canShare",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "canDelete": {
+          "name": "canDelete",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "grantedBy": {
+          "name": "grantedBy",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "grantedAt": {
+          "name": "grantedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expiresAt": {
+          "name": "expiresAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "note": {
+          "name": "note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "page_permissions_page_id_idx": {
+          "name": "page_permissions_page_id_idx",
+          "columns": [
+            {
+              "expression": "pageId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "page_permissions_user_id_idx": {
+          "name": "page_permissions_user_id_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "page_permissions_expires_at_idx": {
+          "name": "page_permissions_expires_at_idx",
+          "columns": [
+            {
+              "expression": "expiresAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "page_permissions_pageId_pages_id_fk": {
+          "name": "page_permissions_pageId_pages_id_fk",
+          "tableFrom": "page_permissions",
+          "tableTo": "pages",
+          "columnsFrom": [
+            "pageId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "page_permissions_userId_users_id_fk": {
+          "name": "page_permissions_userId_users_id_fk",
+          "tableFrom": "page_permissions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "page_permissions_grantedBy_users_id_fk": {
+          "name": "page_permissions_grantedBy_users_id_fk",
+          "tableFrom": "page_permissions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "grantedBy"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "page_permissions_page_user_key": {
+          "name": "page_permissions_page_user_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "pageId",
+            "userId"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_profiles": {
+      "name": "user_profiles",
+      "schema": "",
+      "columns": {
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "username": {
+          "name": "username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "displayName": {
+          "name": "displayName",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "bio": {
+          "name": "bio",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "avatarUrl": {
+          "name": "avatarUrl",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "isPublic": {
+          "name": "isPublic",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "user_profiles_is_public_idx": {
+          "name": "user_profiles_is_public_idx",
+          "columns": [
+            {
+              "expression": "isPublic",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_profiles_userId_users_id_fk": {
+          "name": "user_profiles_userId_users_id_fk",
+          "tableFrom": "user_profiles",
+          "tableTo": "users",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.channel_message_reactions": {
+      "name": "channel_message_reactions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "messageId": {
+          "name": "messageId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "emoji": {
+          "name": "emoji",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "unique_reaction_idx": {
+          "name": "unique_reaction_idx",
+          "columns": [
+            {
+              "expression": "messageId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "emoji",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "reaction_message_idx": {
+          "name": "reaction_message_idx",
+          "columns": [
+            {
+              "expression": "messageId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "channel_message_reactions_messageId_channel_messages_id_fk": {
+          "name": "channel_message_reactions_messageId_channel_messages_id_fk",
+          "tableFrom": "channel_message_reactions",
+          "tableTo": "channel_messages",
+          "columnsFrom": [
+            "messageId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "channel_message_reactions_userId_users_id_fk": {
+          "name": "channel_message_reactions_userId_users_id_fk",
+          "tableFrom": "channel_message_reactions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.channel_messages": {
+      "name": "channel_messages",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "pageId": {
+          "name": "pageId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "fileId": {
+          "name": "fileId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "attachmentMeta": {
+          "name": "attachmentMeta",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "isActive": {
+          "name": "isActive",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "editedAt": {
+          "name": "editedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "aiMeta": {
+          "name": "aiMeta",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "parentId": {
+          "name": "parentId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "replyCount": {
+          "name": "replyCount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "lastReplyAt": {
+          "name": "lastReplyAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mirroredFromId": {
+          "name": "mirroredFromId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "quotedMessageId": {
+          "name": "quotedMessageId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "channel_messages_page_id_idx": {
+          "name": "channel_messages_page_id_idx",
+          "columns": [
+            {
+              "expression": "pageId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "channel_messages_file_id_idx": {
+          "name": "channel_messages_file_id_idx",
+          "columns": [
+            {
+              "expression": "fileId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "channel_messages_parent_created_idx": {
+          "name": "channel_messages_parent_created_idx",
+          "columns": [
+            {
+              "expression": "parentId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "createdAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "channel_messages_quoted_id_idx": {
+          "name": "channel_messages_quoted_id_idx",
+          "columns": [
+            {
+              "expression": "quotedMessageId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "channel_messages_pageId_pages_id_fk": {
+          "name": "channel_messages_pageId_pages_id_fk",
+          "tableFrom": "channel_messages",
+          "tableTo": "pages",
+          "columnsFrom": [
+            "pageId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "channel_messages_userId_users_id_fk": {
+          "name": "channel_messages_userId_users_id_fk",
+          "tableFrom": "channel_messages",
+          "tableTo": "users",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "channel_messages_fileId_files_id_fk": {
+          "name": "channel_messages_fileId_files_id_fk",
+          "tableFrom": "channel_messages",
+          "tableTo": "files",
+          "columnsFrom": [
+            "fileId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "channel_messages_parentId_channel_messages_id_fk": {
+          "name": "channel_messages_parentId_channel_messages_id_fk",
+          "tableFrom": "channel_messages",
+          "tableTo": "channel_messages",
+          "columnsFrom": [
+            "parentId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "channel_messages_mirroredFromId_channel_messages_id_fk": {
+          "name": "channel_messages_mirroredFromId_channel_messages_id_fk",
+          "tableFrom": "channel_messages",
+          "tableTo": "channel_messages",
+          "columnsFrom": [
+            "mirroredFromId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "channel_messages_quotedMessageId_channel_messages_id_fk": {
+          "name": "channel_messages_quotedMessageId_channel_messages_id_fk",
+          "tableFrom": "channel_messages",
+          "tableTo": "channel_messages",
+          "columnsFrom": [
+            "quotedMessageId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.channel_read_status": {
+      "name": "channel_read_status",
+      "schema": "",
+      "columns": {
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "channelId": {
+          "name": "channelId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "lastReadAt": {
+          "name": "lastReadAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "channel_read_status_user_id_idx": {
+          "name": "channel_read_status_user_id_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "channel_read_status_channel_id_idx": {
+          "name": "channel_read_status_channel_id_idx",
+          "columns": [
+            {
+              "expression": "channelId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "channel_read_status_userId_users_id_fk": {
+          "name": "channel_read_status_userId_users_id_fk",
+          "tableFrom": "channel_read_status",
+          "tableTo": "users",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "channel_read_status_channelId_pages_id_fk": {
+          "name": "channel_read_status_channelId_pages_id_fk",
+          "tableFrom": "channel_read_status",
+          "tableTo": "pages",
+          "columnsFrom": [
+            "channelId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "channel_read_status_userId_channelId_pk": {
+          "name": "channel_read_status_userId_channelId_pk",
+          "columns": [
+            "userId",
+            "channelId"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.channel_thread_followers": {
+      "name": "channel_thread_followers",
+      "schema": "",
+      "columns": {
+        "rootMessageId": {
+          "name": "rootMessageId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "channel_thread_followers_user_id_idx": {
+          "name": "channel_thread_followers_user_id_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "channel_thread_followers_rootMessageId_channel_messages_id_fk": {
+          "name": "channel_thread_followers_rootMessageId_channel_messages_id_fk",
+          "tableFrom": "channel_thread_followers",
+          "tableTo": "channel_messages",
+          "columnsFrom": [
+            "rootMessageId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "channel_thread_followers_userId_users_id_fk": {
+          "name": "channel_thread_followers_userId_users_id_fk",
+          "tableFrom": "channel_thread_followers",
+          "tableTo": "users",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "channel_thread_followers_rootMessageId_userId_pk": {
+          "name": "channel_thread_followers_rootMessageId_userId_pk",
+          "columns": [
+            "rootMessageId",
+            "userId"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.pulse_summaries": {
+      "name": "pulse_summaries",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "summary": {
+          "name": "summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "greeting": {
+          "name": "greeting",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "type": {
+          "name": "type",
+          "type": "pulse_summary_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'scheduled'"
+        },
+        "contextData": {
+          "name": "contextData",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "aiProvider": {
+          "name": "aiProvider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "aiModel": {
+          "name": "aiModel",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "periodStart": {
+          "name": "periodStart",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "periodEnd": {
+          "name": "periodEnd",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "generatedAt": {
+          "name": "generatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expiresAt": {
+          "name": "expiresAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_pulse_summaries_user_id": {
+          "name": "idx_pulse_summaries_user_id",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_pulse_summaries_generated_at": {
+          "name": "idx_pulse_summaries_generated_at",
+          "columns": [
+            {
+              "expression": "generatedAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_pulse_summaries_expires_at": {
+          "name": "idx_pulse_summaries_expires_at",
+          "columns": [
+            {
+              "expression": "expiresAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_pulse_summaries_user_generated": {
+          "name": "idx_pulse_summaries_user_generated",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "generatedAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "pulse_summaries_userId_users_id_fk": {
+          "name": "pulse_summaries_userId_users_id_fk",
+          "tableFrom": "pulse_summaries",
+          "tableTo": "users",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_dashboards": {
+      "name": "user_dashboards",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_dashboards_userId_users_id_fk": {
+          "name": "user_dashboards_userId_users_id_fk",
+          "tableFrom": "user_dashboards",
+          "tableTo": "users",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_dashboards_userId_unique": {
+          "name": "user_dashboards_userId_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "userId"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.conversations": {
+      "name": "conversations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "contextId": {
+          "name": "contextId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "agentPageId": {
+          "name": "agentPageId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rev": {
+          "name": "rev",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "planPageId": {
+          "name": "planPageId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lastMessageAt": {
+          "name": "lastMessageAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "isActive": {
+          "name": "isActive",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "isShared": {
+          "name": "isShared",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        }
+      },
+      "indexes": {
+        "conversations_user_id_idx": {
+          "name": "conversations_user_id_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "conversations_user_id_type_idx": {
+          "name": "conversations_user_id_type_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "conversations_user_id_last_message_at_idx": {
+          "name": "conversations_user_id_last_message_at_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "lastMessageAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "conversations_context_id_idx": {
+          "name": "conversations_context_id_idx",
+          "columns": [
+            {
+              "expression": "contextId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "conversations_plan_page_id_idx": {
+          "name": "conversations_plan_page_id_idx",
+          "columns": [
+            {
+              "expression": "planPageId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "conversations_agent_page_id_idx": {
+          "name": "conversations_agent_page_id_idx",
+          "columns": [
+            {
+              "expression": "agentPageId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "conversations_userId_users_id_fk": {
+          "name": "conversations_userId_users_id_fk",
+          "tableFrom": "conversations",
+          "tableTo": "users",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "conversations_agentPageId_pages_id_fk": {
+          "name": "conversations_agentPageId_pages_id_fk",
+          "tableFrom": "conversations",
+          "tableTo": "pages",
+          "columnsFrom": [
+            "agentPageId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "conversations_planPageId_pages_id_fk": {
+          "name": "conversations_planPageId_pages_id_fk",
+          "tableFrom": "conversations",
+          "tableTo": "pages",
+          "columnsFrom": [
+            "planPageId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "conversations_global_context_null_chk": {
+          "name": "conversations_global_context_null_chk",
+          "value": "\"conversations\".\"type\" <> 'global' OR \"conversations\".\"contextId\" IS NULL"
+        },
+        "conversations_page_context_present_chk": {
+          "name": "conversations_page_context_present_chk",
+          "value": "\"conversations\".\"type\" <> 'page' OR \"conversations\".\"contextId\" IS NOT NULL"
+        },
+        "conversations_drive_context_present_chk": {
+          "name": "conversations_drive_context_present_chk",
+          "value": "\"conversations\".\"type\" <> 'drive' OR \"conversations\".\"contextId\" IS NOT NULL"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.messages": {
+      "name": "messages",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "conversationId": {
+          "name": "conversationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "messageType": {
+          "name": "messageType",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'standard'"
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "toolCalls": {
+          "name": "toolCalls",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "toolResults": {
+          "name": "toolResults",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "isActive": {
+          "name": "isActive",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "editedAt": {
+          "name": "editedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'complete'"
+        },
+        "sourceAgentId": {
+          "name": "sourceAgentId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "messages_conversation_id_idx": {
+          "name": "messages_conversation_id_idx",
+          "columns": [
+            {
+              "expression": "conversationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "messages_conversation_id_created_at_idx": {
+          "name": "messages_conversation_id_created_at_idx",
+          "columns": [
+            {
+              "expression": "conversationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "createdAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "messages_user_id_idx": {
+          "name": "messages_user_id_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "messages_conversationId_conversations_id_fk": {
+          "name": "messages_conversationId_conversations_id_fk",
+          "tableFrom": "messages",
+          "tableTo": "conversations",
+          "columnsFrom": [
+            "conversationId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "messages_userId_users_id_fk": {
+          "name": "messages_userId_users_id_fk",
+          "tableFrom": "messages",
+          "tableTo": "users",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "messages_sourceAgentId_pages_id_fk": {
+          "name": "messages_sourceAgentId_pages_id_fk",
+          "tableFrom": "messages",
+          "tableTo": "pages",
+          "columnsFrom": [
+            "sourceAgentId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.notifications": {
+      "name": "notifications",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "NotificationType",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "message": {
+          "name": "message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "isRead": {
+          "name": "isRead",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "readAt": {
+          "name": "readAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pageId": {
+          "name": "pageId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "driveId": {
+          "name": "driveId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "triggeredByUserId": {
+          "name": "triggeredByUserId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "notifications_user_id_idx": {
+          "name": "notifications_user_id_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "notifications_user_id_is_read_idx": {
+          "name": "notifications_user_id_is_read_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "isRead",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "notifications_user_id_is_read_created_at_idx": {
+          "name": "notifications_user_id_is_read_created_at_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "isRead",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "createdAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "notifications_created_at_idx": {
+          "name": "notifications_created_at_idx",
+          "columns": [
+            {
+              "expression": "createdAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "notifications_type_idx": {
+          "name": "notifications_type_idx",
+          "columns": [
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "notifications_userId_users_id_fk": {
+          "name": "notifications_userId_users_id_fk",
+          "tableFrom": "notifications",
+          "tableTo": "users",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "notifications_pageId_pages_id_fk": {
+          "name": "notifications_pageId_pages_id_fk",
+          "tableFrom": "notifications",
+          "tableTo": "pages",
+          "columnsFrom": [
+            "pageId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "notifications_driveId_drives_id_fk": {
+          "name": "notifications_driveId_drives_id_fk",
+          "tableFrom": "notifications",
+          "tableTo": "drives",
+          "columnsFrom": [
+            "driveId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "notifications_triggeredByUserId_users_id_fk": {
+          "name": "notifications_triggeredByUserId_users_id_fk",
+          "tableFrom": "notifications",
+          "tableTo": "users",
+          "columnsFrom": [
+            "triggeredByUserId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.email_notification_log": {
+      "name": "email_notification_log",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "notificationId": {
+          "name": "notificationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notificationType": {
+          "name": "notificationType",
+          "type": "NotificationType",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "recipientEmail": {
+          "name": "recipientEmail",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "success": {
+          "name": "success",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "errorMessage": {
+          "name": "errorMessage",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sentAt": {
+          "name": "sentAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "email_notification_log_user_idx": {
+          "name": "email_notification_log_user_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "email_notification_log_sent_at_idx": {
+          "name": "email_notification_log_sent_at_idx",
+          "columns": [
+            {
+              "expression": "sentAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "email_notification_log_notification_id_idx": {
+          "name": "email_notification_log_notification_id_idx",
+          "columns": [
+            {
+              "expression": "notificationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "email_notification_log_userId_users_id_fk": {
+          "name": "email_notification_log_userId_users_id_fk",
+          "tableFrom": "email_notification_log",
+          "tableTo": "users",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.email_notification_preferences": {
+      "name": "email_notification_preferences",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "notificationType": {
+          "name": "notificationType",
+          "type": "NotificationType",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "emailEnabled": {
+          "name": "emailEnabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "email_notification_preferences_user_type_idx": {
+          "name": "email_notification_preferences_user_type_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "notificationType",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "email_notification_preferences_userId_users_id_fk": {
+          "name": "email_notification_preferences_userId_users_id_fk",
+          "tableFrom": "email_notification_preferences",
+          "tableTo": "users",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_toast_notification_preferences": {
+      "name": "user_toast_notification_preferences",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "level": {
+          "name": "level",
+          "type": "toast_notification_level",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'all'"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "user_toast_notification_preferences_user_idx": {
+          "name": "user_toast_notification_preferences_user_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_toast_notification_preferences_userId_users_id_fk": {
+          "name": "user_toast_notification_preferences_userId_users_id_fk",
+          "tableFrom": "user_toast_notification_preferences",
+          "tableTo": "users",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.display_preferences": {
+      "name": "display_preferences",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "preferenceType": {
+          "name": "preferenceType",
+          "type": "display_preference_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "display_preferences_user_type_idx": {
+          "name": "display_preferences_user_type_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "preferenceType",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "display_preferences_userId_users_id_fk": {
+          "name": "display_preferences_userId_users_id_fk",
+          "tableFrom": "display_preferences",
+          "tableTo": "users",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.activity_logs": {
+      "name": "activity_logs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "actorEmail": {
+          "name": "actorEmail",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'legacy@unknown'"
+        },
+        "actorDisplayName": {
+          "name": "actorDisplayName",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "isAiGenerated": {
+          "name": "isAiGenerated",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "aiProvider": {
+          "name": "aiProvider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "aiModel": {
+          "name": "aiModel",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "aiConversationId": {
+          "name": "aiConversationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "operation": {
+          "name": "operation",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "resourceType": {
+          "name": "resourceType",
+          "type": "activity_resource",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "resourceId": {
+          "name": "resourceId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "resourceTitle": {
+          "name": "resourceTitle",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "driveId": {
+          "name": "driveId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pageId": {
+          "name": "pageId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "contentSnapshot": {
+          "name": "contentSnapshot",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "contentFormat": {
+          "name": "contentFormat",
+          "type": "content_format",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "contentRef": {
+          "name": "contentRef",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "contentSize": {
+          "name": "contentSize",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rollbackFromActivityId": {
+          "name": "rollbackFromActivityId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rollbackSourceOperation": {
+          "name": "rollbackSourceOperation",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rollbackSourceTimestamp": {
+          "name": "rollbackSourceTimestamp",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rollbackSourceTitle": {
+          "name": "rollbackSourceTitle",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updatedFields": {
+          "name": "updatedFields",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "previousValues": {
+          "name": "previousValues",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "newValues": {
+          "name": "newValues",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "streamId": {
+          "name": "streamId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "streamSeq": {
+          "name": "streamSeq",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "changeGroupId": {
+          "name": "changeGroupId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "changeGroupType": {
+          "name": "changeGroupType",
+          "type": "activity_change_group_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stateHashBefore": {
+          "name": "stateHashBefore",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stateHashAfter": {
+          "name": "stateHashAfter",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "dataCategory": {
+          "name": "dataCategory",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "legalBasis": {
+          "name": "legalBasis",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "retentionPolicy": {
+          "name": "retentionPolicy",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "recipients": {
+          "name": "recipients",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "isArchived": {
+          "name": "isArchived",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "chainSeq": {
+          "name": "chainSeq",
+          "type": "bigserial",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "previousLogHash": {
+          "name": "previousLogHash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "logHash": {
+          "name": "logHash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "chainSeed": {
+          "name": "chainSeed",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_activity_logs_timestamp": {
+          "name": "idx_activity_logs_timestamp",
+          "columns": [
+            {
+              "expression": "timestamp",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_activity_logs_user_timestamp": {
+          "name": "idx_activity_logs_user_timestamp",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "timestamp",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_activity_logs_drive_timestamp": {
+          "name": "idx_activity_logs_drive_timestamp",
+          "columns": [
+            {
+              "expression": "driveId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "timestamp",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_activity_logs_page_timestamp": {
+          "name": "idx_activity_logs_page_timestamp",
+          "columns": [
+            {
+              "expression": "pageId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "timestamp",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_activity_logs_archived": {
+          "name": "idx_activity_logs_archived",
+          "columns": [
+            {
+              "expression": "isArchived",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_activity_logs_rollback_from": {
+          "name": "idx_activity_logs_rollback_from",
+          "columns": [
+            {
+              "expression": "rollbackFromActivityId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_activity_logs_stream": {
+          "name": "idx_activity_logs_stream",
+          "columns": [
+            {
+              "expression": "streamId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "streamSeq",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"activity_logs\".\"streamId\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_activity_logs_change_group": {
+          "name": "idx_activity_logs_change_group",
+          "columns": [
+            {
+              "expression": "changeGroupId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"activity_logs\".\"changeGroupId\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_activity_logs_log_hash": {
+          "name": "idx_activity_logs_log_hash",
+          "columns": [
+            {
+              "expression": "logHash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"activity_logs\".\"logHash\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_activity_logs_chain_seq": {
+          "name": "idx_activity_logs_chain_seq",
+          "columns": [
+            {
+              "expression": "chainSeq",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "activity_logs_userId_users_id_fk": {
+          "name": "activity_logs_userId_users_id_fk",
+          "tableFrom": "activity_logs",
+          "tableTo": "users",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "activity_logs_driveId_drives_id_fk": {
+          "name": "activity_logs_driveId_drives_id_fk",
+          "tableFrom": "activity_logs",
+          "tableTo": "drives",
+          "columnsFrom": [
+            "driveId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "activity_logs_pageId_pages_id_fk": {
+          "name": "activity_logs_pageId_pages_id_fk",
+          "tableFrom": "activity_logs",
+          "tableTo": "pages",
+          "columnsFrom": [
+            "pageId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "activity_logs_content_size_limit": {
+          "name": "activity_logs_content_size_limit",
+          "value": "\"activity_logs\".\"contentRef\" IS NOT NULL OR \"activity_logs\".\"contentSize\" IS NULL OR \"activity_logs\".\"contentSize\" <= 1048576"
+        },
+        "activity_logs_stream_pair": {
+          "name": "activity_logs_stream_pair",
+          "value": "(\"activity_logs\".\"streamId\" IS NULL) = (\"activity_logs\".\"streamSeq\" IS NULL)"
+        },
+        "activity_logs_change_group_pair": {
+          "name": "activity_logs_change_group_pair",
+          "value": "(\"activity_logs\".\"changeGroupId\" IS NULL) = (\"activity_logs\".\"changeGroupType\" IS NULL)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.ai_usage_logs": {
+      "name": "ai_usage_logs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "input_tokens": {
+          "name": "input_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "output_tokens": {
+          "name": "output_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "total_tokens": {
+          "name": "total_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cost": {
+          "name": "cost",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "currency": {
+          "name": "currency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'USD'"
+        },
+        "duration": {
+          "name": "duration",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "streaming_duration": {
+          "name": "streaming_duration",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "message_id": {
+          "name": "message_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "page_id": {
+          "name": "page_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "drive_id": {
+          "name": "drive_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "success": {
+          "name": "success",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": true
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "context_messages": {
+          "name": "context_messages",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "context_size": {
+          "name": "context_size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "system_prompt_tokens": {
+          "name": "system_prompt_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tool_definition_tokens": {
+          "name": "tool_definition_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "conversation_tokens": {
+          "name": "conversation_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "message_count": {
+          "name": "message_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "was_truncated": {
+          "name": "was_truncated",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "truncation_strategy": {
+          "name": "truncation_strategy",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reconcile_status": {
+          "name": "reconcile_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reconcile_attempts": {
+          "name": "reconcile_attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "reconciled_at": {
+          "name": "reconciled_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_ai_usage_timestamp": {
+          "name": "idx_ai_usage_timestamp",
+          "columns": [
+            {
+              "expression": "timestamp",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_ai_usage_user_id": {
+          "name": "idx_ai_usage_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "timestamp",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_ai_usage_user_source": {
+          "name": "idx_ai_usage_user_source",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "source",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "timestamp",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_ai_usage_provider": {
+          "name": "idx_ai_usage_provider",
+          "columns": [
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "model",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "timestamp",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_ai_usage_cost": {
+          "name": "idx_ai_usage_cost",
+          "columns": [
+            {
+              "expression": "cost",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_ai_usage_conversation": {
+          "name": "idx_ai_usage_conversation",
+          "columns": [
+            {
+              "expression": "conversation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_ai_usage_context": {
+          "name": "idx_ai_usage_context",
+          "columns": [
+            {
+              "expression": "conversation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "timestamp",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_ai_usage_context_size": {
+          "name": "idx_ai_usage_context_size",
+          "columns": [
+            {
+              "expression": "context_size",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_ai_usage_expires_at": {
+          "name": "idx_ai_usage_expires_at",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_ai_usage_reconcile": {
+          "name": "idx_ai_usage_reconcile",
+          "columns": [
+            {
+              "expression": "reconcile_status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "timestamp",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "reconcile_status = 'pending'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.api_metrics": {
+      "name": "api_metrics",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "endpoint": {
+          "name": "endpoint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "method": {
+          "name": "method",
+          "type": "http_method",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status_code": {
+          "name": "status_code",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "duration": {
+          "name": "duration",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "request_size": {
+          "name": "request_size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "response_size": {
+          "name": "response_size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ip": {
+          "name": "ip",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "request_id": {
+          "name": "request_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cache_hit": {
+          "name": "cache_hit",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "cache_key": {
+          "name": "cache_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_api_metrics_timestamp": {
+          "name": "idx_api_metrics_timestamp",
+          "columns": [
+            {
+              "expression": "timestamp",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_api_metrics_endpoint": {
+          "name": "idx_api_metrics_endpoint",
+          "columns": [
+            {
+              "expression": "endpoint",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "timestamp",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_api_metrics_user_id": {
+          "name": "idx_api_metrics_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "timestamp",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_api_metrics_status": {
+          "name": "idx_api_metrics_status",
+          "columns": [
+            {
+              "expression": "status_code",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "timestamp",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_api_metrics_duration": {
+          "name": "idx_api_metrics_duration",
+          "columns": [
+            {
+              "expression": "duration",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.error_logs": {
+      "name": "error_logs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "message": {
+          "name": "message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stack": {
+          "name": "stack",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "request_id": {
+          "name": "request_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "endpoint": {
+          "name": "endpoint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "method": {
+          "name": "method",
+          "type": "http_method",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "file": {
+          "name": "file",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "line": {
+          "name": "line",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "column": {
+          "name": "column",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ip": {
+          "name": "ip",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolved": {
+          "name": "resolved",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "resolved_at": {
+          "name": "resolved_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolved_by": {
+          "name": "resolved_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolution": {
+          "name": "resolution",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_errors_timestamp": {
+          "name": "idx_errors_timestamp",
+          "columns": [
+            {
+              "expression": "timestamp",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_errors_name": {
+          "name": "idx_errors_name",
+          "columns": [
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "timestamp",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_errors_user_id": {
+          "name": "idx_errors_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_errors_resolved": {
+          "name": "idx_errors_resolved",
+          "columns": [
+            {
+              "expression": "resolved",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_errors_endpoint": {
+          "name": "idx_errors_endpoint",
+          "columns": [
+            {
+              "expression": "endpoint",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.error_resolutions": {
+      "name": "error_resolutions",
+      "schema": "",
+      "columns": {
+        "error_id": {
+          "name": "error_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "resolved": {
+          "name": "resolved",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "resolved_at": {
+          "name": "resolved_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "resolved_by": {
+          "name": "resolved_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolution": {
+          "name": "resolution",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.siem_delivery_cursors": {
+      "name": "siem_delivery_cursors",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "lastDeliveredId": {
+          "name": "lastDeliveredId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lastDeliveredAt": {
+          "name": "lastDeliveredAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lastError": {
+          "name": "lastError",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lastErrorAt": {
+          "name": "lastErrorAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deliveryCount": {
+          "name": "deliveryCount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "siem_delivery_cursors_delivered_cursor_pair": {
+          "name": "siem_delivery_cursors_delivered_cursor_pair",
+          "value": "(\"siem_delivery_cursors\".\"lastDeliveredId\" IS NULL) = (\"siem_delivery_cursors\".\"lastDeliveredAt\" IS NULL)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.siem_delivery_receipts": {
+      "name": "siem_delivery_receipts",
+      "schema": "",
+      "columns": {
+        "receiptId": {
+          "name": "receiptId",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "deliveryId": {
+          "name": "deliveryId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "firstEntryId": {
+          "name": "firstEntryId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "lastEntryId": {
+          "name": "lastEntryId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "firstEntryTimestamp": {
+          "name": "firstEntryTimestamp",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "lastEntryTimestamp": {
+          "name": "lastEntryTimestamp",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entryCount": {
+          "name": "entryCount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "deliveredAt": {
+          "name": "deliveredAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "webhookStatus": {
+          "name": "webhookStatus",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "webhookResponseHash": {
+          "name": "webhookResponseHash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ackReceivedAt": {
+          "name": "ackReceivedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "siem_delivery_receipts_delivery_source_unique": {
+          "name": "siem_delivery_receipts_delivery_source_unique",
+          "columns": [
+            {
+              "expression": "deliveryId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "source",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_siem_receipts_delivery_id": {
+          "name": "idx_siem_receipts_delivery_id",
+          "columns": [
+            {
+              "expression": "deliveryId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_siem_receipts_first_entry": {
+          "name": "idx_siem_receipts_first_entry",
+          "columns": [
+            {
+              "expression": "firstEntryId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_siem_receipts_last_entry": {
+          "name": "idx_siem_receipts_last_entry",
+          "columns": [
+            {
+              "expression": "lastEntryId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_siem_receipts_delivered_at": {
+          "name": "idx_siem_receipts_delivered_at",
+          "columns": [
+            {
+              "expression": "deliveredAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_siem_receipts_source_range": {
+          "name": "idx_siem_receipts_source_range",
+          "columns": [
+            {
+              "expression": "source",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "firstEntryTimestamp",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "lastEntryTimestamp",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.system_logs": {
+      "name": "system_logs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "level": {
+          "name": "level",
+          "type": "log_level",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "message": {
+          "name": "message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "category": {
+          "name": "category",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "request_id": {
+          "name": "request_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "drive_id": {
+          "name": "drive_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "page_id": {
+          "name": "page_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "endpoint": {
+          "name": "endpoint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "method": {
+          "name": "method",
+          "type": "http_method",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ip": {
+          "name": "ip",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_name": {
+          "name": "error_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_stack": {
+          "name": "error_stack",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "duration": {
+          "name": "duration",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "memory_used": {
+          "name": "memory_used",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "memory_total": {
+          "name": "memory_total",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hostname": {
+          "name": "hostname",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pid": {
+          "name": "pid",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "version": {
+          "name": "version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_system_logs_timestamp": {
+          "name": "idx_system_logs_timestamp",
+          "columns": [
+            {
+              "expression": "timestamp",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_system_logs_level": {
+          "name": "idx_system_logs_level",
+          "columns": [
+            {
+              "expression": "level",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_system_logs_category": {
+          "name": "idx_system_logs_category",
+          "columns": [
+            {
+              "expression": "category",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_system_logs_user_id": {
+          "name": "idx_system_logs_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_system_logs_request_id": {
+          "name": "idx_system_logs_request_id",
+          "columns": [
+            {
+              "expression": "request_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_system_logs_error": {
+          "name": "idx_system_logs_error",
+          "columns": [
+            {
+              "expression": "error_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "timestamp",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_activities": {
+      "name": "user_activities",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "action": {
+          "name": "action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "resource": {
+          "name": "resource",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resource_id": {
+          "name": "resource_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "drive_id": {
+          "name": "drive_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "page_id": {
+          "name": "page_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ip": {
+          "name": "ip",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_user_activities_timestamp": {
+          "name": "idx_user_activities_timestamp",
+          "columns": [
+            {
+              "expression": "timestamp",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_user_activities_user_id": {
+          "name": "idx_user_activities_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "timestamp",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_user_activities_action": {
+          "name": "idx_user_activities_action",
+          "columns": [
+            {
+              "expression": "action",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "timestamp",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_user_activities_resource": {
+          "name": "idx_user_activities_resource",
+          "columns": [
+            {
+              "expression": "resource",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "resource_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.drive_backup_files": {
+      "name": "drive_backup_files",
+      "schema": "",
+      "columns": {
+        "backupId": {
+          "name": "backupId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "fileId": {
+          "name": "fileId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "storagePath": {
+          "name": "storagePath",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sizeBytes": {
+          "name": "sizeBytes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mimeType": {
+          "name": "mimeType",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "checksumVersion": {
+          "name": "checksumVersion",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "drive_backup_files_backup_idx": {
+          "name": "drive_backup_files_backup_idx",
+          "columns": [
+            {
+              "expression": "backupId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "drive_backup_files_backupId_drive_backups_id_fk": {
+          "name": "drive_backup_files_backupId_drive_backups_id_fk",
+          "tableFrom": "drive_backup_files",
+          "tableTo": "drive_backups",
+          "columnsFrom": [
+            "backupId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "drive_backup_files_backupId_fileId_pk": {
+          "name": "drive_backup_files_backupId_fileId_pk",
+          "columns": [
+            "backupId",
+            "fileId"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.drive_backup_members": {
+      "name": "drive_backup_members",
+      "schema": "",
+      "columns": {
+        "backupId": {
+          "name": "backupId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "customRoleId": {
+          "name": "customRoleId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "invitedBy": {
+          "name": "invitedBy",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "invitedAt": {
+          "name": "invitedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "acceptedAt": {
+          "name": "acceptedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "drive_backup_members_backup_idx": {
+          "name": "drive_backup_members_backup_idx",
+          "columns": [
+            {
+              "expression": "backupId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "drive_backup_members_backupId_drive_backups_id_fk": {
+          "name": "drive_backup_members_backupId_drive_backups_id_fk",
+          "tableFrom": "drive_backup_members",
+          "tableTo": "drive_backups",
+          "columnsFrom": [
+            "backupId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "drive_backup_members_backupId_userId_pk": {
+          "name": "drive_backup_members_backupId_userId_pk",
+          "columns": [
+            "backupId",
+            "userId"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.drive_backup_pages": {
+      "name": "drive_backup_pages",
+      "schema": "",
+      "columns": {
+        "backupId": {
+          "name": "backupId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pageId": {
+          "name": "pageId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pageVersionId": {
+          "name": "pageVersionId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "parentId": {
+          "name": "parentId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "originalParentId": {
+          "name": "originalParentId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "position": {
+          "name": "position",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "isTrashed": {
+          "name": "isTrashed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "trashedAt": {
+          "name": "trashedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "drive_backup_pages_backup_idx": {
+          "name": "drive_backup_pages_backup_idx",
+          "columns": [
+            {
+              "expression": "backupId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "drive_backup_pages_backupId_drive_backups_id_fk": {
+          "name": "drive_backup_pages_backupId_drive_backups_id_fk",
+          "tableFrom": "drive_backup_pages",
+          "tableTo": "drive_backups",
+          "columnsFrom": [
+            "backupId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "drive_backup_pages_pageVersionId_page_versions_id_fk": {
+          "name": "drive_backup_pages_pageVersionId_page_versions_id_fk",
+          "tableFrom": "drive_backup_pages",
+          "tableTo": "page_versions",
+          "columnsFrom": [
+            "pageVersionId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "drive_backup_pages_backupId_pageId_pk": {
+          "name": "drive_backup_pages_backupId_pageId_pk",
+          "columns": [
+            "backupId",
+            "pageId"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.drive_backup_permissions": {
+      "name": "drive_backup_permissions",
+      "schema": "",
+      "columns": {
+        "backupId": {
+          "name": "backupId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pageId": {
+          "name": "pageId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "canView": {
+          "name": "canView",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "canEdit": {
+          "name": "canEdit",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "canShare": {
+          "name": "canShare",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "canDelete": {
+          "name": "canDelete",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "grantedBy": {
+          "name": "grantedBy",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "note": {
+          "name": "note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expiresAt": {
+          "name": "expiresAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "drive_backup_permissions_backup_idx": {
+          "name": "drive_backup_permissions_backup_idx",
+          "columns": [
+            {
+              "expression": "backupId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "drive_backup_permissions_backupId_drive_backups_id_fk": {
+          "name": "drive_backup_permissions_backupId_drive_backups_id_fk",
+          "tableFrom": "drive_backup_permissions",
+          "tableTo": "drive_backups",
+          "columnsFrom": [
+            "backupId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "drive_backup_permissions_backupId_pageId_userId_pk": {
+          "name": "drive_backup_permissions_backupId_pageId_userId_pk",
+          "columns": [
+            "backupId",
+            "pageId",
+            "userId"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.drive_backup_roles": {
+      "name": "drive_backup_roles",
+      "schema": "",
+      "columns": {
+        "backupId": {
+          "name": "backupId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "roleId": {
+          "name": "roleId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "color": {
+          "name": "color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "isDefault": {
+          "name": "isDefault",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "permissions": {
+          "name": "permissions",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "drive_wide_permissions": {
+          "name": "drive_wide_permissions",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "NULL"
+        },
+        "position": {
+          "name": "position",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "drive_backup_roles_backup_idx": {
+          "name": "drive_backup_roles_backup_idx",
+          "columns": [
+            {
+              "expression": "backupId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "drive_backup_roles_backupId_drive_backups_id_fk": {
+          "name": "drive_backup_roles_backupId_drive_backups_id_fk",
+          "tableFrom": "drive_backup_roles",
+          "tableTo": "drive_backups",
+          "columnsFrom": [
+            "backupId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "drive_backup_roles_backupId_roleId_pk": {
+          "name": "drive_backup_roles_backupId_roleId_pk",
+          "columns": [
+            "backupId",
+            "roleId"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.drive_backup_schedules": {
+      "name": "drive_backup_schedules",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "driveId": {
+          "name": "driveId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "frequency": {
+          "name": "frequency",
+          "type": "drive_backup_schedule_frequency",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'daily'"
+        },
+        "timezone": {
+          "name": "timezone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'UTC'"
+        },
+        "nextRunAt": {
+          "name": "nextRunAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lastRunAt": {
+          "name": "lastRunAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "drive_backup_schedules_enabled_next_run_idx": {
+          "name": "drive_backup_schedules_enabled_next_run_idx",
+          "columns": [
+            {
+              "expression": "enabled",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "nextRunAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "drive_backup_schedules_driveId_drives_id_fk": {
+          "name": "drive_backup_schedules_driveId_drives_id_fk",
+          "tableFrom": "drive_backup_schedules",
+          "tableTo": "drives",
+          "columnsFrom": [
+            "driveId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "drive_backup_schedules_driveId_unique": {
+          "name": "drive_backup_schedules_driveId_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "driveId"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.drive_backups": {
+      "name": "drive_backups",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "driveId": {
+          "name": "driveId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "createdBy": {
+          "name": "createdBy",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source": {
+          "name": "source",
+          "type": "drive_backup_source",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'manual'"
+        },
+        "status": {
+          "name": "status",
+          "type": "drive_backup_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "changeGroupId": {
+          "name": "changeGroupId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "changeGroupType": {
+          "name": "changeGroupType",
+          "type": "activity_change_group_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "isPinned": {
+          "name": "isPinned",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "expiresAt": {
+          "name": "expiresAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completedAt": {
+          "name": "completedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "failedAt": {
+          "name": "failedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "failureReason": {
+          "name": "failureReason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "drive_backups_drive_created_at_idx": {
+          "name": "drive_backups_drive_created_at_idx",
+          "columns": [
+            {
+              "expression": "driveId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "createdAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "drive_backups_status_idx": {
+          "name": "drive_backups_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "drive_backups_driveId_drives_id_fk": {
+          "name": "drive_backups_driveId_drives_id_fk",
+          "tableFrom": "drive_backups",
+          "tableTo": "drives",
+          "columnsFrom": [
+            "driveId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "drive_backups_createdBy_users_id_fk": {
+          "name": "drive_backups_createdBy_users_id_fk",
+          "tableFrom": "drive_backups",
+          "tableTo": "users",
+          "columnsFrom": [
+            "createdBy"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "drive_backups_change_group_pair": {
+          "name": "drive_backups_change_group_pair",
+          "value": "(\"drive_backups\".\"changeGroupId\" IS NULL) = (\"drive_backups\".\"changeGroupType\" IS NULL)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.page_versions": {
+      "name": "page_versions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "pageId": {
+          "name": "pageId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "driveId": {
+          "name": "driveId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "createdBy": {
+          "name": "createdBy",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source": {
+          "name": "source",
+          "type": "page_version_source",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'auto'"
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "changeGroupId": {
+          "name": "changeGroupId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "changeGroupType": {
+          "name": "changeGroupType",
+          "type": "activity_change_group_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "contentRef": {
+          "name": "contentRef",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "contentFormat": {
+          "name": "contentFormat",
+          "type": "content_format",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "contentSize": {
+          "name": "contentSize",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stateHash": {
+          "name": "stateHash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pageRevision": {
+          "name": "pageRevision",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "isPinned": {
+          "name": "isPinned",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "expiresAt": {
+          "name": "expiresAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "page_versions_page_created_at_idx": {
+          "name": "page_versions_page_created_at_idx",
+          "columns": [
+            {
+              "expression": "pageId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "createdAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "page_versions_drive_created_at_idx": {
+          "name": "page_versions_drive_created_at_idx",
+          "columns": [
+            {
+              "expression": "driveId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "createdAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "page_versions_pinned_idx": {
+          "name": "page_versions_pinned_idx",
+          "columns": [
+            {
+              "expression": "isPinned",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "page_versions_page_id_is_pinned_created_at_idx": {
+          "name": "page_versions_page_id_is_pinned_created_at_idx",
+          "columns": [
+            {
+              "expression": "pageId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "isPinned",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "createdAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "page_versions_pageId_pages_id_fk": {
+          "name": "page_versions_pageId_pages_id_fk",
+          "tableFrom": "page_versions",
+          "tableTo": "pages",
+          "columnsFrom": [
+            "pageId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "page_versions_driveId_drives_id_fk": {
+          "name": "page_versions_driveId_drives_id_fk",
+          "tableFrom": "page_versions",
+          "tableTo": "drives",
+          "columnsFrom": [
+            "driveId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "page_versions_createdBy_users_id_fk": {
+          "name": "page_versions_createdBy_users_id_fk",
+          "tableFrom": "page_versions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "createdBy"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "page_versions_change_group_pair": {
+          "name": "page_versions_change_group_pair",
+          "value": "(\"page_versions\".\"changeGroupId\" IS NULL) = (\"page_versions\".\"changeGroupType\" IS NULL)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.connections": {
+      "name": "connections",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user1Id": {
+          "name": "user1Id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user2Id": {
+          "name": "user2Id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "ConnectionStatus",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'PENDING'"
+        },
+        "requestedBy": {
+          "name": "requestedBy",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "requestMessage": {
+          "name": "requestMessage",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "requestedAt": {
+          "name": "requestedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "acceptedAt": {
+          "name": "acceptedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "blockedBy": {
+          "name": "blockedBy",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "blockedAt": {
+          "name": "blockedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "connections_user1_id_idx": {
+          "name": "connections_user1_id_idx",
+          "columns": [
+            {
+              "expression": "user1Id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "connections_user2_id_idx": {
+          "name": "connections_user2_id_idx",
+          "columns": [
+            {
+              "expression": "user2Id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "connections_status_idx": {
+          "name": "connections_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "connections_user1_status_idx": {
+          "name": "connections_user1_status_idx",
+          "columns": [
+            {
+              "expression": "user1Id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "connections_user2_status_idx": {
+          "name": "connections_user2_status_idx",
+          "columns": [
+            {
+              "expression": "user2Id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "connections_user1Id_users_id_fk": {
+          "name": "connections_user1Id_users_id_fk",
+          "tableFrom": "connections",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user1Id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "connections_user2Id_users_id_fk": {
+          "name": "connections_user2Id_users_id_fk",
+          "tableFrom": "connections",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user2Id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "connections_requestedBy_users_id_fk": {
+          "name": "connections_requestedBy_users_id_fk",
+          "tableFrom": "connections",
+          "tableTo": "users",
+          "columnsFrom": [
+            "requestedBy"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "connections_blockedBy_users_id_fk": {
+          "name": "connections_blockedBy_users_id_fk",
+          "tableFrom": "connections",
+          "tableTo": "users",
+          "columnsFrom": [
+            "blockedBy"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "connections_user_pair_key": {
+          "name": "connections_user_pair_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user1Id",
+            "user2Id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.direct_messages": {
+      "name": "direct_messages",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "conversationId": {
+          "name": "conversationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "senderId": {
+          "name": "senderId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "fileId": {
+          "name": "fileId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "attachmentMeta": {
+          "name": "attachmentMeta",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "isRead": {
+          "name": "isRead",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "readAt": {
+          "name": "readAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "isEdited": {
+          "name": "isEdited",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "editedAt": {
+          "name": "editedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "isActive": {
+          "name": "isActive",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "deletedAt": {
+          "name": "deletedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "parentId": {
+          "name": "parentId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "replyCount": {
+          "name": "replyCount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "lastReplyAt": {
+          "name": "lastReplyAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mirroredFromId": {
+          "name": "mirroredFromId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "quotedMessageId": {
+          "name": "quotedMessageId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "direct_messages_conversation_id_idx": {
+          "name": "direct_messages_conversation_id_idx",
+          "columns": [
+            {
+              "expression": "conversationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "direct_messages_sender_id_idx": {
+          "name": "direct_messages_sender_id_idx",
+          "columns": [
+            {
+              "expression": "senderId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "direct_messages_created_at_idx": {
+          "name": "direct_messages_created_at_idx",
+          "columns": [
+            {
+              "expression": "createdAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "direct_messages_file_id_idx": {
+          "name": "direct_messages_file_id_idx",
+          "columns": [
+            {
+              "expression": "fileId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "direct_messages_conversation_active_created_idx": {
+          "name": "direct_messages_conversation_active_created_idx",
+          "columns": [
+            {
+              "expression": "conversationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "isActive",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "createdAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "direct_messages_inactive_deleted_at_idx": {
+          "name": "direct_messages_inactive_deleted_at_idx",
+          "columns": [
+            {
+              "expression": "isActive",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deletedAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "direct_messages_conversation_created_idx": {
+          "name": "direct_messages_conversation_created_idx",
+          "columns": [
+            {
+              "expression": "conversationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "createdAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "direct_messages_conversation_is_read_idx": {
+          "name": "direct_messages_conversation_is_read_idx",
+          "columns": [
+            {
+              "expression": "conversationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "isRead",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "direct_messages_unread_count_idx": {
+          "name": "direct_messages_unread_count_idx",
+          "columns": [
+            {
+              "expression": "conversationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "senderId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "isRead",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "direct_messages_parent_created_idx": {
+          "name": "direct_messages_parent_created_idx",
+          "columns": [
+            {
+              "expression": "parentId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "createdAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "direct_messages_quoted_id_idx": {
+          "name": "direct_messages_quoted_id_idx",
+          "columns": [
+            {
+              "expression": "quotedMessageId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "direct_messages_conversationId_dm_conversations_id_fk": {
+          "name": "direct_messages_conversationId_dm_conversations_id_fk",
+          "tableFrom": "direct_messages",
+          "tableTo": "dm_conversations",
+          "columnsFrom": [
+            "conversationId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "direct_messages_senderId_users_id_fk": {
+          "name": "direct_messages_senderId_users_id_fk",
+          "tableFrom": "direct_messages",
+          "tableTo": "users",
+          "columnsFrom": [
+            "senderId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "direct_messages_fileId_files_id_fk": {
+          "name": "direct_messages_fileId_files_id_fk",
+          "tableFrom": "direct_messages",
+          "tableTo": "files",
+          "columnsFrom": [
+            "fileId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "direct_messages_parentId_direct_messages_id_fk": {
+          "name": "direct_messages_parentId_direct_messages_id_fk",
+          "tableFrom": "direct_messages",
+          "tableTo": "direct_messages",
+          "columnsFrom": [
+            "parentId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "direct_messages_mirroredFromId_direct_messages_id_fk": {
+          "name": "direct_messages_mirroredFromId_direct_messages_id_fk",
+          "tableFrom": "direct_messages",
+          "tableTo": "direct_messages",
+          "columnsFrom": [
+            "mirroredFromId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "direct_messages_quotedMessageId_direct_messages_id_fk": {
+          "name": "direct_messages_quotedMessageId_direct_messages_id_fk",
+          "tableFrom": "direct_messages",
+          "tableTo": "direct_messages",
+          "columnsFrom": [
+            "quotedMessageId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.dm_conversations": {
+      "name": "dm_conversations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "participant1Id": {
+          "name": "participant1Id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "participant2Id": {
+          "name": "participant2Id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "lastMessageAt": {
+          "name": "lastMessageAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lastMessagePreview": {
+          "name": "lastMessagePreview",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "participant1LastRead": {
+          "name": "participant1LastRead",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "participant2LastRead": {
+          "name": "participant2LastRead",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "dm_conversations_participant1_id_idx": {
+          "name": "dm_conversations_participant1_id_idx",
+          "columns": [
+            {
+              "expression": "participant1Id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "dm_conversations_participant2_id_idx": {
+          "name": "dm_conversations_participant2_id_idx",
+          "columns": [
+            {
+              "expression": "participant2Id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "dm_conversations_last_message_at_idx": {
+          "name": "dm_conversations_last_message_at_idx",
+          "columns": [
+            {
+              "expression": "lastMessageAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "dm_conversations_participant1_last_message_idx": {
+          "name": "dm_conversations_participant1_last_message_idx",
+          "columns": [
+            {
+              "expression": "participant1Id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "lastMessageAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "dm_conversations_participant2_last_message_idx": {
+          "name": "dm_conversations_participant2_last_message_idx",
+          "columns": [
+            {
+              "expression": "participant2Id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "lastMessageAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "dm_conversations_participant1Id_users_id_fk": {
+          "name": "dm_conversations_participant1Id_users_id_fk",
+          "tableFrom": "dm_conversations",
+          "tableTo": "users",
+          "columnsFrom": [
+            "participant1Id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "dm_conversations_participant2Id_users_id_fk": {
+          "name": "dm_conversations_participant2Id_users_id_fk",
+          "tableFrom": "dm_conversations",
+          "tableTo": "users",
+          "columnsFrom": [
+            "participant2Id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "dm_conversations_participant_pair_key": {
+          "name": "dm_conversations_participant_pair_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "participant1Id",
+            "participant2Id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.dm_message_reactions": {
+      "name": "dm_message_reactions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "messageId": {
+          "name": "messageId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "emoji": {
+          "name": "emoji",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "dm_unique_reaction_idx": {
+          "name": "dm_unique_reaction_idx",
+          "columns": [
+            {
+              "expression": "messageId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "emoji",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "dm_reaction_message_idx": {
+          "name": "dm_reaction_message_idx",
+          "columns": [
+            {
+              "expression": "messageId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "dm_message_reactions_messageId_direct_messages_id_fk": {
+          "name": "dm_message_reactions_messageId_direct_messages_id_fk",
+          "tableFrom": "dm_message_reactions",
+          "tableTo": "direct_messages",
+          "columnsFrom": [
+            "messageId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "dm_message_reactions_userId_users_id_fk": {
+          "name": "dm_message_reactions_userId_users_id_fk",
+          "tableFrom": "dm_message_reactions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.dm_thread_followers": {
+      "name": "dm_thread_followers",
+      "schema": "",
+      "columns": {
+        "rootMessageId": {
+          "name": "rootMessageId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "dm_thread_followers_user_id_idx": {
+          "name": "dm_thread_followers_user_id_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "dm_thread_followers_rootMessageId_direct_messages_id_fk": {
+          "name": "dm_thread_followers_rootMessageId_direct_messages_id_fk",
+          "tableFrom": "dm_thread_followers",
+          "tableTo": "direct_messages",
+          "columnsFrom": [
+            "rootMessageId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "dm_thread_followers_userId_users_id_fk": {
+          "name": "dm_thread_followers_userId_users_id_fk",
+          "tableFrom": "dm_thread_followers",
+          "tableTo": "users",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "dm_thread_followers_rootMessageId_userId_pk": {
+          "name": "dm_thread_followers_rootMessageId_userId_pk",
+          "columns": [
+            "rootMessageId",
+            "userId"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.stripe_events": {
+      "name": "stripe_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "processedAt": {
+          "name": "processedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "stripe_events_type_idx": {
+          "name": "stripe_events_type_idx",
+          "columns": [
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "stripe_events_processed_at_idx": {
+          "name": "stripe_events_processed_at_idx",
+          "columns": [
+            {
+              "expression": "processedAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.subscriptions": {
+      "name": "subscriptions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stripeSubscriptionId": {
+          "name": "stripeSubscriptionId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stripePriceId": {
+          "name": "stripePriceId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "currentPeriodStart": {
+          "name": "currentPeriodStart",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "currentPeriodEnd": {
+          "name": "currentPeriodEnd",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cancelAtPeriodEnd": {
+          "name": "cancelAtPeriodEnd",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "gifted": {
+          "name": "gifted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "stripeScheduleId": {
+          "name": "stripeScheduleId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scheduledPriceId": {
+          "name": "scheduledPriceId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scheduledChangeDate": {
+          "name": "scheduledChangeDate",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "subscriptions_user_id_idx": {
+          "name": "subscriptions_user_id_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "subscriptions_stripe_subscription_id_idx": {
+          "name": "subscriptions_stripe_subscription_id_idx",
+          "columns": [
+            {
+              "expression": "stripeSubscriptionId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "subscriptions_stripe_schedule_id_idx": {
+          "name": "subscriptions_stripe_schedule_id_idx",
+          "columns": [
+            {
+              "expression": "stripeScheduleId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "subscriptions_userId_users_id_fk": {
+          "name": "subscriptions_userId_users_id_fk",
+          "tableFrom": "subscriptions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "subscriptions_stripeSubscriptionId_unique": {
+          "name": "subscriptions_stripeSubscriptionId_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "stripeSubscriptionId"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.contact_submissions": {
+      "name": "contact_submissions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subject": {
+          "name": "subject",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "message": {
+          "name": "message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "resolvedAt": {
+          "name": "resolvedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "contact_submissions_email_idx": {
+          "name": "contact_submissions_email_idx",
+          "columns": [
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "contact_submissions_created_at_idx": {
+          "name": "contact_submissions_created_at_idx",
+          "columns": [
+            {
+              "expression": "createdAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.feedback_submissions": {
+      "name": "feedback_submissions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "message": {
+          "name": "message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "attachments": {
+          "name": "attachments",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "page_url": {
+          "name": "page_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "screen_size": {
+          "name": "screen_size",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "viewport_size": {
+          "name": "viewport_size",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "app_version": {
+          "name": "app_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "console_errors": {
+          "name": "console_errors",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'new'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "feedback_submissions_user_id_idx": {
+          "name": "feedback_submissions_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "feedback_submissions_status_idx": {
+          "name": "feedback_submissions_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "feedback_submissions_created_at_idx": {
+          "name": "feedback_submissions_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "feedback_submissions_user_id_users_id_fk": {
+          "name": "feedback_submissions_user_id_users_id_fk",
+          "tableFrom": "feedback_submissions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.file_conversations": {
+      "name": "file_conversations",
+      "schema": "",
+      "columns": {
+        "fileId": {
+          "name": "fileId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "conversationId": {
+          "name": "conversationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "linkedBy": {
+          "name": "linkedBy",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "linkedAt": {
+          "name": "linkedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "linkSource": {
+          "name": "linkSource",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "file_conversations_file_id_idx": {
+          "name": "file_conversations_file_id_idx",
+          "columns": [
+            {
+              "expression": "fileId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "file_conversations_conversation_id_idx": {
+          "name": "file_conversations_conversation_id_idx",
+          "columns": [
+            {
+              "expression": "conversationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "file_conversations_fileId_files_id_fk": {
+          "name": "file_conversations_fileId_files_id_fk",
+          "tableFrom": "file_conversations",
+          "tableTo": "files",
+          "columnsFrom": [
+            "fileId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "file_conversations_conversationId_dm_conversations_id_fk": {
+          "name": "file_conversations_conversationId_dm_conversations_id_fk",
+          "tableFrom": "file_conversations",
+          "tableTo": "dm_conversations",
+          "columnsFrom": [
+            "conversationId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "file_conversations_linkedBy_users_id_fk": {
+          "name": "file_conversations_linkedBy_users_id_fk",
+          "tableFrom": "file_conversations",
+          "tableTo": "users",
+          "columnsFrom": [
+            "linkedBy"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "file_conversations_fileId_conversationId_pk": {
+          "name": "file_conversations_fileId_conversationId_pk",
+          "columns": [
+            "fileId",
+            "conversationId"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.file_pages": {
+      "name": "file_pages",
+      "schema": "",
+      "columns": {
+        "fileId": {
+          "name": "fileId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pageId": {
+          "name": "pageId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "linkedBy": {
+          "name": "linkedBy",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "linkedAt": {
+          "name": "linkedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "linkSource": {
+          "name": "linkSource",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "file_pages_file_id_idx": {
+          "name": "file_pages_file_id_idx",
+          "columns": [
+            {
+              "expression": "fileId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "file_pages_page_id_idx": {
+          "name": "file_pages_page_id_idx",
+          "columns": [
+            {
+              "expression": "pageId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "file_pages_fileId_files_id_fk": {
+          "name": "file_pages_fileId_files_id_fk",
+          "tableFrom": "file_pages",
+          "tableTo": "files",
+          "columnsFrom": [
+            "fileId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "file_pages_pageId_pages_id_fk": {
+          "name": "file_pages_pageId_pages_id_fk",
+          "tableFrom": "file_pages",
+          "tableTo": "pages",
+          "columnsFrom": [
+            "pageId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "file_pages_linkedBy_users_id_fk": {
+          "name": "file_pages_linkedBy_users_id_fk",
+          "tableFrom": "file_pages",
+          "tableTo": "users",
+          "columnsFrom": [
+            "linkedBy"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "file_pages_fileId_pageId_pk": {
+          "name": "file_pages_fileId_pageId_pk",
+          "columns": [
+            "fileId",
+            "pageId"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.files": {
+      "name": "files",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "driveId": {
+          "name": "driveId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sizeBytes": {
+          "name": "sizeBytes",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "mimeType": {
+          "name": "mimeType",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "storagePath": {
+          "name": "storagePath",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "checksumVersion": {
+          "name": "checksumVersion",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "createdBy": {
+          "name": "createdBy",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lastAccessedAt": {
+          "name": "lastAccessedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "files_drive_id_idx": {
+          "name": "files_drive_id_idx",
+          "columns": [
+            {
+              "expression": "driveId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "files_driveId_drives_id_fk": {
+          "name": "files_driveId_drives_id_fk",
+          "tableFrom": "files",
+          "tableTo": "drives",
+          "columnsFrom": [
+            "driveId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "files_createdBy_users_id_fk": {
+          "name": "files_createdBy_users_id_fk",
+          "tableFrom": "files",
+          "tableTo": "users",
+          "columnsFrom": [
+            "createdBy"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.pending_uploads": {
+      "name": "pending_uploads",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "fileSize": {
+          "name": "fileSize",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expiresAt": {
+          "name": "expiresAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "pending_uploads_user_expires_idx": {
+          "name": "pending_uploads_user_expires_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "expiresAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "pending_uploads_expires_idx": {
+          "name": "pending_uploads_expires_idx",
+          "columns": [
+            {
+              "expression": "expiresAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "pending_uploads_userId_users_id_fk": {
+          "name": "pending_uploads_userId_users_id_fk",
+          "tableFrom": "pending_uploads",
+          "tableTo": "users",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.task_assignees": {
+      "name": "task_assignees",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "taskId": {
+          "name": "taskId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "agentPageId": {
+          "name": "agentPageId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "task_assignees_task_id_idx": {
+          "name": "task_assignees_task_id_idx",
+          "columns": [
+            {
+              "expression": "taskId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "task_assignees_user_id_idx": {
+          "name": "task_assignees_user_id_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "task_assignees_agent_page_id_idx": {
+          "name": "task_assignees_agent_page_id_idx",
+          "columns": [
+            {
+              "expression": "agentPageId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "task_assignees_taskId_task_items_id_fk": {
+          "name": "task_assignees_taskId_task_items_id_fk",
+          "tableFrom": "task_assignees",
+          "tableTo": "task_items",
+          "columnsFrom": [
+            "taskId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "task_assignees_userId_users_id_fk": {
+          "name": "task_assignees_userId_users_id_fk",
+          "tableFrom": "task_assignees",
+          "tableTo": "users",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "task_assignees_agentPageId_pages_id_fk": {
+          "name": "task_assignees_agentPageId_pages_id_fk",
+          "tableFrom": "task_assignees",
+          "tableTo": "pages",
+          "columnsFrom": [
+            "agentPageId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "task_assignees_task_user": {
+          "name": "task_assignees_task_user",
+          "nullsNotDistinct": false,
+          "columns": [
+            "taskId",
+            "userId"
+          ]
+        },
+        "task_assignees_task_agent": {
+          "name": "task_assignees_task_agent",
+          "nullsNotDistinct": false,
+          "columns": [
+            "taskId",
+            "agentPageId"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "task_assignees_has_assignee": {
+          "name": "task_assignees_has_assignee",
+          "value": "(\"userId\" IS NOT NULL OR \"agentPageId\" IS NOT NULL)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.task_items": {
+      "name": "task_items",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "assigneeId": {
+          "name": "assigneeId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "assigneeAgentId": {
+          "name": "assigneeAgentId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pageId": {
+          "name": "pageId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "priority": {
+          "name": "priority",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'medium'"
+        },
+        "dueDate": {
+          "name": "dueDate",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completedAt": {
+          "name": "completedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "task_items_assignee_id_idx": {
+          "name": "task_items_assignee_id_idx",
+          "columns": [
+            {
+              "expression": "assigneeId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "task_items_assignee_agent_id_idx": {
+          "name": "task_items_assignee_agent_id_idx",
+          "columns": [
+            {
+              "expression": "assigneeAgentId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "task_items_page_id_idx": {
+          "name": "task_items_page_id_idx",
+          "columns": [
+            {
+              "expression": "pageId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "task_items_due_date_idx": {
+          "name": "task_items_due_date_idx",
+          "columns": [
+            {
+              "expression": "dueDate",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "task_items_userId_users_id_fk": {
+          "name": "task_items_userId_users_id_fk",
+          "tableFrom": "task_items",
+          "tableTo": "users",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "task_items_assigneeId_users_id_fk": {
+          "name": "task_items_assigneeId_users_id_fk",
+          "tableFrom": "task_items",
+          "tableTo": "users",
+          "columnsFrom": [
+            "assigneeId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "task_items_assigneeAgentId_pages_id_fk": {
+          "name": "task_items_assigneeAgentId_pages_id_fk",
+          "tableFrom": "task_items",
+          "tableTo": "pages",
+          "columnsFrom": [
+            "assigneeAgentId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "task_items_pageId_pages_id_fk": {
+          "name": "task_items_pageId_pages_id_fk",
+          "tableFrom": "task_items",
+          "tableTo": "pages",
+          "columnsFrom": [
+            "pageId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "task_items_pageId_unique": {
+          "name": "task_items_pageId_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "pageId"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.task_lists": {
+      "name": "task_lists",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pageId": {
+          "name": "pageId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "conversationId": {
+          "name": "conversationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "task_lists_page_id_idx": {
+          "name": "task_lists_page_id_idx",
+          "columns": [
+            {
+              "expression": "pageId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "task_lists_conversation_id_idx": {
+          "name": "task_lists_conversation_id_idx",
+          "columns": [
+            {
+              "expression": "conversationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "task_lists_user_id_idx": {
+          "name": "task_lists_user_id_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "task_lists_userId_users_id_fk": {
+          "name": "task_lists_userId_users_id_fk",
+          "tableFrom": "task_lists",
+          "tableTo": "users",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "task_lists_pageId_pages_id_fk": {
+          "name": "task_lists_pageId_pages_id_fk",
+          "tableFrom": "task_lists",
+          "tableTo": "pages",
+          "columnsFrom": [
+            "pageId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.task_status_configs": {
+      "name": "task_status_configs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "taskListId": {
+          "name": "taskListId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "color": {
+          "name": "color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "group": {
+          "name": "group",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "task_status_configs_task_list_id_idx": {
+          "name": "task_status_configs_task_list_id_idx",
+          "columns": [
+            {
+              "expression": "taskListId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "task_status_configs_taskListId_task_lists_id_fk": {
+          "name": "task_status_configs_taskListId_task_lists_id_fk",
+          "tableFrom": "task_status_configs",
+          "tableTo": "task_lists",
+          "columnsFrom": [
+            "taskListId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "task_status_configs_task_list_slug": {
+          "name": "task_status_configs_task_list_slug",
+          "nullsNotDistinct": false,
+          "columns": [
+            "taskListId",
+            "slug"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sheet_cell_deps": {
+      "name": "sheet_cell_deps",
+      "schema": "",
+      "columns": {
+        "tabId": {
+          "name": "tabId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "address": {
+          "name": "address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "dependsOn": {
+          "name": "dependsOn",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "dependents": {
+          "name": "dependents",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "sheet_cell_deps_tab_idx": {
+          "name": "sheet_cell_deps_tab_idx",
+          "columns": [
+            {
+              "expression": "tabId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "sheet_cell_deps_tabId_sheet_tabs_id_fk": {
+          "name": "sheet_cell_deps_tabId_sheet_tabs_id_fk",
+          "tableFrom": "sheet_cell_deps",
+          "tableTo": "sheet_tabs",
+          "columnsFrom": [
+            "tabId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "sheet_cell_deps_tabId_address_pk": {
+          "name": "sheet_cell_deps_tabId_address_pk",
+          "columns": [
+            "tabId",
+            "address"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sheet_changes": {
+      "name": "sheet_changes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "pageId": {
+          "name": "pageId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tabId": {
+          "name": "tabId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "seq": {
+          "name": "seq",
+          "type": "bigserial",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actorUserId": {
+          "name": "actorUserId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "actorEmail": {
+          "name": "actorEmail",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "changeGroupId": {
+          "name": "changeGroupId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "op": {
+          "name": "op",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "address": {
+          "name": "address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rowIndex": {
+          "name": "rowIndex",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "before": {
+          "name": "before",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "after": {
+          "name": "after",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "sheet_changes_page_seq_idx": {
+          "name": "sheet_changes_page_seq_idx",
+          "columns": [
+            {
+              "expression": "pageId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "seq",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sheet_changes_tab_seq_idx": {
+          "name": "sheet_changes_tab_seq_idx",
+          "columns": [
+            {
+              "expression": "tabId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "seq",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sheet_changes_created_at_idx": {
+          "name": "sheet_changes_created_at_idx",
+          "columns": [
+            {
+              "expression": "createdAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "sheet_changes_pageId_pages_id_fk": {
+          "name": "sheet_changes_pageId_pages_id_fk",
+          "tableFrom": "sheet_changes",
+          "tableTo": "pages",
+          "columnsFrom": [
+            "pageId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "sheet_changes_actorUserId_users_id_fk": {
+          "name": "sheet_changes_actorUserId_users_id_fk",
+          "tableFrom": "sheet_changes",
+          "tableTo": "users",
+          "columnsFrom": [
+            "actorUserId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sheet_range_deps": {
+      "name": "sheet_range_deps",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "tabId": {
+          "name": "tabId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "formulaAddress": {
+          "name": "formulaAddress",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rowStart": {
+          "name": "rowStart",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rowEnd": {
+          "name": "rowEnd",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "colStart": {
+          "name": "colStart",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "colEnd": {
+          "name": "colEnd",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "sheet_range_deps_tab_idx": {
+          "name": "sheet_range_deps_tab_idx",
+          "columns": [
+            {
+              "expression": "tabId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sheet_range_deps_cover_idx": {
+          "name": "sheet_range_deps_cover_idx",
+          "columns": [
+            {
+              "expression": "tabId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "rowStart",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "rowEnd",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sheet_range_deps_formula_idx": {
+          "name": "sheet_range_deps_formula_idx",
+          "columns": [
+            {
+              "expression": "tabId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "formulaAddress",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "sheet_range_deps_tabId_sheet_tabs_id_fk": {
+          "name": "sheet_range_deps_tabId_sheet_tabs_id_fk",
+          "tableFrom": "sheet_range_deps",
+          "tableTo": "sheet_tabs",
+          "columnsFrom": [
+            "tabId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "sheet_range_deps_bounds_ordered": {
+          "name": "sheet_range_deps_bounds_ordered",
+          "value": "(\"sheet_range_deps\".\"rowEnd\" IS NULL OR \"sheet_range_deps\".\"rowEnd\" >= \"sheet_range_deps\".\"rowStart\") AND (\"sheet_range_deps\".\"colEnd\" IS NULL OR \"sheet_range_deps\".\"colEnd\" >= \"sheet_range_deps\".\"colStart\")"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.sheet_rows": {
+      "name": "sheet_rows",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "tabId": {
+          "name": "tabId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pageId": {
+          "name": "pageId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rowIndex": {
+          "name": "rowIndex",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cells": {
+          "name": "cells",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "sheet_rows_page_row_idx": {
+          "name": "sheet_rows_page_row_idx",
+          "columns": [
+            {
+              "expression": "pageId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "rowIndex",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sheet_rows_tab_row_idx": {
+          "name": "sheet_rows_tab_row_idx",
+          "columns": [
+            {
+              "expression": "tabId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "rowIndex",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sheet_rows_cells_gin": {
+          "name": "sheet_rows_cells_gin",
+          "columns": [
+            {
+              "expression": "cells",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "sheet_rows_tabId_sheet_tabs_id_fk": {
+          "name": "sheet_rows_tabId_sheet_tabs_id_fk",
+          "tableFrom": "sheet_rows",
+          "tableTo": "sheet_tabs",
+          "columnsFrom": [
+            "tabId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "sheet_rows_pageId_pages_id_fk": {
+          "name": "sheet_rows_pageId_pages_id_fk",
+          "tableFrom": "sheet_rows",
+          "tableTo": "pages",
+          "columnsFrom": [
+            "pageId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "sheet_rows_tab_row_unique": {
+          "name": "sheet_rows_tab_row_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "tabId",
+            "rowIndex"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "sheet_rows_row_index_non_negative": {
+          "name": "sheet_rows_row_index_non_negative",
+          "value": "\"sheet_rows\".\"rowIndex\" >= 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.sheet_tabs": {
+      "name": "sheet_tabs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "pageId": {
+          "name": "pageId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tabIndex": {
+          "name": "tabIndex",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rowCount": {
+          "name": "rowCount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "columnCount": {
+          "name": "columnCount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "frozenRows": {
+          "name": "frozenRows",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "frozenColumns": {
+          "name": "frozenColumns",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "columnFormats": {
+          "name": "columnFormats",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "columnWidths": {
+          "name": "columnWidths",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rowHeights": {
+          "name": "rowHeights",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ranges": {
+          "name": "ranges",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "conditionalFormats": {
+          "name": "conditionalFormats",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "sheet_tabs_page_id_idx": {
+          "name": "sheet_tabs_page_id_idx",
+          "columns": [
+            {
+              "expression": "pageId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "sheet_tabs_pageId_pages_id_fk": {
+          "name": "sheet_tabs_pageId_pages_id_fk",
+          "tableFrom": "sheet_tabs",
+          "tableTo": "pages",
+          "columnsFrom": [
+            "pageId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "sheet_tabs_page_tab_unique": {
+          "name": "sheet_tabs_page_tab_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "pageId",
+            "tabIndex"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "sheet_tabs_extent_non_negative": {
+          "name": "sheet_tabs_extent_non_negative",
+          "value": "\"sheet_tabs\".\"rowCount\" >= 0 AND \"sheet_tabs\".\"columnCount\" >= 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.security_audit_log": {
+      "name": "security_audit_log",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "service_id": {
+          "name": "service_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resource_type": {
+          "name": "resource_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resource_id": {
+          "name": "resource_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ip_bidx": {
+          "name": "ip_bidx",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "geo_location": {
+          "name": "geo_location",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "details": {
+          "name": "details",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "risk_score": {
+          "name": "risk_score",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "anomaly_flags": {
+          "name": "anomaly_flags",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "chain_seq": {
+          "name": "chain_seq",
+          "type": "bigserial",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "previous_hash": {
+          "name": "previous_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_hash": {
+          "name": "event_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_security_audit_timestamp": {
+          "name": "idx_security_audit_timestamp",
+          "columns": [
+            {
+              "expression": "timestamp",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_security_audit_user_timestamp": {
+          "name": "idx_security_audit_user_timestamp",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "timestamp",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_security_audit_event_type": {
+          "name": "idx_security_audit_event_type",
+          "columns": [
+            {
+              "expression": "event_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "timestamp",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_security_audit_resource": {
+          "name": "idx_security_audit_resource",
+          "columns": [
+            {
+              "expression": "resource_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "resource_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "timestamp",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_security_audit_ip": {
+          "name": "idx_security_audit_ip",
+          "columns": [
+            {
+              "expression": "ip_address",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "timestamp",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_security_audit_ip_bidx": {
+          "name": "idx_security_audit_ip_bidx",
+          "columns": [
+            {
+              "expression": "ip_bidx",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "timestamp",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_security_audit_event_hash": {
+          "name": "idx_security_audit_event_hash",
+          "columns": [
+            {
+              "expression": "event_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_security_audit_chain_seq": {
+          "name": "idx_security_audit_chain_seq",
+          "columns": [
+            {
+              "expression": "chain_seq",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_security_audit_risk_score": {
+          "name": "idx_security_audit_risk_score",
+          "columns": [
+            {
+              "expression": "risk_score",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_security_audit_session": {
+          "name": "idx_security_audit_session",
+          "columns": [
+            {
+              "expression": "session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "timestamp",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "security_audit_log_user_id_users_id_fk": {
+          "name": "security_audit_log_user_id_users_id_fk",
+          "tableFrom": "security_audit_log",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_page_views": {
+      "name": "user_page_views",
+      "schema": "",
+      "columns": {
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pageId": {
+          "name": "pageId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "viewedAt": {
+          "name": "viewedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "user_page_views_user_id_idx": {
+          "name": "user_page_views_user_id_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_page_views_page_id_idx": {
+          "name": "user_page_views_page_id_idx",
+          "columns": [
+            {
+              "expression": "pageId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_page_views_user_page_idx": {
+          "name": "user_page_views_user_page_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "pageId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_page_views_userId_users_id_fk": {
+          "name": "user_page_views_userId_users_id_fk",
+          "tableFrom": "user_page_views",
+          "tableTo": "users",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "user_page_views_pageId_pages_id_fk": {
+          "name": "user_page_views_pageId_pages_id_fk",
+          "tableFrom": "user_page_views",
+          "tableTo": "pages",
+          "columnsFrom": [
+            "pageId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "user_page_views_userId_pageId_pk": {
+          "name": "user_page_views_userId_pageId_pk",
+          "columns": [
+            "userId",
+            "pageId"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_hotkey_preferences": {
+      "name": "user_hotkey_preferences",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "hotkeyId": {
+          "name": "hotkeyId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "binding": {
+          "name": "binding",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "user_hotkey_preferences_user_hotkey_idx": {
+          "name": "user_hotkey_preferences_user_hotkey_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "hotkeyId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_hotkey_preferences_user_idx": {
+          "name": "user_hotkey_preferences_user_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_hotkey_preferences_userId_users_id_fk": {
+          "name": "user_hotkey_preferences_userId_users_id_fk",
+          "tableFrom": "user_hotkey_preferences",
+          "tableTo": "users",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.push_notification_tokens": {
+      "name": "push_notification_tokens",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "platform": {
+          "name": "platform",
+          "type": "PushPlatformType",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "deviceId": {
+          "name": "deviceId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deviceName": {
+          "name": "deviceName",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "isActive": {
+          "name": "isActive",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "webPushSubscription": {
+          "name": "webPushSubscription",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "lastUsedAt": {
+          "name": "lastUsedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "failedAttempts": {
+          "name": "failedAttempts",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'0'"
+        },
+        "lastFailedAt": {
+          "name": "lastFailedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "push_notification_tokens_user_id_idx": {
+          "name": "push_notification_tokens_user_id_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "push_notification_tokens_token_idx": {
+          "name": "push_notification_tokens_token_idx",
+          "columns": [
+            {
+              "expression": "token",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "push_notification_tokens_platform_idx": {
+          "name": "push_notification_tokens_platform_idx",
+          "columns": [
+            {
+              "expression": "platform",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "push_notification_tokens_active_idx": {
+          "name": "push_notification_tokens_active_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "isActive",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "push_notification_tokens_userId_users_id_fk": {
+          "name": "push_notification_tokens_userId_users_id_fk",
+          "tableFrom": "push_notification_tokens",
+          "tableTo": "users",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.global_assistant_config": {
+      "name": "global_assistant_config",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "enabled_user_integrations": {
+          "name": "enabled_user_integrations",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "drive_overrides": {
+          "name": "drive_overrides",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "inherit_drive_integrations": {
+          "name": "inherit_drive_integrations",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "global_assistant_config_user_id_users_id_fk": {
+          "name": "global_assistant_config_user_id_users_id_fk",
+          "tableFrom": "global_assistant_config",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "global_assistant_config_user_id_unique": {
+          "name": "global_assistant_config_user_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.integration_audit_log": {
+      "name": "integration_audit_log",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "drive_id": {
+          "name": "drive_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "connection_id": {
+          "name": "connection_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tool_name": {
+          "name": "tool_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "input_summary": {
+          "name": "input_summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "success": {
+          "name": "success",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "response_code": {
+          "name": "response_code",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_type": {
+          "name": "error_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "duration_ms": {
+          "name": "duration_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "integration_audit_log_drive_id_idx": {
+          "name": "integration_audit_log_drive_id_idx",
+          "columns": [
+            {
+              "expression": "drive_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "integration_audit_log_connection_id_idx": {
+          "name": "integration_audit_log_connection_id_idx",
+          "columns": [
+            {
+              "expression": "connection_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "integration_audit_log_created_at_idx": {
+          "name": "integration_audit_log_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "integration_audit_log_drive_created_at_idx": {
+          "name": "integration_audit_log_drive_created_at_idx",
+          "columns": [
+            {
+              "expression": "drive_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "integration_audit_log_drive_id_drives_id_fk": {
+          "name": "integration_audit_log_drive_id_drives_id_fk",
+          "tableFrom": "integration_audit_log",
+          "tableTo": "drives",
+          "columnsFrom": [
+            "drive_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "integration_audit_log_agent_id_pages_id_fk": {
+          "name": "integration_audit_log_agent_id_pages_id_fk",
+          "tableFrom": "integration_audit_log",
+          "tableTo": "pages",
+          "columnsFrom": [
+            "agent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "integration_audit_log_user_id_users_id_fk": {
+          "name": "integration_audit_log_user_id_users_id_fk",
+          "tableFrom": "integration_audit_log",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "integration_audit_log_connection_id_integration_connections_id_fk": {
+          "name": "integration_audit_log_connection_id_integration_connections_id_fk",
+          "tableFrom": "integration_audit_log",
+          "tableTo": "integration_connections",
+          "columnsFrom": [
+            "connection_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.integration_connections": {
+      "name": "integration_connections",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "drive_id": {
+          "name": "drive_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "integration_connection_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "status_message": {
+          "name": "status_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "credentials": {
+          "name": "credentials",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "base_url_override": {
+          "name": "base_url_override",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "config_overrides": {
+          "name": "config_overrides",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "account_metadata": {
+          "name": "account_metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "visibility": {
+          "name": "visibility",
+          "type": "integration_visibility",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'owned_drives'"
+        },
+        "oauth_state": {
+          "name": "oauth_state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "connected_by": {
+          "name": "connected_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "connected_at": {
+          "name": "connected_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_health_check": {
+          "name": "last_health_check",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "integration_connections_provider_id_idx": {
+          "name": "integration_connections_provider_id_idx",
+          "columns": [
+            {
+              "expression": "provider_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "integration_connections_user_id_idx": {
+          "name": "integration_connections_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "integration_connections_drive_id_idx": {
+          "name": "integration_connections_drive_id_idx",
+          "columns": [
+            {
+              "expression": "drive_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "integration_connections_provider_id_integration_providers_id_fk": {
+          "name": "integration_connections_provider_id_integration_providers_id_fk",
+          "tableFrom": "integration_connections",
+          "tableTo": "integration_providers",
+          "columnsFrom": [
+            "provider_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "integration_connections_user_id_users_id_fk": {
+          "name": "integration_connections_user_id_users_id_fk",
+          "tableFrom": "integration_connections",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "integration_connections_drive_id_drives_id_fk": {
+          "name": "integration_connections_drive_id_drives_id_fk",
+          "tableFrom": "integration_connections",
+          "tableTo": "drives",
+          "columnsFrom": [
+            "drive_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "integration_connections_connected_by_users_id_fk": {
+          "name": "integration_connections_connected_by_users_id_fk",
+          "tableFrom": "integration_connections",
+          "tableTo": "users",
+          "columnsFrom": [
+            "connected_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "integration_connections_user_provider": {
+          "name": "integration_connections_user_provider",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "provider_id"
+          ]
+        },
+        "integration_connections_drive_provider": {
+          "name": "integration_connections_drive_provider",
+          "nullsNotDistinct": false,
+          "columns": [
+            "drive_id",
+            "provider_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "integration_connections_scope_chk": {
+          "name": "integration_connections_scope_chk",
+          "value": "(\"integration_connections\".\"user_id\" IS NOT NULL AND \"integration_connections\".\"drive_id\" IS NULL) OR (\"integration_connections\".\"user_id\" IS NULL AND \"integration_connections\".\"drive_id\" IS NOT NULL)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.integration_providers": {
+      "name": "integration_providers",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "icon_url": {
+          "name": "icon_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "documentation_url": {
+          "name": "documentation_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider_type": {
+          "name": "provider_type",
+          "type": "integration_provider_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "config": {
+          "name": "config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "openapi_spec": {
+          "name": "openapi_spec",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_system": {
+          "name": "is_system",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "drive_id": {
+          "name": "drive_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "integration_providers_slug_idx": {
+          "name": "integration_providers_slug_idx",
+          "columns": [
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "integration_providers_drive_id_idx": {
+          "name": "integration_providers_drive_id_idx",
+          "columns": [
+            {
+              "expression": "drive_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "integration_providers_created_by_users_id_fk": {
+          "name": "integration_providers_created_by_users_id_fk",
+          "tableFrom": "integration_providers",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "integration_providers_drive_id_drives_id_fk": {
+          "name": "integration_providers_drive_id_drives_id_fk",
+          "tableFrom": "integration_providers",
+          "tableTo": "drives",
+          "columnsFrom": [
+            "drive_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "integration_providers_slug_unique": {
+          "name": "integration_providers_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.integration_tool_grants": {
+      "name": "integration_tool_grants",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "connection_id": {
+          "name": "connection_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "allowed_tools": {
+          "name": "allowed_tools",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "denied_tools": {
+          "name": "denied_tools",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "read_only": {
+          "name": "read_only",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "rate_limit_override": {
+          "name": "rate_limit_override",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "integration_tool_grants_agent_id_idx": {
+          "name": "integration_tool_grants_agent_id_idx",
+          "columns": [
+            {
+              "expression": "agent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "integration_tool_grants_connection_id_idx": {
+          "name": "integration_tool_grants_connection_id_idx",
+          "columns": [
+            {
+              "expression": "connection_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "integration_tool_grants_agent_id_pages_id_fk": {
+          "name": "integration_tool_grants_agent_id_pages_id_fk",
+          "tableFrom": "integration_tool_grants",
+          "tableTo": "pages",
+          "columnsFrom": [
+            "agent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "integration_tool_grants_connection_id_integration_connections_id_fk": {
+          "name": "integration_tool_grants_connection_id_integration_connections_id_fk",
+          "tableFrom": "integration_tool_grants",
+          "tableTo": "integration_connections",
+          "columnsFrom": [
+            "connection_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "integration_tool_grants_agent_connection": {
+          "name": "integration_tool_grants_agent_connection",
+          "nullsNotDistinct": false,
+          "columns": [
+            "agent_id",
+            "connection_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.personalization_candidates": {
+      "name": "personalization_candidates",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "field": {
+          "name": "field",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "claim": {
+          "name": "claim",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "claimKey": {
+          "name": "claimKey",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "evidence": {
+          "name": "evidence",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "occurrences": {
+          "name": "occurrences",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "firstSeenAt": {
+          "name": "firstSeenAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "lastSeenAt": {
+          "name": "lastSeenAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "promotedAt": {
+          "name": "promotedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rejectedAt": {
+          "name": "rejectedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "personalization_candidates_user_field_claim_idx": {
+          "name": "personalization_candidates_user_field_claim_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "field",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "claimKey",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "personalization_candidates_userId_users_id_fk": {
+          "name": "personalization_candidates_userId_users_id_fk",
+          "tableFrom": "personalization_candidates",
+          "tableTo": "users",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "personalization_candidates_field_chk": {
+          "name": "personalization_candidates_field_chk",
+          "value": "\"personalization_candidates\".\"field\" IN ('bio', 'writingStyle', 'rules')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.user_personalization": {
+      "name": "user_personalization",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "bio": {
+          "name": "bio",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "writingStyle": {
+          "name": "writingStyle",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rules": {
+          "name": "rules",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "memoryFolderId": {
+          "name": "memoryFolderId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bioPageId": {
+          "name": "bioPageId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "writingStylePageId": {
+          "name": "writingStylePageId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rulesPageId": {
+          "name": "rulesPageId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "user_personalization_user_idx": {
+          "name": "user_personalization_user_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_personalization_userId_users_id_fk": {
+          "name": "user_personalization_userId_users_id_fk",
+          "tableFrom": "user_personalization",
+          "tableTo": "users",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "user_personalization_memoryFolderId_pages_id_fk": {
+          "name": "user_personalization_memoryFolderId_pages_id_fk",
+          "tableFrom": "user_personalization",
+          "tableTo": "pages",
+          "columnsFrom": [
+            "memoryFolderId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "user_personalization_bioPageId_pages_id_fk": {
+          "name": "user_personalization_bioPageId_pages_id_fk",
+          "tableFrom": "user_personalization",
+          "tableTo": "pages",
+          "columnsFrom": [
+            "bioPageId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "user_personalization_writingStylePageId_pages_id_fk": {
+          "name": "user_personalization_writingStylePageId_pages_id_fk",
+          "tableFrom": "user_personalization",
+          "tableTo": "pages",
+          "columnsFrom": [
+            "writingStylePageId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "user_personalization_rulesPageId_pages_id_fk": {
+          "name": "user_personalization_rulesPageId_pages_id_fk",
+          "tableFrom": "user_personalization",
+          "tableTo": "pages",
+          "columnsFrom": [
+            "rulesPageId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_automation_preferences": {
+      "name": "user_automation_preferences",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pulseEnabled": {
+          "name": "pulseEnabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "user_automation_preferences_user_idx": {
+          "name": "user_automation_preferences_user_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_automation_preferences_userId_users_id_fk": {
+          "name": "user_automation_preferences_userId_users_id_fk",
+          "tableFrom": "user_automation_preferences",
+          "tableTo": "users",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.calendar_event_drives": {
+      "name": "calendar_event_drives",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "eventId": {
+          "name": "eventId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "driveId": {
+          "name": "driveId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sharedBy": {
+          "name": "sharedBy",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sharedAt": {
+          "name": "sharedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "calendar_event_drives_event_id_idx": {
+          "name": "calendar_event_drives_event_id_idx",
+          "columns": [
+            {
+              "expression": "eventId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "calendar_event_drives_drive_id_idx": {
+          "name": "calendar_event_drives_drive_id_idx",
+          "columns": [
+            {
+              "expression": "driveId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "calendar_event_drives_eventId_calendar_events_id_fk": {
+          "name": "calendar_event_drives_eventId_calendar_events_id_fk",
+          "tableFrom": "calendar_event_drives",
+          "tableTo": "calendar_events",
+          "columnsFrom": [
+            "eventId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "calendar_event_drives_driveId_drives_id_fk": {
+          "name": "calendar_event_drives_driveId_drives_id_fk",
+          "tableFrom": "calendar_event_drives",
+          "tableTo": "drives",
+          "columnsFrom": [
+            "driveId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "calendar_event_drives_sharedBy_users_id_fk": {
+          "name": "calendar_event_drives_sharedBy_users_id_fk",
+          "tableFrom": "calendar_event_drives",
+          "tableTo": "users",
+          "columnsFrom": [
+            "sharedBy"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "calendar_event_drives_event_drive_key": {
+          "name": "calendar_event_drives_event_drive_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "eventId",
+            "driveId"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.calendar_events": {
+      "name": "calendar_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "driveId": {
+          "name": "driveId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdById": {
+          "name": "createdById",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pageId": {
+          "name": "pageId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "location": {
+          "name": "location",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "startAt": {
+          "name": "startAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "endAt": {
+          "name": "endAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "allDay": {
+          "name": "allDay",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "timezone": {
+          "name": "timezone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'UTC'"
+        },
+        "recurrenceRule": {
+          "name": "recurrenceRule",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "recurrenceExceptions": {
+          "name": "recurrenceExceptions",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'[]'::jsonb"
+        },
+        "recurringEventId": {
+          "name": "recurringEventId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "originalStartAt": {
+          "name": "originalStartAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "visibility": {
+          "name": "visibility",
+          "type": "EventVisibility",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'DRIVE'"
+        },
+        "color": {
+          "name": "color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'default'"
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "isTrashed": {
+          "name": "isTrashed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "trashedAt": {
+          "name": "trashedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "googleEventId": {
+          "name": "googleEventId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "googleCalendarId": {
+          "name": "googleCalendarId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "syncedFromGoogle": {
+          "name": "syncedFromGoogle",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "lastGoogleSync": {
+          "name": "lastGoogleSync",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "googleSyncReadOnly": {
+          "name": "googleSyncReadOnly",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "calendar_events_drive_id_idx": {
+          "name": "calendar_events_drive_id_idx",
+          "columns": [
+            {
+              "expression": "driveId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "calendar_events_created_by_id_idx": {
+          "name": "calendar_events_created_by_id_idx",
+          "columns": [
+            {
+              "expression": "createdById",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "calendar_events_page_id_idx": {
+          "name": "calendar_events_page_id_idx",
+          "columns": [
+            {
+              "expression": "pageId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "calendar_events_start_at_idx": {
+          "name": "calendar_events_start_at_idx",
+          "columns": [
+            {
+              "expression": "startAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "calendar_events_end_at_idx": {
+          "name": "calendar_events_end_at_idx",
+          "columns": [
+            {
+              "expression": "endAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "calendar_events_drive_id_start_at_idx": {
+          "name": "calendar_events_drive_id_start_at_idx",
+          "columns": [
+            {
+              "expression": "driveId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "startAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "calendar_events_recurring_event_id_idx": {
+          "name": "calendar_events_recurring_event_id_idx",
+          "columns": [
+            {
+              "expression": "recurringEventId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "calendar_events_is_trashed_idx": {
+          "name": "calendar_events_is_trashed_idx",
+          "columns": [
+            {
+              "expression": "isTrashed",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "calendar_events_google_event_id_idx": {
+          "name": "calendar_events_google_event_id_idx",
+          "columns": [
+            {
+              "expression": "googleEventId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "calendar_events_synced_from_google_idx": {
+          "name": "calendar_events_synced_from_google_idx",
+          "columns": [
+            {
+              "expression": "syncedFromGoogle",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "calendar_events_driveId_drives_id_fk": {
+          "name": "calendar_events_driveId_drives_id_fk",
+          "tableFrom": "calendar_events",
+          "tableTo": "drives",
+          "columnsFrom": [
+            "driveId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "calendar_events_createdById_users_id_fk": {
+          "name": "calendar_events_createdById_users_id_fk",
+          "tableFrom": "calendar_events",
+          "tableTo": "users",
+          "columnsFrom": [
+            "createdById"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "calendar_events_pageId_pages_id_fk": {
+          "name": "calendar_events_pageId_pages_id_fk",
+          "tableFrom": "calendar_events",
+          "tableTo": "pages",
+          "columnsFrom": [
+            "pageId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "calendar_events_google_source_per_user_key": {
+          "name": "calendar_events_google_source_per_user_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "createdById",
+            "googleCalendarId",
+            "googleEventId"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.event_attendees": {
+      "name": "event_attendees",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "eventId": {
+          "name": "eventId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "AttendeeStatus",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'PENDING'"
+        },
+        "responseNote": {
+          "name": "responseNote",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "isOrganizer": {
+          "name": "isOrganizer",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "isOptional": {
+          "name": "isOptional",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "invitedAt": {
+          "name": "invitedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "respondedAt": {
+          "name": "respondedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "event_attendees_event_id_idx": {
+          "name": "event_attendees_event_id_idx",
+          "columns": [
+            {
+              "expression": "eventId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "event_attendees_user_id_idx": {
+          "name": "event_attendees_user_id_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "event_attendees_status_idx": {
+          "name": "event_attendees_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "event_attendees_user_id_status_idx": {
+          "name": "event_attendees_user_id_status_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "event_attendees_eventId_calendar_events_id_fk": {
+          "name": "event_attendees_eventId_calendar_events_id_fk",
+          "tableFrom": "event_attendees",
+          "tableTo": "calendar_events",
+          "columnsFrom": [
+            "eventId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "event_attendees_userId_users_id_fk": {
+          "name": "event_attendees_userId_users_id_fk",
+          "tableFrom": "event_attendees",
+          "tableTo": "users",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "event_attendees_event_user_key": {
+          "name": "event_attendees_event_user_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "eventId",
+            "userId"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.google_calendar_connections": {
+      "name": "google_calendar_connections",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "accessToken": {
+          "name": "accessToken",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "refreshToken": {
+          "name": "refreshToken",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tokenExpiresAt": {
+          "name": "tokenExpiresAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "googleEmail": {
+          "name": "googleEmail",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "googleAccountId": {
+          "name": "googleAccountId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "GoogleCalendarConnectionStatus",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "statusMessage": {
+          "name": "statusMessage",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "targetDriveId": {
+          "name": "targetDriveId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "selectedCalendars": {
+          "name": "selectedCalendars",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'[]'::jsonb"
+        },
+        "syncFrequencyMinutes": {
+          "name": "syncFrequencyMinutes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 15
+        },
+        "markAsReadOnly": {
+          "name": "markAsReadOnly",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "lastSyncAt": {
+          "name": "lastSyncAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lastSyncError": {
+          "name": "lastSyncError",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "syncCursor": {
+          "name": "syncCursor",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "webhookChannels": {
+          "name": "webhookChannels",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "google_calendar_connections_user_id_idx": {
+          "name": "google_calendar_connections_user_id_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "google_calendar_connections_status_idx": {
+          "name": "google_calendar_connections_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "google_calendar_connections_target_drive_id_idx": {
+          "name": "google_calendar_connections_target_drive_id_idx",
+          "columns": [
+            {
+              "expression": "targetDriveId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "google_calendar_connections_userId_users_id_fk": {
+          "name": "google_calendar_connections_userId_users_id_fk",
+          "tableFrom": "google_calendar_connections",
+          "tableTo": "users",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "google_calendar_connections_targetDriveId_drives_id_fk": {
+          "name": "google_calendar_connections_targetDriveId_drives_id_fk",
+          "tableFrom": "google_calendar_connections",
+          "tableTo": "drives",
+          "columnsFrom": [
+            "targetDriveId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "google_calendar_connections_userId_unique": {
+          "name": "google_calendar_connections_userId_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "userId"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.calendar_triggers": {
+      "name": "calendar_triggers",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "workflowId": {
+          "name": "workflowId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "calendarEventId": {
+          "name": "calendarEventId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "driveId": {
+          "name": "driveId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scheduledById": {
+          "name": "scheduledById",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "triggerAt": {
+          "name": "triggerAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "occurrenceDate": {
+          "name": "occurrenceDate",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'1970-01-01T00:00:00.000Z'"
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "calendar_triggers_trigger_at_idx": {
+          "name": "calendar_triggers_trigger_at_idx",
+          "columns": [
+            {
+              "expression": "triggerAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "calendar_triggers_scheduled_by_idx": {
+          "name": "calendar_triggers_scheduled_by_idx",
+          "columns": [
+            {
+              "expression": "scheduledById",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "calendar_triggers_calendar_event_idx": {
+          "name": "calendar_triggers_calendar_event_idx",
+          "columns": [
+            {
+              "expression": "calendarEventId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "calendar_triggers_workflow_id_idx": {
+          "name": "calendar_triggers_workflow_id_idx",
+          "columns": [
+            {
+              "expression": "workflowId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "calendar_triggers_workflowId_workflows_id_fk": {
+          "name": "calendar_triggers_workflowId_workflows_id_fk",
+          "tableFrom": "calendar_triggers",
+          "tableTo": "workflows",
+          "columnsFrom": [
+            "workflowId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "calendar_triggers_calendarEventId_calendar_events_id_fk": {
+          "name": "calendar_triggers_calendarEventId_calendar_events_id_fk",
+          "tableFrom": "calendar_triggers",
+          "tableTo": "calendar_events",
+          "columnsFrom": [
+            "calendarEventId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "calendar_triggers_driveId_drives_id_fk": {
+          "name": "calendar_triggers_driveId_drives_id_fk",
+          "tableFrom": "calendar_triggers",
+          "tableTo": "drives",
+          "columnsFrom": [
+            "driveId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "calendar_triggers_scheduledById_users_id_fk": {
+          "name": "calendar_triggers_scheduledById_users_id_fk",
+          "tableFrom": "calendar_triggers",
+          "tableTo": "users",
+          "columnsFrom": [
+            "scheduledById"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "calendar_triggers_event_occurrence_key": {
+          "name": "calendar_triggers_event_occurrence_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "calendarEventId",
+            "occurrenceDate"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.workflows": {
+      "name": "workflows",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "driveId": {
+          "name": "driveId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdBy": {
+          "name": "createdBy",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agentPageId": {
+          "name": "agentPageId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "prompt": {
+          "name": "prompt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "steps": {
+          "name": "steps",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "contextPageIds": {
+          "name": "contextPageIds",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'[]'::jsonb"
+        },
+        "cronExpression": {
+          "name": "cronExpression",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "timezone": {
+          "name": "timezone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'UTC'"
+        },
+        "triggerType": {
+          "name": "triggerType",
+          "type": "WorkflowTriggerType",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'cron'"
+        },
+        "eventTriggers": {
+          "name": "eventTriggers",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "watchedFolderIds": {
+          "name": "watchedFolderIds",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "eventDebounceSecs": {
+          "name": "eventDebounceSecs",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 30
+        },
+        "instructionPageId": {
+          "name": "instructionPageId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "isEnabled": {
+          "name": "isEnabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "nextRunAt": {
+          "name": "nextRunAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "workflows_drive_id_idx": {
+          "name": "workflows_drive_id_idx",
+          "columns": [
+            {
+              "expression": "driveId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "workflows_created_by_idx": {
+          "name": "workflows_created_by_idx",
+          "columns": [
+            {
+              "expression": "createdBy",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "workflows_agent_page_id_idx": {
+          "name": "workflows_agent_page_id_idx",
+          "columns": [
+            {
+              "expression": "agentPageId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "workflows_enabled_next_run_idx": {
+          "name": "workflows_enabled_next_run_idx",
+          "columns": [
+            {
+              "expression": "isEnabled",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "nextRunAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "workflows_enabled_trigger_type_idx": {
+          "name": "workflows_enabled_trigger_type_idx",
+          "columns": [
+            {
+              "expression": "isEnabled",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "triggerType",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "workflows_driveId_drives_id_fk": {
+          "name": "workflows_driveId_drives_id_fk",
+          "tableFrom": "workflows",
+          "tableTo": "drives",
+          "columnsFrom": [
+            "driveId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "workflows_createdBy_users_id_fk": {
+          "name": "workflows_createdBy_users_id_fk",
+          "tableFrom": "workflows",
+          "tableTo": "users",
+          "columnsFrom": [
+            "createdBy"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "workflows_agentPageId_pages_id_fk": {
+          "name": "workflows_agentPageId_pages_id_fk",
+          "tableFrom": "workflows",
+          "tableTo": "pages",
+          "columnsFrom": [
+            "agentPageId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "workflows_instructionPageId_pages_id_fk": {
+          "name": "workflows_instructionPageId_pages_id_fk",
+          "tableFrom": "workflows",
+          "tableTo": "pages",
+          "columnsFrom": [
+            "instructionPageId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.workflow_runs": {
+      "name": "workflow_runs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "workflowId": {
+          "name": "workflowId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sourceTable": {
+          "name": "sourceTable",
+          "type": "WorkflowRunSourceTable",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sourceId": {
+          "name": "sourceId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "triggerAt": {
+          "name": "triggerAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "startedAt": {
+          "name": "startedAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "endedAt": {
+          "name": "endedAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "WorkflowRunStatus",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'running'"
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "durationMs": {
+          "name": "durationMs",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "conversationId": {
+          "name": "conversationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "workflow_runs_workflow_started_at_idx": {
+          "name": "workflow_runs_workflow_started_at_idx",
+          "columns": [
+            {
+              "expression": "workflowId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "startedAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "workflow_runs_source_lookup_idx": {
+          "name": "workflow_runs_source_lookup_idx",
+          "columns": [
+            {
+              "expression": "sourceTable",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "sourceId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "workflow_runs_stuck_run_idx": {
+          "name": "workflow_runs_stuck_run_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "startedAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "workflow_runs_running_claim_idx": {
+          "name": "workflow_runs_running_claim_idx",
+          "columns": [
+            {
+              "expression": "workflowId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"workflow_runs\".\"status\" = 'running'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "workflow_runs_workflowId_workflows_id_fk": {
+          "name": "workflow_runs_workflowId_workflows_id_fk",
+          "tableFrom": "workflow_runs",
+          "tableTo": "workflows",
+          "columnsFrom": [
+            "workflowId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.workflow_run_steps": {
+      "name": "workflow_run_steps",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "runId": {
+          "name": "runId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "toolName": {
+          "name": "toolName",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "WorkflowRunStepStatus",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'running'"
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "durationMs": {
+          "name": "durationMs",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "startedAt": {
+          "name": "startedAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "endedAt": {
+          "name": "endedAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "workflow_run_steps_run_position_idx": {
+          "name": "workflow_run_steps_run_position_idx",
+          "columns": [
+            {
+              "expression": "runId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "position",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "workflow_run_steps_runId_workflow_runs_id_fk": {
+          "name": "workflow_run_steps_runId_workflow_runs_id_fk",
+          "tableFrom": "workflow_run_steps",
+          "tableTo": "workflow_runs",
+          "columnsFrom": [
+            "runId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.task_triggers": {
+      "name": "task_triggers",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "workflowId": {
+          "name": "workflowId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "taskItemId": {
+          "name": "taskItemId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "triggerType": {
+          "name": "triggerType",
+          "type": "TaskTriggerType",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "nextRunAt": {
+          "name": "nextRunAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lastFiredAt": {
+          "name": "lastFiredAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lastFireError": {
+          "name": "lastFireError",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "isEnabled": {
+          "name": "isEnabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "task_triggers_workflow_id_idx": {
+          "name": "task_triggers_workflow_id_idx",
+          "columns": [
+            {
+              "expression": "workflowId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "task_triggers_task_item_id_idx": {
+          "name": "task_triggers_task_item_id_idx",
+          "columns": [
+            {
+              "expression": "taskItemId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "task_triggers_enabled_next_run_idx": {
+          "name": "task_triggers_enabled_next_run_idx",
+          "columns": [
+            {
+              "expression": "isEnabled",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "nextRunAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "task_triggers_workflowId_workflows_id_fk": {
+          "name": "task_triggers_workflowId_workflows_id_fk",
+          "tableFrom": "task_triggers",
+          "tableTo": "workflows",
+          "columnsFrom": [
+            "workflowId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "task_triggers_taskItemId_task_items_id_fk": {
+          "name": "task_triggers_taskItemId_task_items_id_fk",
+          "tableFrom": "task_triggers",
+          "tableTo": "task_items",
+          "columnsFrom": [
+            "taskItemId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "task_triggers_task_item_trigger_type_key": {
+          "name": "task_triggers_task_item_trigger_type_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "taskItemId",
+            "triggerType"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.rate_limit_buckets": {
+      "name": "rate_limit_buckets",
+      "schema": "",
+      "columns": {
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "window_start": {
+          "name": "window_start",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "count": {
+          "name": "count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "rate_limit_buckets_expires_at_idx": {
+          "name": "rate_limit_buckets_expires_at_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "rate_limit_buckets_key_window_start_pk": {
+          "name": "rate_limit_buckets_key_window_start_pk",
+          "columns": [
+            "key",
+            "window_start"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.revoked_service_tokens": {
+      "name": "revoked_service_tokens",
+      "schema": "",
+      "columns": {
+        "jti": {
+          "name": "jti",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "revoked_service_tokens_expires_at_idx": {
+          "name": "revoked_service_tokens_expires_at_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.auth_handoff_tokens": {
+      "name": "auth_handoff_tokens",
+      "schema": "",
+      "columns": {
+        "token_hash": {
+          "name": "token_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "auth_handoff_tokens_expires_at_idx": {
+          "name": "auth_handoff_tokens_expires_at_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "auth_handoff_tokens_kind_expires_at_idx": {
+          "name": "auth_handoff_tokens_kind_expires_at_idx",
+          "columns": [
+            {
+              "expression": "kind",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "auth_handoff_tokens_token_hash_kind_pk": {
+          "name": "auth_handoff_tokens_token_hash_kind_pk",
+          "columns": [
+            "token_hash",
+            "kind"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.pending_invites": {
+      "name": "pending_invites",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "drive_id": {
+          "name": "drive_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "MemberRole",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "custom_role_id": {
+          "name": "custom_role_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "invited_by": {
+          "name": "invited_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "consumed_at": {
+          "name": "consumed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "pending_invites_drive_id_idx": {
+          "name": "pending_invites_drive_id_idx",
+          "columns": [
+            {
+              "expression": "drive_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "pending_invites_email_idx": {
+          "name": "pending_invites_email_idx",
+          "columns": [
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "pending_invites_expires_at_idx": {
+          "name": "pending_invites_expires_at_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "pending_invites_custom_role_id_idx": {
+          "name": "pending_invites_custom_role_id_idx",
+          "columns": [
+            {
+              "expression": "custom_role_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "pending_invites_active_drive_email_idx": {
+          "name": "pending_invites_active_drive_email_idx",
+          "columns": [
+            {
+              "expression": "drive_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"pending_invites\".\"consumed_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "pending_invites_drive_id_drives_id_fk": {
+          "name": "pending_invites_drive_id_drives_id_fk",
+          "tableFrom": "pending_invites",
+          "tableTo": "drives",
+          "columnsFrom": [
+            "drive_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "pending_invites_custom_role_id_drive_roles_id_fk": {
+          "name": "pending_invites_custom_role_id_drive_roles_id_fk",
+          "tableFrom": "pending_invites",
+          "tableTo": "drive_roles",
+          "columnsFrom": [
+            "custom_role_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "pending_invites_invited_by_users_id_fk": {
+          "name": "pending_invites_invited_by_users_id_fk",
+          "tableFrom": "pending_invites",
+          "tableTo": "users",
+          "columnsFrom": [
+            "invited_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "pending_invites_token_hash_unique": {
+          "name": "pending_invites_token_hash_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token_hash"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.pending_page_invites": {
+      "name": "pending_page_invites",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "invited_by": {
+          "name": "invited_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "page_id": {
+          "name": "page_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "permissions": {
+          "name": "permissions",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "consumed_at": {
+          "name": "consumed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "pending_page_invites_page_id_idx": {
+          "name": "pending_page_invites_page_id_idx",
+          "columns": [
+            {
+              "expression": "page_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "pending_page_invites_email_idx": {
+          "name": "pending_page_invites_email_idx",
+          "columns": [
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "pending_page_invites_expires_at_idx": {
+          "name": "pending_page_invites_expires_at_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "pending_page_invites_active_page_email_idx": {
+          "name": "pending_page_invites_active_page_email_idx",
+          "columns": [
+            {
+              "expression": "page_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"pending_page_invites\".\"consumed_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "pending_page_invites_invited_by_users_id_fk": {
+          "name": "pending_page_invites_invited_by_users_id_fk",
+          "tableFrom": "pending_page_invites",
+          "tableTo": "users",
+          "columnsFrom": [
+            "invited_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "pending_page_invites_page_id_pages_id_fk": {
+          "name": "pending_page_invites_page_id_pages_id_fk",
+          "tableFrom": "pending_page_invites",
+          "tableTo": "pages",
+          "columnsFrom": [
+            "page_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "pending_page_invites_token_hash_unique": {
+          "name": "pending_page_invites_token_hash_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token_hash"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.pending_connection_invites": {
+      "name": "pending_connection_invites",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "invited_by": {
+          "name": "invited_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "request_message": {
+          "name": "request_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "consumed_at": {
+          "name": "consumed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "pending_connection_invites_invited_by_idx": {
+          "name": "pending_connection_invites_invited_by_idx",
+          "columns": [
+            {
+              "expression": "invited_by",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "pending_connection_invites_email_idx": {
+          "name": "pending_connection_invites_email_idx",
+          "columns": [
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "pending_connection_invites_expires_at_idx": {
+          "name": "pending_connection_invites_expires_at_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "pending_connection_invites_active_inviter_email_idx": {
+          "name": "pending_connection_invites_active_inviter_email_idx",
+          "columns": [
+            {
+              "expression": "invited_by",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"pending_connection_invites\".\"consumed_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "pending_connection_invites_invited_by_users_id_fk": {
+          "name": "pending_connection_invites_invited_by_users_id_fk",
+          "tableFrom": "pending_connection_invites",
+          "tableTo": "users",
+          "columnsFrom": [
+            "invited_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "pending_connection_invites_token_hash_unique": {
+          "name": "pending_connection_invites_token_hash_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token_hash"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ai_pending_abort_intents": {
+      "name": "ai_pending_abort_intents",
+      "schema": "",
+      "columns": {
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "ai_pending_abort_intents_conversation_id_user_id_pk": {
+          "name": "ai_pending_abort_intents_conversation_id_user_id_pk",
+          "columns": [
+            "conversation_id",
+            "user_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ai_stream_frames": {
+      "name": "ai_stream_frames",
+      "schema": "",
+      "columns": {
+        "message_id": {
+          "name": "message_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "from_seq": {
+          "name": "from_seq",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "frame_count": {
+          "name": "frame_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "frames": {
+          "name": "frames",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "byte_size": {
+          "name": "byte_size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "ai_stream_frames_created_at_idx": {
+          "name": "ai_stream_frames_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "ai_stream_frames_conversation_id_conversations_id_fk": {
+          "name": "ai_stream_frames_conversation_id_conversations_id_fk",
+          "tableFrom": "ai_stream_frames",
+          "tableTo": "conversations",
+          "columnsFrom": [
+            "conversation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "ai_stream_frames_message_id_from_seq_pk": {
+          "name": "ai_stream_frames_message_id_from_seq_pk",
+          "columns": [
+            "message_id",
+            "from_seq"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ai_stream_sessions": {
+      "name": "ai_stream_sessions",
+      "schema": "",
+      "columns": {
+        "message_id": {
+          "name": "message_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "channel_id": {
+          "name": "channel_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'Someone'"
+        },
+        "browser_session_id": {
+          "name": "browser_session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'streaming'"
+        },
+        "parts": {
+          "name": "parts",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "raw_parts_count": {
+          "name": "raw_parts_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_heartbeat_at": {
+          "name": "last_heartbeat_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stream_id": {
+          "name": "stream_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "abort_requested_at": {
+          "name": "abort_requested_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reap_claimed_at": {
+          "name": "reap_claimed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "ai_stream_sessions_channel_status_idx": {
+          "name": "ai_stream_sessions_channel_status_idx",
+          "columns": [
+            {
+              "expression": "channel_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ai_stream_sessions_conversation_status_idx": {
+          "name": "ai_stream_sessions_conversation_status_idx",
+          "columns": [
+            {
+              "expression": "conversation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ai_stream_sessions_user_status_idx": {
+          "name": "ai_stream_sessions_user_status_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ai_stream_sessions_stream_id_idx": {
+          "name": "ai_stream_sessions_stream_id_idx",
+          "columns": [
+            {
+              "expression": "stream_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "ai_stream_sessions_conversation_id_conversations_id_fk": {
+          "name": "ai_stream_sessions_conversation_id_conversations_id_fk",
+          "tableFrom": "ai_stream_sessions",
+          "tableTo": "conversations",
+          "columnsFrom": [
+            "conversation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.drive_share_links": {
+      "name": "drive_share_links",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "drive_id": {
+          "name": "drive_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "MemberRole",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'MEMBER'"
+        },
+        "custom_role_id": {
+          "name": "custom_role_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "use_count": {
+          "name": "use_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        }
+      },
+      "indexes": {
+        "drive_share_links_drive_id_idx": {
+          "name": "drive_share_links_drive_id_idx",
+          "columns": [
+            {
+              "expression": "drive_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "drive_share_links_expires_at_idx": {
+          "name": "drive_share_links_expires_at_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "drive_share_links_is_active_idx": {
+          "name": "drive_share_links_is_active_idx",
+          "columns": [
+            {
+              "expression": "is_active",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "drive_share_links_custom_role_id_idx": {
+          "name": "drive_share_links_custom_role_id_idx",
+          "columns": [
+            {
+              "expression": "custom_role_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "drive_share_links_drive_id_drives_id_fk": {
+          "name": "drive_share_links_drive_id_drives_id_fk",
+          "tableFrom": "drive_share_links",
+          "tableTo": "drives",
+          "columnsFrom": [
+            "drive_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "drive_share_links_custom_role_id_drive_roles_id_fk": {
+          "name": "drive_share_links_custom_role_id_drive_roles_id_fk",
+          "tableFrom": "drive_share_links",
+          "tableTo": "drive_roles",
+          "columnsFrom": [
+            "custom_role_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "drive_share_links_created_by_users_id_fk": {
+          "name": "drive_share_links_created_by_users_id_fk",
+          "tableFrom": "drive_share_links",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "drive_share_links_token_unique": {
+          "name": "drive_share_links_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.page_share_links": {
+      "name": "page_share_links",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "page_id": {
+          "name": "page_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "permissions": {
+          "name": "permissions",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "use_count": {
+          "name": "use_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        }
+      },
+      "indexes": {
+        "page_share_links_page_id_idx": {
+          "name": "page_share_links_page_id_idx",
+          "columns": [
+            {
+              "expression": "page_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "page_share_links_expires_at_idx": {
+          "name": "page_share_links_expires_at_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "page_share_links_is_active_idx": {
+          "name": "page_share_links_is_active_idx",
+          "columns": [
+            {
+              "expression": "is_active",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "page_share_links_page_id_pages_id_fk": {
+          "name": "page_share_links_page_id_pages_id_fk",
+          "tableFrom": "page_share_links",
+          "tableTo": "pages",
+          "columnsFrom": [
+            "page_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "page_share_links_created_by_users_id_fk": {
+          "name": "page_share_links_created_by_users_id_fk",
+          "tableFrom": "page_share_links",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "page_share_links_token_unique": {
+          "name": "page_share_links_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.zoom_connections": {
+      "name": "zoom_connections",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "accessToken": {
+          "name": "accessToken",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "refreshToken": {
+          "name": "refreshToken",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tokenExpiresAt": {
+          "name": "tokenExpiresAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "zoomUserId": {
+          "name": "zoomUserId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "zoomAccountId": {
+          "name": "zoomAccountId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "zoomEmail": {
+          "name": "zoomEmail",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "ZoomConnectionStatus",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "targetDriveId": {
+          "name": "targetDriveId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "targetFolderId": {
+          "name": "targetFolderId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scopeVersion": {
+          "name": "scopeVersion",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "includeAiSummary": {
+          "name": "includeAiSummary",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "includeActionItems": {
+          "name": "includeActionItems",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "includeTranscript": {
+          "name": "includeTranscript",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "zoom_connections_user_id_idx": {
+          "name": "zoom_connections_user_id_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "zoom_connections_status_idx": {
+          "name": "zoom_connections_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "zoom_connections_account_id_idx": {
+          "name": "zoom_connections_account_id_idx",
+          "columns": [
+            {
+              "expression": "zoomAccountId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "zoom_connections_target_drive_id_idx": {
+          "name": "zoom_connections_target_drive_id_idx",
+          "columns": [
+            {
+              "expression": "targetDriveId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "zoom_connections_userId_users_id_fk": {
+          "name": "zoom_connections_userId_users_id_fk",
+          "tableFrom": "zoom_connections",
+          "tableTo": "users",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "zoom_connections_targetDriveId_drives_id_fk": {
+          "name": "zoom_connections_targetDriveId_drives_id_fk",
+          "tableFrom": "zoom_connections",
+          "tableTo": "drives",
+          "columnsFrom": [
+            "targetDriveId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "zoom_connections_userId_unique": {
+          "name": "zoom_connections_userId_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "userId"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.webhook_triggers": {
+      "name": "webhook_triggers",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "workflowId": {
+          "name": "workflowId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "connectionId": {
+          "name": "connectionId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pageWebhookId": {
+          "name": "pageWebhookId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "eventType": {
+          "name": "eventType",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "isEnabled": {
+          "name": "isEnabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "lastFiredAt": {
+          "name": "lastFiredAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lastFireError": {
+          "name": "lastFireError",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "webhook_triggers_workflow_id_idx": {
+          "name": "webhook_triggers_workflow_id_idx",
+          "columns": [
+            {
+              "expression": "workflowId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "webhook_triggers_provider_event_idx": {
+          "name": "webhook_triggers_provider_event_idx",
+          "columns": [
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "eventType",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "isEnabled",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "webhook_triggers_connection_id_idx": {
+          "name": "webhook_triggers_connection_id_idx",
+          "columns": [
+            {
+              "expression": "connectionId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "webhook_triggers_page_webhook_id_idx": {
+          "name": "webhook_triggers_page_webhook_id_idx",
+          "columns": [
+            {
+              "expression": "pageWebhookId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "webhook_triggers_page_webhook_workflow_unique": {
+          "name": "webhook_triggers_page_webhook_workflow_unique",
+          "columns": [
+            {
+              "expression": "pageWebhookId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "workflowId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"webhook_triggers\".\"pageWebhookId\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "webhook_triggers_workflowId_workflows_id_fk": {
+          "name": "webhook_triggers_workflowId_workflows_id_fk",
+          "tableFrom": "webhook_triggers",
+          "tableTo": "workflows",
+          "columnsFrom": [
+            "workflowId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "webhook_triggers_connectionId_zoom_connections_id_fk": {
+          "name": "webhook_triggers_connectionId_zoom_connections_id_fk",
+          "tableFrom": "webhook_triggers",
+          "tableTo": "zoom_connections",
+          "columnsFrom": [
+            "connectionId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "webhook_triggers_pageWebhookId_page_webhooks_id_fk": {
+          "name": "webhook_triggers_pageWebhookId_page_webhooks_id_fk",
+          "tableFrom": "webhook_triggers",
+          "tableTo": "page_webhooks",
+          "columnsFrom": [
+            "pageWebhookId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "webhook_triggers_connection_workflow_event_unique": {
+          "name": "webhook_triggers_connection_workflow_event_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "connectionId",
+            "workflowId",
+            "eventType"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "webhook_triggers_anchor_chk": {
+          "name": "webhook_triggers_anchor_chk",
+          "value": "(\"webhook_triggers\".\"connectionId\" IS NOT NULL AND \"webhook_triggers\".\"pageWebhookId\" IS NULL) OR (\"webhook_triggers\".\"connectionId\" IS NULL AND \"webhook_triggers\".\"pageWebhookId\" IS NOT NULL)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.message_drafts": {
+      "name": "message_drafts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "contextKey": {
+          "name": "contextKey",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expiresAt": {
+          "name": "expiresAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "message_drafts_user_context_key": {
+          "name": "message_drafts_user_context_key",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "contextKey",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "message_drafts_expires_at_idx": {
+          "name": "message_drafts_expires_at_idx",
+          "columns": [
+            {
+              "expression": "expiresAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "message_drafts_userId_users_id_fk": {
+          "name": "message_drafts_userId_users_id_fk",
+          "tableFrom": "message_drafts",
+          "tableTo": "users",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.published_pages": {
+      "name": "published_pages",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "drive_id": {
+          "name": "drive_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "page_id": {
+          "name": "page_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "path": {
+          "name": "path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "artifact_key": {
+          "name": "artifact_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "publish_title": {
+          "name": "publish_title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "publish_description": {
+          "name": "publish_description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "publish_og_image_url": {
+          "name": "publish_og_image_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "noindex": {
+          "name": "noindex",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "theme_bridge_enabled": {
+          "name": "theme_bridge_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "published_by": {
+          "name": "published_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "published_at": {
+          "name": "published_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "published_pages_drive_id_idx": {
+          "name": "published_pages_drive_id_idx",
+          "columns": [
+            {
+              "expression": "drive_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "published_pages_page_id_idx": {
+          "name": "published_pages_page_id_idx",
+          "columns": [
+            {
+              "expression": "page_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "published_pages_drive_id_drives_id_fk": {
+          "name": "published_pages_drive_id_drives_id_fk",
+          "tableFrom": "published_pages",
+          "tableTo": "drives",
+          "columnsFrom": [
+            "drive_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "published_pages_page_id_pages_id_fk": {
+          "name": "published_pages_page_id_pages_id_fk",
+          "tableFrom": "published_pages",
+          "tableTo": "pages",
+          "columnsFrom": [
+            "page_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "published_pages_published_by_users_id_fk": {
+          "name": "published_pages_published_by_users_id_fk",
+          "tableFrom": "published_pages",
+          "tableTo": "users",
+          "columnsFrom": [
+            "published_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "published_pages_page_id_key": {
+          "name": "published_pages_page_id_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "page_id"
+          ]
+        },
+        "published_pages_drive_id_path_key": {
+          "name": "published_pages_drive_id_path_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "drive_id",
+            "path"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.credit_balances": {
+      "name": "credit_balances",
+      "schema": "",
+      "columns": {
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "monthlyRemainingCents": {
+          "name": "monthlyRemainingCents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "monthlyAllowanceCents": {
+          "name": "monthlyAllowanceCents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "topupRemainingCents": {
+          "name": "topupRemainingCents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "debtCents": {
+          "name": "debtCents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "pendingMillicents": {
+          "name": "pendingMillicents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "monthlyPeriodStart": {
+          "name": "monthlyPeriodStart",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "monthlyPeriodEnd": {
+          "name": "monthlyPeriodEnd",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "credit_balances_userId_users_id_fk": {
+          "name": "credit_balances_userId_users_id_fk",
+          "tableFrom": "credit_balances",
+          "tableTo": "users",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "credit_balances_monthly_remaining_nonneg": {
+          "name": "credit_balances_monthly_remaining_nonneg",
+          "value": "\"credit_balances\".\"monthlyRemainingCents\" >= 0"
+        },
+        "credit_balances_monthly_allowance_nonneg": {
+          "name": "credit_balances_monthly_allowance_nonneg",
+          "value": "\"credit_balances\".\"monthlyAllowanceCents\" >= 0"
+        },
+        "credit_balances_topup_remaining_nonneg": {
+          "name": "credit_balances_topup_remaining_nonneg",
+          "value": "\"credit_balances\".\"topupRemainingCents\" >= 0"
+        },
+        "credit_balances_debt_cents_nonneg": {
+          "name": "credit_balances_debt_cents_nonneg",
+          "value": "\"credit_balances\".\"debtCents\" >= 0"
+        },
+        "credit_balances_pending_millicents_range": {
+          "name": "credit_balances_pending_millicents_range",
+          "value": "\"credit_balances\".\"pendingMillicents\" >= 0 AND \"credit_balances\".\"pendingMillicents\" < 1000"
+        },
+        "credit_balances_period_order": {
+          "name": "credit_balances_period_order",
+          "value": "\"credit_balances\".\"monthlyPeriodStart\" IS NULL OR \"credit_balances\".\"monthlyPeriodEnd\" IS NULL OR \"credit_balances\".\"monthlyPeriodStart\" <= \"credit_balances\".\"monthlyPeriodEnd\""
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.credit_holds": {
+      "name": "credit_holds",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "estCents": {
+          "name": "estCents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "aiUsageLogId": {
+          "name": "aiUsageLogId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expiresAt": {
+          "name": "expiresAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "credit_holds_user_idx": {
+          "name": "credit_holds_user_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "credit_holds_expires_idx": {
+          "name": "credit_holds_expires_idx",
+          "columns": [
+            {
+              "expression": "expiresAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "credit_holds_userId_users_id_fk": {
+          "name": "credit_holds_userId_users_id_fk",
+          "tableFrom": "credit_holds",
+          "tableTo": "users",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "credit_holds_est_cents_nonneg": {
+          "name": "credit_holds_est_cents_nonneg",
+          "value": "\"credit_holds\".\"estCents\" >= 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.credit_ledger": {
+      "name": "credit_ledger",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entryType": {
+          "name": "entryType",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "bucket": {
+          "name": "bucket",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amountCents": {
+          "name": "amountCents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "appliedCents": {
+          "name": "appliedCents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "chargeMillicents": {
+          "name": "chargeMillicents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "aiUsageLogId": {
+          "name": "aiUsageLogId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "realCostCents": {
+          "name": "realCostCents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "markupBps": {
+          "name": "markupBps",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 15000
+        },
+        "stripeRef": {
+          "name": "stripeRef",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "consumeStatus": {
+          "name": "consumeStatus",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "consumeError": {
+          "name": "consumeError",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reconcileGenerationKey": {
+          "name": "reconcileGenerationKey",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "credit_ledger_user_idx": {
+          "name": "credit_ledger_user_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "createdAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "credit_ledger_usage_log_unique": {
+          "name": "credit_ledger_usage_log_unique",
+          "columns": [
+            {
+              "expression": "aiUsageLogId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"credit_ledger\".\"aiUsageLogId\" IS NOT NULL AND \"credit_ledger\".\"entryType\" = 'usage'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "credit_ledger_stripe_ref_unique": {
+          "name": "credit_ledger_stripe_ref_unique",
+          "columns": [
+            {
+              "expression": "stripeRef",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"credit_ledger\".\"stripeRef\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "credit_ledger_reconcile_key_unique": {
+          "name": "credit_ledger_reconcile_key_unique",
+          "columns": [
+            {
+              "expression": "reconcileGenerationKey",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"credit_ledger\".\"reconcileGenerationKey\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "credit_ledger_consume_status_idx": {
+          "name": "credit_ledger_consume_status_idx",
+          "columns": [
+            {
+              "expression": "consumeStatus",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "createdAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "credit_ledger_userId_users_id_fk": {
+          "name": "credit_ledger_userId_users_id_fk",
+          "tableFrom": "credit_ledger",
+          "tableTo": "users",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.commands": {
+      "name": "commands",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "drive_id": {
+          "name": "drive_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by_id": {
+          "name": "created_by_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "trigger": {
+          "name": "trigger",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entry_page_id": {
+          "name": "entry_page_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'document'"
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "commands_user_id_idx": {
+          "name": "commands_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "commands_drive_id_idx": {
+          "name": "commands_drive_id_idx",
+          "columns": [
+            {
+              "expression": "drive_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "commands_entry_page_id_idx": {
+          "name": "commands_entry_page_id_idx",
+          "columns": [
+            {
+              "expression": "entry_page_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "commands_user_id_users_id_fk": {
+          "name": "commands_user_id_users_id_fk",
+          "tableFrom": "commands",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "commands_drive_id_drives_id_fk": {
+          "name": "commands_drive_id_drives_id_fk",
+          "tableFrom": "commands",
+          "tableTo": "drives",
+          "columnsFrom": [
+            "drive_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "commands_created_by_id_users_id_fk": {
+          "name": "commands_created_by_id_users_id_fk",
+          "tableFrom": "commands",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "commands_entry_page_id_pages_id_fk": {
+          "name": "commands_entry_page_id_pages_id_fk",
+          "tableFrom": "commands",
+          "tableTo": "pages",
+          "columnsFrom": [
+            "entry_page_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "commands_user_trigger": {
+          "name": "commands_user_trigger",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "trigger"
+          ]
+        },
+        "commands_drive_trigger": {
+          "name": "commands_drive_trigger",
+          "nullsNotDistinct": false,
+          "columns": [
+            "drive_id",
+            "trigger"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "commands_scope_chk": {
+          "name": "commands_scope_chk",
+          "value": "(\"commands\".\"user_id\" IS NOT NULL AND \"commands\".\"drive_id\" IS NULL) OR (\"commands\".\"user_id\" IS NULL AND \"commands\".\"drive_id\" IS NOT NULL)"
+        },
+        "commands_type_chk": {
+          "name": "commands_type_chk",
+          "value": "\"commands\".\"type\" IN ('document', 'prompt_template', 'builtin')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.content_tags": {
+      "name": "content_tags",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "tagId": {
+          "name": "tagId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pageId": {
+          "name": "pageId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "targetKind": {
+          "name": "targetKind",
+          "type": "ContentTagTargetKind",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "anchor": {
+          "name": "anchor",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "anchorStatus": {
+          "name": "anchorStatus",
+          "type": "ContentTagAnchorStatus",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "channelMessageId": {
+          "name": "channelMessageId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "aiMessageId": {
+          "name": "aiMessageId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source": {
+          "name": "source",
+          "type": "ContentTagSource",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "confidence": {
+          "name": "confidence",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdBy": {
+          "name": "createdBy",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "content_tags_page_id_idx": {
+          "name": "content_tags_page_id_idx",
+          "columns": [
+            {
+              "expression": "pageId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "content_tags_tag_id_idx": {
+          "name": "content_tags_tag_id_idx",
+          "columns": [
+            {
+              "expression": "tagId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "content_tags_created_by_idx": {
+          "name": "content_tags_created_by_idx",
+          "columns": [
+            {
+              "expression": "createdBy",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "content_tags_page_target_unique": {
+          "name": "content_tags_page_target_unique",
+          "columns": [
+            {
+              "expression": "pageId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "tagId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"content_tags\".\"targetKind\" = 'page'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "content_tags_channel_message_target_unique": {
+          "name": "content_tags_channel_message_target_unique",
+          "columns": [
+            {
+              "expression": "channelMessageId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "tagId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"content_tags\".\"targetKind\" = 'channel_message'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "content_tags_ai_message_target_unique": {
+          "name": "content_tags_ai_message_target_unique",
+          "columns": [
+            {
+              "expression": "aiMessageId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "tagId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"content_tags\".\"targetKind\" = 'ai_message'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "content_tags_tagId_tags_id_fk": {
+          "name": "content_tags_tagId_tags_id_fk",
+          "tableFrom": "content_tags",
+          "tableTo": "tags",
+          "columnsFrom": [
+            "tagId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "content_tags_pageId_pages_id_fk": {
+          "name": "content_tags_pageId_pages_id_fk",
+          "tableFrom": "content_tags",
+          "tableTo": "pages",
+          "columnsFrom": [
+            "pageId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "content_tags_channelMessageId_channel_messages_id_fk": {
+          "name": "content_tags_channelMessageId_channel_messages_id_fk",
+          "tableFrom": "content_tags",
+          "tableTo": "channel_messages",
+          "columnsFrom": [
+            "channelMessageId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "content_tags_aiMessageId_messages_id_fk": {
+          "name": "content_tags_aiMessageId_messages_id_fk",
+          "tableFrom": "content_tags",
+          "tableTo": "messages",
+          "columnsFrom": [
+            "aiMessageId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "content_tags_createdBy_users_id_fk": {
+          "name": "content_tags_createdBy_users_id_fk",
+          "tableFrom": "content_tags",
+          "tableTo": "users",
+          "columnsFrom": [
+            "createdBy"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "content_tags_target_chk": {
+          "name": "content_tags_target_chk",
+          "value": "(\n        (\"content_tags\".\"targetKind\" = 'page' AND \"content_tags\".\"anchor\" IS NULL AND \"content_tags\".\"anchorStatus\" IS NULL AND \"content_tags\".\"channelMessageId\" IS NULL AND \"content_tags\".\"aiMessageId\" IS NULL)\n        OR (\"content_tags\".\"targetKind\" = 'text' AND \"content_tags\".\"anchor\" IS NOT NULL AND \"content_tags\".\"anchorStatus\" IS NOT NULL AND \"content_tags\".\"channelMessageId\" IS NULL AND \"content_tags\".\"aiMessageId\" IS NULL)\n        OR (\"content_tags\".\"targetKind\" = 'sheet_cell' AND \"content_tags\".\"anchor\" IS NOT NULL AND \"content_tags\".\"anchorStatus\" IS NULL AND \"content_tags\".\"channelMessageId\" IS NULL AND \"content_tags\".\"aiMessageId\" IS NULL)\n        OR (\"content_tags\".\"targetKind\" = 'channel_message' AND \"content_tags\".\"anchor\" IS NULL AND \"content_tags\".\"anchorStatus\" IS NULL AND \"content_tags\".\"channelMessageId\" IS NOT NULL AND \"content_tags\".\"aiMessageId\" IS NULL)\n        OR (\"content_tags\".\"targetKind\" = 'ai_message' AND \"content_tags\".\"anchor\" IS NULL AND \"content_tags\".\"anchorStatus\" IS NULL AND \"content_tags\".\"channelMessageId\" IS NULL AND \"content_tags\".\"aiMessageId\" IS NOT NULL)\n      )"
+        },
+        "content_tags_confidence_range_chk": {
+          "name": "content_tags_confidence_range_chk",
+          "value": "\"content_tags\".\"confidence\" IS NULL OR (\"content_tags\".\"confidence\" >= 0 AND \"content_tags\".\"confidence\" <= 1)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.conversation_compactions": {
+      "name": "conversation_compactions",
+      "schema": "",
+      "columns": {
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "page_id": {
+          "name": "page_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "summary": {
+          "name": "summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "summary_tokens": {
+          "name": "summary_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "compacted_up_to_message_id": {
+          "name": "compacted_up_to_message_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "compacted_up_to_created_at": {
+          "name": "compacted_up_to_created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "summary_version": {
+          "name": "summary_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "summarizer_model": {
+          "name": "summarizer_model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_compacted_at": {
+          "name": "last_compacted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "conversation_compactions_page_id_idx": {
+          "name": "conversation_compactions_page_id_idx",
+          "columns": [
+            {
+              "expression": "page_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "conversation_compactions_conversation_id_source_pk": {
+          "name": "conversation_compactions_conversation_id_source_pk",
+          "columns": [
+            "conversation_id",
+            "source"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "conversation_compactions_source_chk": {
+          "name": "conversation_compactions_source_chk",
+          "value": "\"conversation_compactions\".\"source\" IN ('page', 'global')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.custom_domains": {
+      "name": "custom_domains",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "drive_id": {
+          "name": "drive_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "hostname": {
+          "name": "hostname",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "custom_domain_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "is_primary": {
+          "name": "is_primary",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "platform_owned": {
+          "name": "platform_owned",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "publish_landing_page_id": {
+          "name": "publish_landing_page_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "publish_not_found_page_id": {
+          "name": "publish_not_found_page_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "custom_domains_hostname_key": {
+          "name": "custom_domains_hostname_key",
+          "columns": [
+            {
+              "expression": "hostname",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "custom_domains_drive_id_idx": {
+          "name": "custom_domains_drive_id_idx",
+          "columns": [
+            {
+              "expression": "drive_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "custom_domains_primary_per_drive": {
+          "name": "custom_domains_primary_per_drive",
+          "columns": [
+            {
+              "expression": "drive_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"custom_domains\".\"is_primary\"",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "custom_domains_drive_id_drives_id_fk": {
+          "name": "custom_domains_drive_id_drives_id_fk",
+          "tableFrom": "custom_domains",
+          "tableTo": "drives",
+          "columnsFrom": [
+            "drive_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "custom_domains_publish_landing_page_id_pages_id_fk": {
+          "name": "custom_domains_publish_landing_page_id_pages_id_fk",
+          "tableFrom": "custom_domains",
+          "tableTo": "pages",
+          "columnsFrom": [
+            "publish_landing_page_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "custom_domains_publish_not_found_page_id_pages_id_fk": {
+          "name": "custom_domains_publish_not_found_page_id_pages_id_fk",
+          "tableFrom": "custom_domains",
+          "tableTo": "pages",
+          "columnsFrom": [
+            "publish_not_found_page_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.incidents": {
+      "name": "incidents",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "severity": {
+          "name": "severity",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'detected'"
+        },
+        "category": {
+          "name": "category",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "detectedAt": {
+          "name": "detectedAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "reportedBy": {
+          "name": "reportedBy",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "affectedUserCount": {
+          "name": "affectedUserCount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "affectedScope": {
+          "name": "affectedScope",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "riskLevel": {
+          "name": "riskLevel",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "requiresAuthorityNotification": {
+          "name": "requiresAuthorityNotification",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "authorityNotificationDeadline": {
+          "name": "authorityNotificationDeadline",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "authorityNotifiedAt": {
+          "name": "authorityNotifiedAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "requiresSubjectNotification": {
+          "name": "requiresSubjectNotification",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "subjectsNotifiedAt": {
+          "name": "subjectsNotifiedAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "closedAt": {
+          "name": "closedAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_incidents_status": {
+          "name": "idx_incidents_status",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_incidents_detected_at": {
+          "name": "idx_incidents_detected_at",
+          "columns": [
+            {
+              "expression": "detectedAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_incidents_authority_deadline": {
+          "name": "idx_incidents_authority_deadline",
+          "columns": [
+            {
+              "expression": "authorityNotificationDeadline",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "incidents_reportedBy_users_id_fk": {
+          "name": "incidents_reportedBy_users_id_fk",
+          "tableFrom": "incidents",
+          "tableTo": "users",
+          "columnsFrom": [
+            "reportedBy"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.data_subject_requests": {
+      "name": "data_subject_requests",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "subject_email": {
+          "name": "subject_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "request_type": {
+          "name": "request_type",
+          "type": "data_subject_request_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'erasure'"
+        },
+        "status": {
+          "name": "status",
+          "type": "data_subject_request_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "force_delete": {
+          "name": "force_delete",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "requested_by_user_id": {
+          "name": "requested_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "requested_by_type": {
+          "name": "requested_by_type",
+          "type": "data_subject_requester_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'self'"
+        },
+        "legal_basis": {
+          "name": "legal_basis",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "received_at": {
+          "name": "received_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "sla_deadline": {
+          "name": "sla_deadline",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "blocked_reason": {
+          "name": "blocked_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "job_id": {
+          "name": "job_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "attempts": {
+          "name": "attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "last_error": {
+          "name": "last_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "step_results": {
+          "name": "step_results",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "data_subject_requests_status_idx": {
+          "name": "data_subject_requests_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "data_subject_requests_sla_deadline_idx": {
+          "name": "data_subject_requests_sla_deadline_idx",
+          "columns": [
+            {
+              "expression": "sla_deadline",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "data_subject_requests_user_id_idx": {
+          "name": "data_subject_requests_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "data_subject_requests_user_id_users_id_fk": {
+          "name": "data_subject_requests_user_id_users_id_fk",
+          "tableFrom": "data_subject_requests",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "data_subject_requests_requested_by_user_id_users_id_fk": {
+          "name": "data_subject_requests_requested_by_user_id_users_id_fk",
+          "tableFrom": "data_subject_requests",
+          "tableTo": "users",
+          "columnsFrom": [
+            "requested_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.oauth_access_tokens": {
+      "name": "oauth_access_tokens",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "tokenHash": {
+          "name": "tokenHash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tokenPrefix": {
+          "name": "tokenPrefix",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "familyId": {
+          "name": "familyId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "clientId": {
+          "name": "clientId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tokenVersion": {
+          "name": "tokenVersion",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expiresAt": {
+          "name": "expiresAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "revokedAt": {
+          "name": "revokedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revokedReason": {
+          "name": "revokedReason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "oauth_access_tokens_family_id_idx": {
+          "name": "oauth_access_tokens_family_id_idx",
+          "columns": [
+            {
+              "expression": "familyId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "oauth_access_tokens_user_id_idx": {
+          "name": "oauth_access_tokens_user_id_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "oauth_access_tokens_client_id_idx": {
+          "name": "oauth_access_tokens_client_id_idx",
+          "columns": [
+            {
+              "expression": "clientId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "oauth_access_tokens_token_hash_idx": {
+          "name": "oauth_access_tokens_token_hash_idx",
+          "columns": [
+            {
+              "expression": "tokenHash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "oauth_access_tokens_expires_at_idx": {
+          "name": "oauth_access_tokens_expires_at_idx",
+          "columns": [
+            {
+              "expression": "expiresAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "oauth_access_tokens_clientId_oauth_clients_id_fk": {
+          "name": "oauth_access_tokens_clientId_oauth_clients_id_fk",
+          "tableFrom": "oauth_access_tokens",
+          "tableTo": "oauth_clients",
+          "columnsFrom": [
+            "clientId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "oauth_access_tokens_userId_users_id_fk": {
+          "name": "oauth_access_tokens_userId_users_id_fk",
+          "tableFrom": "oauth_access_tokens",
+          "tableTo": "users",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "oauth_access_tokens_tokenHash_unique": {
+          "name": "oauth_access_tokens_tokenHash_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "tokenHash"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.oauth_authorization_codes": {
+      "name": "oauth_authorization_codes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "codeHash": {
+          "name": "codeHash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "codePrefix": {
+          "name": "codePrefix",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "clientId": {
+          "name": "clientId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "redirectUri": {
+          "name": "redirectUri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "codeChallenge": {
+          "name": "codeChallenge",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "codeChallengeMethod": {
+          "name": "codeChallengeMethod",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expiresAt": {
+          "name": "expiresAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "consumedAt": {
+          "name": "consumedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "issuedFamilyId": {
+          "name": "issuedFamilyId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "oauth_authorization_codes_client_id_idx": {
+          "name": "oauth_authorization_codes_client_id_idx",
+          "columns": [
+            {
+              "expression": "clientId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "oauth_authorization_codes_user_id_idx": {
+          "name": "oauth_authorization_codes_user_id_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "oauth_authorization_codes_code_hash_idx": {
+          "name": "oauth_authorization_codes_code_hash_idx",
+          "columns": [
+            {
+              "expression": "codeHash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "oauth_authorization_codes_expires_at_idx": {
+          "name": "oauth_authorization_codes_expires_at_idx",
+          "columns": [
+            {
+              "expression": "expiresAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "oauth_authorization_codes_clientId_oauth_clients_id_fk": {
+          "name": "oauth_authorization_codes_clientId_oauth_clients_id_fk",
+          "tableFrom": "oauth_authorization_codes",
+          "tableTo": "oauth_clients",
+          "columnsFrom": [
+            "clientId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "oauth_authorization_codes_userId_users_id_fk": {
+          "name": "oauth_authorization_codes_userId_users_id_fk",
+          "tableFrom": "oauth_authorization_codes",
+          "tableTo": "users",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "oauth_authorization_codes_codeHash_unique": {
+          "name": "oauth_authorization_codes_codeHash_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "codeHash"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.oauth_clients": {
+      "name": "oauth_clients",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "clientId": {
+          "name": "clientId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "clientType": {
+          "name": "clientType",
+          "type": "OAuthClientType",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "redirectUris": {
+          "name": "redirectUris",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "isFirstParty": {
+          "name": "isFirstParty",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "disabledAt": {
+          "name": "disabledAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "oauth_clients_client_id_idx": {
+          "name": "oauth_clients_client_id_idx",
+          "columns": [
+            {
+              "expression": "clientId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "oauth_clients_clientId_unique": {
+          "name": "oauth_clients_clientId_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "clientId"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.oauth_device_codes": {
+      "name": "oauth_device_codes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "deviceCodeHash": {
+          "name": "deviceCodeHash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "deviceCodePrefix": {
+          "name": "deviceCodePrefix",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "userCodeHash": {
+          "name": "userCodeHash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "userCodePrefix": {
+          "name": "userCodePrefix",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "clientId": {
+          "name": "clientId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expiresAt": {
+          "name": "expiresAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "approvedAt": {
+          "name": "approvedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deniedAt": {
+          "name": "deniedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "redeemedAt": {
+          "name": "redeemedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lastPolledAt": {
+          "name": "lastPolledAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pollIntervalSeconds": {
+          "name": "pollIntervalSeconds",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 5
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "oauth_device_codes_client_id_idx": {
+          "name": "oauth_device_codes_client_id_idx",
+          "columns": [
+            {
+              "expression": "clientId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "oauth_device_codes_user_id_idx": {
+          "name": "oauth_device_codes_user_id_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "oauth_device_codes_device_code_hash_idx": {
+          "name": "oauth_device_codes_device_code_hash_idx",
+          "columns": [
+            {
+              "expression": "deviceCodeHash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "oauth_device_codes_user_code_hash_idx": {
+          "name": "oauth_device_codes_user_code_hash_idx",
+          "columns": [
+            {
+              "expression": "userCodeHash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "oauth_device_codes_expires_at_idx": {
+          "name": "oauth_device_codes_expires_at_idx",
+          "columns": [
+            {
+              "expression": "expiresAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "oauth_device_codes_clientId_oauth_clients_id_fk": {
+          "name": "oauth_device_codes_clientId_oauth_clients_id_fk",
+          "tableFrom": "oauth_device_codes",
+          "tableTo": "oauth_clients",
+          "columnsFrom": [
+            "clientId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "oauth_device_codes_userId_users_id_fk": {
+          "name": "oauth_device_codes_userId_users_id_fk",
+          "tableFrom": "oauth_device_codes",
+          "tableTo": "users",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "oauth_device_codes_deviceCodeHash_unique": {
+          "name": "oauth_device_codes_deviceCodeHash_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "deviceCodeHash"
+          ]
+        },
+        "oauth_device_codes_userCodeHash_unique": {
+          "name": "oauth_device_codes_userCodeHash_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "userCodeHash"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.oauth_refresh_tokens": {
+      "name": "oauth_refresh_tokens",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "tokenHash": {
+          "name": "tokenHash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tokenPrefix": {
+          "name": "tokenPrefix",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "familyId": {
+          "name": "familyId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "clientId": {
+          "name": "clientId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tokenVersion": {
+          "name": "tokenVersion",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expiresAt": {
+          "name": "expiresAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "familyExpiresAt": {
+          "name": "familyExpiresAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "replacedByTokenId": {
+          "name": "replacedByTokenId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revokedAt": {
+          "name": "revokedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revokedReason": {
+          "name": "revokedReason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "oauth_refresh_tokens_family_id_idx": {
+          "name": "oauth_refresh_tokens_family_id_idx",
+          "columns": [
+            {
+              "expression": "familyId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "oauth_refresh_tokens_user_id_idx": {
+          "name": "oauth_refresh_tokens_user_id_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "oauth_refresh_tokens_client_id_idx": {
+          "name": "oauth_refresh_tokens_client_id_idx",
+          "columns": [
+            {
+              "expression": "clientId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "oauth_refresh_tokens_token_hash_idx": {
+          "name": "oauth_refresh_tokens_token_hash_idx",
+          "columns": [
+            {
+              "expression": "tokenHash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "oauth_refresh_tokens_expires_at_idx": {
+          "name": "oauth_refresh_tokens_expires_at_idx",
+          "columns": [
+            {
+              "expression": "expiresAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "oauth_refresh_tokens_clientId_oauth_clients_id_fk": {
+          "name": "oauth_refresh_tokens_clientId_oauth_clients_id_fk",
+          "tableFrom": "oauth_refresh_tokens",
+          "tableTo": "oauth_clients",
+          "columnsFrom": [
+            "clientId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "oauth_refresh_tokens_userId_users_id_fk": {
+          "name": "oauth_refresh_tokens_userId_users_id_fk",
+          "tableFrom": "oauth_refresh_tokens",
+          "tableTo": "users",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "oauth_refresh_tokens_tokenHash_unique": {
+          "name": "oauth_refresh_tokens_tokenHash_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "tokenHash"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.form_targets": {
+      "name": "form_targets",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_prefix": {
+          "name": "token_prefix",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "drive_id": {
+          "name": "drive_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "page_id": {
+          "name": "page_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "action": {
+          "name": "action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'sheet:append'"
+        },
+        "canvas_page_id": {
+          "name": "canvas_page_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "fields": {
+          "name": "fields",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "header_row": {
+          "name": "header_row",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "next_row": {
+          "name": "next_row",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "notification_email": {
+          "name": "notification_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "status_reason": {
+          "name": "status_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_submitted_at": {
+          "name": "last_submitted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "submission_count": {
+          "name": "submission_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        }
+      },
+      "indexes": {
+        "form_targets_page_id_idx": {
+          "name": "form_targets_page_id_idx",
+          "columns": [
+            {
+              "expression": "page_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "form_targets_drive_id_idx": {
+          "name": "form_targets_drive_id_idx",
+          "columns": [
+            {
+              "expression": "drive_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "form_targets_status_idx": {
+          "name": "form_targets_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "form_targets_canvas_page_id_idx": {
+          "name": "form_targets_canvas_page_id_idx",
+          "columns": [
+            {
+              "expression": "canvas_page_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "form_targets_one_active_per_page_idx": {
+          "name": "form_targets_one_active_per_page_idx",
+          "columns": [
+            {
+              "expression": "page_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"form_targets\".\"status\" = 'active'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "form_targets_drive_id_drives_id_fk": {
+          "name": "form_targets_drive_id_drives_id_fk",
+          "tableFrom": "form_targets",
+          "tableTo": "drives",
+          "columnsFrom": [
+            "drive_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "form_targets_page_id_pages_id_fk": {
+          "name": "form_targets_page_id_pages_id_fk",
+          "tableFrom": "form_targets",
+          "tableTo": "pages",
+          "columnsFrom": [
+            "page_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "form_targets_canvas_page_id_pages_id_fk": {
+          "name": "form_targets_canvas_page_id_pages_id_fk",
+          "tableFrom": "form_targets",
+          "tableTo": "pages",
+          "columnsFrom": [
+            "canvas_page_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "form_targets_created_by_users_id_fk": {
+          "name": "form_targets_created_by_users_id_fk",
+          "tableFrom": "form_targets",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "form_targets_token_hash_unique": {
+          "name": "form_targets_token_hash_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token_hash"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.machine_sprite_reclaims": {
+      "name": "machine_sprite_reclaims",
+      "schema": "",
+      "columns": {
+        "sandboxId": {
+          "name": "sandboxId",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "spriteInstanceId": {
+          "name": "spriteInstanceId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "recordedAt": {
+          "name": "recordedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "attempts": {
+          "name": "attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "lastAttemptAt": {
+          "name": "lastAttemptAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lastError": {
+          "name": "lastError",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "machine_sprite_reclaims_recorded_at_idx": {
+          "name": "machine_sprite_reclaims_recorded_at_idx",
+          "columns": [
+            {
+              "expression": "recordedAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.app_deploy_token_mints": {
+      "name": "app_deploy_token_mints",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "publishedAppId": {
+          "name": "publishedAppId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "flyAppName": {
+          "name": "flyAppName",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "mintedAt": {
+          "name": "mintedAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "outcome": {
+          "name": "outcome",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "settledAt": {
+          "name": "settledAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expiry": {
+          "name": "expiry",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "purpose": {
+          "name": "purpose",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "app_deploy_token_mints_app_idx": {
+          "name": "app_deploy_token_mints_app_idx",
+          "columns": [
+            {
+              "expression": "publishedAppId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "mintedAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "app_deploy_token_mints_publishedAppId_published_apps_id_fk": {
+          "name": "app_deploy_token_mints_publishedAppId_published_apps_id_fk",
+          "tableFrom": "app_deploy_token_mints",
+          "tableTo": "published_apps",
+          "columnsFrom": [
+            "publishedAppId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "app_deploy_token_mints_expiry_nonempty": {
+          "name": "app_deploy_token_mints_expiry_nonempty",
+          "value": "length(\"app_deploy_token_mints\".\"expiry\") > 0"
+        },
+        "app_deploy_token_mints_purpose_nonempty": {
+          "name": "app_deploy_token_mints_purpose_nonempty",
+          "value": "length(\"app_deploy_token_mints\".\"purpose\") > 0"
+        },
+        "app_deploy_token_mints_outcome_allowed": {
+          "name": "app_deploy_token_mints_outcome_allowed",
+          "value": "\"app_deploy_token_mints\".\"outcome\" IN ('pending', 'minted', 'failed')"
+        },
+        "app_deploy_token_mints_settled_coherent": {
+          "name": "app_deploy_token_mints_settled_coherent",
+          "value": "(\"app_deploy_token_mints\".\"outcome\" = 'pending') = (\"app_deploy_token_mints\".\"settledAt\" IS NULL)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.app_hosting_reclaims": {
+      "name": "app_hosting_reclaims",
+      "schema": "",
+      "columns": {
+        "flyAppName": {
+          "name": "flyAppName",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "publishedAppId": {
+          "name": "publishedAppId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "machineId": {
+          "name": "machineId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "recordedAt": {
+          "name": "recordedAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "attempts": {
+          "name": "attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "lastAttemptAt": {
+          "name": "lastAttemptAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lastError": {
+          "name": "lastError",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "app_hosting_reclaims_recorded_at_idx": {
+          "name": "app_hosting_reclaims_recorded_at_idx",
+          "columns": [
+            {
+              "expression": "recordedAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "app_hosting_reclaims_attempts_nonneg": {
+          "name": "app_hosting_reclaims_attempts_nonneg",
+          "value": "\"app_hosting_reclaims\".\"attempts\" >= 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.published_app_machine_events": {
+      "name": "published_app_machine_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "publishedAppId": {
+          "name": "publishedAppId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "flyAppName": {
+          "name": "flyAppName",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "machineId": {
+          "name": "machineId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "origin": {
+          "name": "origin",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "action": {
+          "name": "action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "flyEventId": {
+          "name": "flyEventId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "flyEventType": {
+          "name": "flyEventType",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "flyEventStatus": {
+          "name": "flyEventStatus",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "occurredAt": {
+          "name": "occurredAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "recordedAt": {
+          "name": "recordedAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "published_app_machine_events_app_idx": {
+          "name": "published_app_machine_events_app_idx",
+          "columns": [
+            {
+              "expression": "publishedAppId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "occurredAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "published_app_machine_events_fly_event_unique": {
+          "name": "published_app_machine_events_fly_event_unique",
+          "columns": [
+            {
+              "expression": "machineId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "flyEventId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"flyEventId\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "published_app_machine_events_publishedAppId_published_apps_id_fk": {
+          "name": "published_app_machine_events_publishedAppId_published_apps_id_fk",
+          "tableFrom": "published_app_machine_events",
+          "tableTo": "published_apps",
+          "columnsFrom": [
+            "publishedAppId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "published_app_machine_events_origin_allowed": {
+          "name": "published_app_machine_events_origin_allowed",
+          "value": "\"published_app_machine_events\".\"origin\" IN ('orchestrator', 'fly')"
+        },
+        "published_app_machine_events_action_allowed": {
+          "name": "published_app_machine_events_action_allowed",
+          "value": "\"published_app_machine_events\".\"action\" IN ('start', 'stop')"
+        },
+        "published_app_machine_events_fly_event_id_coherent": {
+          "name": "published_app_machine_events_fly_event_id_coherent",
+          "value": "(\"published_app_machine_events\".\"origin\" = 'fly') = (\"published_app_machine_events\".\"flyEventId\" IS NOT NULL)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.published_apps": {
+      "name": "published_apps",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "envId": {
+          "name": "envId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "driveId": {
+          "name": "driveId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ownerId": {
+          "name": "ownerId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "flyAppName": {
+          "name": "flyAppName",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "networkName": {
+          "name": "networkName",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subdomain": {
+          "name": "subdomain",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "published_app_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'provisioning'"
+        },
+        "guestPreset": {
+          "name": "guestPreset",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'shared-cpu-1x-512'"
+        },
+        "imageDigest": {
+          "name": "imageDigest",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "imageSizeBytes": {
+          "name": "imageSizeBytes",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "imageSizeMeasuredAt": {
+          "name": "imageSizeMeasuredAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tier": {
+          "name": "tier",
+          "type": "published_app_tier",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'metered'"
+        },
+        "machineId": {
+          "name": "machineId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lastWakeAt": {
+          "name": "lastWakeAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lastStopAt": {
+          "name": "lastStopAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "awakeBilledThrough": {
+          "name": "awakeBilledThrough",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "awakeHoldId": {
+          "name": "awakeHoldId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "storageLastBilledAt": {
+          "name": "storageLastBilledAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "lastError": {
+          "name": "lastError",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "claimedAt": {
+          "name": "claimedAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "claimedBy": {
+          "name": "claimedBy",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "published_apps_drive_idx": {
+          "name": "published_apps_drive_idx",
+          "columns": [
+            {
+              "expression": "driveId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "published_apps_owner_idx": {
+          "name": "published_apps_owner_idx",
+          "columns": [
+            {
+              "expression": "ownerId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "published_apps_status_idx": {
+          "name": "published_apps_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "updatedAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "published_apps_envId_drive_envs_id_fk": {
+          "name": "published_apps_envId_drive_envs_id_fk",
+          "tableFrom": "published_apps",
+          "tableTo": "drive_envs",
+          "columnsFrom": [
+            "envId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "published_apps_driveId_drives_id_fk": {
+          "name": "published_apps_driveId_drives_id_fk",
+          "tableFrom": "published_apps",
+          "tableTo": "drives",
+          "columnsFrom": [
+            "driveId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "published_apps_ownerId_users_id_fk": {
+          "name": "published_apps_ownerId_users_id_fk",
+          "tableFrom": "published_apps",
+          "tableTo": "users",
+          "columnsFrom": [
+            "ownerId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "published_apps_envId_unique": {
+          "name": "published_apps_envId_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "envId"
+          ]
+        },
+        "published_apps_flyAppName_unique": {
+          "name": "published_apps_flyAppName_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "flyAppName"
+          ]
+        },
+        "published_apps_subdomain_unique": {
+          "name": "published_apps_subdomain_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "subdomain"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "published_apps_serving_requires_image": {
+          "name": "published_apps_serving_requires_image",
+          "value": "\"published_apps\".\"status\" NOT IN ('running', 'deploying') OR \"published_apps\".\"imageDigest\" IS NOT NULL"
+        },
+        "published_apps_running_requires_machine": {
+          "name": "published_apps_running_requires_machine",
+          "value": "\"published_apps\".\"status\" <> 'running' OR \"published_apps\".\"machineId\" IS NOT NULL"
+        },
+        "published_apps_parked_is_metered_only": {
+          "name": "published_apps_parked_is_metered_only",
+          "value": "\"published_apps\".\"status\" <> 'parked' OR \"published_apps\".\"tier\" = 'metered'"
+        },
+        "published_apps_guest_preset_allowed": {
+          "name": "published_apps_guest_preset_allowed",
+          "value": "\"published_apps\".\"guestPreset\" IN ('shared-cpu-1x-512')"
+        },
+        "published_apps_image_size_nonneg": {
+          "name": "published_apps_image_size_nonneg",
+          "value": "\"published_apps\".\"imageSizeBytes\" IS NULL OR \"published_apps\".\"imageSizeBytes\" >= 0"
+        },
+        "published_apps_subdomain_nonempty": {
+          "name": "published_apps_subdomain_nonempty",
+          "value": "length(\"published_apps\".\"subdomain\") > 0"
+        },
+        "published_apps_claim_coherent": {
+          "name": "published_apps_claim_coherent",
+          "value": "(\"published_apps\".\"claimedAt\" IS NULL) = (\"published_apps\".\"claimedBy\" IS NULL)"
+        },
+        "published_apps_image_size_measured_coherent": {
+          "name": "published_apps_image_size_measured_coherent",
+          "value": "(\"published_apps\".\"imageSizeBytes\" IS NULL) = (\"published_apps\".\"imageSizeMeasuredAt\" IS NULL)"
+        },
+        "published_apps_awake_window_needs_wake": {
+          "name": "published_apps_awake_window_needs_wake",
+          "value": "\"published_apps\".\"awakeBilledThrough\" IS NULL OR \"published_apps\".\"lastWakeAt\" IS NOT NULL"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.broadcast_recipients": {
+      "name": "broadcast_recipients",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "broadcast_id": {
+          "name": "broadcast_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "recipient_email": {
+          "name": "recipient_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "broadcast_recipient_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "skip_reason": {
+          "name": "skip_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "attempts": {
+          "name": "attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "sent_at": {
+          "name": "sent_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "claimed_at": {
+          "name": "claimed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "claimed_by": {
+          "name": "claimed_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "broadcast_recipients_broadcast_user_unique": {
+          "name": "broadcast_recipients_broadcast_user_unique",
+          "columns": [
+            {
+              "expression": "broadcast_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "broadcast_recipients_broadcast_status_idx": {
+          "name": "broadcast_recipients_broadcast_status_idx",
+          "columns": [
+            {
+              "expression": "broadcast_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "broadcast_recipients_broadcast_id_email_broadcasts_id_fk": {
+          "name": "broadcast_recipients_broadcast_id_email_broadcasts_id_fk",
+          "tableFrom": "broadcast_recipients",
+          "tableTo": "email_broadcasts",
+          "columnsFrom": [
+            "broadcast_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "broadcast_recipients_user_id_users_id_fk": {
+          "name": "broadcast_recipients_user_id_users_id_fk",
+          "tableFrom": "broadcast_recipients",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.broadcast_templates": {
+      "name": "broadcast_templates",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subject": {
+          "name": "subject",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "body_markdown": {
+          "name": "body_markdown",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "broadcast_templates_active_idx": {
+          "name": "broadcast_templates_active_idx",
+          "columns": [
+            {
+              "expression": "is_active",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "broadcast_templates_created_by_user_id_users_id_fk": {
+          "name": "broadcast_templates_created_by_user_id_users_id_fk",
+          "tableFrom": "broadcast_templates",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.email_broadcasts": {
+      "name": "email_broadcasts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "subject": {
+          "name": "subject",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "engine": {
+          "name": "engine",
+          "type": "email_broadcast_engine",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'transactional'"
+        },
+        "content_mode": {
+          "name": "content_mode",
+          "type": "email_broadcast_content_mode",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'compose'"
+        },
+        "template_id": {
+          "name": "template_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "body_markdown": {
+          "name": "body_markdown",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notification_type": {
+          "name": "notification_type",
+          "type": "NotificationType",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'PRODUCT_UPDATE'"
+        },
+        "audience_definition": {
+          "name": "audience_definition",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "status": {
+          "name": "status",
+          "type": "email_broadcast_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'draft'"
+        },
+        "dry_run": {
+          "name": "dry_run",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "send_limit": {
+          "name": "send_limit",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "delay_ms": {
+          "name": "delay_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 120
+        },
+        "total_targeted": {
+          "name": "total_targeted",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "sent_count": {
+          "name": "sent_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "skipped_count": {
+          "name": "skipped_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "failed_count": {
+          "name": "failed_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "step_results": {
+          "name": "step_results",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "job_id": {
+          "name": "job_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "attempts": {
+          "name": "attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "last_error": {
+          "name": "last_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "blocked_reason": {
+          "name": "blocked_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "email_broadcasts_status_idx": {
+          "name": "email_broadcasts_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "email_broadcasts_created_at_idx": {
+          "name": "email_broadcasts_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "email_broadcasts_created_by_idx": {
+          "name": "email_broadcasts_created_by_idx",
+          "columns": [
+            {
+              "expression": "created_by_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "email_broadcasts_template_id_broadcast_templates_id_fk": {
+          "name": "email_broadcasts_template_id_broadcast_templates_id_fk",
+          "tableFrom": "email_broadcasts",
+          "tableTo": "broadcast_templates",
+          "columnsFrom": [
+            "template_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "email_broadcasts_created_by_user_id_users_id_fk": {
+          "name": "email_broadcasts_created_by_user_id_users_id_fk",
+          "tableFrom": "email_broadcasts",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.page_webhooks": {
+      "name": "page_webhooks",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "pageId": {
+          "name": "pageId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "webhookToken": {
+          "name": "webhookToken",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "webhookSecretEncrypted": {
+          "name": "webhookSecretEncrypted",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "isEnabled": {
+          "name": "isEnabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "createdBy": {
+          "name": "createdBy",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "lastFiredAt": {
+          "name": "lastFiredAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lastFireError": {
+          "name": "lastFireError",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "page_webhooks_page_id_idx": {
+          "name": "page_webhooks_page_id_idx",
+          "columns": [
+            {
+              "expression": "pageId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "page_webhooks_token_idx": {
+          "name": "page_webhooks_token_idx",
+          "columns": [
+            {
+              "expression": "webhookToken",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "page_webhooks_pageId_pages_id_fk": {
+          "name": "page_webhooks_pageId_pages_id_fk",
+          "tableFrom": "page_webhooks",
+          "tableTo": "pages",
+          "columnsFrom": [
+            "pageId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "page_webhooks_createdBy_users_id_fk": {
+          "name": "page_webhooks_createdBy_users_id_fk",
+          "tableFrom": "page_webhooks",
+          "tableTo": "users",
+          "columnsFrom": [
+            "createdBy"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "page_webhooks_webhookToken_unique": {
+          "name": "page_webhooks_webhookToken_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "webhookToken"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agent_workspace_shells": {
+      "name": "agent_workspace_shells",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "workspaceId": {
+          "name": "workspaceId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ownerId": {
+          "name": "ownerId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agentType": {
+          "name": "agentType",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "command": {
+          "name": "command",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "spriteExecId": {
+          "name": "spriteExecId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "coldTail": {
+          "name": "coldTail",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "coldTailAt": {
+          "name": "coldTailAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "coldTailHasOutput": {
+          "name": "coldTailHasOutput",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "agent_workspace_shells_workspace_id_idx": {
+          "name": "agent_workspace_shells_workspace_id_idx",
+          "columns": [
+            {
+              "expression": "workspaceId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "agent_workspace_shells_workspace_name_idx": {
+          "name": "agent_workspace_shells_workspace_name_idx",
+          "columns": [
+            {
+              "expression": "workspaceId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "agent_workspace_shells_workspaceId_agent_workspaces_id_fk": {
+          "name": "agent_workspace_shells_workspaceId_agent_workspaces_id_fk",
+          "tableFrom": "agent_workspace_shells",
+          "tableTo": "agent_workspaces",
+          "columnsFrom": [
+            "workspaceId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "agent_workspace_shells_ownerId_users_id_fk": {
+          "name": "agent_workspace_shells_ownerId_users_id_fk",
+          "tableFrom": "agent_workspace_shells",
+          "tableTo": "users",
+          "columnsFrom": [
+            "ownerId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agent_workspaces": {
+      "name": "agent_workspaces",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "driveId": {
+          "name": "driveId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ownerId": {
+          "name": "ownerId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "envId": {
+          "name": "envId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "spriteKey": {
+          "name": "spriteKey",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sandboxId": {
+          "name": "sandboxId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "spriteInstanceId": {
+          "name": "spriteInstanceId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "egressPolicyToken": {
+          "name": "egressPolicyToken",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "teardownRequestedAt": {
+          "name": "teardownRequestedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "spriteTornDownAt": {
+          "name": "spriteTornDownAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "storageLastBilledAt": {
+          "name": "storageLastBilledAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "storageMeasuredBytes": {
+          "name": "storageMeasuredBytes",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "storageMeasuredAt": {
+          "name": "storageMeasuredAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lastActiveAt": {
+          "name": "lastActiveAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "endedAt": {
+          "name": "endedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "agent_workspaces_drive_id_idx": {
+          "name": "agent_workspaces_drive_id_idx",
+          "columns": [
+            {
+              "expression": "driveId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "agent_workspaces_owner_id_idx": {
+          "name": "agent_workspaces_owner_id_idx",
+          "columns": [
+            {
+              "expression": "ownerId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "agent_workspaces_live_sprite_idx": {
+          "name": "agent_workspaces_live_sprite_idx",
+          "columns": [
+            {
+              "expression": "sandboxId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "spriteTornDownAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"agent_workspaces\".\"sandboxId\" IS NOT NULL AND \"agent_workspaces\".\"spriteTornDownAt\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "agent_workspaces_env_id_idx": {
+          "name": "agent_workspaces_env_id_idx",
+          "columns": [
+            {
+              "expression": "envId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "agent_workspaces_driveId_drives_id_fk": {
+          "name": "agent_workspaces_driveId_drives_id_fk",
+          "tableFrom": "agent_workspaces",
+          "tableTo": "drives",
+          "columnsFrom": [
+            "driveId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "agent_workspaces_ownerId_users_id_fk": {
+          "name": "agent_workspaces_ownerId_users_id_fk",
+          "tableFrom": "agent_workspaces",
+          "tableTo": "users",
+          "columnsFrom": [
+            "ownerId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "agent_workspaces_envId_drive_envs_id_fk": {
+          "name": "agent_workspaces_envId_drive_envs_id_fk",
+          "tableFrom": "agent_workspaces",
+          "tableTo": "drive_envs",
+          "columnsFrom": [
+            "envId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "agent_workspaces_env_no_sprite_check": {
+          "name": "agent_workspaces_env_no_sprite_check",
+          "value": "\"agent_workspaces\".\"envId\" IS NULL OR (\"agent_workspaces\".\"sandboxId\" IS NULL AND \"agent_workspaces\".\"spriteKey\" IS NULL AND \"agent_workspaces\".\"spriteInstanceId\" IS NULL)"
+        },
+        "agent_workspaces_env_needs_drive_check": {
+          "name": "agent_workspaces_env_needs_drive_check",
+          "value": "\"agent_workspaces\".\"envId\" IS NULL OR \"agent_workspaces\".\"driveId\" IS NOT NULL"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.agent_workspace_node_revs": {
+      "name": "agent_workspace_node_revs",
+      "schema": "",
+      "columns": {
+        "rootId": {
+          "name": "rootId",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "rev": {
+          "name": "rev",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "agent_workspace_node_revs_rootId_agent_workspaces_id_fk": {
+          "name": "agent_workspace_node_revs_rootId_agent_workspaces_id_fk",
+          "tableFrom": "agent_workspace_node_revs",
+          "tableTo": "agent_workspaces",
+          "columnsFrom": [
+            "rootId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agent_workspace_nodes": {
+      "name": "agent_workspace_nodes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rootId": {
+          "name": "rootId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "parentId": {
+          "name": "parentId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "nodeType": {
+          "name": "nodeType",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "axis": {
+          "name": "axis",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "fraction": {
+          "name": "fraction",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "targetKind": {
+          "name": "targetKind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "targetId": {
+          "name": "targetId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "agent_workspace_nodes_one_root_idx": {
+          "name": "agent_workspace_nodes_one_root_idx",
+          "columns": [
+            {
+              "expression": "rootId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"agent_workspace_nodes\".\"nodeType\" = 'root'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "agent_workspace_nodes_chat_target_idx": {
+          "name": "agent_workspace_nodes_chat_target_idx",
+          "columns": [
+            {
+              "expression": "targetId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"agent_workspace_nodes\".\"targetKind\" = 'chat'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "agent_workspace_nodes_parent_idx": {
+          "name": "agent_workspace_nodes_parent_idx",
+          "columns": [
+            {
+              "expression": "rootId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "parentId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "agent_workspace_nodes_rootId_agent_workspaces_id_fk": {
+          "name": "agent_workspace_nodes_rootId_agent_workspaces_id_fk",
+          "tableFrom": "agent_workspace_nodes",
+          "tableTo": "agent_workspaces",
+          "columnsFrom": [
+            "rootId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "agent_workspace_nodes_rootId_parentId_agent_workspace_nodes_rootId_id_fk": {
+          "name": "agent_workspace_nodes_rootId_parentId_agent_workspace_nodes_rootId_id_fk",
+          "tableFrom": "agent_workspace_nodes",
+          "tableTo": "agent_workspace_nodes",
+          "columnsFrom": [
+            "rootId",
+            "parentId"
+          ],
+          "columnsTo": [
+            "rootId",
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "agent_workspace_nodes_rootId_id_pk": {
+          "name": "agent_workspace_nodes_rootId_id_pk",
+          "columns": [
+            "rootId",
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "agent_workspace_nodes_root_no_parent_chk": {
+          "name": "agent_workspace_nodes_root_no_parent_chk",
+          "value": "(\"agent_workspace_nodes\".\"nodeType\" = 'root') = (\"agent_workspace_nodes\".\"parentId\" IS NULL)"
+        },
+        "agent_workspace_nodes_node_type_chk": {
+          "name": "agent_workspace_nodes_node_type_chk",
+          "value": "\"agent_workspace_nodes\".\"nodeType\" IN ('root', 'split', 'pane')"
+        },
+        "agent_workspace_nodes_target_kind_chk": {
+          "name": "agent_workspace_nodes_target_kind_chk",
+          "value": "\"agent_workspace_nodes\".\"targetKind\" IS NULL OR \"agent_workspace_nodes\".\"targetKind\" IN ('chat', 'terminal', 'page')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.drive_envs": {
+      "name": "drive_envs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "driveId": {
+          "name": "driveId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdBy": {
+          "name": "createdBy",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "spriteKey": {
+          "name": "spriteKey",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sandboxId": {
+          "name": "sandboxId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "spriteInstanceId": {
+          "name": "spriteInstanceId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "egressPolicyToken": {
+          "name": "egressPolicyToken",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "teardownRequestedAt": {
+          "name": "teardownRequestedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "spriteTornDownAt": {
+          "name": "spriteTornDownAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "storageLastBilledAt": {
+          "name": "storageLastBilledAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "storageMeasuredBytes": {
+          "name": "storageMeasuredBytes",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "storageMeasuredAt": {
+          "name": "storageMeasuredAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lastActiveAt": {
+          "name": "lastActiveAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "drive_envs_drive_id_idx": {
+          "name": "drive_envs_drive_id_idx",
+          "columns": [
+            {
+              "expression": "driveId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "drive_envs_drive_name_idx": {
+          "name": "drive_envs_drive_name_idx",
+          "columns": [
+            {
+              "expression": "driveId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "drive_envs_live_sprite_idx": {
+          "name": "drive_envs_live_sprite_idx",
+          "columns": [
+            {
+              "expression": "sandboxId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "spriteTornDownAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"drive_envs\".\"sandboxId\" IS NOT NULL AND \"drive_envs\".\"spriteTornDownAt\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "drive_envs_driveId_drives_id_fk": {
+          "name": "drive_envs_driveId_drives_id_fk",
+          "tableFrom": "drive_envs",
+          "tableTo": "drives",
+          "columnsFrom": [
+            "driveId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "drive_envs_createdBy_users_id_fk": {
+          "name": "drive_envs_createdBy_users_id_fk",
+          "tableFrom": "drive_envs",
+          "tableTo": "users",
+          "columnsFrom": [
+            "createdBy"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.AuthProvider": {
+      "name": "AuthProvider",
+      "schema": "public",
+      "values": [
+        "email",
+        "google",
+        "apple"
+      ]
+    },
+    "public.PlatformType": {
+      "name": "PlatformType",
+      "schema": "public",
+      "values": [
+        "web",
+        "desktop",
+        "ios",
+        "android"
+      ]
+    },
+    "public.UserRole": {
+      "name": "UserRole",
+      "schema": "public",
+      "values": [
+        "user",
+        "admin"
+      ]
+    },
+    "public.DriveKind": {
+      "name": "DriveKind",
+      "schema": "public",
+      "values": [
+        "STANDARD",
+        "HOME"
+      ]
+    },
+    "public.FavoriteItemType": {
+      "name": "FavoriteItemType",
+      "schema": "public",
+      "values": [
+        "page",
+        "drive"
+      ]
+    },
+    "public.PageType": {
+      "name": "PageType",
+      "schema": "public",
+      "values": [
+        "FOLDER",
+        "DOCUMENT",
+        "CHANNEL",
+        "AI_CHAT",
+        "CANVAS",
+        "FILE",
+        "SHEET",
+        "TASK_LIST",
+        "CODE",
+        "MACHINE"
+      ]
+    },
+    "public.MemberRole": {
+      "name": "MemberRole",
+      "schema": "public",
+      "values": [
+        "OWNER",
+        "ADMIN",
+        "MEMBER"
+      ]
+    },
+    "public.pulse_summary_type": {
+      "name": "pulse_summary_type",
+      "schema": "public",
+      "values": [
+        "scheduled",
+        "on_demand",
+        "welcome"
+      ]
+    },
+    "public.NotificationType": {
+      "name": "NotificationType",
+      "schema": "public",
+      "values": [
+        "PERMISSION_GRANTED",
+        "PERMISSION_REVOKED",
+        "PERMISSION_UPDATED",
+        "PAGE_SHARED",
+        "DRIVE_INVITED",
+        "DRIVE_JOINED",
+        "DRIVE_ROLE_CHANGED",
+        "CONNECTION_REQUEST",
+        "CONNECTION_ACCEPTED",
+        "CONNECTION_REJECTED",
+        "NEW_DIRECT_MESSAGE",
+        "EMAIL_VERIFICATION_REQUIRED",
+        "TOS_PRIVACY_UPDATED",
+        "MENTION",
+        "TASK_ASSIGNED",
+        "PRODUCT_UPDATE"
+      ]
+    },
+    "public.toast_notification_level": {
+      "name": "toast_notification_level",
+      "schema": "public",
+      "values": [
+        "all",
+        "mentions",
+        "off"
+      ]
+    },
+    "public.display_preference_type": {
+      "name": "display_preference_type",
+      "schema": "public",
+      "values": [
+        "SHOW_TOKEN_COUNTS",
+        "SHOW_CODE_TOGGLE",
+        "DEFAULT_MARKDOWN_MODE"
+      ]
+    },
+    "public.activity_change_group_type": {
+      "name": "activity_change_group_type",
+      "schema": "public",
+      "values": [
+        "user",
+        "ai",
+        "automation",
+        "system"
+      ]
+    },
+    "public.activity_resource": {
+      "name": "activity_resource",
+      "schema": "public",
+      "values": [
+        "page",
+        "drive",
+        "permission",
+        "agent",
+        "user",
+        "member",
+        "role",
+        "file",
+        "token",
+        "device",
+        "message",
+        "conversation"
+      ]
+    },
+    "public.content_format": {
+      "name": "content_format",
+      "schema": "public",
+      "values": [
+        "text",
+        "html",
+        "json",
+        "tiptap"
+      ]
+    },
+    "public.http_method": {
+      "name": "http_method",
+      "schema": "public",
+      "values": [
+        "GET",
+        "POST",
+        "PUT",
+        "DELETE",
+        "PATCH",
+        "HEAD",
+        "OPTIONS"
+      ]
+    },
+    "public.log_level": {
+      "name": "log_level",
+      "schema": "public",
+      "values": [
+        "trace",
+        "debug",
+        "info",
+        "warn",
+        "error",
+        "fatal"
+      ]
+    },
+    "public.drive_backup_schedule_frequency": {
+      "name": "drive_backup_schedule_frequency",
+      "schema": "public",
+      "values": [
+        "daily",
+        "weekly",
+        "monthly"
+      ]
+    },
+    "public.drive_backup_source": {
+      "name": "drive_backup_source",
+      "schema": "public",
+      "values": [
+        "manual",
+        "scheduled",
+        "pre_restore",
+        "system"
+      ]
+    },
+    "public.drive_backup_status": {
+      "name": "drive_backup_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "ready",
+        "failed"
+      ]
+    },
+    "public.page_version_source": {
+      "name": "page_version_source",
+      "schema": "public",
+      "values": [
+        "manual",
+        "auto",
+        "pre_ai",
+        "pre_restore",
+        "restore",
+        "system"
+      ]
+    },
+    "public.ConnectionStatus": {
+      "name": "ConnectionStatus",
+      "schema": "public",
+      "values": [
+        "PENDING",
+        "ACCEPTED",
+        "BLOCKED"
+      ]
+    },
+    "public.PushPlatformType": {
+      "name": "PushPlatformType",
+      "schema": "public",
+      "values": [
+        "ios",
+        "android",
+        "web"
+      ]
+    },
+    "public.integration_connection_status": {
+      "name": "integration_connection_status",
+      "schema": "public",
+      "values": [
+        "active",
+        "expired",
+        "error",
+        "pending",
+        "revoked"
+      ]
+    },
+    "public.integration_provider_type": {
+      "name": "integration_provider_type",
+      "schema": "public",
+      "values": [
+        "builtin",
+        "openapi",
+        "custom",
+        "mcp",
+        "webhook"
+      ]
+    },
+    "public.integration_visibility": {
+      "name": "integration_visibility",
+      "schema": "public",
+      "values": [
+        "private",
+        "owned_drives",
+        "all_drives"
+      ]
+    },
+    "public.AttendeeStatus": {
+      "name": "AttendeeStatus",
+      "schema": "public",
+      "values": [
+        "PENDING",
+        "ACCEPTED",
+        "DECLINED",
+        "TENTATIVE"
+      ]
+    },
+    "public.EventVisibility": {
+      "name": "EventVisibility",
+      "schema": "public",
+      "values": [
+        "DRIVE",
+        "ATTENDEES_ONLY",
+        "PRIVATE"
+      ]
+    },
+    "public.GoogleCalendarConnectionStatus": {
+      "name": "GoogleCalendarConnectionStatus",
+      "schema": "public",
+      "values": [
+        "active",
+        "expired",
+        "error",
+        "disconnected"
+      ]
+    },
+    "public.RecurrenceFrequency": {
+      "name": "RecurrenceFrequency",
+      "schema": "public",
+      "values": [
+        "DAILY",
+        "WEEKLY",
+        "MONTHLY",
+        "YEARLY"
+      ]
+    },
+    "public.WorkflowTriggerType": {
+      "name": "WorkflowTriggerType",
+      "schema": "public",
+      "values": [
+        "cron",
+        "event"
+      ]
+    },
+    "public.WorkflowRunSourceTable": {
+      "name": "WorkflowRunSourceTable",
+      "schema": "public",
+      "values": [
+        "taskTriggers",
+        "calendarTriggers",
+        "webhookTriggers",
+        "cron",
+        "manual"
+      ]
+    },
+    "public.WorkflowRunStatus": {
+      "name": "WorkflowRunStatus",
+      "schema": "public",
+      "values": [
+        "running",
+        "success",
+        "error",
+        "cancelled"
+      ]
+    },
+    "public.WorkflowRunStepStatus": {
+      "name": "WorkflowRunStepStatus",
+      "schema": "public",
+      "values": [
+        "running",
+        "success",
+        "error",
+        "skipped"
+      ]
+    },
+    "public.TaskTriggerType": {
+      "name": "TaskTriggerType",
+      "schema": "public",
+      "values": [
+        "due_date",
+        "completion"
+      ]
+    },
+    "public.ZoomConnectionStatus": {
+      "name": "ZoomConnectionStatus",
+      "schema": "public",
+      "values": [
+        "active",
+        "expired",
+        "error",
+        "disconnected"
+      ]
+    },
+    "public.ContentTagAnchorStatus": {
+      "name": "ContentTagAnchorStatus",
+      "schema": "public",
+      "values": [
+        "exact",
+        "shifted",
+        "fuzzy",
+        "orphaned"
+      ]
+    },
+    "public.ContentTagSource": {
+      "name": "ContentTagSource",
+      "schema": "public",
+      "values": [
+        "user",
+        "ai",
+        "system",
+        "rule"
+      ]
+    },
+    "public.ContentTagTargetKind": {
+      "name": "ContentTagTargetKind",
+      "schema": "public",
+      "values": [
+        "page",
+        "text",
+        "sheet_cell",
+        "channel_message",
+        "ai_message"
+      ]
+    },
+    "public.custom_domain_status": {
+      "name": "custom_domain_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "verified",
+        "failed",
+        "provisioning",
+        "active",
+        "dns_failed",
+        "cert_failed"
+      ]
+    },
+    "public.data_subject_request_status": {
+      "name": "data_subject_request_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "queued",
+        "in_progress",
+        "blocked",
+        "completed",
+        "failed",
+        "cancelled"
+      ]
+    },
+    "public.data_subject_request_type": {
+      "name": "data_subject_request_type",
+      "schema": "public",
+      "values": [
+        "erasure",
+        "export",
+        "access",
+        "rectification",
+        "restriction",
+        "portability",
+        "objection"
+      ]
+    },
+    "public.data_subject_requester_type": {
+      "name": "data_subject_requester_type",
+      "schema": "public",
+      "values": [
+        "self",
+        "admin"
+      ]
+    },
+    "public.OAuthClientType": {
+      "name": "OAuthClientType",
+      "schema": "public",
+      "values": [
+        "public",
+        "confidential"
+      ]
+    },
+    "public.published_app_status": {
+      "name": "published_app_status",
+      "schema": "public",
+      "values": [
+        "provisioning",
+        "building",
+        "deploying",
+        "running",
+        "stopped",
+        "parked",
+        "destroying",
+        "failed"
+      ]
+    },
+    "public.published_app_tier": {
+      "name": "published_app_tier",
+      "schema": "public",
+      "values": [
+        "metered",
+        "dedicated"
+      ]
+    },
+    "public.broadcast_recipient_status": {
+      "name": "broadcast_recipient_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "sent",
+        "skipped",
+        "failed"
+      ]
+    },
+    "public.email_broadcast_content_mode": {
+      "name": "email_broadcast_content_mode",
+      "schema": "public",
+      "values": [
+        "compose",
+        "template"
+      ]
+    },
+    "public.email_broadcast_engine": {
+      "name": "email_broadcast_engine",
+      "schema": "public",
+      "values": [
+        "transactional",
+        "resend_broadcast"
+      ]
+    },
+    "public.email_broadcast_status": {
+      "name": "email_broadcast_status",
+      "schema": "public",
+      "values": [
+        "draft",
+        "pending",
+        "queued",
+        "in_progress",
+        "paused",
+        "completed",
+        "failed",
+        "cancelled"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/packages/db/drizzle/meta/_journal.json
+++ b/packages/db/drizzle/meta/_journal.json
@@ -1919,6 +1919,13 @@
       "when": 1787620331528,
       "tag": "0273_foamy_mother_askani",
       "breakpoints": true
+    },
+    {
+      "idx": 274,
+      "version": "7",
+      "when": 1787668050796,
+      "tag": "0274_swift_reaper",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/db/src/schema/published-apps.ts
+++ b/packages/db/src/schema/published-apps.ts
@@ -1,4 +1,4 @@
-import { pgTable, text, integer, bigint, timestamp, index, pgEnum, check } from 'drizzle-orm/pg-core';
+import { pgTable, text, integer, bigint, timestamp, index, uniqueIndex, pgEnum, check } from 'drizzle-orm/pg-core';
 import { relations, sql } from 'drizzle-orm';
 import { createId } from '@paralleldrive/cuid2';
 import { users } from './auth';
@@ -164,6 +164,24 @@ export const publishedApps = pgTable('published_apps', {
    */
   imageSizeBytes: bigint('imageSizeBytes', { mode: 'number' }),
 
+  /**
+   * When `imageSizeBytes` was recorded — i.e. which build's manifest it came
+   * from, expressed as a time rather than a digest.
+   *
+   * Exists because the storage meter cannot use a measurement it cannot date. The
+   * shared reconcile prices a window from a MEASURED footprint and reports a
+   * staleness signal from the measurement's age, and its `pickBillableGB` treats
+   * either column being NULL as "never measured" — so a size with no timestamp
+   * would bill the conservative 0 floor forever while the watermark advanced over
+   * real rootfs the platform is paying Fly for.
+   *
+   * Written in the SAME statement as `imageSizeBytes`, and enforced as such by
+   * `published_apps_image_size_measured_coherent` below — `transitionPublishedApp`
+   * is the single writer and stamps this whenever the patch carries a size,
+   * including when the size is cleared back to NULL.
+   */
+  imageSizeMeasuredAt: timestamp('imageSizeMeasuredAt', { mode: 'date', withTimezone: true }),
+
   tier: publishedAppTier('tier').default('metered').notNull(),
 
   /** The current Fly machine. NULL before the first create and between blue/green swaps. */
@@ -176,6 +194,56 @@ export const publishedApps = pgTable('published_apps', {
    */
   lastWakeAt: timestamp('lastWakeAt', { mode: 'date', withTimezone: true }),
   lastStopAt: timestamp('lastStopAt', { mode: 'date', withTimezone: true }),
+
+  /**
+   * The awake window BILLED THROUGH — the metering watermark, and the only column
+   * the awake-seconds drain reads to decide what it owes.
+   *
+   * Stamped to the wake instant when the wake seam starts a machine, advanced
+   * MONOTONICALLY by each heartbeat settle, and cleared to NULL by the final
+   * settle at stop. Deliberately a separate column from `lastWakeAt`, which is the
+   * BOUNDARY stamp and must not move: a heartbeat that advanced `lastWakeAt`
+   * itself would erase the record of when this awake period actually began, which
+   * is the one thing the weekly `fly_instance_up` reconcile compares against.
+   *
+   * NULL therefore means "no awake window is open" — either the app has never been
+   * woken, or its last window was settled and closed. A NULL here on a `running`
+   * row is an anomaly the meter counts (`unstamped`) and repairs by stamping NOW,
+   * never retroactively: an unknown window start must cost the payer nothing
+   * rather than an invented amount.
+   */
+  awakeBilledThrough: timestamp('awakeBilledThrough', { mode: 'date', withTimezone: true }),
+
+  /**
+   * The credit HOLD placed by the wake gate, carried for the life of the awake
+   * window so every settle in that window bills against the reservation the gate
+   * actually made.
+   *
+   * A hold is a reservation, not a charge: it is what stops a fleet of concurrent
+   * wakes from collectively overshooting a balance that each of them individually
+   * cleared. It is released (or settled against) at stop. NULL on an app that was
+   * woken on a billing-disabled deployment with no ceiling configured, where the
+   * gate takes the query-free unlimited path and places no hold at all — so this
+   * being NULL is never on its own evidence that a wake skipped the gate.
+   */
+  awakeHoldId: text('awakeHoldId'),
+
+  /**
+   * Watermark for the ROOTFS storage drain — the published-app half of the shared
+   * storage reconcile, exactly as `drive_envs.storageLastBilledAt` is the env half.
+   *
+   * A stopped published app costs zero awake-seconds and still costs Fly
+   * $0.15/GB-month for the image its machine assembles from, which is the entire
+   * per-app idle floor. That drip is billed by the SAME meter, on the same cron and
+   * behind the same advisory lock as session and env persistence — a third row
+   * source, not a third meter.
+   *
+   * Defaults to now() so a row provisioned today can never bill retroactively for
+   * time before it existed.
+   */
+  storageLastBilledAt: timestamp('storageLastBilledAt', { mode: 'date', withTimezone: true })
+    .defaultNow()
+    .notNull(),
 
   /** Why a `failed` row failed — the operator's first read when an app won't provision. */
   lastError: text('lastError'),
@@ -268,6 +336,21 @@ export const publishedApps = pgTable('published_apps', {
   claimCoherent: check(
     'published_apps_claim_coherent',
     sql`(${table.claimedAt} IS NULL) = (${table.claimedBy} IS NULL)`,
+  ),
+  // A size the meter cannot date is a size the meter cannot use — it reads as
+  // "never measured" and bills the 0 floor while the watermark advances over real
+  // rootfs. Biconditional rather than a one-way implication so the reverse (a
+  // measurement time for a size that was never recorded) is equally unrepresentable.
+  imageSizeMeasuredCoherent: check(
+    'published_apps_image_size_measured_coherent',
+    sql`(${table.imageSizeBytes} IS NULL) = (${table.imageSizeMeasuredAt} IS NULL)`,
+  ),
+  // An open awake window with no wake boundary is a window with no origin: the
+  // weekly reconcile compares our billed span against `fly_instance_up` from
+  // `lastWakeAt`, and a watermark without one cannot be checked against anything.
+  awakeWindowNeedsWake: check(
+    'published_apps_awake_window_needs_wake',
+    sql`${table.awakeBilledThrough} IS NULL OR ${table.lastWakeAt} IS NOT NULL`,
   ),
 }));
 
@@ -436,6 +519,116 @@ export const appHostingReclaims = pgTable('app_hosting_reclaims', {
   attemptsNonNeg: check('app_hosting_reclaims_attempts_nonneg', sql`${table.attempts} >= 0`),
 }));
 
+/**
+ * publishedAppMachineEvents — the LOCAL MIRROR of a published app's machine
+ * lifecycle, and the primary billing record for awake-seconds.
+ *
+ * Fly keeps only the MOST RECENT 20 EVENTS per machine, with no pagination and no
+ * time window (measured in the Phase 0 spike — see `listMachineEvents`). Twenty
+ * events is about five stop/start cycles, so on a busy app that endpoint has
+ * forgotten yesterday by lunchtime. **Awake-seconds history therefore cannot be
+ * rebuilt from Fly after the fact.** It has to be written down as it happens, and
+ * this table is where.
+ *
+ * Two origins, one shape:
+ *  - `orchestrator` — OUR OWN start/stop API call, written in the same step as the
+ *    call itself. `autostop` is off precisely so that every awake boundary is one
+ *    of these: an API call we made, at a time we know exactly, rather than a proxy
+ *    behavior we would have to infer.
+ *  - `fly` — an event mirrored from `GET /machines/{id}/events`, captured
+ *    opportunistically right after our own call while the last-20 window still
+ *    contains it. This is CONFIRMATION and drift detection, never the source: a
+ *    machine can also go down for reasons we did not ask for (an OOM kill, a host
+ *    migration), and those only ever appear here.
+ *
+ * The two are kept as separate rows rather than reconciled into one because they
+ * answer different questions — "what did we ask for" and "what did Fly do" — and
+ * collapsing them would lose exactly the disagreement the weekly `fly_instance_up`
+ * reconcile exists to find.
+ *
+ * Deliberately FK-CASCADED off `published_apps`, unlike `app_hosting_reclaims`
+ * next door, which is FK-free on purpose. The difference is what each table is FOR:
+ * a reclaim pointer must outlive its row because it is the only handle that can
+ * stop a resource from billing, whereas these events are an operational record for
+ * reconciling a LIVE app. The money they produced already lives in the credit
+ * ledger and `ai_usage_logs`, which no app delete touches; the weekly reconcile
+ * only ever enumerates live rows; and unbounded retention with no owner would need
+ * a purge cron of its own to stop growing. Destroying the app therefore takes its
+ * event mirror with it, and loses nothing that is anybody's evidence of a charge.
+ */
+export const publishedAppMachineEvents = pgTable('published_app_machine_events', {
+  id: text('id').primaryKey().$defaultFn(() => createId()),
+
+  publishedAppId: text('publishedAppId')
+    .notNull()
+    .references(() => publishedApps.id, { onDelete: 'cascade' }),
+
+  /** Denormalized so an operator reading this table alone can address the Fly resources it names. */
+  flyAppName: text('flyAppName').notNull(),
+  machineId: text('machineId').notNull(),
+
+  /** 'orchestrator' (our own API call) | 'fly' (mirrored from the last-20 event window). */
+  origin: text('origin').notNull(),
+
+  /**
+   * The awake boundary this event marks: 'start' or 'stop'. NORMALIZED, because
+   * the billing question is only ever which direction the machine crossed —
+   * Fly's own vocabulary is preserved verbatim in `flyEventType` beside it rather
+   * than being flattened away.
+   */
+  action: text('action').notNull(),
+
+  /**
+   * Fly's own event id, when this row mirrors one. NULL for an `orchestrator` row:
+   * our API call has no Fly event id (the response carries none), and the event
+   * Fly logs for it arrives separately as its own `fly` row.
+   *
+   * The unique index below is keyed on this, so re-reading the last-20 window —
+   * which the mirror does on every start and stop — inserts each Fly event exactly
+   * once no matter how many times it is seen.
+   */
+  flyEventId: text('flyEventId'),
+
+  /** Fly's raw `type` and `status` strings, kept verbatim: the normalization above is ours, and a future Fly event type must not be silently retyped as one we already understand. */
+  flyEventType: text('flyEventType'),
+  flyEventStatus: text('flyEventStatus'),
+
+  /**
+   * When the boundary happened. For an `orchestrator` row this is the instant we
+   * made the call; for a `fly` row it is Fly's own event timestamp. This is the
+   * column the awake-seconds arithmetic reads — never `recordedAt`, which can lag
+   * it by however long the mirroring write took.
+   */
+  occurredAt: timestamp('occurredAt', { mode: 'date', withTimezone: true }).notNull(),
+
+  /** When WE wrote the row. Distinct from `occurredAt` so mirroring lag is visible rather than folded into the billed span. */
+  recordedAt: timestamp('recordedAt', { mode: 'date', withTimezone: true }).defaultNow().notNull(),
+}, (table) => ({
+  // The reconcile's access path: one app's boundaries, in time order.
+  appIdx: index('published_app_machine_events_app_idx').on(table.publishedAppId, table.occurredAt),
+  // Idempotent mirroring. PARTIAL, because `orchestrator` rows carry no Fly event
+  // id and a plain unique index would collapse every one of them into a single
+  // permitted row per machine — silently discarding the primary billing record
+  // this table exists to keep.
+  flyEventUnique: uniqueIndex('published_app_machine_events_fly_event_unique')
+    .on(table.machineId, table.flyEventId)
+    .where(sql`"flyEventId" IS NOT NULL`),
+  originAllowed: check(
+    'published_app_machine_events_origin_allowed',
+    sql`${table.origin} IN ('orchestrator', 'fly')`,
+  ),
+  actionAllowed: check(
+    'published_app_machine_events_action_allowed',
+    sql`${table.action} IN ('start', 'stop')`,
+  ),
+  // Our own call has no Fly event id, and a mirrored Fly event is worthless
+  // without one — it is the only thing that makes re-reading the window idempotent.
+  flyEventIdCoherent: check(
+    'published_app_machine_events_fly_event_id_coherent',
+    sql`(${table.origin} = 'fly') = (${table.flyEventId} IS NOT NULL)`,
+  ),
+}));
+
 export const publishedAppsRelations = relations(publishedApps, ({ one, many }) => ({
   env: one(driveEnvs, {
     fields: [publishedApps.envId],
@@ -463,5 +656,7 @@ export type PublishedApp = typeof publishedApps.$inferSelect;
 export type NewPublishedApp = typeof publishedApps.$inferInsert;
 export type AppDeployTokenMint = typeof appDeployTokenMints.$inferSelect;
 export type NewAppDeployTokenMint = typeof appDeployTokenMints.$inferInsert;
+export type PublishedAppMachineEvent = typeof publishedAppMachineEvents.$inferSelect;
+export type NewPublishedAppMachineEvent = typeof publishedAppMachineEvents.$inferInsert;
 export type AppHostingReclaim = typeof appHostingReclaims.$inferSelect;
 export type NewAppHostingReclaim = typeof appHostingReclaims.$inferInsert;

--- a/packages/lib/package.json
+++ b/packages/lib/package.json
@@ -608,6 +608,41 @@
       "import": "./dist/services/app-hosting/provisioner.js",
       "require": "./dist/services/app-hosting/provisioner.js"
     },
+    "./services/app-hosting/app-billing": {
+      "types": "./dist/services/app-hosting/app-billing.d.ts",
+      "import": "./dist/services/app-hosting/app-billing.js",
+      "require": "./dist/services/app-hosting/app-billing.js"
+    },
+    "./services/app-hosting/app-lifecycle-metering": {
+      "types": "./dist/services/app-hosting/app-lifecycle-metering.d.ts",
+      "import": "./dist/services/app-hosting/app-lifecycle-metering.js",
+      "require": "./dist/services/app-hosting/app-lifecycle-metering.js"
+    },
+    "./services/app-hosting/app-machine-events": {
+      "types": "./dist/services/app-hosting/app-machine-events.d.ts",
+      "import": "./dist/services/app-hosting/app-machine-events.js",
+      "require": "./dist/services/app-hosting/app-machine-events.js"
+    },
+    "./services/app-hosting/app-metering-core": {
+      "types": "./dist/services/app-hosting/app-metering-core.d.ts",
+      "import": "./dist/services/app-hosting/app-metering-core.js",
+      "require": "./dist/services/app-hosting/app-metering-core.js"
+    },
+    "./services/app-hosting/awake-meter": {
+      "types": "./dist/services/app-hosting/awake-meter.d.ts",
+      "import": "./dist/services/app-hosting/awake-meter.js",
+      "require": "./dist/services/app-hosting/awake-meter.js"
+    },
+    "./services/app-hosting/awake-reconcile": {
+      "types": "./dist/services/app-hosting/awake-reconcile.d.ts",
+      "import": "./dist/services/app-hosting/awake-reconcile.js",
+      "require": "./dist/services/app-hosting/awake-reconcile.js"
+    },
+    "./services/fly/prometheus-client": {
+      "types": "./dist/services/fly/prometheus-client.d.ts",
+      "import": "./dist/services/fly/prometheus-client.js",
+      "require": "./dist/services/fly/prometheus-client.js"
+    },
     "./services/fly/flaps-retry": {
       "types": "./dist/services/fly/flaps-retry.d.ts",
       "import": "./dist/services/fly/flaps-retry.js",

--- a/packages/lib/src/billing/credit-pricing.ts
+++ b/packages/lib/src/billing/credit-pricing.ts
@@ -308,6 +308,70 @@ export const MACHINE_ASSUMED_MEMORY_GB = envFloat('MACHINE_ASSUMED_MEMORY_GB', 0
 export const MACHINE_STORAGE_USD_PER_GB_MONTH = envFloat('MACHINE_STORAGE_USD_PER_GB_MONTH', 0.15);
 
 /**
+ * The guest shape a PUBLISHED APP's machine actually runs — and, unlike the
+ * sandbox shape above, it is a shape we KNOW rather than assume.
+ *
+ * `published_apps.guestPreset` is fixed at `shared-cpu-1x-512` by a CHECK
+ * constraint (the v1 unit-economics guardrail), so the memory figure here is the
+ * guest we asked Fly for, not a guess about somebody else's default. Pricing
+ * published apps at the sandbox shape's 0.25GB instead would under-bill every
+ * awake second by half the memory component for as long as the two happened to
+ * differ, silently and invisibly.
+ *
+ * Env-overridable in step with the preset: widening the allowed guest set is an
+ * additive migration on that CHECK, and this is the other half of the same change.
+ */
+export const PUBLISHED_APP_ASSUMED_CPUS = envFloat('PUBLISHED_APP_ASSUMED_CPUS', 1);
+export const PUBLISHED_APP_ASSUMED_MEMORY_GB = envFloat('PUBLISHED_APP_ASSUMED_MEMORY_GB', 0.5);
+
+/**
+ * Reservation placed when a published app is WOKEN, covering the span between
+ * heartbeat settles rather than the whole awake period.
+ *
+ * An awake window settles continuously — the metering cron bills the accrued
+ * seconds every tick — so, exactly like {@link REALTIME_SESSION_HOLD_ESTIMATE_CENTS},
+ * the hold only has to cover the window between settles plus the moments after the
+ * wake, not the app's entire uptime. At the fixed v1 guest that is well under a
+ * cent per ten-minute tick; 5¢ leaves generous headroom for a slower cadence
+ * without reserving a meaningful slice of a small balance.
+ *
+ * Like every hold in this file it is an ESTIMATE, not a cap: the real cost settles
+ * exactly through `consumeCredits` at the 1.5× substrate markup.
+ */
+export const PUBLISHED_APP_WAKE_HOLD_ESTIMATE_CENTS = envInt('PUBLISHED_APP_WAKE_HOLD_ESTIMATE_CENTS', 5);
+
+/**
+ * Max concurrently-awake published apps per payer that the wake gate will reserve
+ * for — the same bound `MACHINE_MAX_INFLIGHT` places on sandbox runs, applied to
+ * the one thing that can genuinely fan out here: a drive owner publishing many
+ * apps that all get woken at once by traffic.
+ *
+ * Unlike the sandbox gate there is no per-tier semaphore to reconcile this against
+ * (nothing limits how many apps a drive may publish), so this is the only bound on
+ * concurrent awake reservations and is applied flat across tiers.
+ */
+export const PUBLISHED_APP_MAX_INFLIGHT = envInt('PUBLISHED_APP_MAX_INFLIGHT', 50);
+
+/**
+ * The runaway ceiling the published-app wake gate always passes, in whole cents
+ * per payer per UTC day.
+ *
+ * Its whole reason for existing is the billing-DISABLED deployment. On tenant and
+ * onprem `isBillingEnabled()` is false and hosting is unlimited by design — there
+ * is no credit ledger and no balance to gate against — but "unlimited" must not
+ * mean "unbounded": a loop that wakes an app thousands of times, or a fleet left
+ * awake by a broken idle reaper, spends real substrate money on somebody's
+ * infrastructure. `canConsumeAI` honours `dailyCapCeilingCents` in EVERY
+ * deployment mode, metering the day from `ai_usage_logs` when there is no ledger,
+ * which is exactly the property this constant leans on.
+ *
+ * Set generously (default $20/payer/day) — it is a runaway backstop, not a
+ * product limit, and a legitimate always-awake app at the v1 guest costs a few
+ * cents a day. Set to 0 to disable it entirely.
+ */
+export const PUBLISHED_APP_DAILY_CAP_CEILING_CENTS = envInt('PUBLISHED_APP_DAILY_CAP_CEILING_CENTS', 2000);
+
+/**
  * How long a hold lives before the reconcile cron may sweep it. Must exceed the
  * longest possible stream plus its settle window (AI routes cap streams at 300s),
  * so a still-running call's reservation is never reclaimed out from under it.

--- a/packages/lib/src/compliance/export/gdpr-export-coverage.ts
+++ b/packages/lib/src/compliance/export/gdpr-export-coverage.ts
@@ -207,6 +207,17 @@ export const EXCLUDED_TABLES: Readonly<Record<string, string>> = {
     // `machine_sprite_reclaims` above, holding a Fly app name awaiting a
     // confirmed kill.
     'app_hosting_reclaims',
+    // The local mirror of a published app's MACHINE lifecycle — start/stop
+    // boundaries kept because Fly retains only the last 20 events per machine.
+    // Every column is fleet telemetry: a Fly app name, a machine id, a
+    // normalized start/stop, Fly's own event id and a timestamp. Nothing is
+    // authored by or about the subject, and the row keys on a `published_apps`
+    // id, which is itself the DRIVE's infrastructure record. The money these
+    // boundaries produced is exported under the subject's billing categories
+    // (`ai_usage_logs`, the credit ledger), which is where a charge is actually
+    // evidenced — this table is how we priced the drive's machine, not a record
+    // of anything the subject did.
+    'published_app_machine_events',
     'rate_limit_buckets',
     'siem_delivery_cursors',
     'siem_delivery_receipts',

--- a/packages/lib/src/monitoring/__tests__/machine-pricing.test.ts
+++ b/packages/lib/src/monitoring/__tests__/machine-pricing.test.ts
@@ -2,6 +2,8 @@ import { describe, it, expect } from 'vitest';
 import {
   calculateMachineCostDollars,
   calculateMachineStorageCostDollars,
+  PUBLISHED_APP_GUEST_SHAPE,
+  SANDBOX_GUEST_SHAPE,
 } from '../machine-pricing';
 import {
   MACHINE_MARKUP_BPS,
@@ -35,6 +37,43 @@ describe('calculateMachineCostDollars', () => {
 
   it('bills hibernated (zero-duration) runs nothing', () => {
     expect(calculateMachineCostDollars({ activeSeconds: 0 })).toBe(0);
+  });
+});
+
+describe('the guest SHAPE a run is priced at', () => {
+  it('defaults to the ASSUMED sandbox shape when no shape is given', () => {
+    // Sprites sets no resource caps at creation, so its shape genuinely has to be
+    // assumed — which is why the default exists at all.
+    expect(SANDBOX_GUEST_SHAPE).toEqual({
+      cpus: MACHINE_ASSUMED_CPUS,
+      memoryGB: MACHINE_ASSUMED_MEMORY_GB,
+    });
+    expect(calculateMachineCostDollars({ activeSeconds: 3600 })).toBe(
+      calculateMachineCostDollars({ activeSeconds: 3600, shape: SANDBOX_GUEST_SHAPE }),
+    );
+  });
+
+  it('prices a PUBLISHED APP at its known guest, which is NOT the sandbox default', () => {
+    // `published_apps.guestPreset` is pinned to shared-cpu-1x-512 by a CHECK, so
+    // this shape is known rather than assumed. Pricing a published app at the
+    // sandbox default would under-bill every awake second by half the memory
+    // component — silently, and for as long as the two shapes differed.
+    expect(PUBLISHED_APP_GUEST_SHAPE.memoryGB).toBe(0.5);
+    expect(PUBLISHED_APP_GUEST_SHAPE.memoryGB).not.toBe(SANDBOX_GUEST_SHAPE.memoryGB);
+
+    // 1 cpu x $0.07/hr + 0.5 GB x $0.04375/hr for one hour.
+    const expected =
+      MACHINE_RATES.usdPerCpuHour * 1 + MACHINE_RATES.usdPerMemGbHour * 0.5;
+    expect(
+      calculateMachineCostDollars({ activeSeconds: 3600, shape: PUBLISHED_APP_GUEST_SHAPE }),
+    ).toBeCloseTo(expected, 5);
+  });
+
+  it('scales linearly with the billed seconds at either shape', () => {
+    const hour = calculateMachineCostDollars({ activeSeconds: 3600, shape: PUBLISHED_APP_GUEST_SHAPE });
+    const halfHour = calculateMachineCostDollars({ activeSeconds: 1800, shape: PUBLISHED_APP_GUEST_SHAPE });
+    // Both sides are rounded to 6dp by the pricer, so compare at 5dp.
+    expect(halfHour).toBeCloseTo(hour / 2, 5);
   });
 });
 

--- a/packages/lib/src/monitoring/machine-pricing.ts
+++ b/packages/lib/src/monitoring/machine-pricing.ts
@@ -31,12 +31,45 @@ import {
   MACHINE_ASSUMED_CPUS,
   MACHINE_ASSUMED_MEMORY_GB,
   MACHINE_STORAGE_USD_PER_GB_MONTH,
+  PUBLISHED_APP_ASSUMED_CPUS,
+  PUBLISHED_APP_ASSUMED_MEMORY_GB,
 } from '../billing/credit-pricing';
 
 export interface MachineUsageQuantity {
   /** Wall-clock seconds the machine was ACTIVE (not hibernating) for this run. */
   activeSeconds?: number;
+  /**
+   * The guest this runtime actually ran on. Omitted -> the assumed sandbox shape
+   * (see the module doc): Sprites sets no resource caps, so its shape genuinely
+   * has to be assumed.
+   *
+   * A PUBLISHED APP's shape is not assumed — `published_apps.guestPreset` is
+   * pinned by a CHECK constraint, so that meter passes
+   * {@link PUBLISHED_APP_GUEST_SHAPE} and is billed for the guest we asked Fly
+   * for. Reusing the sandbox default there would under-bill every awake second
+   * by half the memory component, invisibly, for as long as the two shapes
+   * differed.
+   */
+  shape?: MachineShape;
 }
+
+/** vCPUs and RAM, the two quantities the published rate table prices. */
+export interface MachineShape {
+  cpus: number;
+  memoryGB: number;
+}
+
+/** The assumed default SANDBOX (Sprites) shape — no caps are set at creation, so this is a genuine assumption. */
+export const SANDBOX_GUEST_SHAPE: MachineShape = {
+  cpus: MACHINE_ASSUMED_CPUS,
+  memoryGB: MACHINE_ASSUMED_MEMORY_GB,
+};
+
+/** The v1 published-app guest (`shared-cpu-1x-512`) — known, not assumed. */
+export const PUBLISHED_APP_GUEST_SHAPE: MachineShape = {
+  cpus: PUBLISHED_APP_ASSUMED_CPUS,
+  memoryGB: PUBLISHED_APP_ASSUMED_MEMORY_GB,
+};
 
 /**
  * Real provider cost (USD, pre-markup) for one machine run. Returns 0 for a
@@ -46,10 +79,9 @@ export interface MachineUsageQuantity {
 export function calculateMachineCostDollars(quantity: MachineUsageQuantity): number {
   const seconds = quantity.activeSeconds;
   if (typeof seconds !== 'number' || !Number.isFinite(seconds) || seconds <= 0) return 0;
+  const shape = quantity.shape ?? SANDBOX_GUEST_SHAPE;
   const perSecondRate =
-    (MACHINE_ASSUMED_CPUS * MACHINE_RATES.usdPerCpuHour +
-      MACHINE_ASSUMED_MEMORY_GB * MACHINE_RATES.usdPerMemGbHour) /
-    3600;
+    (shape.cpus * MACHINE_RATES.usdPerCpuHour + shape.memoryGB * MACHINE_RATES.usdPerMemGbHour) / 3600;
   return Number((seconds * perSecondRate).toFixed(6));
 }
 

--- a/packages/lib/src/monitoring/usage-source.ts
+++ b/packages/lib/src/monitoring/usage-source.ts
@@ -73,4 +73,21 @@ export const USAGE_SOURCE_LABELS: Record<AIUsageSource, string> = {
 export const SANDBOX_STORAGE_MODELS = {
   session: 'terminal-machine-storage',
   env: 'drive-env-storage',
+  /**
+   * A PUBLISHED APP's rootfs — the third row source on the same meter. A stopped
+   * published app costs nothing per second and still costs image storage, and
+   * that drip is the whole per-app idle floor.
+   */
+  hosting: 'published-app-storage',
 } as const;
+
+/**
+ * The `model` label for a published app's AWAKE-SECONDS charge — its runtime, as
+ * distinct from the rootfs storage label above.
+ *
+ * Lives here for the same reason those do: a hosting runtime row carries
+ * `source: 'terminal'` and no `pageId`, exactly like a sandbox terminal row, so
+ * this label is the only thing that says which meter produced a charge. Written
+ * by `defaultAppBillingDeps.trackUsage` and read by the usage breakdown.
+ */
+export const PUBLISHED_APP_AWAKE_MODEL = 'published-app-awake';

--- a/packages/lib/src/services/app-hosting/__tests__/app-billing.test.ts
+++ b/packages/lib/src/services/app-hosting/__tests__/app-billing.test.ts
@@ -1,0 +1,234 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { assert } from '../../sandbox/__tests__/riteway';
+
+const mockDb = vi.hoisted(() => ({ select: vi.fn() }));
+vi.mock('@pagespace/db/db', () => ({ db: mockDb }));
+vi.mock('@pagespace/db/operators', () => ({ eq: vi.fn((a, b) => ({ op: 'eq', a, b })) }));
+vi.mock('@pagespace/db/schema/auth', () => ({
+  users: { id: 'users.id', subscriptionTier: 'users.subscriptionTier' },
+}));
+vi.mock('@pagespace/db/schema/core', () => ({
+  pages: { id: 'pages.id', driveId: 'pages.driveId' },
+  drives: { id: 'drives.id', ownerId: 'drives.ownerId' },
+}));
+
+const mockCanConsumeAI = vi.hoisted(() => vi.fn());
+vi.mock('../../../billing/credit-gate', () => ({ canConsumeAI: mockCanConsumeAI }));
+
+const mockReleaseHold = vi.hoisted(() => vi.fn());
+vi.mock('../../../billing/credit-consume', () => ({ releaseHold: mockReleaseHold }));
+
+const mockTrackUsage = vi.hoisted(() => vi.fn());
+vi.mock('../../../monitoring/ai-monitoring', () => ({ AIMonitoring: { trackUsage: mockTrackUsage } }));
+
+import { defaultAppBillingDeps } from '../app-billing';
+import {
+  MACHINE_MARKUP_BPS,
+  PUBLISHED_APP_DAILY_CAP_CEILING_CENTS,
+  PUBLISHED_APP_MAX_INFLIGHT,
+  PUBLISHED_APP_WAKE_HOLD_ESTIMATE_CENTS,
+} from '../../../billing/credit-pricing';
+import { PUBLISHED_APP_AWAKE_MODEL } from '../../../monitoring/usage-source';
+import {
+  calculateMachineCostDollars,
+  PUBLISHED_APP_GUEST_SHAPE,
+  SANDBOX_GUEST_SHAPE,
+} from '../../../monitoring/machine-pricing';
+
+beforeEach(() => {
+  mockDb.select.mockReset();
+  mockCanConsumeAI.mockReset();
+  mockReleaseHold.mockReset();
+  mockTrackUsage.mockReset();
+});
+
+function mockSingleRow(row: Record<string, unknown> | undefined) {
+  mockDb.select.mockReturnValue({
+    from: () => ({ where: () => ({ limit: async () => (row ? [row] : []) }) }),
+  });
+}
+
+describe('defaultAppBillingDeps.resolvePayerId', () => {
+  it('bills the DRIVE OWNER — the payer for anything hanging off an environment', async () => {
+    mockSingleRow({ ownerId: 'drive-owner-1' });
+
+    assert({
+      given: 'a published app whose drive resolves',
+      should: 'pay from the drive owner',
+      actual: await defaultAppBillingDeps.resolvePayerId({ driveId: 'drive-1' }),
+      expected: 'drive-owner-1',
+    });
+  });
+
+  it('given an unresolvable drive, should yield NO payer rather than substituting one', async () => {
+    // There is deliberately no fallback to `published_apps.ownerId`: that column
+    // is a denormalized cascade handle, and a money movement to the wrong person
+    // cannot be taken back while a skipped cycle self-corrects.
+    mockSingleRow(undefined);
+
+    assert({
+      given: 'a stale read of a drive mid-delete',
+      should: 'resolve to null',
+      actual: await defaultAppBillingDeps.resolvePayerId({ driveId: 'gone' }),
+      expected: null,
+    });
+  });
+});
+
+describe('defaultAppBillingDeps.gate', () => {
+  it('gates on the PAYER’s own tier, read from the resolved payer rather than an acting user', async () => {
+    // Nobody is necessarily "acting" when a published app wakes — the trigger is
+    // an inbound request from a stranger — so the tier has to come from the payer.
+    mockSingleRow({ subscriptionTier: 'pro' });
+    mockCanConsumeAI.mockResolvedValue({ allowed: true, holdId: 'hold-1' });
+
+    await defaultAppBillingDeps.gate({ payerId: 'payer-1' });
+
+    expect(mockCanConsumeAI).toHaveBeenCalledWith('payer-1', 'pro', expect.anything());
+  });
+
+  it('ALWAYS passes a daily-cap ceiling — the "unlimited but not unbounded" rule for tenant/onprem', async () => {
+    // `canConsumeAI` short-circuits to the query-free unlimited path when billing
+    // is disabled AND no ceiling is supplied. Supplying one keeps a per-payer
+    // daily bound in force there, metered from `ai_usage_logs`.
+    mockSingleRow({ subscriptionTier: 'free' });
+    mockCanConsumeAI.mockResolvedValue({ allowed: true, holdId: 'hold-1' });
+
+    await defaultAppBillingDeps.gate({ payerId: 'payer-1' });
+
+    expect(mockCanConsumeAI).toHaveBeenCalledWith('payer-1', 'free', {
+      estCostCents: PUBLISHED_APP_WAKE_HOLD_ESTIMATE_CENTS,
+      maxInFlight: PUBLISHED_APP_MAX_INFLIGHT,
+      dailyCapCeilingCents: PUBLISHED_APP_DAILY_CAP_CEILING_CENTS,
+    });
+    expect(PUBLISHED_APP_DAILY_CAP_CEILING_CENTS).toBeGreaterThan(0);
+  });
+
+  it('passes the hold through on an allowed gate, and the reason on a refusal', async () => {
+    mockSingleRow({ subscriptionTier: 'pro' });
+    mockCanConsumeAI.mockResolvedValue({ allowed: true, holdId: 'hold-9' });
+    expect(await defaultAppBillingDeps.gate({ payerId: 'p' })).toEqual({
+      allowed: true,
+      holdId: 'hold-9',
+      reason: undefined,
+    });
+
+    mockCanConsumeAI.mockResolvedValue({ allowed: false, reason: 'insufficient_credits' });
+    expect(await defaultAppBillingDeps.gate({ payerId: 'p' })).toEqual({
+      allowed: false,
+      holdId: undefined,
+      reason: 'insufficient_credits',
+    });
+  });
+});
+
+describe('defaultAppBillingDeps.trackUsage', () => {
+  const settle = () =>
+    defaultAppBillingDeps.trackUsage({
+      payerId: 'payer-1',
+      holdId: 'hold-1',
+      activeSeconds: 600,
+      driveId: 'drive-1',
+      publishedAppId: 'app-1',
+    });
+
+  it('attributes the charge to the payer, the drive, and the published app', async () => {
+    await settle();
+
+    const call = mockTrackUsage.mock.calls[0][0];
+    assert({
+      given: 'a settled awake window',
+      should: 'carry the payer, the drive and the app id',
+      actual: { userId: call.userId, driveId: call.driveId, sessionId: call.sessionId },
+      // `sessionId` is the shared analytics column; `model` below is what says
+      // which table this id addresses.
+      expected: { userId: 'payer-1', driveId: 'drive-1', sessionId: 'app-1' },
+    });
+  });
+
+  it('labels the row with the published-app AWAKE model — the only thing separating it from a terminal row', async () => {
+    // A hosting runtime row carries `source: 'terminal'` and no `pageId`, exactly
+    // like a sandbox terminal row, so the model label is the whole discriminator.
+    await settle();
+
+    const call = mockTrackUsage.mock.calls[0][0];
+    assert({
+      given: 'a published-app runtime charge',
+      should: 'be labelled published-app-awake, sourced to terminal, with no pageId',
+      actual: { model: call.model, source: call.source, pageId: call.pageId, provider: call.provider },
+      expected: {
+        model: PUBLISHED_APP_AWAKE_MODEL,
+        source: 'terminal',
+        pageId: undefined,
+        provider: 'fly',
+      },
+    });
+  });
+
+  it('prices at the KNOWN published-app guest, not the assumed sandbox shape', async () => {
+    // `published_apps.guestPreset` is pinned to shared-cpu-1x-512 by a CHECK, so
+    // pricing at the sandbox default would under-bill every awake second by half
+    // the memory component, silently.
+    await settle();
+
+    const call = mockTrackUsage.mock.calls[0][0];
+    expect(call.providerCostDollars).toBe(
+      calculateMachineCostDollars({ activeSeconds: 600, shape: PUBLISHED_APP_GUEST_SHAPE }),
+    );
+    expect(PUBLISHED_APP_GUEST_SHAPE.memoryGB).not.toBe(SANDBOX_GUEST_SHAPE.memoryGB);
+    expect(call.providerCostDollars).not.toBe(
+      calculateMachineCostDollars({ activeSeconds: 600, shape: SANDBOX_GUEST_SHAPE }),
+    );
+  });
+
+  it('settles against the wake’s hold at the substrate markup, as a deterministic list price', async () => {
+    // Fly has no billing API, so the figure is always ours (awake seconds x the
+    // published rate) and never a provider-returned one.
+    await settle();
+
+    const call = mockTrackUsage.mock.calls[0][0];
+    assert({
+      given: 'a settle carrying the wake’s hold',
+      should: 'consume that hold at the machine markup as a list price',
+      actual: {
+        holdId: call.holdId,
+        markupBpsOverride: call.markupBpsOverride,
+        costSource: call.costSource,
+        success: call.success,
+      },
+      expected: {
+        holdId: 'hold-1',
+        markupBpsOverride: MACHINE_MARKUP_BPS,
+        costSource: 'list_price',
+        success: true,
+      },
+    });
+  });
+
+  it('records the billed span in both the duration and the metadata', async () => {
+    await settle();
+
+    const call = mockTrackUsage.mock.calls[0][0];
+    expect(call.duration).toBe(600_000);
+    expect(call.metadata).toEqual({ type: 'published_app_awake', activeSeconds: 600 });
+  });
+
+  it('given no hold (a billing-disabled wake that took the unlimited path), should still settle', async () => {
+    await defaultAppBillingDeps.trackUsage({
+      payerId: 'payer-1',
+      holdId: undefined,
+      activeSeconds: 30,
+      driveId: 'drive-1',
+      publishedAppId: 'app-1',
+    });
+
+    expect(mockTrackUsage.mock.calls[0][0].holdId).toBeUndefined();
+  });
+});
+
+describe('defaultAppBillingDeps.releaseHold', () => {
+  it('returns the reservation through the shared credit pipeline', async () => {
+    await defaultAppBillingDeps.releaseHold('hold-3');
+    expect(mockReleaseHold).toHaveBeenCalledWith('hold-3');
+  });
+});

--- a/packages/lib/src/services/app-hosting/__tests__/app-lifecycle-metering.test.ts
+++ b/packages/lib/src/services/app-hosting/__tests__/app-lifecycle-metering.test.ts
@@ -1,0 +1,409 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { assert } from '../../sandbox/__tests__/riteway';
+
+/**
+ * A db double that records every UPDATE's SET payload.
+ *
+ * `.where()` is a thenable that ALSO carries `.returning()`, because the module
+ * under test awaits `.where(...)` directly for the writes whose result it does not
+ * read, and chains `.returning()` for the wake's guarded write.
+ */
+const mockDb = vi.hoisted(() => {
+  const state: {
+    selectRows: unknown[];
+    updateSets: Array<Record<string, unknown>>;
+    returningRows: unknown[][];
+  } = { selectRows: [], updateSets: [], returningRows: [] };
+
+  const db = {
+    __state: state,
+    select: () => ({
+      from: () => ({ where: () => ({ limit: async () => state.selectRows }) }),
+    }),
+    update: () => ({
+      set: (payload: Record<string, unknown>) => {
+        state.updateSets.push(payload);
+        const result = {
+          then: (resolve: (v: unknown) => unknown) => Promise.resolve(undefined).then(resolve),
+          returning: async () => state.returningRows.shift() ?? [],
+        };
+        return { where: () => result };
+      },
+    }),
+  };
+  return db;
+});
+vi.mock('@pagespace/db/db', () => ({ db: mockDb }));
+// PARTIAL: `credit-gate` is pulled in transitively and builds a `sql` template at
+// module load, so the real operators have to stay available.
+vi.mock('@pagespace/db/operators', async (importOriginal) => ({
+  ...(await importOriginal<Record<string, unknown>>()),
+  and: (...a: unknown[]) => ({ op: 'and', a }),
+  eq: (a: unknown, b: unknown) => ({ op: 'eq', a, b }),
+}));
+
+const mockRecordBoundary = vi.hoisted(() => vi.fn(async () => true));
+const mockMirror = vi.hoisted(() => vi.fn(async () => ({ boundaries: 0, inserted: 0, failed: false })));
+const mockFindStop = vi.hoisted(() => vi.fn(async () => null));
+vi.mock('../app-machine-events', () => ({
+  recordOrchestratorBoundary: mockRecordBoundary,
+  mirrorFlyMachineEvents: mockMirror,
+  findStopBoundarySince: mockFindStop,
+}));
+
+import {
+  wakePublishedApp,
+  stopPublishedApp,
+  closeAppWindowAtBoundary,
+  type AppLifecycleMeteringDeps,
+} from '../app-lifecycle-metering';
+import type { PublishedApp } from '@pagespace/db/schema/published-apps';
+
+const NOW = new Date('2026-08-20T12:00:00.000Z');
+const WOKEN_AT = new Date('2026-08-20T11:00:00.000Z');
+
+function appRow(over: Partial<PublishedApp> = {}): PublishedApp {
+  return {
+    id: 'app-1',
+    driveId: 'drive-1',
+    flyAppName: 'pgs-app-1',
+    machineId: 'machine-1',
+    status: 'stopped',
+    tier: 'metered',
+    imageDigest: 'sha256:abc',
+    lastWakeAt: null,
+    lastStopAt: null,
+    awakeBilledThrough: null,
+    awakeHoldId: null,
+    ...over,
+  } as unknown as PublishedApp;
+}
+
+function makeDeps(over: Partial<AppLifecycleMeteringDeps> = {}): {
+  deps: AppLifecycleMeteringDeps;
+  gate: ReturnType<typeof vi.fn>;
+  trackUsage: ReturnType<typeof vi.fn>;
+  releaseHold: ReturnType<typeof vi.fn>;
+  startMachine: ReturnType<typeof vi.fn>;
+  stopMachine: ReturnType<typeof vi.fn>;
+} {
+  const gate = vi.fn(async () => ({ allowed: true, holdId: 'hold-1' }));
+  const trackUsage = vi.fn(async () => {});
+  const releaseHold = vi.fn(async () => {});
+  const startMachine = vi.fn(async () => {});
+  const stopMachine = vi.fn(async () => {});
+  const deps: AppLifecycleMeteringDeps = {
+    isEnabled: () => true,
+    billing: {
+      resolvePayerId: async () => 'payer-1',
+      gate,
+      trackUsage,
+      releaseHold,
+    },
+    startMachine,
+    stopMachine,
+    listMachineEvents: async () => [],
+    now: () => NOW,
+    ...over,
+  };
+  return { deps, gate, trackUsage, releaseHold, startMachine, stopMachine };
+}
+
+function seed(row: PublishedApp | null, returning: unknown[][] = []) {
+  mockDb.__state.selectRows = row ? [row] : [];
+  mockDb.__state.updateSets = [];
+  mockDb.__state.returningRows = returning;
+}
+
+beforeEach(() => {
+  mockRecordBoundary.mockClear();
+  mockMirror.mockClear();
+  mockFindStop.mockClear();
+  mockDb.__state.updateSets = [];
+  mockDb.__state.returningRows = [];
+});
+
+describe('wakePublishedApp', () => {
+  it('given the kill switch is off, should refuse and read NOTHING', async () => {
+    const { deps, gate } = makeDeps({ isEnabled: () => false });
+    seed(appRow());
+
+    assert({
+      given: 'APP_HOSTING_ENABLED unset',
+      should: 'refuse as disabled without gating anyone',
+      actual: await wakePublishedApp('app-1', deps),
+      expected: { outcome: 'refused', reason: 'disabled' },
+    });
+    expect(gate).not.toHaveBeenCalled();
+  });
+
+  it('GATES BEFORE STARTING the machine — the whole of hosting’s credit enforcement', async () => {
+    const { deps, gate, startMachine } = makeDeps();
+    gate.mockResolvedValue({ allowed: false, reason: 'insufficient_credits' });
+    seed(appRow());
+
+    const result = await wakePublishedApp('app-1', deps);
+
+    assert({
+      given: 'a payer the gate refuses',
+      should: 'park the app and never start a machine',
+      actual: { result, started: startMachine.mock.calls.length },
+      expected: { result: { outcome: 'parked', reason: 'insufficient_credits' }, started: 0 },
+    });
+    expect(mockDb.__state.updateSets[0]).toMatchObject({ status: 'parked' });
+  });
+
+  it('given an unresolvable drive, should refuse the wake rather than bill somebody else', async () => {
+    const { deps, gate, startMachine } = makeDeps();
+    deps.billing.resolvePayerId = async () => null;
+    seed(appRow());
+
+    assert({
+      given: 'a published app whose owning drive cannot be resolved',
+      should: 'refuse without gating or starting',
+      actual: await wakePublishedApp('app-1', deps),
+      expected: { outcome: 'refused', reason: 'unresolved_payer' },
+    });
+    expect(gate).not.toHaveBeenCalled();
+    expect(startMachine).not.toHaveBeenCalled();
+  });
+
+  it('opens the awake window at the wake instant and records the boundary', async () => {
+    const { deps } = makeDeps();
+    const row = appRow();
+    seed(row, [[{ ...row, status: 'running' }]]);
+
+    const result = await wakePublishedApp('app-1', deps);
+
+    expect(result.outcome).toBe('woken');
+    assert({
+      given: 'a successful wake',
+      should: 'stamp the boundary and the watermark at the same instant, carrying the hold',
+      actual: mockDb.__state.updateSets[0],
+      expected: {
+        status: 'running',
+        lastWakeAt: NOW,
+        awakeBilledThrough: NOW,
+        awakeHoldId: 'hold-1',
+      },
+    });
+    expect(mockRecordBoundary).toHaveBeenCalledWith(
+      { publishedAppId: 'app-1', flyAppName: 'pgs-app-1', machineId: 'machine-1' },
+      'start',
+      NOW,
+    );
+  });
+
+  it('given Fly refuses the start, should release the hold and stamp NOTHING', async () => {
+    // Nothing started, so nothing may be billed — and a stranded hold would
+    // suppress the payer's own spendable balance for its whole TTL.
+    const { deps, releaseHold, startMachine } = makeDeps();
+    startMachine.mockRejectedValue(new Error('capacity'));
+    seed(appRow());
+
+    const result = await wakePublishedApp('app-1', deps);
+
+    expect(result).toEqual({ outcome: 'start_failed', error: 'capacity' });
+    expect(releaseHold).toHaveBeenCalledWith('hold-1');
+    expect(mockDb.__state.updateSets).toEqual([]);
+  });
+
+  it('given a concurrent wake won the race, should release ITS OWN hold and not overwrite the winner’s window', async () => {
+    // The status-guarded UPDATE matches no row for the loser. Overwriting the
+    // winner's window start with a later one would silently forgive the seconds
+    // in between.
+    const { deps, releaseHold } = makeDeps();
+    seed(appRow(), [[]]);
+
+    assert({
+      given: 'two requests racing the same cold app',
+      should: 'refuse the loser and return its reservation',
+      actual: await wakePublishedApp('app-1', deps),
+      expected: { outcome: 'refused', reason: 'not_wakeable' },
+    });
+    expect(releaseHold).toHaveBeenCalledWith('hold-1');
+  });
+
+  it('refuses a row with no machine, and a row the status machine will not move', async () => {
+    const { deps } = makeDeps();
+
+    seed(appRow({ machineId: null }));
+    expect(await wakePublishedApp('app-1', deps)).toEqual({ outcome: 'refused', reason: 'no_machine' });
+
+    seed(appRow({ status: 'running' }));
+    expect(await wakePublishedApp('app-1', deps)).toEqual({ outcome: 'refused', reason: 'not_wakeable' });
+
+    seed(null);
+    expect(await wakePublishedApp('app-1', deps)).toEqual({ outcome: 'refused', reason: 'not_found' });
+  });
+});
+
+describe('stopPublishedApp', () => {
+  const running = () =>
+    appRow({ status: 'running', lastWakeAt: WOKEN_AT, awakeBilledThrough: WOKEN_AT, awakeHoldId: 'hold-1' });
+
+  it('settles the tail of the window against the wake’s hold and closes it', async () => {
+    const { deps, trackUsage } = makeDeps();
+    seed(running());
+
+    const result = await stopPublishedApp('app-1', 'idle', deps);
+
+    assert({
+      given: 'an app awake for an hour',
+      should: 'bill exactly that hour',
+      actual: { outcome: result.outcome, billed: result.outcome === 'stopped' ? result.billedSeconds : null },
+      expected: { outcome: 'stopped', billed: 3600 },
+    });
+    expect(trackUsage).toHaveBeenCalledWith({
+      payerId: 'payer-1',
+      holdId: 'hold-1',
+      activeSeconds: 3600,
+      driveId: 'drive-1',
+      publishedAppId: 'app-1',
+    });
+    assert({
+      given: 'a settled stop',
+      should: 'close the window and stamp the stop boundary',
+      actual: mockDb.__state.updateSets[0],
+      expected: {
+        status: 'stopped',
+        lastStopAt: NOW,
+        awakeBilledThrough: null,
+        awakeHoldId: null,
+      },
+    });
+  });
+
+  it('MIRRORS THE BOUNDARY BEFORE THE MONEY, so a crash mid-settle is self-healing', async () => {
+    const order: string[] = [];
+    mockRecordBoundary.mockImplementation(async () => {
+      order.push('mirror');
+      return true;
+    });
+    const { deps, trackUsage } = makeDeps();
+    trackUsage.mockImplementation(async () => {
+      order.push('settle');
+    });
+    seed(running());
+
+    await stopPublishedApp('app-1', 'idle', deps);
+
+    assert({
+      given: 'a stop that settles',
+      should: 'write the boundary before charging',
+      actual: order,
+      expected: ['mirror', 'settle'],
+    });
+  });
+
+  it('given `insolvent`, should land in PARKED rather than stopped', async () => {
+    // The difference is load-bearing downstream: a stopped app wakes on the next
+    // request and a parked one does not.
+    const { deps } = makeDeps();
+    seed(running());
+
+    const result = await stopPublishedApp('app-1', 'insolvent', deps);
+
+    expect(result).toMatchObject({ outcome: 'stopped', status: 'parked' });
+    expect(mockDb.__state.updateSets[0]).toMatchObject({ status: 'parked' });
+  });
+
+  it('given Fly refuses the stop, should leave the window OPEN and still billing', async () => {
+    // A failed stop very likely means the machine is still running and still
+    // costing money; closing the window would stop billing time genuinely used.
+    const { deps, stopMachine, trackUsage } = makeDeps();
+    stopMachine.mockRejectedValue(new Error('flaps 500'));
+    seed(running());
+
+    expect(await stopPublishedApp('app-1', 'idle', deps)).toEqual({
+      outcome: 'stop_failed',
+      error: 'flaps 500',
+    });
+    expect(trackUsage).not.toHaveBeenCalled();
+    expect(mockDb.__state.updateSets).toEqual([]);
+  });
+
+  it('given the settle throws, should close the STATUS but keep the window open for a retry', async () => {
+    // Closing it would silently lose the app's last awake window; leaving the row
+    // `running` over a stopped machine would be worse still.
+    const { deps, trackUsage } = makeDeps();
+    trackUsage.mockRejectedValue(new Error('ledger down'));
+    seed(running());
+
+    const result = await stopPublishedApp('app-1', 'idle', deps);
+
+    expect(result).toMatchObject({ outcome: 'stopped', billedSeconds: 0 });
+    const written = mockDb.__state.updateSets[0];
+    assert({
+      given: 'a failed settle',
+      should: 'move the status without clearing the billing watermark',
+      actual: {
+        status: written.status,
+        clearedWatermark: 'awakeBilledThrough' in written,
+      },
+      expected: { status: 'stopped', clearedWatermark: false },
+    });
+  });
+
+  it('given an unresolvable drive at settle time, should skip the charge and RELEASE the hold', async () => {
+    const { deps, trackUsage, releaseHold } = makeDeps();
+    deps.billing.resolvePayerId = async () => null;
+    seed(running());
+
+    await stopPublishedApp('app-1', 'idle', deps);
+
+    expect(trackUsage).not.toHaveBeenCalled();
+    expect(releaseHold).toHaveBeenCalledWith('hold-1');
+  });
+
+  it('given nothing to bill, should RELEASE the hold rather than settle against it', async () => {
+    const { deps, trackUsage, releaseHold } = makeDeps();
+    // Watermark already at `now` — a stop immediately after a settle.
+    seed(appRow({ status: 'running', lastWakeAt: WOKEN_AT, awakeBilledThrough: NOW, awakeHoldId: 'hold-1' }));
+
+    await stopPublishedApp('app-1', 'idle', deps);
+
+    expect(trackUsage).not.toHaveBeenCalled();
+    expect(releaseHold).toHaveBeenCalledWith('hold-1');
+  });
+
+  it('refuses to stop a row that is not running', async () => {
+    const { deps } = makeDeps();
+    seed(appRow({ status: 'stopped' }));
+    expect(await stopPublishedApp('app-1', 'idle', deps)).toEqual({
+      outcome: 'refused',
+      reason: 'not_running',
+    });
+  });
+});
+
+describe('closeAppWindowAtBoundary', () => {
+  it('bills only up to the REAL stop boundary, never to now', async () => {
+    // The repair path: a stop that happened and whose status write was lost.
+    // Billing through `now` would charge for the span between a stop we did not
+    // record and the moment we noticed it.
+    const { deps, trackUsage } = makeDeps();
+    const boundary = new Date(WOKEN_AT.getTime() + 600_000);
+    const row = appRow({
+      status: 'running',
+      lastWakeAt: WOKEN_AT,
+      awakeBilledThrough: WOKEN_AT,
+      awakeHoldId: 'hold-1',
+    });
+    seed(row);
+
+    const result = await closeAppWindowAtBoundary(row, boundary, deps);
+
+    assert({
+      given: 'a mirrored stop ten minutes into an hour-old window',
+      should: 'bill ten minutes, not the hour to now',
+      actual: { billed: result.billedSeconds, failed: result.failed },
+      expected: { billed: 600, failed: false },
+    });
+    expect(trackUsage.mock.calls[0][0].activeSeconds).toBe(600);
+    expect(mockDb.__state.updateSets[0]).toMatchObject({
+      lastStopAt: boundary,
+      awakeBilledThrough: null,
+    });
+  });
+});

--- a/packages/lib/src/services/app-hosting/__tests__/app-metering-core.test.ts
+++ b/packages/lib/src/services/app-hosting/__tests__/app-metering-core.test.ts
@@ -1,0 +1,329 @@
+import { describe, it, expect } from 'vitest';
+import { assert } from '../../sandbox/__tests__/riteway';
+import {
+  msToSeconds,
+  planAwakeSettle,
+  classifyFlyEventAction,
+  flyEventInstant,
+  awakeSecondsFromEvents,
+  evaluateAwakeDrift,
+  MAX_AWAKE_SETTLE_SPAN_MS,
+  AWAKE_DRIFT_TOLERANCE,
+  AWAKE_DRIFT_FLOOR_SECONDS,
+} from '../app-metering-core';
+
+const NOW = new Date('2026-08-20T12:00:00.000Z');
+const ago = (ms: number) => new Date(NOW.getTime() - ms);
+
+describe('msToSeconds', () => {
+  it('converts a positive span to seconds', () => {
+    assert({
+      given: '90 seconds in milliseconds',
+      should: 'be 90 seconds',
+      actual: msToSeconds(90_000),
+      expected: 90,
+    });
+  });
+
+  it('floors a negative, zero or non-finite span at 0 rather than producing a negative charge', () => {
+    // Every one of these reaches a `providerCostDollars` multiplication. A
+    // negative here is not a refund, it is a corrupt ledger row.
+    expect(msToSeconds(0)).toBe(0);
+    expect(msToSeconds(-1)).toBe(0);
+    expect(msToSeconds(Number.NaN)).toBe(0);
+    expect(msToSeconds(Number.POSITIVE_INFINITY)).toBe(0);
+  });
+});
+
+describe('planAwakeSettle', () => {
+  it('given no watermark, should STAMP and bill nothing — an unknown window start costs the payer nothing', () => {
+    assert({
+      given: 'a row believed awake with no billing watermark',
+      should: 'stamp the clock and bill nothing',
+      actual: planAwakeSettle({ billedThrough: null, now: NOW }),
+      expected: { action: 'stamp' },
+    });
+  });
+
+  it('given an ordinary elapsed window, should settle exactly that span', () => {
+    assert({
+      given: 'a watermark ten minutes before now',
+      should: 'bill 600 seconds and advance the watermark to now',
+      actual: planAwakeSettle({ billedThrough: ago(600_000), now: NOW }),
+      expected: { action: 'settle', activeSeconds: 600, billedThrough: NOW, clamped: false },
+    });
+  });
+
+  it('given a back-to-back rerun with no elapsed time, should SKIP', () => {
+    assert({
+      given: 'a watermark exactly at now',
+      should: 'skip — nothing to bill and nothing to move',
+      actual: planAwakeSettle({ billedThrough: NOW, now: NOW }),
+      expected: { action: 'skip' },
+    });
+  });
+
+  it('given a watermark AHEAD of now (clock skew), should SKIP rather than bill a negative span', () => {
+    assert({
+      given: 'a watermark one minute in the future',
+      should: 'skip — a negative span is not a refund mechanism',
+      actual: planAwakeSettle({ billedThrough: new Date(NOW.getTime() + 60_000), now: NOW }),
+      expected: { action: 'skip' },
+    });
+  });
+
+  it('given a span longer than a day, should clamp the BILLED seconds but still advance to now', () => {
+    // The clamp FORGIVES REVENUE — the excess is dropped once rather than
+    // carried, so the next tick starts from `now` and cannot re-bill it.
+    const plan = planAwakeSettle({ billedThrough: ago(MAX_AWAKE_SETTLE_SPAN_MS * 3), now: NOW });
+    expect(plan).toEqual({
+      action: 'settle',
+      activeSeconds: MAX_AWAKE_SETTLE_SPAN_MS / 1000,
+      billedThrough: NOW,
+      clamped: true,
+    });
+  });
+
+  it('given a span exactly at the cap, should NOT report itself clamped', () => {
+    const plan = planAwakeSettle({ billedThrough: ago(MAX_AWAKE_SETTLE_SPAN_MS), now: NOW });
+    assert({
+      given: 'a span exactly at the maximum',
+      should: 'bill it whole and not flag a clamp',
+      actual: plan.action === 'settle' ? plan.clamped : 'not-a-settle',
+      expected: false,
+    });
+  });
+});
+
+describe('classifyFlyEventAction', () => {
+  it('maps the start and stop vocabularies Fly actually logs', () => {
+    expect(classifyFlyEventAction('start')).toBe('start');
+    expect(classifyFlyEventAction('started')).toBe('start');
+    expect(classifyFlyEventAction('stop')).toBe('stop');
+    expect(classifyFlyEventAction('exit')).toBe('stop');
+  });
+
+  it('given an event type we do not recognise, should fold to NULL rather than guess a boundary', () => {
+    // A fabricated boundary lands in the one table that cannot be rebuilt from
+    // Fly afterwards, so an unknown type must never be retyped as one we know.
+    assert({
+      given: 'a Fly event type outside the known vocabulary',
+      should: 'classify as not-a-boundary',
+      actual: [
+        classifyFlyEventAction('restart'),
+        classifyFlyEventAction('health_check_status_changed'),
+        classifyFlyEventAction(undefined),
+        classifyFlyEventAction(''),
+      ],
+      expected: [null, null, null, null],
+    });
+  });
+});
+
+describe('flyEventInstant', () => {
+  it('reads Fly epoch-millisecond timestamps', () => {
+    expect(flyEventInstant(NOW.getTime())).toEqual(NOW);
+  });
+
+  it('given a malformed or non-positive timestamp, should return null rather than a 1970 date', () => {
+    // A 1970 date would read to the reconcile as a decades-long awake window.
+    assert({
+      given: 'timestamps that are not usable instants',
+      should: 'be dropped rather than dated to the epoch',
+      actual: [
+        flyEventInstant(0),
+        flyEventInstant(-1),
+        flyEventInstant('2026-08-20'),
+        flyEventInstant(undefined),
+        flyEventInstant(Number.NaN),
+        flyEventInstant(Number.POSITIVE_INFINITY),
+      ],
+      expected: [null, null, null, null, null, null],
+    });
+  });
+});
+
+describe('awakeSecondsFromEvents', () => {
+  const at = (ms: number) => new Date(NOW.getTime() - ms);
+
+  it('sums a simple start/stop pair', () => {
+    assert({
+      given: 'a machine up for ten minutes and then stopped',
+      should: 'total 600 awake seconds',
+      actual: awakeSecondsFromEvents(
+        [
+          { action: 'start', occurredAt: at(900_000) },
+          { action: 'stop', occurredAt: at(300_000) },
+        ],
+        NOW,
+      ),
+      expected: 600,
+    });
+  });
+
+  it('consumes events in TIMESTAMP order whatever order they arrive in', () => {
+    // The mirror holds two origins written at different moments, so arrival
+    // order is not chronological order.
+    assert({
+      given: 'the stop listed before the start',
+      should: 'still total the real span',
+      actual: awakeSecondsFromEvents(
+        [
+          { action: 'stop', occurredAt: at(300_000) },
+          { action: 'start', occurredAt: at(900_000) },
+        ],
+        NOW,
+      ),
+      expected: 600,
+    });
+  });
+
+  it('given a START while already started, should ignore it rather than restart the clock', () => {
+    // Our own `orchestrator` start and Fly's mirrored `fly` start are the SAME
+    // crossing seen twice. Counting the second would lose the span before it.
+    assert({
+      given: 'a duplicate start midway through an open window',
+      should: 'keep the original window open and lose nothing',
+      actual: awakeSecondsFromEvents(
+        [
+          { action: 'start', occurredAt: at(900_000) },
+          { action: 'start', occurredAt: at(600_000) },
+          { action: 'stop', occurredAt: at(300_000) },
+        ],
+        NOW,
+      ),
+      expected: 600,
+    });
+  });
+
+  it('given a STOP with no open start, should ignore it', () => {
+    // Its matching start fell outside the reconciled window — that span belongs
+    // to the previous window, not this one.
+    assert({
+      given: 'a stop whose start predates the window',
+      should: 'count nothing for it',
+      actual: awakeSecondsFromEvents([{ action: 'stop', occurredAt: at(300_000) }], NOW),
+      expected: 0,
+    });
+  });
+
+  it('given a window still open at `until`, should count up to `until`', () => {
+    assert({
+      given: 'a machine started five minutes ago and never stopped',
+      should: 'count it as awake right now',
+      actual: awakeSecondsFromEvents([{ action: 'start', occurredAt: at(300_000) }], NOW),
+      expected: 300,
+    });
+  });
+
+  it('given events after `until`, should stop counting at the boundary', () => {
+    assert({
+      given: 'a start inside the window and a stop after it',
+      should: 'count only up to `until`',
+      actual: awakeSecondsFromEvents(
+        [
+          { action: 'start', occurredAt: at(600_000) },
+          { action: 'stop', occurredAt: new Date(NOW.getTime() + 600_000) },
+        ],
+        NOW,
+      ),
+      expected: 600,
+    });
+  });
+
+  it('totals several separate awake windows', () => {
+    assert({
+      given: 'two complete stop/start cycles',
+      should: 'sum both spans',
+      actual: awakeSecondsFromEvents(
+        [
+          { action: 'start', occurredAt: at(1_800_000) },
+          { action: 'stop', occurredAt: at(1_500_000) },
+          { action: 'start', occurredAt: at(900_000) },
+          { action: 'stop', occurredAt: at(600_000) },
+        ],
+        NOW,
+      ),
+      expected: 600,
+    });
+  });
+
+  it('given no events at all, should total zero', () => {
+    expect(awakeSecondsFromEvents([], NOW)).toBe(0);
+  });
+});
+
+describe('evaluateAwakeDrift', () => {
+  it('given two figures within tolerance, should not flag drift', () => {
+    assert({
+      given: 'a 1% disagreement over a long window',
+      should: 'report no drift',
+      actual: evaluateAwakeDrift({ localSeconds: 10_000, prometheusSeconds: 9_900 }).exceeded,
+      expected: false,
+    });
+  });
+
+  it('given we billed MORE than Fly saw, should flag `over_billed` — the direction that costs a customer', () => {
+    const drift = evaluateAwakeDrift({ localSeconds: 10_000, prometheusSeconds: 5_000 });
+    assert({
+      given: 'our figure double Prometheus’',
+      should: 'flag over_billed with a positive delta',
+      actual: { exceeded: drift.exceeded, direction: drift.direction, deltaSeconds: drift.deltaSeconds },
+      expected: { exceeded: true, direction: 'over_billed', deltaSeconds: 5_000 },
+    });
+  });
+
+  it('given Fly saw MORE than we billed, should flag `under_billed`', () => {
+    const drift = evaluateAwakeDrift({ localSeconds: 5_000, prometheusSeconds: 10_000 });
+    assert({
+      given: 'Prometheus double our figure',
+      should: 'flag under_billed with a negative delta',
+      actual: { exceeded: drift.exceeded, direction: drift.direction, deltaSeconds: drift.deltaSeconds },
+      expected: { exceeded: true, direction: 'under_billed', deltaSeconds: -5_000 },
+    });
+  });
+
+  it('given a disagreement BELOW the absolute floor, should stay quiet however large the ratio', () => {
+    // Under two minutes one scrape interval is the whole signal, so a 100%
+    // relative disagreement there is noise, not a finding.
+    const drift = evaluateAwakeDrift({ localSeconds: 60, prometheusSeconds: 0 });
+    assert({
+      given: 'a total disagreement over a span shorter than the floor',
+      should: 'not be flagged as drift',
+      actual: { exceeded: drift.exceeded, direction: drift.direction },
+      expected: { exceeded: false, direction: 'none' },
+    });
+  });
+
+  it('flags a disagreement just past the floor and the tolerance, and not one just inside them', () => {
+    const justPast = evaluateAwakeDrift({
+      localSeconds: AWAKE_DRIFT_FLOOR_SECONDS,
+      prometheusSeconds: AWAKE_DRIFT_FLOOR_SECONDS * (1 - AWAKE_DRIFT_TOLERANCE * 2),
+    });
+    const justInside = evaluateAwakeDrift({
+      localSeconds: AWAKE_DRIFT_FLOOR_SECONDS,
+      prometheusSeconds: AWAKE_DRIFT_FLOOR_SECONDS * (1 - AWAKE_DRIFT_TOLERANCE / 2),
+    });
+    expect(justPast.exceeded).toBe(true);
+    expect(justInside.exceeded).toBe(false);
+  });
+
+  it('given both figures zero, should report a zero relative drift rather than dividing by zero', () => {
+    assert({
+      given: 'an app that was never awake, per both records',
+      should: 'report no drift and no NaN',
+      actual: evaluateAwakeDrift({ localSeconds: 0, prometheusSeconds: 0 }),
+      expected: { deltaSeconds: 0, relative: 0, exceeded: false, direction: 'none' },
+    });
+  });
+
+  it('floors negative or non-finite inputs at 0 rather than propagating them into the comparison', () => {
+    const drift = evaluateAwakeDrift({ localSeconds: Number.NaN, prometheusSeconds: -5 });
+    assert({
+      given: 'a NaN local figure and a negative remote one',
+      should: 'compare 0 against 0',
+      actual: { deltaSeconds: drift.deltaSeconds, exceeded: drift.exceeded },
+      expected: { deltaSeconds: 0, exceeded: false },
+    });
+  });
+});

--- a/packages/lib/src/services/app-hosting/__tests__/awake-meter.test.ts
+++ b/packages/lib/src/services/app-hosting/__tests__/awake-meter.test.ts
@@ -1,0 +1,394 @@
+import { describe, it, expect, vi } from 'vitest';
+import { assert } from '../../sandbox/__tests__/riteway';
+import { meterAwakePublishedApps, type AwakeMeterDeps } from '../awake-meter';
+import type { AppBillingDeps } from '../app-billing';
+import { MAX_AWAKE_SETTLE_SPAN_MS } from '../app-metering-core';
+import type { PublishedApp } from '@pagespace/db/schema/published-apps';
+
+const NOW = new Date('2026-08-20T12:00:00.000Z');
+const ago = (ms: number) => new Date(NOW.getTime() - ms);
+
+function runningApp(over: Partial<PublishedApp> = {}): PublishedApp {
+  return {
+    id: 'app-1',
+    driveId: 'drive-1',
+    flyAppName: 'pgs-app-1',
+    machineId: 'machine-1',
+    status: 'running',
+    tier: 'metered',
+    imageDigest: 'sha256:abc',
+    lastWakeAt: ago(3_600_000),
+    lastStopAt: null,
+    awakeBilledThrough: ago(600_000),
+    awakeHoldId: 'hold-1',
+    ...over,
+  } as unknown as PublishedApp;
+}
+
+function makeDeps(over: Partial<AwakeMeterDeps> = {}) {
+  const trackUsage = vi.fn<AppBillingDeps['trackUsage']>(async () => {});
+  // Typed to the seam rather than inferred from this one happy-path literal, so a
+  // test can hand it a refusal (which carries `reason` and no `holdId`).
+  const gate = vi.fn<AppBillingDeps['gate']>(async () => ({ allowed: true, holdId: 'hold-next' }));
+  const releaseHold = vi.fn(async () => {});
+  const writeSettle = vi.fn(async () => 'advanced' as const);
+  const stampWindowStart = vi.fn(async () => 'stamped' as const);
+  const closeAtBoundary = vi.fn(async () => ({ billedSeconds: 600, failed: false }));
+  const parkInsolvent = vi.fn(async () => {});
+  const findStopBoundary = vi.fn(async () => null);
+
+  const deps: AwakeMeterDeps = {
+    isEnabled: () => true,
+    billing: { resolvePayerId: async () => 'payer-1', gate, trackUsage, releaseHold },
+    listRunningApps: async () => [runningApp()],
+    findStopBoundary,
+    writeSettle,
+    stampWindowStart,
+    closeAtBoundary,
+    parkInsolvent,
+    now: () => NOW,
+    ...over,
+  };
+  return { deps, trackUsage, gate, releaseHold, writeSettle, stampWindowStart, closeAtBoundary, parkInsolvent, findStopBoundary };
+}
+
+/** Narrow the run to its metered shape — `disabled` carries no counters. */
+async function meter(deps: AwakeMeterDeps) {
+  const run = await meterAwakePublishedApps(deps);
+  if (run.outcome !== 'metered') throw new Error(`expected a metered run, got ${run.outcome}`);
+  return run;
+}
+
+describe('meterAwakePublishedApps — the kill switch', () => {
+  it('given APP_HOSTING_ENABLED is off, should report `disabled` and read NOTHING', async () => {
+    // A dark feature must never redden a live cron, and must not query for rows
+    // it has no business billing.
+    const listRunningApps = vi.fn(async () => []);
+    const { deps } = makeDeps({ isEnabled: () => false, listRunningApps });
+
+    assert({
+      given: 'the hosting kill switch off',
+      should: 'report disabled without listing a single app',
+      actual: {
+        outcome: (await meterAwakePublishedApps(deps)).outcome,
+        listed: listRunningApps.mock.calls.length,
+      },
+      expected: { outcome: 'disabled', listed: 0 },
+    });
+  });
+});
+
+describe('meterAwakePublishedApps — the ordinary settle', () => {
+  it('bills the accrued seconds against the window’s hold and advances the watermark', async () => {
+    const { deps, trackUsage, writeSettle } = makeDeps();
+
+    const run = await meter(deps);
+
+    expect(trackUsage).toHaveBeenCalledWith({
+      payerId: 'payer-1',
+      holdId: 'hold-1',
+      activeSeconds: 600,
+      driveId: 'drive-1',
+      publishedAppId: 'app-1',
+    });
+    assert({
+      given: 'an app awake ten minutes past its watermark',
+      should: 'settle 600 seconds and advance to now',
+      actual: { settled: run.settled, seconds: run.totalAwakeSeconds },
+      expected: { settled: 1, seconds: 600 },
+    });
+    expect(writeSettle).toHaveBeenCalledWith({
+      publishedAppId: 'app-1',
+      billedThrough: NOW,
+      holdId: 'hold-next',
+    });
+  });
+
+  it('RE-GATES after every settle, because the settle consumed the wake’s hold', async () => {
+    // Without the re-hold, a payer who runs out mid-window keeps a machine awake
+    // indefinitely and the balance is only ever consulted at the next cold wake.
+    const { deps, gate } = makeDeps();
+
+    await meter(deps);
+
+    expect(gate).toHaveBeenCalledWith({ payerId: 'payer-1' });
+  });
+
+  it('given the re-gate REFUSES, should stop and PARK the app without advancing the watermark', async () => {
+    // The park path's own final settle owns closing this window; advancing first
+    // would leave it to bill the same span twice.
+    const { deps, gate, parkInsolvent, writeSettle } = makeDeps();
+    gate.mockResolvedValue({ allowed: false, reason: 'insufficient_credits' });
+
+    const run = await meter(deps);
+
+    assert({
+      given: 'a payer who ran out of credits mid-window',
+      should: 'park the app and leave the watermark alone',
+      actual: { parked: run.parked, parkCalls: parkInsolvent.mock.calls.length, advanced: writeSettle.mock.calls.length },
+      expected: { parked: 1, parkCalls: 1, advanced: 0 },
+    });
+  });
+
+  it('given the re-gate THROWS, should keep the app up and still close the window with no hold', async () => {
+    // A transient billing outage must not kill a live app.
+    const { deps, gate, writeSettle, parkInsolvent } = makeDeps();
+    gate.mockRejectedValue(new Error('gate down'));
+
+    const run = await meter(deps);
+
+    expect(parkInsolvent).not.toHaveBeenCalled();
+    expect(writeSettle).toHaveBeenCalledWith({ publishedAppId: 'app-1', billedThrough: NOW, holdId: null });
+    expect(run.settled).toBe(1);
+  });
+
+  it('given a span longer than a day, should clamp it and count the clamp', async () => {
+    const { deps, trackUsage } = makeDeps({
+      listRunningApps: async () => [runningApp({ awakeBilledThrough: ago(MAX_AWAKE_SETTLE_SPAN_MS * 2) })],
+    });
+
+    const run = await meter(deps);
+
+    expect(run.clamped).toBe(1);
+    expect(trackUsage.mock.calls[0]?.[0].activeSeconds).toBe(MAX_AWAKE_SETTLE_SPAN_MS / 1000);
+  });
+
+  it('given no elapsed time, should SKIP without billing', async () => {
+    const { deps, trackUsage } = makeDeps({
+      listRunningApps: async () => [runningApp({ awakeBilledThrough: NOW })],
+    });
+
+    const run = await meter(deps);
+
+    assert({
+      given: 'a back-to-back rerun',
+      should: 'skip and charge nothing',
+      actual: { skipped: run.skipped, settled: run.settled, charges: trackUsage.mock.calls.length },
+      expected: { skipped: 1, settled: 0, charges: 0 },
+    });
+  });
+});
+
+describe('meterAwakePublishedApps — the repair path', () => {
+  it('given the mirror holds a stop after the watermark, should close at the REAL boundary and never bill to now', async () => {
+    const boundary = ago(300_000);
+    const { deps, closeAtBoundary, trackUsage } = makeDeps({
+      findStopBoundary: vi.fn(async () => boundary),
+    });
+
+    const run = await meter(deps);
+
+    assert({
+      given: 'a stop whose status write was lost',
+      should: 'repair the window at the mirrored boundary',
+      actual: { repaired: run.repaired, seconds: run.totalAwakeSeconds },
+      expected: { repaired: 1, seconds: 600 },
+    });
+    expect(closeAtBoundary).toHaveBeenCalledWith(expect.objectContaining({ id: 'app-1' }), boundary);
+    // The ordinary settle path must NOT also run for this row.
+    expect(trackUsage).not.toHaveBeenCalled();
+  });
+
+  it('given the repair’s settle failed, should count the failure and not the seconds', async () => {
+    const { deps } = makeDeps({
+      findStopBoundary: vi.fn(async () => ago(300_000)),
+      closeAtBoundary: vi.fn(async () => ({ billedSeconds: 0, failed: true })),
+    });
+
+    const run = await meter(deps);
+
+    expect({ repaired: run.repaired, failed: run.failed, seconds: run.totalAwakeSeconds }).toEqual({
+      repaired: 1,
+      failed: 1,
+      seconds: 0,
+    });
+  });
+
+  it('given a running row with no machine, should not ask the mirror for boundaries with an empty id', async () => {
+    const findStopBoundary = vi.fn(async () => null);
+    const { deps } = makeDeps({
+      listRunningApps: async () => [runningApp({ machineId: null })],
+      findStopBoundary,
+    });
+
+    await meter(deps);
+
+    expect(findStopBoundary).not.toHaveBeenCalled();
+  });
+});
+
+describe('meterAwakePublishedApps — a running row with no window', () => {
+  it('STAMPS the clock at now and bills nothing for the unknown span', async () => {
+    // An unknown window start must cost the payer nothing rather than an
+    // invented amount.
+    const { deps, trackUsage, stampWindowStart } = makeDeps({
+      listRunningApps: async () => [runningApp({ awakeBilledThrough: null })],
+    });
+
+    const run = await meter(deps);
+
+    assert({
+      given: 'a `running` row carrying no watermark',
+      should: 'start its clock at now and charge nothing',
+      actual: { stamped: run.stamped, settled: run.settled, charges: trackUsage.mock.calls.length },
+      expected: { stamped: 1, settled: 0, charges: 0 },
+    });
+    expect(stampWindowStart).toHaveBeenCalledWith({ publishedAppId: 'app-1', at: NOW, holdId: 'hold-next' });
+  });
+
+  it('gates before stamping, and parks an insolvent payer instead of opening a window', async () => {
+    const { deps, gate, stampWindowStart, parkInsolvent } = makeDeps({
+      listRunningApps: async () => [runningApp({ awakeBilledThrough: null })],
+    });
+    gate.mockResolvedValue({ allowed: false, reason: 'insufficient_credits' });
+
+    const run = await meter(deps);
+
+    expect(run.parked).toBe(1);
+    expect(parkInsolvent).toHaveBeenCalledWith('app-1');
+    expect(stampWindowStart).not.toHaveBeenCalled();
+  });
+
+  it('given an unresolvable drive, should count it and open no window', async () => {
+    const { deps, stampWindowStart } = makeDeps({
+      listRunningApps: async () => [runningApp({ awakeBilledThrough: null })],
+    });
+    deps.billing.resolvePayerId = async () => null;
+
+    const run = await meter(deps);
+
+    expect(run.unresolvedPayer).toBe(1);
+    expect(stampWindowStart).not.toHaveBeenCalled();
+  });
+});
+
+describe('meterAwakePublishedApps — attribution and isolation', () => {
+  it('given an unresolvable drive on a settle, should leave the watermark so the span is billed in full later', async () => {
+    // Never substitute a payer: a misdirected charge cannot be taken back, a
+    // skipped tick corrects itself.
+    const { deps, trackUsage, writeSettle } = makeDeps();
+    deps.billing.resolvePayerId = async () => null;
+
+    const run = await meter(deps);
+
+    assert({
+      given: 'a drive that cannot be resolved to an owner',
+      should: 'charge nobody and move no watermark',
+      actual: {
+        unresolved: run.unresolvedPayer,
+        charges: trackUsage.mock.calls.length,
+        advances: writeSettle.mock.calls.length,
+      },
+      expected: { unresolved: 1, charges: 0, advances: 0 },
+    });
+  });
+
+  it('ISOLATES one bad row — the rest of the fleet is still billed', async () => {
+    const trackUsage = vi.fn(async (input: { publishedAppId: string }) => {
+      if (input.publishedAppId === 'app-bad') throw new Error('boom');
+    });
+    const { deps } = makeDeps({
+      listRunningApps: async () => [
+        runningApp({ id: 'app-bad' }),
+        runningApp({ id: 'app-good' }),
+      ],
+    });
+    deps.billing.trackUsage = trackUsage;
+
+    const run = await meter(deps);
+
+    assert({
+      given: 'one app whose settle throws',
+      should: 'count it failed and still bill the other',
+      actual: { processed: run.processed, failed: run.failed, settled: run.settled },
+      expected: { processed: 2, failed: 1, settled: 1 },
+    });
+  });
+
+  it('given the ROW SOURCE itself fails, should report `sourceFailed` rather than throwing', async () => {
+    const { deps } = makeDeps({
+      listRunningApps: async () => {
+        throw new Error('db down');
+      },
+    });
+
+    const run = await meter(deps);
+
+    expect({ sourceFailed: run.sourceFailed, processed: run.processed }).toEqual({
+      sourceFailed: true,
+      processed: 0,
+    });
+  });
+
+  it('given the watermark write fails AFTER a successful settle, should count `settledButUnadvanced`', async () => {
+    // Money moved and the window did not close, so this span WILL be billed
+    // again next tick — the opposite of `failed`, and counted under its own name.
+    const { deps } = makeDeps({
+      writeSettle: vi.fn(async () => {
+        throw new Error('write lost');
+      }),
+    });
+
+    const run = await meter(deps);
+
+    assert({
+      given: 'a charge that committed and a watermark advance that did not',
+      should: 'flag the double-bill risk distinctly from an ordinary failure',
+      actual: { settledButUnadvanced: run.settledButUnadvanced, failed: run.failed, settled: run.settled },
+      expected: { settledButUnadvanced: 1, failed: 0, settled: 1 },
+    });
+  });
+
+  it('given a concurrent wake already carried the watermark past this tick, should count it superseded AND return the re-hold', async () => {
+    // The wake owns the window and holds its own reservation for it. Ours covers
+    // nothing, so leaving it in place would suppress the payer's spendable
+    // balance for the whole hold TTL with nothing ever settling it.
+    const { deps, releaseHold } = makeDeps({ writeSettle: vi.fn(async () => 'superseded' as const) });
+
+    const run = await meter(deps);
+
+    assert({
+      given: 'a wake that carried the row past this tick mid-settle',
+      should: 'count the refusal and release the reservation nothing will settle',
+      actual: { superseded: run.watermarkSuperseded, released: releaseHold.mock.calls },
+      expected: { superseded: 1, released: [['hold-next']] },
+    });
+  });
+
+  it('given the row vanished mid-tick, should also return the re-hold rather than strand it', async () => {
+    const { deps, releaseHold } = makeDeps({ writeSettle: vi.fn(async () => 'row_gone' as const) });
+
+    const run = await meter(deps);
+
+    expect(run.watermarkSuperseded).toBe(1);
+    expect(releaseHold).toHaveBeenCalledWith('hold-next');
+  });
+
+  it('given a wake opened the window while the STAMP path was gating, should release that hold too', async () => {
+    const { deps, releaseHold } = makeDeps({
+      listRunningApps: async () => [runningApp({ awakeBilledThrough: null })],
+      stampWindowStart: vi.fn(async () => 'superseded' as const),
+    });
+
+    const run = await meter(deps);
+
+    assert({
+      given: 'a row that acquired a window between the read and the stamp',
+      should: 'not count it stamped, and return the unused reservation',
+      actual: { stamped: run.stamped, superseded: run.watermarkSuperseded, released: releaseHold.mock.calls },
+      expected: { stamped: 0, superseded: 1, released: [['hold-next']] },
+    });
+  });
+
+  it('uses ONE clock for the whole tick, so two rows cannot overlap at the seam', async () => {
+    const now = vi.fn(() => NOW);
+    const { deps } = makeDeps({
+      now,
+      listRunningApps: async () => [runningApp({ id: 'a' }), runningApp({ id: 'b' }), runningApp({ id: 'c' })],
+    });
+
+    await meter(deps);
+
+    expect(now).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/lib/src/services/app-hosting/__tests__/awake-meter.test.ts
+++ b/packages/lib/src/services/app-hosting/__tests__/awake-meter.test.ts
@@ -114,19 +114,35 @@ describe('meterAwakePublishedApps — the ordinary settle', () => {
     expect(gate).toHaveBeenCalledWith({ payerId: 'payer-1' });
   });
 
-  it('given the re-gate REFUSES, should stop and PARK the app without advancing the watermark', async () => {
-    // The park path's own final settle owns closing this window; advancing first
-    // would leave it to bill the same span twice.
+  it('given the re-gate REFUSES, should ADVANCE THE WATERMARK BEFORE parking — the span is already charged', async () => {
+    // The regression this guards: parking on the stale watermark makes
+    // `stopPublishedApp` re-read it and settle the same span a SECOND time, so
+    // every insolvency park double-charged nearly a whole heartbeat interval.
+    const order: string[] = [];
     const { deps, gate, parkInsolvent, writeSettle } = makeDeps();
     gate.mockResolvedValue({ allowed: false, reason: 'insufficient_credits' });
+    writeSettle.mockImplementation(async () => {
+      order.push('advance');
+      return 'advanced' as const;
+    });
+    parkInsolvent.mockImplementation(async () => {
+      order.push('park');
+    });
 
     const run = await meter(deps);
 
     assert({
       given: 'a payer who ran out of credits mid-window',
-      should: 'park the app and leave the watermark alone',
-      actual: { parked: run.parked, parkCalls: parkInsolvent.mock.calls.length, advanced: writeSettle.mock.calls.length },
-      expected: { parked: 1, parkCalls: 1, advanced: 0 },
+      should: 'record the charge it already made, then park',
+      actual: { parked: run.parked, order },
+      expected: { parked: 1, order: ['advance', 'park'] },
+    });
+    // Advanced to the instant just billed, carrying NO hold: the settle consumed
+    // the wake's, and the gate refused to give another.
+    expect(writeSettle).toHaveBeenCalledWith({
+      publishedAppId: 'app-1',
+      billedThrough: NOW,
+      holdId: null,
     });
   });
 
@@ -355,8 +371,8 @@ describe('meterAwakePublishedApps — attribution and isolation', () => {
     });
   });
 
-  it('given the row vanished mid-tick, should also return the re-hold rather than strand it', async () => {
-    const { deps, releaseHold } = makeDeps({ writeSettle: vi.fn(async () => 'row_gone' as const) });
+  it('given a stop closed the window mid-tick, should also return the re-hold rather than strand it', async () => {
+    const { deps, releaseHold } = makeDeps({ writeSettle: vi.fn(async () => 'superseded' as const) });
 
     const run = await meter(deps);
 

--- a/packages/lib/src/services/app-hosting/__tests__/awake-metering.integration.test.ts
+++ b/packages/lib/src/services/app-hosting/__tests__/awake-metering.integration.test.ts
@@ -1,0 +1,421 @@
+/**
+ * Awake-seconds metering against the REAL tables — the parts of this feature that
+ * a mocked db cannot prove:
+ *
+ *  1. **The event mirror's idempotency.** `mirrorFlyMachineEvents` re-reads Fly's
+ *     last-20 window on every start and stop, so it re-offers rows it has already
+ *     written. Its `ON CONFLICT DO NOTHING` names a PARTIAL unique index, and
+ *     Postgres only infers a partial index as the arbiter when its predicate is
+ *     restated — get that wrong and every re-mirror THROWS rather than no-ops,
+ *     turning a routine call into a mirroring outage. Only a real Postgres can
+ *     tell the two apart.
+ *  2. **The watermark's monotonic guard.** `writeSettle` uses `GREATEST` so a wake
+ *     landing mid-tick is not dragged backward, and guards the HOLD that rides in
+ *     the same statement on the same comparison. A hold overwritten there is
+ *     stranded for its whole TTL, suppressing a real payer's spendable balance.
+ *  3. **The CHECK constraints** that make an incoherent billing row
+ *     unrepresentable rather than merely unwritten.
+ *
+ * Runs in CI (the Unit Tests job provides Postgres) and is deliberately NOT
+ * excluded from the coverage run — a billing proof that never executes is worse
+ * than no proof, because the green tick still appears. `requireDb` makes a missing
+ * database a LOUD failure with one explicit opt-out (`ALLOW_SKIP_DB_TESTS=1`) that
+ * CI never sets.
+ *
+ * Locally:
+ *     DATABASE_URL=postgresql://user:password@localhost:5433/pagespace_test \
+ *       bun run --filter '@pagespace/lib' test -- src/services/app-hosting/__tests__/awake-metering.integration.test.ts
+ */
+
+import { describe, it, expect, beforeAll, afterAll, beforeEach } from 'vitest';
+import { createId } from '@paralleldrive/cuid2';
+import { db } from '@pagespace/db/db';
+import { and, eq, inArray, sql } from '@pagespace/db/operators';
+import { requireDb, dbSkipExplicitlyAllowed } from '@pagespace/db/test/require-db';
+import { users } from '@pagespace/db/schema/auth';
+import { drives } from '@pagespace/db/schema/core';
+import { publishedApps, publishedAppMachineEvents } from '@pagespace/db/schema/published-apps';
+import { driveEnvs } from '@pagespace/db/schema/drive-envs';
+import { assert } from '../../sandbox/__tests__/riteway';
+import { defaultAwakeMeterDeps } from '../awake-meter';
+import {
+  mirrorFlyMachineEvents,
+  recordOrchestratorBoundary,
+  findStopBoundarySince,
+  listBoundaryEvents,
+} from '../app-machine-events';
+import type { MachineEvent } from '../../fly/flaps-client';
+
+const ownerId = createId();
+const driveId = createId();
+const envId = createId();
+const appId = createId();
+const machineId = 'd8901e2f3a4b5c';
+const flyAppName = `pgs-app-${appId}`;
+
+const NOW = new Date('2026-08-20T12:00:00.000Z');
+const ago = (ms: number) => new Date(NOW.getTime() - ms);
+
+let dbAvailable = true;
+
+async function seedApp(over: Record<string, unknown> = {}): Promise<void> {
+  await db.delete(publishedApps).where(eq(publishedApps.id, appId));
+  await db.insert(publishedApps).values({
+    id: appId,
+    envId,
+    driveId,
+    ownerId,
+    flyAppName,
+    networkName: 'published-apps',
+    subdomain: `awake-${appId}`,
+    machineId,
+    status: 'running',
+    tier: 'metered',
+    imageDigest: 'sha256:abc',
+    lastWakeAt: ago(3_600_000),
+    awakeBilledThrough: ago(600_000),
+    awakeHoldId: 'hold-live',
+    updatedAt: NOW,
+    ...over,
+  } as never);
+}
+
+async function readApp() {
+  const [row] = await db
+    .select({
+      awakeBilledThrough: publishedApps.awakeBilledThrough,
+      awakeHoldId: publishedApps.awakeHoldId,
+      lastWakeAt: publishedApps.lastWakeAt,
+    })
+    .from(publishedApps)
+    .where(eq(publishedApps.id, appId));
+  return row;
+}
+
+function flyEvent(over: Partial<MachineEvent> = {}): MachineEvent {
+  return {
+    id: '01JABCDEF',
+    type: 'start',
+    status: 'started',
+    timestamp: ago(1_800_000).getTime(),
+    ...over,
+  } as MachineEvent;
+}
+
+const ref = () => ({ publishedAppId: appId, flyAppName, machineId });
+
+beforeAll(async () => {
+  try {
+    await db.execute(sql`SELECT 1`);
+  } catch (error) {
+    requireDb('awake-metering.integration.test.ts', error);
+    dbAvailable = false;
+    return;
+  }
+  await db
+    .insert(users)
+    .values({ id: ownerId, email: `awake-${ownerId}@test.local`, name: 'Drive Owner', updatedAt: new Date() })
+    .onConflictDoNothing();
+  await db
+    .insert(drives)
+    .values({ id: driveId, name: 'Awake Drive', slug: `awake-${driveId}`, ownerId, updatedAt: new Date() })
+    .onConflictDoNothing();
+  // A published app hangs off an ENVIRONMENT — that is the whole reason its payer
+  // is the drive owner rather than its own `ownerId` column.
+  await db
+    .insert(driveEnvs)
+    .values({ id: envId, driveId, name: 'Awake Env', createdBy: ownerId, updatedAt: new Date() })
+    .onConflictDoNothing();
+});
+
+beforeEach(async () => {
+  if (!dbAvailable) return;
+  await db.delete(publishedAppMachineEvents).where(eq(publishedAppMachineEvents.publishedAppId, appId));
+  await seedApp();
+});
+
+afterAll(async () => {
+  if (!dbAvailable) return;
+  await db.delete(publishedAppMachineEvents).where(eq(publishedAppMachineEvents.publishedAppId, appId));
+  await db.delete(publishedApps).where(eq(publishedApps.id, appId));
+  await db.delete(driveEnvs).where(eq(driveEnvs.id, envId));
+  await db.delete(drives).where(eq(drives.id, driveId));
+  await db.delete(users).where(inArray(users.id, [ownerId]));
+});
+
+describe.skipIf(dbSkipExplicitlyAllowed())('the machine-event mirror — real table, real conflict arbiter', () => {
+  it('RE-MIRRORING the same Fly window is a clean no-op, not a throw', async () => {
+    // The partial unique index needs its predicate restated in ON CONFLICT for
+    // Postgres to infer it as the arbiter. If it is not, this second call raises
+    // "there is no unique or exclusion constraint matching the ON CONFLICT
+    // specification" and every start/stop after the first stops mirroring.
+    const events = [flyEvent({ id: 'ev-1' }), flyEvent({ id: 'ev-2', type: 'exit' })];
+
+    const first = await mirrorFlyMachineEvents(ref(), events);
+    const second = await mirrorFlyMachineEvents(ref(), events);
+
+    assert({
+      given: 'the same last-20 window read twice, as every start and stop does',
+      should: 'insert each Fly event exactly once and never fail',
+      actual: { first, second },
+      expected: {
+        first: { boundaries: 2, inserted: 2, failed: false },
+        second: { boundaries: 2, inserted: 0, failed: false },
+      },
+    });
+  });
+
+  it('does NOT collapse our own orchestrator boundaries, which carry no Fly event id', async () => {
+    // A plain (non-partial) unique index on (machineId, flyEventId) would permit
+    // exactly ONE null-id row per machine and silently discard the primary
+    // billing record this table exists to keep.
+    await recordOrchestratorBoundary(ref(), 'start', ago(3_600_000));
+    await recordOrchestratorBoundary(ref(), 'stop', ago(1_800_000));
+    await recordOrchestratorBoundary(ref(), 'start', ago(900_000));
+
+    const rows = await db
+      .select({ id: publishedAppMachineEvents.id })
+      .from(publishedAppMachineEvents)
+      .where(
+        and(
+          eq(publishedAppMachineEvents.publishedAppId, appId),
+          eq(publishedAppMachineEvents.origin, 'orchestrator'),
+        ),
+      );
+
+    assert({
+      given: 'three of our own start/stop calls on one machine',
+      should: 'keep all three',
+      actual: rows.length,
+      expected: 3,
+    });
+  });
+
+  it('drops a Fly event that is not a boundary, or whose timestamp is unusable', async () => {
+    // An unrecognised type must not be guessed at, and a malformed timestamp must
+    // not land dated to 1970 — the reconcile would read that as a decades-long
+    // awake window.
+    const result = await mirrorFlyMachineEvents(ref(), [
+      flyEvent({ id: 'ev-restart', type: 'restart' }),
+      flyEvent({ id: 'ev-bad-time', type: 'start', timestamp: 0 as never }),
+      flyEvent({ id: '', type: 'start' }),
+    ]);
+
+    expect(result).toEqual({ boundaries: 0, inserted: 0, failed: false });
+  });
+
+  it('refuses an incoherent origin/event-id pair at the DATABASE, not merely in code', async () => {
+    // `published_app_machine_events_fly_event_id_coherent`: our own call has no
+    // Fly event id, and a mirrored Fly event is worthless without one.
+    await expect(
+      db.insert(publishedAppMachineEvents).values({
+        publishedAppId: appId,
+        flyAppName,
+        machineId,
+        origin: 'fly',
+        action: 'start',
+        flyEventId: null,
+        occurredAt: NOW,
+      } as never),
+    ).rejects.toThrow();
+
+    await expect(
+      db.insert(publishedAppMachineEvents).values({
+        publishedAppId: appId,
+        flyAppName,
+        machineId,
+        origin: 'orchestrator',
+        action: 'start',
+        flyEventId: 'ev-x',
+        occurredAt: NOW,
+      } as never),
+    ).rejects.toThrow();
+  });
+});
+
+describe.skipIf(dbSkipExplicitlyAllowed())('findStopBoundarySince / listBoundaryEvents — real reads', () => {
+  it('finds the LATEST stop after the watermark, never an earlier one', async () => {
+    // Between `since` and now the machine may have stopped, been restarted by a
+    // wake we did record, and stopped again. Closing at the earliest would
+    // forgive the real awake time in between.
+    await recordOrchestratorBoundary(ref(), 'stop', ago(1_500_000));
+    await recordOrchestratorBoundary(ref(), 'stop', ago(300_000));
+
+    const boundary = await findStopBoundarySince(machineId, ago(1_800_000), NOW);
+
+    expect(boundary?.toISOString()).toBe(ago(300_000).toISOString());
+  });
+
+  it('ignores a stop at or before the watermark, and one dated in the future', async () => {
+    await recordOrchestratorBoundary(ref(), 'stop', ago(3_600_000));
+    await recordOrchestratorBoundary(ref(), 'stop', new Date(NOW.getTime() + 600_000));
+
+    assert({
+      given: 'a stop belonging to the previous window and one from a skewed clock',
+      should: 'find neither',
+      actual: await findStopBoundarySince(machineId, ago(1_800_000), NOW),
+      expected: null,
+    });
+  });
+
+  it('returns both origins as one ordered boundary stream', async () => {
+    await recordOrchestratorBoundary(ref(), 'start', ago(3_600_000));
+    await mirrorFlyMachineEvents(ref(), [flyEvent({ id: 'ev-stop', type: 'exit', timestamp: ago(1_800_000).getTime() })]);
+
+    const boundaries = await listBoundaryEvents(appId, ago(7_200_000), NOW);
+
+    assert({
+      given: 'our own start and Fly’s own stop',
+      should: 'read back in time order, both origins together',
+      actual: boundaries.map((b) => b.action),
+      expected: ['start', 'stop'],
+    });
+  });
+});
+
+describe.skipIf(dbSkipExplicitlyAllowed())('writeSettle — the monotonic watermark and its hold', () => {
+  it('advances the watermark and installs the re-hold', async () => {
+    const outcome = await defaultAwakeMeterDeps.writeSettle({
+      publishedAppId: appId,
+      billedThrough: NOW,
+      holdId: 'hold-next',
+    });
+
+    const row = await readApp();
+    assert({
+      given: 'a settle for a window that is still ours',
+      should: 'advance the watermark and carry the new reservation',
+      actual: { outcome, billedThrough: row?.awakeBilledThrough?.toISOString(), holdId: row?.awakeHoldId },
+      expected: { outcome: 'advanced', billedThrough: NOW.toISOString(), holdId: 'hold-next' },
+    });
+  });
+
+  it('given a wake carried the row PAST this tick, should refuse the advance AND leave the wake’s hold intact', async () => {
+    // The regression this guards: `awakeHoldId` used to be written
+    // unconditionally beside the GREATEST-guarded watermark, so a superseded
+    // settle clobbered the wake's live reservation — stranded for its whole TTL,
+    // never settled, never released, suppressing the payer's spendable balance.
+    const wakeInstant = new Date(NOW.getTime() + 300_000);
+    await seedApp({ awakeBilledThrough: wakeInstant, awakeHoldId: 'hold-from-wake', lastWakeAt: wakeInstant });
+
+    const outcome = await defaultAwakeMeterDeps.writeSettle({
+      publishedAppId: appId,
+      billedThrough: NOW,
+      holdId: 'hold-next',
+    });
+
+    const row = await readApp();
+    assert({
+      given: 'a concurrent wake that opened a newer window mid-tick',
+      should: 'keep the wake’s watermark and the wake’s hold',
+      actual: { outcome, billedThrough: row?.awakeBilledThrough?.toISOString(), holdId: row?.awakeHoldId },
+      expected: {
+        outcome: 'superseded',
+        billedThrough: wakeInstant.toISOString(),
+        holdId: 'hold-from-wake',
+      },
+    });
+  });
+
+  it('given the row vanished mid-tick, should report `row_gone` rather than throwing', async () => {
+    await db.delete(publishedApps).where(eq(publishedApps.id, appId));
+
+    expect(
+      await defaultAwakeMeterDeps.writeSettle({
+        publishedAppId: appId,
+        billedThrough: NOW,
+        holdId: 'hold-next',
+      }),
+    ).toBe('row_gone');
+  });
+});
+
+describe.skipIf(dbSkipExplicitlyAllowed())('stampWindowStart — opens a window only where there is none', () => {
+  it('stamps a running row that carries no watermark, and seeds `lastWakeAt` with it', async () => {
+    await seedApp({ awakeBilledThrough: null, awakeHoldId: null, lastWakeAt: null });
+
+    const outcome = await defaultAwakeMeterDeps.stampWindowStart({
+      publishedAppId: appId,
+      at: NOW,
+      holdId: 'hold-stamp',
+    });
+
+    const row = await readApp();
+    assert({
+      given: 'a `running` row with no billing window',
+      should: 'open one at now, satisfying the wake-boundary CHECK',
+      actual: {
+        outcome,
+        billedThrough: row?.awakeBilledThrough?.toISOString(),
+        lastWakeAt: row?.lastWakeAt?.toISOString(),
+        holdId: row?.awakeHoldId,
+      },
+      expected: {
+        outcome: 'stamped',
+        billedThrough: NOW.toISOString(),
+        lastWakeAt: NOW.toISOString(),
+        holdId: 'hold-stamp',
+      },
+    });
+  });
+
+  it('given a wake opened a window first, should REFUSE rather than drag the watermark backward', async () => {
+    // The tick captures one clock then makes several awaits per row, so a wake
+    // landing inside that span opens a window at a LATER instant. Stamping over
+    // it would hand the next tick a span to re-bill and replace a live hold.
+    const wakeInstant = new Date(NOW.getTime() + 300_000);
+    await seedApp({ awakeBilledThrough: wakeInstant, awakeHoldId: 'hold-from-wake', lastWakeAt: wakeInstant });
+
+    const outcome = await defaultAwakeMeterDeps.stampWindowStart({
+      publishedAppId: appId,
+      at: NOW,
+      holdId: 'hold-stamp',
+    });
+
+    const row = await readApp();
+    assert({
+      given: 'a row that acquired a window between the read and the stamp',
+      should: 'leave the wake’s window and hold untouched',
+      actual: { outcome, billedThrough: row?.awakeBilledThrough?.toISOString(), holdId: row?.awakeHoldId },
+      expected: {
+        outcome: 'superseded',
+        billedThrough: wakeInstant.toISOString(),
+        holdId: 'hold-from-wake',
+      },
+    });
+  });
+});
+
+describe.skipIf(dbSkipExplicitlyAllowed())('the billing CHECK constraints', () => {
+  it('refuses an open awake window on a row with no wake boundary', async () => {
+    // `published_apps_awake_window_needs_wake`: the weekly reconcile compares our
+    // billed span from `lastWakeAt`, and a watermark without one cannot be
+    // checked against anything.
+    await expect(
+      db.update(publishedApps).set({ awakeBilledThrough: NOW, lastWakeAt: null }).where(eq(publishedApps.id, appId)),
+    ).rejects.toThrow();
+  });
+
+  it('refuses an image size the storage meter could not date', async () => {
+    // `published_apps_image_size_measured_coherent`: a size with no timestamp
+    // reads to the meter as "never measured" and bills the 0 floor forever while
+    // the watermark advances over real rootfs.
+    await expect(
+      db
+        .update(publishedApps)
+        .set({ imageSizeBytes: 1_000_000_000, imageSizeMeasuredAt: null })
+        .where(eq(publishedApps.id, appId)),
+    ).rejects.toThrow();
+  });
+
+  it('defaults a new row’s storage watermark to now, so it can never bill retroactively', async () => {
+    const [row] = await db
+      .select({ storageLastBilledAt: publishedApps.storageLastBilledAt })
+      .from(publishedApps)
+      .where(eq(publishedApps.id, appId));
+
+    expect(row?.storageLastBilledAt).toBeInstanceOf(Date);
+    // Seeded moments ago, and certainly not before this suite started running.
+    expect(row!.storageLastBilledAt.getTime()).toBeGreaterThan(Date.now() - 5 * 60_000);
+  });
+});

--- a/packages/lib/src/services/app-hosting/__tests__/awake-metering.integration.test.ts
+++ b/packages/lib/src/services/app-hosting/__tests__/awake-metering.integration.test.ts
@@ -38,6 +38,7 @@ import { publishedApps, publishedAppMachineEvents } from '@pagespace/db/schema/p
 import { driveEnvs } from '@pagespace/db/schema/drive-envs';
 import { assert } from '../../sandbox/__tests__/riteway';
 import { defaultAwakeMeterDeps } from '../awake-meter';
+import { awakeSecondsFromEvents } from '../app-metering-core';
 import {
   mirrorFlyMachineEvents,
   recordOrchestratorBoundary,
@@ -258,6 +259,53 @@ describe.skipIf(dbSkipExplicitlyAllowed())('findStopBoundarySince / listBoundary
     });
   });
 
+  it('given a machine that was ALREADY UP at the window start, should seed an open start at the edge', async () => {
+    // The false-alarm this guards: an app woken ten days ago and still running has
+    // NO events inside a seven-day window, so it reconciled as zero local seconds
+    // against a full week of `fly_instance_up` — a standing `under_billed` alert on
+    // exactly the longest-running apps.
+    const from = ago(7 * 24 * 60 * 60 * 1000);
+    await recordOrchestratorBoundary(ref(), 'start', ago(10 * 24 * 60 * 60 * 1000));
+
+    const boundaries = await listBoundaryEvents(appId, from, NOW);
+
+    assert({
+      given: 'a start ten days ago and nothing since',
+      should: 'seed one start clamped to the window edge, not an empty stream',
+      actual: boundaries.map((b) => ({ action: b.action, at: b.occurredAt.toISOString() })),
+      expected: [{ action: 'start', at: from.toISOString() }],
+    });
+  });
+
+  it('given the machine was DOWN at the window start, should seed nothing', async () => {
+    // Claiming an app was running because we have no evidence either way would
+    // invent awake time. Only a start as the last prior boundary seeds a window.
+    const from = ago(7 * 24 * 60 * 60 * 1000);
+    await recordOrchestratorBoundary(ref(), 'start', ago(12 * 24 * 60 * 60 * 1000));
+    await recordOrchestratorBoundary(ref(), 'stop', ago(10 * 24 * 60 * 60 * 1000));
+
+    assert({
+      given: 'a stop as the last boundary before the window',
+      should: 'read back no boundaries at all',
+      actual: await listBoundaryEvents(appId, from, NOW),
+      expected: [],
+    });
+  });
+
+  it('given an app already up that STOPS inside the window, should bill the prefix rather than dropping it', async () => {
+    // Without the seed this stop is unmatched, and `awakeSecondsFromEvents`
+    // correctly ignores an unmatched stop — so the whole span silently vanished.
+    const from = ago(7 * 24 * 60 * 60 * 1000);
+    await recordOrchestratorBoundary(ref(), 'start', ago(9 * 24 * 60 * 60 * 1000));
+    await recordOrchestratorBoundary(ref(), 'stop', ago(6 * 24 * 60 * 60 * 1000));
+
+    const boundaries = await listBoundaryEvents(appId, from, NOW);
+
+    expect(boundaries.map((b) => b.action)).toEqual(['start', 'stop']);
+    // One full day of the window elapsed before the stop.
+    expect(awakeSecondsFromEvents(boundaries, NOW)).toBe(24 * 60 * 60);
+  });
+
   it('returns both origins as one ordered boundary stream', async () => {
     await recordOrchestratorBoundary(ref(), 'start', ago(3_600_000));
     await mirrorFlyMachineEvents(ref(), [flyEvent({ id: 'ev-stop', type: 'exit', timestamp: ago(1_800_000).getTime() })]);
@@ -317,7 +365,7 @@ describe.skipIf(dbSkipExplicitlyAllowed())('writeSettle — the monotonic waterm
     });
   });
 
-  it('given the row vanished mid-tick, should report `row_gone` rather than throwing', async () => {
+  it('given the row vanished mid-tick, should report `superseded` rather than throwing', async () => {
     await db.delete(publishedApps).where(eq(publishedApps.id, appId));
 
     expect(
@@ -326,7 +374,29 @@ describe.skipIf(dbSkipExplicitlyAllowed())('writeSettle — the monotonic waterm
         billedThrough: NOW,
         holdId: 'hold-next',
       }),
-    ).toBe('row_gone');
+    ).toBe('superseded');
+  });
+
+  it('given a STOP closed the window mid-tick, should refuse rather than REOPEN a window on a stopped row', async () => {
+    // The regression this guards: an id-only UPDATE would compute
+    // `GREATEST(NULL, billedThrough)` on the closed window and reopen it, installing
+    // a hold that no later tick can settle or release — `listRunningApps` only ever
+    // sees `running` rows, so it would be stranded until its TTL.
+    await seedApp({ status: 'stopped', awakeBilledThrough: null, awakeHoldId: null, lastStopAt: NOW });
+
+    const outcome = await defaultAwakeMeterDeps.writeSettle({
+      publishedAppId: appId,
+      billedThrough: NOW,
+      holdId: 'hold-next',
+    });
+
+    const row = await readApp();
+    assert({
+      given: 'a stop that closed the window between this tick’s read and its write',
+      should: 'leave the window closed and install no hold',
+      actual: { outcome, billedThrough: row?.awakeBilledThrough, holdId: row?.awakeHoldId },
+      expected: { outcome: 'superseded', billedThrough: null, holdId: null },
+    });
   });
 });
 

--- a/packages/lib/src/services/app-hosting/__tests__/awake-reconcile.test.ts
+++ b/packages/lib/src/services/app-hosting/__tests__/awake-reconcile.test.ts
@@ -1,0 +1,233 @@
+import { describe, it, expect, vi } from 'vitest';
+import { assert } from '../../sandbox/__tests__/riteway';
+import {
+  reconcileAwakeSeconds,
+  AWAKE_RECONCILE_WINDOW_DAYS,
+  MAX_DRIFT_REPORTS,
+  type AwakeReconcileDeps,
+} from '../awake-reconcile';
+
+const NOW = new Date('2026-08-20T12:00:00.000Z');
+const ago = (ms: number) => new Date(NOW.getTime() - ms);
+
+function makeDeps(over: Partial<AwakeReconcileDeps> = {}) {
+  const queryAwakeSeconds = vi.fn(async () => 3600);
+  const listBoundaries = vi.fn(async () => [
+    { action: 'start' as const, occurredAt: ago(7_200_000) },
+    { action: 'stop' as const, occurredAt: ago(3_600_000) },
+  ]);
+  const deps: AwakeReconcileDeps = {
+    isEnabled: () => true,
+    resolvePrometheus: () => ({ orgSlug: 'org', token: 'tok' }),
+    listApps: async () => [{ id: 'app-1', driveId: 'drive-1', flyAppName: 'pgs-app-1' }],
+    listBoundaries,
+    queryAwakeSeconds,
+    now: () => NOW,
+    ...over,
+  };
+  return { deps, queryAwakeSeconds, listBoundaries };
+}
+
+async function reconciled(deps: AwakeReconcileDeps) {
+  const run = await reconcileAwakeSeconds(deps);
+  if (run.outcome !== 'reconciled') throw new Error(`expected a reconciled run, got ${run.outcome}`);
+  return run;
+}
+
+describe('reconcileAwakeSeconds — the dark switches', () => {
+  it('given the kill switch is off, should report `disabled` and query nothing', async () => {
+    const { deps, queryAwakeSeconds } = makeDeps({ isEnabled: () => false });
+
+    expect(await reconcileAwakeSeconds(deps)).toEqual({ outcome: 'disabled' });
+    expect(queryAwakeSeconds).not.toHaveBeenCalled();
+  });
+
+  it('given no Prometheus credential, should report `unconfigured` — inert, never an error', async () => {
+    const listApps = vi.fn(async () => []);
+    const { deps } = makeDeps({ resolvePrometheus: () => null, listApps });
+
+    assert({
+      given: 'a deployment with no FLY_PROMETHEUS_ORG_SLUG',
+      should: 'skip cleanly without listing apps',
+      actual: { run: await reconcileAwakeSeconds(deps), listed: listApps.mock.calls.length },
+      expected: { run: { outcome: 'unconfigured' }, listed: 0 },
+    });
+  });
+});
+
+describe('reconcileAwakeSeconds — comparison', () => {
+  it('compares OUR MIRRORED BOUNDARIES against Prometheus, not our billing watermark', async () => {
+    // Comparing the watermark would be comparing our arithmetic against itself.
+    const { deps, listBoundaries } = makeDeps();
+
+    const run = await reconciled(deps);
+
+    expect(listBoundaries).toHaveBeenCalledWith(
+      'app-1',
+      new Date(NOW.getTime() - AWAKE_RECONCILE_WINDOW_DAYS * 24 * 60 * 60 * 1000),
+      NOW,
+    );
+    assert({
+      given: 'an hour of awake time in both records',
+      should: 'compare it and find no drift',
+      actual: { compared: run.compared, drifted: run.drifted },
+      expected: { compared: 1, drifted: 0 },
+    });
+  });
+
+  it('queries Prometheus over the SAME window it reads boundaries for', async () => {
+    const { deps, queryAwakeSeconds } = makeDeps();
+
+    await reconciled(deps);
+
+    expect(queryAwakeSeconds).toHaveBeenCalledWith(
+      'pgs-app-1',
+      AWAKE_RECONCILE_WINDOW_DAYS * 24 * 60 * 60,
+    );
+  });
+
+  it('given an app with NO series, should count `noSeries` rather than a fault', async () => {
+    // An app that has never been woken has no `fly_instance_up` series at all.
+    const { deps, listBoundaries } = makeDeps({ queryAwakeSeconds: vi.fn(async () => null) });
+
+    const run = await reconciled(deps);
+
+    assert({
+      given: 'an app Prometheus has never seen',
+      should: 'count it as noSeries and not compare it',
+      actual: { noSeries: run.noSeries, compared: run.compared, failed: run.failed },
+      expected: { noSeries: 1, compared: 0, failed: 0 },
+    });
+    expect(listBoundaries).not.toHaveBeenCalled();
+  });
+
+  it('reports drift with its direction when the two records disagree', async () => {
+    const { deps } = makeDeps({ queryAwakeSeconds: vi.fn(async () => 100) });
+
+    const run = await reconciled(deps);
+
+    expect(run.drifted).toBe(1);
+    expect(run.reports[0]).toMatchObject({
+      publishedAppId: 'app-1',
+      driveId: 'drive-1',
+      flyAppName: 'pgs-app-1',
+      localSeconds: 3600,
+      prometheusSeconds: 100,
+    });
+    // We billed far more than Fly saw — the direction that costs a customer.
+    expect(run.reports[0].drift.direction).toBe('over_billed');
+  });
+
+  it('MOVES NO MONEY — it exposes no settle, charge or adjustment seam at all', async () => {
+    // A scraped gauge is not evidence of a charge. The deps surface is the proof:
+    // there is nothing here that could write to a ledger.
+    const { deps } = makeDeps({ queryAwakeSeconds: vi.fn(async () => 100) });
+
+    await reconciled(deps);
+
+    assert({
+      given: 'the reconcile’s full dependency surface',
+      should: 'contain only reads and no money movement',
+      actual: Object.keys(deps).sort(),
+      expected: [
+        'isEnabled',
+        'listApps',
+        'listBoundaries',
+        'now',
+        'queryAwakeSeconds',
+        'resolvePrometheus',
+      ],
+    });
+  });
+});
+
+describe('reconcileAwakeSeconds — reporting and isolation', () => {
+  it('sorts OVER-BILLED ahead of under-billed, then by magnitude', async () => {
+    // An operator reading a truncated list should see the charges somebody may
+    // have to be refunded before the revenue we failed to capture.
+    const apps = [
+      { id: 'under-big', driveId: 'd', flyAppName: 'under-big' },
+      { id: 'over-small', driveId: 'd', flyAppName: 'over-small' },
+    ];
+    const { deps } = makeDeps({
+      listApps: async () => apps,
+      // `under-big` : we billed 3600, Fly saw 100000 (huge under-bill).
+      // `over-small`: we billed 3600, Fly saw 3000 (modest over-bill).
+      queryAwakeSeconds: vi.fn(async (flyAppName: string) =>
+        flyAppName === 'under-big' ? 100_000 : 3_000,
+      ),
+    });
+
+    const run = await reconciled(deps);
+
+    assert({
+      given: 'a large under-bill and a small over-bill',
+      should: 'rank the over-bill first regardless of magnitude',
+      actual: run.reports.map((r) => r.drift.direction),
+      expected: ['over_billed', 'under_billed'],
+    });
+  });
+
+  it('caps the report LIST while keeping the drifted COUNT exact', async () => {
+    const apps = Array.from({ length: MAX_DRIFT_REPORTS + 10 }, (_, i) => ({
+      id: `app-${i}`,
+      driveId: 'd',
+      flyAppName: `fly-${i}`,
+    }));
+    const { deps } = makeDeps({ listApps: async () => apps, queryAwakeSeconds: vi.fn(async () => 100) });
+
+    const run = await reconciled(deps);
+
+    assert({
+      given: 'more drifting apps than the report cap',
+      should: 'truncate the list but not the count',
+      actual: { count: run.drifted, listed: run.reports.length },
+      expected: { count: MAX_DRIFT_REPORTS + 10, listed: MAX_DRIFT_REPORTS },
+    });
+  });
+
+  it('ISOLATES one app’s failure — the rest of the run still reports', async () => {
+    const { deps } = makeDeps({
+      listApps: async () => [
+        { id: 'bad', driveId: 'd', flyAppName: 'bad' },
+        { id: 'good', driveId: 'd', flyAppName: 'good' },
+      ],
+      queryAwakeSeconds: vi.fn(async (flyAppName: string) => {
+        if (flyAppName === 'bad') throw new Error('prometheus 502');
+        return 3600;
+      }),
+    });
+
+    const run = await reconciled(deps);
+
+    assert({
+      given: 'a Prometheus outage on one app mid-run',
+      should: 'count it failed and still compare the other',
+      actual: { processed: run.processed, failed: run.failed, compared: run.compared },
+      expected: { processed: 2, failed: 1, compared: 1 },
+    });
+  });
+
+  it('given the app list itself fails, should report rather than throw', async () => {
+    const { deps } = makeDeps({
+      listApps: async () => {
+        throw new Error('db down');
+      },
+    });
+
+    const run = await reconciled(deps);
+
+    expect({ processed: run.processed, compared: run.compared, failed: run.failed }).toEqual({
+      processed: 0,
+      compared: 0,
+      failed: 1,
+    });
+  });
+
+  it('keeps the window inside Prometheus’ ~15-day retention', async () => {
+    // Widening past retention would silently compare against samples that no
+    // longer exist, reading as a fleet-wide under-bill rather than missing data.
+    expect(AWAKE_RECONCILE_WINDOW_DAYS).toBeLessThan(15);
+    expect(AWAKE_RECONCILE_WINDOW_DAYS).toBeGreaterThanOrEqual(7);
+  });
+});

--- a/packages/lib/src/services/app-hosting/__tests__/provisioner-claim.integration.test.ts
+++ b/packages/lib/src/services/app-hosting/__tests__/provisioner-claim.integration.test.ts
@@ -251,13 +251,21 @@ describe('claimPublishedAppsForWork — the staleness filter is the query’s, n
  * not a small number, it is a silent credit against every other app's storage cost
  * — so the column is CHECK-constrained, and this is the test that the database
  * actually enforces it rather than the schema merely describing it.
+ *
+ * The size travels WITH `imageSizeMeasuredAt` (`published_apps_image_size_measured_coherent`),
+ * because the storage meter cannot use a measurement it cannot date — an undated
+ * size reads to it as "never measured" and bills the 0 floor forever while the
+ * watermark advances over real rootfs. Production never writes one without the
+ * other (`transitionPublishedApp` stamps the pair), so these tests write the pair
+ * too; the coherence constraint has its own coverage in
+ * `awake-metering.integration.test.ts`.
  */
 describe('published_apps.imageSizeBytes — the economics column', () => {
   it('given a negative size, should be rejected by Postgres', async () => {
     const appId = await seedApp('building');
     const error = await db
       .update(publishedApps)
-      .set({ imageSizeBytes: -1 })
+      .set({ imageSizeBytes: -1, imageSizeMeasuredAt: new Date() })
       .where(eq(publishedApps.id, appId))
       .then(() => null)
       .catch((err: unknown) => err);
@@ -274,7 +282,7 @@ describe('published_apps.imageSizeBytes — the economics column', () => {
     const appId = await seedApp('building');
     await db
       .update(publishedApps)
-      .set({ imageSizeBytes: 8_000_000_000 })
+      .set({ imageSizeBytes: 8_000_000_000, imageSizeMeasuredAt: new Date() })
       .where(eq(publishedApps.id, appId));
 
     const [row] = await db.select().from(publishedApps).where(eq(publishedApps.id, appId));

--- a/packages/lib/src/services/app-hosting/app-billing.ts
+++ b/packages/lib/src/services/app-hosting/app-billing.ts
@@ -55,7 +55,24 @@ export interface AppBillingDeps {
    * not meant to be one.
    */
   gate: (input: { payerId: string }) => Promise<{ allowed: boolean; holdId?: string; reason?: string }>;
-  /** Settles accrued awake-seconds against the wake's hold. Called by every heartbeat and once more at the stop boundary. */
+  /**
+   * Settles accrued awake-seconds against the wake's hold. Called by every
+   * heartbeat and once more at the stop boundary.
+   *
+   * CAVEAT, and it is a real one: the default binding goes through
+   * `AIMonitoring.trackUsage`, which CATCHES its own persistence failures — a
+   * failed `writeAiUsage`, or a `consumeCredits` that rejects — logs them, and
+   * resolves normally. So a resolved call here is NOT proof that a usage row or a
+   * ledger claim exists, and the callers' "a failed settle leaves the window open
+   * for the next tick" behaviour only covers a settle that actually throws.
+   *
+   * This is a property of the shared credit pipeline rather than of hosting —
+   * every meter in the repo that calls `trackUsage` inherits it, the sandbox
+   * storage reconcile included — so it is deliberately NOT worked around here
+   * with a second, hosting-only write path. Fixing it means giving
+   * `trackUsage` a durable-persistence result, which is a change with a
+   * platform-wide blast radius and belongs in its own PR.
+   */
   trackUsage: (input: {
     payerId: string;
     holdId?: string;

--- a/packages/lib/src/services/app-hosting/app-billing.ts
+++ b/packages/lib/src/services/app-hosting/app-billing.ts
@@ -1,0 +1,157 @@
+/**
+ * app-billing — the billing SEAM for published-app hosting, and its default
+ * (real) composition.
+ *
+ * Deliberately the same shape as `defaultSandboxBillingDeps`
+ * (`services/sandbox/sandbox-billing.ts`): resolve a payer, gate + hold, settle
+ * against the hold, release. Two meters, one credit pipeline, one vocabulary — a
+ * published app is metered through `canConsumeAI` / `AIMonitoring.trackUsage` /
+ * `releaseHold` exactly as a sandbox run is, so there is one place where money
+ * moves and one place where a gate can be got wrong.
+ *
+ * THE PAYER IS THE DRIVE OWNER, via `resolveEnvPayerId`. A published app hangs off
+ * an ENVIRONMENT, and an environment is drive-owned and drive-shared; billing is
+ * keyed to the environment and is deliberately substrate-agnostic, so nothing here
+ * names Fly. `published_apps.ownerId` is denormalized for indexing and cascade
+ * reach and is NOT consulted as the payer: a drive that changes hands, or an owner
+ * column that drifts from `drives.ownerId`, must not silently redirect a charge.
+ * An unresolvable drive yields NO payer, and the caller SKIPS rather than
+ * substituting one — a money movement to the wrong person cannot be taken back,
+ * while a skipped cycle self-corrects on the next tick.
+ *
+ * Everything here is dark behind `APP_HOSTING_ENABLED`: the callers
+ * (`app-lifecycle-metering`, `awake-meter`) check the kill switch before they ever
+ * reach these deps.
+ */
+
+import { eq } from '@pagespace/db/operators';
+import { db } from '@pagespace/db/db';
+import { users } from '@pagespace/db/schema/auth';
+import { canConsumeAI } from '../../billing/credit-gate';
+import { releaseHold as releaseCreditHold } from '../../billing/credit-consume';
+import {
+  MACHINE_MARKUP_BPS,
+  PUBLISHED_APP_DAILY_CAP_CEILING_CENTS,
+  PUBLISHED_APP_MAX_INFLIGHT,
+  PUBLISHED_APP_WAKE_HOLD_ESTIMATE_CENTS,
+} from '../../billing/credit-pricing';
+import { resolveEnvPayerId, lookupDriveOwnerId } from '../../billing/sandbox-payer';
+import { AIMonitoring } from '../../monitoring/ai-monitoring';
+import { calculateMachineCostDollars, PUBLISHED_APP_GUEST_SHAPE } from '../../monitoring/machine-pricing';
+import { toSubscriptionTier, type SubscriptionTier } from '../../billing/subscription-tiers';
+import { PUBLISHED_APP_AWAKE_MODEL } from '../../monitoring/usage-source';
+
+export interface AppBillingDeps {
+  /**
+   * Who pays for this app's runtime — the OWNING DRIVE's owner, with no fallback.
+   * Null means unresolvable (a stale read of a drive mid-delete): the caller
+   * refuses the wake or skips the settle rather than billing anyone else.
+   */
+  resolvePayerId: (input: { driveId: string }) => Promise<string | null>;
+  /**
+   * Balance check + reservation, run BEFORE the machine is started. This is the
+   * whole of hosting's credit enforcement: an exhausted payer is refused a wake
+   * and the router serves a parked page. There is no clawback path and there is
+   * not meant to be one.
+   */
+  gate: (input: { payerId: string }) => Promise<{ allowed: boolean; holdId?: string; reason?: string }>;
+  /** Settles accrued awake-seconds against the wake's hold. Called by every heartbeat and once more at the stop boundary. */
+  trackUsage: (input: {
+    payerId: string;
+    holdId?: string;
+    activeSeconds: number;
+    driveId: string;
+    publishedAppId: string;
+  }) => Promise<void>;
+  /** Releases a reservation without billing — every exit that never settles. */
+  releaseHold: (holdId: string) => Promise<void>;
+}
+
+/**
+ * The gate evaluates the PAYER's tier, never an acting user's. Nobody is
+ * necessarily "acting" at all when a published app wakes — the trigger is an
+ * inbound HTTP request from a stranger on the internet — so the tier has to be
+ * read from the resolved payer directly. Mirrors `resolvePayerTier` in
+ * sandbox-billing.ts.
+ */
+async function resolvePayerTier(payerId: string): Promise<SubscriptionTier> {
+  const [row] = await db
+    .select({ subscriptionTier: users.subscriptionTier })
+    .from(users)
+    .where(eq(users.id, payerId))
+    .limit(1);
+  return toSubscriptionTier(row?.subscriptionTier);
+}
+
+export const defaultAppBillingDeps: AppBillingDeps = {
+  resolvePayerId({ driveId }) {
+    // Called through a closure rather than passed unbound: `resolveEnvPayerId`
+    // invokes its input off its own object, and handing over a bare method
+    // reference would drop `this` for any non-literal deps implementation.
+    return resolveEnvPayerId({ driveId, lookupDriveOwnerId: (id) => lookupDriveOwnerId(id) });
+  },
+
+  async gate({ payerId }) {
+    const tier = await resolvePayerTier(payerId);
+    const result = await canConsumeAI(payerId, tier, {
+      estCostCents: PUBLISHED_APP_WAKE_HOLD_ESTIMATE_CENTS,
+      maxInFlight: PUBLISHED_APP_MAX_INFLIGHT,
+      // ALWAYS passed, in every deployment mode — this is the "unlimited but not
+      // unbounded" half of the tenant/onprem rule. `canConsumeAI` short-circuits
+      // to the query-free unlimited path when billing is disabled AND no ceiling
+      // is supplied; supplying one keeps a per-payer daily bound in force there,
+      // metered from `ai_usage_logs` since those deployments have no ledger.
+      dailyCapCeilingCents: PUBLISHED_APP_DAILY_CAP_CEILING_CENTS,
+    });
+    return {
+      allowed: result.allowed,
+      holdId: result.holdId,
+      reason: result.allowed ? undefined : result.reason,
+    };
+  },
+
+  async trackUsage({ payerId, holdId, activeSeconds, driveId, publishedAppId }) {
+    await AIMonitoring.trackUsage({
+      userId: payerId,
+      // The substrate, named where substrate names belong — in the usage row's
+      // provider field, not in the payer resolution or the billed unit above it.
+      provider: 'fly',
+      // The BILLED UNIT. Shared constant rather than a literal because the usage
+      // breakdown splits on exactly this string (a hosting row and a terminal row
+      // both carry `source: 'terminal'` and no `pageId`).
+      model: PUBLISHED_APP_AWAKE_MODEL,
+      // One feature bucket with the rest of sandbox/substrate runtime: splitting
+      // the source would fragment the usage breakdown's totals for no gain the
+      // model label does not already give.
+      source: 'terminal',
+      // No pageId — a published app serves an environment, not a page.
+      pageId: undefined,
+      // First-class drive attribution, so hosting spend can be grouped by drive
+      // without JSON forensics. An app's drive is NOT NULL by construction.
+      driveId,
+      // `AIUsageData.sessionId` is the shared analytics column written by many
+      // sources; map at the boundary. Carries the `published_apps` id — `model`
+      // above is what says which table that id addresses.
+      sessionId: publishedAppId,
+      // Priced at the app's KNOWN guest, not the sandbox's assumed one.
+      providerCostDollars: calculateMachineCostDollars({
+        activeSeconds,
+        shape: PUBLISHED_APP_GUEST_SHAPE,
+      }),
+      duration: Math.round(activeSeconds * 1000),
+      success: true,
+      holdId,
+      // The same 1.5x substrate floor every machine meter uses, independent of
+      // the shared AI markup default.
+      markupBpsOverride: MACHINE_MARKUP_BPS,
+      // Deterministic list price (awake seconds x published rate), never a
+      // provider-returned figure — Fly has no billing API.
+      costSource: 'list_price',
+      metadata: { type: 'published_app_awake', activeSeconds },
+    });
+  },
+
+  async releaseHold(holdId) {
+    await releaseCreditHold(holdId);
+  },
+};

--- a/packages/lib/src/services/app-hosting/app-lifecycle-metering.ts
+++ b/packages/lib/src/services/app-hosting/app-lifecycle-metering.ts
@@ -331,6 +331,12 @@ async function settleAndClose(
         // lose the app's last awake window. The status still moves below — the
         // machine really did stop, and leaving a `running` row over it would be
         // worse than a window that gets retried.
+        //
+        // Reached only when the settle actually THROWS. The default binding runs
+        // through `AIMonitoring.trackUsage`, which swallows its own persistence
+        // failures and resolves — see the caveat on `AppBillingDeps.trackUsage`.
+        // So this covers a deps-level or transport failure, not a lost ledger
+        // write, and it is not the whole guarantee the shape suggests.
         loggers.ai.error(
           'Published-app final settle failed — the awake window stays open for the next tick to retry',
           error instanceof Error ? error : new Error(String(error)),

--- a/packages/lib/src/services/app-hosting/app-lifecycle-metering.ts
+++ b/packages/lib/src/services/app-hosting/app-lifecycle-metering.ts
@@ -1,0 +1,419 @@
+/**
+ * app-lifecycle-metering — the WAKE and STOP seams for a published app, and the
+ * only two places an awake window is opened or closed.
+ *
+ * The whole metering design rests on one property: our orchestrator owns every
+ * start and stop (`autostop: "off"`), so a billing boundary is an API call we made
+ * at a time we know exactly, rather than a proxy behavior we would have to infer.
+ * These two functions ARE that ownership. Anything that starts or stops a
+ * published app's machine without going through them opens a window nobody closes
+ * or closes one nobody opened.
+ *
+ * Ordering, and which way each crash window fails:
+ *
+ *  - WAKE gates and holds BEFORE the machine starts, and stamps the boundary
+ *    AFTER Fly confirms the start. A crash in between leaves a machine awake that
+ *    our row calls `stopped` — the platform eats that time and the customer is
+ *    never billed for it. The reverse ordering would bill a customer for a machine
+ *    that failed to start, which is the unacceptable direction. The weekly
+ *    `fly_instance_up` reconcile is what surfaces it (Fly saw awake time we never
+ *    billed → `under_billed` drift).
+ *  - STOP asks Fly to stop, mirrors the boundary, and only then settles and closes
+ *    the window. A crash between the stop and the settle leaves a `running` row
+ *    over a stopped machine — but the boundary is already in the mirror, so the
+ *    next heartbeat finds it (`findStopBoundarySince`), settles only up to the real
+ *    stop, and closes the window itself. That self-heal is why the mirror write
+ *    comes before the money.
+ *
+ * Everything is dark behind `APP_HOSTING_ENABLED`, checked before any read.
+ */
+
+import { and, eq } from '@pagespace/db/operators';
+import { db } from '@pagespace/db/db';
+import { publishedApps, type PublishedApp } from '@pagespace/db/schema/published-apps';
+import { loggers } from '../../logging/logger-config';
+import {
+  isAppHostingEnabled,
+  resolveFlyMachinesToken,
+} from './app-hosting-env';
+import {
+  listMachineEvents as flapsListMachineEvents,
+  startMachine as flapsStartMachine,
+  stopMachine as flapsStopMachine,
+  type FlapsTransport,
+  type MachineEvent,
+} from '../fly/flaps-client';
+import { defaultAppBillingDeps, type AppBillingDeps } from './app-billing';
+import {
+  findStopBoundarySince,
+  mirrorFlyMachineEvents,
+  recordOrchestratorBoundary,
+} from './app-machine-events';
+import { planAwakeSettle } from './app-metering-core';
+import { planTransition } from './provisioner-core';
+
+export interface AppLifecycleMeteringDeps {
+  isEnabled: () => boolean;
+  billing: AppBillingDeps;
+  startMachine: (flyAppName: string, machineId: string) => Promise<void>;
+  stopMachine: (flyAppName: string, machineId: string) => Promise<void>;
+  /** Fly's last-20 event window for one machine. Mirroring is best-effort, so a throw here is caught and counted, never propagated. */
+  listMachineEvents: (flyAppName: string, machineId: string) => Promise<MachineEvent[]>;
+  now: () => Date;
+}
+
+function defaultTransport(): FlapsTransport {
+  return { token: resolveFlyMachinesToken() };
+}
+
+export const defaultAppLifecycleMeteringDeps: AppLifecycleMeteringDeps = {
+  isEnabled: isAppHostingEnabled,
+  billing: defaultAppBillingDeps,
+  startMachine: (flyAppName, machineId) => flapsStartMachine(defaultTransport(), flyAppName, machineId),
+  stopMachine: (flyAppName, machineId) => flapsStopMachine(defaultTransport(), flyAppName, machineId),
+  listMachineEvents: (flyAppName, machineId) =>
+    flapsListMachineEvents(defaultTransport(), flyAppName, machineId),
+  now: () => new Date(),
+};
+
+export type WakeRefusal =
+  | 'disabled'
+  | 'not_found'
+  /** The row has no machine to start (never deployed, or mid blue/green swap). */
+  | 'no_machine'
+  /** The row is not in a state a wake may leave — already running, destroying, failed. */
+  | 'not_wakeable'
+  /** The owning drive could not be resolved, so there is no honest payer. Nothing is started. */
+  | 'unresolved_payer';
+
+export type WakePublishedAppResult =
+  | { outcome: 'woken'; app: PublishedApp; holdId?: string }
+  /** The gate refused: the app is PARKED and the router serves a parked page. Enforcement is "don't wake", never a clawback. */
+  | { outcome: 'parked'; reason: string }
+  /** Fly refused the start. The hold is released; nothing is billed and nothing is stamped. */
+  | { outcome: 'start_failed'; error: string }
+  | { outcome: 'refused'; reason: WakeRefusal };
+
+/**
+ * Wake a published app: gate the payer, place a hold, start the machine, open the
+ * awake window.
+ *
+ * THE GATE RUNS BEFORE THE MACHINE STARTS, which is the entire credit enforcement
+ * story for hosting. An exhausted payer's app is moved to `parked` and never
+ * started, so there is nothing to claw back and no negative balance to chase — the
+ * epic's D7 decision made literal.
+ */
+export async function wakePublishedApp(
+  publishedAppId: string,
+  deps: AppLifecycleMeteringDeps = defaultAppLifecycleMeteringDeps,
+): Promise<WakePublishedAppResult> {
+  if (!deps.isEnabled()) return { outcome: 'refused', reason: 'disabled' };
+
+  const [row] = await db
+    .select()
+    .from(publishedApps)
+    .where(eq(publishedApps.id, publishedAppId))
+    .limit(1);
+  if (!row) return { outcome: 'refused', reason: 'not_found' };
+  if (!row.machineId) return { outcome: 'refused', reason: 'no_machine' };
+  // Judged against the SAME pure planner the transition itself uses, with the
+  // columns as they will be after the write. Asking here means a wake that the
+  // status machine would refuse never reaches Fly — otherwise we would start a
+  // machine and then discover we cannot record that we did.
+  const plan = planTransition(row.status, 'running', {
+    imageDigest: row.imageDigest,
+    machineId: row.machineId,
+    tier: row.tier,
+  });
+  if (!plan.allowed) return { outcome: 'refused', reason: 'not_wakeable' };
+
+  const payerId = await deps.billing.resolvePayerId({ driveId: row.driveId });
+  // No fallback, by design: an app is drive-owned, and `published_apps.ownerId`
+  // is a denormalized cascade handle, not an answer to "who pays". Billing a
+  // machine to somebody who may not own the drive is a money movement that cannot
+  // be taken back; refusing the wake costs one request a parked page.
+  if (!payerId) return { outcome: 'refused', reason: 'unresolved_payer' };
+
+  const gate = await deps.billing.gate({ payerId });
+  if (!gate.allowed) {
+    await parkPublishedApp(row, gate.reason ?? 'insufficient_credits');
+    return { outcome: 'parked', reason: gate.reason ?? 'insufficient_credits' };
+  }
+
+  try {
+    await deps.startMachine(row.flyAppName, row.machineId);
+  } catch (error) {
+    // Nothing started, so nothing may be billed. Release the reservation rather
+    // than leaving it to expire — a stranded hold suppresses the payer's own
+    // spendable balance for the whole hold TTL.
+    if (gate.holdId) await deps.billing.releaseHold(gate.holdId);
+    return { outcome: 'start_failed', error: error instanceof Error ? error.message : String(error) };
+  }
+
+  const wokenAt = deps.now();
+  const ref = { publishedAppId: row.id, flyAppName: row.flyAppName, machineId: row.machineId };
+  await recordOrchestratorBoundary(ref, 'start', wokenAt);
+  await mirrorRecentFlyEvents(ref, deps);
+
+  // The status and both stamps land in ONE statement, guarded on the status we
+  // planned against. A concurrent wake (two requests racing the same cold app)
+  // therefore produces one winner: the loser's UPDATE matches no row, and it
+  // releases its own hold instead of overwriting the winner's window start with a
+  // later one — which would silently forgive the seconds in between.
+  const [updated] = await db
+    .update(publishedApps)
+    .set({
+      status: 'running',
+      lastWakeAt: wokenAt,
+      awakeBilledThrough: wokenAt,
+      awakeHoldId: gate.holdId ?? null,
+    })
+    .where(and(eq(publishedApps.id, row.id), eq(publishedApps.status, row.status)))
+    .returning();
+
+  if (!updated) {
+    // Someone else won the race and owns the window now. Our hold reserves
+    // against a window we will never settle, so release it.
+    if (gate.holdId) await deps.billing.releaseHold(gate.holdId);
+    return { outcome: 'refused', reason: 'not_wakeable' };
+  }
+  return { outcome: 'woken', app: updated, holdId: gate.holdId };
+}
+
+/** Why a stop happened. `insolvent` parks the app instead of merely stopping it — the credit gate refusing to keep it awake. */
+export type StopReason = 'idle' | 'insolvent' | 'operator';
+
+export type StopPublishedAppResult =
+  | { outcome: 'stopped'; status: 'stopped' | 'parked'; billedSeconds: number }
+  /** Fly refused the stop. The window stays OPEN and keeps billing — the machine may well still be running. */
+  | { outcome: 'stop_failed'; error: string }
+  | { outcome: 'refused'; reason: 'disabled' | 'not_found' | 'not_running' | 'illegal_transition' };
+
+/**
+ * Stop a published app: stop the machine, mirror the boundary, settle the tail of
+ * the awake window, and close it.
+ *
+ * `reason: 'insolvent'` lands the app in `parked` rather than `stopped`, through
+ * the status machine's own legal `running → parked` edge — parking is the credit
+ * gate's enforcement state, and the difference is load-bearing downstream: a
+ * `stopped` app wakes on the next request and a `parked` one does not.
+ *
+ * The final settle bills through `now`, which on THIS path IS the real boundary:
+ * Fly has just confirmed the stop, so the machine went down at the instant we are
+ * about to stamp. The other case — a stop that already happened and whose status
+ * write was lost — is not repaired here but by the heartbeat, which finds the
+ * boundary in the mirror and closes the window at it through
+ * `closeAppWindowAtBoundary`.
+ */
+export async function stopPublishedApp(
+  publishedAppId: string,
+  reason: StopReason,
+  deps: AppLifecycleMeteringDeps = defaultAppLifecycleMeteringDeps,
+): Promise<StopPublishedAppResult> {
+  if (!deps.isEnabled()) return { outcome: 'refused', reason: 'disabled' };
+
+  const [row] = await db
+    .select()
+    .from(publishedApps)
+    .where(eq(publishedApps.id, publishedAppId))
+    .limit(1);
+  if (!row) return { outcome: 'refused', reason: 'not_found' };
+  if (row.status !== 'running') return { outcome: 'refused', reason: 'not_running' };
+
+  const nextStatus: 'stopped' | 'parked' = reason === 'insolvent' ? 'parked' : 'stopped';
+  // Asked BEFORE the Fly call, against the same pure planner the write uses. A
+  // dedicated app cannot be parked (`parked_is_metered_only`), and discovering
+  // that after stopping its machine would leave a stopped machine on a `running`
+  // row for the heartbeat to keep billing.
+  const plan = planTransition(row.status, nextStatus, {
+    imageDigest: row.imageDigest,
+    machineId: row.machineId,
+    tier: row.tier,
+  });
+  if (!plan.allowed) return { outcome: 'refused', reason: 'illegal_transition' };
+
+  if (row.machineId) {
+    try {
+      await deps.stopMachine(row.flyAppName, row.machineId);
+    } catch (error) {
+      // The window stays open deliberately. A failed stop very likely means the
+      // machine is still running and still costing money; closing the window here
+      // would stop billing awake time the payer is genuinely consuming.
+      return { outcome: 'stop_failed', error: error instanceof Error ? error.message : String(error) };
+    }
+  }
+
+  const stoppedAt = deps.now();
+  if (row.machineId) {
+    const ref = { publishedAppId: row.id, flyAppName: row.flyAppName, machineId: row.machineId };
+    // BEFORE the money, on purpose: if everything below is lost to a crash, this
+    // row is what lets the next heartbeat close the window at the real boundary
+    // instead of billing a stopped machine.
+    await recordOrchestratorBoundary(ref, 'stop', stoppedAt);
+    await mirrorRecentFlyEvents(ref, deps);
+  }
+
+  const settled = await settleAndClose(row, stoppedAt, nextStatus, stoppedAt, deps);
+  return { outcome: 'stopped', status: nextStatus, billedSeconds: settled.billedSeconds };
+}
+
+/**
+ * Move an app to `parked` without billing anything — the wake gate's refusal path.
+ *
+ * Not routed through `stopPublishedApp`: nothing was started, so there is no
+ * machine to stop, no window to settle and no hold to carry. It is a status write
+ * and nothing else, still made through the pure planner so a `dedicated` app (which
+ * cannot be parked) is refused here rather than by a constraint violation.
+ */
+async function parkPublishedApp(row: PublishedApp, reason: string): Promise<void> {
+  const plan = planTransition(row.status, 'parked', {
+    imageDigest: row.imageDigest,
+    machineId: row.machineId,
+    tier: row.tier,
+  });
+  if (!plan.allowed) {
+    loggers.ai.warn('Published app could not be parked after a gate refusal', {
+      publishedAppId: row.id,
+      from: row.status,
+      refusal: plan.reason,
+      reason,
+    });
+    return;
+  }
+  await db
+    .update(publishedApps)
+    .set({ status: 'parked', lastError: `parked: ${reason}` })
+    .where(and(eq(publishedApps.id, row.id), eq(publishedApps.status, row.status)));
+}
+
+export interface SettleAndCloseResult {
+  billedSeconds: number;
+  /** The settle threw. The window is left OPEN so the next tick retries it rather than losing it. */
+  failed: boolean;
+}
+
+/**
+ * Settle the tail of an awake window and close it — the shared ending for the stop
+ * seam and for the heartbeat's mirror-driven repair.
+ *
+ * `billedThrough` is the instant the window really ended, which is NOT always
+ * `now`: a repair closes at the mirrored stop boundary. `stampedStopAt` is what
+ * lands in `lastStopAt`, the boundary column the weekly reconcile reads.
+ *
+ * The hold is disposed of exactly once, whichever way the window ends: settled
+ * against by `trackUsage` when there are seconds to bill, released otherwise. A
+ * hold left behind would suppress the payer's spendable balance for its whole TTL.
+ */
+async function settleAndClose(
+  row: PublishedApp,
+  billedThrough: Date,
+  nextStatus: 'stopped' | 'parked',
+  stampedStopAt: Date,
+  deps: AppLifecycleMeteringDeps,
+): Promise<SettleAndCloseResult> {
+  const plan = planAwakeSettle({ billedThrough: row.awakeBilledThrough, now: billedThrough });
+  let billedSeconds = 0;
+  if (plan.action === 'settle') {
+    const payerId = await deps.billing.resolvePayerId({ driveId: row.driveId });
+    if (payerId) {
+      try {
+        await deps.billing.trackUsage({
+          payerId,
+          holdId: row.awakeHoldId ?? undefined,
+          activeSeconds: plan.activeSeconds,
+          driveId: row.driveId,
+          publishedAppId: row.id,
+        });
+        billedSeconds = plan.activeSeconds;
+      } catch (error) {
+        // The window is NOT closed on a failed settle: leaving it open means the
+        // next heartbeat retries the whole span, where closing it would silently
+        // lose the app's last awake window. The status still moves below — the
+        // machine really did stop, and leaving a `running` row over it would be
+        // worse than a window that gets retried.
+        loggers.ai.error(
+          'Published-app final settle failed — the awake window stays open for the next tick to retry',
+          error instanceof Error ? error : new Error(String(error)),
+          { publishedAppId: row.id, driveId: row.driveId, activeSeconds: plan.activeSeconds },
+        );
+        await closeStatusOnly(row, nextStatus, stampedStopAt);
+        return { billedSeconds: 0, failed: true };
+      }
+    } else {
+      // Unresolvable drive: skip the charge rather than misattribute it, exactly
+      // as the storage reconcile does. The hold is still released below — it
+      // reserves against a window nobody will ever settle.
+      loggers.ai.warn('Published-app final settle skipped: the owning drive could not be resolved', {
+        publishedAppId: row.id,
+        driveId: row.driveId,
+      });
+      if (row.awakeHoldId) await deps.billing.releaseHold(row.awakeHoldId);
+    }
+  } else if (row.awakeHoldId) {
+    // Nothing to bill (no window, or no time in it) — the reservation is returned
+    // rather than settled.
+    await deps.billing.releaseHold(row.awakeHoldId);
+  }
+
+  await db
+    .update(publishedApps)
+    .set({
+      status: nextStatus,
+      lastStopAt: stampedStopAt,
+      awakeBilledThrough: null,
+      awakeHoldId: null,
+    })
+    .where(and(eq(publishedApps.id, row.id), eq(publishedApps.status, 'running')));
+  return { billedSeconds, failed: false };
+}
+
+/**
+ * Close the STATUS without closing the billing window — the failed-settle path.
+ * `awakeBilledThrough` deliberately survives, so the unbilled span is retried
+ * instead of being forgiven, while the row stops claiming to be running.
+ */
+async function closeStatusOnly(
+  row: PublishedApp,
+  nextStatus: 'stopped' | 'parked',
+  stampedStopAt: Date,
+): Promise<void> {
+  await db
+    .update(publishedApps)
+    .set({ status: nextStatus, lastStopAt: stampedStopAt })
+    .where(and(eq(publishedApps.id, row.id), eq(publishedApps.status, 'running')));
+}
+
+/**
+ * Settle a window the mirror says already ended, and close it at the REAL boundary
+ * — the heartbeat's self-heal for a stop whose status write was lost.
+ *
+ * Exported for the meter rather than inlined there so the "settle then close"
+ * sequence, and its hold disposal, exist in exactly one place.
+ */
+export async function closeAppWindowAtBoundary(
+  row: PublishedApp,
+  boundary: Date,
+  deps: AppLifecycleMeteringDeps,
+): Promise<SettleAndCloseResult> {
+  return settleAndClose(row, boundary, 'stopped', boundary, deps);
+}
+
+/** Best-effort mirroring of Fly's last-20 window; a failure is logged inside and never propagates. */
+async function mirrorRecentFlyEvents(
+  ref: { publishedAppId: string; flyAppName: string; machineId: string },
+  deps: AppLifecycleMeteringDeps,
+): Promise<void> {
+  try {
+    const events = await deps.listMachineEvents(ref.flyAppName, ref.machineId);
+    await mirrorFlyMachineEvents(ref, events);
+  } catch (error) {
+    loggers.ai.warn('Published-app Fly event window could not be read for mirroring', {
+      publishedAppId: ref.publishedAppId,
+      machineId: ref.machineId,
+      error: error instanceof Error ? error.message : String(error),
+    });
+  }
+}
+
+/** Re-exported so the meter reads its repair boundary through the same module the writes go through. */
+export { findStopBoundarySince };

--- a/packages/lib/src/services/app-hosting/app-machine-events.ts
+++ b/packages/lib/src/services/app-hosting/app-machine-events.ts
@@ -1,0 +1,233 @@
+/**
+ * app-machine-events — writing and reading the LOCAL MIRROR of a published app's
+ * machine lifecycle.
+ *
+ * Fly retains only the most recent 20 events per machine, with no pagination and
+ * no time window (`listMachineEvents`). About five stop/start cycles. So
+ * **awake-seconds history cannot be rebuilt from Fly after the fact** and the
+ * mirror is not a cache of Fly's log — it is the record, written as the boundaries
+ * happen. Everything here exists to keep that record honest:
+ *
+ *  - `recordOrchestratorBoundary` writes OUR OWN start/stop at the moment we make
+ *    the call. `autostop` is off precisely so these are the boundaries that matter.
+ *  - `mirrorFlyMachineEvents` opportunistically copies Fly's own view while the
+ *    last-20 window still holds it — confirmation and drift detection, and the only
+ *    way a boundary we did NOT ask for (an OOM kill, a host migration) is ever seen.
+ *  - `findStopBoundarySince` is the SELF-HEAL: it lets the meter discover that a
+ *    machine stopped even though the row still says `running`, and close the window
+ *    at the real boundary instead of billing a stopped machine until the weekly
+ *    reconcile notices.
+ *
+ * Mirroring is BEST-EFFORT by construction. It runs after a lifecycle call has
+ * already succeeded, and a failure to write an audit row must never turn a
+ * successful wake into a failed one — so every function here reports rather than
+ * throws, and the caller carries on.
+ */
+
+import { and, desc, eq, gt, gte, inArray, lte, sql } from '@pagespace/db/operators';
+import { db } from '@pagespace/db/db';
+import { publishedAppMachineEvents } from '@pagespace/db/schema/published-apps';
+import { loggers } from '../../logging/logger-config';
+import { classifyFlyEventAction, flyEventInstant } from './app-metering-core';
+import type { MachineEvent } from '../fly/flaps-client';
+
+export interface MachineBoundaryRef {
+  publishedAppId: string;
+  flyAppName: string;
+  machineId: string;
+}
+
+/**
+ * Record an awake boundary WE caused, at the instant we caused it.
+ *
+ * Written unconditionally — including for a call whose effect was a no-op (Fly's
+ * start and stop are idempotent, so a second start against an already-running
+ * machine changes nothing). That is deliberate: the row says "we asked for this at
+ * this time", which is the fact the reconcile needs, and suppressing the no-ops
+ * would make the mirror silently disagree with the calls we actually made.
+ *
+ * Never throws. Returns false when the row could not be written, so the caller can
+ * count a mirror gap rather than mistake it for an absent boundary.
+ */
+export async function recordOrchestratorBoundary(
+  ref: MachineBoundaryRef,
+  action: 'start' | 'stop',
+  occurredAt: Date,
+): Promise<boolean> {
+  try {
+    await db.insert(publishedAppMachineEvents).values({
+      publishedAppId: ref.publishedAppId,
+      flyAppName: ref.flyAppName,
+      machineId: ref.machineId,
+      origin: 'orchestrator',
+      action,
+      occurredAt,
+    });
+    return true;
+  } catch (error) {
+    // The severity is real and the response is still "carry on": the machine has
+    // already started or stopped, and refusing to proceed because an audit row
+    // failed would leave the far more dangerous state (a live machine with no
+    // status of its own). Logged loudly because a persistent failure here means
+    // the primary billing record is not being written.
+    loggers.ai.error(
+      'Published-app machine boundary could not be mirrored — this awake boundary is not recoverable from Fly',
+      error instanceof Error ? error : new Error(String(error)),
+      { publishedAppId: ref.publishedAppId, machineId: ref.machineId, action },
+    );
+    return false;
+  }
+}
+
+export interface MirrorFlyEventsResult {
+  /** Events Fly returned that we recognised as awake boundaries. */
+  boundaries: number;
+  /** Rows actually inserted — lower than `boundaries` when the window still held events we had already mirrored. */
+  inserted: number;
+  /** The read or the write failed; nothing (or only part) was mirrored this pass. */
+  failed: boolean;
+}
+
+/**
+ * Copy Fly's own event log for one machine into the mirror, idempotently.
+ *
+ * Called right after our own start/stop, while the last-20 window is guaranteed to
+ * contain the event Fly logged for that call. Only events that classify as an
+ * awake boundary are stored: Fly's event vocabulary is open, and a type we do not
+ * recognise must fold to "not a boundary" rather than be guessed at — a fabricated
+ * boundary in the one table that cannot be rebuilt is worse than a missing one.
+ *
+ * Idempotency is the database's, not ours: the partial unique index on
+ * `(machineId, flyEventId)` makes re-mirroring the same window a no-op, so this
+ * can be called as often as it is useful without accumulating duplicates.
+ */
+export async function mirrorFlyMachineEvents(
+  ref: MachineBoundaryRef,
+  events: readonly MachineEvent[],
+): Promise<MirrorFlyEventsResult> {
+  const rows = events.flatMap((event) => {
+    const action = classifyFlyEventAction(typeof event.type === 'string' ? event.type : undefined);
+    const occurredAt = flyEventInstant(event.timestamp);
+    // An event with no usable id cannot be de-duplicated, and one with no usable
+    // instant would be dated to the epoch — which the reconcile would read as a
+    // decades-long awake window. Both are dropped rather than stored wrong.
+    if (action === null || occurredAt === null || typeof event.id !== 'string' || event.id === '') return [];
+    return [{
+      publishedAppId: ref.publishedAppId,
+      flyAppName: ref.flyAppName,
+      machineId: ref.machineId,
+      origin: 'fly' as const,
+      action,
+      flyEventId: event.id,
+      flyEventType: typeof event.type === 'string' ? event.type : null,
+      flyEventStatus: typeof event.status === 'string' ? event.status : null,
+      occurredAt,
+    }];
+  });
+  if (rows.length === 0) return { boundaries: 0, inserted: 0, failed: false };
+  try {
+    const inserted = await db
+      .insert(publishedAppMachineEvents)
+      .values(rows)
+      .onConflictDoNothing({
+        target: [publishedAppMachineEvents.machineId, publishedAppMachineEvents.flyEventId],
+        // The index is PARTIAL, and Postgres only infers a partial index as the
+        // ON CONFLICT arbiter when its predicate is restated here (the same
+        // requirement `credit_ledger_stripe_ref_unique` documents in
+        // credit-gate.ts). Omit it and the statement finds no arbiter and throws,
+        // turning every re-mirror into a mirroring outage.
+        where: sql`${publishedAppMachineEvents.flyEventId} IS NOT NULL`,
+      })
+      .returning({ id: publishedAppMachineEvents.id });
+    return { boundaries: rows.length, inserted: inserted.length, failed: false };
+  } catch (error) {
+    loggers.ai.error(
+      'Published-app Fly event mirror failed — confirmation for these boundaries is lost once the last-20 window rolls',
+      error instanceof Error ? error : new Error(String(error)),
+      { publishedAppId: ref.publishedAppId, machineId: ref.machineId, boundaries: rows.length },
+    );
+    return { boundaries: rows.length, inserted: 0, failed: true };
+  }
+}
+
+/**
+ * The most recent STOP boundary for this machine strictly after `since`, from
+ * either origin — the meter's self-heal.
+ *
+ * A row can be left saying `running` while its machine is not: a stop call that
+ * succeeded at Fly and then crashed before the status write, or a machine Fly took
+ * down on its own. Both would otherwise bill a stopped machine every tick until the
+ * weekly reconcile. This is how the meter finds the real boundary and closes the
+ * window at it instead.
+ *
+ * Deliberately takes the LATEST such stop rather than the earliest: between `since`
+ * and now the machine may have stopped, been restarted by a wake we did record, and
+ * stopped again. Closing at the earliest would forgive real awake time in between;
+ * the latest is the boundary the window is actually still open past.
+ *
+ * Only STOPS after a start are meaningful here — a stop preceding this window's
+ * start belongs to the previous window — which is what `since` (the billing
+ * watermark, itself never earlier than the wake) enforces.
+ */
+export async function findStopBoundarySince(
+  machineId: string,
+  since: Date,
+  now: Date,
+): Promise<Date | null> {
+  const [row] = await db
+    .select({ occurredAt: publishedAppMachineEvents.occurredAt })
+    .from(publishedAppMachineEvents)
+    .where(
+      and(
+        eq(publishedAppMachineEvents.machineId, machineId),
+        eq(publishedAppMachineEvents.action, 'stop'),
+        gt(publishedAppMachineEvents.occurredAt, since),
+        // A boundary dated in the future (clock skew between containers) must not
+        // close a window early and forgive real awake time.
+        lte(publishedAppMachineEvents.occurredAt, now),
+      ),
+    )
+    .orderBy(desc(publishedAppMachineEvents.occurredAt))
+    .limit(1);
+  return row?.occurredAt ?? null;
+}
+
+/**
+ * Every awake boundary this app crossed inside a window, oldest first — the local
+ * side of the weekly `fly_instance_up` comparison.
+ *
+ * Both origins are read together and treated as one stream. They are separate ROWS
+ * because they answer different questions, but for "was this machine up?" our own
+ * start and Fly's logged start are the same crossing seen twice, and
+ * `awakeSecondsFromEvents` already ignores a start while started and a stop while
+ * stopped — so the duplication collapses in the arithmetic rather than needing a
+ * lossy de-duplication here.
+ */
+export async function listBoundaryEvents(
+  publishedAppId: string,
+  from: Date,
+  until: Date,
+): Promise<Array<{ action: 'start' | 'stop'; occurredAt: Date }>> {
+  const rows = await db
+    .select({
+      action: publishedAppMachineEvents.action,
+      occurredAt: publishedAppMachineEvents.occurredAt,
+    })
+    .from(publishedAppMachineEvents)
+    .where(
+      and(
+        eq(publishedAppMachineEvents.publishedAppId, publishedAppId),
+        gte(publishedAppMachineEvents.occurredAt, from),
+        lte(publishedAppMachineEvents.occurredAt, until),
+        inArray(publishedAppMachineEvents.action, ['start', 'stop']),
+      ),
+    )
+    .orderBy(publishedAppMachineEvents.occurredAt);
+  // The column is a plain text column with a CHECK, so narrow at the boundary
+  // rather than casting: an unexpected value is dropped, never billed as a start.
+  return rows.flatMap((row) =>
+    row.action === 'start' || row.action === 'stop'
+      ? [{ action: row.action, occurredAt: row.occurredAt }]
+      : [],
+  );
+}

--- a/packages/lib/src/services/app-hosting/app-machine-events.ts
+++ b/packages/lib/src/services/app-hosting/app-machine-events.ts
@@ -225,9 +225,51 @@ export async function listBoundaryEvents(
     .orderBy(publishedAppMachineEvents.occurredAt);
   // The column is a plain text column with a CHECK, so narrow at the boundary
   // rather than casting: an unexpected value is dropped, never billed as a start.
-  return rows.flatMap((row) =>
+  // Annotated rather than inferred: assigning to a local drops the contextual
+  // typing the return position used to supply, and the narrowing collapses to
+  // `string`.
+  const inWindow: Array<{ action: 'start' | 'stop'; occurredAt: Date }> = rows.flatMap((row) =>
     row.action === 'start' || row.action === 'stop'
       ? [{ action: row.action, occurredAt: row.occurredAt }]
       : [],
   );
+
+  // SEED THE WINDOW WITH THE STATE AT `from`.
+  //
+  // Boundaries inside the window are not enough to say whether the machine was up
+  // at the start of it. An app woken ten days ago and still running has NO events
+  // in a seven-day window, and would otherwise reconcile as zero local seconds
+  // against a full week of `fly_instance_up` — a fleet-wide false `under_billed`
+  // on exactly the longest-running apps. The mirror image is an app that was
+  // already up and stopped inside the window: its stop has no matching start, and
+  // `awakeSecondsFromEvents` correctly ignores an unmatched stop, so that span
+  // would vanish too.
+  //
+  // So look at the last boundary at or before `from`. If the machine was UP then,
+  // synthesise a start at the window edge — the seconds before `from` belong to
+  // the previous window, and clamping here is what keeps them out of this one.
+  const openAtStart = await wasAwakeAt(publishedAppId, from);
+  return openAtStart ? [{ action: 'start' as const, occurredAt: from }, ...inWindow] : inWindow;
+}
+
+/**
+ * Was this app's machine up at `instant`, per the last boundary recorded at or
+ * before it? False when the mirror holds nothing that early — an app with no
+ * history before the window is one we cannot claim was running, and claiming it
+ * was would invent awake time.
+ */
+async function wasAwakeAt(publishedAppId: string, instant: Date): Promise<boolean> {
+  const [row] = await db
+    .select({ action: publishedAppMachineEvents.action })
+    .from(publishedAppMachineEvents)
+    .where(
+      and(
+        eq(publishedAppMachineEvents.publishedAppId, publishedAppId),
+        lte(publishedAppMachineEvents.occurredAt, instant),
+        inArray(publishedAppMachineEvents.action, ['start', 'stop']),
+      ),
+    )
+    .orderBy(desc(publishedAppMachineEvents.occurredAt))
+    .limit(1);
+  return row?.action === 'start';
 }

--- a/packages/lib/src/services/app-hosting/app-metering-core.ts
+++ b/packages/lib/src/services/app-hosting/app-metering-core.ts
@@ -1,0 +1,229 @@
+/**
+ * app-metering-core — the PURE arithmetic and decisions behind the published-app
+ * awake-seconds drain.
+ *
+ * INVARIANT: zero I/O. No db, no fetch, no env, no clock. Every input is an
+ * explicit argument, every output is a value, and nothing throws — the same
+ * arrangement as `provisioner-core` beside it and `credit-core` in billing, and
+ * for the same reason: this is money arithmetic, and money arithmetic should be
+ * exhaustively testable without a database.
+ *
+ * WHAT IS BILLED. A published app's machine runs with `autostop: "off"`, so every
+ * awake boundary is an API call WE made. The billed quantity is therefore exact
+ * wall-clock seconds between our own boundaries — not an inference from proxy
+ * behavior, and not a figure Fly hands us (there is no billing API). Only the
+ * machine SHAPE is assumed, exactly as it is for sandbox runtime: see
+ * `calculateMachineCostDollars`, which both meters share.
+ */
+
+/**
+ * The longest span one settle may bill.
+ *
+ * The machine really was awake for however long it was awake, so this cap FORGIVES
+ * REVENUE rather than protecting the payer from an over-bill — the opposite
+ * direction from most clamps. It is here for the failure mode that has no other
+ * bound: a row stuck at `running` because a stop call failed to stamp its boundary
+ * accrues awake-seconds forever against a machine that is not running, and every
+ * tick of that is a charge to a real person for nothing. One day per settle bounds
+ * how much any single tick can be wrong by, and the weekly `fly_instance_up`
+ * reconcile is what actually catches the stuck row.
+ *
+ * It does NOT bound the cumulative error — a stuck row keeps accruing a capped day
+ * per tick. That is deliberate: capping cumulatively would mean silently deciding
+ * not to bill a genuinely long-running app, which is the product working as sold.
+ */
+export const MAX_AWAKE_SETTLE_SPAN_MS = 24 * 60 * 60 * 1000;
+
+/** Seconds, from a millisecond span. Negative and non-finite spans price to 0, never to a negative charge. */
+export function msToSeconds(ms: number): number {
+  if (!Number.isFinite(ms) || ms <= 0) return 0;
+  return ms / 1000;
+}
+
+/**
+ * One row's awake window as the meter sees it, before any decision about what to
+ * do with it. `billedThrough` is the watermark (`awakeBilledThrough`); `now` is
+ * the tick's single captured clock.
+ */
+export interface AwakeWindowInput {
+  /** The metering watermark. NULL means no window is open — see `planAwakeSettle`. */
+  billedThrough: Date | null;
+  now: Date;
+}
+
+/**
+ * What a settle should do with one row.
+ *
+ *  - `stamp`  — the row is believed awake but carries no watermark. Start the
+ *    clock at `now`; bill NOTHING. An unknown window start must cost the payer
+ *    nothing rather than an invented amount.
+ *  - `skip`   — a window is open but no time has elapsed in it (a back-to-back
+ *    rerun). Nothing to bill and nothing to move.
+ *  - `settle` — bill `activeSeconds` and advance the watermark to `now`.
+ */
+export type AwakeSettlePlan =
+  | { action: 'stamp' }
+  | { action: 'skip' }
+  | {
+      action: 'settle';
+      activeSeconds: number;
+      /** The watermark to write. Always `now` — the excess of a clamped window is forgiven once, never carried. */
+      billedThrough: Date;
+      /** The raw span exceeded {@link MAX_AWAKE_SETTLE_SPAN_MS} and was shortened. */
+      clamped: boolean;
+    };
+
+/**
+ * Decide what one row's settle owes (pure).
+ *
+ * The clamp shortens the BILLED span but never the watermark advance: the excess
+ * is forgiven once rather than accumulating into an ever-larger retroactive charge
+ * the next tick would bill instead. Same shape, and the same reasoning, as the
+ * storage reconcile's `MAX_BILLABLE_SPAN_MS`.
+ */
+export function planAwakeSettle({ billedThrough, now }: AwakeWindowInput): AwakeSettlePlan {
+  if (billedThrough === null) return { action: 'stamp' };
+  const rawElapsedMs = now.getTime() - billedThrough.getTime();
+  // A watermark AHEAD of now (a clock skew between containers, or a wake that
+  // landed mid-tick) bills nothing and moves nothing: `settle`'s monotonic write
+  // would refuse the advance anyway, and billing a negative span is not a refund
+  // mechanism, it is a corrupt ledger row.
+  if (rawElapsedMs <= 0) return { action: 'skip' };
+  const elapsedMs = Math.min(rawElapsedMs, MAX_AWAKE_SETTLE_SPAN_MS);
+  return {
+    action: 'settle',
+    activeSeconds: msToSeconds(elapsedMs),
+    billedThrough: now,
+    clamped: rawElapsedMs > MAX_AWAKE_SETTLE_SPAN_MS,
+  };
+}
+
+/**
+ * The awake boundary a mirrored event marks, or null for an event that is not a
+ * boundary at all.
+ *
+ * Fly's event vocabulary is open — it logs restarts, health-check transitions,
+ * exits and host events alongside the starts and stops we asked for — and a type
+ * we do not recognise must fold to "not a boundary" rather than being guessed at.
+ * Guessing would write a fabricated awake boundary into the one table that cannot
+ * be rebuilt from Fly afterwards.
+ *
+ * `start`/`exit` are the pair Fly actually logs for a machine's lifecycle;
+ * `stop` appears for an explicit stop request. Everything else is recorded by the
+ * mirror with a NULL action refused at the database (see the table's
+ * `action` CHECK), which is why non-boundary events are dropped rather than stored.
+ */
+export function classifyFlyEventAction(eventType: string | undefined): 'start' | 'stop' | null {
+  switch (eventType) {
+    case 'start':
+    case 'started':
+      return 'start';
+    case 'stop':
+    case 'exit':
+      return 'stop';
+    default:
+      return null;
+  }
+}
+
+/**
+ * Fly event timestamps are epoch MILLISECONDS (`MachineEvent.timestamp`). Returns
+ * null for anything that is not a usable instant, so a malformed event is dropped
+ * from the mirror rather than landing there dated to 1970 — which the reconcile
+ * would read as a decades-long awake window.
+ */
+export function flyEventInstant(timestamp: unknown): Date | null {
+  if (typeof timestamp !== 'number' || !Number.isFinite(timestamp) || timestamp <= 0) return null;
+  const date = new Date(timestamp);
+  return Number.isNaN(date.getTime()) ? null : date;
+}
+
+/**
+ * Awake seconds implied by a sequence of mirrored boundaries — the local
+ * reconcile's side of the weekly `fly_instance_up` comparison.
+ *
+ * Written against boundaries rather than against the billing watermark on purpose:
+ * the watermark says what we CHARGED, and the point of the reconcile is to check
+ * that against what the machine actually DID. If they agreed by construction the
+ * comparison would be worthless.
+ *
+ * Rules, all of which exist because real event streams are ragged:
+ *  - events are consumed in timestamp order, whatever order they arrive in;
+ *  - a `start` while already started is ignored (Fly logs a start for a machine
+ *    that was already up; counting it would restart the clock and lose the span);
+ *  - a `stop` with no open start is ignored (the matching start fell outside the
+ *    window being reconciled — its span belongs to the previous window, not this one);
+ *  - a window still open at `until` is counted up to `until`, because a machine
+ *    that is awake right now is awake right now.
+ */
+export function awakeSecondsFromEvents(
+  events: ReadonlyArray<{ action: 'start' | 'stop'; occurredAt: Date }>,
+  until: Date,
+): number {
+  const ordered = [...events].sort((a, b) => a.occurredAt.getTime() - b.occurredAt.getTime());
+  let openedAt: number | null = null;
+  let totalMs = 0;
+  for (const event of ordered) {
+    const at = event.occurredAt.getTime();
+    if (at > until.getTime()) break;
+    if (event.action === 'start') {
+      if (openedAt === null) openedAt = at;
+      continue;
+    }
+    if (openedAt !== null) {
+      totalMs += Math.max(0, at - openedAt);
+      openedAt = null;
+    }
+  }
+  if (openedAt !== null) totalMs += Math.max(0, until.getTime() - openedAt);
+  return msToSeconds(totalMs);
+}
+
+/**
+ * How far apart two awake-seconds figures may be before the reconcile calls it
+ * drift, as a FRACTION of the larger of the two.
+ *
+ * Relative rather than absolute because the two sources are sampled differently:
+ * `fly_instance_up` is a scraped gauge (a step function sampled every ~15s), while
+ * our boundaries are exact API-call instants. A few sample periods of disagreement
+ * is expected on every app, and would be a constant false alarm at an absolute
+ * threshold that a busy app could never meet.
+ */
+export const AWAKE_DRIFT_TOLERANCE = 0.05;
+
+/** A minimum absolute span before drift is even asked about — below it, one scrape interval is the whole signal. */
+export const AWAKE_DRIFT_FLOOR_SECONDS = 120;
+
+export interface AwakeDriftInput {
+  /** Awake seconds implied by OUR mirrored boundaries. */
+  localSeconds: number;
+  /** Awake seconds implied by managed Prometheus `fly_instance_up`. */
+  prometheusSeconds: number;
+}
+
+export interface AwakeDrift {
+  deltaSeconds: number;
+  /** Fraction of the larger figure. 0 when both are 0. */
+  relative: number;
+  /** Past both the floor and the tolerance — worth an operator's attention. */
+  exceeded: boolean;
+  /**
+   * Which way. `under_billed` means Fly saw MORE awake time than we billed (a
+   * boundary we never recorded — the failure mode that costs the platform money);
+   * `over_billed` means we billed more than Fly saw, which costs a customer money
+   * and is the more serious of the two.
+   */
+  direction: 'over_billed' | 'under_billed' | 'none';
+}
+
+/** Compare the two awake-seconds figures for one app (pure). */
+export function evaluateAwakeDrift({ localSeconds, prometheusSeconds }: AwakeDriftInput): AwakeDrift {
+  const local = Number.isFinite(localSeconds) && localSeconds > 0 ? localSeconds : 0;
+  const remote = Number.isFinite(prometheusSeconds) && prometheusSeconds > 0 ? prometheusSeconds : 0;
+  const deltaSeconds = local - remote;
+  const larger = Math.max(local, remote);
+  const relative = larger === 0 ? 0 : Math.abs(deltaSeconds) / larger;
+  const exceeded = larger >= AWAKE_DRIFT_FLOOR_SECONDS && relative > AWAKE_DRIFT_TOLERANCE;
+  const direction = !exceeded ? 'none' : deltaSeconds > 0 ? 'over_billed' : 'under_billed';
+  return { deltaSeconds, relative, exceeded, direction };
+}

--- a/packages/lib/src/services/app-hosting/awake-meter.ts
+++ b/packages/lib/src/services/app-hosting/awake-meter.ts
@@ -28,7 +28,7 @@
  * reads nothing.
  */
 
-import { and, eq, isNull, sql } from '@pagespace/db/operators';
+import { and, eq, isNotNull, isNull, sql } from '@pagespace/db/operators';
 import { db, getAdvisoryLockPool } from '@pagespace/db/db';
 import { withAdvisoryLock, type AdvisoryLockPool } from '@pagespace/db/advisory-lock';
 import { publishedApps, type PublishedApp } from '@pagespace/db/schema/published-apps';
@@ -45,8 +45,17 @@ import {
   type SettleAndCloseResult,
 } from './app-lifecycle-metering';
 
-/** What a watermark write did. Same three-way answer, and the same reasoning, as the storage reconcile's. */
-export type AwakeWatermarkOutcome = 'advanced' | 'superseded' | 'row_gone';
+/**
+ * What a watermark write did.
+ *
+ * TWO answers, not the storage reconcile's three: this write is a compare-and-set
+ * over "still running, window still open", so every way of losing that race —
+ * a newer wake, a stop that closed the window, a destroyed row — is the same fact
+ * to the caller, that somebody else owns this window now. Distinguishing a
+ * vanished row from a stopped one would cost a second query per settle and change
+ * nothing about what the caller then does (release the reservation it placed).
+ */
+export type AwakeWatermarkOutcome = 'advanced' | 'superseded';
 
 export interface AwakeMeterDeps {
   isEnabled: () => boolean;
@@ -117,11 +126,27 @@ export const defaultAwakeMeterDeps: AwakeMeterDeps = {
         // settling against a reservation made for a window that no longer
         // exists. `GREATEST` decides the watermark, so the same comparison has
         // to decide the hold.
-        awakeHoldId: sql`CASE WHEN ${publishedApps.awakeBilledThrough} IS NULL OR ${publishedApps.awakeBilledThrough} <= ${watermark} THEN ${sql.param(holdId, publishedApps.awakeHoldId)} ELSE ${publishedApps.awakeHoldId} END`,
+        awakeHoldId: sql`CASE WHEN ${publishedApps.awakeBilledThrough} <= ${watermark} THEN ${sql.param(holdId, publishedApps.awakeHoldId)} ELSE ${publishedApps.awakeHoldId} END`,
       })
-      .where(eq(publishedApps.id, publishedAppId))
+      // A COMPARE-AND-SET over the window this tick actually metered, not an
+      // id-only write. A stop can land between this tick's read and this write:
+      // it sets `status = stopped` and NULLs the watermark, and an unguarded
+      // update would then compute `GREATEST(NULL, billedThrough)` and REOPEN a
+      // billing window on a stopped row — installing a hold that no later tick
+      // can ever settle or release, because `listRunningApps` only sees
+      // `running`. Requiring the row to still be running with a window open
+      // makes the stop the unambiguous winner and turns this into a clean
+      // `superseded`, whose caller releases the reservation.
+      .where(
+        and(
+          eq(publishedApps.id, publishedAppId),
+          eq(publishedApps.status, 'running'),
+          isNotNull(publishedApps.awakeBilledThrough),
+        ),
+      )
       .returning({ awakeBilledThrough: publishedApps.awakeBilledThrough });
-    if (!row?.awakeBilledThrough) return 'row_gone';
+    // No row matched the CAS: stopped, parked or destroyed under us.
+    if (!row?.awakeBilledThrough) return 'superseded';
     return row.awakeBilledThrough.getTime() > billedThrough.getTime() ? 'superseded' : 'advanced';
   },
 
@@ -350,9 +375,15 @@ async function meterOneApp(
     const gate = await deps.billing.gate({ payerId });
     if (!gate.allowed) {
       // Insolvent: stop the machine and park it, through the status machine's own
-      // legal `running -> parked` edge. The watermark is NOT advanced here — the
-      // park path's final settle owns closing this window, and advancing first
-      // would leave it to bill the same span twice.
+      // legal `running -> parked` edge.
+      //
+      // ADVANCE THE WATERMARK FIRST. The span above is already CHARGED, and
+      // `stopPublishedApp` re-reads the row and settles from whatever watermark it
+      // finds — so parking on the stale one bills this same span a second time, on
+      // every single insolvency park. Advancing first leaves the park's own final
+      // settle with nothing to bill (it plans a `skip`) and lets it do what it is
+      // actually for: stopping the machine and closing the window.
+      await advanceSettledWatermark(row, plan.billedThrough, null, deps, result);
       await deps.parkInsolvent(row.id);
       result.parked += 1;
       return;
@@ -369,19 +400,34 @@ async function meterOneApp(
     );
   }
 
+  await advanceSettledWatermark(row, plan.billedThrough, nextHoldId, deps, result);
+}
+
+/**
+ * Persist a settle that has already CHARGED: advance the watermark and install
+ * whatever reservation now covers the window.
+ *
+ * Shared by the ordinary settle and the insolvency park, because both have moved
+ * money by the time they get here and both must record that fact before anything
+ * else reads the row. The park path in particular hands the row straight to
+ * `stopPublishedApp`, which settles from the watermark it finds.
+ */
+async function advanceSettledWatermark(
+  row: PublishedApp,
+  billedThrough: Date,
+  holdId: string | null,
+  deps: AwakeMeterDeps,
+  result: MeterAwakeResult,
+): Promise<void> {
   try {
-    const outcome = await deps.writeSettle({
-      publishedAppId: row.id,
-      billedThrough: plan.billedThrough,
-      holdId: nextHoldId,
-    });
+    const outcome = await deps.writeSettle({ publishedAppId: row.id, billedThrough, holdId });
     if (outcome !== 'advanced') {
       result.watermarkSuperseded += 1;
       // The write declined to install our re-hold — a wake already carried this
-      // row past our tick and owns the window, or the row is gone. Either way
-      // nothing will ever settle or release the reservation we just placed, so
-      // return it here.
-      if (nextHoldId) await deps.billing.releaseHold(nextHoldId);
+      // row past our tick and owns the window, a stop already closed it, or the
+      // row is gone. Either way nothing will ever settle or release the
+      // reservation we just placed, so return it here.
+      if (holdId) await deps.billing.releaseHold(holdId);
     }
   } catch (error) {
     // The charge already committed. Only the watermark write failed, so this span

--- a/packages/lib/src/services/app-hosting/awake-meter.ts
+++ b/packages/lib/src/services/app-hosting/awake-meter.ts
@@ -1,0 +1,421 @@
+/**
+ * awake-meter — the HEARTBEAT settle for published apps: every awake app's
+ * accrued seconds, billed on a cadence rather than only at stop.
+ *
+ * WHY A HEARTBEAT AT ALL. Settling only at stop makes the whole of an app's awake
+ * time a single unbilled liability until something closes it — and the thing that
+ * closes it is a process that can crash, a Fly call that can fail, and a status
+ * write that can be lost. A published app can stay up for weeks. Heartbeat
+ * settling bounds that exposure to one tick, which is the same reason the realtime
+ * shell handler settles a live PTY every ten minutes rather than at hangup.
+ *
+ * THREE THINGS EACH TICK, per row:
+ *   1. REPAIR. If the mirror holds a stop boundary after this row's watermark, the
+ *      machine already stopped and its status write was lost. Settle up to the REAL
+ *      boundary and close the window there — never bill a stopped machine to now.
+ *   2. SETTLE. Otherwise bill the accrued seconds and advance the watermark
+ *      monotonically.
+ *   3. RE-GATE. `trackUsage` consumes the wake's hold, so a settled window has no
+ *      live reservation. Re-hold immediately; a refusal means the payer is out of
+ *      credits, and the app is STOPPED AND PARKED — enforcement is "don't keep it
+ *      awake", the running counterpart of the wake gate's "don't wake".
+ *
+ * NEVER THROWS out of `meterAwakePublishedApps`: every row is isolated, and the row
+ * source's own failure is reported as a value. One app's bad state must not stop
+ * the fleet from billing.
+ *
+ * Dark behind `APP_HOSTING_ENABLED`: a disabled deployment reports `disabled` and
+ * reads nothing.
+ */
+
+import { and, eq, isNull, sql } from '@pagespace/db/operators';
+import { db, getAdvisoryLockPool } from '@pagespace/db/db';
+import { withAdvisoryLock, type AdvisoryLockPool } from '@pagespace/db/advisory-lock';
+import { publishedApps, type PublishedApp } from '@pagespace/db/schema/published-apps';
+import { loggers } from '../../logging/logger-config';
+import { isAppHostingEnabled } from './app-hosting-env';
+import { defaultAppBillingDeps, type AppBillingDeps } from './app-billing';
+import { findStopBoundarySince } from './app-machine-events';
+import { planAwakeSettle } from './app-metering-core';
+import {
+  closeAppWindowAtBoundary,
+  defaultAppLifecycleMeteringDeps,
+  stopPublishedApp,
+  type AppLifecycleMeteringDeps,
+  type SettleAndCloseResult,
+} from './app-lifecycle-metering';
+
+/** What a watermark write did. Same three-way answer, and the same reasoning, as the storage reconcile's. */
+export type AwakeWatermarkOutcome = 'advanced' | 'superseded' | 'row_gone';
+
+export interface AwakeMeterDeps {
+  isEnabled: () => boolean;
+  billing: AppBillingDeps;
+  /** Every app believed AWAKE. `running` is that belief; the repair step is what checks it. */
+  listRunningApps: () => Promise<PublishedApp[]>;
+  /** The mirror's latest stop boundary strictly after `since` — the repair signal. */
+  findStopBoundary: (machineId: string, since: Date, now: Date) => Promise<Date | null>;
+  /** Advance the watermark and install the re-hold in ONE statement, monotonically. */
+  writeSettle: (input: {
+    publishedAppId: string;
+    billedThrough: Date;
+    holdId: string | null;
+  }) => Promise<AwakeWatermarkOutcome>;
+  /**
+   * Open a window on a `running` row that has none — stamps the clock at NOW,
+   * bills nothing. Answers `superseded` when the row acquired a window while this
+   * tick was working, in which case the caller's hold covers nothing and is
+   * released rather than left to expire.
+   */
+  stampWindowStart: (input: {
+    publishedAppId: string;
+    at: Date;
+    holdId: string | null;
+  }) => Promise<'stamped' | 'superseded'>;
+  /** Settle the tail and close the window at a boundary the mirror already knows. */
+  closeAtBoundary: (row: PublishedApp, boundary: Date) => Promise<SettleAndCloseResult>;
+  /** Stop + park an app whose payer has run out of credits. */
+  parkInsolvent: (publishedAppId: string) => Promise<void>;
+  now: () => Date;
+}
+
+export const defaultAwakeMeterDeps: AwakeMeterDeps = {
+  isEnabled: isAppHostingEnabled,
+  billing: defaultAppBillingDeps,
+
+  async listRunningApps() {
+    return db.select().from(publishedApps).where(eq(publishedApps.status, 'running'));
+  },
+
+  findStopBoundary: (machineId, since, now) => findStopBoundarySince(machineId, since, now),
+
+  /**
+   * MONOTONIC, and the guard is load-bearing rather than defensive: a tick captures
+   * one `now` and then makes several awaits per row, so a wake landing inside that
+   * span resets `awakeBilledThrough` FORWARD to its own instant. An unguarded write
+   * would drag the watermark back over that reset and re-bill the span between them
+   * on the next tick. `GREATEST` in the SET (not a `WHERE ... <= ...` predicate) so
+   * "the guard declined" and "the row is gone" stay distinguishable — the same
+   * shape, and the same scar, as the storage reconcile's watermark write.
+   *
+   * The re-hold rides along in the same statement because a hold recorded without
+   * the watermark that justifies it, or vice versa, is a reservation nothing will
+   * ever settle or release.
+   */
+  async writeSettle({ publishedAppId, billedThrough, holdId }) {
+    const watermark = sql.param(billedThrough, publishedApps.awakeBilledThrough);
+    const [row] = await db
+      .update(publishedApps)
+      .set({
+        awakeBilledThrough: sql`GREATEST(${publishedApps.awakeBilledThrough}, ${watermark})`,
+        // The hold is guarded on the SAME condition as the watermark it rides
+        // with, not written unconditionally. If a wake has already carried this
+        // row past our tick, that wake owns the window AND the reservation
+        // covering it; overwriting `awakeHoldId` here would strand the wake's
+        // hold — never settled, never released, suppressing the payer's
+        // spendable balance for its whole TTL — and leave the new window
+        // settling against a reservation made for a window that no longer
+        // exists. `GREATEST` decides the watermark, so the same comparison has
+        // to decide the hold.
+        awakeHoldId: sql`CASE WHEN ${publishedApps.awakeBilledThrough} IS NULL OR ${publishedApps.awakeBilledThrough} <= ${watermark} THEN ${sql.param(holdId, publishedApps.awakeHoldId)} ELSE ${publishedApps.awakeHoldId} END`,
+      })
+      .where(eq(publishedApps.id, publishedAppId))
+      .returning({ awakeBilledThrough: publishedApps.awakeBilledThrough });
+    if (!row?.awakeBilledThrough) return 'row_gone';
+    return row.awakeBilledThrough.getTime() > billedThrough.getTime() ? 'superseded' : 'advanced';
+  },
+
+  /**
+   * Opens a window on a row that has NONE, and only on such a row — the
+   * `awakeBilledThrough IS NULL` predicate is the guard, not a redundancy.
+   *
+   * The tick captures one clock and then makes several awaits per row, so a wake
+   * landing inside that span opens its own window at an instant LATER than this
+   * tick's `now`. An unguarded write would drag that fresh watermark backward and
+   * hand the next tick a span to re-bill, while replacing the wake's hold with
+   * one placed for a window that never existed.
+   */
+  async stampWindowStart({ publishedAppId, at, holdId }) {
+    const [row] = await db
+      .update(publishedApps)
+      .set({ awakeBilledThrough: at, awakeHoldId: holdId, lastWakeAt: sql`COALESCE(${publishedApps.lastWakeAt}, ${sql.param(at, publishedApps.lastWakeAt)})` })
+      .where(and(eq(publishedApps.id, publishedAppId), isNull(publishedApps.awakeBilledThrough)))
+      .returning({ id: publishedApps.id });
+    return row ? 'stamped' : 'superseded';
+  },
+
+  closeAtBoundary: (row, boundary) => closeAppWindowAtBoundary(row, boundary, defaultAppLifecycleMeteringDeps),
+
+  async parkInsolvent(publishedAppId) {
+    await stopPublishedApp(publishedAppId, 'insolvent');
+  },
+
+  now: () => new Date(),
+};
+
+export interface MeterAwakeResult {
+  processed: number;
+  /** Rows that billed awake seconds this tick. */
+  settled: number;
+  /** Rows whose window was closed at a mirrored stop boundary — a lost stop, repaired. */
+  repaired: number;
+  /** `running` rows carrying no window at all. Their clock is started at NOW and nothing is billed for the unknown span. */
+  stamped: number;
+  /** Rows with an open window and no elapsed time (a back-to-back rerun). */
+  skipped: number;
+  /** Rows left unbilled because the owning drive could not be resolved — retried next tick. */
+  unresolvedPayer: number;
+  /** Rows stopped and parked because the payer ran out of credits at the re-gate. */
+  parked: number;
+  /** Rows where something threw. Isolated; the window is left open so the span is retried. */
+  failed: number;
+  /** Settles whose span exceeded {@link MAX_AWAKE_SETTLE_SPAN_MS} and was shortened — expected to be ZERO in steady state. */
+  clamped: number;
+  /**
+   * Window writes this tick declined to make — a wake had already carried the row
+   * past this tick's `now` (or the row is gone), so that wake owns the window.
+   * The reservation this tick placed is released rather than stranded.
+   */
+  watermarkSuperseded: number;
+  /**
+   * Rows that billed but whose watermark write then failed — money moved and the
+   * window did not close, so this span WILL be billed again next tick. The
+   * opposite of `failed`, and worth distinguishing for exactly that reason.
+   */
+  settledButUnadvanced: number;
+  totalAwakeSeconds: number;
+  /** The row source itself failed; nothing was metered this tick and everything accrues for the next. */
+  sourceFailed: boolean;
+}
+
+const EMPTY_RESULT: MeterAwakeResult = {
+  processed: 0,
+  settled: 0,
+  repaired: 0,
+  stamped: 0,
+  skipped: 0,
+  unresolvedPayer: 0,
+  parked: 0,
+  failed: 0,
+  clamped: 0,
+  watermarkSuperseded: 0,
+  settledButUnadvanced: 0,
+  totalAwakeSeconds: 0,
+  sourceFailed: false,
+};
+
+export type MeterAwakeRun = { outcome: 'disabled' } | ({ outcome: 'metered' } & MeterAwakeResult);
+
+/**
+ * Settle every awake published app's accrued seconds.
+ *
+ * NEVER THROWS. The row source's failure is a value (`sourceFailed`), and every
+ * row is isolated — one app whose payer lookup or Fly state is broken must not
+ * stop the rest of the fleet from being billed, exactly as one unreadable row
+ * source must not stop the storage meter.
+ */
+export async function meterAwakePublishedApps(
+  deps: AwakeMeterDeps = defaultAwakeMeterDeps,
+): Promise<MeterAwakeRun> {
+  if (!deps.isEnabled()) return { outcome: 'disabled' };
+
+  const result: MeterAwakeResult = { ...EMPTY_RESULT };
+  let rows: PublishedApp[];
+  try {
+    rows = await deps.listRunningApps();
+  } catch (error) {
+    loggers.ai.error(
+      'Published-app awake meter could not list running apps — nothing was metered this tick',
+      error instanceof Error ? error : new Error(String(error)),
+    );
+    return { outcome: 'metered', ...result, sourceFailed: true };
+  }
+
+  // ONE clock for the whole tick, captured before any await — a tick is a
+  // snapshot, and a row metered against a later clock than its neighbour would
+  // make two rows' windows overlap at the seam.
+  const now = deps.now();
+  result.processed = rows.length;
+
+  for (const row of rows) {
+    try {
+      await meterOneApp(row, now, deps, result);
+    } catch (error) {
+      result.failed += 1;
+      loggers.ai.error(
+        'Published-app awake meter failed for one app — its window stays open and is retried next tick',
+        error instanceof Error ? error : new Error(String(error)),
+        { publishedAppId: row.id, driveId: row.driveId },
+      );
+    }
+  }
+  return { outcome: 'metered', ...result };
+}
+
+async function meterOneApp(
+  row: PublishedApp,
+  now: Date,
+  deps: AwakeMeterDeps,
+  result: MeterAwakeResult,
+): Promise<void> {
+  // 1. NO WINDOW. The row says running and carries no watermark — a wake whose
+  // stamp was lost, or a machine started outside the wake seam. Start the clock at
+  // NOW and bill nothing: an unknown window start must cost the payer nothing
+  // rather than an invented amount. A hold is placed with it so the very next tick
+  // settles against a real reservation.
+  if (row.awakeBilledThrough === null) {
+    const payerId = await deps.billing.resolvePayerId({ driveId: row.driveId });
+    if (!payerId) {
+      result.unresolvedPayer += 1;
+      return;
+    }
+    const gate = await deps.billing.gate({ payerId });
+    if (!gate.allowed) {
+      await deps.parkInsolvent(row.id);
+      result.parked += 1;
+      return;
+    }
+    const stamp = await deps.stampWindowStart({ publishedAppId: row.id, at: now, holdId: gate.holdId ?? null });
+    if (stamp === 'superseded') {
+      // A wake opened the window while we were gating. It owns both the window
+      // and a reservation for it, so ours covers nothing — return it rather than
+      // leaving it to suppress the payer's balance until its TTL.
+      if (gate.holdId) await deps.billing.releaseHold(gate.holdId);
+      result.watermarkSuperseded += 1;
+      return;
+    }
+    result.stamped += 1;
+    return;
+  }
+
+  // 2. REPAIR. The mirror is the source of truth for boundaries, so a stop
+  // recorded after this row's watermark means the machine is already down and
+  // only the status write was lost. Settle up to the REAL boundary and close the
+  // window there — billing through `now` would charge for the span between a stop
+  // we did not notice and the moment we did.
+  // A `running` row always has a machine (`published_apps_running_requires_machine`),
+  // so this is unreachable — but a row with no machine has no boundaries to find
+  // and must not be handed an empty id that silently matches nothing.
+  const boundary = row.machineId
+    ? await deps.findStopBoundary(row.machineId, row.awakeBilledThrough, now)
+    : null;
+  if (boundary) {
+    const closed = await deps.closeAtBoundary(row, boundary);
+    result.repaired += 1;
+    if (closed.failed) result.failed += 1;
+    else {
+      result.totalAwakeSeconds += closed.billedSeconds;
+      if (closed.billedSeconds > 0) result.settled += 1;
+    }
+    return;
+  }
+
+  // 3. ORDINARY SETTLE.
+  const plan = planAwakeSettle({ billedThrough: row.awakeBilledThrough, now });
+  if (plan.action !== 'settle') {
+    // `stamp` is unreachable here (the null case returned above); `skip` is a
+    // back-to-back rerun or a watermark ahead of this tick's clock.
+    result.skipped += 1;
+    return;
+  }
+
+  const payerId = await deps.billing.resolvePayerId({ driveId: row.driveId });
+  if (!payerId) {
+    // Leave the watermark alone so the span keeps accruing and is billed in full
+    // once the drive resolves — or is torn down with the row. Never substitute a
+    // payer: a misdirected charge cannot be taken back, a skipped tick corrects
+    // itself.
+    result.unresolvedPayer += 1;
+    return;
+  }
+
+  await deps.billing.trackUsage({
+    payerId,
+    holdId: row.awakeHoldId ?? undefined,
+    activeSeconds: plan.activeSeconds,
+    driveId: row.driveId,
+    publishedAppId: row.id,
+  });
+  result.settled += 1;
+  result.totalAwakeSeconds += plan.activeSeconds;
+  if (plan.clamped) result.clamped += 1;
+
+  // RE-GATE. The settle above consumed the wake's hold, so the window is now
+  // unreserved. Re-holding is what makes the gate keep binding on a long-lived
+  // app: without it, a payer who runs out of credits mid-window would keep a
+  // machine awake indefinitely and the balance check would only ever be consulted
+  // at the next cold wake.
+  let nextHoldId: string | null = null;
+  try {
+    const gate = await deps.billing.gate({ payerId });
+    if (!gate.allowed) {
+      // Insolvent: stop the machine and park it, through the status machine's own
+      // legal `running -> parked` edge. The watermark is NOT advanced here — the
+      // park path's final settle owns closing this window, and advancing first
+      // would leave it to bill the same span twice.
+      await deps.parkInsolvent(row.id);
+      result.parked += 1;
+      return;
+    }
+    nextHoldId = gate.holdId ?? null;
+  } catch (error) {
+    // A transient billing outage must not kill a live app. The window still
+    // closes below with no hold; the next tick re-gates. Same trade-off the
+    // realtime shell handler makes for its own re-hold.
+    loggers.ai.error(
+      'Published-app awake re-hold failed — the app stays up and is re-gated next tick',
+      error instanceof Error ? error : new Error(String(error)),
+      { publishedAppId: row.id },
+    );
+  }
+
+  try {
+    const outcome = await deps.writeSettle({
+      publishedAppId: row.id,
+      billedThrough: plan.billedThrough,
+      holdId: nextHoldId,
+    });
+    if (outcome !== 'advanced') {
+      result.watermarkSuperseded += 1;
+      // The write declined to install our re-hold — a wake already carried this
+      // row past our tick and owns the window, or the row is gone. Either way
+      // nothing will ever settle or release the reservation we just placed, so
+      // return it here.
+      if (nextHoldId) await deps.billing.releaseHold(nextHoldId);
+    }
+  } catch (error) {
+    // The charge already committed. Only the watermark write failed, so this span
+    // WILL be billed again next tick — a real double-bill risk, counted under its
+    // own name rather than folded into `failed`, which means the opposite.
+    result.settledButUnadvanced += 1;
+    loggers.ai.error(
+      'Published-app awake watermark advance failed after a successful settle — this window will be re-billed next tick',
+      error instanceof Error ? error : new Error(String(error)),
+      { publishedAppId: row.id, driveId: row.driveId },
+    );
+  }
+}
+
+/**
+ * Advisory-lock key serializing the awake meter across EVERY caller — a second
+ * container, a manual trigger, an API invocation. `trackUsage` and the watermark
+ * advance are two separate un-transactioned writes, so two overlapping runs can
+ * bill the same window twice.
+ */
+const METER_AWAKE_LOCK_KEY = 'meter-published-apps-awake';
+
+export type MeterAwakeRunResult = { outcome: 'lock_busy' } | MeterAwakeRun;
+
+/**
+ * Serialize the meter with a Postgres session-level advisory try-lock: a run that
+ * cannot acquire it is a clean no-op and never reads a row or moves a cent.
+ */
+export async function meterAwakePublishedAppsSerialized(
+  deps: AwakeMeterDeps = defaultAwakeMeterDeps,
+  pgPool: AdvisoryLockPool = getAdvisoryLockPool(),
+): Promise<MeterAwakeRunResult> {
+  const locked = await withAdvisoryLock(pgPool, METER_AWAKE_LOCK_KEY, () => meterAwakePublishedApps(deps));
+  if (locked.outcome === 'lock_busy') return { outcome: 'lock_busy' };
+  if (locked.outcome === 'connection_error') throw locked.error;
+  return locked.result;
+}

--- a/packages/lib/src/services/app-hosting/awake-reconcile.ts
+++ b/packages/lib/src/services/app-hosting/awake-reconcile.ts
@@ -1,0 +1,249 @@
+/**
+ * awake-reconcile — the WEEKLY check of what we billed against what Fly's managed
+ * Prometheus says actually ran.
+ *
+ * THREE RECORDS, RANKED. Our own start/stop calls are primary — `autostop` is off
+ * so every boundary is an API call we made. The local event mirror is where those
+ * boundaries are KEPT, because Fly's own event log holds only the last 20 entries
+ * and cannot be paged or time-filtered: history is not rebuildable from it, which
+ * is why the mirror is the source of truth and this reconcile is a check on it.
+ * Managed Prometheus is the third, independent leg, retained about 15 days.
+ *
+ * WHY WEEKLY, AND WHY THAT IS THE CEILING. ~15 days of retention means a
+ * disagreement older than that can never be examined again. Weekly leaves a full
+ * window of slack for a missed run; a monthly cadence would routinely be asking
+ * about samples that no longer exist.
+ *
+ * IT COMPARES AND ALERTS. IT DOES NOT MOVE MONEY. A scraped gauge is not evidence
+ * of a charge: it samples every ~15s, its series goes absent rather than zero when
+ * a machine is down, and its scrape interval is a constant we have not yet verified
+ * against a live org. Auto-adjusting a customer's ledger from that would let one
+ * metrics artifact issue refunds or back-charges nobody reviewed. What drift buys
+ * is a NAMED, DIRECTIONAL signal — `over_billed` (a customer was charged for time
+ * Fly did not see: the serious one) versus `under_billed` (a boundary we never
+ * recorded: the platform's own loss) — and an operator decides what, if anything,
+ * to do about it while the window is still open.
+ *
+ * NEVER THROWS, and inert when unconfigured: no Prometheus credential means a
+ * counter and a clean skip, never an error. The feature ships dark.
+ */
+
+import { ne } from '@pagespace/db/operators';
+import { db, getAdvisoryLockPool } from '@pagespace/db/db';
+import { withAdvisoryLock, type AdvisoryLockPool } from '@pagespace/db/advisory-lock';
+import { publishedApps } from '@pagespace/db/schema/published-apps';
+import { loggers } from '../../logging/logger-config';
+import { isAppHostingEnabled } from './app-hosting-env';
+import { listBoundaryEvents } from './app-machine-events';
+import { awakeSecondsFromEvents, evaluateAwakeDrift, type AwakeDrift } from './app-metering-core';
+import {
+  queryAwakeSeconds,
+  resolveFlyPrometheus,
+  type FlyPrometheusConfig,
+} from '../fly/prometheus-client';
+
+/**
+ * The window each run compares, in days.
+ *
+ * Comfortably inside Prometheus' ~15-day retention AND at least the cadence, so a
+ * single missed weekly run still leaves every day covered by the next one. Widening
+ * this past retention would silently compare against samples that no longer exist,
+ * which reads as a fleet-wide `under_billed` drift rather than as missing data.
+ */
+export const AWAKE_RECONCILE_WINDOW_DAYS = 7;
+
+const MS_PER_DAY = 24 * 60 * 60 * 1000;
+
+export interface AwakeReconcileDeps {
+  isEnabled: () => boolean;
+  /** Null when no Prometheus credential/org slug is configured — the reconcile then skips cleanly. */
+  resolvePrometheus: () => FlyPrometheusConfig | null;
+  /** Every app worth checking. Rows mid-teardown are excluded by the default binding. */
+  listApps: () => Promise<Array<{ id: string; driveId: string; flyAppName: string }>>;
+  /** Our own mirrored boundaries for one app inside the window. */
+  listBoundaries: (
+    publishedAppId: string,
+    from: Date,
+    until: Date,
+  ) => Promise<Array<{ action: 'start' | 'stop'; occurredAt: Date }>>;
+  /** Fly's independent figure. Null when the app has no series at all. */
+  queryAwakeSeconds: (flyAppName: string, windowSeconds: number) => Promise<number | null>;
+  now: () => Date;
+}
+
+export const defaultAwakeReconcileDeps: AwakeReconcileDeps = {
+  isEnabled: isAppHostingEnabled,
+  resolvePrometheus: resolveFlyPrometheus,
+
+  async listApps() {
+    // `destroying` rows are excluded: their Fly app is being torn down, so a
+    // disagreement about it is expected rather than informative.
+    return db
+      .select({ id: publishedApps.id, driveId: publishedApps.driveId, flyAppName: publishedApps.flyAppName })
+      .from(publishedApps)
+      .where(ne(publishedApps.status, 'destroying'));
+  },
+
+  listBoundaries: (publishedAppId, from, until) => listBoundaryEvents(publishedAppId, from, until),
+
+  async queryAwakeSeconds(flyAppName, windowSeconds) {
+    const config = resolveFlyPrometheus();
+    // Unreachable in the normal flow (`reconcileAwakeSeconds` resolves the config
+    // before it ever gets here), and still handled: a partially-configured
+    // deployment must skip rather than throw at the first app.
+    if (!config) return null;
+    return queryAwakeSeconds(config, flyAppName, windowSeconds);
+  },
+
+  now: () => new Date(),
+};
+
+/** One app's disagreement, kept whole so an operator can see both sides rather than only the delta. */
+export interface AwakeDriftReport {
+  publishedAppId: string;
+  driveId: string;
+  flyAppName: string;
+  localSeconds: number;
+  prometheusSeconds: number;
+  drift: AwakeDrift;
+}
+
+export interface AwakeReconcileResult {
+  processed: number;
+  /** Apps compared against a real Prometheus figure. */
+  compared: number;
+  /** Apps with no `fly_instance_up` series at all — never woken, or aged out of retention. Not a fault. */
+  noSeries: number;
+  /** Apps whose comparison threw (a Prometheus outage, a bad read). Isolated per app. */
+  failed: number;
+  /** Apps whose drift exceeded the tolerance. The number an operator actually reads. */
+  drifted: number;
+  /** The drifted apps, worst first. Capped for reporting; `drifted` is the true count. */
+  reports: AwakeDriftReport[];
+  windowDays: number;
+}
+
+export type AwakeReconcileRun =
+  | { outcome: 'disabled' }
+  /** No Prometheus org slug or token configured. Inert by design, not an error. */
+  | { outcome: 'unconfigured' }
+  | ({ outcome: 'reconciled' } & AwakeReconcileResult);
+
+/** How many drift reports a run returns. The count is exact; the LIST is capped so one bad deploy cannot produce a megabyte of cron output. */
+export const MAX_DRIFT_REPORTS = 25;
+
+/**
+ * Compare each app's mirrored awake-seconds against managed Prometheus.
+ *
+ * NEVER THROWS. Each app is isolated: a Prometheus outage mid-run leaves the
+ * apps already compared reported and the rest counted as failures, rather than
+ * discarding a whole run's findings.
+ */
+export async function reconcileAwakeSeconds(
+  deps: AwakeReconcileDeps = defaultAwakeReconcileDeps,
+): Promise<AwakeReconcileRun> {
+  if (!deps.isEnabled()) return { outcome: 'disabled' };
+  if (!deps.resolvePrometheus()) return { outcome: 'unconfigured' };
+
+  const now = deps.now();
+  const windowSeconds = AWAKE_RECONCILE_WINDOW_DAYS * 24 * 60 * 60;
+  const from = new Date(now.getTime() - AWAKE_RECONCILE_WINDOW_DAYS * MS_PER_DAY);
+
+  let apps: Array<{ id: string; driveId: string; flyAppName: string }>;
+  try {
+    apps = await deps.listApps();
+  } catch (error) {
+    loggers.ai.error(
+      'Published-app awake reconcile could not list apps — nothing was compared this run',
+      error instanceof Error ? error : new Error(String(error)),
+    );
+    return {
+      outcome: 'reconciled',
+      processed: 0,
+      compared: 0,
+      noSeries: 0,
+      failed: 1,
+      drifted: 0,
+      reports: [],
+      windowDays: AWAKE_RECONCILE_WINDOW_DAYS,
+    };
+  }
+
+  const result: AwakeReconcileResult = {
+    processed: apps.length,
+    compared: 0,
+    noSeries: 0,
+    failed: 0,
+    drifted: 0,
+    reports: [],
+    windowDays: AWAKE_RECONCILE_WINDOW_DAYS,
+  };
+
+  for (const app of apps) {
+    try {
+      const prometheusSeconds = await deps.queryAwakeSeconds(app.flyAppName, windowSeconds);
+      if (prometheusSeconds === null) {
+        result.noSeries += 1;
+        continue;
+      }
+      const boundaries = await deps.listBoundaries(app.id, from, now);
+      // Deliberately computed from BOUNDARIES, not from the billing watermark. The
+      // watermark says what we charged; comparing it against Prometheus would be
+      // comparing our arithmetic against itself. Boundaries say what the machine
+      // did, which is the thing Prometheus also measured.
+      const localSeconds = awakeSecondsFromEvents(boundaries, now);
+      const drift = evaluateAwakeDrift({ localSeconds, prometheusSeconds });
+      result.compared += 1;
+      if (drift.exceeded) {
+        result.drifted += 1;
+        result.reports.push({
+          publishedAppId: app.id,
+          driveId: app.driveId,
+          flyAppName: app.flyAppName,
+          localSeconds,
+          prometheusSeconds,
+          drift,
+        });
+      }
+    } catch (error) {
+      result.failed += 1;
+      loggers.ai.error(
+        'Published-app awake reconcile failed for one app',
+        error instanceof Error ? error : new Error(String(error)),
+        { publishedAppId: app.id, flyAppName: app.flyAppName },
+      );
+    }
+  }
+
+  // Worst first, and OVER-BILLED ahead of under-billed at equal magnitude: one
+  // costs a customer money and the other costs us. An operator reading a truncated
+  // list should see the charges somebody may have to be refunded before the
+  // revenue we failed to capture.
+  result.reports.sort((a, b) => {
+    const severity = (report: AwakeDriftReport) => (report.drift.direction === 'over_billed' ? 1 : 0);
+    const bySeverity = severity(b) - severity(a);
+    return bySeverity !== 0 ? bySeverity : b.drift.relative - a.drift.relative;
+  });
+  result.reports = result.reports.slice(0, MAX_DRIFT_REPORTS);
+  return { outcome: 'reconciled', ...result };
+}
+
+/**
+ * Advisory-lock key for the weekly reconcile. It moves no money, so the lock is
+ * not protecting a ledger — it stops two containers (or a manual trigger racing
+ * the schedule) from doubling a fleet-wide Prometheus query burst and reporting
+ * the same drift twice.
+ */
+const AWAKE_RECONCILE_LOCK_KEY = 'reconcile-published-app-awake-seconds';
+
+export type AwakeReconcileRunResult = { outcome: 'lock_busy' } | AwakeReconcileRun;
+
+export async function reconcileAwakeSecondsSerialized(
+  deps: AwakeReconcileDeps = defaultAwakeReconcileDeps,
+  pgPool: AdvisoryLockPool = getAdvisoryLockPool(),
+): Promise<AwakeReconcileRunResult> {
+  const locked = await withAdvisoryLock(pgPool, AWAKE_RECONCILE_LOCK_KEY, () => reconcileAwakeSeconds(deps));
+  if (locked.outcome === 'lock_busy') return { outcome: 'lock_busy' };
+  if (locked.outcome === 'connection_error') throw locked.error;
+  return locked.result;
+}

--- a/packages/lib/src/services/app-hosting/provisioner.ts
+++ b/packages/lib/src/services/app-hosting/provisioner.ts
@@ -500,6 +500,10 @@ export interface TransitionPatch {
   /**
    * Travels with `imageDigest` and never alone — a size attributed to the wrong
    * digest is worse than an absent one.
+   *
+   * Supplying this also STAMPS `imageSizeMeasuredAt` (see `transitionPublishedApp`):
+   * the storage meter cannot use a measurement it cannot date, and the pair is a
+   * CHECK constraint, so the caller never sets the timestamp itself.
    */
   imageSizeBytes?: number | null;
   lastError?: string | null;
@@ -551,7 +555,19 @@ export async function transitionPublishedApp(
 
     const [updated] = await tx
       .update(publishedApps)
-      .set({ status: to, ...patch })
+      .set({
+        status: to,
+        ...patch,
+        // The size and its timestamp are one fact and land in one statement, which
+        // is what `published_apps_image_size_measured_coherent` enforces. Stamped
+        // HERE rather than by each caller because this is the only writer of
+        // `imageSizeBytes`, and a size the storage meter cannot date reads to it as
+        // "never measured" — billing the 0 floor forever while the watermark
+        // advances over real rootfs. Clearing the size clears the stamp with it.
+        ...(patch.imageSizeBytes === undefined
+          ? {}
+          : { imageSizeMeasuredAt: patch.imageSizeBytes === null ? null : new Date() }),
+      })
       .where(eq(publishedApps.id, publishedAppId))
       .returning();
     return { ok: true as const, app: updated };

--- a/packages/lib/src/services/fly/__tests__/prometheus-client.test.ts
+++ b/packages/lib/src/services/fly/__tests__/prometheus-client.test.ts
@@ -68,13 +68,20 @@ describe('awakeSamplesQuery', () => {
       given: 'an app name and a one-hour window',
       should: 'build a count_over_time query',
       actual: awakeSamplesQuery('pgs-app-1', 3600),
-      expected: 'count_over_time(fly_instance_up{app="pgs-app-1"}[3600s])',
+      expected: 'sum(count_over_time(fly_instance_up{app="pgs-app-1"}[3600s]))',
     });
+  });
+
+  it('AGGREGATES every matching series, so a replaced machine is not read as drift', () => {
+    // `count_over_time` keeps the labels the selector did not pin, so an app whose
+    // machine has been replaced has one series per machine id. Without `sum()` the
+    // client reads only the first and reports the rest as missing awake time.
+    expect(awakeSamplesQuery('pgs-app-1', 3600).startsWith('sum(')).toBe(true);
   });
 
   it('escapes quotes and backslashes in the app label', () => {
     expect(awakeSamplesQuery('a"b\\c', 60)).toBe(
-      'count_over_time(fly_instance_up{app="a\\"b\\\\c"}[60s])',
+      'sum(count_over_time(fly_instance_up{app="a\\"b\\\\c"}[60s]))',
     );
   });
 

--- a/packages/lib/src/services/fly/__tests__/prometheus-client.test.ts
+++ b/packages/lib/src/services/fly/__tests__/prometheus-client.test.ts
@@ -1,0 +1,173 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { assert } from '../../sandbox/__tests__/riteway';
+import {
+  awakeSamplesQuery,
+  queryInstant,
+  queryAwakeSeconds,
+  resolveFlyPrometheus,
+  FlyPrometheusError,
+  FLY_METRICS_SCRAPE_INTERVAL_SECONDS,
+  FLY_PROMETHEUS_BASE_URL,
+  type FlyPrometheusConfig,
+} from '../prometheus-client';
+
+const ORIGINAL_ENV = { ...process.env };
+
+afterEach(() => {
+  process.env = { ...ORIGINAL_ENV };
+});
+
+function okResponse(body: unknown) {
+  return {
+    ok: true,
+    status: 200,
+    json: async () => body,
+  } as unknown as Response;
+}
+
+function config(fetchImpl: typeof fetch): FlyPrometheusConfig {
+  return { orgSlug: 'my-org', token: 'tok-1', fetchImpl };
+}
+
+describe('resolveFlyPrometheus', () => {
+  beforeEach(() => {
+    process.env = { ...ORIGINAL_ENV };
+  });
+
+  it('given both halves configured, should resolve the endpoint', () => {
+    process.env.FLY_PROMETHEUS_ORG_SLUG = 'my-org';
+    // The org token that drives the Machines API is reused as the metrics Bearer.
+    process.env.FLY_MACHINES_ORG_TOKEN = 'tok-1';
+
+    expect(resolveFlyPrometheus()).toEqual({ orgSlug: 'my-org', token: 'tok-1' });
+  });
+
+  it('given either half missing, should resolve NULL so the reconcile skips cleanly', () => {
+    // A dark, unconfigured feature must not redden a live cron.
+    process.env.FLY_PROMETHEUS_ORG_SLUG = 'my-org';
+    delete process.env.FLY_MACHINES_ORG_TOKEN;
+    expect(resolveFlyPrometheus()).toBeNull();
+
+    process.env.FLY_MACHINES_ORG_TOKEN = 'tok-1';
+    delete process.env.FLY_PROMETHEUS_ORG_SLUG;
+    expect(resolveFlyPrometheus()).toBeNull();
+  });
+
+  it('treats a whitespace-only org slug as unconfigured', () => {
+    process.env.FLY_PROMETHEUS_ORG_SLUG = '   ';
+    process.env.FLY_MACHINES_ORG_TOKEN = 'tok-1';
+    expect(resolveFlyPrometheus()).toBeNull();
+  });
+});
+
+describe('awakeSamplesQuery', () => {
+  it('counts SAMPLES rather than summing the gauge’s value', () => {
+    // `sum_over_time` agrees today only because the gauge's value is 1; a future
+    // value other than 1 would silently scale the answer.
+    assert({
+      given: 'an app name and a one-hour window',
+      should: 'build a count_over_time query',
+      actual: awakeSamplesQuery('pgs-app-1', 3600),
+      expected: 'count_over_time(fly_instance_up{app="pgs-app-1"}[3600s])',
+    });
+  });
+
+  it('escapes quotes and backslashes in the app label', () => {
+    expect(awakeSamplesQuery('a"b\\c', 60)).toBe(
+      'count_over_time(fly_instance_up{app="a\\"b\\\\c"}[60s])',
+    );
+  });
+
+  it('floors the window at a whole positive number of seconds', () => {
+    expect(awakeSamplesQuery('app', 0)).toContain('[1s]');
+    expect(awakeSamplesQuery('app', -10)).toContain('[1s]');
+    expect(awakeSamplesQuery('app', 90.7)).toContain('[90s]');
+  });
+});
+
+describe('queryInstant', () => {
+  it('sends the org-scoped instant query with a Bearer token', async () => {
+    const fetchImpl = vi.fn(async () =>
+      okResponse({ status: 'success', data: { result: [{ value: [1, '42'] }] } }),
+    );
+
+    const value = await queryInstant(config(fetchImpl as unknown as typeof fetch), 'up');
+
+    expect(value).toBe(42);
+    const [url, init] = fetchImpl.mock.calls[0] as unknown as [string, RequestInit];
+    expect(url).toBe(`${FLY_PROMETHEUS_BASE_URL}/my-org/api/v1/query?query=up`);
+    expect((init.headers as Record<string, string>).Authorization).toBe('Bearer tok-1');
+  });
+
+  it('given a query that matched NOTHING, should return null — an ordinary answer, not an error', async () => {
+    // An app that has never been woken has no series at all; reading that as a
+    // failure would make every unwoken app look like a metrics outage.
+    const fetchImpl = vi.fn(async () => okResponse({ status: 'success', data: { result: [] } }));
+
+    assert({
+      given: 'an empty Prometheus result set',
+      should: 'be null rather than an error',
+      actual: await queryInstant(config(fetchImpl as unknown as typeof fetch), 'up'),
+      expected: null,
+    });
+  });
+
+  it('given a non-OK HTTP status, should throw a FlyPrometheusError carrying it', async () => {
+    const fetchImpl = vi.fn(async () => ({ ok: false, status: 503 }) as unknown as Response);
+
+    await expect(queryInstant(config(fetchImpl as unknown as typeof fetch), 'up')).rejects.toMatchObject({
+      name: 'FlyPrometheusError',
+      status: 503,
+    });
+  });
+
+  it('given a non-success body, should throw with Prometheus’ own error text', async () => {
+    const fetchImpl = vi.fn(async () => okResponse({ status: 'error', error: 'bad query' }));
+
+    await expect(
+      queryInstant(config(fetchImpl as unknown as typeof fetch), 'up('),
+    ).rejects.toBeInstanceOf(FlyPrometheusError);
+  });
+
+  it('given a non-numeric value, should return null rather than NaN', async () => {
+    const fetchImpl = vi.fn(async () =>
+      okResponse({ status: 'success', data: { result: [{ value: [1, 'NaN'] }] } }),
+    );
+
+    expect(await queryInstant(config(fetchImpl as unknown as typeof fetch), 'up')).toBeNull();
+  });
+});
+
+describe('queryAwakeSeconds', () => {
+  it('converts a SAMPLE COUNT into seconds via the scrape interval', async () => {
+    // `count_over_time` returns a count; seconds-awake is that count times the
+    // scrape interval. A stopped machine's series goes ABSENT rather than zero,
+    // which is why an average would read as "up 100%" for every app.
+    const fetchImpl = vi.fn(async () =>
+      okResponse({ status: 'success', data: { result: [{ value: [1, '240'] }] } }),
+    );
+
+    assert({
+      given: '240 scraped samples',
+      should: 'price them at the scrape interval',
+      actual: await queryAwakeSeconds(config(fetchImpl as unknown as typeof fetch), 'pgs-app-1', 3600),
+      expected: 240 * FLY_METRICS_SCRAPE_INTERVAL_SECONDS,
+    });
+  });
+
+  it('given no series, should stay null rather than becoming a zero figure', async () => {
+    // Null and 0 mean different things to the drift comparison: "never seen" is
+    // not "seen, and awake for no time".
+    const fetchImpl = vi.fn(async () => okResponse({ status: 'success', data: { result: [] } }));
+
+    expect(await queryAwakeSeconds(config(fetchImpl as unknown as typeof fetch), 'app', 3600)).toBeNull();
+  });
+
+  it('floors a negative sample count at 0', async () => {
+    const fetchImpl = vi.fn(async () =>
+      okResponse({ status: 'success', data: { result: [{ value: [1, '-5'] }] } }),
+    );
+
+    expect(await queryAwakeSeconds(config(fetchImpl as unknown as typeof fetch), 'app', 3600)).toBe(0);
+  });
+});

--- a/packages/lib/src/services/fly/prometheus-client.ts
+++ b/packages/lib/src/services/fly/prometheus-client.ts
@@ -1,0 +1,153 @@
+/**
+ * prometheus-client — reads Fly's MANAGED PROMETHEUS, the only independent record
+ * of whether a machine was actually up.
+ *
+ * Fly has no billing API. Our own start/stop calls are the primary awake-seconds
+ * record and the local event mirror is what keeps them (Fly's own event log holds
+ * only the last 20 entries). Managed Prometheus is the third leg: an
+ * independently-produced series, retained about 15 days, that can be compared
+ * against what we billed. It is a CHECK, never a source — 15 days of retention
+ * cannot rebuild a billing history, and a scraped gauge is not evidence of a
+ * charge.
+ *
+ * CREDENTIAL. The org token that drives the Machines API is reused as the Bearer
+ * here, and the org slug comes from `FLY_PROMETHEUS_ORG_SLUG`. If the two ever
+ * need to diverge — a read-only metrics token, a different org for staging —
+ * `resolveFlyPrometheus` is the single seam that changes; nothing else in the
+ * reconcile knows where either value came from.
+ *
+ * INERT WHEN UNCONFIGURED. Missing slug or missing token resolves to `null` and
+ * the reconcile skips cleanly with a counter, never an error. The feature ships
+ * dark, and a dark feature must not redden a live cron.
+ */
+
+import { resolveFlyMachinesToken } from '../app-hosting/app-hosting-env';
+
+export const FLY_PROMETHEUS_BASE_URL = 'https://api.fly.io/prometheus';
+
+/** Request budget for one instant query. Generous: a `count_over_time` across a week is not a fast query. */
+export const FLY_PROMETHEUS_TIMEOUT_MS = 30_000;
+
+/**
+ * How often Fly scrapes `fly_instance_up`, in seconds.
+ *
+ * Load-bearing: `count_over_time` returns a SAMPLE COUNT, and seconds-awake is
+ * that count times this interval. `avg_over_time` would avoid needing it, but only
+ * if the series reported 0 while a machine is down — a stopped machine has nothing
+ * to scrape, so its series goes ABSENT rather than zero, and an average over the
+ * samples that exist reads as "up 100% of the time" for every app.
+ *
+ * NOT VERIFIED against a live org — it is on the epic's "verify before depending"
+ * list. A wrong value scales the reconcile's remote figure linearly, which shows
+ * up as a constant proportional drift on every app rather than as a silent error,
+ * and is corrected by this one env var.
+ */
+export const FLY_METRICS_SCRAPE_INTERVAL_SECONDS = (() => {
+  const raw = process.env.FLY_METRICS_SCRAPE_INTERVAL_SECONDS?.trim();
+  if (!raw || !/^\d+$/.test(raw)) return 15;
+  const parsed = Number.parseInt(raw, 10);
+  return parsed > 0 ? parsed : 15;
+})();
+
+export interface FlyPrometheusConfig {
+  orgSlug: string;
+  token: string;
+  baseUrl?: string;
+  fetchImpl?: typeof fetch;
+}
+
+/**
+ * The configured endpoint, or null when either half is missing.
+ *
+ * Reads `process.env` directly rather than through `getValidatedEnv()`, matching
+ * `resolveFlyMachinesToken` next door and for the same reason: this is read from
+ * services whose lean env makes the validated accessor THROW, which would blank a
+ * correctly-configured credential.
+ */
+export function resolveFlyPrometheus(): FlyPrometheusConfig | null {
+  const orgSlug = process.env.FLY_PROMETHEUS_ORG_SLUG?.trim();
+  const token = resolveFlyMachinesToken();
+  if (!orgSlug || !token) return null;
+  return { orgSlug, token };
+}
+
+export class FlyPrometheusError extends Error {
+  constructor(message: string, public readonly status: number | null) {
+    super(message);
+    this.name = 'FlyPrometheusError';
+  }
+}
+
+interface InstantQueryBody {
+  status?: string;
+  data?: { resultType?: string; result?: Array<{ value?: [number, string] }> };
+  error?: string;
+}
+
+/**
+ * Run one instant PromQL query and return the FIRST series' scalar value, or null
+ * when the query matched nothing.
+ *
+ * "Matched nothing" is an ordinary answer here, not an error: an app that has never
+ * been woken has no `fly_instance_up` series at all, and reading that as a failure
+ * would make every unwoken app look like a metrics outage.
+ */
+export async function queryInstant(
+  config: FlyPrometheusConfig,
+  query: string,
+): Promise<number | null> {
+  const fetchImpl = config.fetchImpl ?? fetch;
+  const base = config.baseUrl ?? FLY_PROMETHEUS_BASE_URL;
+  const url = `${base}/${encodeURIComponent(config.orgSlug)}/api/v1/query?query=${encodeURIComponent(query)}`;
+  const response = await fetchImpl(url, {
+    method: 'GET',
+    headers: { Authorization: `Bearer ${config.token}`, Accept: 'application/json' },
+    signal: AbortSignal.timeout(FLY_PROMETHEUS_TIMEOUT_MS),
+  });
+  if (!response.ok) {
+    throw new FlyPrometheusError(
+      `Fly Prometheus query failed with ${response.status}`,
+      response.status,
+    );
+  }
+  const body = (await response.json()) as InstantQueryBody;
+  if (body.status !== 'success') {
+    throw new FlyPrometheusError(body.error ?? 'Fly Prometheus returned a non-success status', null);
+  }
+  const raw = body.data?.result?.[0]?.value?.[1];
+  if (raw === undefined) return null;
+  const value = Number(raw);
+  return Number.isFinite(value) ? value : null;
+}
+
+/**
+ * The PromQL for "how many samples saw this app's instance up over `windowSeconds`".
+ *
+ * `count_over_time` rather than `sum_over_time` deliberately: the gauge's VALUE is
+ * 1 while up, so the two agree today, but a future value other than 1 would make
+ * `sum_over_time` silently scale the answer. Counting samples asks the question
+ * the reconcile actually means — how much of the window had a live instance to
+ * scrape.
+ */
+export function awakeSamplesQuery(flyAppName: string, windowSeconds: number): string {
+  // The app label is a Fly app name (`pgs-app-<cuid2>`), so it cannot contain a
+  // quote or backslash — but escaping it anyway keeps this function safe to call
+  // with any string rather than only with names we happen to generate.
+  const escaped = flyAppName.replace(/\\/g, '\\\\').replace(/"/g, '\\"');
+  return `count_over_time(fly_instance_up{app="${escaped}"}[${Math.max(1, Math.floor(windowSeconds))}s])`;
+}
+
+/**
+ * Seconds this app's instance was up over the window, per managed Prometheus.
+ * Null when the app has no series at all (never woken, or destroyed long enough
+ * ago that its samples have aged out).
+ */
+export async function queryAwakeSeconds(
+  config: FlyPrometheusConfig,
+  flyAppName: string,
+  windowSeconds: number,
+): Promise<number | null> {
+  const samples = await queryInstant(config, awakeSamplesQuery(flyAppName, windowSeconds));
+  if (samples === null) return null;
+  return Math.max(0, samples * FLY_METRICS_SCRAPE_INTERVAL_SECONDS);
+}

--- a/packages/lib/src/services/fly/prometheus-client.ts
+++ b/packages/lib/src/services/fly/prometheus-client.ts
@@ -134,7 +134,13 @@ export function awakeSamplesQuery(flyAppName: string, windowSeconds: number): st
   // quote or backslash — but escaping it anyway keeps this function safe to call
   // with any string rather than only with names we happen to generate.
   const escaped = flyAppName.replace(/\\/g, '\\\\').replace(/"/g, '\\"');
-  return `count_over_time(fly_instance_up{app="${escaped}"}[${Math.max(1, Math.floor(windowSeconds))}s])`;
+  // WRAPPED IN `sum()`, which is what collapses this to ONE series.
+  // `count_over_time` preserves every label the selector did not pin, so an app
+  // whose machine has been replaced (a blue/green deploy, a host migration) has a
+  // separate series per machine id. Reading the first of those would silently
+  // discard the other machine's samples and report the difference as drift on
+  // exactly the apps that were most recently deployed.
+  return `sum(count_over_time(fly_instance_up{app="${escaped}"}[${Math.max(1, Math.floor(windowSeconds))}s]))`;
 }
 
 /**

--- a/packages/lib/src/services/sandbox/__tests__/sandbox-storage-billing.test.ts
+++ b/packages/lib/src/services/sandbox/__tests__/sandbox-storage-billing.test.ts
@@ -445,10 +445,12 @@ describe('reconcileSandboxStorageSerialized', () => {
     return {
       listAgentSessionSprites: vi.fn(async () => []),
       listDriveEnvSprites: vi.fn(async () => []),
+      listPublishedAppRootfs: vi.fn(async () => []),
       lookupDriveOwnerId: vi.fn(async () => null),
       chargeStorage: vi.fn(async () => {}),
       advanceAgentSessionWatermark: vi.fn(async () => 'advanced' as const),
       advanceDriveEnvWatermark: vi.fn(async () => 'advanced' as const),
+      advancePublishedAppWatermark: vi.fn(async () => 'advanced' as const),
       now: () => new Date('2026-07-13T00:00:00.000Z'),
       ...overrides,
     };

--- a/packages/lib/src/services/sandbox/__tests__/sandbox-storage-reconcile.test.ts
+++ b/packages/lib/src/services/sandbox/__tests__/sandbox-storage-reconcile.test.ts
@@ -11,6 +11,7 @@ import {
   type ReconcileSandboxStorageDeps,
   type AgentSessionStorageRow,
   type DriveEnvStorageRow,
+  type PublishedAppStorageRow,
 } from '../sandbox-storage-reconcile';
 
 describe('bytesToGB', () => {
@@ -136,13 +137,16 @@ function makeDeps(over: Partial<ReconcileSandboxStorageDeps> = {}): {
   chargeCalls: ChargeCall[];
   agentSessionAdvanceCalls: Array<{ workspaceId: string; billedThrough: Date }>;
   driveEnvAdvanceCalls: Array<{ envId: string; billedThrough: Date }>;
+  publishedAppAdvanceCalls: Array<{ publishedAppId: string; billedThrough: Date }>;
 } {
   const chargeCalls: ChargeCall[] = [];
   const agentSessionAdvanceCalls: Array<{ workspaceId: string; billedThrough: Date }> = [];
   const driveEnvAdvanceCalls: Array<{ envId: string; billedThrough: Date }> = [];
+  const publishedAppAdvanceCalls: Array<{ publishedAppId: string; billedThrough: Date }> = [];
   const deps: ReconcileSandboxStorageDeps = {
     listAgentSessionSprites: async () => [],
     listDriveEnvSprites: async () => [],
+    listPublishedAppRootfs: async () => [],
     lookupDriveOwnerId: async () => 'owner-1',
     chargeStorage: async (input) => {
       chargeCalls.push(input);
@@ -159,10 +163,14 @@ function makeDeps(over: Partial<ReconcileSandboxStorageDeps> = {}): {
       driveEnvAdvanceCalls.push(input);
       return 'advanced';
     },
+    advancePublishedAppWatermark: async (input) => {
+      publishedAppAdvanceCalls.push(input);
+      return 'advanced';
+    },
     now: () => new Date('2026-07-01T00:00:00.000Z'),
     ...over,
   };
-  return { deps, chargeCalls, agentSessionAdvanceCalls, driveEnvAdvanceCalls };
+  return { deps, chargeCalls, agentSessionAdvanceCalls, driveEnvAdvanceCalls, publishedAppAdvanceCalls };
 }
 
 /**
@@ -193,6 +201,22 @@ function driveEnv(over: Partial<DriveEnvStorageRow> = {}): DriveEnvStorageRow {
     measuredBytes: 1_000_000_000, // 1 GB
     measuredAt: new Date('2026-06-30T23:00:00.000Z'),
     lastActiveAt: new Date('2026-06-30T23:59:00.000Z'),
+    ...over,
+  };
+}
+
+/**
+ * A published app's ROOTFS row, same one-span-old watermark as the two Sprite
+ * sources. Its measurement is a BUILD-TIME registry size rather than a live `du`,
+ * so it carries no `lastActiveAt` of its own.
+ */
+function publishedAppRootfs(over: Partial<PublishedAppStorageRow> = {}): PublishedAppStorageRow {
+  return {
+    publishedAppId: 'app-1',
+    driveId: 'drive-1',
+    storageLastBilledAt: new Date(new Date('2026-07-01T00:00:00.000Z').getTime() - MAX_BILLABLE_SPAN_MS),
+    measuredBytes: 1_000_000_000, // 1 GB
+    measuredAt: new Date('2026-06-30T23:00:00.000Z'),
     ...over,
   };
 }
@@ -404,6 +428,128 @@ describe('reconcileSandboxStorage', () => {
       actual: { charged: result.charged, charges: chargeCalls.length, advanced: driveEnvAdvanceCalls.length },
       expected: { charged: 0, charges: 0, advanced: 1 },
     });
+  });
+
+  // -------------------------------------------------------------------------
+  // Published-app ROOTFS — the THIRD row source on the same meter. The only cost
+  // a stopped published app still incurs, and for a fleet of mostly-idle apps the
+  // entire per-app floor.
+  // -------------------------------------------------------------------------
+
+  it("bills a published app's rootfs to its DRIVE OWNER and advances the APP's own watermark", async () => {
+    const lookup = vi.fn(async (driveId: string) => `owner-of-${driveId}`);
+    const { deps, chargeCalls, publishedAppAdvanceCalls, driveEnvAdvanceCalls, agentSessionAdvanceCalls } = makeDeps({
+      listPublishedAppRootfs: async () => [publishedAppRootfs({ publishedAppId: 'app-9', driveId: 'drive-9' })],
+      lookupDriveOwnerId: lookup,
+    });
+
+    const result = await reconcileSandboxStorage(deps);
+
+    expect(lookup).toHaveBeenCalledWith('drive-9');
+    assert({
+      given: 'a published app holding a measured 1GB image',
+      should: "charge the DRIVE OWNER, attributed to the app's drive and named as a hosting subject",
+      actual: {
+        charged: result.charged,
+        payerId: chargeCalls[0]?.payerId,
+        driveId: chargeCalls[0]?.driveId,
+        subjectKind: chargeCalls[0]?.subjectKind,
+        subjectId: chargeCalls[0]?.subjectId,
+      },
+      expected: {
+        charged: 1,
+        payerId: 'owner-of-drive-9',
+        driveId: 'drive-9',
+        subjectKind: 'hosting',
+        subjectId: 'app-9',
+      },
+    });
+    expect(chargeCalls[0].gbMonths).toBeCloseTo(MAX_BILLABLE_SPAN_MS / MS_PER_STORAGE_MONTH, 8);
+    // Its OWN watermark moved, and neither of the other two writers was touched.
+    expect(publishedAppAdvanceCalls).toEqual([
+      { publishedAppId: 'app-9', billedThrough: new Date('2026-07-01T00:00:00.000Z') },
+    ]);
+    expect(driveEnvAdvanceCalls).toEqual([]);
+    expect(agentSessionAdvanceCalls).toEqual([]);
+  });
+
+  it('SKIPS a published app whose drive owner cannot be resolved — never a fallback to its `ownerId` column', async () => {
+    // `published_apps.ownerId` is a denormalized cascade handle, not an answer to
+    // "who pays". Billing it would be a money movement that cannot be taken back.
+    const { deps, chargeCalls, publishedAppAdvanceCalls } = makeDeps({
+      listPublishedAppRootfs: async () => [publishedAppRootfs({ driveId: 'drive-mid-delete' })],
+      lookupDriveOwnerId: async () => null,
+    });
+
+    const result = await reconcileSandboxStorage(deps);
+
+    assert({
+      given: 'a published app whose drive is mid-delete',
+      should: 'skip the cycle rather than bill anybody else',
+      actual: { charged: result.charged, skipped: result.skipped, charges: chargeCalls.length, advanced: publishedAppAdvanceCalls.length },
+      expected: { charged: 0, skipped: 1, charges: 0, advanced: 0 },
+    });
+  });
+
+  it('bills the never-measured 0 floor for an app with no build yet, and still advances its watermark', async () => {
+    // `imageSizeMeasuredAt` is NOT NULL exactly when `imageSizeBytes` is, so this
+    // branch means precisely "no build has landed" — an app holding no rootfs.
+    const { deps, chargeCalls, publishedAppAdvanceCalls } = makeDeps({
+      listPublishedAppRootfs: async () => [publishedAppRootfs({ measuredBytes: null, measuredAt: null })],
+    });
+
+    const result = await reconcileSandboxStorage(deps);
+
+    assert({
+      given: 'a published app whose image has never been measured',
+      should: 'charge nothing but still advance its watermark',
+      actual: { charged: result.charged, charges: chargeCalls.length, advanced: publishedAppAdvanceCalls.length },
+      expected: { charged: 0, charges: 0, advanced: 1 },
+    });
+  });
+
+  it('reports an unreadable published-app source as a failed SOURCE without stopping the other two', async () => {
+    // A dark row source must never stop the live one's money.
+    const { deps, chargeCalls } = makeDeps({
+      listAgentSessionSprites: async () => [agentSession()],
+      listPublishedAppRootfs: async () => {
+        throw new Error('published_apps unreadable');
+      },
+    });
+
+    const result = await reconcileSandboxStorage(deps);
+
+    assert({
+      given: 'the published-app row source throwing mid-tick',
+      should: 'name it in failedSources and still bill the session',
+      actual: { failedSources: result.failedSources, charged: result.charged, charges: chargeCalls.length },
+      expected: { failedSources: ['hosting'], charged: 1, charges: 1 },
+    });
+  });
+
+  it('meters ALL THREE row sources in one run, each to its own payer and its own watermark', async () => {
+    const { deps, chargeCalls, agentSessionAdvanceCalls, driveEnvAdvanceCalls, publishedAppAdvanceCalls } = makeDeps({
+      listAgentSessionSprites: async () => [agentSession({ workspaceId: 'session-a', driveId: null, ownerId: 'global-owner' })],
+      listDriveEnvSprites: async () => [driveEnv({ envId: 'env-b', driveId: 'drive-b' })],
+      listPublishedAppRootfs: async () => [publishedAppRootfs({ publishedAppId: 'app-c', driveId: 'drive-c' })],
+      lookupDriveOwnerId: async (driveId) => `owner-of-${driveId}`,
+    });
+
+    const result = await reconcileSandboxStorage(deps);
+
+    assert({
+      given: 'one session, one env and one published app in the same tick',
+      should: 'charge each subject once, under its own kind',
+      actual: {
+        processed: result.processed,
+        charged: result.charged,
+        kinds: chargeCalls.map((c) => c.subjectKind).sort(),
+      },
+      expected: { processed: 3, charged: 3, kinds: ['env', 'hosting', 'session'] },
+    });
+    expect(agentSessionAdvanceCalls).toHaveLength(1);
+    expect(driveEnvAdvanceCalls).toHaveLength(1);
+    expect(publishedAppAdvanceCalls).toHaveLength(1);
   });
 
   it('meters BOTH row sources in one run, attributing each to its own payer and its own watermark', async () => {
@@ -768,6 +914,7 @@ describe('reconcileSandboxStorage', () => {
       expected: {
         session: { live: 1, neverMeasured: 0, stale: 0 },
         env: { live: 2, neverMeasured: 0, stale: 2 },
+        hosting: { live: 0, neverMeasured: 0, stale: 0 },
       },
     });
     // The flat totals still hold — the split is additive detail, not a redefinition.
@@ -785,6 +932,7 @@ describe('reconcileSandboxStorage', () => {
     expect(result.measurementHealth).toEqual({
       session: { live: 1, neverMeasured: 1, stale: 0 },
       env: { live: 1, neverMeasured: 1, stale: 0 },
+      hosting: { live: 0, neverMeasured: 0, stale: 0 },
     });
   });
 
@@ -957,6 +1105,7 @@ describe('reconcileSandboxStorage', () => {
       expected: {
         session: { billable: 2, charged: 0, skipped: 2, failed: 0 },
         env: { billable: 1, charged: 1, skipped: 0, failed: 0 },
+        hosting: { billable: 0, charged: 0, skipped: 0, failed: 0 },
       },
     });
     // The flat totals still add up — the split is detail, not a redefinition.
@@ -1051,6 +1200,7 @@ describe('reconcileSandboxStorage', () => {
     expect(result.measurementHealth).toEqual({
       session: { live: 1, neverMeasured: 0, stale: 0 },
       env: { live: 1, neverMeasured: 0, stale: 0 },
+      hosting: { live: 0, neverMeasured: 0, stale: 0 },
     });
   });
 

--- a/packages/lib/src/services/sandbox/sandbox-storage-billing.ts
+++ b/packages/lib/src/services/sandbox/sandbox-storage-billing.ts
@@ -1,8 +1,8 @@
 /**
  * Default (real) IO composition for the storage reconcile cron (Sprites
  * Platform Alignment 6-1) — binds `reconcileSandboxStorage`'s deps seam to its
- * TWO row sources (`agent_workspaces` and `drive_envs`) and the credit
- * pipeline. Reads the last PERSISTED measured bytes (never the provisioned cap,
+ * THREE row sources (`agent_workspaces`, `drive_envs` and `published_apps`) and
+ * the credit pipeline. Reads the last PERSISTED measured bytes (never the provisioned cap,
  * never waking a sprite).
  *
  * **Envs are a row source here, not a meter of their own.** A drive environment
@@ -35,6 +35,14 @@
  * All three are throttled per session and best-effort: a billing observation
  * must never wake a paused Sprite, delay a tool call, or fail one.
  *
+ * **A PUBLISHED APP's measurement has no such seam and needs none.** Its billed
+ * footprint is the registry size of the image it serves, recorded at BUILD time
+ * into `imageSizeBytes`/`imageSizeMeasuredAt` — the only moment the number is
+ * cheaply knowable (reading it later costs a registry round-trip per app; reading
+ * it after the image is replaced is impossible). So there is nothing to refresh
+ * opportunistically, and an app billing the never-measured 0 floor means precisely
+ * that no build has landed yet, which is an app that genuinely holds no rootfs.
+ *
  * An ENV's measurements come from the same seam, bound once at
  * `buildEnvProvisionDeps` (`services/drive-envs/env-provision-deps.ts`) — the
  * single path the web tier's rebuild and a session's ensure in both the web and
@@ -43,11 +51,12 @@
  * forever while this cron kept advancing its watermark.
  */
 
-import { eq, and, isNotNull, isNull, sql } from '@pagespace/db/operators';
+import { eq, and, isNotNull, isNull, ne, sql } from '@pagespace/db/operators';
 import { db, getAdvisoryLockPool } from '@pagespace/db/db';
 import { withAdvisoryLock, type AdvisoryLockPool } from '@pagespace/db/advisory-lock';
 import { agentWorkspaces } from '@pagespace/db/schema/agent-workspaces';
 import { driveEnvs } from '@pagespace/db/schema/drive-envs';
+import { publishedApps } from '@pagespace/db/schema/published-apps';
 import { lookupDriveOwnerId } from '../../billing/sandbox-payer';
 import { MACHINE_MARKUP_BPS } from '../../billing/credit-pricing';
 import { AIMonitoring } from '../../monitoring/ai-monitoring';
@@ -56,7 +65,19 @@ import {
   reconcileSandboxStorage,
   type ReconcileSandboxStorageDeps,
   type ReconcileSandboxStorageResult,
+  type StorageSubjectKind,
 } from './sandbox-storage-reconcile';
+
+/**
+ * The `metadata.type` tag per persistence unit — the freeform companion to the
+ * `model` label above. A `Record` keyed on `StorageSubjectKind` rather than a
+ * ternary, so a new unit cannot be silently filed under an existing one.
+ */
+const STORAGE_METADATA_TYPES: Record<StorageSubjectKind, string> = {
+  session: 'terminal_storage',
+  env: 'env_storage',
+  hosting: 'published_app_storage',
+};
 
 /**
  * Read a watermark write's outcome off the value the UPDATE returned.
@@ -127,6 +148,33 @@ export const defaultReconcileSandboxStorageDeps: ReconcileSandboxStorageDeps = {
     return rows.map((row) => ({ ...row, lastActiveAt: row.lastActiveAt ?? new Date(0) }));
   },
 
+  /**
+   * The PUBLISHED-APP row source — every app's rootfs, whatever its status.
+   *
+   * No liveness predicate, unlike the two Sprite sources: their filter exists
+   * because a torn-down Sprite holds no filesystem, whereas a published app holds
+   * its image from the moment a build pins one until the row is destroyed.
+   * `destroying` rows are the one exclusion — their Fly app is being killed, and
+   * billing a resource we are actively removing bills for our own teardown latency.
+   *
+   * `imageSizeMeasuredAt` is NOT NULL exactly when `imageSizeBytes` is (a CHECK
+   * constraint), so the never-measured branch here means precisely "no build has
+   * landed yet" — an app with no image, which genuinely holds no rootfs and
+   * correctly bills the 0 floor.
+   */
+  async listPublishedAppRootfs() {
+    return db
+      .select({
+        publishedAppId: publishedApps.id,
+        driveId: publishedApps.driveId,
+        storageLastBilledAt: publishedApps.storageLastBilledAt,
+        measuredBytes: publishedApps.imageSizeBytes,
+        measuredAt: publishedApps.imageSizeMeasuredAt,
+      })
+      .from(publishedApps)
+      .where(ne(publishedApps.status, 'destroying'));
+  },
+
   lookupDriveOwnerId,
 
   /**
@@ -157,7 +205,11 @@ export const defaultReconcileSandboxStorageDeps: ReconcileSandboxStorageDeps = {
       // Hence the shared constant rather than a literal spelled at each end —
       // the breakdown's environments section keys off the same value
       // (`apps/web/src/lib/subscription/usage-breakdown.ts`).
-      model: subjectKind === 'env' ? SANDBOX_STORAGE_MODELS.env : SANDBOX_STORAGE_MODELS.session,
+      // Keyed off the subject kind through the shared constant map, never an
+      // inline ternary chain: adding a fourth persistence unit must be a new key,
+      // not another `subjectKind === ... ? ... :` that silently defaults a new
+      // unit's charges into the session label.
+      model: SANDBOX_STORAGE_MODELS[subjectKind],
       // One feature bucket for both: this is sandbox persistence either way, and
       // splitting the source would fragment the usage breakdown's totals.
       source: 'terminal',
@@ -187,7 +239,7 @@ export const defaultReconcileSandboxStorageDeps: ReconcileSandboxStorageDeps = {
       // Same 1.5x substrate floor as active-runtime billing (machine-billing.ts),
       // independent of the shared AI MARKUP_BPS default.
       markupBpsOverride: MACHINE_MARKUP_BPS,
-      metadata: { type: subjectKind === 'env' ? 'env_storage' : 'terminal_storage', gbMonths },
+      metadata: { type: STORAGE_METADATA_TYPES[subjectKind], gbMonths },
     });
   },
 
@@ -234,6 +286,19 @@ export const defaultReconcileSandboxStorageDeps: ReconcileSandboxStorageDeps = {
       .set({ storageLastBilledAt: sql`GREATEST(${driveEnvs.storageLastBilledAt}, ${sql.param(billedThrough, driveEnvs.storageLastBilledAt)})` })
       .where(eq(driveEnvs.id, envId))
       .returning({ storageLastBilledAt: driveEnvs.storageLastBilledAt });
+    return classifyWatermarkWrite(row?.storageLastBilledAt, billedThrough);
+  },
+
+  // The published app's OWN watermark, same literal per-row design and the same
+  // monotonic guard. Deliberately NOT predicated on status: the charge it follows
+  // has already happened, so refusing the advance because the app was stopped or
+  // parked mid-tick would re-bill that window on the next run.
+  async advancePublishedAppWatermark({ publishedAppId, billedThrough }) {
+    const [row] = await db
+      .update(publishedApps)
+      .set({ storageLastBilledAt: sql`GREATEST(${publishedApps.storageLastBilledAt}, ${sql.param(billedThrough, publishedApps.storageLastBilledAt)})` })
+      .where(eq(publishedApps.id, publishedAppId))
+      .returning({ storageLastBilledAt: publishedApps.storageLastBilledAt });
     return classifyWatermarkWrite(row?.storageLastBilledAt, billedThrough);
   },
 

--- a/packages/lib/src/services/sandbox/sandbox-storage-reconcile.ts
+++ b/packages/lib/src/services/sandbox/sandbox-storage-reconcile.ts
@@ -1,8 +1,9 @@
 /**
  * Storage reconcile (Sprites Platform Alignment 6-1) — periodically meters the
  * cost of a PERSISTENT filesystem, whether its sandbox is active or
- * hibernating. TWO row sources, ONE meter: an agent session
- * (`agent_workspaces`) and a drive ENVIRONMENT (`drive_envs`). The platform bills for the bytes actually
+ * hibernating. THREE row sources, ONE meter: an agent session
+ * (`agent_workspaces`), a drive ENVIRONMENT (`drive_envs`), and a PUBLISHED APP's
+ * rootfs (`published_apps`). The platform bills for the bytes actually
  * written (TRIM-friendly — deleting files lowers the bill), NOT the
  * provisioned volume size (docs.sprites.dev/concepts/lifecycle). So this
  * bills the last PERSISTED MEASURED footprint, never the provisioned cap — a
@@ -111,6 +112,16 @@
  * audit only), so its payer is the drive owner or nobody — see
  * `resolveEnvPayerId`, and the skip-on-unresolvable rule below.
  *
+ * **Widened once more by published apps, on exactly the same terms.** A published
+ * app's rootfs is the only cost a stopped app still incurs — its awake-seconds go
+ * to zero and its image keeps costing $0.15/GB-month — and for a fleet of
+ * mostly-idle apps that drip IS the per-app floor. It joins as a third row source
+ * for the same reason envs did: a second meter would be a second place for a
+ * double-bill to hide. Its measurement is not a filesystem `du` but the registry
+ * size recorded at BUILD time (`imageSizeBytes` + `imageSizeMeasuredAt`), and its
+ * payer is the drive owner with no fallback, identical to an env's — a published
+ * app hangs off an env, and an env is drive-owned. See `PublishedAppStorageRow`.
+ *
  * **`reconcileSandboxStorage` NEVER THROWS**, and `reconcileSandboxStorageSerialized`
  * relies on that to tell an advisory-lock connection error apart from a failure
  * of the work itself. Every per-row failure is already isolated in its own
@@ -196,7 +207,7 @@ export const MAX_BILLABLE_SPAN_MS = 24 * 60 * 60 * 1000;
  * only, because forgiving revenue on a LIVE meter is a product decision this PR
  * deliberately does not make.
  */
-const CLAMPED_SUBJECT_KINDS: readonly StorageSubjectKind[] = ['env'];
+const CLAMPED_SUBJECT_KINDS: readonly StorageSubjectKind[] = ['env', 'hosting'];
 
 /** Pure: bytes → DECIMAL gigabytes (÷1e9), matching how the platform expresses its allocation ("100 GB") and its per-GB-month rate — NOT binary GiB. Invalid or non-positive input floors to 0. */
 export function bytesToGB(bytes: number): number {
@@ -292,8 +303,48 @@ export interface DriveEnvStorageRow {
   lastActiveAt: Date;
 }
 
-/** WHICH kind of row a charge is for. The meter is one; the persistence units it meters are two. */
-export type StorageSubjectKind = 'session' | 'env';
+/**
+ * A PUBLISHED APP's ROOTFS — the third row source, and the only per-app cost that
+ * does not stop when the app does.
+ *
+ * A published app's machine is stopped by the idle reaper and costs zero
+ * awake-seconds while it sits there; its IMAGE still costs $0.15/GB-month for as
+ * long as the app exists. For a fleet of mostly-idle published apps that drip is
+ * the entire per-app floor, which is why it is metered at all — and why it is
+ * metered HERE, as a row source on the existing meter, rather than as a meter of
+ * its own. One cron, one advisory lock, one credit pipeline, one watermark
+ * discipline.
+ *
+ * Two differences from the two Sprite-backed sources, both structural:
+ *
+ *  - the measurement is not a `du` of a live filesystem. It is
+ *    `published_apps.imageSizeBytes`, recorded from the registry manifest at BUILD
+ *    time — which is also the only moment it is cheaply knowable, since reading it
+ *    later costs a registry round-trip per app and reading it after the image is
+ *    replaced is impossible. So this source is never "measured while awake"; it is
+ *    measured when the thing being measured is created.
+ *  - it is billed whatever the app's status. A stopped, or even a `parked`, app
+ *    holds its rootfs. Only a DESTROYED app stops costing, and that row is gone.
+ *
+ * The payer is the same as an env's, for the same reason and through the same
+ * function: a published app hangs off an environment, and an environment is
+ * drive-owned. `published_apps.ownerId` is a denormalized cascade handle and is
+ * deliberately not read here.
+ */
+export interface PublishedAppStorageRow {
+  /** The `published_apps` row's own id. Where THIS app's watermark is persisted. */
+  publishedAppId: string;
+  /** The owning drive — NOT NULL, and the ONLY route to a payer. */
+  driveId: string;
+  storageLastBilledAt: Date;
+  /** The pinned image's registry size, from `imageSizeBytes`; null until the first build lands. */
+  measuredBytes: number | null;
+  /** When that size was recorded — the build that pinned the digest. Null alongside null bytes. */
+  measuredAt: Date | null;
+}
+
+/** WHICH kind of row a charge is for. The meter is one; the persistence units it meters are three. */
+export type StorageSubjectKind = 'session' | 'env' | 'hosting';
 
 /**
  * What a watermark write actually did. Three outcomes, because collapsing the
@@ -314,10 +365,15 @@ export interface ReconcileSandboxStorageDeps {
    */
   listDriveEnvSprites: () => Promise<DriveEnvStorageRow[]>;
   /**
+   * Every published app's ROOTFS to meter — the third row source. Billed whatever
+   * the app's status: a stopped published app still holds its image.
+   */
+  listPublishedAppRootfs: () => Promise<PublishedAppStorageRow[]>;
+  /**
    * Resolves a drive's ownerId; null when it can't be resolved (e.g. a stale
-   * read of a drive mid-delete). Used for every env row, and for a session
-   * subject whose `driveId` is set — the session `driveId === null` case
-   * bypasses this entirely (see `storageBillingTarget`, whose `{ ownerId }`
+   * read of a drive mid-delete). Used for every env and published-app row, and
+   * for a session subject whose `driveId` is set — the session `driveId === null`
+   * case bypasses this entirely (see `storageBillingTarget`, whose `{ ownerId }`
    * branch is already resolved, pure data with no IO needed).
    */
   lookupDriveOwnerId: (driveId: string) => Promise<string | null>;
@@ -354,6 +410,11 @@ export interface ReconcileSandboxStorageDeps {
   advanceAgentSessionWatermark: (input: { workspaceId: string; billedThrough: Date }) => Promise<WatermarkWriteOutcome>;
   /** The same per-row watermark write, against `drive_envs`, with the same monotonic contract. */
   advanceDriveEnvWatermark: (input: { envId: string; billedThrough: Date }) => Promise<WatermarkWriteOutcome>;
+  /** The same per-row watermark write, against `published_apps`, with the same monotonic contract. */
+  advancePublishedAppWatermark: (input: {
+    publishedAppId: string;
+    billedThrough: Date;
+  }) => Promise<WatermarkWriteOutcome>;
   now: () => Date;
 }
 
@@ -610,6 +671,35 @@ function toEnvSubject(
   };
 }
 
+function toHostingSubject(
+  app: PublishedAppStorageRow,
+  lookupDriveOwnerId: (driveId: string) => Promise<string | null>,
+  deps: ReconcileSandboxStorageDeps,
+): BillableStorageSubject {
+  return {
+    kind: 'hosting',
+    subjectId: app.publishedAppId,
+    // Always attributed: a published app's `driveId` is NOT NULL.
+    attributionDriveId: app.driveId,
+    // The drive owner, with no fallback — identical to an env's, because a
+    // published app hangs off an env and an env is drive-owned. The memoized
+    // closure, not a bare deps reference (see `toEnvSubject`).
+    resolvePayerId: () => resolveEnvPayerId({ driveId: app.driveId, lookupDriveOwnerId }),
+    advanceWatermark: (billedThrough) =>
+      deps.advancePublishedAppWatermark({ publishedAppId: app.publishedAppId, billedThrough }),
+    storageLastBilledAt: app.storageLastBilledAt,
+    measuredBytes: app.measuredBytes,
+    measuredAt: app.measuredAt,
+    // A rootfs has no "awake" state to refresh a measurement from — the size is
+    // recorded once, at build. The epoch reads as "not awake", which is the
+    // honest input to the staleness flag: an app that has not been rebuilt in a
+    // day genuinely is billing from an ageing (and still perfectly correct)
+    // measurement. See `measurementHealth` on why that saturation is expected
+    // rather than alarming for a build-time-measured source.
+    lastActiveAt: new Date(0),
+  };
+}
+
 /** What one subject's window prices to this tick. Pure — no IO, no counters, no decisions about what to DO with it. */
 interface SubjectWindowPrice {
   /** The span actually billed, after any cap. */
@@ -721,20 +811,23 @@ export async function reconcileSandboxStorage(
   // from one consistent-enough snapshot), but they are read INDEPENDENTLY —
   // see `listSource` for why one source's failure must not stop the other's
   // money.
-  const [sessions, envs] = await Promise.all([
+  const [sessions, envs, hosting] = await Promise.all([
     // Called through a closure, not passed unbound: a deps implementation is
     // free to be a real object whose row source reads `this`, and an unbound
     // reference would break it in a way only production would show.
     listSource('session', () => deps.listAgentSessionSprites()),
     listSource('env', () => deps.listDriveEnvSprites()),
+    listSource('hosting', () => deps.listPublishedAppRootfs()),
   ]);
   const subjects: BillableStorageSubject[] = [
     ...sessions.rows.map((session) => toSessionSubject(session, lookupDriveOwnerIdOnce, deps)),
     ...envs.rows.map((env) => toEnvSubject(env, lookupDriveOwnerIdOnce, deps)),
+    ...hosting.rows.map((app) => toHostingSubject(app, lookupDriveOwnerIdOnce, deps)),
   ];
   const failedSources: StorageSubjectKind[] = [];
   if (sessions.failed) failedSources.push('session');
   if (envs.failed) failedSources.push('env');
+  if (hosting.failed) failedSources.push('hosting');
   const now = deps.now();
 
 
@@ -746,6 +839,7 @@ export async function reconcileSandboxStorage(
   const measurementHealth: Record<StorageSubjectKind, { live: number; neverMeasured: number; stale: number }> = {
     session: { live: 0, neverMeasured: 0, stale: 0 },
     env: { live: 0, neverMeasured: 0, stale: 0 },
+    hosting: { live: 0, neverMeasured: 0, stale: 0 },
   };
   const billingByKind: Record<
     StorageSubjectKind,
@@ -753,6 +847,7 @@ export async function reconcileSandboxStorage(
   > = {
     session: { billable: 0, charged: 0, skipped: 0, failed: 0 },
     env: { billable: 0, charged: 0, skipped: 0, failed: 0 },
+    hosting: { billable: 0, charged: 0, skipped: 0, failed: 0 },
   };
 
   // Failures on rows we never established were BILLABLE — a pricing throw, or


### PR DESCRIPTION
## What

Drains credits on **awake-seconds** for published environments, and folds their **rootfs** into the storage meter that already exists. Ships dark behind `APP_HOSTING_ENABLED`.

A published app's machine runs with `autostop: off`, so our orchestrator owns every start and stop — a billing boundary is an API call we made at a time we know exactly, not a proxy behaviour we have to infer.

- **Wake** — `canConsumeAI` gate + hold *before* the machine starts, then stamp the boundary. That gate is the whole of hosting's credit enforcement: an exhausted payer's app is parked and never started, so there is nothing to claw back.
- **While running** — a 10-minute heartbeat settles accrued seconds and **re-holds**, so the gate keeps binding on a long-lived app instead of only at the next cold wake. A payer who runs out mid-window is stopped and parked.
- **Stop** — mirror the boundary, then settle the tail and close the window.
- **Payer** — the **drive owner**, via `resolveEnvPayerId`. `published_apps.ownerId` is a denormalized cascade handle and is deliberately not consulted; an unresolvable drive skips rather than misattributing a charge that cannot be taken back.

## Why a local event mirror

Fly retains only the **last 20 events per machine**, with no pagination and no time filter — about five stop/start cycles. **Awake history cannot be rebuilt from Fly after the fact**, so `published_app_machine_events` is the record, not a cache of one: our own boundaries are written in the same step as the call, and Fly's own events are mirrored opportunistically while the window still holds them. A weekly advisory-locked cron compares our figure against managed Prometheus `fly_instance_up` (~15-day retention) and **alerts** — it never moves money, because a scraped gauge is not evidence of a charge.

## Which way each crash window fails

Chosen, not incidental:

- A wake stamps **after** Fly confirms the start — the platform eats an unrecorded start rather than billing a customer for a machine that failed to start. The weekly reconcile surfaces it as `under_billed`.
- A stop mirrors its boundary **before** the money, so a lost status write is repaired by the next heartbeat at the **real** boundary rather than billing a stopped machine to `now`.
- A failed settle leaves the window **open** (retried) while still moving the status; a settle that commits but whose watermark write fails is counted under its own name (`settledButUnadvanced`) and alerts, because that is a genuine double-bill in progress.

## Tenant / onprem

`isBillingEnabled()` false stays unlimited but **not unbounded**: the wake gate always passes `dailyCapCeilingCents`, which `canConsumeAI` honours in every deployment mode, metering the day from `ai_usage_logs` where there is no ledger.

## Rootfs storage

A third **row source** on `reconcileSandboxStorage` — following exactly how #2440 folded `drive_envs` in — rather than a new meter or a new cron. One advisory lock, one credit pipeline, one watermark discipline; a second meter would be a second place for a double-bill to hide. Its size is the registry manifest recorded at build time, and `imageSizeMeasuredAt` now lands in the same statement as `imageSizeBytes` under a CHECK: the meter cannot use a measurement it cannot date.

## Insolvency parking landed here

Ratified on the questions page: the heartbeat's re-gate is what *discovers* insolvency, so the stop + `running -> parked` belongs with it — without it a long-running awake machine drains unbounded once credits hit zero. It goes through the status machine's legal edge via the transition planner, stays metered-tier-only per the CHECK, and is dep-injected. **The idle-reaper task keeps daily-cap parking and should not duplicate this.**

## Defects found and fixed while testing

`writeSettle` guarded the watermark against a concurrent wake with `GREATEST`, but wrote `awakeHoldId` **unconditionally in the same statement**. A settle superseded by a wake therefore clobbered that wake's live reservation — stranded for its whole TTL, never settled and never released, suppressing a real payer's spendable balance, while the new window settled against a hold placed for a window that no longer existed. `stampWindowStart` had the same unguarded shape and could additionally drag a fresh watermark **backward** into a re-billed span.

Both writes now decide the hold on the same comparison that decides the window, and a refused write releases the reservation nothing will ever settle. Proved against a real Postgres — reverting either fix turns the guarding test red.

## Testing

Seven new modules arrived on the money path with **no tests at all**; this adds them.

- **113 new tests** across the metering arithmetic, the billing seam's attribution, the wake/stop seams, the heartbeat meter, the weekly reconcile and the Prometheus client.
- **15 integration tests against a real Postgres** for what a mocked db cannot prove: the mirror's `ON CONFLICT` arbiter on a **partial** unique index (get the predicate wrong and every re-mirror throws, turning a routine call into a mirroring outage), the monotonic watermark and its hold guard, and the billing CHECK constraints.
- **Mutation-checked**, not just green: 13 deliberate breaks — dropping the clamp, billing to `now` on repair, pricing at the sandbox guest instead of the published one, dropping the daily-cap ceiling, removing the ON CONFLICT predicate, reverting both of my own fixes — each turns a test red.

Existing storage-reconcile harnesses were repaired for the widened three-source deps (they would not have compiled), and `published_app_machine_events` is registered with an Art 15 export decision as service infrastructure.

## Gates

`typecheck` 17/17 · `lint` 15/15 · `turbo test:coverage` (CI's own command) 14/14, ~34,000 tests, 0 failures · `test:infra` 343 · `test:security` 51/51 · knip within baseline · `drizzle-kit check` clean · `db:generate` a no-op against the committed migration.

Migration regenerated as **0273** after master took 0268–0272, and verified to apply against a real database.

## Two follow-ups, both ratified as out of scope

- **`AIMonitoring.trackUsage` swallows its own persistence failures.** It catches a failing `writeAiUsage` and `.catch()`es a rejecting `consumeCredits`, then resolves — so no caller can tell a committed charge from a lost one, and *every* meter that advances a watermark after awaiting it inherits the same silent-loss shape (the sandbox storage reconcile and the realtime shell handler included). Owned by board task `ltdp7fba2fc1egtu14p3xui5`, which carries the persistence-outcome contract change and the all-callers sweep. This PR does not fork a hosting-only write path; it only stops the code claiming a guarantee it does not have.
- **Heartbeat vs lifecycle-stop can still duplicate a charge.** `stopPublishedApp` does not take the meter's advisory lock, so a stop landing mid-tick can price the same window from the same snapshot. The **state**-corruption half is closed here by the compare-and-set; taking the lock is now binding on the idle-reaper task, which owns that caller. The weekly reconcile reports the residual as `over_billed`.

## Notes for the reviewer

- **Nothing calls `wakePublishedApp` / `stopPublishedApp` yet** — the routing track wires them. Dark and inert by design.
- `FLY_METRICS_SCRAPE_INTERVAL_SECONDS` (default 15) is **not yet verified against a live org**. A wrong value scales the reconcile's remote figure linearly, which shows up as a constant proportional drift on every app rather than a silent error, and is corrected by that one env var. It affects the alert only — never a charge.
