### PR TITLE
fix(desktop): make dev:coder actually run the coder bundle

### DIFF
--- a/apps/desktop/electron.vite.config.ts
+++ b/apps/desktop/electron.vite.config.ts
@@ -1,5 +1,6 @@
 import { defineConfig } from 'electron-vite';
 import { resolve } from 'path';
+import { outRootFor } from './src/shared/out-root';
 
 /**
  * One codebase, two apps. `PAGESPACE_APP_VARIANT` selects which one this build
@@ -12,7 +13,10 @@ import { resolve } from 'path';
  * electron-builder configs.
  */
 const variant = process.env.PAGESPACE_APP_VARIANT ?? 'pagespace';
-const outRoot = variant === 'pagespace' ? 'out' : `out-${variant}`;
+
+// Shared with the dev scripts and the packaging configs — see out-root.ts for
+// why all three have to agree, and build-config-drift.test.ts for the guard.
+const outRoot = outRootFor(variant);
 
 const define = { __APP_VARIANT__: JSON.stringify(variant) };
 

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -12,7 +12,7 @@
   "main": "out/main/index.js",
   "scripts": {
     "dev": "electron-vite dev",
-    "dev:coder": "PAGESPACE_APP_VARIANT=coder electron-vite dev",
+    "dev:coder": "PAGESPACE_APP_VARIANT=coder ELECTRON_ENTRY=out-coder/main/index.js electron-vite dev",
     "lint": "eslint src",
     "test": "vitest run",
     "test:coverage": "vitest run --coverage",

--- a/apps/desktop/src/main/__tests__/build-config-drift.test.ts
+++ b/apps/desktop/src/main/__tests__/build-config-drift.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect } from 'vitest';
 import { readFileSync } from 'node:fs';
 import { join } from 'node:path';
 import { APP_VARIANTS, resolveAppIdentity, type AppVariant } from '../../shared/app-identity';
+import { outRootFor } from '../../shared/out-root';
 
 /**
  * The app identity exists twice by necessity: once in TypeScript, where the
@@ -150,6 +151,58 @@ describe('the two packaging configs', () => {
     for (const config of [pagespace, coder]) {
       expect(config.mac.entitlements).toBeUndefined();
       expect(config.mac.entitlementsInherit).toBeUndefined();
+    }
+  });
+});
+
+/**
+ * One layer below the packaging configs, and the same class of bug.
+ *
+ * `electron-vite dev` launches Electron with entry `.`, which resolves through
+ * package.json's single `main`. A variant that only redirects `outDir` would
+ * therefore compile the coder bundle and then run the PageSpace one — and since
+ * `setupProtocolClient` claims the scheme of whatever is actually running, a
+ * coder dev session would take `pagespace://` from the installed app. The only
+ * thing keeping the dev script and the vite config in agreement is this test.
+ */
+describe('the dev scripts', () => {
+  function electronEntry(script: string): string | undefined {
+    return /ELECTRON_ENTRY=(\S+)/.exec(script)?.[1];
+  }
+
+  it('runs PageSpace from the directory package.json main points at', () => {
+    // No override needed: `main` already names the pagespace bundle.
+    expect(electronEntry(pkg.scripts.dev)).toBeUndefined();
+    expect(pkg.main.split('/')[0]).toBe(outRootFor('pagespace'));
+  });
+
+  it('runs the coder bundle, not whatever main points at', () => {
+    const entry = electronEntry(pkg.scripts['dev:coder']);
+    expect(entry).toBeDefined();
+    expect(entry!.split('/')[0]).toBe(outRootFor('coder'));
+    // The whole point: it must NOT fall through to package.json main.
+    expect(entry).not.toBe(pkg.main);
+    // And it must name a main-process entry, not just the directory.
+    expect(entry).toBe(`${outRootFor('coder')}/main/index.js`);
+  });
+
+  it('builds and runs the same variant', () => {
+    for (const script of [pkg.scripts['dev:coder'], pkg.scripts['build:coder']]) {
+      expect(script).toContain('PAGESPACE_APP_VARIANT=coder');
+    }
+  });
+
+  it('gives every variant its own out root, and PageSpace the one main names', () => {
+    const roots = APP_VARIANTS.map(outRootFor);
+    expect(new Set(roots).size).toBe(APP_VARIANTS.length);
+    expect(outRootFor('pagespace')).toBe(pkg.main.split('/')[0]);
+  });
+
+  it('packages each variant from the out root its dev script runs', () => {
+    // Closes the loop: vite writes outRootFor(v), dev runs it, and the
+    // packaging config reads from it.
+    for (const variant of APP_VARIANTS) {
+      expect(sourceRoot(configs[variant])).toBe(outRootFor(variant));
     }
   });
 });

