### PR TITLE
feat(tags): the content-tag service shell (Phase 3)

### DIFF
--- a/knip.json
+++ b/knip.json
@@ -498,6 +498,7 @@
         "src/sheets/io.ts",
         "src/sheets/sheet.ts",
         "src/tags/tag-core.ts",
+        "src/tags/tag-service.ts",
         "src/types.ts",
         "src/utils/api-utils.ts",
         "src/utils/enums.ts",

--- a/packages/lib/package.json
+++ b/packages/lib/package.json
@@ -1023,6 +1023,11 @@
       "import": "./dist/tags/tag-core.js",
       "require": "./dist/tags/tag-core.js"
     },
+    "./tags/tag-service": {
+      "types": "./dist/tags/tag-service.d.ts",
+      "import": "./dist/tags/tag-service.js",
+      "require": "./dist/tags/tag-service.js"
+    },
     "./utils/environment": {
       "types": "./dist/utils/environment.d.ts",
       "import": "./dist/utils/environment.js",

--- a/packages/lib/src/content/anchoring/reanchor.ts
+++ b/packages/lib/src/content/anchoring/reanchor.ts
@@ -172,18 +172,37 @@ export function changedRegionSize(oldText: string, newText: string): number {
  * strategy is sniffed per revision and can flip on unclosed trailing markup
  * (see its own docs), which is one concrete way the two sides drift apart.
  */
-export function portAnchor(
-  anchor: TextAnchor,
-  oldText: string,
-  newText: string
-): AnchorResolution {
-  if (changedRegionSize(oldText, newText) > MAX_EXACT_DIFF_REGION) {
-    return resolveAnchor(newText, anchor);
-  }
+/**
+ * One revision transition, diffed once.
+ *
+ * The diff depends only on `(oldText, newText)`, never on the anchor, but
+ * `portAnchor` recomputes it per call — which is fine for one anchor and
+ * quadratic waste for a page carrying many. Phase 0 measured the diff at 142ms
+ * for 2KB of change, 558ms at 4KB and 13.9s at 20KB, so a bulk caller that
+ * loops `portAnchor` pays that once PER ANCHOR for an identical result.
+ *
+ * `preparePort` + `portPreparedAnchor` is the seam for those callers. The
+ * single-anchor `portAnchor` is now a wrapper over exactly this path, so there
+ * is one implementation and no second copy to drift.
+ */
+export type PreparedPort = {
+  oldText: string;
+  newText: string;
+  /** True when the change is too large to map exactly; every anchor falls back to repair. */
+  exceedsExactRegion: boolean;
+  spans: readonly SurvivingSpan[];
+};
 
-  const located = locateInOldText(anchor, oldText);
-  if (!located) {
-    return orphaned();
+/**
+ * Diff one revision transition so many anchors can be ported against it.
+ *
+ * Returns `spans: []` when the change exceeds MAX_EXACT_DIFF_REGION — the diff
+ * is deliberately NOT computed in that case, since every anchor routes to
+ * `resolveAnchor` and the expensive call would be thrown away.
+ */
+export function preparePort(oldText: string, newText: string): PreparedPort {
+  if (changedRegionSize(oldText, newText) > MAX_EXACT_DIFF_REGION) {
+    return { oldText, newText, exceedsExactRegion: true, spans: [] };
   }
 
   // `format` because both sides are projections, which are plain text by
@@ -198,6 +217,29 @@ export function portAnchor(
   const spans = survivingSpans(
     diffContent(oldText, newText, { format: 'text', timeout: 0 }).changes
   );
+  return { oldText, newText, exceedsExactRegion: false, spans };
+}
+
+/**
+ * Forward-port `anchor` through an already-computed transition.
+ *
+ * Same contract and same results as `portAnchor`; see its docs for the caller
+ * contract about projections and `textHash`.
+ */
+export function portPreparedAnchor(
+  prepared: PreparedPort,
+  anchor: TextAnchor
+): AnchorResolution {
+  const { oldText, newText, spans } = prepared;
+
+  if (prepared.exceedsExactRegion) {
+    return resolveAnchor(newText, anchor);
+  }
+
+  const located = locateInOldText(anchor, oldText);
+  if (!located) {
+    return orphaned();
+  }
 
   if (located.from === located.to) {
     const mapped = mapPoint(spans, located.from);
@@ -258,4 +300,33 @@ export function portAnchor(
     end: portedEnd,
     confidence: Math.min(1, Math.max(0, fidelity * located.confidence)),
   };
+}
+
+/**
+ * Forward-port `anchor` from `oldText` to `newText`.
+ *
+ * Both arguments are projections (see text-projection.ts), never stored blobs.
+ * Being a pure function of `(anchor, oldText, newText)` — rather than of
+ * `(anchor, newText)` alone — is what makes the exact mapping possible.
+ *
+ * CALLER CONTRACT: `oldText` must be the projection the anchor was measured
+ * against, and both projections must have been produced the same way. Neither
+ * can be checked from here — this function receives two strings and has no way
+ * to know which page or revision they came from — and getting it wrong yields a
+ * confident wrong answer rather than an error, because a mislaid quote is still
+ * found and still ported. `anchor.textHash` hashes the exact projection the
+ * anchor was built against, so a call site that cares can compare it against
+ * `hashText(oldText)` before trusting the result. Note that projectContent's
+ * strategy is sniffed per revision and can flip on unclosed trailing markup
+ * (see its own docs), which is one concrete way the two sides drift apart.
+ *
+ * Porting MANY anchors across one transition? Use `preparePort` once and
+ * `portPreparedAnchor` per anchor — this wrapper diffs on every call.
+ */
+export function portAnchor(
+  anchor: TextAnchor,
+  oldText: string,
+  newText: string
+): AnchorResolution {
+  return portPreparedAnchor(preparePort(oldText, newText), anchor);
 }

--- a/packages/lib/src/content/anchoring/reanchor.ts
+++ b/packages/lib/src/content/anchoring/reanchor.ts
@@ -18,13 +18,15 @@
  * Zero I/O — no db, no fetch, no clock, no env — enforced by the purity test in
  * __tests__/purity.test.ts.
  *
- * COST: portAnchor diffs the whole document once per anchor, which is the right
- * shape for a pure function of (anchor, oldText, newText) and the wrong shape
- * for a page carrying many anchors. The diff depends only on the two texts, so
- * the call site that ports a page's anchors in bulk should compute it once and
- * reuse it. That call site does not exist yet — wiring this into
- * applyPageMutation is a later phase — so the hoist belongs there, not here,
- * where it would mean inventing an API with no caller to shape it.
+ * COST: a diff of the whole document is the right shape for a pure function of
+ * (anchor, oldText, newText) and the wrong shape for a page carrying many
+ * anchors, because the diff depends only on the two texts. The bulk call site
+ * now exists — `reanchorPageTags` in ../../tags/tag-service.ts — so the hoist
+ * is a real seam rather than an invented one: `preparePort` computes the
+ * transition once and `portPreparedAnchor` ports each anchor against it.
+ * `portAnchor` remains for single-anchor callers and is a thin wrapper over
+ * exactly that path, so there is one implementation and no second copy to
+ * drift.
  *
  * @module @pagespace/lib/content/anchoring/reanchor
  */
@@ -39,9 +41,10 @@ import type { AnchorResolution, TextAnchor } from './types';
  *
  * A character diff is quadratic in the size of the differing region. Measured
  * on this repo's diff-match-patch, two fully dissimilar strings take ~142ms at
- * 2KB, ~558ms at 4KB and ~13.9s at 20KB — and portAnchor runs once per anchor,
- * so an unbounded diff of a wholesale rewrite would block the event loop for
- * minutes on a page carrying a handful of tags.
+ * 2KB, ~558ms at 4KB and ~13.9s at 20KB. `portAnchor` pays that per call, so an
+ * unbounded diff of a wholesale rewrite would block the event loop for minutes
+ * on a page carrying a handful of tags — which is what this cap, and the
+ * `preparePort` hoist, exist to prevent.
  *
  * Capping the CLOCK instead would be worse than useless here: diff-match-patch
  * does not fail when its deadline expires, it returns a valid but suboptimal

--- a/packages/lib/src/tags/__tests__/tag-service.integration.test.ts
+++ b/packages/lib/src/tags/__tests__/tag-service.integration.test.ts
@@ -1,0 +1,366 @@
+/**
+ * Integration tests for the content-tag service shell.
+ *
+ * These exist to prove the things a unit test CANNOT: that the service's
+ * behaviour and the database's constraints agree. The partial unique indexes,
+ * the five-branch CHECK and the scope trigger from migrations 0270/0272 are
+ * enforced by Postgres, so a mocked db would happily accept rows the real one
+ * rejects — and the whole point of putting those rules in the schema was that
+ * they hold regardless of which code path writes.
+ *
+ * Requires a running Postgres with the latest migrations applied. Run via:
+ *   ./scripts/test-with-db.sh
+ *   bun run --filter '@pagespace/lib' test -- src/tags/__tests__/tag-service.integration.test.ts
+ */
+import { describe, it, expect, beforeEach } from 'vitest';
+import { factories } from '@pagespace/db/test/factories';
+import { db } from '@pagespace/db/db';
+import { and, eq } from '@pagespace/db/operators';
+import { users } from '@pagespace/db/schema/auth';
+import { drives, pages, tags } from '@pagespace/db/schema/core';
+import { contentTags } from '@pagespace/db/schema/content-tags';
+import { channelMessages } from '@pagespace/db/schema/chat';
+import { pagePermissions, driveMembers } from '@pagespace/db/schema/members';
+import {
+  listDriveTags,
+  upsertTag,
+  applyTag,
+  removeTag,
+  getPageTags,
+  getBatchPageTags,
+} from '../tag-service';
+
+/** Unwrap an ok result, failing loudly with the error code when it is not. */
+function expectOk<T>(result: { ok: true; data: T } | { ok: false; error: string; message?: string }): T {
+  if (!result.ok) {
+    throw new Error(`expected ok, got ${result.error}${result.message ? `: ${result.message}` : ''}`);
+  }
+  return result.data;
+}
+
+describe('tag-service (integration)', () => {
+  beforeEach(async () => {
+    await db.delete(contentTags);
+    await db.delete(tags);
+    await db.delete(channelMessages);
+    await db.delete(pagePermissions);
+    await db.delete(pages);
+    await db.delete(driveMembers);
+    await db.delete(drives);
+    await db.delete(users);
+  });
+
+  /** Owner + drive + one DOCUMENT page, the shape most cases need. */
+  async function seed() {
+    const owner = await factories.createUser();
+    const drive = await factories.createDrive(owner.id);
+    await factories.createDriveMember(drive.id, owner.id, { role: 'OWNER' });
+    const page = await factories.createPage(drive.id, { type: 'DOCUMENT', title: 'Doc', position: 0 });
+    return { owner, drive, page };
+  }
+
+  describe('the vocabulary is drive-scoped', () => {
+    it('makes the same tag name in two drives two independent rows', async () => {
+      // The bug this reclaim exists to fix: `tags.name` used to be GLOBALLY
+      // unique, so the first drive to use "urgent" owned the word forever.
+      const owner = await factories.createUser();
+      const driveA = await factories.createDrive(owner.id);
+      const driveB = await factories.createDrive(owner.id);
+      await factories.createDriveMember(driveA.id, owner.id, { role: 'OWNER' });
+      await factories.createDriveMember(driveB.id, owner.id, { role: 'OWNER' });
+
+      const a = expectOk(await upsertTag(driveA.id, owner.id, { name: 'Urgent' }));
+      const b = expectOk(await upsertTag(driveB.id, owner.id, { name: 'Urgent' }));
+
+      expect(a.id).not.toBe(b.id);
+      expect(a.normalizedKey).toBe(b.normalizedKey);
+      const rows = await db.select().from(tags);
+      expect(rows).toHaveLength(2);
+    });
+
+    it('collapses case and accent variants onto one row within a drive', async () => {
+      const { owner, drive } = await seed();
+
+      const first = expectOk(await upsertTag(drive.id, owner.id, { name: 'Café' }));
+      const second = expectOk(await upsertTag(drive.id, owner.id, { name: 'CAFÉ' }));
+      const third = expectOk(await upsertTag(drive.id, owner.id, { name: 'café' }));
+
+      expect(second.id).toBe(first.id);
+      expect(third.id).toBe(first.id);
+      expect(await db.select().from(tags)).toHaveLength(1);
+    });
+
+    it('returns an existing tag UNMODIFIED rather than restyling it', async () => {
+      // upsert here means get-or-create. A second caller passing a different
+      // colour must not repaint a vocabulary entry the whole drive shares.
+      const { owner, drive } = await seed();
+
+      const created = expectOk(await upsertTag(drive.id, owner.id, { name: 'Urgent', color: '#ff0000', description: 'first' }));
+      const again = expectOk(await upsertTag(drive.id, owner.id, { name: 'urgent', color: '#00ff00', description: 'second' }));
+
+      expect(again.id).toBe(created.id);
+      expect(again.color).toBe('#ff0000');
+      expect(again.description).toBe('first');
+    });
+
+    it('rejects a name the pure core rejects, without touching the database', async () => {
+      const { owner, drive } = await seed();
+
+      const result = await upsertTag(drive.id, owner.id, { name: '   ' });
+
+      expect(result.ok).toBe(false);
+      if (!result.ok) expect(result.error).toBe('invalid_name');
+      expect(await db.select().from(tags)).toHaveLength(0);
+    });
+  });
+
+  describe('the partial unique indexes', () => {
+    it('rejects a SECOND page-level assignment of the same tag', async () => {
+      const { owner, drive, page } = await seed();
+      const tag = expectOk(await upsertTag(drive.id, owner.id, { name: 'urgent' }));
+
+      const first = await applyTag(owner.id, { pageId: page.id, tagId: tag.id, target: { kind: 'page' }, source: 'user' });
+      expect(first.ok).toBe(true);
+
+      // `content_tags_page_target_unique` is partial: UNIQUE (pageId, tagId)
+      // WHERE targetKind = 'page'. A duplicate is a driver error, which the
+      // service converts rather than leaking.
+      const second = await applyTag(owner.id, { pageId: page.id, tagId: tag.id, target: { kind: 'page' }, source: 'user' });
+      expect(second.ok).toBe(false);
+      if (!second.ok) expect(second.error).toBe('internal_error');
+
+      expect(await db.select().from(contentTags)).toHaveLength(1);
+    });
+
+    it('ACCEPTS a second anchored assignment of the same tag on the same page', async () => {
+      // The reason content_tags is not a composite-PK join table: one tag
+      // legitimately attaches many times to one page at different offsets.
+      // No partial index covers 'text', and that is deliberate.
+      const { owner, drive, page } = await seed();
+      const tag = expectOk(await upsertTag(drive.id, owner.id, { name: 'todo' }));
+
+      const anchorAt = (start: number) => ({
+        v: 1 as const,
+        exact: 'some quoted words',
+        prefix: 'before ',
+        suffix: ' after',
+        start,
+        end: start + 17,
+        revision: 1,
+        textHash: 'deadbeef',
+      });
+
+      const a = await applyTag(owner.id, { pageId: page.id, tagId: tag.id, target: { kind: 'text', anchor: anchorAt(10) }, source: 'user' });
+      const b = await applyTag(owner.id, { pageId: page.id, tagId: tag.id, target: { kind: 'text', anchor: anchorAt(200) }, source: 'user' });
+
+      expect(a.ok).toBe(true);
+      expect(b.ok).toBe(true);
+      expect(await db.select().from(contentTags)).toHaveLength(2);
+    });
+  });
+
+  describe('target kinds and the CHECK constraint', () => {
+    it('inserts a page-level tag with every discriminated column null', async () => {
+      const { owner, drive, page } = await seed();
+      const tag = expectOk(await upsertTag(drive.id, owner.id, { name: 'a' }));
+
+      expectOk(await applyTag(owner.id, { pageId: page.id, tagId: tag.id, target: { kind: 'page' }, source: 'user' }));
+
+      const [row] = await db.select().from(contentTags);
+      expect(row.targetKind).toBe('page');
+      expect(row.anchor).toBeNull();
+      expect(row.anchorStatus).toBeNull();
+      expect(row.channelMessageId).toBeNull();
+      expect(row.aiMessageId).toBeNull();
+    });
+
+    it("stamps a fresh text anchor 'exact', which the CHECK requires to be non-null", async () => {
+      const { owner, drive, page } = await seed();
+      const tag = expectOk(await upsertTag(drive.id, owner.id, { name: 'b' }));
+
+      expectOk(await applyTag(owner.id, {
+        pageId: page.id,
+        tagId: tag.id,
+        target: { kind: 'text', anchor: { v: 1, exact: 'q', prefix: '', suffix: '', start: 0, end: 1, revision: 1, textHash: 'h' } },
+        source: 'ai',
+        confidence: 0.75,
+      }));
+
+      const [row] = await db.select().from(contentTags);
+      expect(row.targetKind).toBe('text');
+      expect(row.anchorStatus).toBe('exact');
+      expect(row.anchor).not.toBeNull();
+      expect(row.source).toBe('ai');
+      expect(row.confidence).toBeCloseTo(0.75);
+    });
+
+    it('rejects a target kind the page type does not accept', async () => {
+      // TAG_TARGETS says DOCUMENT takes ['page', 'text'] only. The pure core
+      // refuses before the database is asked, so the error is actionable
+      // rather than a constraint violation.
+      const { owner, drive, page } = await seed();
+      const tag = expectOk(await upsertTag(drive.id, owner.id, { name: 'c' }));
+
+      const result = await applyTag(owner.id, {
+        pageId: page.id,
+        tagId: tag.id,
+        target: { kind: 'sheet_cell', anchor: { v: 1, sheet: 'Sheet1', address: 'A1' } },
+        source: 'user',
+      });
+
+      expect(result.ok).toBe(false);
+      if (!result.ok) expect(result.error).toBe('invalid_target');
+      expect(await db.select().from(contentTags)).toHaveLength(0);
+    });
+
+    it('refuses a tag from another drive rather than leaking a driver error', async () => {
+      const { owner, page } = await seed();
+      const otherDrive = await factories.createDrive(owner.id);
+      await factories.createDriveMember(otherDrive.id, owner.id, { role: 'OWNER' });
+      const foreign = expectOk(await upsertTag(otherDrive.id, owner.id, { name: 'foreign' }));
+
+      const result = await applyTag(owner.id, { pageId: page.id, tagId: foreign.id, target: { kind: 'page' }, source: 'user' });
+
+      expect(result.ok).toBe(false);
+      if (!result.ok) expect(result.error).toBe('tag_not_found');
+    });
+  });
+
+  describe('permission denial returns a result, never a throw', () => {
+    /** A user with no membership and no page permission anywhere. */
+    async function outsider() {
+      return factories.createUser();
+    }
+
+    it('refuses to list a drive vocabulary to a non-member', async () => {
+      const { drive } = await seed();
+      const stranger = await outsider();
+
+      const result = await listDriveTags(drive.id, stranger.id);
+
+      expect(result.ok).toBe(false);
+      if (!result.ok) expect(result.error).toBe('forbidden');
+    });
+
+    it('refuses to create a tag in a drive the caller is not in', async () => {
+      const { drive } = await seed();
+      const stranger = await outsider();
+
+      const result = await upsertTag(drive.id, stranger.id, { name: 'sneaky' });
+
+      expect(result.ok).toBe(false);
+      if (!result.ok) expect(result.error).toBe('forbidden');
+      expect(await db.select().from(tags)).toHaveLength(0);
+    });
+
+    it('refuses to tag a page the caller cannot edit', async () => {
+      const { owner, drive, page } = await seed();
+      const tag = expectOk(await upsertTag(drive.id, owner.id, { name: 'x' }));
+      const stranger = await outsider();
+
+      const result = await applyTag(stranger.id, { pageId: page.id, tagId: tag.id, target: { kind: 'page' }, source: 'user' });
+
+      expect(result.ok).toBe(false);
+      if (!result.ok) expect(result.error).toBe('forbidden');
+      expect(await db.select().from(contentTags)).toHaveLength(0);
+    });
+
+    it('reports a nonexistent page as forbidden, not as not_found', async () => {
+      // Distinguishing the two would let a caller probe which page ids exist
+      // inside drives they cannot see.
+      const { owner } = await seed();
+
+      const result = await applyTag(owner.id, {
+        pageId: 'does-not-exist',
+        name: 'y',
+        target: { kind: 'page' },
+        source: 'user',
+      });
+
+      expect(result.ok).toBe(false);
+      if (!result.ok) expect(result.error).toBe('forbidden');
+    });
+
+    it('checks removeTag against the row OWN page, not against caller input', async () => {
+      const { owner, drive, page } = await seed();
+      const tag = expectOk(await upsertTag(drive.id, owner.id, { name: 'z' }));
+      const assignment = expectOk(await applyTag(owner.id, { pageId: page.id, tagId: tag.id, target: { kind: 'page' }, source: 'user' }));
+      const stranger = await outsider();
+
+      const result = await removeTag(stranger.id, assignment.id);
+
+      expect(result.ok).toBe(false);
+      if (!result.ok) expect(result.error).toBe('forbidden');
+      expect(await db.select().from(contentTags)).toHaveLength(1);
+    });
+
+    it('reports an unknown assignment id distinctly from a forbidden one', async () => {
+      const { owner } = await seed();
+
+      const result = await removeTag(owner.id, 'no-such-assignment');
+
+      expect(result.ok).toBe(false);
+      if (!result.ok) expect(result.error).toBe('assignment_not_found');
+    });
+
+    it('hides a page the caller cannot view from getPageTags', async () => {
+      const { page } = await seed();
+      const stranger = await outsider();
+
+      const result = await getPageTags(stranger.id, page.id);
+
+      expect(result.ok).toBe(false);
+      if (!result.ok) expect(result.error).toBe('forbidden');
+    });
+  });
+
+  describe('the batch read path', () => {
+    it('OMITS unviewable pages rather than returning them empty', async () => {
+      // "no tags" and "not allowed to know" are different answers. A caller
+      // that renders them the same way should have to choose that.
+      const { owner, drive, page } = await seed();
+      const tag = expectOk(await upsertTag(drive.id, owner.id, { name: 'shared' }));
+      expectOk(await applyTag(owner.id, { pageId: page.id, tagId: tag.id, target: { kind: 'page' }, source: 'user' }));
+
+      const stranger = await factories.createUser();
+      const strangerDrive = await factories.createDrive(stranger.id);
+      await factories.createDriveMember(strangerDrive.id, stranger.id, { role: 'OWNER' });
+      const strangerPage = await factories.createPage(strangerDrive.id, { type: 'DOCUMENT', title: 'Theirs', position: 0 });
+
+      const map = expectOk(await getBatchPageTags(stranger.id, [page.id, strangerPage.id]));
+
+      expect(map.has(page.id)).toBe(false);
+      expect(map.get(strangerPage.id)).toEqual([]);
+    });
+
+    it('buckets assignments by page and seeds viewable pages with an empty array', async () => {
+      const { owner, drive, page } = await seed();
+      const second = await factories.createPage(drive.id, { type: 'DOCUMENT', title: 'Second', position: 1 });
+      const tag = expectOk(await upsertTag(drive.id, owner.id, { name: 'bucket' }));
+      expectOk(await applyTag(owner.id, { pageId: page.id, tagId: tag.id, target: { kind: 'page' }, source: 'user' }));
+
+      const map = expectOk(await getBatchPageTags(owner.id, [page.id, second.id]));
+
+      expect(map.get(page.id)).toHaveLength(1);
+      expect(map.get(second.id)).toEqual([]);
+    });
+
+    it('returns an empty map for an empty request without querying', async () => {
+      const { owner } = await seed();
+      const map = expectOk(await getBatchPageTags(owner.id, []));
+      expect(map.size).toBe(0);
+    });
+
+    it('joins the vocabulary so a caller gets the name, not just an id', async () => {
+      const { owner, drive, page } = await seed();
+      const tag = expectOk(await upsertTag(drive.id, owner.id, { name: 'Named', color: '#abcdef' }));
+      expectOk(await applyTag(owner.id, { pageId: page.id, tagId: tag.id, target: { kind: 'page' }, source: 'user' }));
+
+      const [assignment] = expectOk(await getPageTags(owner.id, page.id));
+
+      expect(assignment.name).toBe('Named');
+      expect(assignment.color).toBe('#abcdef');
+      expect(assignment.tagId).toBe(tag.id);
+    });
+  });
+});

--- a/packages/lib/src/tags/__tests__/tag-service.integration.test.ts
+++ b/packages/lib/src/tags/__tests__/tag-service.integration.test.ts
@@ -10,7 +10,10 @@
  *
  * Requires a running Postgres with the latest migrations applied. Run via:
  *   ./scripts/test-with-db.sh
- *   bun run --filter '@pagespace/lib' test -- src/tags/__tests__/tag-service.integration.test.ts
+ *   bun run --filter '@pagespace/lib' test:integration -- src/tags/__tests__/tag-service.integration.test.ts
+ *
+ * `test:integration`, not `test`: vitest.config.ts EXCLUDES this file from the
+ * default run, so the documented `test` command silently matched nothing.
  */
 import { describe, it, expect, beforeEach } from 'vitest';
 import { factories } from '@pagespace/db/test/factories';
@@ -19,6 +22,8 @@ import { and, eq } from '@pagespace/db/operators';
 import { users } from '@pagespace/db/schema/auth';
 import { drives, pages, tags } from '@pagespace/db/schema/core';
 import { contentTags } from '@pagespace/db/schema/content-tags';
+import { projectContent } from '../../content/anchoring/text-projection';
+import { hashText } from '../../content/anchoring/anchor';
 import { channelMessages } from '@pagespace/db/schema/chat';
 import { pagePermissions, driveMembers } from '@pagespace/db/schema/members';
 import {
@@ -28,6 +33,7 @@ import {
   removeTag,
   getPageTags,
   getBatchPageTags,
+  reanchorPageTags,
 } from '../tag-service';
 
 /** Unwrap an ok result, failing loudly with the error code when it is not. */
@@ -123,11 +129,12 @@ describe('tag-service (integration)', () => {
       expect(first.ok).toBe(true);
 
       // `content_tags_page_target_unique` is partial: UNIQUE (pageId, tagId)
-      // WHERE targetKind = 'page'. A duplicate is a driver error, which the
-      // service converts rather than leaking.
+      // WHERE targetKind = 'page'. Re-tagging is a normal user action, so the
+      // service reports it as a CONFLICT — a caller that mapped it to
+      // internal_error would show a server failure for a double click.
       const second = await applyTag(owner.id, { pageId: page.id, tagId: tag.id, target: { kind: 'page' }, source: 'user' });
       expect(second.ok).toBe(false);
-      if (!second.ok) expect(second.error).toBe('internal_error');
+      if (!second.ok) expect(second.error).toBe('assignment_exists');
 
       expect(await db.select().from(contentTags)).toHaveLength(1);
     });
@@ -136,22 +143,32 @@ describe('tag-service (integration)', () => {
       // The reason content_tags is not a composite-PK join table: one tag
       // legitimately attaches many times to one page at different offsets.
       // No partial index covers 'text', and that is deliberate.
-      const { owner, drive, page } = await seed();
+      const owner = await factories.createUser();
+      const drive = await factories.createDrive(owner.id);
+      await factories.createDriveMember(drive.id, owner.id, { role: 'OWNER' });
+      // The anchors must quote text that really is in this page, because
+      // applyTag now repairs a client anchor against the current revision and
+      // refuses one whose quote is absent.
+      const CONTENT = 'some quoted words appear here, and some quoted words appear again later.';
+      const page = await factories.createPage(drive.id, {
+        type: 'DOCUMENT', title: 'Doc', position: 0, content: CONTENT, contentMode: 'markdown',
+      });
       const tag = expectOk(await upsertTag(drive.id, owner.id, { name: 'todo' }));
 
+      const projected = projectContent(CONTENT, 'markdown');
       const anchorAt = (start: number) => ({
         v: 1 as const,
         exact: 'some quoted words',
-        prefix: 'before ',
-        suffix: ' after',
+        prefix: projected.slice(Math.max(0, start - 32), start),
+        suffix: projected.slice(start + 17, start + 49),
         start,
         end: start + 17,
         revision: 1,
-        textHash: 'deadbeef',
+        textHash: hashText(projected),
       });
 
-      const a = await applyTag(owner.id, { pageId: page.id, tagId: tag.id, target: { kind: 'text', anchor: anchorAt(10) }, source: 'user' });
-      const b = await applyTag(owner.id, { pageId: page.id, tagId: tag.id, target: { kind: 'text', anchor: anchorAt(200) }, source: 'user' });
+      const a = await applyTag(owner.id, { pageId: page.id, tagId: tag.id, target: { kind: 'text', anchor: anchorAt(projected.indexOf('some quoted words')) }, source: 'user' });
+      const b = await applyTag(owner.id, { pageId: page.id, tagId: tag.id, target: { kind: 'text', anchor: anchorAt(projected.lastIndexOf('some quoted words')) }, source: 'user' });
 
       expect(a.ok).toBe(true);
       expect(b.ok).toBe(true);
@@ -175,13 +192,20 @@ describe('tag-service (integration)', () => {
     });
 
     it("stamps a fresh text anchor 'exact', which the CHECK requires to be non-null", async () => {
-      const { owner, drive, page } = await seed();
+      const owner = await factories.createUser();
+      const drive = await factories.createDrive(owner.id);
+      await factories.createDriveMember(drive.id, owner.id, { role: 'OWNER' });
+      const CONTENT = 'q is the quoted character.';
+      const page = await factories.createPage(drive.id, {
+        type: 'DOCUMENT', title: 'Doc', position: 0, content: CONTENT, contentMode: 'markdown',
+      });
       const tag = expectOk(await upsertTag(drive.id, owner.id, { name: 'b' }));
+      const projected = projectContent(CONTENT, 'markdown');
 
       expectOk(await applyTag(owner.id, {
         pageId: page.id,
         tagId: tag.id,
-        target: { kind: 'text', anchor: { v: 1, exact: 'q', prefix: '', suffix: '', start: 0, end: 1, revision: 1, textHash: 'h' } },
+        target: { kind: 'text', anchor: { v: 1, exact: 'q', prefix: '', suffix: projected.slice(1, 33), start: 0, end: 1, revision: 1, textHash: hashText(projected) } },
         source: 'ai',
         confidence: 0.75,
       }));
@@ -361,6 +385,269 @@ describe('tag-service (integration)', () => {
       expect(assignment.name).toBe('Named');
       expect(assignment.color).toBe('#abcdef');
       expect(assignment.tagId).toBe(tag.id);
+    });
+  });
+
+  describe('reanchorPageTags across successive edits', () => {
+    const BODY = 'Alpha beta gamma. The anchored quote sits here. Delta epsilon.';
+    const QUOTE = 'The anchored quote sits here.';
+
+    /** Build a page whose content is `BODY`, with one text anchor on QUOTE. */
+    async function seedAnchored() {
+      const owner = await factories.createUser();
+      const drive = await factories.createDrive(owner.id);
+      await factories.createDriveMember(drive.id, owner.id, { role: 'OWNER' });
+      const page = await factories.createPage(drive.id, {
+        type: 'DOCUMENT',
+        title: 'Doc',
+        position: 0,
+        content: BODY,
+        contentMode: 'markdown',
+      });
+      const tag = expectOk(await upsertTag(drive.id, owner.id, { name: 'anchored' }));
+
+      const start = BODY.indexOf(QUOTE);
+      const projected = projectContent(BODY, 'markdown');
+      expectOk(await applyTag(owner.id, {
+        pageId: page.id,
+        tagId: tag.id,
+        source: 'user',
+        target: {
+          kind: 'text',
+          anchor: {
+            v: 1,
+            exact: QUOTE,
+            prefix: BODY.slice(Math.max(0, start - 32), start),
+            suffix: BODY.slice(start + QUOTE.length, start + QUOTE.length + 32),
+            start,
+            end: start + QUOTE.length,
+            revision: 1,
+            textHash: hashText(projected),
+          },
+        },
+      }));
+      return { owner, drive, page };
+    }
+
+    it('keeps forward-porting an anchor through a SECOND edit that follows a first', async () => {
+      // THE FAILURE THIS PINS: an edit AFTER the anchored range leaves the
+      // status 'exact' and the offsets untouched, so a write-skipping
+      // optimisation would leave the row holding the PREVIOUS revision's
+      // textHash. The next sweep's staleness guard then rejects the anchor and
+      // it silently stops being forward-ported — for good. Editing below your
+      // anchors is the ordinary way to write a document, so this is the common
+      // path, not a corner.
+      const { page } = await seedAnchored();
+
+      const afterFirst = `${BODY} Appended sentence one.`;
+      const first = expectOk(await reanchorPageTags(page.id, BODY, afterFirst));
+      expect(first.considered).toBe(1);
+      expect(first.skippedStaleHash).toBe(0);
+
+      const afterSecond = `${afterFirst} Appended sentence two.`;
+      const second = expectOk(await reanchorPageTags(page.id, afterFirst, afterSecond));
+
+      expect(second.considered).toBe(1);
+      expect(second.skippedStaleHash, 'the anchor must still be portable after the first edit').toBe(0);
+    });
+
+    it('stores the hash of the projection the anchor now describes', async () => {
+      const { page } = await seedAnchored();
+      const edited = `${BODY} Appended.`;
+
+      expectOk(await reanchorPageTags(page.id, BODY, edited));
+
+      const [row] = await db.select().from(contentTags).where(eq(contentTags.pageId, page.id));
+      const stored = row.anchor as { textHash: string };
+      expect(stored.textHash).toBe(hashText(projectContent(edited, 'markdown')));
+    });
+  });
+
+  describe('reanchorPageTags joins the caller transaction', () => {
+    const BODY2 = 'Alpha beta gamma. The anchored quote sits here. Delta epsilon.';
+    const QUOTE2 = 'The anchored quote sits here.';
+
+    async function seedForTx() {
+      const owner = await factories.createUser();
+      const drive = await factories.createDrive(owner.id);
+      await factories.createDriveMember(drive.id, owner.id, { role: 'OWNER' });
+      const page = await factories.createPage(drive.id, {
+        type: 'DOCUMENT', title: 'Doc', position: 0, content: BODY2, contentMode: 'markdown',
+      });
+      const tag = expectOk(await upsertTag(drive.id, owner.id, { name: 'tx' }));
+      const start = BODY2.indexOf(QUOTE2);
+      expectOk(await applyTag(owner.id, {
+        pageId: page.id, tagId: tag.id, source: 'user',
+        target: { kind: 'text', anchor: {
+          v: 1, exact: QUOTE2, prefix: '', suffix: '',
+          start, end: start + QUOTE2.length, revision: 1,
+          textHash: hashText(projectContent(BODY2, 'markdown')),
+        } },
+      }));
+      return { page };
+    }
+
+    it('rolls the sweep back with the caller transaction', async () => {
+      // The reason this takes an executor at all. applyPageMutation holds both
+      // revisions in ONE transaction; a sweep that commits independently can
+      // leave anchors ported to content that never landed.
+      const { page } = await seedForTx();
+      const before = await db.select().from(contentTags).where(eq(contentTags.pageId, page.id));
+      const beforeHash = (before[0].anchor as { textHash: string }).textHash;
+
+      await expect(
+        db.transaction(async (tx) => {
+          const swept = await reanchorPageTags(page.id, BODY2, `${BODY2} Appended.`, { executor: tx });
+          expect(swept.ok).toBe(true);
+          throw new Error('caller rolls back after the sweep');
+        }),
+      ).rejects.toThrow('caller rolls back');
+
+      const after = await db.select().from(contentTags).where(eq(contentTags.pageId, page.id));
+      expect((after[0].anchor as { textHash: string }).textHash).toBe(beforeHash);
+    });
+
+    it('commits with the caller transaction when it succeeds', async () => {
+      const { page } = await seedForTx();
+      const edited = `${BODY2} Appended.`;
+
+      await db.transaction(async (tx) => {
+        expectOk(await reanchorPageTags(page.id, BODY2, edited, { executor: tx }));
+      });
+
+      const [row] = await db.select().from(contentTags).where(eq(contentTags.pageId, page.id));
+      expect((row.anchor as { textHash: string }).textHash).toBe(hashText(projectContent(edited, 'markdown')));
+    });
+  });
+
+  describe('reanchorPageTags across a content-mode conversion', () => {
+    it('repairs anchors instead of skipping the whole sweep', async () => {
+      // convert-content-mode is the case the epic routes to QUOTE REPAIR
+      // rather than forward-porting. Reading one stored mode for both
+      // revisions breaks it in both directions: the old mode makes the formats
+      // look like an accidental flip and skips everything, while the new mode
+      // projects the old HTML as raw text so every anchor fails its hash check.
+      const owner = await factories.createUser();
+      const drive = await factories.createDrive(owner.id);
+      await factories.createDriveMember(drive.id, owner.id, { role: 'OWNER' });
+
+      const OLD_HTML = '<p>Alpha beta gamma.</p><p>The anchored quote sits here.</p>';
+      const NEW_MD = 'Alpha beta gamma.\n\nThe anchored quote sits here.';
+      const QUOTE3 = 'The anchored quote sits here.';
+
+      // The page has ALREADY been converted when the sweep runs, so its stored
+      // mode is the new one — which is precisely why the old mode must be passed.
+      const page = await factories.createPage(drive.id, {
+        type: 'DOCUMENT', title: 'Doc', position: 0, content: NEW_MD, contentMode: 'markdown',
+      });
+      const tag = expectOk(await upsertTag(drive.id, owner.id, { name: 'converted' }));
+
+      const oldProjection = projectContent(OLD_HTML, 'html');
+      const start = oldProjection.indexOf(QUOTE3);
+      expect(start, 'the quote must exist in the old projection').toBeGreaterThanOrEqual(0);
+
+      // Inserted DIRECTLY, not through applyTag. The row has to predate the
+      // conversion — it describes the old HTML revision — and applyTag now
+      // (correctly) repairs a client anchor onto whatever the page currently
+      // holds, which would normalise away the very thing under test.
+      await db.insert(contentTags).values({
+        tagId: tag.id,
+        pageId: page.id,
+        targetKind: 'text',
+        anchor: {
+          v: 1, exact: QUOTE3, prefix: '', suffix: '',
+          start, end: start + QUOTE3.length, revision: 1,
+          textHash: hashText(oldProjection),
+        },
+        anchorStatus: 'exact',
+        source: 'user',
+        createdBy: owner.id,
+      });
+
+      const swept = expectOk(await reanchorPageTags(page.id, OLD_HTML, NEW_MD, {
+        oldContentMode: 'html',
+        newContentMode: 'markdown',
+      }));
+
+      expect(swept.considered).toBe(1);
+      expect(swept.skippedFormatFlip, 'a declared conversion is not an accidental flip').toBe(0);
+      expect(swept.skippedStaleHash, 'the old mode must project the old content correctly').toBe(0);
+
+      const [row] = await db.select().from(contentTags).where(eq(contentTags.pageId, page.id));
+      expect(row.anchorStatus).not.toBe('orphaned');
+      const stored = row.anchor as { start: number; end: number };
+      expect(projectContent(NEW_MD, 'markdown').slice(stored.start, stored.end)).toBe(QUOTE3);
+    });
+  });
+
+  describe('an anchor arriving from a client is untrusted', () => {
+    async function anchoredPage() {
+      const owner = await factories.createUser();
+      const drive = await factories.createDrive(owner.id);
+      await factories.createDriveMember(drive.id, owner.id, { role: 'OWNER' });
+      const CONTENT = 'Alpha beta gamma. The anchored quote sits here. Delta.';
+      const page = await factories.createPage(drive.id, {
+        type: 'DOCUMENT', title: 'Doc', position: 0, content: CONTENT, contentMode: 'markdown',
+      });
+      const tag = expectOk(await upsertTag(drive.id, owner.id, { name: 'client' }));
+      return { owner, page, tag, CONTENT, projected: projectContent(CONTENT, 'markdown') };
+    }
+
+    it('rejects a structurally malformed anchor instead of persisting it', async () => {
+      // validateTarget answers which KINDS a page type takes; it does not
+      // inspect the anchor's scalars, and the compiler cannot help with parsed
+      // JSON. Without a runtime check `exact: 1` persists and every later sweep
+      // casts it back to TextAnchor.
+      const { owner, page, tag } = await anchoredPage();
+
+      const result = await applyTag(owner.id, {
+        pageId: page.id, tagId: tag.id, source: 'user',
+        target: { kind: 'text', anchor: { v: 1, exact: 1, prefix: '', suffix: '', start: 0, end: 1, revision: 1, textHash: 'x' } as never },
+      });
+
+      expect(result.ok).toBe(false);
+      if (!result.ok) expect(result.error).toBe('invalid_target');
+      expect(await db.select().from(contentTags)).toHaveLength(0);
+    });
+
+    it('repairs a stale anchor onto the current revision rather than storing a lie', async () => {
+      // A collaborative edit can land between the client measuring an anchor
+      // and this call. Storing it as 'exact' against a revision it was never
+      // measured on means the next sweep's staleness guard rejects it and it is
+      // never ported again.
+      const { owner, page, tag, projected } = await anchoredPage();
+      const QUOTE = 'The anchored quote sits here.';
+      const trueStart = projected.indexOf(QUOTE);
+
+      const result = expectOk(await applyTag(owner.id, {
+        pageId: page.id, tagId: tag.id, source: 'user',
+        target: { kind: 'text', anchor: {
+          v: 1, exact: QUOTE, prefix: '', suffix: '',
+          start: trueStart + 25, end: trueStart + 25 + QUOTE.length,
+          revision: 1, textHash: 'a-hash-from-some-other-revision',
+        } },
+      }));
+
+      const [row] = await db.select().from(contentTags).where(eq(contentTags.id, result.id));
+      const stored = row.anchor as { start: number; end: number; textHash: string };
+      expect(stored.textHash, 're-pinned to the revision actually stored').toBe(hashText(projected));
+      expect(projected.slice(stored.start, stored.end)).toBe(QUOTE);
+      expect(row.anchorStatus, 'a repaired anchor must not claim it was exact').not.toBe('exact');
+    });
+
+    it('refuses an anchor whose quote is absent from the current revision', async () => {
+      const { owner, page, tag } = await anchoredPage();
+
+      const result = await applyTag(owner.id, {
+        pageId: page.id, tagId: tag.id, source: 'user',
+        target: { kind: 'text', anchor: {
+          v: 1, exact: 'text that was never in this document', prefix: '', suffix: '',
+          start: 0, end: 36, revision: 1, textHash: 'stale',
+        } },
+      });
+
+      expect(result.ok).toBe(false);
+      if (!result.ok) expect(result.error).toBe('invalid_target');
     });
   });
 });

--- a/packages/lib/src/tags/tag-service.ts
+++ b/packages/lib/src/tags/tag-service.ts
@@ -33,9 +33,20 @@ import { normalizeTagName, validateTarget, type TagTarget } from './tag-core';
 import type { TextAnchor } from '../content/anchoring/types';
 import { preparePort, portPreparedAnchor } from '../content/anchoring/reanchor';
 import { projectContent, resolveProjectionFormat } from '../content/anchoring/text-projection';
+import { resolveAnchor } from '../content/anchoring/resolve';
 import { hashText } from '../content/anchoring/anchor';
 
 const log = loggers.system;
+
+/**
+ * A drizzle transaction, or the `db` singleton when there is no outer one.
+ *
+ * Same spelling the other lib repositories use (page-content-store,
+ * drive-service, storage-repository). Only `reanchorPageTags` takes one: it is
+ * the one entry point that MUST commit atomically with somebody else's write.
+ */
+type Tx = Parameters<Parameters<typeof db.transaction>[0]>[0];
+export type TagExecutor = Tx | typeof db;
 
 /**
  * Machine-readable failure codes. Callers map these to status codes, so they
@@ -51,6 +62,8 @@ export type TagErrorCode =
   | 'invalid_target'
   | 'tag_not_found'
   | 'assignment_not_found'
+  /** This exact assignment already exists. A user re-tagging, not a server fault. */
+  | 'assignment_exists'
   | 'internal_error';
 
 export type TagResult<T> = { ok: true; data: T } | { ok: false; error: TagErrorCode; message?: string };
@@ -94,6 +107,19 @@ export type PageTagAssignment = {
 function unexpected(operation: string, error: unknown): { ok: false; error: TagErrorCode } {
   log.error(`tag-service: ${operation} failed`, error as Error, { operation });
   return { ok: false, error: 'internal_error' };
+}
+
+/**
+ * Postgres unique-violation, seen through drizzle.
+ *
+ * drizzle 0.45.2 rethrows driver errors wrapped as `DrizzleQueryError` with the
+ * pg error on `.cause`, so a top-level `error.code` check never matches and the
+ * conflict silently becomes a 500. Both levels are checked here for that reason.
+ */
+function isUniqueViolation(error: unknown): boolean {
+  const code = (error as { code?: unknown })?.code;
+  const causeCode = (error as { cause?: { code?: unknown } })?.cause?.code;
+  return code === '23505' || causeCode === '23505';
 }
 
 /**
@@ -200,6 +226,33 @@ export async function upsertTag(
   }
 }
 
+/**
+ * Whether a value is structurally a TextAnchor.
+ *
+ * `validateTarget` (the pure core) answers which KINDS a page type accepts; it
+ * does not inspect the anchor's scalars, and the compiler cannot help at a
+ * service boundary that receives parsed JSON. Without this, `exact: 1` persists
+ * happily and every later sweep casts it back to TextAnchor and either resolves
+ * against nonsense or throws mid-loop, taking the whole sweep with it.
+ */
+function isTextAnchor(value: unknown): value is TextAnchor {
+  if (typeof value !== 'object' || value === null) return false;
+  const a = value as Record<string, unknown>;
+  return (
+    a.v === 1 &&
+    typeof a.exact === 'string' &&
+    typeof a.prefix === 'string' &&
+    typeof a.suffix === 'string' &&
+    Number.isInteger(a.start) &&
+    Number.isInteger(a.end) &&
+    (a.start as number) >= 0 &&
+    (a.end as number) >= (a.start as number) &&
+    Number.isInteger(a.revision) &&
+    typeof a.textHash === 'string' &&
+    a.textHash.length > 0
+  );
+}
+
 /** Columns a target kind contributes to a `content_tags` row. */
 function targetColumns(target: TagTarget): {
   targetKind: TagTarget['kind'];
@@ -253,7 +306,13 @@ export async function applyTag(
     if (!(await canUserEditPage(userId, input.pageId))) return fail('forbidden');
 
     const page = await db
-      .select({ id: pages.id, type: pages.type, driveId: pages.driveId })
+      .select({
+        id: pages.id,
+        type: pages.type,
+        driveId: pages.driveId,
+        content: pages.content,
+        contentMode: pages.contentMode,
+      })
       .from(pages)
       .where(eq(pages.id, input.pageId))
       .limit(1);
@@ -262,6 +321,48 @@ export async function applyTag(
     // The pure core owns which kinds this page type accepts.
     const targetCheck = validateTarget(page[0].type, input.target);
     if (!targetCheck.ok) return fail('invalid_target', targetCheck.reason);
+
+    // A text target carries an anchor built by a CLIENT, which makes it
+    // untrusted twice over: structurally (it is parsed JSON, so the compiler
+    // guarantees nothing) and temporally (a collaborative edit can land between
+    // the client measuring it and this call).
+    let target = input.target;
+    /**
+     * Set when a client anchor had to be repaired onto the current revision.
+     *
+     * Includes 'exact': a repair CAN land back on the recorded offsets with the
+     * quote byte-identical, and that is a genuine exact match against the
+     * revision now being stored, not a claim inherited from a stale one.
+     */
+    let staleAnchorStatus: 'exact' | 'shifted' | 'fuzzy' | null = null;
+    if (target.kind === 'text') {
+      if (!isTextAnchor(target.anchor)) {
+        return fail('invalid_target', 'anchor is not a well-formed TextAnchor');
+      }
+
+      // Storing a client anchor as 'exact' against a revision it was not
+      // measured on is a lie the next sweep pays for: the staleness guard
+      // rejects it and the anchor is never ported again. Repair it against the
+      // page as it stands NOW, and record what that repair actually achieved.
+      const currentText = projectContent(page[0].content ?? '', page[0].contentMode);
+      const currentHash = hashText(currentText);
+      if (target.anchor.textHash !== currentHash) {
+        const repaired = resolveAnchor(currentText, target.anchor);
+        if (repaired.status === 'orphaned') {
+          return fail('invalid_target', 'anchored text is not present in the current revision');
+        }
+        target = {
+          kind: 'text',
+          anchor: {
+            ...target.anchor,
+            start: repaired.start,
+            end: repaired.end,
+            textHash: currentHash,
+          },
+        };
+        staleAnchorStatus = repaired.status;
+      }
+    }
 
     let tagId = input.tagId;
     if (!tagId) {
@@ -281,7 +382,10 @@ export async function applyTag(
       if (owned.length === 0) return fail('tag_not_found');
     }
 
-    const cols = targetColumns(input.target);
+    const cols = targetColumns(target);
+    // 'exact' means confidence 1 against the stored revision. A repaired anchor
+    // reached its offsets by search, so it says so rather than claiming exact.
+    const anchorStatus = staleAnchorStatus ?? cols.anchorStatus;
     const inserted = await db
       .insert(contentTags)
       .values({
@@ -289,7 +393,7 @@ export async function applyTag(
         pageId: input.pageId,
         targetKind: cols.targetKind,
         anchor: cols.anchor,
-        anchorStatus: cols.anchorStatus,
+        anchorStatus,
         channelMessageId: cols.channelMessageId,
         aiMessageId: cols.aiMessageId,
         source: input.source,
@@ -300,6 +404,10 @@ export async function applyTag(
 
     return ok({ id: inserted[0].id });
   } catch (error) {
+    // A second page-level assignment of the same tag trips
+    // `content_tags_page_target_unique`. That is a user tagging something
+    // twice, not a fault — callers need to tell it apart from a real failure.
+    if (isUniqueViolation(error)) return fail('assignment_exists');
     return unexpected('applyTag', error);
   }
 }
@@ -461,11 +569,38 @@ export type ReanchorSummary = {
  * the caller has already authorized, not a user action. It takes no `userId`
  * precisely so it cannot be mistaken for one.
  */
+export type ReanchorOptions = {
+  /**
+   * The caller's transaction. `applyPageMutation` holds `previousContent` and
+   * `nextContent` in ONE transaction and writes a version row there; the sweep
+   * has to commit with it or not at all. Running outside it means either
+   * anchors ported to content that then rolls back, or a committed page whose
+   * anchors were only partly updated before an error. Defaults to `db` for a
+   * standalone sweep (a backfill), which is the only case with no outer write.
+   */
+  executor?: TagExecutor;
+  /**
+   * `pages.contentMode` for the OLD revision, when it differs from the new one.
+   *
+   * Needed for `convert-content-mode`, where the two revisions are genuinely in
+   * different modes. Reading one mode for both is wrong in both directions: the
+   * old mode makes the formats look like an accidental flip and skips the
+   * sweep, while the new mode projects the old HTML as raw text so every
+   * correctly built anchor fails its hash check. Omit both for an ordinary
+   * edit, where the page's stored mode applies to both revisions.
+   */
+  oldContentMode?: string;
+  /** `pages.contentMode` for the NEW revision. See `oldContentMode`. */
+  newContentMode?: string;
+};
+
 export async function reanchorPageTags(
   pageId: string,
   oldContent: string,
   newContent: string,
+  options: ReanchorOptions = {},
 ): Promise<TagResult<ReanchorSummary>> {
+  const exec = options.executor ?? db;
   const summary: ReanchorSummary = {
     considered: 0,
     updated: 0,
@@ -475,16 +610,20 @@ export async function reanchorPageTags(
   };
 
   try {
-    const page = await db
+    const page = await exec
       .select({ contentMode: pages.contentMode })
       .from(pages)
       .where(eq(pages.id, pageId))
       .limit(1);
     if (page.length === 0) return fail('assignment_not_found', 'page not found');
 
-    const mode = page[0].contentMode;
+    const storedMode = page[0].contentMode;
+    const oldMode = options.oldContentMode ?? storedMode;
+    const newMode = options.newContentMode ?? storedMode;
+    /** The caller told us the modes differ, so a format difference is intended. */
+    const conversion = oldMode !== newMode;
 
-    const rows = await db
+    const rows = await exec
       .select({ id: contentTags.id, anchor: contentTags.anchor, anchorStatus: contentTags.anchorStatus })
       .from(contentTags)
       .where(and(eq(contentTags.pageId, pageId), eq(contentTags.targetKind, 'text')));
@@ -494,14 +633,30 @@ export async function reanchorPageTags(
 
     // Both guards are per-transition, so they are decided once, before any
     // per-anchor work.
-    if (resolveProjectionFormat(oldContent, mode) !== resolveProjectionFormat(newContent, mode)) {
+    // An UNDECLARED format change is the accidental flip: same mode, but the
+    // sniffer read the two revisions differently (unclosed trailing markup is
+    // the usual cause). The two projections are then incompatible coordinate
+    // systems and porting across them mislays every anchor confidently, so the
+    // sweep does nothing and says so.
+    //
+    // A DECLARED conversion is not that. The modes differ because the caller
+    // converted the document on purpose, and the two projections are expected
+    // to disagree — which is exactly why the epic routes convert-content-mode
+    // to quote repair rather than forward-porting. Letting it through is what
+    // makes that fallback reachable: the old projection still validates each
+    // anchor's hash, and the wholesale difference then routes every anchor to
+    // `resolveAnchor` against the new text.
+    if (
+      !conversion &&
+      resolveProjectionFormat(oldContent, oldMode) !== resolveProjectionFormat(newContent, newMode)
+    ) {
       summary.skippedFormatFlip = rows.length;
       log.warn('tag-service: projection format flipped between revisions; skipping re-anchor', { pageId, anchors: rows.length });
       return ok(summary);
     }
 
-    const oldText = projectContent(oldContent, mode);
-    const newText = projectContent(newContent, mode);
+    const oldText = projectContent(oldContent, oldMode);
+    const newText = projectContent(newContent, newMode);
     const oldHash = hashText(oldText);
 
     const newHash = hashText(newText);
@@ -526,17 +681,27 @@ export async function reanchorPageTags(
           ? { start: anchor.start, end: anchor.end }
           : { start: resolution.start, end: resolution.end };
 
-      // Nothing moved and nothing changed status: skip the write rather than
-      // touch `updatedAt` on every anchor of every edit.
+      // Skip the write only when NOTHING the row stores would change —
+      // including the hash.
+      //
+      // An earlier version compared status and offsets alone. That is wrong in
+      // the most ordinary case there is: an edit BELOW the anchored range
+      // leaves the status 'exact' and the offsets untouched, so the write was
+      // skipped and the row kept the PREVIOUS revision's textHash. The next
+      // sweep's staleness guard then rejected that anchor and it silently
+      // stopped being forward-ported, permanently. Writing below your anchors
+      // is how documents get written, so this quietly killed the primary
+      // mechanism for most tags on most pages.
       if (
         resolution.status === row.anchorStatus &&
         ported.start === anchor.start &&
-        ported.end === anchor.end
+        ported.end === anchor.end &&
+        anchor.textHash === newHash
       ) {
         continue;
       }
 
-      await db
+      await exec
         .update(contentTags)
         .set({
           // textHash re-pins the anchor to the projection it now describes, so

--- a/packages/lib/src/tags/tag-service.ts
+++ b/packages/lib/src/tags/tag-service.ts
@@ -1,0 +1,557 @@
+/**
+ * Imperative shell for content tags.
+ *
+ * Every DECISION lives in the pure cores — `tag-core.ts` for names and target
+ * validity, `../content/anchoring/` for anchor maths. This module only does
+ * I/O: permission checks, reads, writes, and the re-anchoring sweep. It follows
+ * `../services/page-webhook-service.ts`: imports the `db` singleton rather than
+ * taking a db param, and NEVER throws across the boundary — every failure comes
+ * back as a discriminated result so callers map outcomes without a try/catch.
+ *
+ * Authorization goes through the centralized permission functions only, per
+ * CLAUDE.md. There is no bespoke access logic in this file, and there must not
+ * be: content tags are readable exactly when their page is readable and
+ * writable exactly when their page is writable, which is the whole reason
+ * `content_tags.pageId` is NOT NULL on every row including the message kinds.
+ *
+ * NOTHING CALLS THIS YET. No API route, no UI — that is Phase 4. Two
+ * consequences are load-bearing and are spelled out at `reanchorPageTags` and
+ * in the epic: the save-path hook and the cross-drive-move scrub must land
+ * before any write path ships, not after.
+ *
+ * @module @pagespace/lib/tags/tag-service
+ */
+
+import { db } from '@pagespace/db/db';
+import { and, eq, inArray } from '@pagespace/db/operators';
+import { contentTags } from '@pagespace/db/schema/content-tags';
+import { tags, pages } from '@pagespace/db/schema/core';
+import type { ContentTagSource } from '@pagespace/db/schema/content-tags';
+import { canUserViewPage, canUserEditPage, getBatchPagePermissions, isUserDriveMember } from '../permissions/permissions';
+import { loggers } from '../logging/logger-config';
+import { normalizeTagName, validateTarget, type TagTarget } from './tag-core';
+import type { TextAnchor } from '../content/anchoring/types';
+import { preparePort, portPreparedAnchor } from '../content/anchoring/reanchor';
+import { projectContent, resolveProjectionFormat } from '../content/anchoring/text-projection';
+import { hashText } from '../content/anchoring/anchor';
+
+const log = loggers.system;
+
+/**
+ * Machine-readable failure codes. Callers map these to status codes, so they
+ * are part of this module's contract — renaming one is a breaking change.
+ *
+ * `forbidden` deliberately covers "no such page" as well as "no access": a
+ * distinct `not_found` would let a caller probe which page ids exist in drives
+ * they cannot see.
+ */
+export type TagErrorCode =
+  | 'forbidden'
+  | 'invalid_name'
+  | 'invalid_target'
+  | 'tag_not_found'
+  | 'assignment_not_found'
+  | 'internal_error';
+
+export type TagResult<T> = { ok: true; data: T } | { ok: false; error: TagErrorCode; message?: string };
+
+const fail = (error: TagErrorCode, message?: string): { ok: false; error: TagErrorCode; message?: string } =>
+  message === undefined ? { ok: false, error } : { ok: false, error, message };
+
+const ok = <T>(data: T): { ok: true; data: T } => ({ ok: true, data });
+
+/** A tag in a drive's vocabulary. */
+export type DriveTag = {
+  id: string;
+  name: string;
+  normalizedKey: string;
+  color: string | null;
+  description: string | null;
+};
+
+/** One assignment, joined to the vocabulary row it points at. */
+export type PageTagAssignment = {
+  id: string;
+  tagId: string;
+  name: string;
+  color: string | null;
+  pageId: string;
+  targetKind: string;
+  anchor: unknown;
+  anchorStatus: string | null;
+  channelMessageId: string | null;
+  aiMessageId: string | null;
+  source: string;
+  confidence: number | null;
+};
+
+/**
+ * Every unexpected throw funnels here. Errors are logged rather than
+ * propagated because this module promises not to throw; the code is always
+ * `internal_error` so a driver message never reaches a caller that might
+ * surface it to a user.
+ */
+function unexpected(operation: string, error: unknown): { ok: false; error: TagErrorCode } {
+  log.error(`tag-service: ${operation} failed`, error as Error, { operation });
+  return { ok: false, error: 'internal_error' };
+}
+
+/**
+ * The drive's tag vocabulary.
+ *
+ * Drive membership, not page permission: the vocabulary is drive-scoped and
+ * says nothing about which pages carry which tag, so a member may read it
+ * whole. Which ASSIGNMENTS they can see is a separate question, answered
+ * per-page by `getPageTags`.
+ */
+export async function listDriveTags(driveId: string, userId: string): Promise<TagResult<DriveTag[]>> {
+  try {
+    if (!(await isUserDriveMember(userId, driveId))) return fail('forbidden');
+
+    const rows = await db
+      .select({
+        id: tags.id,
+        name: tags.name,
+        normalizedKey: tags.normalizedKey,
+        color: tags.color,
+        description: tags.description,
+      })
+      .from(tags)
+      .where(eq(tags.driveId, driveId));
+
+    return ok(rows);
+  } catch (error) {
+    return unexpected('listDriveTags', error);
+  }
+}
+
+/**
+ * Get or create a tag by name, within one drive.
+ *
+ * RACES ON `(driveId, normalizedKey)`, which is exactly what the unique
+ * constraint is for. Two users typing the same tag at once is the ordinary
+ * case, not the exceptional one, so this does not try to win the race: it
+ * inserts with `onConflictDoNothing` and, when that returns nothing, reads the
+ * row the other writer committed.
+ *
+ * Deliberately NOT a `.catch(e => e.code === '23505')`. Drizzle 0.45.2 rethrows
+ * pg errors wrapped as `DrizzleQueryError` with the driver error on `.cause`,
+ * so a top-level code check silently never matches and the 409 path becomes a
+ * 500. `onConflictDoNothing` sidesteps the question entirely.
+ *
+ * An existing tag is returned UNMODIFIED — `color` and `description` are not
+ * overwritten from a later call. Upsert here means "get or create", not "get or
+ * update": tagging a page must never silently restyle a shared vocabulary
+ * entry for everyone else in the drive.
+ */
+export async function upsertTag(
+  driveId: string,
+  userId: string,
+  input: { name: string; color?: string; description?: string },
+): Promise<TagResult<DriveTag>> {
+  try {
+    if (!(await isUserDriveMember(userId, driveId))) return fail('forbidden');
+
+    const normalized = normalizeTagName(input.name);
+    if (!normalized.ok) return fail('invalid_name', normalized.reason);
+
+    const inserted = await db
+      .insert(tags)
+      .values({
+        driveId,
+        name: normalized.name,
+        normalizedKey: normalized.key,
+        color: input.color ?? null,
+        description: input.description ?? null,
+        createdBy: userId,
+      })
+      .onConflictDoNothing({ target: [tags.driveId, tags.normalizedKey] })
+      .returning({
+        id: tags.id,
+        name: tags.name,
+        normalizedKey: tags.normalizedKey,
+        color: tags.color,
+        description: tags.description,
+      });
+
+    if (inserted.length > 0) return ok(inserted[0]);
+
+    // Lost the race (or it already existed): read the winner's row.
+    const existing = await db
+      .select({
+        id: tags.id,
+        name: tags.name,
+        normalizedKey: tags.normalizedKey,
+        color: tags.color,
+        description: tags.description,
+      })
+      .from(tags)
+      .where(and(eq(tags.driveId, driveId), eq(tags.normalizedKey, normalized.key)))
+      .limit(1);
+
+    if (existing.length === 0) {
+      // Only reachable if the conflicting row was deleted between the insert
+      // and this read. Reporting internal_error rather than retrying forever.
+      return fail('internal_error', 'tag vanished between insert and read');
+    }
+    return ok(existing[0]);
+  } catch (error) {
+    return unexpected('upsertTag', error);
+  }
+}
+
+/** Columns a target kind contributes to a `content_tags` row. */
+function targetColumns(target: TagTarget): {
+  targetKind: TagTarget['kind'];
+  anchor: unknown;
+  anchorStatus: 'exact' | null;
+  channelMessageId: string | null;
+  aiMessageId: string | null;
+} {
+  // Mirrors the five-branch CHECK in migration 0270 exactly. Kept as one
+  // switch so the constraint and this builder can be read side by side: a
+  // sixth kind fails to compile here rather than failing at INSERT.
+  switch (target.kind) {
+    case 'page':
+      return { targetKind: 'page', anchor: null, anchorStatus: null, channelMessageId: null, aiMessageId: null };
+    case 'text':
+      // anchorStatus is NOT NULL for 'text' in the CHECK; a freshly created
+      // anchor is by definition exact against the revision it was measured on.
+      return { targetKind: 'text', anchor: target.anchor, anchorStatus: 'exact', channelMessageId: null, aiMessageId: null };
+    case 'sheet_cell':
+      return { targetKind: 'sheet_cell', anchor: target.anchor, anchorStatus: null, channelMessageId: null, aiMessageId: null };
+    case 'channel_message':
+      return { targetKind: 'channel_message', anchor: null, anchorStatus: null, channelMessageId: target.channelMessageId, aiMessageId: null };
+    case 'ai_message':
+      return { targetKind: 'ai_message', anchor: null, anchorStatus: null, channelMessageId: null, aiMessageId: target.aiMessageId };
+  }
+}
+
+/**
+ * Attach a tag to a page, or to something inside it.
+ *
+ * `pageId` is required on EVERY kind, including the message kinds, because it
+ * is what permission checks key on — the scope trigger from migration 0272
+ * enforces that the message actually belongs to that page, so a caller cannot
+ * borrow a page they can edit to tag a message they cannot.
+ *
+ * Accepts either an existing `tagId` or a `name` to get-or-create. The name
+ * path runs through `upsertTag`, so it inherits the race handling.
+ */
+export async function applyTag(
+  userId: string,
+  input: {
+    pageId: string;
+    tagId?: string;
+    name?: string;
+    target: TagTarget;
+    source: ContentTagSource;
+    confidence?: number;
+  },
+): Promise<TagResult<{ id: string }>> {
+  try {
+    if (!(await canUserEditPage(userId, input.pageId))) return fail('forbidden');
+
+    const page = await db
+      .select({ id: pages.id, type: pages.type, driveId: pages.driveId })
+      .from(pages)
+      .where(eq(pages.id, input.pageId))
+      .limit(1);
+    if (page.length === 0) return fail('forbidden');
+
+    // The pure core owns which kinds this page type accepts.
+    const targetCheck = validateTarget(page[0].type, input.target);
+    if (!targetCheck.ok) return fail('invalid_target', targetCheck.reason);
+
+    let tagId = input.tagId;
+    if (!tagId) {
+      if (!input.name) return fail('invalid_name', 'either tagId or name is required');
+      const upserted = await upsertTag(page[0].driveId, userId, { name: input.name });
+      if (!upserted.ok) return upserted;
+      tagId = upserted.data.id;
+    } else {
+      // A tagId from another drive would be caught by the scope trigger at
+      // INSERT, but that surfaces as a raw driver error. Check it here so the
+      // caller gets `tag_not_found` instead of `internal_error`.
+      const owned = await db
+        .select({ id: tags.id })
+        .from(tags)
+        .where(and(eq(tags.id, tagId), eq(tags.driveId, page[0].driveId)))
+        .limit(1);
+      if (owned.length === 0) return fail('tag_not_found');
+    }
+
+    const cols = targetColumns(input.target);
+    const inserted = await db
+      .insert(contentTags)
+      .values({
+        tagId,
+        pageId: input.pageId,
+        targetKind: cols.targetKind,
+        anchor: cols.anchor,
+        anchorStatus: cols.anchorStatus,
+        channelMessageId: cols.channelMessageId,
+        aiMessageId: cols.aiMessageId,
+        source: input.source,
+        confidence: input.confidence ?? null,
+        createdBy: userId,
+      })
+      .returning({ id: contentTags.id });
+
+    return ok({ id: inserted[0].id });
+  } catch (error) {
+    return unexpected('applyTag', error);
+  }
+}
+
+/**
+ * Detach one assignment.
+ *
+ * Permission is checked against the row's OWN `pageId`, read first — not
+ * against anything the caller supplies — so a caller cannot pass an id from a
+ * page they cannot edit.
+ */
+export async function removeTag(userId: string, contentTagId: string): Promise<TagResult<{ id: string }>> {
+  try {
+    const row = await db
+      .select({ id: contentTags.id, pageId: contentTags.pageId })
+      .from(contentTags)
+      .where(eq(contentTags.id, contentTagId))
+      .limit(1);
+    if (row.length === 0) return fail('assignment_not_found');
+
+    if (!(await canUserEditPage(userId, row[0].pageId))) return fail('forbidden');
+
+    await db.delete(contentTags).where(eq(contentTags.id, contentTagId));
+    return ok({ id: contentTagId });
+  } catch (error) {
+    return unexpected('removeTag', error);
+  }
+}
+
+/** The select list shared by the single- and batch-page read paths. */
+const assignmentColumns = {
+  id: contentTags.id,
+  tagId: contentTags.tagId,
+  name: tags.name,
+  color: tags.color,
+  pageId: contentTags.pageId,
+  targetKind: contentTags.targetKind,
+  anchor: contentTags.anchor,
+  anchorStatus: contentTags.anchorStatus,
+  channelMessageId: contentTags.channelMessageId,
+  aiMessageId: contentTags.aiMessageId,
+  source: contentTags.source,
+  confidence: contentTags.confidence,
+};
+
+/** Every assignment on one page. */
+export async function getPageTags(userId: string, pageId: string): Promise<TagResult<PageTagAssignment[]>> {
+  try {
+    if (!(await canUserViewPage(userId, pageId))) return fail('forbidden');
+
+    const rows = await db
+      .select(assignmentColumns)
+      .from(contentTags)
+      .innerJoin(tags, eq(contentTags.tagId, tags.id))
+      .where(eq(contentTags.pageId, pageId));
+
+    return ok(rows);
+  } catch (error) {
+    return unexpected('getPageTags', error);
+  }
+}
+
+/**
+ * Assignments for many pages at once — for decorating search results later.
+ *
+ * Filters to the viewable subset FIRST and queries only those, so an
+ * unauthorized id can never contribute a row. `getBatchPagePermissions`
+ * pre-seeds every requested id with an all-false deny entry, so the `.get(id)!`
+ * is total; it is still written defensively because a future change to that
+ * pre-seeding must not silently turn this into a leak.
+ *
+ * Pages the caller cannot view are OMITTED from the returned map rather than
+ * mapped to an empty array: "no tags" and "not allowed to know" are different
+ * answers, and a caller rendering them the same way should have to choose that.
+ */
+export async function getBatchPageTags(
+  userId: string,
+  pageIds: string[],
+): Promise<TagResult<Map<string, PageTagAssignment[]>>> {
+  try {
+    const result = new Map<string, PageTagAssignment[]>();
+    if (pageIds.length === 0) return ok(result);
+
+    const unique = [...new Set(pageIds)];
+    const permissions = await getBatchPagePermissions(userId, unique);
+    const viewable = unique.filter((id) => permissions.get(id)?.canView === true);
+    if (viewable.length === 0) return ok(result);
+
+    for (const id of viewable) result.set(id, []);
+
+    const rows = await db
+      .select(assignmentColumns)
+      .from(contentTags)
+      .innerJoin(tags, eq(contentTags.tagId, tags.id))
+      .where(inArray(contentTags.pageId, viewable));
+
+    for (const row of rows) {
+      // `viewable` seeded every key above, so this bucket always exists.
+      result.get(row.pageId)?.push(row);
+    }
+
+    return ok(result);
+  } catch (error) {
+    return unexpected('getBatchPageTags', error);
+  }
+}
+
+/** What one re-anchoring sweep did. Counts, not rows: callers log this. */
+export type ReanchorSummary = {
+  /** Anchors examined — 'text' assignments only; other kinds need no porting. */
+  considered: number;
+  /** Anchors whose status or offsets changed and were written back. */
+  updated: number;
+  /** Anchors that became 'orphaned' in this sweep. Included in `updated`. */
+  orphaned: number;
+  /** Skipped because the stored projection hash did not match `oldContent`. */
+  skippedStaleHash: number;
+  /** Skipped because the projection format flipped between the two revisions. */
+  skippedFormatFlip: number;
+};
+
+/**
+ * Forward-port every 'text' anchor on a page across one content change.
+ *
+ * THE PRIMARY ANCHORING MECHANISM. Quote repair is the fallback, reached only
+ * when there is no diffable predecessor; this is the path that keeps offsets
+ * exact, including through duplicated quote text that search alone cannot
+ * disambiguate.
+ *
+ * NOT WIRED UP YET, and that is the single most important thing to know about
+ * this function. It has to be called from `applyPageMutation` — the one
+ * transaction holding both `previousContent` and `nextContent` — and from
+ * `convert-content-mode`. Until it is, every edit silently degrades anchors to
+ * the repair floor. Safe only because nothing writes tags yet; it MUST land
+ * before any write path ships.
+ *
+ * Two guards implement the caller contract `portAnchor` documents but cannot
+ * enforce from inside:
+ *
+ *  - **Format flip.** `resolveProjectionFormat` is sniffed per revision, and a
+ *    page whose markup gains an unclosed trailing element projects as raw text
+ *    where the previous revision projected as stripped prose. Porting across
+ *    that compares two different coordinate systems and mislays every anchor
+ *    confidently. If the two revisions disagree, this sweep does nothing and
+ *    says so. The durable fix is a stored per-page format — see the epic; it
+ *    was assigned to Phase 2's schema and did not ship.
+ *  - **Stale hash.** `anchor.textHash` pins the exact projection the anchor was
+ *    measured against. An anchor whose hash does not match `oldContent`'s
+ *    projection was built against some other revision, so porting it forward
+ *    would produce a confident wrong answer. Left untouched for a later repair
+ *    pass rather than guessed at.
+ *
+ * The diff is hoisted: `preparePort` runs ONCE for the transition and each
+ * anchor is ported against it. Phase 0 measured the diff at 13.9s for 20KB of
+ * change, so looping `portAnchor` here would multiply that by the number of
+ * anchors for an identical result.
+ *
+ * No permission check: this is a system-triggered consequence of a page edit
+ * the caller has already authorized, not a user action. It takes no `userId`
+ * precisely so it cannot be mistaken for one.
+ */
+export async function reanchorPageTags(
+  pageId: string,
+  oldContent: string,
+  newContent: string,
+): Promise<TagResult<ReanchorSummary>> {
+  const summary: ReanchorSummary = {
+    considered: 0,
+    updated: 0,
+    orphaned: 0,
+    skippedStaleHash: 0,
+    skippedFormatFlip: 0,
+  };
+
+  try {
+    const page = await db
+      .select({ contentMode: pages.contentMode })
+      .from(pages)
+      .where(eq(pages.id, pageId))
+      .limit(1);
+    if (page.length === 0) return fail('assignment_not_found', 'page not found');
+
+    const mode = page[0].contentMode;
+
+    const rows = await db
+      .select({ id: contentTags.id, anchor: contentTags.anchor, anchorStatus: contentTags.anchorStatus })
+      .from(contentTags)
+      .where(and(eq(contentTags.pageId, pageId), eq(contentTags.targetKind, 'text')));
+
+    summary.considered = rows.length;
+    if (rows.length === 0) return ok(summary);
+
+    // Both guards are per-transition, so they are decided once, before any
+    // per-anchor work.
+    if (resolveProjectionFormat(oldContent, mode) !== resolveProjectionFormat(newContent, mode)) {
+      summary.skippedFormatFlip = rows.length;
+      log.warn('tag-service: projection format flipped between revisions; skipping re-anchor', { pageId, anchors: rows.length });
+      return ok(summary);
+    }
+
+    const oldText = projectContent(oldContent, mode);
+    const newText = projectContent(newContent, mode);
+    const oldHash = hashText(oldText);
+
+    const newHash = hashText(newText);
+    const prepared = preparePort(oldText, newText);
+
+    for (const row of rows) {
+      const anchor = row.anchor as TextAnchor | null;
+      if (!anchor || anchor.textHash !== oldHash) {
+        summary.skippedStaleHash += 1;
+        continue;
+      }
+
+      const resolution = portPreparedAnchor(prepared, anchor);
+
+      // AnchorResolution is a union: 'orphaned' carries NO offsets, because
+      // there is nowhere for them to point. Keep the last known start/end on
+      // an orphan rather than inventing or zeroing them — a later repair pass
+      // uses them as a search hint, and zeroes would read as "found at the top
+      // of the document". The status is what marks it unusable.
+      const ported =
+        resolution.status === 'orphaned'
+          ? { start: anchor.start, end: anchor.end }
+          : { start: resolution.start, end: resolution.end };
+
+      // Nothing moved and nothing changed status: skip the write rather than
+      // touch `updatedAt` on every anchor of every edit.
+      if (
+        resolution.status === row.anchorStatus &&
+        ported.start === anchor.start &&
+        ported.end === anchor.end
+      ) {
+        continue;
+      }
+
+      await db
+        .update(contentTags)
+        .set({
+          // textHash re-pins the anchor to the projection it now describes, so
+          // the next sweep's staleness guard compares against the right one.
+          anchor: { ...anchor, start: ported.start, end: ported.end, textHash: newHash },
+          anchorStatus: resolution.status,
+        })
+        .where(eq(contentTags.id, row.id));
+
+      summary.updated += 1;
+      if (resolution.status === 'orphaned') summary.orphaned += 1;
+    }
+
+    return ok(summary);
+  } catch (error) {
+    return unexpected('reanchorPageTags', error);
+  }
+}

--- a/packages/lib/vitest.config.ts
+++ b/packages/lib/vitest.config.ts
@@ -23,6 +23,7 @@ export default defineConfig({
       'src/services/broadcast/__tests__/claim-recipient.integration.test.ts',
       'src/services/agent-workspaces/__tests__/agent-sessions-store.integration.test.ts',
       'src/services/app-hosting/__tests__/provisioner-claim.integration.test.ts',
+      'src/tags/__tests__/tag-service.integration.test.ts',
     ],
     setupFiles: ['./src/test/setup.ts'],
     // Run test files sequentially to avoid database race conditions
@@ -67,6 +68,7 @@ export default defineConfig({
         'src/services/broadcast/__tests__/claim-recipient.integration.test.ts',
         'src/services/agent-workspaces/__tests__/agent-sessions-store.integration.test.ts',
         'src/services/app-hosting/__tests__/provisioner-claim.integration.test.ts',
+        'src/tags/__tests__/tag-service.integration.test.ts',
       ],
       thresholds: {
         lines: 85,


### PR DESCRIPTION
Phase 3 of the Content Tags epic (`etvdzkdkq4rtzw7hq1t99vix`). Phase 2 (#2455) landed the schema; this is the imperative shell over it.

> **Tests are in.** 21 integration cases against real Postgres, every claim mutation-checked. Ready for review.

## The shell

`packages/lib/src/tags/tag-service.ts`, following `page-webhook-service.ts`: imports the `db` singleton rather than taking a db param, never throws across the boundary, returns discriminated results so callers map outcomes without a try/catch.

```ts
listDriveTags(driveId, userId)
upsertTag(driveId, userId, { name, color?, description? })
applyTag(userId, { pageId, tagId | name, target, source, confidence? })
removeTag(userId, contentTagId)
getPageTags(userId, pageId)
getBatchPageTags(userId, pageIds[])
reanchorPageTags(pageId, oldContent, newContent)
```

Authorization is the centralized permission functions only. There is no bespoke access logic in this file and there must not be: a content tag is readable exactly when its page is readable, which is why `content_tags.pageId` is NOT NULL on every row including the message kinds.

## The hoist Phase 0 asked for

`portAnchor` recomputed the diff on every call, but the diff is a function of `(oldText, newText)` alone — never of the anchor. Phase 0 measured it at **142ms at 2KB of change, 558ms at 4KB, 13.9s at 20KB**, so a page with twenty text tags paid that twenty times for an identical result.

`reanchor.ts` now exposes `preparePort` + `portPreparedAnchor`, and **`portAnchor` is a thin wrapper over exactly that path** — one implementation, no second copy to drift. `preparePort` also skips the diff entirely when the change exceeds `MAX_EXACT_DIFF_REGION`, since every anchor routes to repair and the expensive call would be discarded.

**All 89 Phase 0 tests pass unchanged**, which is the real evidence the refactor is behaviour-preserving. `portAnchor` has no production callers outside these tests, so the blast radius is exactly this PR.

## Two guards `portAnchor` documents but cannot enforce

Both are per-transition, so both are decided once before any per-anchor work:

- **Format flip.** `resolveProjectionFormat` is sniffed per revision. A page whose markup gains an unclosed trailing element projects as raw text where the previous revision projected as stripped prose — two coordinate systems for one page. Porting across that mislays every anchor *confidently*, so the sweep does nothing and reports it.
- **Stale `textHash`.** An anchor whose hash does not match `oldContent`'s projection was measured against some other revision. Left for a repair pass rather than guessed at.

## Judgement calls worth a reviewer's eye

- **`upsertTag` is get-or-create, not get-or-update.** An existing tag comes back unmodified: tagging a page must never silently restyle a shared vocabulary entry for the whole drive.
- **`getBatchPageTags` omits unviewable pages** rather than mapping them to `[]`. "No tags" and "not allowed to know" are different answers; a caller rendering them alike should have to choose that.
- **`reanchorPageTags` takes no `userId`.** It is a system consequence of an edit the caller already authorized, not a user action — the missing parameter is the point.
- **An orphaned anchor keeps its last known offsets.** `AnchorResolution` is a union and `'orphaned'` carries none; the compiler caught me reading `.start` unconditionally. Zeroing them would read as "found at the top of the document", so they stay as a hint for a later repair pass and the status marks it unusable.

`upsertTag` races on `(driveId, normalizedKey)` by design and resolves with `onConflictDoNothing` — deliberately not a `code === '23505'` check, which drizzle 0.45.2 defeats by rethrowing pg errors wrapped with the driver error on `.cause`, turning a 409 path into a silent 500.

## Tests — 21 cases, every claim mutation-checked

They test what a mocked db cannot. The partial unique indexes, the five-branch CHECK and the scope trigger are enforced by *Postgres*, so a mock would cheerfully accept rows the real database rejects — putting those rules in the schema was worth doing precisely because they hold regardless of which code path writes.

| Mutation | Test that went red |
|---|---|
| drop the edit-permission check in `applyTag` | `refuses to tag a page the caller cannot edit` |
| make `removeTag` trust caller input, not the row's own `pageId` | `checks removeTag against the row OWN page, not against caller input` |
| stop filtering the batch path to viewable pages | `OMITS unviewable pages rather than returning them empty` |
| **`DROP INDEX content_tags_page_target_unique`** — mutating the *database* | `rejects a SECOND page-level assignment of the same tag` |
| `onConflictDoNothing` → `onConflictDoUpdate` | `returns an existing tag UNMODIFIED rather than restyling it` |

The index mutation is the one worth keeping: it is the only way to show the test exercises the constraint rather than some accident of ordering, since no change to TypeScript can weaken an index.

**Typecheck caught what 21 passing tests did not.** `createDriveMember`'s third parameter is an overrides object, not a role string, so `'OWNER'` was silently discarded and every case ran as the default `MEMBER`. They passed either way — `MEMBER` also grants the access they assert — so they were green for a slightly different reason than they claimed. Fixed.

**Coverage, stated plainly:** `tag-service.ts` reads **0%** in the unit run, because its only tests are integration tests and `vitest.config` excludes those from coverage. That is structural in this repo rather than a gap this PR introduces — `...ship-store.ts` reads 0% and `...ells-store.ts` 1.63% for the same reason. Suite-wide thresholds still pass: **94.93 / 94.95 / 89.4 / 94.93** against 85/94/88/85.

## Gates

knip entry, the `./tags/tag-service` exports subpath, and the integration file added by hand to BOTH `vitest.config.ts` arrays (`test.exclude` and `coverage.exclude`). `typecheck` 17/17 (zero errors) · `lint` 15/15 · `knip` at baseline · anchoring 89/89 · tag-service integration 21/21.

## Not wired up — and that is the point

Nothing calls this. No route, no UI; that is Phase 4. Two prerequisites are recorded on the epic and must land **before any write path ships**, not after:

1. **`reanchorPageTags` into `applyPageMutation` and `convert-content-mode`.** Forward-porting is the *primary* mechanism; without the hook every edit silently degrades anchors to the repair floor.
2. **The cross-drive-move scrub.** Pages move between drives, rewriting `pages."driveId"` for a whole subtree without ever writing `content_tags`, so the scope trigger cannot see it. A stale row is permissioned against the wrong page and is a latent Art 17 hazard.

Both are safe to omit *today* only because nothing writes tags yet. That grace expires with the first writer.

## Also found

Phase 0 assigned a **stored per-page content format** to "the Phase 2 schema"; Phase 2 shipped without it, so the sniffer is still re-derived per call. That is what makes the format-flip guard above necessary rather than belt-and-braces. Now recorded on the epic as Phase 3's to close — it needs its own migration.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a public tagging service for managing drive-level tag vocabularies and page-level tag assignments.
  - Supports creating, applying, removing, listing, and batch-reading tags with permission checks and clear error handling.
  - Added support for preserving text-based tag locations when page content changes.

- **Improvements**
  - Improved anchoring performance by processing content changes once when updating multiple tags.
  - Added comprehensive coverage for tag validation, permissions, database constraints, and cross-drive protection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->