### PR TITLE
census: measure the images and the sizes, not just the gaps

### DIFF
--- a/.pu-reports/pu-mp-census.md
+++ b/.pu-reports/pu-mp-census.md
@@ -1,14 +1,16 @@
-# Phase B — content census, run against production 2026-08-24
+# Phase B — content census, run against production 2026-08-25
 
-## What it found, and what it overturned
+Two runs, and the second one exists because the first one's most-quoted number was a tautology.
 
-Ran read-only against production: **4,769 DOCUMENT pages** (3,762 html-mode, 1,007 markdown-mode,
-318 empty). Every number below is from that run.
+## Round one: what it found, and what it overturned
+
+Ran read-only against production: **4,771 DOCUMENT pages** (3,762 html-mode, 1,009 markdown-mode,
+318 empty). Every number below is from the latest run.
 
 ### What the census can and cannot answer
 
 It measures what documents **contain**. The schema must represent what the product **intends**.
-Those diverge exactly where a feature is missing, and that is the trap this run walked into.
+Those diverge exactly where a feature is missing, and that is the trap the first run walked into.
 
 | construct | pages |
 |---|---|
@@ -21,34 +23,33 @@ Most of those zeros are tautologies. The editor has no image node, so no documen
 **That is not evidence against an `image` node in v1** — images in documents are wanted, they are
 simply unbuilt. Under the irreversibility model, adding a node once documents exist is Class B
 (version skew, a lockstep client upgrade); including it in v1 is free. Maximal in what it can
-represent, minimal in what it commits to keeping.
-
-Positive evidence points the same way: `md:image` appears in markdown source, and ~4,000 markdown
-documents migrate onto this surface in Phase K. Without the node they flatten on seed.
-
-What the census does settle is narrower and still worth having: nothing in stored HTML is
-*silently* at risk today beyond `<h4>` on 14 pages. Read a zero as a licence to omit only when the
+represent, minimal in what it commits to keeping. Read a zero as a licence to omit only when the
 feature already exists and nobody used it.
 
-### The real finding: 3,003 documents are markdown mislabelled as HTML
+### The real finding: most html-mode documents are markdown mislabelled as HTML
 
 ```
 html-mode DOCUMENT pages, non-empty:      3,488
-  …containing NO HTML tag at all:         3,003   (86%)
+  …containing NO HTML element at all:     3,169   (91%)
 ```
 
 Markdown source stored under `contentMode='html'`. Seeding one produces a single paragraph holding
-the raw markdown as literal text — every heading, list and code fence flattened, permanently.
-That is the catastrophic-seed scenario, and it is not the one anybody was looking for. Own leaf on
-the board; Phase E's "Refuse a lossy seed" now carries it as a hard precondition.
+the raw markdown as literal text — every heading, list and code fence flattened, permanently. That
+is the catastrophic-seed scenario, and it is not the one anybody was looking for. Own leaf on the
+board; Phase E's "Refuse a lossy seed" carries it as a hard precondition.
 
-It also resizes Phase K: the markdown migration is ~4,000 pages, not the 1,007 that carry the label.
+It also resizes Phase K: the markdown migration is ~4,200 pages, not the 1,009 that carry the label.
 
-### The headline number was a false positive
+**3,169, not the 3,003 first reported.** That figure came from an ad-hoc query run beside the
+census; this one is measured by the scan itself and excludes the parser's own artefacts. The gap is
+the 183 pages that contain an unescaped `<` in prose or a code sample: a query looking for a tag
+finds `<string>` in `Set<string>` and calls the page HTML.
 
-"Text lost in the round trip: 3,114 of 3,762" is the same population. Round-tripping tagless
-markdown through an HTML parser re-blocks the text and changes its projection; nothing is destroyed
-by the schema. 3,114 flagged against 3,003 tagless is the tell.
+### The headline text-loss number was a false positive
+
+"Text lost in the round trip: 3,114 of 3,762" is the same population, and 3,114 now sits **inside**
+the 3,169 rather than beside 3,003. Round-tripping tagless markdown through an HTML parser re-blocks
+the text and changes its projection; nothing is destroyed by the schema.
 
 Diagnosed by adding example page ids to that bucket — it reported a bare count, which made the most
 alarming number in the report the only one you could not investigate. Three examples
@@ -59,27 +60,109 @@ Probed first against synthetic HTML — code blocks with newlines, hard breaks, 
 with `thead`, blockquotes, links, mentions, inline code, escaped and unescaped generics — all
 preserved text. That ruled out the schema before production data was touched.
 
-## Fix: unescaped angle brackets were flooding the report
+### Fix: unescaped angle brackets were flooding the report
 
 `ActionResult<void>`, `Set<string>`, `<task-id>`, even `<noreply@anthropic.com>` — unescaped `<` in
 prose and code samples, which happy-dom turns into elements. ~200 phantom rows buried the real
-findings. They now collapse into one `text:unescaped-angle-bracket` key: still counted, because
-"stored HTML contains unescaped angle brackets" is worth knowing, but never named individually.
+findings. They now collapse into one `text:unescaped-angle-bracket` key (183 pages): still counted,
+because "stored HTML contains unescaped angle brackets" is worth knowing, but never named
+individually.
 
-**Mutation-checked:** removing the bucketing turns 2 tests red. 72/72 green with it.
+## Round two: real evidence for images, and for turning pagination on
+
+Round one left three things undone, and each one was load-bearing.
+
+### 1. The mislabelled population was never scanned as markdown
+
+Markdown detection ran only over the 1,009 pages that carry the label — a quarter of the markdown
+that exists. It now runs over the tagless html-mode pages too, in their own table so the labelled
+numbers stay comparable between runs.
+
+| construct | labelled markdown | mislabelled as html |
+|---|---|---|
+| `md:task-list` | 34 | **325** |
+| `md:heading-4-6` | 8 | 18 |
+| `md:raw-html` | 11 | 13 |
+| `md:highlight` | 1 | 3 |
+| `md:image` | 2 | **0** |
+
+Task lists are a **ten-fold** undercount, not the four-fold the first report guessed, and they are
+now the largest single schema gap the census has found. Images are the opposite: the mislabelled
+population contains none at all.
+
+### 2. Images: 9 instances, on 2 pages, and one of them is the finding
+
+```
+where images point (scheme only — never a URL)
+  img-src:pagespace-file        1 page
+  img-src:relative              1 page
+external image hosts            (none)
+images in one document          7 (max)
+```
+
+This is thin evidence, and it has to be reported as thin. The census can now say something better
+than a tautology about images, but what it says is: **there is almost no image content in
+production, and the argument for an image node in v1 rests on product intent, not on the corpus.**
+That argument is unaffected — a node is free in v1 and Class B afterwards — but it should not be
+dressed up as a measurement. The first PR body's "positive evidence points the same way: `md:image`
+appears in markdown source" is two pages.
+
+What the run does settle, and could not have been guessed:
+
+- **No `data:` URIs anywhere.** The CRDT-bloat hazard does not exist in the corpus yet, so paste and
+  migration only have to keep it that way rather than clean it up. Base64 bytes in a Y.Doc are
+  replicated to every client and never forgotten.
+- **No external hosts at all.** Nothing is hotlinked, so Phase K needs no ingestion pipeline and v1
+  need not decide whether to proxy somebody else's CDN.
+- **One of the two pages already points at `/api/files/{id}/view`.** Somebody hand-wrote the
+  file-serving URL into markdown to get an image into a document, which is a user routing around the
+  missing node — and it names the attribute shape: a stable internal reference the client resolves
+  at render time, never a signed URL, which in a CRDT would be permanent, expiring and leaky at
+  once.
+
+### 3. Pagination: the corpus already contains blocks no page can hold
+
+`PaginationPlus` exists, is wired behind `isPaginated`, and is unreachable — `DocumentView.tsx:399`
+hardcodes `isPaginated={false}`. It is decoration-based, which is the right shape for a CRDT (it
+adds no nodes), but it breaks pages BETWEEN blocks and nothing splits a block.
+
+```
+pages with isPaginated set        0
+lines in one code block         261   (a US Letter page holds ~40)
+rows in one table                57
+columns in one table             15
+characters in one block      16,582
+```
+
+Nobody has the switch set, so flipping the default is safe as a data matter. Turning it on is not:
+today's documents already contain a single code fence six pages tall and a single block of 16.5k
+characters. Overflow handling is a precondition for the pagination work, not a polish item — and
+images are about to join that list as the one block whose height is unknown until it loads, which is
+the argument for intrinsic `width`/`height` on the node at insert time.
+
+### 4. `md:strikethrough` was never a gap
+
+Raised in review on #2495 and confirmed: StarterKit ships the `strike` mark and the bubble menu
+exposes it, so 17 documents were sitting in a table headed "syntax the schema has no node for" that
+the schema represents perfectly. Removed from the tally, and `round-trip.test.ts` now holds `<s>` to
+surviving the round trip so the claim is pinned rather than asserted.
 
 ## Gates
 
-- `bun run --filter web test -- src/lib/editor/census` — 72 passed
-- `bun run typecheck` (monorepo root)
+- `bun run --filter web test -- src/lib/editor/census` — 124 passed
+- Mutation-checked, each independently red: the credentials check in `hostOf`, the `data:` branch,
+  `hasHtmlElement` ignoring the unescaped-bracket bucket, the markdown table header counting as a
+  row, the mislabelled tally being kept separate, image buckets counting pages not instances, the
+  ten-host cap, and magnitudes measuring the stored document rather than the round trip.
+- Production run: read-only via `fly proxy`, `default_transaction_read_only` asserted at startup.
+  The html construct tallies and the text-loss counts are **unchanged** from round one, which is
+  what makes the two runs comparable.
 
 ## Deliberately not done
 
-- **No schema freeze.** It was meant to follow the census in the same PR. The census changed what
-  the input is: the question is no longer "which of six constructs does v1 need" (answer: in HTML,
-  none) but "what do ~4,000 markdown documents need once they are migrated". Freezing v1 against
-  the wrong population would be the expensive kind of mistake.
-- **No fix for the mislabelled 3,003.** Recorded as its own leaf. It is a production data change
-  and belongs in a PR that is only that.
-- **Markdown constructs undercount by ~4x** — detection only ran over correctly-labelled pages.
-  Re-run once labels are fixed.
+- **No schema freeze.** The input changed again: the largest gap is task lists (359 pages across
+  both populations), not any of the six constructs v1 was going to be argued about.
+- **No fix for the mislabelled 3,169.** Own leaf. It is a production data change and belongs in a PR
+  that is only that.
+- **No image node, no upload path, no `isPaginated` wiring.** This run is the evidence; each of
+  those is its own decision.

--- a/.pu-reports/pu-mp-census.md
+++ b/.pu-reports/pu-mp-census.md
@@ -41,9 +41,12 @@ board; Phase E's "Refuse a lossy seed" carries it as a hard precondition.
 It also resizes Phase K: the markdown migration is ~4,200 pages, not the 1,009 that carry the label.
 
 **3,169, not the 3,003 first reported.** That figure came from an ad-hoc query run beside the
-census; this one is measured by the scan itself and excludes the parser's own artefacts. The gap is
-the 183 pages that contain an unescaped `<` in prose or a code sample: a query looking for a tag
-finds `<string>` in `Set<string>` and calls the page HTML.
+census; this one is measured by the scan itself and excludes the parser's own artefacts. A query
+looking for a tag finds `<string>` in `Set<string>` and calls the page HTML, which is the direction
+of the 166-page difference — 183 pages contain an unescaped `<` in prose or a code sample. It does
+not decompose exactly, and should not be presented as if it did: the 3,003 came from a rule that was
+not written down, so only the 3,169 is a measurement. Take the older number as superseded rather
+than as explained.
 
 ### The headline text-loss number was a false positive
 
@@ -140,7 +143,23 @@ characters. Overflow handling is a precondition for the pagination work, not a p
 images are about to join that list as the one block whose height is unknown until it loads, which is
 the argument for intrinsic `width`/`height` on the node at insert time.
 
-### 4. `md:strikethrough` was never a gap
+### 4. Raw HTML inside markdown was going unread
+
+Raised in review on #2497 as a P1, and correct: `marked` emits raw HTML as one opaque `html` token
+and never looks inside it. An `<img src="data:...">`, a 60-row `<table>` or a long `<pre>` written
+into a markdown document was invisible to both the image classification and the magnitudes — and
+those are precisely the two conclusions this run exists to draw. 24 pages carry `md:raw-html`.
+
+Fixed by handing the markdown walk the same DOM the HTML half of the census uses. **The re-run
+returned every number unchanged**, which is the good outcome and also the only reason "no data URIs,
+no external hosts" is now a measurement rather than an assumption.
+
+Two smaller review points fixed alongside it: a table cell is measured as a block, the way the HTML
+half already measured `td`/`th` (a table-only document reported no block at all), and a src that
+announces a scheme and then will not parse — `https://`, a truncated paste — is malformed rather
+than relative.
+
+### 5. `md:strikethrough` was never a gap
 
 Raised in review on #2495 and confirmed: StarterKit ships the `strike` mark and the bubble menu
 exposes it, so 17 documents were sitting in a table headed "syntax the schema has no node for" that
@@ -149,11 +168,13 @@ surviving the round trip so the claim is pinned rather than asserted.
 
 ## Gates
 