--- a/apps/desktop/src/shared/out-root.ts
+++ b/apps/desktop/src/shared/out-root.ts
@@ -1,0 +1,17 @@
+/**
+ * Where a given variant's compiled bundle lands.
+ *
+ * Build-time rather than runtime config, but it lives beside the identity
+ * registry because three places have to agree on it and nothing else forces
+ * them to: `electron.vite.config.ts` writes here, `dev:coder` sets
+ * `ELECTRON_ENTRY` to here, and `electron-builder.coder.json` packages from
+ * here. When they disagree the failure is silent — `electron-vite dev` resolves
+ * its entry through package.json's single `main`, so a variant that only moved
+ * `outDir` would compile the coder bundle and then run the PageSpace one.
+ *
+ * PageSpace keeps the bare `out` that package.json `main` names, so its dev
+ * script needs no override at all.
+ */
+export function outRootFor(variant: string): string {
+  return variant === 'pagespace' ? 'out' : `out-${variant}`;
+}


### PR DESCRIPTION
`bun run dev:coder` compiled the coder bundle and then ran **PageSpace**.

`electron-vite dev` launches Electron with entry `.`, which Electron resolves through
`package.json`'s single `main` — always `out/main/index.js`. `dev:coder` only redirected the *build*
output to `out-coder/`, so the two never met. Verified on disk before the fix:

```
out/main/index.js:        const variant = "pagespace"
out-coder/main/index.js:  const variant = "coder"
```

## Why it mattered beyond "wrong app opens"

`setupProtocolClient` claims the scheme of whatever is *actually running*. So a coder dev session
called `setAsDefaultProtocolClient('pagespace')` from the dev Electron binary and took the
`pagespace://` handler away from the installed PageSpace app — breaking its OAuth and magic-link
returns until that app was launched again.

Confirmed on macOS: the LaunchServices `handlerpref` record for `pagespace` really does move to
`com.github.electron`.

## The fix

`dev:coder` now sets `ELECTRON_ENTRY`, which electron-vite honours in both its entry-file validation
(`dist/chunks/lib-ClgyQuZx.js:79-81` early-returns when it is set) and at spawn (`:220-221` uses it
verbatim).

The out-root rule moves to `src/shared/out-root.ts` because **three** places have to agree on it and
nothing forced them to: the vite config writes there, the dev script runs from there, and
`electron-builder.coder.json` packages from there. `build-config-drift.test.ts` now closes that loop
— it already reconciled runtime identity against packaging identity, and this is the same class of
bug one layer down.

## Verification

Each new assertion was mutation-checked — reverting the script, collapsing the two out roots, and
moving PageSpace off the root that `main` names each turn it red.

Ran for real after the fix: `dev:coder` loads `http://localhost:3000/dashboard/agents` under
`PageSpace Coder (dev)` userData, and the `pagespace` handlerpref keeps its original owner **and its
original modification date** — untouched.

Gates green monorepo-wide: `typecheck`, `lint`, `knip:check`, and `desktop test:coverage`
(264 passed; `out-root.ts` at 100% branch).

Note this is still live on `master` — nothing in the last 228 commits touched these files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WPkyHTY5GWCirXCxQsUnC8
