### PR TITLE
feat(web): capability-based native detection in the Capacitor bridge

### DIFF
--- a/apps/web/src/components/auth/GoogleOneTap.tsx
+++ b/apps/web/src/components/auth/GoogleOneTap.tsx
@@ -7,6 +7,7 @@ import { detectInAppBrowser } from '@/lib/auth/browser-detection';
 import { Button } from '@/components/ui/button';
 import { useConsentStore } from '@/stores/useConsentStore';
 import { shouldLoadThirdPartyScript } from '@pagespace/lib/consent';
+import { isCapacitorApp } from '@/lib/capacitor-bridge';
 
 /**
  * Platform eligibility for One Tap (desktop/native/mobile/in-app browsers are excluded).
@@ -15,9 +16,7 @@ import { shouldLoadThirdPartyScript } from '@pagespace/lib/consent';
 function isOneTapPlatformEligible(): boolean {
   if (typeof window === 'undefined' || typeof navigator === 'undefined') return false;
   if (window.electron?.isDesktop) return false;
-  if ((window as Window & { Capacitor?: { isNativePlatform?: () => boolean } }).Capacitor?.isNativePlatform?.()) {
-    return false;
-  }
+  if (isCapacitorApp()) return false;
   const ua = navigator.userAgent;
   const isMobile = /android|webos|iphone|ipad|ipod|blackberry|iemobile|opera mini|mobile|tablet/i.test(ua);
   const isWebView = /\bwv\b|WebView/i.test(ua);

--- a/apps/web/src/hooks/__tests__/useAppStateRecovery.test.ts
+++ b/apps/web/src/hooks/__tests__/useAppStateRecovery.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest';
 import { renderHook, act } from '@testing-library/react';
 
-vi.mock('@/hooks/useCapacitor', () => ({
+vi.mock('@/lib/capacitor-bridge', () => ({
   isCapacitorApp: () => false,
 }));
 

--- a/apps/web/src/hooks/__tests__/useAppStateRecovery.test.ts
+++ b/apps/web/src/hooks/__tests__/useAppStateRecovery.test.ts
@@ -1,7 +1,8 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest';
 import { renderHook, act } from '@testing-library/react';
 
-vi.mock('@/lib/capacitor-bridge', () => ({
+vi.mock('@/lib/capacitor-bridge', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('@/lib/capacitor-bridge')>()),
   isCapacitorApp: () => false,
 }));
 

--- a/apps/web/src/hooks/__tests__/useCapacitor.test.ts
+++ b/apps/web/src/hooks/__tests__/useCapacitor.test.ts
@@ -300,6 +300,31 @@ describe('useCapacitor', () => {
       });
     });
 
+    it('renders unsupported first on iOS, so hydration cannot mismatch', async () => {
+      // The server has no window.Capacitor, so it always renders the
+      // unsupported set. If the hook's initial state read the real platform,
+      // the first client render would disagree with the server's HTML.
+      (window as Window & { Capacitor?: MockCapacitor }).Capacitor = {
+        isNativePlatform: vi.fn(() => true),
+        getPlatform: vi.fn(() => 'ios'),
+      };
+      vi.resetModules();
+      useCapacitorModule = await import('../useCapacitor');
+
+      const seen: Array<{ badge: boolean; isReady: boolean }> = [];
+      const { result } = renderHook(() => {
+        const state = useCapacitorModule.useCapacitor();
+        seen.push({ badge: state.capabilities.badge, isReady: state.isReady });
+        return state;
+      });
+      await waitFor(() => expect(result.current.isReady).toBe(true));
+
+      // First render (pre-effect) must look exactly like the server's.
+      expect(seen[0]).toEqual({ badge: false, isReady: false });
+      // and only then move to the real capability set.
+      expect(result.current.capabilities.badge).toBe(true);
+    });
+
     it('reports everything unsupported in a browser tab', async () => {
       delete (window as Window & { Capacitor?: MockCapacitor }).Capacitor;
       vi.resetModules();

--- a/apps/web/src/hooks/__tests__/useCapacitor.test.ts
+++ b/apps/web/src/hooks/__tests__/useCapacitor.test.ts
@@ -343,8 +343,8 @@ describe('useCapacitor', () => {
     });
   });
 
-  // Note: isCapacitorApp() and getPlatform() utility functions are re-exported
-  // from capacitor-bridge.ts and thoroughly tested in capacitor-bridge.test.ts.
+  // Note: isCapacitorApp(), getPlatform() and isIPad() live in
+  // capacitor-bridge.ts and are thoroughly tested in capacitor-bridge.test.ts.
   // This file focuses on the React hook behavior only.
 
   describe('usage patterns', () => {

--- a/apps/web/src/hooks/__tests__/useCapacitor.test.ts
+++ b/apps/web/src/hooks/__tests__/useCapacitor.test.ts
@@ -241,10 +241,79 @@ describe('useCapacitor', () => {
           expect(result.current.isReady).toBe(true);
         });
 
+        // Still a native shell — that is about Capacitor, not about which
+        // platform row we recognize.
         expect(result.current.isNative).toBe(true);
-        expect(result.current.platform).toBe('unknown');
+        // `platform` is typed `Platform`, so an unrecognized value normalizes to
+        // 'web' rather than leaking a string outside that union.
+        expect(result.current.platform).toBe('web');
         expect(result.current.isIOS).toBe(false);
         expect(result.current.isAndroid).toBe(false);
+        // No capability row for it, so nothing is claimed as supported.
+        expect(result.current.capabilities).toEqual({
+          secureStore: false,
+          nativeAuth: false,
+          push: false,
+          badge: false,
+        });
+      });
+    });
+  });
+
+  describe('capabilities', () => {
+    it('exposes the iOS capability set', async () => {
+      (window as Window & { Capacitor?: MockCapacitor }).Capacitor = {
+        isNativePlatform: vi.fn(() => true),
+        getPlatform: vi.fn(() => 'ios'),
+      };
+      vi.resetModules();
+      useCapacitorModule = await import('../useCapacitor');
+
+      const { result } = renderHook(() => useCapacitorModule.useCapacitor());
+      await waitFor(() => expect(result.current.isReady).toBe(true));
+
+      expect(result.current.capabilities).toEqual({
+        secureStore: true,
+        nativeAuth: true,
+        push: true,
+        badge: true,
+      });
+    });
+
+    it('exposes the Android capability set, badge still unsupported', async () => {
+      (window as Window & { Capacitor?: MockCapacitor }).Capacitor = {
+        isNativePlatform: vi.fn(() => true),
+        getPlatform: vi.fn(() => 'android'),
+      };
+      vi.resetModules();
+      useCapacitorModule = await import('../useCapacitor');
+
+      const { result } = renderHook(() => useCapacitorModule.useCapacitor());
+      await waitFor(() => expect(result.current.isReady).toBe(true));
+
+      expect(result.current.isAndroid).toBe(true);
+      expect(result.current.capabilities).toEqual({
+        secureStore: true,
+        nativeAuth: true,
+        push: true,
+        badge: false,
+      });
+    });
+
+    it('reports everything unsupported in a browser tab', async () => {
+      delete (window as Window & { Capacitor?: MockCapacitor }).Capacitor;
+      vi.resetModules();
+      useCapacitorModule = await import('../useCapacitor');
+
+      const { result } = renderHook(() => useCapacitorModule.useCapacitor());
+      await waitFor(() => expect(result.current.isReady).toBe(true));
+
+      expect(result.current.isNative).toBe(false);
+      expect(result.current.capabilities).toEqual({
+        secureStore: false,
+        nativeAuth: false,
+        push: false,
+        badge: false,
       });
     });
   });

--- a/apps/web/src/hooks/__tests__/useDeviceTier.test.ts
+++ b/apps/web/src/hooks/__tests__/useDeviceTier.test.ts
@@ -1,0 +1,99 @@
+/**
+ * useDeviceTier Tests
+ *
+ * Tablet detection is delegated to `isIPad()` in the capability bridge, so the
+ * 768px threshold has exactly one definition. These tests pin that delegation
+ * and the tier derivation on top of it.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { renderHook } from '@testing-library/react';
+
+const mockIsIPad = vi.fn<() => boolean>();
+const mockUseBreakpoint = vi.fn<() => boolean>();
+
+vi.mock('@/lib/capacitor-bridge', () => ({
+  isIPad: () => mockIsIPad(),
+}));
+
+vi.mock('../useBreakpoint', () => ({
+  useBreakpoint: () => mockUseBreakpoint(),
+}));
+
+import { useDeviceTier, useIsTablet } from '../useDeviceTier';
+
+describe('useDeviceTier', () => {
+  beforeEach(() => {
+    mockIsIPad.mockReset();
+    mockUseBreakpoint.mockReset();
+    mockIsIPad.mockReturnValue(false);
+    mockUseBreakpoint.mockReturnValue(false);
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('useIsTablet', () => {
+    it('reports the bridge answer when it says iPad', () => {
+      mockIsIPad.mockReturnValue(true);
+
+      const { result } = renderHook(() => useIsTablet());
+
+      expect(result.current).toBe(true);
+    });
+
+    it('reports false when the bridge says not an iPad', () => {
+      mockIsIPad.mockReturnValue(false);
+
+      const { result } = renderHook(() => useIsTablet());
+
+      expect(result.current).toBe(false);
+    });
+
+    it('asks the bridge rather than reading window.Capacitor itself', () => {
+      mockIsIPad.mockReturnValue(true);
+
+      renderHook(() => useIsTablet());
+
+      expect(mockIsIPad).toHaveBeenCalled();
+    });
+  });
+
+  describe('tier derivation', () => {
+    it('is tablet on iPad, whatever the viewport reports', () => {
+      mockIsIPad.mockReturnValue(true);
+      mockUseBreakpoint.mockReturnValue(true); // small viewport too
+
+      const { result } = renderHook(() => useDeviceTier());
+
+      expect(result.current.tier).toBe('tablet');
+      expect(result.current.isTablet).toBe(true);
+      expect(result.current.isMobile).toBe(false);
+      expect(result.current.isDesktop).toBe(false);
+      expect(result.current.isMobileOrTablet).toBe(true);
+    });
+
+    it('is mobile on a small viewport that is not an iPad', () => {
+      mockIsIPad.mockReturnValue(false);
+      mockUseBreakpoint.mockReturnValue(true);
+
+      const { result } = renderHook(() => useDeviceTier());
+
+      expect(result.current.tier).toBe('mobile');
+      expect(result.current.isMobile).toBe(true);
+      expect(result.current.isMobileOrTablet).toBe(true);
+    });
+
+    it('is desktop on a large viewport that is not an iPad', () => {
+      mockIsIPad.mockReturnValue(false);
+      mockUseBreakpoint.mockReturnValue(false);
+
+      const { result } = renderHook(() => useDeviceTier());
+
+      expect(result.current.tier).toBe('desktop');
+      expect(result.current.isDesktop).toBe(true);
+      expect(result.current.isMobileOrTablet).toBe(false);
+    });
+  });
+});

--- a/apps/web/src/hooks/__tests__/useIosBadgeSync.test.tsx
+++ b/apps/web/src/hooks/__tests__/useIosBadgeSync.test.tsx
@@ -25,11 +25,20 @@ let mockCapacitorState: MockCapacitorState = {
   isReady: true,
 };
 
+vi.mock('@/hooks/useCapacitor', () => ({
+  useCapacitor: () => mockCapacitorState,
+}));
+
 // isCapacitorApp() is what useAppStateRecovery uses internally to pick its Capacitor
 // vs. web resume path — forcing it false makes the test drive resume via
 // document.visibilitychange (jsdom has no real Capacitor bridge to fire appStateChange).
-vi.mock('@/hooks/useCapacitor', () => ({
-  useCapacitor: () => mockCapacitorState,
+// It lives on the bridge, so it has to be mocked there: mocking it on
+// @/hooks/useCapacitor would be dead and the suite would pass only by accident,
+// until some later test stubs window.Capacitor and silently flips the branch.
+// Spread the real module: auth-fetch (reached via useNotificationStore) also
+// imports getPlatform from here, and a bare factory would leave it undefined.
+vi.mock('@/lib/capacitor-bridge', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('@/lib/capacitor-bridge')>()),
   isCapacitorApp: () => false,
 }));
 

--- a/apps/web/src/hooks/__tests__/useMobileKeyboard.test.ts
+++ b/apps/web/src/hooks/__tests__/useMobileKeyboard.test.ts
@@ -22,7 +22,7 @@ const { mockIsCapacitorApp, mockGetPlatform } = vi.hoisted(() => {
 });
 
 // Mock useCapacitor module
-vi.mock('../useCapacitor', () => ({
+vi.mock('@/lib/capacitor-bridge', () => ({
   isCapacitorApp: () => mockIsCapacitorApp(),
   getPlatform: () => mockGetPlatform(),
 }));

--- a/apps/web/src/hooks/__tests__/useMobileKeyboard.test.ts
+++ b/apps/web/src/hooks/__tests__/useMobileKeyboard.test.ts
@@ -22,7 +22,8 @@ const { mockIsCapacitorApp, mockGetPlatform } = vi.hoisted(() => {
 });
 
 // Mock useCapacitor module
-vi.mock('@/lib/capacitor-bridge', () => ({
+vi.mock('@/lib/capacitor-bridge', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('@/lib/capacitor-bridge')>()),
   isCapacitorApp: () => mockIsCapacitorApp(),
   getPlatform: () => mockGetPlatform(),
 }));

--- a/apps/web/src/hooks/useAppStateRecovery.ts
+++ b/apps/web/src/hooks/useAppStateRecovery.ts
@@ -1,7 +1,7 @@
 'use client';
 
 import { useEffect, useRef, useCallback } from 'react';
-import { isCapacitorApp } from './useCapacitor';
+import { isCapacitorApp } from '@/lib/capacitor-bridge';
 
 export interface UseAppStateRecoveryOptions {
   /**

--- a/apps/web/src/hooks/useCapacitor.ts
+++ b/apps/web/src/hooks/useCapacitor.ts
@@ -7,6 +7,7 @@ import {
   isAndroid,
   isIOS,
   isNativeApp,
+  NO_NATIVE_CAPABILITIES,
   type NativeCapability,
   type Platform,
 } from '@/lib/capacitor-bridge';
@@ -59,15 +60,18 @@ interface CapacitorState {
  * ```
  */
 export function useCapacitor(): CapacitorState {
-  const [state, setState] = useState<CapacitorState>(() => ({
+  // The initial state must match what the server rendered: no native platform
+  // and no capabilities. Reading the real platform here instead would make the
+  // first client render disagree with the server's HTML on any native build.
+  const [state, setState] = useState<CapacitorState>({
     isNative: false,
     platform: 'web',
     isIOS: false,
     isAndroid: false,
     isIPad: false,
-    capabilities: getNativeCapabilities(),
+    capabilities: NO_NATIVE_CAPABILITIES,
     isReady: false,
-  }));
+  });
 
   useEffect(() => {
     const platform = getPlatform();

--- a/apps/web/src/hooks/useCapacitor.ts
+++ b/apps/web/src/hooks/useCapacitor.ts
@@ -6,23 +6,12 @@ import {
   getPlatform,
   isAndroid,
   isIOS,
+  isIPad,
   isNativeApp,
   NO_NATIVE_CAPABILITIES,
   type NativeCapability,
   type Platform,
 } from '@/lib/capacitor-bridge';
-
-/**
- * Platform detection re-exported from the bridge.
- *
- * This module used to carry its own copy of `isCapacitorApp`/`getPlatform`,
- * reading `window.Capacitor` a second time. That is exactly the drift the
- * capability bridge exists to remove, so these are now thin re-exports and
- * `@/lib/capacitor-bridge` is the single detection path.
- *
- * @deprecated Import from `@/lib/capacitor-bridge` directly in new code.
- */
-export { isCapacitorApp, getPlatform } from '@/lib/capacitor-bridge';
 
 interface CapacitorState {
   /** Whether running in a native Capacitor app */
@@ -74,19 +63,12 @@ export function useCapacitor(): CapacitorState {
   });
 
   useEffect(() => {
-    const platform = getPlatform();
-    const isIOSPlatform = isIOS();
-    // Detect iPad: iOS Capacitor + tablet-sized screen (min dimension >= 768px).
-    // All iPads have min(width, height) >= 768px; all iPhones are well under.
-    const isIPadDevice =
-      isIOSPlatform && Math.min(window.screen.width, window.screen.height) >= 768;
-
     setState({
       isNative: isNativeApp(),
-      platform,
-      isIOS: isIOSPlatform,
+      platform: getPlatform(),
+      isIOS: isIOS(),
       isAndroid: isAndroid(),
-      isIPad: isIPadDevice,
+      isIPad: isIPad(),
       capabilities: getNativeCapabilities(),
       isReady: true,
     });

--- a/apps/web/src/hooks/useCapacitor.ts
+++ b/apps/web/src/hooks/useCapacitor.ts
@@ -1,8 +1,27 @@
 'use client';
 
 import { useEffect, useState } from 'react';
+import {
+  getNativeCapabilities,
+  getPlatform,
+  isAndroid,
+  isIOS,
+  isNativeApp,
+  type NativeCapability,
+  type Platform,
+} from '@/lib/capacitor-bridge';
 
-type Platform = 'ios' | 'android' | 'web';
+/**
+ * Platform detection re-exported from the bridge.
+ *
+ * This module used to carry its own copy of `isCapacitorApp`/`getPlatform`,
+ * reading `window.Capacitor` a second time. That is exactly the drift the
+ * capability bridge exists to remove, so these are now thin re-exports and
+ * `@/lib/capacitor-bridge` is the single detection path.
+ *
+ * @deprecated Import from `@/lib/capacitor-bridge` directly in new code.
+ */
+export { isCapacitorApp, getPlatform } from '@/lib/capacitor-bridge';
 
 interface CapacitorState {
   /** Whether running in a native Capacitor app */
@@ -15,90 +34,59 @@ interface CapacitorState {
   isAndroid: boolean;
   /** Whether running on iPad (iOS Capacitor with tablet-sized screen) */
   isIPad: boolean;
+  /**
+   * What this platform can actually do.
+   *
+   * Prefer this over `isIOS`/`isAndroid` when gating a native feature — see
+   * `hasNativeCapability` in `@/lib/capacitor-bridge`.
+   */
+  capabilities: Readonly<Record<NativeCapability, boolean>>;
   /** Whether state has been determined (for SSR hydration) */
   isReady: boolean;
 }
 
 /**
  * Hook to detect Capacitor native environment.
- * Provides platform information for conditional rendering and behavior.
+ * Provides platform and capability information for conditional rendering.
  *
  * @example
  * ```tsx
- * const { isNative, isIOS, platform } = useCapacitor();
+ * const { isNative, capabilities } = useCapacitor();
  *
- * if (isIOS) {
- *   // iOS-specific behavior
+ * if (capabilities.badge) {
+ *   // this platform can set an app badge
  * }
  * ```
  */
 export function useCapacitor(): CapacitorState {
-  const [state, setState] = useState<CapacitorState>({
+  const [state, setState] = useState<CapacitorState>(() => ({
     isNative: false,
     platform: 'web',
     isIOS: false,
     isAndroid: false,
     isIPad: false,
+    capabilities: getNativeCapabilities(),
     isReady: false,
-  });
+  }));
 
   useEffect(() => {
-    // Check for Capacitor global object
-    const capacitor = (window as Window & { Capacitor?: CapacitorGlobal }).Capacitor;
-    const isCapacitor = typeof capacitor !== 'undefined' && capacitor.isNativePlatform?.();
+    const platform = getPlatform();
+    const isIOSPlatform = isIOS();
+    // Detect iPad: iOS Capacitor + tablet-sized screen (min dimension >= 768px).
+    // All iPads have min(width, height) >= 768px; all iPhones are well under.
+    const isIPadDevice =
+      isIOSPlatform && Math.min(window.screen.width, window.screen.height) >= 768;
 
-    if (isCapacitor && capacitor) {
-      const platform = capacitor.getPlatform?.() as Platform || 'web';
-      const isIOSPlatform = platform === 'ios';
-      // Detect iPad: iOS Capacitor + tablet-sized screen (min dimension >= 768px).
-      // All iPads have min(width, height) >= 768px; all iPhones are well under.
-      const isIPadDevice = isIOSPlatform &&
-        Math.min(window.screen.width, window.screen.height) >= 768;
-      setState({
-        isNative: true,
-        platform,
-        isIOS: isIOSPlatform,
-        isAndroid: platform === 'android',
-        isIPad: isIPadDevice,
-        isReady: true,
-      });
-    } else {
-      setState({
-        isNative: false,
-        platform: 'web',
-        isIOS: false,
-        isAndroid: false,
-        isIPad: false,
-        isReady: true,
-      });
-    }
+    setState({
+      isNative: isNativeApp(),
+      platform,
+      isIOS: isIOSPlatform,
+      isAndroid: isAndroid(),
+      isIPad: isIPadDevice,
+      capabilities: getNativeCapabilities(),
+      isReady: true,
+    });
   }, []);
 
   return state;
-}
-
-interface CapacitorGlobal {
-  isNativePlatform?: () => boolean;
-  getPlatform?: () => string;
-}
-
-/**
- * Non-hook function to check if running in Capacitor.
- * Use when you need platform detection outside of React components.
- */
-export function isCapacitorApp(): boolean {
-  if (typeof window === 'undefined') return false;
-  const capacitor = (window as Window & { Capacitor?: CapacitorGlobal }).Capacitor;
-  return typeof capacitor !== 'undefined' && !!capacitor.isNativePlatform?.();
-}
-
-/**
- * Get the current platform synchronously.
- * Returns 'web' if not in Capacitor or if called during SSR.
- */
-export function getPlatform(): Platform {
-  if (typeof window === 'undefined') return 'web';
-  const capacitor = (window as Window & { Capacitor?: CapacitorGlobal }).Capacitor;
-  if (!capacitor?.isNativePlatform?.()) return 'web';
-  return (capacitor.getPlatform?.() as Platform) || 'web';
 }

--- a/apps/web/src/hooks/useDeviceTier.ts
+++ b/apps/web/src/hooks/useDeviceTier.ts
@@ -2,26 +2,20 @@
 
 import { useSyncExternalStore } from "react";
 import { useBreakpoint } from "./useBreakpoint";
+import { isIPad } from "@/lib/capacitor-bridge";
 
 export type DeviceTier = "mobile" | "tablet" | "desktop";
 
-interface CapacitorGlobal {
-  isNativePlatform?: () => boolean;
-  getPlatform?: () => string;
-}
-
 /**
- * Synchronous tablet detection via Capacitor.
- * iPad is identified as iOS Capacitor with min screen dimension >= 768px.
+ * Synchronous tablet detection.
+ *
+ * Delegates to the capability bridge so the iPad threshold has one definition —
+ * this used to re-implement the detection and the 768px heuristic, which meant
+ * tuning one copy silently disagreed with `useCapacitor().isIPad`.
  * Device type is static for a session, so no subscription/reactivity needed.
  */
 function getIsTablet(): boolean {
-  if (typeof window === "undefined") return false;
-  const capacitor = (window as Window & { Capacitor?: CapacitorGlobal })
-    .Capacitor;
-  if (!capacitor?.isNativePlatform?.()) return false;
-  if (capacitor.getPlatform?.() !== "ios") return false;
-  return Math.min(window.screen.width, window.screen.height) >= 768;
+  return isIPad();
 }
 
 const noopSubscribe = () => () => {};

--- a/apps/web/src/hooks/useMobileKeyboard.ts
+++ b/apps/web/src/hooks/useMobileKeyboard.ts
@@ -1,7 +1,7 @@
 'use client';
 
 import { useEffect, useState, useCallback, useRef } from 'react';
-import { isCapacitorApp, getPlatform } from './useCapacitor';
+import { isCapacitorApp, getPlatform } from '@/lib/capacitor-bridge';
 
 export interface UseMobileKeyboardReturn {
   /** Whether the keyboard is currently open */

--- a/apps/web/src/lib/__tests__/capacitor-bridge.test.ts
+++ b/apps/web/src/lib/__tests__/capacitor-bridge.test.ts
@@ -36,6 +36,24 @@ function removeCapacitorMock(): void {
   delete (window as Window & { Capacitor?: MockCapacitor }).Capacitor;
 }
 
+/**
+ * Run `fn` with `globalThis.window` removed, then restore it in a `finally`.
+ *
+ * The restore has to be unconditional: if an assertion or a dynamic import
+ * throws while window is missing, an inline restore never runs and every later
+ * test in the file inherits a leaked SSR global.
+ */
+async function withoutWindow(fn: () => Promise<void> | void): Promise<void> {
+  const windowBackup = globalThis.window;
+  // @ts-expect-error - intentionally testing undefined window
+  delete globalThis.window;
+  try {
+    await fn();
+  } finally {
+    globalThis.window = windowBackup;
+  }
+}
+
 describe('capacitor-bridge', () => {
   let capacitorBridge: typeof import('../capacitor-bridge');
 
@@ -102,16 +120,14 @@ describe('capacitor-bridge', () => {
 
     describe('SSR safety', () => {
       it('returns false when window is undefined', async () => {
-        const windowBackup = globalThis.window;
-        // @ts-expect-error - intentionally testing undefined window
-        delete globalThis.window;
+        await withoutWindow(async () => {
 
-        vi.resetModules();
-        capacitorBridge = await import('../capacitor-bridge');
+          vi.resetModules();
+          capacitorBridge = await import('../capacitor-bridge');
 
-        expect(capacitorBridge.isCapacitorApp()).toBe(false);
+          expect(capacitorBridge.isCapacitorApp()).toBe(false);
 
-        globalThis.window = windowBackup;
+        });
       });
     });
   });
@@ -162,16 +178,14 @@ describe('capacitor-bridge', () => {
 
     describe('SSR safety', () => {
       it('returns web when window is undefined', async () => {
-        const windowBackup = globalThis.window;
-        // @ts-expect-error - intentionally testing undefined window
-        delete globalThis.window;
+        await withoutWindow(async () => {
 
-        vi.resetModules();
-        capacitorBridge = await import('../capacitor-bridge');
+          vi.resetModules();
+          capacitorBridge = await import('../capacitor-bridge');
 
-        expect(capacitorBridge.getPlatform()).toBe('web');
+          expect(capacitorBridge.getPlatform()).toBe('web');
 
-        globalThis.window = windowBackup;
+        });
       });
     });
   });
@@ -226,16 +240,14 @@ describe('capacitor-bridge', () => {
     });
 
     it('does not throw when window is undefined', async () => {
-      const windowBackup = globalThis.window;
-      // @ts-expect-error - intentionally testing undefined window
-      delete globalThis.window;
+      await withoutWindow(async () => {
 
-      vi.resetModules();
-      capacitorBridge = await import('../capacitor-bridge');
+        vi.resetModules();
+        capacitorBridge = await import('../capacitor-bridge');
 
-      expect(() => capacitorBridge.injectPlatformInfo()).not.toThrow();
+        expect(() => capacitorBridge.injectPlatformInfo()).not.toThrow();
 
-      globalThis.window = windowBackup;
+      });
     });
   });
 
@@ -318,16 +330,14 @@ describe('capacitor-bridge', () => {
     });
 
     it('returns false when window is undefined', async () => {
-      const windowBackup = globalThis.window;
-      // @ts-expect-error - intentionally testing undefined window
-      delete globalThis.window;
+      await withoutWindow(async () => {
 
-      vi.resetModules();
-      capacitorBridge = await import('../capacitor-bridge');
+        vi.resetModules();
+        capacitorBridge = await import('../capacitor-bridge');
 
-      expect(capacitorBridge.isAndroid()).toBe(false);
+        expect(capacitorBridge.isAndroid()).toBe(false);
 
-      globalThis.window = windowBackup;
+      });
     });
   });
 
@@ -363,16 +373,26 @@ describe('capacitor-bridge', () => {
     });
 
     it('returns false during SSR when window is undefined', async () => {
-      const windowBackup = globalThis.window;
-      // @ts-expect-error - intentionally testing undefined window
-      delete globalThis.window;
+      await withoutWindow(async () => {
 
+        vi.resetModules();
+        capacitorBridge = await import('../capacitor-bridge');
+
+        expect(capacitorBridge.isNativeApp()).toBe(false);
+
+      });
+    });
+
+    it('stays true on a native platform we have no capability row for', async () => {
+      // isNativeApp reflects the shell, not the capability-table key. A future
+      // Capacitor target is still a native app; it just has no capabilities.
+      setupCapacitorMock(true, 'windows');
       vi.resetModules();
       capacitorBridge = await import('../capacitor-bridge');
 
-      expect(capacitorBridge.isNativeApp()).toBe(false);
-
-      globalThis.window = windowBackup;
+      expect(capacitorBridge.isNativeApp()).toBe(true);
+      expect(capacitorBridge.getPlatform()).toBe('web');
+      expect(capacitorBridge.hasNativeCapability('push')).toBe(false);
     });
   });
 
@@ -430,21 +450,19 @@ describe('capacitor-bridge', () => {
 
     describe('SSR safety', () => {
       it('reports every capability unsupported without throwing when window is undefined', async () => {
-        const windowBackup = globalThis.window;
-        // @ts-expect-error - intentionally testing undefined window
-        delete globalThis.window;
+        await withoutWindow(async () => {
 
-        vi.resetModules();
-        capacitorBridge = await import('../capacitor-bridge');
+          vi.resetModules();
+          capacitorBridge = await import('../capacitor-bridge');
 
-        for (const capability of CAPABILITIES) {
-          expect(() =>
-            capacitorBridge.hasNativeCapability(capability)
-          ).not.toThrow();
-          expect(capacitorBridge.hasNativeCapability(capability)).toBe(false);
-        }
+          for (const capability of CAPABILITIES) {
+            expect(() =>
+              capacitorBridge.hasNativeCapability(capability)
+            ).not.toThrow();
+            expect(capacitorBridge.hasNativeCapability(capability)).toBe(false);
+          }
 
-        globalThis.window = windowBackup;
+        });
       });
     });
 
@@ -565,19 +583,17 @@ describe('capacitor-bridge', () => {
     });
 
     it('supports no provider during SSR without throwing', async () => {
-      const windowBackup = globalThis.window;
-      // @ts-expect-error - intentionally testing undefined window
-      delete globalThis.window;
+      await withoutWindow(async () => {
 
-      vi.resetModules();
-      capacitorBridge = await import('../capacitor-bridge');
+        vi.resetModules();
+        capacitorBridge = await import('../capacitor-bridge');
 
-      expect(() =>
-        capacitorBridge.supportsNativeAuthProvider('google')
-      ).not.toThrow();
-      expect(capacitorBridge.supportsNativeAuthProvider('google')).toBe(false);
+        expect(() =>
+          capacitorBridge.supportsNativeAuthProvider('google')
+        ).not.toThrow();
+        expect(capacitorBridge.supportsNativeAuthProvider('google')).toBe(false);
 
-      globalThis.window = windowBackup;
+      });
     });
 
     it('supports no provider on an unrecognised native platform', async () => {
@@ -589,47 +605,6 @@ describe('capacitor-bridge', () => {
         capacitorBridge.supportsNativeAuthProvider('google')
       ).not.toThrow();
       expect(capacitorBridge.supportsNativeAuthProvider('google')).toBe(false);
-    });
-  });
-
-  describe('getNativeAuthProviders', () => {
-    it('lists Google and Apple on iOS', async () => {
-      setupCapacitorMock(true, 'ios');
-      vi.resetModules();
-      capacitorBridge = await import('../capacitor-bridge');
-
-      expect([...capacitorBridge.getNativeAuthProviders()].sort()).toEqual([
-        'apple',
-        'google',
-      ]);
-    });
-
-    it('lists only Google on Android', async () => {
-      setupCapacitorMock(true, 'android');
-      vi.resetModules();
-      capacitorBridge = await import('../capacitor-bridge');
-
-      expect([...capacitorBridge.getNativeAuthProviders()]).toEqual(['google']);
-    });
-
-    it('lists nothing on web', () => {
-      removeCapacitorMock();
-
-      expect([...capacitorBridge.getNativeAuthProviders()]).toEqual([]);
-    });
-
-    it('lists nothing during SSR without throwing', async () => {
-      const windowBackup = globalThis.window;
-      // @ts-expect-error - intentionally testing undefined window
-      delete globalThis.window;
-
-      vi.resetModules();
-      capacitorBridge = await import('../capacitor-bridge');
-
-      expect(() => capacitorBridge.getNativeAuthProviders()).not.toThrow();
-      expect([...capacitorBridge.getNativeAuthProviders()]).toEqual([]);
-
-      globalThis.window = windowBackup;
     });
   });
 

--- a/apps/web/src/lib/__tests__/capacitor-bridge.test.ts
+++ b/apps/web/src/lib/__tests__/capacitor-bridge.test.ts
@@ -37,18 +37,31 @@ function removeCapacitorMock(): void {
 }
 
 /**
+ * Set the reported screen size.
+ *
+ * jsdom's default (1024x768) already reads as a tablet, so any isIPad test must
+ * state the size it means rather than inherit it. `restoreScreenSize` in
+ * afterEach puts the default back so a later test cannot depend on where it
+ * happens to sit in the file.
+ */
+function setScreenSize(width: number, height: number): void {
+  Object.defineProperty(window.screen, 'width', { value: width, configurable: true });
+  Object.defineProperty(window.screen, 'height', { value: height, configurable: true });
+}
+
+const DEFAULT_SCREEN = { width: window.screen.width, height: window.screen.height };
+
+function restoreScreenSize(): void {
+  setScreenSize(DEFAULT_SCREEN.width, DEFAULT_SCREEN.height);
+}
+
+/**
  * Run `fn` with `globalThis.window` removed, then restore it in a `finally`.
  *
  * The restore has to be unconditional: if an assertion or a dynamic import
  * throws while window is missing, an inline restore never runs and every later
  * test in the file inherits a leaked SSR global.
  */
-/** Set the reported screen size; jsdom's default (1024x768) already reads as a tablet. */
-function setScreenSize(width: number, height: number): void {
-  Object.defineProperty(window.screen, 'width', { value: width, configurable: true });
-  Object.defineProperty(window.screen, 'height', { value: height, configurable: true });
-}
-
 async function withoutWindow(fn: () => Promise<void> | void): Promise<void> {
   const windowBackup = globalThis.window;
   // @ts-expect-error - intentionally testing undefined window
@@ -77,6 +90,7 @@ describe('capacitor-bridge', () => {
   afterEach(() => {
     vi.restoreAllMocks();
     removeCapacitorMock();
+    restoreScreenSize();
   });
 
   describe('isCapacitorApp', () => {

--- a/apps/web/src/lib/__tests__/capacitor-bridge.test.ts
+++ b/apps/web/src/lib/__tests__/capacitor-bridge.test.ts
@@ -4,7 +4,9 @@
  * Comprehensive test coverage for platform detection utilities:
  * - isCapacitorApp detection
  * - getPlatform function
- * - Platform-specific checks (isIOS)
+ * - Platform-specific checks (isIOS, isAndroid, isNativeApp)
+ * - Capability detection (hasNativeCapability, getNativeCapabilities)
+ * - Native auth provider support (Apple is iOS-only)
  * - Platform info injection
  * - SSR safety
  */
@@ -289,6 +291,366 @@ describe('capacitor-bridge', () => {
       ]);
 
       expect(results).toEqual([true, 'ios', true]);
+    });
+  });
+
+  describe('isAndroid', () => {
+    it('returns true for Android platform', async () => {
+      setupCapacitorMock(true, 'android');
+      vi.resetModules();
+      capacitorBridge = await import('../capacitor-bridge');
+
+      expect(capacitorBridge.isAndroid()).toBe(true);
+    });
+
+    it('returns false for iOS platform', async () => {
+      setupCapacitorMock(true, 'ios');
+      vi.resetModules();
+      capacitorBridge = await import('../capacitor-bridge');
+
+      expect(capacitorBridge.isAndroid()).toBe(false);
+    });
+
+    it('returns false for web platform', () => {
+      removeCapacitorMock();
+
+      expect(capacitorBridge.isAndroid()).toBe(false);
+    });
+
+    it('returns false when window is undefined', async () => {
+      const windowBackup = globalThis.window;
+      // @ts-expect-error - intentionally testing undefined window
+      delete globalThis.window;
+
+      vi.resetModules();
+      capacitorBridge = await import('../capacitor-bridge');
+
+      expect(capacitorBridge.isAndroid()).toBe(false);
+
+      globalThis.window = windowBackup;
+    });
+  });
+
+  describe('isNativeApp', () => {
+    it('returns true for iOS platform', async () => {
+      setupCapacitorMock(true, 'ios');
+      vi.resetModules();
+      capacitorBridge = await import('../capacitor-bridge');
+
+      expect(capacitorBridge.isNativeApp()).toBe(true);
+    });
+
+    it('returns true for Android platform', async () => {
+      setupCapacitorMock(true, 'android');
+      vi.resetModules();
+      capacitorBridge = await import('../capacitor-bridge');
+
+      expect(capacitorBridge.isNativeApp()).toBe(true);
+    });
+
+    it('returns false in a browser tab', () => {
+      removeCapacitorMock();
+
+      expect(capacitorBridge.isNativeApp()).toBe(false);
+    });
+
+    it('returns false when Capacitor is present but not native', async () => {
+      setupCapacitorMock(false, 'web');
+      vi.resetModules();
+      capacitorBridge = await import('../capacitor-bridge');
+
+      expect(capacitorBridge.isNativeApp()).toBe(false);
+    });
+
+    it('returns false during SSR when window is undefined', async () => {
+      const windowBackup = globalThis.window;
+      // @ts-expect-error - intentionally testing undefined window
+      delete globalThis.window;
+
+      vi.resetModules();
+      capacitorBridge = await import('../capacitor-bridge');
+
+      expect(capacitorBridge.isNativeApp()).toBe(false);
+
+      globalThis.window = windowBackup;
+    });
+  });
+
+  describe('hasNativeCapability', () => {
+    // The capability truth table this module encodes. Each row is asserted
+    // exhaustively so a wrong flag anywhere fails a named test.
+    const TRUTH_TABLE = {
+      ios: { secureStore: true, nativeAuth: true, push: true, badge: true },
+      android: { secureStore: true, nativeAuth: true, push: true, badge: false },
+      web: { secureStore: false, nativeAuth: false, push: false, badge: false },
+    } as const;
+
+    const CAPABILITIES = [
+      'secureStore',
+      'nativeAuth',
+      'push',
+      'badge',
+    ] as const;
+
+    describe('on iOS', () => {
+      for (const capability of CAPABILITIES) {
+        const expected = TRUTH_TABLE.ios[capability];
+        it(`reports ${capability} as ${expected}`, async () => {
+          setupCapacitorMock(true, 'ios');
+          vi.resetModules();
+          capacitorBridge = await import('../capacitor-bridge');
+
+          expect(capacitorBridge.hasNativeCapability(capability)).toBe(expected);
+        });
+      }
+    });
+
+    describe('on Android', () => {
+      for (const capability of CAPABILITIES) {
+        const expected = TRUTH_TABLE.android[capability];
+        it(`reports ${capability} as ${expected}`, async () => {
+          setupCapacitorMock(true, 'android');
+          vi.resetModules();
+          capacitorBridge = await import('../capacitor-bridge');
+
+          expect(capacitorBridge.hasNativeCapability(capability)).toBe(expected);
+        });
+      }
+    });
+
+    describe('in a browser tab', () => {
+      for (const capability of CAPABILITIES) {
+        it(`reports ${capability} as unsupported`, () => {
+          removeCapacitorMock();
+
+          expect(capacitorBridge.hasNativeCapability(capability)).toBe(false);
+        });
+      }
+    });
+
+    describe('SSR safety', () => {
+      it('reports every capability unsupported without throwing when window is undefined', async () => {
+        const windowBackup = globalThis.window;
+        // @ts-expect-error - intentionally testing undefined window
+        delete globalThis.window;
+
+        vi.resetModules();
+        capacitorBridge = await import('../capacitor-bridge');
+
+        for (const capability of CAPABILITIES) {
+          expect(() =>
+            capacitorBridge.hasNativeCapability(capability)
+          ).not.toThrow();
+          expect(capacitorBridge.hasNativeCapability(capability)).toBe(false);
+        }
+
+        globalThis.window = windowBackup;
+      });
+    });
+
+    it('reports unsupported for an unrecognised native platform', async () => {
+      // A Capacitor shell reporting a platform we have no row for must not
+      // throw or claim capabilities it cannot deliver.
+      setupCapacitorMock(true, 'windows');
+      vi.resetModules();
+      capacitorBridge = await import('../capacitor-bridge');
+
+      for (const capability of CAPABILITIES) {
+        expect(() =>
+          capacitorBridge.hasNativeCapability(capability)
+        ).not.toThrow();
+        expect(capacitorBridge.hasNativeCapability(capability)).toBe(false);
+      }
+    });
+  });
+
+  describe('getNativeCapabilities', () => {
+    it('returns the full iOS capability set', async () => {
+      setupCapacitorMock(true, 'ios');
+      vi.resetModules();
+      capacitorBridge = await import('../capacitor-bridge');
+
+      expect(capacitorBridge.getNativeCapabilities()).toEqual({
+        secureStore: true,
+        nativeAuth: true,
+        push: true,
+        badge: true,
+      });
+    });
+
+    it('returns the full Android capability set with badge unsupported', async () => {
+      setupCapacitorMock(true, 'android');
+      vi.resetModules();
+      capacitorBridge = await import('../capacitor-bridge');
+
+      expect(capacitorBridge.getNativeCapabilities()).toEqual({
+        secureStore: true,
+        nativeAuth: true,
+        push: true,
+        badge: false,
+      });
+    });
+
+    it('returns everything unsupported on web', () => {
+      removeCapacitorMock();
+
+      expect(capacitorBridge.getNativeCapabilities()).toEqual({
+        secureStore: false,
+        nativeAuth: false,
+        push: false,
+        badge: false,
+      });
+    });
+
+    it('returns a frozen table entry callers cannot corrupt', async () => {
+      setupCapacitorMock(true, 'android');
+      vi.resetModules();
+      capacitorBridge = await import('../capacitor-bridge');
+
+      const capabilities = capacitorBridge.getNativeCapabilities();
+      expect(Object.isFrozen(capabilities)).toBe(true);
+
+      // Silently ignored in sloppy mode; the point is the table is unchanged.
+      try {
+        (capabilities as { badge: boolean }).badge = true;
+      } catch {
+        // strict-mode TypeError is equally acceptable
+      }
+
+      expect(capacitorBridge.getNativeCapabilities().badge).toBe(false);
+    });
+  });
+
+  describe('supportsNativeAuthProvider', () => {
+    it('supports Google natively on iOS', async () => {
+      setupCapacitorMock(true, 'ios');
+      vi.resetModules();
+      capacitorBridge = await import('../capacitor-bridge');
+
+      expect(capacitorBridge.supportsNativeAuthProvider('google')).toBe(true);
+    });
+
+    it('supports Apple natively on iOS', async () => {
+      setupCapacitorMock(true, 'ios');
+      vi.resetModules();
+      capacitorBridge = await import('../capacitor-bridge');
+
+      expect(capacitorBridge.supportsNativeAuthProvider('apple')).toBe(true);
+    });
+
+    it('supports Google natively on Android', async () => {
+      setupCapacitorMock(true, 'android');
+      vi.resetModules();
+      capacitorBridge = await import('../capacitor-bridge');
+
+      expect(capacitorBridge.supportsNativeAuthProvider('google')).toBe(true);
+    });
+
+    it('does NOT support Apple natively on Android (web flow only)', async () => {
+      // There is no native Android SDK for Sign in with Apple. Modelling
+      // nativeAuth as one boolean would get this wrong.
+      setupCapacitorMock(true, 'android');
+      vi.resetModules();
+      capacitorBridge = await import('../capacitor-bridge');
+
+      expect(capacitorBridge.hasNativeCapability('nativeAuth')).toBe(true);
+      expect(capacitorBridge.supportsNativeAuthProvider('apple')).toBe(false);
+    });
+
+    it('supports no provider in a browser tab', () => {
+      removeCapacitorMock();
+
+      expect(capacitorBridge.supportsNativeAuthProvider('google')).toBe(false);
+      expect(capacitorBridge.supportsNativeAuthProvider('apple')).toBe(false);
+    });
+
+    it('supports no provider during SSR without throwing', async () => {
+      const windowBackup = globalThis.window;
+      // @ts-expect-error - intentionally testing undefined window
+      delete globalThis.window;
+
+      vi.resetModules();
+      capacitorBridge = await import('../capacitor-bridge');
+
+      expect(() =>
+        capacitorBridge.supportsNativeAuthProvider('google')
+      ).not.toThrow();
+      expect(capacitorBridge.supportsNativeAuthProvider('google')).toBe(false);
+
+      globalThis.window = windowBackup;
+    });
+
+    it('supports no provider on an unrecognised native platform', async () => {
+      setupCapacitorMock(true, 'windows');
+      vi.resetModules();
+      capacitorBridge = await import('../capacitor-bridge');
+
+      expect(() =>
+        capacitorBridge.supportsNativeAuthProvider('google')
+      ).not.toThrow();
+      expect(capacitorBridge.supportsNativeAuthProvider('google')).toBe(false);
+    });
+  });
+
+  describe('getNativeAuthProviders', () => {
+    it('lists Google and Apple on iOS', async () => {
+      setupCapacitorMock(true, 'ios');
+      vi.resetModules();
+      capacitorBridge = await import('../capacitor-bridge');
+
+      expect([...capacitorBridge.getNativeAuthProviders()].sort()).toEqual([
+        'apple',
+        'google',
+      ]);
+    });
+
+    it('lists only Google on Android', async () => {
+      setupCapacitorMock(true, 'android');
+      vi.resetModules();
+      capacitorBridge = await import('../capacitor-bridge');
+
+      expect([...capacitorBridge.getNativeAuthProviders()]).toEqual(['google']);
+    });
+
+    it('lists nothing on web', () => {
+      removeCapacitorMock();
+
+      expect([...capacitorBridge.getNativeAuthProviders()]).toEqual([]);
+    });
+
+    it('lists nothing during SSR without throwing', async () => {
+      const windowBackup = globalThis.window;
+      // @ts-expect-error - intentionally testing undefined window
+      delete globalThis.window;
+
+      vi.resetModules();
+      capacitorBridge = await import('../capacitor-bridge');
+
+      expect(() => capacitorBridge.getNativeAuthProviders()).not.toThrow();
+      expect([...capacitorBridge.getNativeAuthProviders()]).toEqual([]);
+
+      globalThis.window = windowBackup;
+    });
+  });
+
+  describe('capability consumers', () => {
+    it('needs no call-site change when a platform gains a capability', async () => {
+      // Consumers ask hasNativeCapability('badge'); they never name a platform.
+      // Adding badge support to Android is a one-line table edit, and this
+      // simulated consumer picks it up unchanged.
+      const consumer = (
+        bridge: typeof import('../capacitor-bridge')
+      ): string => (bridge.hasNativeCapability('badge') ? 'sync' : 'skip');
+
+      setupCapacitorMock(true, 'android');
+      vi.resetModules();
+      capacitorBridge = await import('../capacitor-bridge');
+      expect(consumer(capacitorBridge)).toBe('skip');
+
+      setupCapacitorMock(true, 'ios');
+      vi.resetModules();
+      capacitorBridge = await import('../capacitor-bridge');
+      expect(consumer(capacitorBridge)).toBe('sync');
     });
   });
 

--- a/apps/web/src/lib/__tests__/capacitor-bridge.test.ts
+++ b/apps/web/src/lib/__tests__/capacitor-bridge.test.ts
@@ -43,6 +43,12 @@ function removeCapacitorMock(): void {
  * throws while window is missing, an inline restore never runs and every later
  * test in the file inherits a leaked SSR global.
  */
+/** Set the reported screen size; jsdom's default (1024x768) already reads as a tablet. */
+function setScreenSize(width: number, height: number): void {
+  Object.defineProperty(window.screen, 'width', { value: width, configurable: true });
+  Object.defineProperty(window.screen, 'height', { value: height, configurable: true });
+}
+
 async function withoutWindow(fn: () => Promise<void> | void): Promise<void> {
   const windowBackup = globalThis.window;
   // @ts-expect-error - intentionally testing undefined window
@@ -336,6 +342,74 @@ describe('capacitor-bridge', () => {
         capacitorBridge = await import('../capacitor-bridge');
 
         expect(capacitorBridge.isAndroid()).toBe(false);
+
+      });
+    });
+  });
+
+  describe('isIPad', () => {
+    it('is true for iOS with a tablet-sized screen', async () => {
+      setupCapacitorMock(true, 'ios');
+      setScreenSize(834, 1194); // iPad Air
+      vi.resetModules();
+      capacitorBridge = await import('../capacitor-bridge');
+
+      expect(capacitorBridge.isIPad()).toBe(true);
+    });
+
+    it('is true at exactly the 768px threshold', async () => {
+      setupCapacitorMock(true, 'ios');
+      setScreenSize(768, 1024); // original iPad
+      vi.resetModules();
+      capacitorBridge = await import('../capacitor-bridge');
+
+      expect(capacitorBridge.isIPad()).toBe(true);
+    });
+
+    it('is false for iOS on a phone-sized screen', async () => {
+      setupCapacitorMock(true, 'ios');
+      setScreenSize(390, 844); // iPhone 14
+      vi.resetModules();
+      capacitorBridge = await import('../capacitor-bridge');
+
+      expect(capacitorBridge.isIPad()).toBe(false);
+    });
+
+    it('is false one pixel below the threshold', async () => {
+      setupCapacitorMock(true, 'ios');
+      setScreenSize(767, 1024);
+      vi.resetModules();
+      capacitorBridge = await import('../capacitor-bridge');
+
+      expect(capacitorBridge.isIPad()).toBe(false);
+    });
+
+    it('is false for an Android tablet — the heuristic is iOS-only', async () => {
+      setupCapacitorMock(true, 'android');
+      setScreenSize(800, 1280);
+      vi.resetModules();
+      capacitorBridge = await import('../capacitor-bridge');
+
+      expect(capacitorBridge.isIPad()).toBe(false);
+    });
+
+    it('is false in a browser tab, however large the screen', async () => {
+      removeCapacitorMock();
+      setScreenSize(1440, 2560);
+      vi.resetModules();
+      capacitorBridge = await import('../capacitor-bridge');
+
+      expect(capacitorBridge.isIPad()).toBe(false);
+    });
+
+    it('does not touch window.screen during SSR', async () => {
+      await withoutWindow(async () => {
+
+        vi.resetModules();
+        capacitorBridge = await import('../capacitor-bridge');
+
+        expect(() => capacitorBridge.isIPad()).not.toThrow();
+        expect(capacitorBridge.isIPad()).toBe(false);
 
       });
     });

--- a/apps/web/src/lib/capacitor-bridge.ts
+++ b/apps/web/src/lib/capacitor-bridge.ts
@@ -5,10 +5,14 @@
  * and the native Capacitor layer. It handles platform detection and
  * provides a safe way to call native functions.
  *
- * This module is the only place in the app that reads `window.Capacitor`.
- * Everything platform-shaped — the hooks, the capability table, the auth
- * helpers — derives from `isCapacitorApp()` and `getPlatform()` here, so there
- * is no second detection path that can drift.
+ * This module owns platform detection: every hook, capability lookup and auth
+ * helper derives from `isCapacitorApp()` and `getPlatform()` here rather than
+ * reading `window.Capacitor` itself, so there is no second path that can drift.
+ *
+ * One deliberate exception remains: `POINTER_CAPABILITY_SCRIPT` in
+ * `pointer-capability.ts` is a hand-minified copy that runs before any bundle
+ * loads, so it cannot import from here. A parity test in that file's test suite
+ * keeps the two in agreement.
  */
 
 export type Platform = 'ios' | 'android' | 'web';
@@ -132,6 +136,22 @@ export function isAndroid(): boolean {
 }
 
 /**
+ * Check if running on an iPad.
+ *
+ * iPad is iOS Capacitor plus a tablet-sized screen: every iPad has
+ * min(width, height) >= 768px and every iPhone is well under it.
+ *
+ * Lives here rather than in a hook because `useDeviceTier` needs the same
+ * answer synchronously; two copies of the threshold would drift the moment one
+ * is tuned. SSR-safe — `isIOS()` is false on the server, so `window.screen` is
+ * never touched there.
+ */
+export function isIPad(): boolean {
+  if (!isIOS()) return false;
+  return Math.min(window.screen.width, window.screen.height) >= 768;
+}
+
+/**
  * Check if running inside any native Capacitor shell.
  *
  * Prefer this over `isIOS()` for anything that is not genuinely iOS-specific.
@@ -140,10 +160,10 @@ export function isAndroid(): boolean {
  * stays true on a native platform we have no capability row for (see
  * `getPlatform()`). "I am in a native app" and "we know what this platform can
  * do" are different questions: the first gates native-vs-browser behaviour, the
- * second is `hasNativeCapability()`. An unrecognized native platform is
- * therefore native with every capability unsupported — which is the safe
- * combination, and the reason capability checks must never be spelled as
- * `isNativeApp() && ...`.
+ * second is `hasNativeCapability()`, which already answers false for a platform
+ * with no row. So use it to gate native-vs-browser behaviour, and never as the
+ * native half of a hand-rolled capability test — `isNativeApp() && someIosOnly`
+ * is how a native platform gets handed a feature it cannot deliver.
  */
 export function isNativeApp(): boolean {
   return isCapacitorApp();

--- a/apps/web/src/lib/capacitor-bridge.ts
+++ b/apps/web/src/lib/capacitor-bridge.ts
@@ -4,9 +4,76 @@
  * This module provides utilities for communicating between the web app
  * and the native Capacitor layer. It handles platform detection and
  * provides a safe way to call native functions.
+ *
+ * Platform detection has exactly one entry point — `getPlatform()`. Everything
+ * else (including the capability table) is derived from it, so there is no
+ * second path to `window.Capacitor` that can drift.
  */
 
-type Platform = 'ios' | 'android' | 'web';
+export type Platform = 'ios' | 'android' | 'web';
+
+/**
+ * A native capability the shared web app may depend on.
+ *
+ * Call sites should ask "can this platform do X?" via {@link hasNativeCapability}
+ * rather than "is this iOS?" — that keeps platform knowledge in the single table
+ * below instead of scattering it across the app.
+ */
+export type NativeCapability = 'secureStore' | 'nativeAuth' | 'push' | 'badge';
+
+/**
+ * An identity provider that can be driven through a native SDK.
+ *
+ * `nativeAuth` is deliberately not a single boolean: Android has a native Google
+ * sign-in SDK but no native Apple one — Apple sign-in on Android goes through
+ * Apple's web flow — so provider support has to be modelled per platform.
+ */
+export type NativeAuthProvider = 'google' | 'apple';
+
+/**
+ * What each platform can actually do *today*.
+ *
+ * This table is the single source of truth. When a platform gains a capability,
+ * flip the flag here and every consumer picks it up with no call-site change.
+ */
+const PLATFORM_CAPABILITIES: Record<
+  Platform,
+  Readonly<Record<NativeCapability, boolean>>
+> = {
+  // PageSpaceKeychain (Swift), @capgo/capacitor-social-login,
+  // @capacitor/push-notifications, @capawesome/capacitor-badge.
+  ios: Object.freeze({
+    secureStore: true,
+    nativeAuth: true,
+    push: true,
+    badge: true,
+  }),
+  // PageSpaceSecureStoragePlugin (registered in MainActivity.java as
+  // "PageSpaceKeychain"), @capgo/capacitor-social-login (Google only),
+  // Firebase Messaging via the Gradle build. The badge plugin is not yet in
+  // apps/android/package.json.
+  android: Object.freeze({
+    secureStore: true,
+    nativeAuth: true,
+    push: true,
+    badge: false,
+  }),
+  // A plain browser tab has none of these.
+  web: Object.freeze({
+    secureStore: false,
+    nativeAuth: false,
+    push: false,
+    badge: false,
+  }),
+};
+
+/** Which auth providers each platform can drive through a native SDK. */
+const NATIVE_AUTH_PROVIDERS: Record<Platform, readonly NativeAuthProvider[]> = {
+  ios: ['google', 'apple'],
+  // No native Android SDK for Sign in with Apple — that flow stays on the web.
+  android: ['google'],
+  web: [],
+};
 
 interface CapacitorGlobal {
   isNativePlatform?: () => boolean;
@@ -22,14 +89,22 @@ export function isCapacitorApp(): boolean {
   return typeof capacitor !== 'undefined' && !!capacitor.isNativePlatform?.();
 }
 
+const KNOWN_PLATFORMS: readonly Platform[] = ['ios', 'android', 'web'];
+
 /**
  * Get the current platform.
+ *
+ * This is the module's only reader of `window.Capacitor` — every other helper
+ * derives from it. Anything the shell reports that we don't have a row for
+ * (a future Capacitor target) normalizes to 'web', so the declared return type
+ * stays honest and capability lookups can never miss.
  */
 export function getPlatform(): Platform {
   if (typeof window === 'undefined') return 'web';
   const capacitor = (window as Window & { Capacitor?: CapacitorGlobal }).Capacitor;
   if (!capacitor?.isNativePlatform?.()) return 'web';
-  return (capacitor.getPlatform?.() as Platform) || 'web';
+  const platform = capacitor.getPlatform?.();
+  return KNOWN_PLATFORMS.find((known) => known === platform) ?? 'web';
 }
 
 /**
@@ -37,6 +112,63 @@ export function getPlatform(): Platform {
  */
 export function isIOS(): boolean {
   return getPlatform() === 'ios';
+}
+
+/**
+ * Check if running on Android (native app).
+ */
+export function isAndroid(): boolean {
+  return getPlatform() === 'android';
+}
+
+/**
+ * Check if running inside any native Capacitor shell (iOS or Android).
+ *
+ * Prefer this over `isIOS()` for anything that is not genuinely iOS-specific.
+ */
+export function isNativeApp(): boolean {
+  return getPlatform() !== 'web';
+}
+
+/**
+ * Check whether the current platform supports a native capability.
+ *
+ * Safe during SSR: `getPlatform()` returns 'web' when `window` is undefined,
+ * so every capability reports unsupported rather than throwing.
+ */
+export function hasNativeCapability(capability: NativeCapability): boolean {
+  return PLATFORM_CAPABILITIES[getPlatform()][capability];
+}
+
+/**
+ * Get the full capability set for the current platform.
+ *
+ * Useful for hooks that expose capabilities as a single object. The returned
+ * object is frozen — it is the shared table entry, not a copy.
+ */
+export function getNativeCapabilities(): Readonly<
+  Record<NativeCapability, boolean>
+> {
+  return PLATFORM_CAPABILITIES[getPlatform()];
+}
+
+/**
+ * Check whether a specific auth provider can be driven natively here.
+ *
+ * Note this is finer-grained than `hasNativeCapability('nativeAuth')`: Android
+ * has nativeAuth but cannot drive Apple.
+ */
+export function supportsNativeAuthProvider(
+  provider: NativeAuthProvider
+): boolean {
+  return NATIVE_AUTH_PROVIDERS[getPlatform()].includes(provider);
+}
+
+/**
+ * Get every auth provider the current platform can drive natively.
+ */
+export function getNativeAuthProviders(): readonly NativeAuthProvider[] {
+  return NATIVE_AUTH_PROVIDERS[getPlatform()];
 }
 
 /**

--- a/apps/web/src/lib/capacitor-bridge.ts
+++ b/apps/web/src/lib/capacitor-bridge.ts
@@ -5,9 +5,10 @@
  * and the native Capacitor layer. It handles platform detection and
  * provides a safe way to call native functions.
  *
- * Platform detection has exactly one entry point — `getPlatform()`. Everything
- * else (including the capability table) is derived from it, so there is no
- * second path to `window.Capacitor` that can drift.
+ * This module is the only place in the app that reads `window.Capacitor`.
+ * Everything platform-shaped — the hooks, the capability table, the auth
+ * helpers — derives from `isCapacitorApp()` and `getPlatform()` here, so there
+ * is no second detection path that can drift.
  */
 
 export type Platform = 'ios' | 'android' | 'web';
@@ -100,10 +101,9 @@ const KNOWN_PLATFORMS: readonly Platform[] = ['ios', 'android', 'web'];
  * stays honest and capability lookups can never miss.
  */
 export function getPlatform(): Platform {
-  if (typeof window === 'undefined') return 'web';
+  if (!isCapacitorApp()) return 'web';
   const capacitor = (window as Window & { Capacitor?: CapacitorGlobal }).Capacitor;
-  if (!capacitor?.isNativePlatform?.()) return 'web';
-  const platform = capacitor.getPlatform?.();
+  const platform = capacitor?.getPlatform?.();
   return KNOWN_PLATFORMS.find((known) => known === platform) ?? 'web';
 }
 

--- a/apps/web/src/lib/capacitor-bridge.ts
+++ b/apps/web/src/lib/capacitor-bridge.ts
@@ -68,6 +68,16 @@ const PLATFORM_CAPABILITIES: Record<
   }),
 };
 
+/**
+ * The capability set of a platform with no native support.
+ *
+ * This is what the server renders, so a client that starts from it and only
+ * moves to the real set inside an effect cannot produce a hydration mismatch.
+ * Reach for this as an initial/SSR state rather than calling
+ * `getNativeCapabilities()` during the first render.
+ */
+export const NO_NATIVE_CAPABILITIES = PLATFORM_CAPABILITIES.web;
+
 /** Which auth providers each platform can drive through a native SDK. */
 const NATIVE_AUTH_PROVIDERS: Record<Platform, readonly NativeAuthProvider[]> = {
   ios: Object.freeze<NativeAuthProvider[]>(['google', 'apple']),
@@ -95,10 +105,10 @@ const KNOWN_PLATFORMS: readonly Platform[] = ['ios', 'android', 'web'];
 /**
  * Get the current platform.
  *
- * This is the module's only reader of `window.Capacitor` — every other helper
- * derives from it. Anything the shell reports that we don't have a row for
- * (a future Capacitor target) normalizes to 'web', so the declared return type
- * stays honest and capability lookups can never miss.
+ * Anything the shell reports that we have no row for (a future Capacitor
+ * target) normalizes to 'web', so the declared return type stays honest and
+ * capability lookups can never miss the table. Use `isNativeApp()` when you
+ * need "is this a native shell?" — that question survives normalization.
  */
 export function getPlatform(): Platform {
   if (!isCapacitorApp()) return 'web';
@@ -158,16 +168,6 @@ export function hasNativeCapability(capability: NativeCapability): boolean {
 }
 
 /**
- * The capability set of a platform with no native support.
- *
- * This is what the server renders, so a client that starts from it and only
- * moves to the real set inside an effect cannot produce a hydration mismatch.
- * Reach for this as an initial/SSR state rather than calling
- * `getNativeCapabilities()` during the first render.
- */
-export const NO_NATIVE_CAPABILITIES = PLATFORM_CAPABILITIES.web;
-
-/**
  * Get the full capability set for the current platform.
  *
  * Useful for hooks that expose capabilities as a single object. The returned
@@ -194,7 +194,6 @@ export function supportsNativeAuthProvider(
 ): boolean {
   return NATIVE_AUTH_PROVIDERS[getPlatform()].includes(provider);
 }
-
 
 /**
  * Inject platform information into the window object.

--- a/apps/web/src/lib/capacitor-bridge.ts
+++ b/apps/web/src/lib/capacitor-bridge.ts
@@ -69,10 +69,10 @@ const PLATFORM_CAPABILITIES: Record<
 
 /** Which auth providers each platform can drive through a native SDK. */
 const NATIVE_AUTH_PROVIDERS: Record<Platform, readonly NativeAuthProvider[]> = {
-  ios: ['google', 'apple'],
+  ios: Object.freeze<NativeAuthProvider[]>(['google', 'apple']),
   // No native Android SDK for Sign in with Apple — that flow stays on the web.
-  android: ['google'],
-  web: [],
+  android: Object.freeze<NativeAuthProvider[]>(['google']),
+  web: Object.freeze<NativeAuthProvider[]>([]),
 };
 
 interface CapacitorGlobal {
@@ -122,12 +122,21 @@ export function isAndroid(): boolean {
 }
 
 /**
- * Check if running inside any native Capacitor shell (iOS or Android).
+ * Check if running inside any native Capacitor shell.
  *
  * Prefer this over `isIOS()` for anything that is not genuinely iOS-specific.
+ *
+ * This deliberately reflects the *shell*, not the capability-table key, so it
+ * stays true on a native platform we have no capability row for (see
+ * `getPlatform()`). "I am in a native app" and "we know what this platform can
+ * do" are different questions: the first gates native-vs-browser behaviour, the
+ * second is `hasNativeCapability()`. An unrecognized native platform is
+ * therefore native with every capability unsupported — which is the safe
+ * combination, and the reason capability checks must never be spelled as
+ * `isNativeApp() && ...`.
  */
 export function isNativeApp(): boolean {
-  return getPlatform() !== 'web';
+  return isCapacitorApp();
 }
 
 /**
@@ -135,6 +144,14 @@ export function isNativeApp(): boolean {
  *
  * Safe during SSR: `getPlatform()` returns 'web' when `window` is undefined,
  * so every capability reports unsupported rather than throwing.
+ *
+ * This is the non-React entry point, for modules like `auth-fetch` and
+ * `platform-storage` that cannot call `useCapacitor()`. Components should
+ * prefer `useCapacitor().capabilities`.
+ *
+ * @public Published API of the capability bridge. The call sites that consume
+ * it (secure storage, push registration, badge sync) land in later leaves of
+ * the Android parity epic, so knip cannot see a consumer yet.
  */
 export function hasNativeCapability(capability: NativeCapability): boolean {
   return PLATFORM_CAPABILITIES[getPlatform()][capability];
@@ -157,6 +174,10 @@ export function getNativeCapabilities(): Readonly<
  *
  * Note this is finer-grained than `hasNativeCapability('nativeAuth')`: Android
  * has nativeAuth but cannot drive Apple.
+ *
+ * @public Published API of the capability bridge. Its consumer is the native
+ * auth module generalization leaf of the Android parity epic, so knip cannot
+ * see a consumer yet.
  */
 export function supportsNativeAuthProvider(
   provider: NativeAuthProvider
@@ -164,12 +185,6 @@ export function supportsNativeAuthProvider(
   return NATIVE_AUTH_PROVIDERS[getPlatform()].includes(provider);
 }
 
-/**
- * Get every auth provider the current platform can drive natively.
- */
-export function getNativeAuthProviders(): readonly NativeAuthProvider[] {
-  return NATIVE_AUTH_PROVIDERS[getPlatform()];
-}
 
 /**
  * Inject platform information into the window object.

--- a/apps/web/src/lib/capacitor-bridge.ts
+++ b/apps/web/src/lib/capacitor-bridge.ts
@@ -158,6 +158,16 @@ export function hasNativeCapability(capability: NativeCapability): boolean {
 }
 
 /**
+ * The capability set of a platform with no native support.
+ *
+ * This is what the server renders, so a client that starts from it and only
+ * moves to the real set inside an effect cannot produce a hydration mismatch.
+ * Reach for this as an initial/SSR state rather than calling
+ * `getNativeCapabilities()` during the first render.
+ */
+export const NO_NATIVE_CAPABILITIES = PLATFORM_CAPABILITIES.web;
+
+/**
  * Get the full capability set for the current platform.
  *
  * Useful for hooks that expose capabilities as a single object. The returned

--- a/apps/web/src/lib/haptics.ts
+++ b/apps/web/src/lib/haptics.ts
@@ -1,4 +1,4 @@
-import { isCapacitorApp } from '@/hooks/useCapacitor';
+import { isCapacitorApp } from '@/lib/capacitor-bridge';
 
 export type HapticStyle = 'light' | 'medium' | 'heavy';
 


### PR DESCRIPTION
## Why

PageSpace ships an iOS app; the Android app has never been released. The blocker isn't the native shell — Android already has `PageSpaceSecureStoragePlugin` (EncryptedSharedPreferences), Firebase Messaging in Gradle, and every server route already accepts `platform: 'android'`.

The blocker is that **the shared web app treats "native" as a synonym for iOS.** Native capabilities are gated behind `getPlatform() === 'ios'`, so an Android build silently degrades to the plain browser experience while its native plugins sit orphaned.

This is leaf 1 of 11 in the Android Parity epic — the foundation five later leaves consume (Android secure storage wiring, native auth generalization, auth session gate sweep, push permission/registration, badge sync generalization).

## What changed

**1. A capability API on `capacitor-bridge.ts`** — call sites stop asking "is this iOS?" and start asking "can this platform do X?"

| Export | Purpose |
|---|---|
| `isNativeApp()` | true in any Capacitor native shell |
| `isAndroid()` | the missing sibling of `isIOS()` |
| `isIPad()` | the iPad heuristic, now with one definition |
| `hasNativeCapability(cap)` | the capability predicate — `'secureStore' \| 'nativeAuth' \| 'push' \| 'badge'` |
| `getNativeCapabilities()` / `NO_NATIVE_CAPABILITIES` | the whole (frozen) set, and the SSR-safe default |
| `supportsNativeAuthProvider(p)` | per-provider auth — `'google' \| 'apple'` |
| `NativeCapability`, `NativeAuthProvider`, `Platform` | the types |

`isIOS()`, `isCapacitorApp()`, `getPlatform()` and `injectPlatformInfo()` are unchanged and still exported, so the ~13 iOS-gated call sites migrate incrementally in later leaves.

**2. Collapsed four parallel detection paths into one.** `window.Capacitor` was being read in four places:

| Module | Was | Now |
|---|---|---|
| `useCapacitor.ts` | its own `isCapacitorApp`, `getPlatform`, `Platform`, `CapacitorGlobal` | derives from the bridge; exports only the hook |
| `useDeviceTier.ts` | its own detection **plus a verbatim copy of the 768px iPad heuristic** | `isIPad()` |
| `GoogleOneTap.tsx` | inline `Capacitor?.isNativePlatform?.()` | `isCapacitorApp()` |
| `pointer-capability.ts` | hand-minified pre-paint script | **unchanged** — runs before any bundle loads, guarded by an existing parity test |

The `useDeviceTier` duplicate was the dangerous one: two copies of a tuned constant, one of which this PR was already moving. Change the threshold and `useCapacitor().isIPad` and `useIsTablet()` disagree on the same device.

`useCapacitor.ts`'s own test file already *claimed* its helpers were "re-exported from capacitor-bridge.ts" — the source had drifted from its documented design.

## Capability truth table

Encoded as what is true *today*, not what is aspirational:

| | secureStore | nativeAuth | push | badge |
|---|---|---|---|---|
| **ios** | ✅ PageSpaceKeychain (Swift) | ✅ Google + Apple | ✅ | ✅ `@capawesome/capacitor-badge` |
| **android** | ✅ `PageSpaceSecureStoragePlugin`, registered in `MainActivity.java` as `PageSpaceKeychain` | ✅ **Google only** | ✅ Firebase Messaging (Gradle) | ❌ plugin not in `apps/android/package.json` |
| **web** | ❌ | ❌ | ❌ | ❌ |

**`nativeAuth` is deliberately not a single boolean.** Android has a native Google SDK but no native Apple one — Apple sign-in on Android goes through Apple's web flow. Modelling it as one boolean gets Apple-on-Android wrong, so provider support is a second per-platform table behind `supportsNativeAuthProvider()`.

## Design notes

- **`getPlatform()` normalizes an unrecognized platform to `'web'`.** It previously cast whatever the shell reported straight to `Platform` — a value outside its own declared return type, which also missed the capability table. The same bug was live in the hook, whose test asserted `platform === 'unknown'`. Verified no behaviour change for existing consumers: all five compare against `'ios'`.
- **`isNativeApp()` reflects the shell, not the table.** An unrecognized native platform is native with every capability unsupported — the safe combination.
- **Table-driven, so call sites never change.** A platform gaining a capability is a one-line table edit; there is a test asserting exactly this.
- **SSR-safe throughout.** Capabilities report unsupported rather than throwing, and `useCapacitor`'s initial state is `NO_NATIVE_CAPABILITIES` so the first client render matches the server's HTML.
- Capability rows and provider lists are frozen; `getNativeAuthProviders()` was dropped so the provider table is unreachable by any caller.
- `hasNativeCapability` and `supportsNativeAuthProvider` are tagged `@public` — their consumers land in later leaves. Every other export has a real consumer, so the knip ratchet passes without an ignore.

## Validation

All four CI checks green on `16f14947`: Unit Tests, E2E, Lint & TypeScript (which runs the blocking `knip:check` — `[ok] knip: 4 issue(s), all within baseline (4)`), CodeRabbit.

Locally:
- **115 tests green** across the 5 suites runnable in this worktree; `capacitor-bridge` + `useCapacitor` + `useDeviceTier` alone are 91
- `useDeviceTier` gets its **first test file** — a surviving mutation is what surfaced that gap
- `isIPad` had **no test in either copy**; it now has 7 (both sides of the 768px threshold, Android tablet, browser, SSR)
- tsc (`--strict`, real `apps/web` tsconfig) and eslint clean on all 13 changed files

### Mutation checks — 39 applied, 38 killed on the spot

Every capability cell, every new branch and every delegation was broken in the source and watched go red: all 8 native cells, all 4 web cells, the auth-provider rows, `isAndroid`, `isNativeApp` (three ways), the unknown-platform normalization, the freezes, the SSR paths, the hook's capability/`isAndroid`/`isNative` wiring, the hydration-safe initial state, and `isIPad`'s threshold, comparison, iOS gate and `min`-vs-`max`.

The **one survivor** — replacing `useDeviceTier`'s delegation with a constant — proved that hook had no test file at all. Adding one kills it and two further mutations there.

Two defects were found this way rather than by review: the hydration mismatch (self-inflicted, caught by mutating the initializer) and the `useDeviceTier` coverage hole.

### Review passes

Two independent review passes ran over the diff. Acted on: the false "only place that reads `window.Capacitor`" claim (made true rather than softened), inverted `isNativeApp` guidance, a `useIosBadgeSync` mock that had silently stopped intercepting, `window.screen` leaking between tests, and a misplaced JSDoc block. One finding — that the `@public` exports would fail knip — was checked and is not correct: knip 5.82.1 honours the tag unconditionally (`ProjectPrincipal.js:180,201`), not via config, and CI confirms it.

Per repo policy `bun run build` / `typecheck` were not run locally (other agents on the box); CI is the gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017c8Fqim7XqfRJ4hLjQ3im7