-- `bun run --filter web test -- src/lib/editor/census` — 124 passed
-- Mutation-checked, each independently red: the credentials check in `hostOf`, the `data:` branch,
-  `hasHtmlElement` ignoring the unescaped-bracket bucket, the markdown table header counting as a
-  row, the mislabelled tally being kept separate, image buckets counting pages not instances, the
-  ten-host cap, and magnitudes measuring the stored document rather than the round trip.
+- `bun run --filter web test -- src/lib/editor/census` — 131 passed
+- Mutation-checked, twelve of them, each independently red: the credentials check in `hostOf`, the
+  `data:` branch, the malformed-scheme guard, `hasHtmlElement` ignoring the unescaped-bracket
+  bucket, the markdown table header counting as a row, table cells counting as blocks, raw HTML
+  being read at all, `absorb` summing images rather than taking their maximum, the mislabelled
+  tally being kept separate, image buckets counting pages not instances, the ten-host cap, and
+  magnitudes measuring the stored document rather than the round trip.
 - Production run: read-only via `fly proxy`, `default_transaction_read_only` asserted at startup.
   The html construct tallies and the text-loss counts are **unchanged** from round one, which is
   what makes the two runs comparable.

--- a/apps/web/scripts/collab-content-census.ts
+++ b/apps/web/scripts/collab-content-census.ts
@@ -28,6 +28,24 @@
  * them onto this surface, and markdown natively carries images and checkboxes
  * the schema has no node for. Their tally is source-syntax detection.
  *
+ * A `contentMode='html'` page that parses to NO element is markdown under the
+ * wrong label — the first production run found 3,003 of them — so it is read a
+ * second time by the markdown detector and tallied in its own table. Without
+ * that, markdown syntax is measured over a quarter of the markdown documents
+ * that exist, and images live almost entirely in the other three quarters.
+ *
+ * Images get a section of their own because the headline `<img>: 0` is a
+ * tautology: the editor has no image node, so no document can contain one. What
+ * the census can answer is where the images in MARKDOWN source point — a data
+ * URI, a host somebody else controls, or a file PageSpace already stores — and
+ * that decides what an image node's attributes have to hold before v1 freezes
+ * them. Scheme and bare hostname only, never a URL (see census/images.ts).
+ *
+ * Magnitudes are the one measurement here that is a size rather than a
+ * presence, and they exist for pagination: PaginationPlus breaks BETWEEN
+ * blocks, so a table, a code fence or an image taller than a page cannot be
+ * paginated at all (see census/magnitudes.ts).
+ *
  * Trashed pages are included: a restored page is seeded like any other, so its
  * content is as much at stake.
  *
@@ -65,7 +83,7 @@ import { getSchema } from '@tiptap/core';
 import { buildRichEditorExtensions } from '../src/lib/editor/rich-editor-extensions';
 import { createDomWorkspace } from '../src/lib/editor/census/constructs';
 import { analyzeHtmlDocument } from '../src/lib/editor/census/round-trip';
-import { markdownConstructs } from '../src/lib/editor/census/markdown';
+import { analyzeMarkdown } from '../src/lib/editor/census/markdown';
 import { createCensusAccumulator, formatCensusReport } from '../src/lib/editor/census/report';
 import { assertReadOnlySession, enforceReadOnlySession } from '../src/lib/editor/census/read-only-session';
 
@@ -110,6 +128,19 @@ async function main(): Promise<void> {
   // same content. readOnly only adds the placeholder, which has no schema.
   // round-trip.test.ts holds all four combinations to one schema.
   const schema = getSchema(buildRichEditorExtensions({ readOnly: false, isPaginated: false }));
+
+  // The one aggregate in the run. `isPaginated` has a column, an API field and
+  // a paginated-layout extension behind it, and no UI that writes it, so
+  // whether anything has it set is worth one query and cannot be answered by
+  // reading page content.
+  const [paginated] = (
+    await db
+      .select({ pages: sql<number>`count(*)` })
+      .from(pages)
+      .where(and(eq(pages.type, 'DOCUMENT'), eq(pages.isPaginated, true)))
+  );
+  const paginatedPages = Number(paginated?.pages ?? 0);
+
   const workspace = createDomWorkspace();
   const census = createCensusAccumulator();
 
@@ -147,9 +178,17 @@ async function main(): Promise<void> {
         if (!/\S/.test(page.content)) {
           census.recordEmpty(page.contentMode);
         } else if (page.contentMode === 'markdown') {
-          census.recordMarkdown(page.id, markdownConstructs(page.content));
+          census.recordMarkdown(page.id, analyzeMarkdown(page.content));
         } else {
-          census.recordHtml(page.id, analyzeHtmlDocument(page.content, schema, workspace));
+          const analysis = analyzeHtmlDocument(page.content, schema, workspace);
+          census.recordHtml(page.id, analysis);
+          // An html-mode page that parsed to no element is markdown wearing the
+          // wrong label, and the HTML scan is blind to everything in it. Read it
+          // a second time as what it is — otherwise the markdown numbers are
+          // drawn from a quarter of the markdown documents that exist.
+          if (analysis.status === 'analysed' && analysis.tagless) {
+            census.recordMislabelledMarkdown(page.id, analyzeMarkdown(page.content));
+          }
         }
 
         scanned += 1;
@@ -166,7 +205,9 @@ async function main(): Promise<void> {
     await getMigrationPool().end();
   }
 
-  process.stdout.write(`${formatCensusReport(census.snapshot(), { partial: interrupted })}\n`);
+  process.stdout.write(
+    `${formatCensusReport(census.snapshot(), { partial: interrupted, paginatedPages })}\n`,
+  );
 }
 
 await main();

--- a/apps/web/scripts/collab-content-census.ts
+++ b/apps/web/scripts/collab-content-census.ts
@@ -178,7 +178,7 @@ async function main(): Promise<void> {
         if (!/\S/.test(page.content)) {
           census.recordEmpty(page.contentMode);
         } else if (page.contentMode === 'markdown') {
-          census.recordMarkdown(page.id, analyzeMarkdown(page.content));
+          census.recordMarkdown(page.id, analyzeMarkdown(page.content, workspace));
         } else {
           const analysis = analyzeHtmlDocument(page.content, schema, workspace);
           census.recordHtml(page.id, analysis);
@@ -187,7 +187,7 @@ async function main(): Promise<void> {
           // a second time as what it is — otherwise the markdown numbers are
           // drawn from a quarter of the markdown documents that exist.
           if (analysis.status === 'analysed' && analysis.tagless) {
-            census.recordMislabelledMarkdown(page.id, analyzeMarkdown(page.content));
+            census.recordMislabelledMarkdown(page.id, analyzeMarkdown(page.content, workspace));
           }
         }
 

--- a/apps/web/src/lib/editor/census/__tests__/images.test.ts
+++ b/apps/web/src/lib/editor/census/__tests__/images.test.ts
@@ -1,0 +1,104 @@
+import { describe, it, expect, afterAll } from 'vitest';
+import { createDomWorkspace } from '../constructs';
+import { classifyImageSource, htmlImageSources, IMAGE_SOURCE_KEYS } from '../images';
+
+const workspace = createDomWorkspace();
+afterAll(() => workspace.close());
+
+describe('classifyImageSource', () => {
+  it('names a data URI, the one source that cannot be carried into a Y.Doc', () => {
+    // Not a size question: a CRDT keeps every version of every byte forever, so
+    // base64 in a document is permanent whatever it weighs.
+    expect(classifyImageSource('data:image/png;base64,iVBORw0KGgo=')).toEqual({
+      bucket: IMAGE_SOURCE_KEYS.dataUri,
+      host: null,
+    });
+    expect(classifyImageSource('DATA:image/png;base64,x').bucket).toBe(IMAGE_SOURCE_KEYS.dataUri);
+  });
+
+  it('recognises an image PageSpace already stores, absolute or relative', () => {
+    for (const src of [
+      '/api/files/abc123/view',
+      '/api/files/abc123/thumbnail',
+      'https://app.pagespace.test/api/files/abc123/view',
+      '/api/files/abc123/view?width=200',
+    ]) {
+      expect(classifyImageSource(src)).toEqual({ bucket: IMAGE_SOURCE_KEYS.pagespaceFile, host: null });
+    }
+  });
+
+  it('separates https from http, and keeps the host', () => {
+    expect(classifyImageSource('https://images.example.test/a/b/c.png?token=secret')).toEqual({
+      bucket: IMAGE_SOURCE_KEYS.externalHttps,
+      host: 'images.example.test',
+    });
+    expect(classifyImageSource('http://old.example.test/a.png')).toEqual({
+      bucket: IMAGE_SOURCE_KEYS.externalHttp,
+      host: 'old.example.test',
+    });
+  });
+
+  it('treats a scheme-relative URL as the https it becomes in production', () => {
+    expect(classifyImageSource('//cdn.example.test/a.png')).toEqual({
+      bucket: IMAGE_SOURCE_KEYS.externalHttps,
+      host: 'cdn.example.test',
+    });
+  });
+
+  it('reports a relative path, which resolves against nothing once migrated', () => {
+    expect(classifyImageSource('./images/a.png')).toEqual({ bucket: IMAGE_SOURCE_KEYS.relative, host: null });
+    expect(classifyImageSource('a.png')).toEqual({ bucket: IMAGE_SOURCE_KEYS.relative, host: null });
+  });
+
+  it('buckets blob: and file:, which only one browser on one machine can resolve', () => {
+    expect(classifyImageSource('blob:https://app.test/9f2').bucket).toBe(IMAGE_SOURCE_KEYS.otherScheme);
+    expect(classifyImageSource('file:///Users/someone/a.png').bucket).toBe(IMAGE_SOURCE_KEYS.otherScheme);
+  });
+
+  it('calls an empty src malformed rather than relative', () => {
+    expect(classifyImageSource('   ')).toEqual({ bucket: IMAGE_SOURCE_KEYS.malformed, host: null });
+  });
+});
+
+describe('what leaves this module', () => {
+  // The census reports construct names and page ids, never content. A src is
+  // content: it carries a filename, and a query string carries tokens.
+  it('never returns the path, the query string or the filename', () => {
+    const source = classifyImageSource('https://images.example.test/private/quarterly-results.png?sig=abc');
+    expect(JSON.stringify(source)).not.toContain('quarterly-results');
+    expect(JSON.stringify(source)).not.toContain('sig=abc');
+    expect(JSON.stringify(source)).not.toContain('/private/');
+  });
+
+  it('drops even the host when the URL carries credentials', () => {
+    expect(classifyImageSource('https://user:pw@internal.example.test/a.png')).toEqual({
+      bucket: IMAGE_SOURCE_KEYS.externalHttps,
+      host: null,
+    });
+  });
+
+  it('reports the bare hostname, without the port or the userinfo', () => {
+    expect(classifyImageSource('https://images.example.test:8443/a.png').host).toBe('images.example.test');
+  });
+
+  it('lower-cases the host so one host is one row', () => {
+    expect(classifyImageSource('https://Images.Example.Test/a.png').host).toBe('images.example.test');
+  });
+});
+
+describe('htmlImageSources', () => {
+  it('classifies every <img> in a stored document', () => {
+    const container = workspace.parse(
+      '<p>a</p><img src="https://a.example.test/1.png"><img src="data:image/png;base64,x">',
+    );
+    expect(htmlImageSources(container).map((image) => image.bucket)).toEqual([
+      IMAGE_SOURCE_KEYS.externalHttps,
+      IMAGE_SOURCE_KEYS.dataUri,
+    ]);
+  });
+
+  it('counts an <img> with no src rather than ignoring it', () => {
+    const container = workspace.parse('<img alt="a">');
+    expect(htmlImageSources(container)).toEqual([{ bucket: IMAGE_SOURCE_KEYS.malformed, host: null }]);
+  });
+});

--- a/apps/web/src/lib/editor/census/__tests__/images.test.ts
+++ b/apps/web/src/lib/editor/census/__tests__/images.test.ts
@@ -58,6 +58,20 @@ describe('classifyImageSource', () => {
   it('calls an empty src malformed rather than relative', () => {
     expect(classifyImageSource('   ')).toEqual({ bucket: IMAGE_SOURCE_KEYS.malformed, host: null });
   });
+
+  it('calls a src that announces a scheme and then will not parse malformed', () => {
+    // A truncated paste. Filed as a relative path it looks like a migration
+    // problem; it is a broken image.
+    for (const src of ['https://', '//', 'http://']) {
+      expect(classifyImageSource(src)).toEqual({ bucket: IMAGE_SOURCE_KEYS.malformed, host: null });
+    }
+    // `mailto:` parses, so it is a scheme the census can name rather than a
+    // broken one — the guard only catches what announces a scheme and fails.
+    expect(classifyImageSource('mailto:')).toEqual({
+      bucket: IMAGE_SOURCE_KEYS.otherScheme,
+      host: null,
+    });
+  });
 });
 
 describe('what leaves this module', () => {

--- a/apps/web/src/lib/editor/census/__tests__/magnitudes.test.ts
+++ b/apps/web/src/lib/editor/census/__tests__/magnitudes.test.ts
@@ -1,0 +1,89 @@
+import { describe, it, expect, afterAll } from 'vitest';
+import { createDomWorkspace } from '../constructs';
+import { emptyMagnitudes, htmlMagnitudes, lineCount, MAGNITUDE_METRICS } from '../magnitudes';
+import { analyzeMarkdown } from '../markdown';
+
+const workspace = createDomWorkspace();
+afterAll(() => workspace.close());
+
+const measure = (html: string) => htmlMagnitudes(workspace.parse(html));
+
+describe('htmlMagnitudes', () => {
+  it('counts the images in a document', () => {
+    expect(measure('<p>a</p><img src="a.png"><img src="b.png">').images).toBe(2);
+  });
+
+  it('reports the tallest table, not the last one', () => {
+    const html =
+      '<table><tr><td>1</td></tr><tr><td>2</td></tr><tr><td>3</td></tr></table>' +
+      '<table><tr><td>1</td></tr></table>';
+    expect(measure(html).tableRows).toBe(3);
+  });
+
+  it('reports the widest row as the column count', () => {
+    // A table whose header is narrower than a body row still has to fit the
+    // body row on the page.
+    const html = '<table><tr><th>a</th></tr><tr><td>1</td><td>2</td><td>3</td></tr></table>';
+    expect(measure(html).tableColumns).toBe(3);
+  });
+
+  it('counts the lines in a code block, which the paginator cannot split', () => {
+    expect(measure('<pre><code>one\ntwo\nthree</code></pre>').codeBlockLines).toBe(3);
+  });
+
+  it('measures the longest block, and reports its length rather than its text', () => {
+    const result = measure('<p>short</p><p>a much longer paragraph than the first one</p>');
+    expect(result.blockCharacters).toBe('a much longer paragraph than the first one'.length);
+    expect(JSON.stringify(result)).not.toContain('longer');
+  });
+
+  it('measures a list item as everything it holds, which is how it is laid out', () => {
+    const result = measure('<ul><li>outer<ul><li>inner</li></ul></li></ul>');
+    expect(result.blockCharacters).toBe('outerinner'.length);
+  });
+
+  it('is all zeroes for a document with no block in it at all', () => {
+    expect(measure('')).toEqual(emptyMagnitudes());
+  });
+});
+
+describe('markdown magnitudes', () => {
+  it('counts the header as a row, because the page has to fit it', () => {
+    const markdown = '| a | b |\n| --- | --- |\n| 1 | 2 |\n| 3 | 4 |\n';
+    expect(analyzeMarkdown(markdown).magnitudes).toMatchObject({ tableRows: 3, tableColumns: 2 });
+  });
+
+  it('counts the lines in a fenced block', () => {
+    expect(analyzeMarkdown('```ts\none\ntwo\n```\n').magnitudes.codeBlockLines).toBe(2);
+  });
+
+  it('counts images, including one inside a table cell', () => {
+    const markdown = '![a](a.png)\n\n| x |\n| --- |\n| ![b](b.png) |\n';
+    expect(analyzeMarkdown(markdown).magnitudes.images).toBe(2);
+  });
+
+  it('measures the longest block without reporting it', () => {
+    const result = analyzeMarkdown('short\n\na considerably longer paragraph of prose\n');
+    expect(result.magnitudes.blockCharacters).toBeGreaterThan('short'.length);
+    expect(JSON.stringify(result.magnitudes)).not.toContain('prose');
+  });
+});
+
+describe('lineCount', () => {
+  it('counts a block with no newline in it as one line, not none', () => {
+    expect(lineCount('one')).toBe(1);
+    expect(lineCount('')).toBe(1);
+  });
+
+  it('counts a trailing newline as the line it opens', () => {
+    expect(lineCount('one\n')).toBe(2);
+  });
+});
+
+describe('MAGNITUDE_METRICS', () => {
+  it('names every field the measurements produce, so the report cannot go stale', () => {
+    expect(MAGNITUDE_METRICS.map((metric) => metric.key).sort()).toEqual(
+      Object.keys(emptyMagnitudes()).sort(),
+    );
+  });
+});

--- a/apps/web/src/lib/editor/census/__tests__/magnitudes.test.ts
+++ b/apps/web/src/lib/editor/census/__tests__/magnitudes.test.ts
@@ -50,20 +50,20 @@ describe('htmlMagnitudes', () => {
 describe('markdown magnitudes', () => {
   it('counts the header as a row, because the page has to fit it', () => {
     const markdown = '| a | b |\n| --- | --- |\n| 1 | 2 |\n| 3 | 4 |\n';
-    expect(analyzeMarkdown(markdown).magnitudes).toMatchObject({ tableRows: 3, tableColumns: 2 });
+    expect(analyzeMarkdown(markdown, workspace).magnitudes).toMatchObject({ tableRows: 3, tableColumns: 2 });
   });
 
   it('counts the lines in a fenced block', () => {
-    expect(analyzeMarkdown('```ts\none\ntwo\n```\n').magnitudes.codeBlockLines).toBe(2);
+    expect(analyzeMarkdown('```ts\none\ntwo\n```\n', workspace).magnitudes.codeBlockLines).toBe(2);
   });
 
   it('counts images, including one inside a table cell', () => {
     const markdown = '![a](a.png)\n\n| x |\n| --- |\n| ![b](b.png) |\n';
-    expect(analyzeMarkdown(markdown).magnitudes.images).toBe(2);
+    expect(analyzeMarkdown(markdown, workspace).magnitudes.images).toBe(2);
   });
 
   it('measures the longest block without reporting it', () => {
-    const result = analyzeMarkdown('short\n\na considerably longer paragraph of prose\n');
+    const result = analyzeMarkdown('short\n\na considerably longer paragraph of prose\n', workspace);
     expect(result.magnitudes.blockCharacters).toBeGreaterThan('short'.length);
     expect(JSON.stringify(result.magnitudes)).not.toContain('prose');
   });

--- a/apps/web/src/lib/editor/census/__tests__/markdown.test.ts
+++ b/apps/web/src/lib/editor/census/__tests__/markdown.test.ts
@@ -1,33 +1,40 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, afterAll } from 'vitest';
 import { analyzeMarkdown, markdownConstructs } from '../markdown';
+import { createDomWorkspace } from '../constructs';
+
+const workspace = createDomWorkspace();
+afterAll(() => workspace.close());
+
+const constructsOf = (markdown: string) => markdownConstructs(markdown, workspace);
+const analyse = (markdown: string) => analyzeMarkdown(markdown, workspace);
 
 describe('markdownConstructs', () => {
   it('finds an image, which the schema has no node for', () => {
-    expect(markdownConstructs('text\n\n![alt](https://example.test/a.png)\n')).toContain('md:image');
+    expect(constructsOf('text\n\n![alt](https://example.test/a.png)\n')).toContain('md:image');
   });
 
   it('finds a task list, which the schema has no node for', () => {
-    expect(markdownConstructs('- [ ] todo\n- [x] done\n')).toContain('md:task-list');
+    expect(constructsOf('- [ ] todo\n- [x] done\n')).toContain('md:task-list');
   });
 
   it('finds headings below level 3', () => {
-    expect(markdownConstructs('# a\n#### b\n')).toContain('md:heading-4-6');
+    expect(constructsOf('# a\n#### b\n')).toContain('md:heading-4-6');
   });
 
   it('does not report a level 1-3 heading', () => {
-    expect(markdownConstructs('### a\n')).toEqual([]);
+    expect(constructsOf('### a\n')).toEqual([]);
   });
 
   it('finds raw HTML', () => {
-    expect(markdownConstructs('<figure><img src="a.png"></figure>\n')).toContain('md:raw-html');
+    expect(constructsOf('<figure><img src="a.png"></figure>\n')).toContain('md:raw-html');
   });
 
   it('finds constructs inside a table cell, which hangs off no token list', () => {
-    expect(markdownConstructs('| a | b |\n| --- | --- |\n| ![alt](a.png) | x |\n')).toContain('md:image');
+    expect(constructsOf('| a | b |\n| --- | --- |\n| ![alt](a.png) | x |\n')).toContain('md:image');
   });
 
   it('finds highlight and footnote syntax', () => {
-    expect(markdownConstructs('==a==\n\n[^1]: c\n')).toEqual(
+    expect(constructsOf('==a==\n\n[^1]: c\n')).toEqual(
       expect.arrayContaining(['md:highlight', 'md:footnote']),
     );
   });
@@ -36,29 +43,29 @@ describe('markdownConstructs', () => {
     // It was counted as one, and put 17 documents in a table headed "syntax the
     // schema has no node for". StarterKit ships `strike`; round-trip.test.ts
     // holds the schema to it.
-    expect(markdownConstructs('~~struck~~\n')).toEqual([]);
+    expect(constructsOf('~~struck~~\n')).toEqual([]);
   });
 
   it('ignores syntax inside a fenced code block, which is literal text', () => {
-    expect(markdownConstructs('```md\n![alt](a.png)\n- [ ] todo\n```\n')).toEqual([]);
+    expect(constructsOf('```md\n![alt](a.png)\n- [ ] todo\n```\n')).toEqual([]);
   });
 
   it('ignores syntax inside an indented code block and a backtick span', () => {
-    expect(markdownConstructs('    ![alt](a.png)\n\nInline `![alt](b.png)` here.\n')).toEqual([]);
+    expect(constructsOf('    ![alt](a.png)\n\nInline `![alt](b.png)` here.\n')).toEqual([]);
   });
 
   it('returns a sorted list, so the report is stable between runs', () => {
-    expect(markdownConstructs('#### a\n\n![b](c.png)\n')).toEqual(['md:heading-4-6', 'md:image']);
+    expect(constructsOf('#### a\n\n![b](c.png)\n')).toEqual(['md:heading-4-6', 'md:image']);
   });
 
   it('returns nothing for prose the schema can hold', () => {
-    expect(markdownConstructs('# Title\n\nSome **bold** text.\n')).toEqual([]);
+    expect(constructsOf('# Title\n\nSome **bold** text.\n')).toEqual([]);
   });
 });
 
 describe('analyzeMarkdown images', () => {
   it('classifies where each image points, in one pass with the constructs', () => {
-    const result = analyzeMarkdown('![a](https://cdn.example.test/a.png)\n\n![b](/api/files/xyz/view)\n');
+    const result = analyse('![a](https://cdn.example.test/a.png)\n\n![b](/api/files/xyz/view)\n');
     expect(result.constructs).toContain('md:image');
     expect(result.images).toEqual([
       { bucket: 'img-src:external-https', host: 'cdn.example.test' },
@@ -67,17 +74,59 @@ describe('analyzeMarkdown images', () => {
   });
 
   it('finds the image in a table cell, which hangs off no token list', () => {
-    const result = analyzeMarkdown('| a |\n| --- |\n| ![x](data:image/png;base64,y) |\n');
+    const result = analyse('| a |\n| --- |\n| ![x](data:image/png;base64,y) |\n');
     expect(result.images).toEqual([{ bucket: 'img-src:data-uri', host: null }]);
   });
 
   it('does not treat an image inside a code fence as an image', () => {
-    const result = analyzeMarkdown('```md\n![a](a.png)\n```\n');
+    const result = analyse('```md\n![a](a.png)\n```\n');
     expect(result.images).toEqual([]);
     expect(result.constructs).toEqual([]);
   });
 
   it('reports no image and no construct for prose', () => {
-    expect(analyzeMarkdown('just words\n')).toMatchObject({ constructs: [], images: [] });
+    expect(analyse('just words\n')).toMatchObject({ constructs: [], images: [] });
+  });
+});
+
+describe('raw HTML embedded in markdown', () => {
+  // `marked` emits one opaque `html` token and never looks inside it, so every
+  // measurement below was reading zero until the census parsed it as HTML.
+  it('finds an image written as a tag rather than as markdown syntax', () => {
+    const result = analyse('text\n\n<img src="https://cdn.example.test/a.png">\n');
+    expect(result.constructs).toContain('md:raw-html');
+    expect(result.images).toEqual([
+      { bucket: 'img-src:external-https', host: 'cdn.example.test' },
+    ]);
+    expect(result.magnitudes.images).toBe(1);
+  });
+
+  it('finds a data URI hidden in raw HTML, which is the one that must never be seeded', () => {
+    const result = analyse('<img src="data:image/png;base64,iVBORw0KGgo=">\n');
+    expect(result.images).toEqual([{ bucket: 'img-src:data-uri', host: null }]);
+  });
+
+  it('measures a table written as raw HTML', () => {
+    const result = analyse('<table><tr><td>1</td><td>2</td></tr><tr><td>3</td><td>4</td></tr></table>\n');
+    expect(result.magnitudes).toMatchObject({ tableRows: 2, tableColumns: 2 });
+  });
+
+  it('measures a code block written as raw HTML', () => {
+    expect(analyse('<pre><code>a\nb\nc</code></pre>\n').magnitudes.codeBlockLines).toBe(3);
+  });
+
+  it('adds raw-HTML images to the markdown ones rather than replacing them', () => {
+    const result = analyse('![a](a.png)\n\n<img src="b.png">\n');
+    expect(result.magnitudes.images).toBe(2);
+    expect(result.images).toHaveLength(2);
+  });
+});
+
+describe('markdown table cells', () => {
+  it('measures a cell as a block, the way the HTML half measures td', () => {
+    // A table-only document reported no block at all, so the two populations
+    // were being measured by different rules.
+    const markdown = '| a | b |\n| --- | --- |\n| short | a considerably longer cell |\n';
+    expect(analyse(markdown).magnitudes.blockCharacters).toBe('a considerably longer cell'.length);
   });
 });

--- a/apps/web/src/lib/editor/census/__tests__/markdown.test.ts
+++ b/apps/web/src/lib/editor/census/__tests__/markdown.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { markdownConstructs } from '../markdown';
+import { analyzeMarkdown, markdownConstructs } from '../markdown';
 
 describe('markdownConstructs', () => {
   it('finds an image, which the schema has no node for', () => {
@@ -26,10 +26,17 @@ describe('markdownConstructs', () => {
     expect(markdownConstructs('| a | b |\n| --- | --- |\n| ![alt](a.png) | x |\n')).toContain('md:image');
   });
 
-  it('finds highlight, footnote and strikethrough syntax', () => {
-    expect(markdownConstructs('==a== ~~b~~\n\n[^1]: c\n')).toEqual(
-      expect.arrayContaining(['md:highlight', 'md:strikethrough', 'md:footnote']),
+  it('finds highlight and footnote syntax', () => {
+    expect(markdownConstructs('==a==\n\n[^1]: c\n')).toEqual(
+      expect.arrayContaining(['md:highlight', 'md:footnote']),
     );
+  });
+
+  it('does not call strikethrough a gap, because the schema has the mark', () => {
+    // It was counted as one, and put 17 documents in a table headed "syntax the
+    // schema has no node for". StarterKit ships `strike`; round-trip.test.ts
+    // holds the schema to it.
+    expect(markdownConstructs('~~struck~~\n')).toEqual([]);
   });
 
   it('ignores syntax inside a fenced code block, which is literal text', () => {
@@ -41,10 +48,36 @@ describe('markdownConstructs', () => {
   });
 
   it('returns a sorted list, so the report is stable between runs', () => {
-    expect(markdownConstructs('~~a~~\n![b](c.png)\n')).toEqual(['md:image', 'md:strikethrough']);
+    expect(markdownConstructs('#### a\n\n![b](c.png)\n')).toEqual(['md:heading-4-6', 'md:image']);
   });
 
   it('returns nothing for prose the schema can hold', () => {
     expect(markdownConstructs('# Title\n\nSome **bold** text.\n')).toEqual([]);
+  });
+});
+
+describe('analyzeMarkdown images', () => {
+  it('classifies where each image points, in one pass with the constructs', () => {
+    const result = analyzeMarkdown('![a](https://cdn.example.test/a.png)\n\n![b](/api/files/xyz/view)\n');
+    expect(result.constructs).toContain('md:image');
+    expect(result.images).toEqual([
+      { bucket: 'img-src:external-https', host: 'cdn.example.test' },
+      { bucket: 'img-src:pagespace-file', host: null },
+    ]);
+  });
+
+  it('finds the image in a table cell, which hangs off no token list', () => {
+    const result = analyzeMarkdown('| a |\n| --- |\n| ![x](data:image/png;base64,y) |\n');
+    expect(result.images).toEqual([{ bucket: 'img-src:data-uri', host: null }]);
+  });
+
+  it('does not treat an image inside a code fence as an image', () => {
+    const result = analyzeMarkdown('```md\n![a](a.png)\n```\n');
+    expect(result.images).toEqual([]);
+    expect(result.constructs).toEqual([]);
+  });
+
+  it('reports no image and no construct for prose', () => {
+    expect(analyzeMarkdown('just words\n')).toMatchObject({ constructs: [], images: [] });
   });
 });

--- a/apps/web/src/lib/editor/census/__tests__/report.test.ts
+++ b/apps/web/src/lib/editor/census/__tests__/report.test.ts
@@ -1,11 +1,38 @@
 import { describe, it, expect } from 'vitest';
 import { createCensusAccumulator, formatCensusReport, TRACKED_HTML_CONSTRUCTS } from '../report';
+import { emptyMagnitudes, type Magnitudes } from '../magnitudes';
+import type { HtmlDocumentAnalysis } from '../round-trip';
+import type { MarkdownAnalysis } from '../markdown';
+import type { ImageSource } from '../images';
+
+/**
+ * The fields these tests are not about, filled in once. Spelling out
+ * `tagless`/`images`/`magnitudes` at all twelve call sites would bury the one
+ * field each test is actually asserting on.
+ */
+const analysed = (
+  overrides: Partial<Extract<HtmlDocumentAnalysis, { status: 'analysed' }>> = {},
+): HtmlDocumentAnalysis => ({
+  status: 'analysed',
+  dropped: [],
+  textPreserved: true,
+  tagless: false,
+  images: [],
+  magnitudes: emptyMagnitudes(),
+  ...overrides,
+});
+
+const markdown = (
+  constructs: string[] = [],
+  images: ImageSource[] = [],
+  magnitudes: Magnitudes = emptyMagnitudes(),
+): MarkdownAnalysis => ({ constructs, images, magnitudes });
 
 describe('createCensusAccumulator', () => {
   it('counts pages per construct and keeps at most three example page ids', () => {
     const accumulator = createCensusAccumulator();
     for (const pageId of ['p1', 'p2', 'p3', 'p4']) {
-      accumulator.recordHtml(pageId, { status: 'analysed', dropped: ['<img>'], textPreserved: true });
+      accumulator.recordHtml(pageId, analysed({ dropped: ['<img>'], textPreserved: true }));
     }
 
     const [tally] = accumulator.snapshot().htmlConstructs.filter((row) => row.construct === '<img>');
@@ -15,7 +42,7 @@ describe('createCensusAccumulator', () => {
 
   it('counts a construct once per page, however many times the page carries it', () => {
     const accumulator = createCensusAccumulator();
-    accumulator.recordHtml('p1', { status: 'analysed', dropped: ['<img>', '<img>'], textPreserved: true });
+    accumulator.recordHtml('p1', analysed({ dropped: ['<img>', '<img>'], textPreserved: true }));
     const [tally] = accumulator.snapshot().htmlConstructs.filter((row) => row.construct === '<img>');
     expect(tally.pages).toBe(1);
     expect(tally.examplePageIds).toEqual(['p1']);
@@ -23,8 +50,8 @@ describe('createCensusAccumulator', () => {
 
   it('sorts constructs by page count descending, then by name', () => {
     const accumulator = createCensusAccumulator();
-    accumulator.recordHtml('p1', { status: 'analysed', dropped: ['<mark>', '<sup>', '<figure>'], textPreserved: true });
-    accumulator.recordHtml('p2', { status: 'analysed', dropped: ['<sup>'], textPreserved: true });
+    accumulator.recordHtml('p1', analysed({ dropped: ['<mark>', '<sup>', '<figure>'], textPreserved: true }));
+    accumulator.recordHtml('p2', analysed({ dropped: ['<sup>'], textPreserved: true }));
 
     const found = accumulator.snapshot().htmlConstructs.filter((row) => row.pages > 0);
     expect(found.map((row) => row.construct)).toEqual(['<sup>', '<figure>', '<mark>']);
@@ -49,8 +76,8 @@ describe('createCensusAccumulator', () => {
 
   it('keeps markdown documents in their own tally', () => {
     const accumulator = createCensusAccumulator();
-    accumulator.recordMarkdown('p1', ['md:image']);
-    accumulator.recordHtml('p2', { status: 'analysed', dropped: ['<img>'], textPreserved: true });
+    accumulator.recordMarkdown('p1', markdown(['md:image']));
+    accumulator.recordHtml('p2', analysed({ dropped: ['<img>'], textPreserved: true }));
 
     const snapshot = accumulator.snapshot();
     expect(snapshot.markdownConstructs.map((row) => row.construct)).toEqual(['md:image']);
@@ -60,12 +87,12 @@ describe('createCensusAccumulator', () => {
 
   it('counts text loss, and separately the text loss no named construct explains', () => {
     const accumulator = createCensusAccumulator();
-    accumulator.recordHtml('p1', { status: 'analysed', dropped: [], textPreserved: false });
-    accumulator.recordHtml('p2', { status: 'analysed', dropped: [], textPreserved: true });
+    accumulator.recordHtml('p1', analysed({ dropped: [], textPreserved: false }));
+    accumulator.recordHtml('p2', analysed({ dropped: [], textPreserved: true }));
     // A page that lost text AND a construct the census already names is counted
     // as text loss but not as an alarm: the alarm exists to say "the catalogue
     // is missing something", and explained losses would drown it out.
-    accumulator.recordHtml('p3', { status: 'analysed', dropped: ['<img>'], textPreserved: false });
+    accumulator.recordHtml('p3', analysed({ dropped: ['<img>'], textPreserved: false }));
     expect(accumulator.snapshot().totals).toMatchObject({ textLost: 2, textLostWithNoNamedConstruct: 1 });
   });
 
@@ -90,8 +117,8 @@ describe('createCensusAccumulator', () => {
 describe('formatCensusReport', () => {
   const snapshotWith = () => {
     const accumulator = createCensusAccumulator();
-    accumulator.recordHtml('page-one', { status: 'analysed', dropped: ['<img>'], textPreserved: true });
-    accumulator.recordMarkdown('page-two', ['md:task-list']);
+    accumulator.recordHtml('page-one', analysed({ dropped: ['<img>'], textPreserved: true }));
+    accumulator.recordMarkdown('page-two', markdown(['md:task-list']));
     return accumulator.snapshot();
   };
 
@@ -106,5 +133,137 @@ describe('formatCensusReport', () => {
   it('says so when the run was interrupted, so a partial count is never read as final', () => {
     expect(formatCensusReport(snapshotWith(), { partial: true })).toContain('INTERRUPTED');
     expect(formatCensusReport(snapshotWith(), { partial: false })).not.toContain('INTERRUPTED');
+  });
+});
+
+const image = (bucket: string, host: string | null = null): ImageSource => ({ bucket, host });
+
+describe('the mislabelled markdown tally', () => {
+  it('keeps markdown found in html-mode pages apart from the pages that carry the label', () => {
+    // Merging them would make every labelled-markdown number incomparable with
+    // the run that produced them, which is the one number the re-run has to
+    // hold still.
+    const accumulator = createCensusAccumulator();
+    accumulator.recordMarkdown('labelled', markdown(['md:image']));
+    accumulator.recordMislabelledMarkdown('mislabelled', markdown(['md:task-list']));
+
+    const snapshot = accumulator.snapshot();
+    expect(snapshot.markdownConstructs.map((row) => row.construct)).toEqual(['md:image']);
+    expect(snapshot.mislabelledMarkdownConstructs.map((row) => row.construct)).toEqual(['md:task-list']);
+  });
+
+  it('does not count the same page twice, because it was already counted as html', () => {
+    const accumulator = createCensusAccumulator();
+    accumulator.recordHtml('p1', analysed({ tagless: true }));
+    accumulator.recordMislabelledMarkdown('p1', markdown(['md:image']));
+
+    expect(accumulator.snapshot().totals).toMatchObject({ documents: 1, html: 1, markdown: 0, taglessHtml: 1 });
+  });
+
+  it('counts a tagless html page whether or not anything routed it onward', () => {
+    const accumulator = createCensusAccumulator();
+    accumulator.recordHtml('p1', analysed({ tagless: true }));
+    accumulator.recordHtml('p2', analysed({ tagless: false }));
+    expect(accumulator.snapshot().totals.taglessHtml).toBe(1);
+  });
+});
+
+describe('the image tallies', () => {
+  it('counts a page once per bucket, and every image in the instance total', () => {
+    const accumulator = createCensusAccumulator();
+    accumulator.recordMarkdown('p1', markdown([], [image('img-src:data-uri'), image('img-src:data-uri')]));
+
+    const snapshot = accumulator.snapshot();
+    expect(snapshot.imageSources).toEqual([
+      { construct: 'img-src:data-uri', pages: 1, examplePageIds: ['p1'] },
+    ]);
+    expect(snapshot.totals.images).toBe(2);
+  });
+
+  it('tallies images from html, markdown and mislabelled pages into one section', () => {
+    const accumulator = createCensusAccumulator();
+    accumulator.recordHtml('p1', analysed({ images: [image('img-src:relative')] }));
+    accumulator.recordMarkdown('p2', markdown([], [image('img-src:relative')]));
+    accumulator.recordMislabelledMarkdown('p3', markdown([], [image('img-src:relative')]));
+
+    expect(accumulator.snapshot().imageSources).toEqual([
+      { construct: 'img-src:relative', pages: 3, examplePageIds: ['p1', 'p2', 'p3'] },
+    ]);
+  });
+
+  it('reports at most ten hosts, because the tail is a list of one-off blogs', () => {
+    const accumulator = createCensusAccumulator();
+    for (let index = 0; index < 14; index += 1) {
+      accumulator.recordMarkdown(`p${index}`, markdown([], [image('img-src:external-https', `host${index}.test`)]));
+    }
+    expect(accumulator.snapshot().imageHosts).toHaveLength(10);
+  });
+
+  it('does not invent a host row for an image that has no host', () => {
+    const accumulator = createCensusAccumulator();
+    accumulator.recordMarkdown('p1', markdown([], [image('img-src:data-uri', null)]));
+    expect(accumulator.snapshot().imageHosts).toEqual([]);
+  });
+});
+
+describe('the magnitudes', () => {
+  const withImages = (count: number) => ({ ...emptyMagnitudes(), images: count });
+
+  it('reports the largest single instance and the pages holding the top few', () => {
+    const accumulator = createCensusAccumulator();
+    accumulator.recordMarkdown('small', markdown([], [], withImages(1)));
+    accumulator.recordMarkdown('largest', markdown([], [], withImages(40)));
+    accumulator.recordMarkdown('second', markdown([], [], withImages(9)));
+
+    const [images] = accumulator.snapshot().magnitudes.filter((row) => row.metric === 'images');
+    expect(images.value).toBe(40);
+    expect(images.examplePageIds).toEqual(['largest', 'second', 'small']);
+  });
+
+  it('keeps three examples however many pages are measured', () => {
+    const accumulator = createCensusAccumulator();
+    for (let index = 0; index < 8; index += 1) {
+      accumulator.recordMarkdown(`p${index}`, markdown([], [], withImages(index + 1)));
+    }
+    const [images] = accumulator.snapshot().magnitudes.filter((row) => row.metric === 'images');
+    expect(images.examplePageIds).toEqual(['p7', 'p6', 'p5']);
+  });
+
+  it('reports a row per metric even when nothing in the corpus has one', () => {
+    const rows = createCensusAccumulator().snapshot().magnitudes;
+    expect(rows.map((row) => row.metric)).toContain('tableRows');
+    expect(rows.every((row) => row.value === 0 && row.examplePageIds.length === 0)).toBe(true);
+  });
+});
+
+describe('formatCensusReport, the new sections', () => {
+  const snapshot = () => {
+    const accumulator = createCensusAccumulator();
+    accumulator.recordHtml('page-one', analysed({ tagless: true }));
+    accumulator.recordMislabelledMarkdown(
+      'page-one',
+      markdown(['md:image'], [image('img-src:external-https', 'cdn.example.test')], {
+        ...emptyMagnitudes(),
+        images: 3,
+      }),
+    );
+    return accumulator.snapshot();
+  };
+
+  it('prints the mislabelled table, the image sections and the magnitudes', () => {
+    const report = formatCensusReport(snapshot(), { partial: false });
+    expect(report).toContain('really markdown');
+    expect(report).toContain('md:image');
+    expect(report).toContain('img-src:external-https');
+    expect(report).toContain('cdn.example.test');
+    expect(report).toContain('images in one document');
+    expect(report).toContain('html-mode with no HTML at all');
+  });
+
+  it('prints the isPaginated count only when the run asked the database for it', () => {
+    expect(formatCensusReport(snapshot(), { partial: false, paginatedPages: 7 })).toContain(
+      'pages with isPaginated set      7',
+    );
+    expect(formatCensusReport(snapshot(), { partial: false })).not.toContain('isPaginated');
   });
 });

--- a/apps/web/src/lib/editor/census/__tests__/report.test.ts
+++ b/apps/web/src/lib/editor/census/__tests__/report.test.ts
@@ -3,7 +3,7 @@ import { createCensusAccumulator, formatCensusReport, TRACKED_HTML_CONSTRUCTS } 
 import { emptyMagnitudes, type Magnitudes } from '../magnitudes';
 import type { HtmlDocumentAnalysis } from '../round-trip';
 import type { MarkdownAnalysis } from '../markdown';
-import type { ImageSource } from '../images';
+import type { ImageSource, ImageSourceBucket } from '../images';
 
 /**
  * The fields these tests are not about, filled in once. Spelling out
@@ -136,7 +136,7 @@ describe('formatCensusReport', () => {
   });
 });
 
-const image = (bucket: string, host: string | null = null): ImageSource => ({ bucket, host });
+const image = (bucket: ImageSourceBucket, host: string | null = null): ImageSource => ({ bucket, host });
 
 describe('the mislabelled markdown tally', () => {
   it('keeps markdown found in html-mode pages apart from the pages that carry the label', () => {
@@ -262,7 +262,7 @@ describe('formatCensusReport, the new sections', () => {
 
   it('prints the isPaginated count only when the run asked the database for it', () => {
     expect(formatCensusReport(snapshot(), { partial: false, paginatedPages: 7 })).toContain(
-      'pages with isPaginated set      7',
+      'isPaginated set (whole table)   7',
     );
     expect(formatCensusReport(snapshot(), { partial: false })).not.toContain('isPaginated');
   });

--- a/apps/web/src/lib/editor/census/__tests__/round-trip.test.ts
+++ b/apps/web/src/lib/editor/census/__tests__/round-trip.test.ts
@@ -51,21 +51,21 @@ describe('roundTripHtml', () => {
 describe('analyzeHtmlDocument', () => {
   it('reports nothing dropped for content the schema fully represents', () => {
     const result = analyse('<p><strong>a</strong> <em>b</em></p><h2>c</h2>');
-    expect(result).toEqual({ status: 'analysed', dropped: [], textPreserved: true });
+    expect(result).toMatchObject({ status: 'analysed', dropped: [], textPreserved: true });
   });
 
   it('does not call a document changed because the Link extension added attributes', () => {
     // TipTap stamps target/rel onto every <a> it parses. Byte comparison would
     // report every linked document as changed and bury the real signal.
     const result = analyse('<p><a href="https://example.test">link</a></p>');
-    expect(result).toEqual({ status: 'analysed', dropped: [], textPreserved: true });
+    expect(result).toMatchObject({ status: 'analysed', dropped: [], textPreserved: true });
   });
 
   it('reports text loss when the round trip deletes words rather than unwrapping them', () => {
     // Most unknown elements unwrap and keep their text (<details> becomes a
     // paragraph); <object> is one whose contents ProseMirror discards outright.
     const result = analyse('<p>kept</p><object>lost</object>');
-    expect(result).toEqual({ status: 'analysed', dropped: ['<object>'], textPreserved: false });
+    expect(result).toMatchObject({ status: 'analysed', dropped: ['<object>'], textPreserved: false });
   });
 
   it('reports an <img> as dropped', () => {
@@ -97,11 +97,11 @@ describe('analyzeHtmlDocument', () => {
     // <div> unwraps to its children: the construct is named as dropped, the
     // words inside it are not lost.
     const result = analyse('<div><p>a</p></div>');
-    expect(result).toEqual({ status: 'analysed', dropped: ['<div>'], textPreserved: true });
+    expect(result).toMatchObject({ status: 'analysed', dropped: ['<div>'], textPreserved: true });
   });
 
   it('treats empty content as an intact round trip', () => {
-    expect(analyse('')).toEqual({ status: 'analysed', dropped: [], textPreserved: true });
+    expect(analyse('')).toMatchObject({ status: 'analysed', dropped: [], textPreserved: true });
   });
 
   it('records only the error type when a document will not parse, never its content', () => {
@@ -117,5 +117,49 @@ describe('analyzeHtmlDocument', () => {
     };
     const result = analyzeHtmlDocument('<p>a</p>', schema, workspaceThatThrows);
     expect(result).toEqual({ status: 'failed', errorName: 'unknown' });
+  });
+});
+
+describe('mislabelled markdown, and what a stored document held', () => {
+  it('reports a document with no HTML element at all as tagless', () => {
+    const result = analyse('# a heading\n\n- one\n- two\n');
+    expect(result.status === 'analysed' && result.tagless).toBe(true);
+  });
+
+  it('is still tagless when an unescaped angle bracket in prose parsed as an element', () => {
+    // `Set<string>` in markdown source becomes a `<string>` element in the
+    // parser. Counting that as HTML would hide the mislabelled page that is
+    // most likely to be full of code samples.
+    const result = analyse('# a\n\nreturns Set<string> for each row\n');
+    expect(result.status === 'analysed' && result.tagless).toBe(true);
+  });
+
+  it('is not tagless when the document is real HTML', () => {
+    const result = analyse('<p>a</p>');
+    expect(result.status === 'analysed' && result.tagless).toBe(false);
+  });
+
+  it('reports where an <img> pointed, though the schema drops the node itself', () => {
+    // The measurement is of the STORED document, not of what survives: the
+    // point is what v1 would have to be able to represent.
+    const result = analyse('<p>a</p><img src="https://cdn.example.test/a.png">');
+    expect(result.status === 'analysed' && result.images).toEqual([
+      { bucket: 'img-src:external-https', host: 'cdn.example.test' },
+    ]);
+    expect(result.status === 'analysed' && result.dropped).toContain('<img>');
+  });
+
+  it('measures the stored document rather than the round trip', () => {
+    const result = analyse('<p>a</p><img src="a.png"><table><tr><td>1</td></tr><tr><td>2</td></tr></table>');
+    expect(result.status === 'analysed' && result.magnitudes).toMatchObject({ images: 1, tableRows: 2 });
+  });
+});
+
+describe('the constructs the census deliberately does not count', () => {
+  it('keeps <s>, because the schema has the strike mark markdown maps onto', () => {
+    // The reason `md:strikethrough` is not in the markdown tally: the gap it
+    // claimed does not exist.
+    const result = analyse('<p><s>struck</s></p>');
+    expect(result.status === 'analysed' && result.dropped).toEqual([]);
   });
 });

--- a/apps/web/src/lib/editor/census/constructs.ts
+++ b/apps/web/src/lib/editor/census/constructs.ts
@@ -46,11 +46,16 @@ export interface DomWorkspace {
  */
 export interface DomElement {
   innerHTML: string;
-  querySelectorAll(selector: string): Iterable<{
-    tagName: string;
-    getAttributeNames(): string[];
-    getAttribute(name: string): string | null;
-  }>;
+  /**
+   * Read by the magnitude measurements only, and never reported — what leaves
+   * `magnitudes.ts` is a length, not the text it was measured from.
+   */
+  textContent: string;
+  tagName: string;
+  getAttributeNames(): string[];
+  getAttribute(name: string): string | null;
+  /** Recursive: measuring a table means asking it for its own rows. */
+  querySelectorAll(selector: string): Iterable<DomElement>;
 }
 
 /**
@@ -173,6 +178,26 @@ export function collectConstructs(container: DomElement): DocumentConstructs {
   }
 
   return { elements, attributesByElement };
+}
+
+/**
+ * Whether a stored `contentMode='html'` document contains any HTML at all.
+ *
+ * A document that parses to no element is not HTML — it is markdown source
+ * filed under the wrong content mode, and it is the population the first
+ * production run found 3,003 of. Those pages carry images, headings and code
+ * fences the HTML scan cannot see, so the census has to route them through the
+ * markdown detector as well.
+ *
+ * `text:unescaped-angle-bracket` does not count as an element: it exists
+ * precisely because the parser turned a `<` in prose into one, and prose with a
+ * generic in it is exactly what a mislabelled markdown document looks like.
+ */
+export function hasHtmlElement(constructs: DocumentConstructs): boolean {
+  for (const element of constructs.elements) {
+    if (element !== UNESCAPED_ANGLE_BRACKET_KEY) return true;
+  }
+  return false;
 }
 
 /**

--- a/apps/web/src/lib/editor/census/images.ts
+++ b/apps/web/src/lib/editor/census/images.ts
@@ -1,0 +1,114 @@
+import type { DomElement } from './constructs';
+
+/**
+ * Where the images in stored documents actually point.
+ *
+ * The first production run reported `<img>` on zero pages and that number is
+ * worthless: the editor has no image node, so no document can contain one. It
+ * is the absence of an unimplemented feature, not evidence about the schema.
+ * The real image population is in markdown source — the ~1,000 documents
+ * labelled `contentMode='markdown'` and the ~3,000 more mislabelled as HTML —
+ * and what those images point AT is the part that has to be decided before v1
+ * is frozen, because an image node's attributes are as permanent as the node:
+ *
+ *   - `data:` is the hazard. Base64 bytes written into a Y.Doc are replicated
+ *     to every client and never forgotten, so if any exist today the paste and
+ *     migration paths have to reject them rather than carry them across.
+ *   - an external host means v1 either hotlinks it forever or ingests it once,
+ *     and Phase K is the only cheap moment to ingest.
+ *   - `/api/files/{id}/view` means the asset is already PageSpace-hosted and
+ *     the node can hold a stable internal id instead of a URL. A signed URL
+ *     written into a CRDT is permanent, expiring and leaky, all at once.
+ *
+ * NEVER RETURNS A URL. A src carries a filename, sometimes a query string, and
+ * a query string sometimes carries a token; this census runs against production
+ * user data. What leaves this module is a scheme bucket and, for external
+ * images, a bare hostname — enough to answer "whose images are these", and
+ * nothing else. A URL with credentials in it loses even the hostname.
+ */
+export const IMAGE_SOURCE_KEYS = {
+  dataUri: 'img-src:data-uri',
+  pagespaceFile: 'img-src:pagespace-file',
+  externalHttps: 'img-src:external-https',
+  externalHttp: 'img-src:external-http',
+  relative: 'img-src:relative',
+  otherScheme: 'img-src:other-scheme',
+  malformed: 'img-src:malformed',
+} as const;
+
+export interface ImageSource {
+  /** One of `IMAGE_SOURCE_KEYS`. */
+  bucket: string;
+  /** Bare hostname for external images; null for everything else. */
+  host: string | null;
+}
+
+/** `/api/files/{pageId}/view`, the URL `ImageViewer` already serves images from. */
+const PAGESPACE_FILE_PATH = /^\/api\/files\/[^/]+\/(view|thumbnail)$/;
+
+/**
+ * A scheme-relative `//host/path` inherits the page's scheme, which in
+ * production is https. Parsing it needs a base, and the base is never reported.
+ */
+const SCHEME_RELATIVE_BASE = 'https://scheme.relative.invalid';
+
+function hostOf(url: URL): string | null {
+  // Credentials in a src are rare enough to be interesting and sensitive enough
+  // that the host they belong to is not worth printing next to the count.
+  if (url.username !== '' || url.password !== '') return null;
+  return url.hostname === '' ? null : url.hostname.toLowerCase();
+}
+
+export function classifyImageSource(src: string): ImageSource {
+  const trimmed = src.trim();
+  if (trimmed === '') return { bucket: IMAGE_SOURCE_KEYS.malformed, host: null };
+
+  // Matched before parsing: a data URI is megabytes of base64 and `new URL` on
+  // one is pointless work repeated per image per document.
+  if (/^data:/i.test(trimmed)) return { bucket: IMAGE_SOURCE_KEYS.dataUri, host: null };
+
+  const schemeRelative = trimmed.startsWith('//');
+  let url: URL;
+  try {
+    url = schemeRelative ? new URL(trimmed, SCHEME_RELATIVE_BASE) : new URL(trimmed);
+  } catch {
+    // Not absolute. Relative to what, though, is the open question: markdown
+    // written elsewhere and pasted in carries `./images/x.png` paths that
+    // resolve against nothing here, and they are a migration problem whether or
+    // not they are well-formed.
+    return {
+      bucket: PAGESPACE_FILE_PATH.test(trimmed.split('?')[0])
+        ? IMAGE_SOURCE_KEYS.pagespaceFile
+        : IMAGE_SOURCE_KEYS.relative,
+      host: null,
+    };
+  }
+
+  if (schemeRelative || url.protocol === 'https:') {
+    if (PAGESPACE_FILE_PATH.test(url.pathname)) {
+      return { bucket: IMAGE_SOURCE_KEYS.pagespaceFile, host: null };
+    }
+    return { bucket: IMAGE_SOURCE_KEYS.externalHttps, host: hostOf(url) };
+  }
+
+  if (url.protocol === 'http:') {
+    if (PAGESPACE_FILE_PATH.test(url.pathname)) {
+      return { bucket: IMAGE_SOURCE_KEYS.pagespaceFile, host: null };
+    }
+    return { bucket: IMAGE_SOURCE_KEYS.externalHttp, host: hostOf(url) };
+  }
+
+  // blob: and file: are the ones that matter here — both are references to
+  // something only one browser on one machine can resolve, and both would seed
+  // a permanently broken image.
+  return { bucket: IMAGE_SOURCE_KEYS.otherScheme, host: null };
+}
+
+/** Every `<img>` in a stored HTML document, classified. */
+export function htmlImageSources(container: DomElement): ImageSource[] {
+  const sources: ImageSource[] = [];
+  for (const image of container.querySelectorAll('img')) {
+    sources.push(classifyImageSource(image.getAttribute('src') ?? ''));
+  }
+  return sources;
+}

--- a/apps/web/src/lib/editor/census/images.ts
+++ b/apps/web/src/lib/editor/census/images.ts
@@ -36,9 +36,11 @@ export const IMAGE_SOURCE_KEYS = {
   malformed: 'img-src:malformed',
 } as const;
 
+/** The bucket keys themselves, so a tally cannot be filed under a typo. */
+export type ImageSourceBucket = (typeof IMAGE_SOURCE_KEYS)[keyof typeof IMAGE_SOURCE_KEYS];
+
 export interface ImageSource {
-  /** One of `IMAGE_SOURCE_KEYS`. */
-  bucket: string;
+  bucket: ImageSourceBucket;
   /** Bare hostname for external images; null for everything else. */
   host: string | null;
 }
@@ -51,6 +53,14 @@ const PAGESPACE_FILE_PATH = /^\/api\/files\/[^/]+\/(view|thumbnail)$/;
  * production is https. Parsing it needs a base, and the base is never reported.
  */
 const SCHEME_RELATIVE_BASE = 'https://scheme.relative.invalid';
+
+/**
+ * A src that announces itself as absolute — `https://`, `mailto:`, `//host` —
+ * and then fails to parse is broken, not relative. `https://` on its own is the
+ * case that matters: a truncated paste, which would otherwise be filed as a
+ * relative path and look like a migration problem instead of a broken image.
+ */
+const ANNOUNCES_A_SCHEME = /^([a-z][a-z0-9+.-]*:|\/\/)/i;
 
 function hostOf(url: URL): string | null {
   // Credentials in a src are rare enough to be interesting and sensitive enough
@@ -76,6 +86,9 @@ export function classifyImageSource(src: string): ImageSource {
     // written elsewhere and pasted in carries `./images/x.png` paths that
     // resolve against nothing here, and they are a migration problem whether or
     // not they are well-formed.
+    if (ANNOUNCES_A_SCHEME.test(trimmed)) {
+      return { bucket: IMAGE_SOURCE_KEYS.malformed, host: null };
+    }
     return {
       bucket: PAGESPACE_FILE_PATH.test(trimmed.split('?')[0])
         ? IMAGE_SOURCE_KEYS.pagespaceFile

--- a/apps/web/src/lib/editor/census/magnitudes.ts
+++ b/apps/web/src/lib/editor/census/magnitudes.ts
@@ -1,0 +1,86 @@
+import type { DomElement } from './constructs';
+
+/**
+ * How big the biggest single thing in a document is.
+ *
+ * Every other tally in this census is presence per page — the question "would
+ * v1 lose this construct" only ever needed a yes. Pagination asks a different
+ * question and needs a size.
+ *
+ * `PaginationExtension.ts` is decoration-based: it measures the rendered height
+ * of each block and inserts page breaks BETWEEN blocks. Nothing splits a block.
+ * So a table taller than `--rm-max-content-child-height`, a 400-line code fence
+ * or a wall-of-text paragraph cannot be paginated at all — they overflow their
+ * page, and the count of pages that already contain one is the precondition for
+ * ever flipping `isPaginated` on.
+ *
+ * Images are about to join that list, which is why they are counted here as
+ * well as classified in `images.ts`: an image is the one block whose height is
+ * unknown until it loads, so a decoration-based paginator measures the page
+ * wrong and then re-measures when the byte arrives. That is the argument for
+ * intrinsic width/height on the node at insert time, and the count of images
+ * per document is the argument's magnitude.
+ *
+ * Lengths only. Nothing here returns the text it measured.
+ */
+export const MAGNITUDE_METRICS = [
+  { key: 'images', label: 'images in one document' },
+  { key: 'tableRows', label: 'rows in one table' },
+  { key: 'tableColumns', label: 'columns in one table' },
+  { key: 'codeBlockLines', label: 'lines in one code block' },
+  { key: 'blockCharacters', label: 'characters in one block' },
+] as const;
+
+export type MagnitudeKey = (typeof MAGNITUDE_METRICS)[number]['key'];
+export type Magnitudes = Record<MagnitudeKey, number>;
+
+export function emptyMagnitudes(): Magnitudes {
+  return { images: 0, tableRows: 0, tableColumns: 0, codeBlockLines: 0, blockCharacters: 0 };
+}
+
+/**
+ * Elements the editor renders as a block, and therefore the units the
+ * paginator has to fit whole onto a page. `li`/`td` are included because a list
+ * item holding a nested list, or a cell holding a paragraph, is as tall as
+ * everything inside it — which is exactly what the layout has to place.
+ */
+const BLOCK_SELECTOR = 'p, h1, h2, h3, h4, h5, h6, blockquote, pre, li, td, th';
+
+export function lineCount(text: string): number {
+  let lines = 1;
+  for (const character of text) {
+    if (character === '\n') lines += 1;
+  }
+  return lines;
+}
+
+export function htmlMagnitudes(container: DomElement): Magnitudes {
+  const magnitudes = emptyMagnitudes();
+
+  for (const _image of container.querySelectorAll('img')) {
+    magnitudes.images += 1;
+  }
+
+  for (const table of container.querySelectorAll('table')) {
+    let rows = 0;
+    for (const row of table.querySelectorAll('tr')) {
+      rows += 1;
+      let columns = 0;
+      for (const _cell of row.querySelectorAll('td, th')) {
+        columns += 1;
+      }
+      magnitudes.tableColumns = Math.max(magnitudes.tableColumns, columns);
+    }
+    magnitudes.tableRows = Math.max(magnitudes.tableRows, rows);
+  }
+
+  for (const block of container.querySelectorAll(BLOCK_SELECTOR)) {
+    const text = block.textContent ?? '';
+    magnitudes.blockCharacters = Math.max(magnitudes.blockCharacters, text.length);
+    if (block.tagName.toLowerCase() === 'pre') {
+      magnitudes.codeBlockLines = Math.max(magnitudes.codeBlockLines, lineCount(text));
+    }
+  }
+
+  return magnitudes;
+}

--- a/apps/web/src/lib/editor/census/magnitudes.ts
+++ b/apps/web/src/lib/editor/census/magnitudes.ts
@@ -84,3 +84,19 @@ export function htmlMagnitudes(container: DomElement): Magnitudes {
 
   return magnitudes;
 }
+
+/**
+ * Fold one document's measurements into another's. Images SUM because they are
+ * a count of things on the page; everything else is a maximum, because the
+ * question is whether any single block fits.
+ *
+ * Used where markdown source embeds raw HTML: the two halves of one document
+ * are measured by two different readers and have to come out as one document.
+ */
+export function absorb(into: Magnitudes, from: Magnitudes): void {
+  into.images += from.images;
+  into.tableRows = Math.max(into.tableRows, from.tableRows);
+  into.tableColumns = Math.max(into.tableColumns, from.tableColumns);
+  into.codeBlockLines = Math.max(into.codeBlockLines, from.codeBlockLines);
+  into.blockCharacters = Math.max(into.blockCharacters, from.blockCharacters);
+}

--- a/apps/web/src/lib/editor/census/markdown.ts
+++ b/apps/web/src/lib/editor/census/markdown.ts
@@ -1,4 +1,6 @@
 import { lexer, type Token, type Tokens } from 'marked';
+import { classifyImageSource, type ImageSource } from './images';
+import { emptyMagnitudes, lineCount, type Magnitudes } from './magnitudes';
 
 /**
  * Markdown constructs the ProseMirror schema has no node or mark for.
@@ -16,6 +18,12 @@ import { lexer, type Token, type Tokens } from 'marked';
  * fenced block, an indented block or a backtick span is an EXAMPLE of an image
  * rather than an image, which is exactly the content a knowledge base about
  * markdown is full of.
+ *
+ * Only syntax the schema has NO home for is listed. `~~strikethrough~~` was
+ * here and is not: StarterKit ships the `strike` mark and the bubble menu
+ * exposes it, so counting it as a gap put 17 documents in a table headed
+ * "source syntax the schema has no node for" that the schema represents
+ * perfectly well. `round-trip.test.ts` holds the schema to that.
  */
 const enum Construct {
   Image = 'md:image',
@@ -24,7 +32,6 @@ const enum Construct {
   RawHtml = 'md:raw-html',
   Footnote = 'md:footnote',
   Highlight = 'md:highlight',
-  Strikethrough = 'md:strikethrough',
 }
 
 /** `==highlight==` is an extension marked's core does not tokenize. */
@@ -43,15 +50,59 @@ function childTokens(token: Token): Token[] {
   return children;
 }
 
-function collect(tokens: Token[], found: Set<string>): void {
+/**
+ * Everything one pass of the lexer can answer, gathered in that one pass.
+ *
+ * The census re-reads the whole `pages` table to produce this, and after the
+ * mislabelled population is routed through here too it re-reads most of it
+ * twice. Lexing markdown three times to answer three questions about it is the
+ * kind of cost that turns a scan into an afternoon.
+ */
+export interface MarkdownAnalysis {
+  constructs: string[];
+  /** Scheme buckets and bare hostnames — never a URL. See `images.ts`. */
+  images: ImageSource[];
+  magnitudes: Magnitudes;
+}
+
+interface Walk {
+  found: Set<string>;
+  images: ImageSource[];
+  magnitudes: Magnitudes;
+}
+
+/** Markdown tokens the editor renders as one block the paginator cannot split. */
+const BLOCK_TOKEN_TYPES = new Set(['paragraph', 'heading', 'blockquote', 'code', 'list_item']);
+
+function collect(tokens: Token[], walk: Walk): void {
+  const { found } = walk;
   for (const token of tokens) {
+    if (BLOCK_TOKEN_TYPES.has(token.type)) {
+      walk.magnitudes.blockCharacters = Math.max(walk.magnitudes.blockCharacters, token.raw.length);
+    }
+
     switch (token.type) {
       case 'image':
         found.add(Construct.Image);
+        walk.magnitudes.images += 1;
+        walk.images.push(classifyImageSource((token as Tokens.Image).href ?? ''));
         break;
-      case 'del':
-        found.add(Construct.Strikethrough);
+      case 'code': {
+        walk.magnitudes.codeBlockLines = Math.max(
+          walk.magnitudes.codeBlockLines,
+          lineCount((token as Tokens.Code).text),
+        );
         break;
+      }
+      case 'table': {
+        const table = token as Tokens.Table;
+        // The header is a row on the page even though `marked` keeps it apart
+        // from `rows`, and a table that overflows a page overflows it by one
+        // row more than `rows.length` says.
+        walk.magnitudes.tableRows = Math.max(walk.magnitudes.tableRows, table.rows.length + 1);
+        walk.magnitudes.tableColumns = Math.max(walk.magnitudes.tableColumns, table.header.length);
+        break;
+      }
       case 'html':
         found.add(Construct.RawHtml);
         break;
@@ -74,12 +125,20 @@ function collect(tokens: Token[], found: Set<string>): void {
         break;
     }
 
-    collect(childTokens(token), found);
+    collect(childTokens(token), walk);
   }
 }
 
+export function analyzeMarkdown(markdown: string): MarkdownAnalysis {
+  const walk: Walk = { found: new Set<string>(), images: [], magnitudes: emptyMagnitudes() };
+  collect(lexer(markdown), walk);
+  return {
+    constructs: [...walk.found].sort(),
+    images: walk.images,
+    magnitudes: walk.magnitudes,
+  };
+}
+
 export function markdownConstructs(markdown: string): string[] {
-  const found = new Set<string>();
-  collect(lexer(markdown), found);
-  return [...found].sort();
+  return analyzeMarkdown(markdown).constructs;
 }

--- a/apps/web/src/lib/editor/census/markdown.ts
+++ b/apps/web/src/lib/editor/census/markdown.ts
@@ -1,6 +1,7 @@
 import { lexer, type Token, type Tokens } from 'marked';
-import { classifyImageSource, type ImageSource } from './images';
-import { emptyMagnitudes, lineCount, type Magnitudes } from './magnitudes';
+import { classifyImageSource, htmlImageSources, type ImageSource } from './images';
+import { absorb, emptyMagnitudes, htmlMagnitudes, lineCount, type Magnitudes } from './magnitudes';
+import type { DomWorkspace } from './constructs';
 
 /**
  * Markdown constructs the ProseMirror schema has no node or mark for.
@@ -69,6 +70,7 @@ interface Walk {
   found: Set<string>;
   images: ImageSource[];
   magnitudes: Magnitudes;
+  workspace: DomWorkspace;
 }
 
 /** Markdown tokens the editor renders as one block the paginator cannot split. */
@@ -101,11 +103,27 @@ function collect(tokens: Token[], walk: Walk): void {
         // row more than `rows.length` says.
         walk.magnitudes.tableRows = Math.max(walk.magnitudes.tableRows, table.rows.length + 1);
         walk.magnitudes.tableColumns = Math.max(walk.magnitudes.tableColumns, table.header.length);
+        // A cell is a block the layout has to place whole, and the HTML half
+        // measures `td`/`th` for that reason. Without this a table-only
+        // document reported no block at all.
+        for (const cell of [...table.header, ...table.rows.flat()]) {
+          walk.magnitudes.blockCharacters = Math.max(walk.magnitudes.blockCharacters, cell.text.length);
+        }
         break;
       }
-      case 'html':
+      case 'html': {
         found.add(Construct.RawHtml);
+        // `marked` hands raw HTML over as one opaque token and never looks
+        // inside it, so `<img src="data:...">`, a 60-row `<table>` and a long
+        // `<pre>` written into a markdown document were all invisible here —
+        // and the conclusions this census draws about images and about page
+        // sizes are exactly the ones that would have been wrong. Read it with
+        // the same DOM the HTML half of the census uses.
+        const container = walk.workspace.parse(token.raw);
+        walk.images.push(...htmlImageSources(container));
+        absorb(walk.magnitudes, htmlMagnitudes(container));
         break;
+      }
       case 'heading':
         if ((token as Tokens.Heading).depth >= 4) found.add(Construct.DeepHeading);
         break;
@@ -129,8 +147,13 @@ function collect(tokens: Token[], walk: Walk): void {
   }
 }
 
-export function analyzeMarkdown(markdown: string): MarkdownAnalysis {
-  const walk: Walk = { found: new Set<string>(), images: [], magnitudes: emptyMagnitudes() };
+/**
+ * The workspace is required rather than optional on purpose: markdown embeds
+ * raw HTML, and a signature that lets the caller omit the reader for it is a
+ * signature that silently under-measures.
+ */
+export function analyzeMarkdown(markdown: string, workspace: DomWorkspace): MarkdownAnalysis {
+  const walk: Walk = { found: new Set<string>(), images: [], magnitudes: emptyMagnitudes(), workspace };
   collect(lexer(markdown), walk);
   return {
     constructs: [...walk.found].sort(),
@@ -139,6 +162,6 @@ export function analyzeMarkdown(markdown: string): MarkdownAnalysis {
   };
 }
 
-export function markdownConstructs(markdown: string): string[] {
-  return analyzeMarkdown(markdown).constructs;
+export function markdownConstructs(markdown: string, workspace: DomWorkspace): string[] {
+  return analyzeMarkdown(markdown, workspace).constructs;
 }

--- a/apps/web/src/lib/editor/census/report.ts
+++ b/apps/web/src/lib/editor/census/report.ts
@@ -1,4 +1,7 @@
 import type { HtmlDocumentAnalysis } from './round-trip';
+import type { MarkdownAnalysis } from './markdown';
+import type { ImageSource } from './images';
+import { MAGNITUDE_METRICS, type MagnitudeKey, type Magnitudes } from './magnitudes';
 
 /**
  * Constructs the census always reports a row for, even when the count is zero:
@@ -6,6 +9,11 @@ import type { HtmlDocumentAnalysis } from './round-trip';
  * scoping, so a zero here is a finding ("no stored document uses it") rather
  * than a gap in the scan. Anything else the round trip loses is discovered and
  * added to the report by `droppedConstructs`, not listed here.
+ *
+ * `<img>` is the exception that proves the rule, and the reason the report now
+ * carries an image section of its own: the editor has no image node, so its
+ * zero says nothing about whether v1 needs one. A zero is a finding only when
+ * the feature exists and nobody used it.
  */
 export const TRACKED_HTML_CONSTRUCTS: readonly string[] = [
   '<img>',
@@ -32,9 +40,28 @@ export const TRACKED_HTML_CONSTRUCTS: readonly string[] = [
  */
 const MAX_EXAMPLE_PAGE_IDS = 3;
 
+/**
+ * Hosts are a long tail by nature. Ten answers "whose images are these" —
+ * enough to tell one CDN from forty one-off blogs, which is the decision
+ * (ingest at migration, or hotlink forever) the number is for.
+ */
+const MAX_REPORTED_IMAGE_HOSTS = 10;
+
 export interface ConstructTally {
   construct: string;
   pages: number;
+  examplePageIds: string[];
+}
+
+/**
+ * A magnitude is the largest single instance seen anywhere, with the pages that
+ * hold the top few — not a page count. See `magnitudes.ts` for why pagination
+ * needs sizes where everything else here needs presence.
+ */
+export interface MagnitudeRow {
+  metric: MagnitudeKey;
+  label: string;
+  value: number;
   examplePageIds: string[];
 }
 
@@ -45,6 +72,14 @@ export interface CensusTotals {
   markdown: number;
   empty: number;
   failed: number;
+  /**
+   * `contentMode='html'` documents that parsed to no HTML element at all:
+   * markdown source under the wrong label. The first production run found
+   * 3,003 of them, and they are the population that actually carries images.
+   */
+  taglessHtml: number;
+  /** Image instances, not pages — the only count here that is not per page. */
+  images: number;
   /** Documents the round trip returned with less text than they went in with. */
   textLost: number;
   /**
@@ -59,6 +94,18 @@ export interface CensusSnapshot {
   totals: CensusTotals;
   htmlConstructs: ConstructTally[];
   markdownConstructs: ConstructTally[];
+  /**
+   * Markdown syntax found in documents labelled `contentMode='html'`. Kept
+   * apart from `markdownConstructs` on purpose: merging them would make the
+   * labelled-markdown numbers incomparable with the runs that came before this
+   * population was scanned at all.
+   */
+  mislabelledMarkdownConstructs: ConstructTally[];
+  /** Scheme buckets, per page. See `images.ts`. */
+  imageSources: ConstructTally[];
+  /** Bare hostnames, per page, top `MAX_REPORTED_IMAGE_HOSTS` only. */
+  imageHosts: ConstructTally[];
+  magnitudes: MagnitudeRow[];
   /** Keyed by error type rather than construct — see `recordHtml`. */
   failures: ConstructTally[];
   textLoss: ConstructTally[];
@@ -66,12 +113,20 @@ export interface CensusSnapshot {
 
 export interface CensusAccumulator {
   recordHtml(pageId: string, analysis: HtmlDocumentAnalysis): void;
-  recordMarkdown(pageId: string, constructs: readonly string[]): void;
+  recordMarkdown(pageId: string, analysis: MarkdownAnalysis): void;
+  /**
+   * A tagless `contentMode='html'` page, read a second time as the markdown it
+   * actually is. Deliberately does NOT touch the html/markdown document totals:
+   * the page has already been counted once as html, and counting it twice would
+   * make `documents` disagree with the row count of the table it came from.
+   */
+  recordMislabelledMarkdown(pageId: string, analysis: MarkdownAnalysis): void;
   recordEmpty(contentMode: 'html' | 'markdown'): void;
   snapshot(): CensusSnapshot;
 }
 
 type Tallies = Map<string, { pages: number; examplePageIds: string[] }>;
+type Leaderboards = Map<MagnitudeKey, Array<{ value: number; pageId: string }>>;
 
 function tally(tallies: Tallies, key: string, pageId: string): void {
   let entry = tallies.get(key);
@@ -94,19 +149,52 @@ function rows(tallies: Tallies): ConstructTally[] {
 export function createCensusAccumulator(): CensusAccumulator {
   const htmlTallies: Tallies = new Map(TRACKED_HTML_CONSTRUCTS.map((construct) => [construct, { pages: 0, examplePageIds: [] }]));
   const markdownTallies: Tallies = new Map();
+  const mislabelledTallies: Tallies = new Map();
+  const imageSourceTallies: Tallies = new Map();
+  const imageHostTallies: Tallies = new Map();
   const failureTallies: Tallies = new Map();
   // Diagnostic bucket: the text-loss counters are the most alarming numbers in
   // the report and, as bare counts, the least actionable — there is no way to go
   // and look at a page that lost text. Ids only, same rule as everywhere else.
   const textLossTallies: Tallies = new Map();
+  const leaderboards: Leaderboards = new Map(MAGNITUDE_METRICS.map((metric) => [metric.key, []]));
   const totals: Omit<CensusTotals, 'documents'> = {
     html: 0,
     markdown: 0,
     empty: 0,
     failed: 0,
+    taglessHtml: 0,
+    images: 0,
     textLost: 0,
     textLostWithNoNamedConstruct: 0,
   };
+
+  function recordImages(pageId: string, images: readonly ImageSource[]): void {
+    totals.images += images.length;
+    // Per page, like every other tally: "how many documents would a decision
+    // about data URIs affect" is the question, not how many tags exist.
+    const buckets = new Set(images.map((image) => image.bucket));
+    for (const bucket of buckets) {
+      tally(imageSourceTallies, bucket, pageId);
+    }
+    const hosts = new Set(images.map((image) => image.host).filter((host): host is string => host !== null));
+    for (const host of hosts) {
+      tally(imageHostTallies, host, pageId);
+    }
+  }
+
+  function recordMagnitudes(pageId: string, magnitudes: Magnitudes): void {
+    for (const { key } of MAGNITUDE_METRICS) {
+      const value = magnitudes[key];
+      if (value <= 0) continue;
+
+      const board = leaderboards.get(key);
+      if (!board) continue;
+      board.push({ value, pageId });
+      board.sort((a, b) => b.value - a.value);
+      if (board.length > MAX_EXAMPLE_PAGE_IDS) board.length = MAX_EXAMPLE_PAGE_IDS;
+    }
+  }
 
   return {
     recordHtml(pageId, analysis) {
@@ -117,6 +205,10 @@ export function createCensusAccumulator(): CensusAccumulator {
         tally(failureTallies, analysis.errorName, pageId);
         return;
       }
+
+      if (analysis.tagless) totals.taglessHtml += 1;
+      recordImages(pageId, analysis.images);
+      recordMagnitudes(pageId, analysis.magnitudes);
 
       // A page carrying three <img> is one page for this count. The census is
       // asked how many DOCUMENTS a v1 omission would damage, not how many tags.
@@ -137,10 +229,20 @@ export function createCensusAccumulator(): CensusAccumulator {
       }
     },
 
-    recordMarkdown(pageId, constructs) {
+    recordMarkdown(pageId, analysis) {
       totals.markdown += 1;
-      for (const construct of new Set(constructs)) {
+      recordImages(pageId, analysis.images);
+      recordMagnitudes(pageId, analysis.magnitudes);
+      for (const construct of new Set(analysis.constructs)) {
         tally(markdownTallies, construct, pageId);
+      }
+    },
+
+    recordMislabelledMarkdown(pageId, analysis) {
+      recordImages(pageId, analysis.images);
+      recordMagnitudes(pageId, analysis.magnitudes);
+      for (const construct of new Set(analysis.constructs)) {
+        tally(mislabelledTallies, construct, pageId);
       }
     },
 
@@ -158,6 +260,18 @@ export function createCensusAccumulator(): CensusAccumulator {
         totals: { ...totals, documents: totals.html + totals.markdown },
         htmlConstructs: rows(htmlTallies),
         markdownConstructs: rows(markdownTallies),
+        mislabelledMarkdownConstructs: rows(mislabelledTallies),
+        imageSources: rows(imageSourceTallies),
+        imageHosts: rows(imageHostTallies).slice(0, MAX_REPORTED_IMAGE_HOSTS),
+        magnitudes: MAGNITUDE_METRICS.map(({ key, label }) => {
+          const board = leaderboards.get(key) ?? [];
+          return {
+            metric: key,
+            label,
+            value: board[0]?.value ?? 0,
+            examplePageIds: board.map((entry) => entry.pageId),
+          };
+        }),
         failures: rows(failureTallies),
         textLoss: rows(textLossTallies),
       };
@@ -181,7 +295,30 @@ function table(title: string, tallies: ConstructTally[]): string[] {
   ];
 }
 
-export function formatCensusReport(snapshot: CensusSnapshot, { partial }: { partial: boolean }): string {
+function magnitudeTable(magnitudes: MagnitudeRow[]): string[] {
+  const width = Math.max(...magnitudes.map((row) => row.label.length), 'LARGEST'.length);
+  return [
+    'magnitudes — the biggest single instance anywhere (paged layout cannot split a block)',
+    `  ${'LARGEST'.padEnd(width)}  ${'VALUE'.padStart(7)}  EXAMPLE PAGE IDS`,
+    ...magnitudes.map(
+      (row) => `  ${row.label.padEnd(width)}  ${String(row.value).padStart(7)}  ${row.examplePageIds.join(' ')}`,
+    ),
+    '',
+  ];
+}
+
+export interface ReportOptions {
+  partial: boolean;
+  /**
+   * Pages with `isPaginated` set, straight from the database. Nothing in the UI
+   * writes that column today — `DocumentView` hardcodes `isPaginated={false}` —
+   * so the count answers whether the switch is genuinely unused or whether the
+   * API has been setting it all along.
+   */
+  paginatedPages?: number;
+}
+
+export function formatCensusReport(snapshot: CensusSnapshot, { partial, paginatedPages }: ReportOptions): string {
   const { totals } = snapshot;
   const lines = [
     '',
@@ -191,12 +328,22 @@ export function formatCensusReport(snapshot: CensusSnapshot, { partial }: { part
     `  contentMode=html                ${totals.html}`,
     `  contentMode=markdown            ${totals.markdown}`,
     `  empty documents                 ${totals.empty}`,
+    `  html-mode with no HTML at all   ${totals.taglessHtml}`,
     `  round trip failed               ${totals.failed}`,
     `  text lost in the round trip     ${totals.textLost}`,
     `  text lost, no named construct   ${totals.textLostWithNoNamedConstruct}`,
+    `  images found (instances)        ${totals.images}`,
+    ...(paginatedPages === undefined ? [] : [`  pages with isPaginated set      ${paginatedPages}`]),
     '',
     ...table('HTML documents — constructs the schema drops', snapshot.htmlConstructs),
     ...table('markdown documents — source syntax the schema has no node for', snapshot.markdownConstructs),
+    ...table(
+      'html-mode documents that are really markdown — source syntax the schema has no node for',
+      snapshot.mislabelledMarkdownConstructs,
+    ),
+    ...table('where images point (scheme only — never a URL)', snapshot.imageSources),
+    ...table(`external image hosts (top ${MAX_REPORTED_IMAGE_HOSTS}, hostname only)`, snapshot.imageHosts),
+    ...magnitudeTable(snapshot.magnitudes),
   ];
 
   if (snapshot.textLoss.length > 0) {

--- a/apps/web/src/lib/editor/census/report.ts
+++ b/apps/web/src/lib/editor/census/report.ts
@@ -314,6 +314,11 @@ export interface ReportOptions {
    * writes that column today — `DocumentView` hardcodes `isPaginated={false}` —
    * so the count answers whether the switch is genuinely unused or whether the
    * API has been setting it all along.
+   *
+   * A whole-table aggregate, and labelled as one in the report: every other
+   * total counts what the scan reached, and under `--limit` or a Ctrl-C the two
+   * scopes differ. Scoping it to the scanned batch would need the ids, which
+   * would mean holding every id in memory to answer a question about a boolean.
    */
   paginatedPages?: number;
 }
@@ -333,7 +338,9 @@ export function formatCensusReport(snapshot: CensusSnapshot, { partial, paginate
     `  text lost in the round trip     ${totals.textLost}`,
     `  text lost, no named construct   ${totals.textLostWithNoNamedConstruct}`,
     `  images found (instances)        ${totals.images}`,
-    ...(paginatedPages === undefined ? [] : [`  pages with isPaginated set      ${paginatedPages}`]),
+    ...(paginatedPages === undefined
+      ? []
+      : [`  isPaginated set (whole table)   ${paginatedPages}`]),
     '',
     ...table('HTML documents — constructs the schema drops', snapshot.htmlConstructs),
     ...table('markdown documents — source syntax the schema has no node for', snapshot.markdownConstructs),

--- a/apps/web/src/lib/editor/census/round-trip.ts
+++ b/apps/web/src/lib/editor/census/round-trip.ts
@@ -1,7 +1,9 @@
 import type { Schema } from '@tiptap/pm/model';
 import { DOMParser as ProseMirrorDOMParser, DOMSerializer } from '@tiptap/pm/model';
 import { projectContent } from '@pagespace/lib/content/anchoring/text-projection';
-import { collectConstructs, droppedConstructs, type DomWorkspace } from './constructs';
+import { collectConstructs, droppedConstructs, hasHtmlElement, type DomWorkspace } from './constructs';
+import { htmlImageSources, type ImageSource } from './images';
+import { emptyMagnitudes, htmlMagnitudes, type Magnitudes } from './magnitudes';
 
 export type HtmlDocumentAnalysis =
   | {
@@ -16,6 +18,16 @@ export type HtmlDocumentAnalysis =
        * to carry — that the schema lost something the census does not name.
        */
       textPreserved: boolean;
+      /**
+       * The stored document parsed to no HTML element at all — markdown source
+       * filed under `contentMode='html'`. The census routes these through the
+       * markdown detector as well, because the HTML scan is blind to every
+       * construct they contain.
+       */
+      tagless: boolean;
+      /** Scheme buckets and bare hostnames — never a URL. See `images.ts`. */
+      images: ImageSource[];
+      magnitudes: Magnitudes;
     }
   | {
       /**
@@ -61,7 +73,14 @@ export function analyzeHtmlDocument(
     // `empty` tally before it gets here. Round-tripping '' would compare it
     // against TipTap's `<p></p>` and report every empty page as changed.
     if (!/\S/.test(html)) {
-      return { status: 'analysed', dropped: [], textPreserved: true };
+      return {
+        status: 'analysed',
+        dropped: [],
+        textPreserved: true,
+        tagless: false,
+        images: [],
+        magnitudes: emptyMagnitudes(),
+      };
     }
 
     const source = workspace.parse(html);
@@ -71,6 +90,9 @@ export function analyzeHtmlDocument(
     return {
       status: 'analysed',
       dropped: droppedConstructs(constructs, collectConstructs(output)),
+      tagless: !hasHtmlElement(constructs),
+      images: htmlImageSources(source),
+      magnitudes: htmlMagnitudes(source),
       // projectContent is the repo's shared page-text flattener: it ends a run
       // of text at every block boundary and drops <script>/<style> bodies.
       // Element.textContent does neither, so two paragraphs merging into one


### PR DESCRIPTION
Follows #2495 (merged). The census, asked the questions it can actually answer about images and about pagination — because both are about to land, and the first run's answer on images was a tautology.

> `<img>` — **0 pages**. The editor has no image node, so no document can hold one.

## What this adds

**1. The mislabelled population is finally scanned as markdown.** #2495 detected markdown syntax only over the 1,009 pages that carry the label — a quarter of the markdown that exists. A tagless `contentMode='html'` page now goes through the detector a second time, into its own tally so the labelled numbers stay comparable between runs.

| construct | labelled markdown | mislabelled as html |
|---|---|---|
| `md:task-list` | 34 | **325** |
| `md:heading-4-6` | 8 | 18 |
| `md:raw-html` | 11 | 13 |
| `md:highlight` | 1 | 3 |
| `md:image` | 2 | **0** |

Task lists are a ten-fold undercount, not the four-fold #2495 guessed, and they are now the largest single schema gap the census has found. The tagless count itself is **3,169, not 3,003**: that number came from an ad-hoc query beside the census, and a query looking for a tag finds `<string>` inside `Set<string>`. 183 pages carry an unescaped angle bracket. It also puts the 3,114 text-loss figure *inside* the tagless population rather than beside it, which is a cleaner form of the same tell.

**2. Where images point** — a scheme bucket and a bare hostname, never a URL. Production holds **9 images on 2 pages**:

```
img-src:pagespace-file        1 page
img-src:relative              1 page
external image hosts          (none)
images in one document        7 (max)
```

This is thin evidence and the report says so. The census can now say something better than a tautology about images, and what it says is that **the argument for an image node in v1 rests on product intent, not on the corpus** — unaffected (free in v1, Class B afterwards), but it should not be dressed up as a measurement. #2495's "positive evidence points the same way: `md:image` appears in markdown source" is two pages.

What the run does settle, and could not have been guessed:

- **No `data:` URIs anywhere.** The CRDT-bloat hazard does not exist yet, so paste and migration only have to keep it that way. Base64 in a Y.Doc is replicated to every client and never forgotten.
- **No external hosts at all.** Nothing is hotlinked, so Phase K needs no ingestion pipeline and v1 need not decide whether to proxy somebody else's CDN.
- **One of the two pages already points at `/api/files/{id}/view`** — somebody hand-wrote the file-serving URL into markdown to get an image into a document. That is a user routing around the missing node, and it names the attribute shape: a stable internal reference resolved at render time, never a signed URL, which in a CRDT would be permanent, expiring and leaky at once.

**3. Magnitudes, for pagination.** Every other tally here is presence per page, because "would v1 lose this" only ever needed a yes. Pagination needs a size: `PaginationPlus` is decoration-based — the right shape for a CRDT, it adds no nodes — but it breaks pages *between* blocks and splits none of them.

```
pages with isPaginated set        0
lines in one code block         261   (a US Letter page holds ~40)
rows in one table                57
columns in one table             15
characters in one block      16,582
```

Nobody has the switch set (`DocumentView.tsx:399` hardcodes `isPaginated={false}`), so flipping the default is safe as a data matter — turning it on is not. Today's documents already contain a single code fence six pages tall. Images join that list as the one block whose height is unknown until it loads, which is the argument for intrinsic `width`/`height` on the node at insert time.

## Review on this PR

Six findings, all valid, all fixed in `23a76ae5c`. One of them was a hole in the method rather than a nit:

**`marked` emits raw HTML as one opaque `html` token and never looks inside it** (Codex, P1). An `<img src="data:...">`, a 60-row `<table>` or a long `<pre>` written into a markdown document was invisible to both the image classification and the magnitudes — the two conclusions this run exists to draw. 24 pages carry `md:raw-html`. The markdown walk now hands those tokens to the same `DomWorkspace` the HTML half uses.

**The re-run returned every number unchanged.** No image, no data URI, no larger block was hiding in there — which is the good outcome, and also the only reason "no data URIs anywhere, no external hosts" above is a measurement rather than an assumption.

The rest: a markdown table cell is measured as a block (the HTML half was already measuring `td`/`th`, so a table-only document reported no block at all); a src that announces a scheme and then will not parse — `https://`, a truncated paste — is malformed rather than relative; `ImageSource.bucket` is the literal union of `IMAGE_SOURCE_KEYS` rather than `string`; the `isPaginated` count is labelled as the whole-table aggregate it is; and the report no longer explains the 3,003 → 3,169 move as if the 166-page difference decomposed — the old number came from a rule that was never written down, so only the new one is a measurement.

## Review feedback carried over from #2495

`md:strikethrough` is dropped from the gap tally. StarterKit ships the `strike` mark and the bubble menu exposes it, so 17 documents were sitting in a table headed "syntax the schema has no node for" that the schema represents perfectly. `round-trip.test.ts` now holds `<s>` to surviving the round trip, so the claim is pinned rather than asserted.

## Still read-only, still prints no content

Every connection stays in `default_transaction_read_only`, and the build gate that scans census sources for writes now covers the two new modules automatically (it globs, it does not list). The one new query is a `count(*)`.

The privacy rule needed a new clause, because a src is content: it carries a filename, and a query string carries tokens. `classifyImageSource` returns a scheme bucket and a bare hostname — no path, no query, no port, no userinfo — and drops even the hostname when the URL parses with credentials in it. Pinned by test.

## Validation

- `bun run --filter web test -- src/lib/editor/census` — **131 passed**
- `bun run knip:check` — within baseline
- `eslint` on every changed file — clean
- **Mutation-checked**, twelve of them, each independently red: the credentials check in `hostOf`, the `data:` branch, the malformed-scheme guard, `hasHtmlElement` ignoring the unescaped-bracket bucket, the markdown table header counting as a row, table cells counting as blocks, raw HTML being read at all, `absorb` summing image counts rather than taking their maximum, the mislabelled tally being kept separate from the labelled one, image buckets counting pages rather than instances, the ten-host cap, and magnitudes measuring the stored document rather than the round trip.
- Production run, read-only, `default_transaction_read_only` asserted at startup. **The html construct tallies and the text-loss counts are unchanged from #2495's run** — which is what makes the two comparable, and the check that this refactor did not change what the census measures.
- `typecheck`/`build` left to CI, per the standing no-local-builds rule. The pre-review commit went green on all three jobs.

## Deliberately not done

- **No schema freeze.** The input moved again: the largest gap is task lists (359 pages across both populations), not any of the six constructs v1 was going to be argued over.
- **No fix for the mislabelled 3,169.** Production data change; its own PR.
- **No image node, no upload path, no `isPaginated` wiring.** This is the evidence; each of those is its own decision.
