### PR TITLE
feat(notifications): android devices can actually be sent a push

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -293,6 +293,17 @@ APNS_KEY_ID=your_10_char_apns_key_id
 APNS_PRIVATE_KEY=your_p8_private_key_pem
 APNS_BUNDLE_ID=ai.pagespace.ios
 
+# Firebase Cloud Messaging (Android Capacitor app)
+# From the Firebase console -> Project settings -> Service accounts -> Generate
+# new private key. FCM_SERVICE_ACCOUNT_JSON is that whole JSON file on ONE line.
+# The Firebase project id is read out of the JSON, so there is no second variable
+# to keep in sync with it. Like APNS_PRIVATE_KEY above, the `private_key` inside
+# keeps its linebreaks as literal \n, e.g.:
+#   FCM_SERVICE_ACCOUNT_JSON='{"type":"service_account","project_id":"your-project","client_email":"...","private_key":"-----BEGIN PRIVATE KEY-----\n...\n-----END PRIVATE KEY-----\n"}'
+# Left blank it fails closed: Android sends report a configuration error naming
+# the missing field, and iOS/other platforms in the same dispatch still deliver.
+FCM_SERVICE_ACCOUNT_JSON=
+
 # Published Apps (Fly Machines) — OFF by default (ships dark).
 # Only the exact value APP_HOSTING_ENABLED=true turns it on; every provisioner
 # entry point no-ops or denies when it is anything else, including unset. A blank

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,10 +7,12 @@ All notable user-facing changes to PageSpace are documented here. Format follows
 
 ### Added
 
-- **Android phones can be sent a notification** — the server has always accepted and stored Android
-  push tokens, then dropped every message aimed at one: the send path had an iOS branch and a stub.
-  It now delivers through Firebase Cloud Messaging, so a mention or a share reaches an Android
-  device the same way it reaches an iPhone. A background sync is sent as a data-only message, which
+- **The server can send an Android notification** — it has always accepted and stored Android push
+  tokens, then dropped every message aimed at one: the send path had an iOS branch and a stub. It
+  now delivers through Firebase Cloud Messaging. Nothing changes for anyone yet, because the app
+  still only registers for push on iOS (`usePushNotifications`, "Only supported on iOS for now") —
+  when that lands, a mention or a share will reach an Android device the same way it reaches an
+  iPhone, with no further server work. A background sync is sent as a data-only message, which
   is what stops Android from putting a notification in the tray for something the app was only meant
   to quietly act on. A token Firebase reports as unregistered — the app was uninstalled, or the
   token was replaced — is deactivated on the spot rather than retried forever, matching how expired

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ All notable user-facing changes to PageSpace are documented here. Format follows
 
 ### Added
 
+- **Android phones can be sent a notification** — the server has always accepted and stored Android
+  push tokens, then dropped every message aimed at one: the send path had an iOS branch and a stub.
+  It now delivers through Firebase Cloud Messaging, so a mention or a share reaches an Android
+  device the same way it reaches an iPhone. A background sync is sent as a data-only message, which
+  is what stops Android from putting a notification in the tray for something the app was only meant
+  to quietly act on. A token Firebase reports as unregistered — the app was uninstalled, or the
+  token was replaced — is deactivated on the spot rather than retried forever, matching how expired
+  Apple tokens are already handled. If the Firebase credential is missing or malformed the Android
+  send fails with a message that says exactly which field is wrong, and every other device on the
+  account still receives the notification.
+
 - **A key can tell you what it is allowed to do** — `pagespace keys describe` reports the credential
   the machine is using: which drives it reaches, the role it holds in each, and what that role
   actually resolves to — can it read, write, share, delete. That answer comes from the same

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,11 +15,13 @@ All notable user-facing changes to PageSpace are documented here. Format follows
   to quietly act on. A token Firebase reports as unregistered — the app was uninstalled, or the
   token was replaced — is deactivated on the spot rather than retried forever, matching how expired
   Apple tokens are already handled. That only happens when Firebase says something is wrong with
-  *that token*: a rejection aimed at the request as a whole, such as a wrong project or a message
-  the server built badly, is retried rather than being allowed to unregister working phones. If the
-  Firebase credential is missing or malformed the Android send fails with a message that says
-  exactly which field is wrong, and every other device on the account still receives the
-  notification.
+  *that token* — the registration is gone, or the token itself is malformed. A rejection aimed at
+  the request as a whole is retried instead: a message the server built badly, or a credential
+  pointing at the wrong Firebase project, would otherwise unregister every Android phone at once
+  and leave them dark until each app was next opened. If the Firebase credential is missing or
+  malformed the Android send fails with a message that says exactly which field is wrong, every
+  other device on the account still receives the notification, and no phone is penalised for a
+  problem on the server's side.
 
 - **A key can tell you what it is allowed to do** — `pagespace keys describe` reports the credential
   the machine is using: which drives it reaches, the role it holds in each, and what that role

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,9 +14,12 @@ All notable user-facing changes to PageSpace are documented here. Format follows
   is what stops Android from putting a notification in the tray for something the app was only meant
   to quietly act on. A token Firebase reports as unregistered — the app was uninstalled, or the
   token was replaced — is deactivated on the spot rather than retried forever, matching how expired
-  Apple tokens are already handled. If the Firebase credential is missing or malformed the Android
-  send fails with a message that says exactly which field is wrong, and every other device on the
-  account still receives the notification.
+  Apple tokens are already handled. That only happens when Firebase says something is wrong with
+  *that token*: a rejection aimed at the request as a whole, such as a wrong project or a message
+  the server built badly, is retried rather than being allowed to unregister working phones. If the
+  Firebase credential is missing or malformed the Android send fails with a message that says
+  exactly which field is wrong, and every other device on the account still receives the
+  notification.
 
 - **A key can tell you what it is allowed to do** — `pagespace keys describe` reports the credential
   the machine is using: which drives it reaches, the role it holds in each, and what that role

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,9 +16,10 @@ All notable user-facing changes to PageSpace are documented here. Format follows
   token was replaced — is deactivated on the spot rather than retried forever, matching how expired
   Apple tokens are already handled. That only happens when Firebase says something is wrong with
   *that token* — the registration is gone, or the token itself is malformed. A rejection aimed at
-  the request as a whole is retried instead: a message the server built badly, or a credential
-  pointing at the wrong Firebase project, would otherwise unregister every Android phone at once
-  and leave them dark until each app was next opened. If the Firebase credential is missing or
+  the request as a whole is retried instead — and is never counted against the phone either, no
+  matter how many times it happens: a message the server built badly, or a credential pointing at
+  the wrong Firebase project, would otherwise unregister every Android phone at once and leave
+  them dark until each app was next opened. If the Firebase credential is missing or
   malformed the Android send fails with a message that says exactly which field is wrong, every
   other device on the account still receives the notification, and no phone is penalised for a
   problem on the server's side.

--- a/apps/android/README.md
+++ b/apps/android/README.md
@@ -1,0 +1,46 @@
+# PageSpace Android
+
+Capacitor wrapper around the web app, mirroring `apps/ios`.
+
+> **Scope of this file today:** only the server-side push requirements below, added with the FCM
+> sender. Client-side setup — the runtime permission prompt, token registration, build and signing
+> — belongs to the Android client work and is not documented here yet.
+
+## Server-side push requirements (production `pagespace-web`)
+
+FCM sending needs one secret set on the Fly web app:
+
+- `FCM_SERVICE_ACCOUNT_JSON` — the whole service account JSON on a single line, from the Firebase
+  console → Project settings → Service accounts → Generate new private key.
+
+The Firebase project id is read out of that JSON, so there is no second variable to keep in sync
+with it. The project the app is built against is `pagespace-f328e`
+(`apps/android/android/app/google-services.json`) — a service account from any other project will
+be rejected by FCM with `SENDER_ID_MISMATCH` on every send.
+
+Like `APNS_PRIVATE_KEY`, the `private_key` inside the JSON keeps its linebreaks as literal `\n` so
+the value stays single-line; the sender unescapes them before signing.
+
+Unlike the APNs path, there is no sandbox/production host split — FCM has one endpoint, so
+`NODE_ENV` does not affect Android delivery.
+
+**Left unset, Android sends fail closed:** each send reports a configuration error naming the
+missing field, iOS and web deliveries in the same dispatch still go out, and no device is
+deactivated for it. It is safe to deploy without the secret; Android simply receives nothing.
+
+Push is driven from the same web layer as iOS (`/api/notifications/push-tokens` for registration),
+and the server sends via `packages/lib/src/notifications/push-notifications.ts` — an OAuth2 access
+token minted from the service account, then FCM HTTP v1.
+
+### Verifying it works
+
+Once the secret is set, three sends confirm the whole path:
+
+1. a visible notification — should appear in the tray
+2. a silent one (a badge sync) — should **not** appear in the tray; it is sent data-only precisely
+   so Android does not render it
+3. one to a deliberately corrupted registration token — the row should be deactivated immediately
+   rather than retried
+
+Only a token-specific verdict from FCM deactivates a device. Credential, project, quota, outage
+and malformed-message rejections never count against a phone, however many times they occur.

--- a/apps/android/README.md
+++ b/apps/android/README.md
@@ -14,9 +14,15 @@ FCM sending needs one secret set on the Fly web app:
   console → Project settings → Service accounts → Generate new private key.
 
 The Firebase project id is read out of that JSON, so there is no second variable to keep in sync
-with it. The project the app is built against is `pagespace-f328e`
-(`apps/android/android/app/google-services.json`) — a service account from any other project will
-be rejected by FCM with `SENDER_ID_MISMATCH` on every send.
+with it. That also means **cross-project sending is not supported here**: FCM HTTP v1 does allow it
+when the sender has `roles/firebasecloudmessaging.admin` on the target project and the request URL
+names that target, but this sender derives the URL project from the credential itself and has no
+separate target setting.
+
+In practice the service account must therefore come from the project the app is built against,
+`pagespace-f328e` (`apps/android/android/app/google-services.json`). One from a different project
+will be rejected — `SENDER_ID_MISMATCH` if it is a sender mismatch, a project-level `NOT_FOUND` if
+the project simply does not match — on every send.
 
 Like `APNS_PRIVATE_KEY`, the `private_key` inside the JSON keeps its linebreaks as literal `\n` so
 the value stays single-line; the sender unescapes them before signing.
@@ -37,10 +43,15 @@ token minted from the service account, then FCM HTTP v1.
 Once the secret is set, three sends confirm the whole path:
 
 1. a visible notification — should appear in the tray
-2. a silent one (a badge sync) — should **not** appear in the tray; it is sent data-only precisely
-   so Android does not render it
-3. one to a deliberately corrupted registration token — the row should be deactivated immediately
-   rather than retried
+2. a silent one (a badge sync) — the server sends it data-only, with no `notification` block, so
+   FCM will not display it of its own accord. Whether anything reaches the tray from there is the
+   client handler's business, not this sender's; the server-side half of the claim is what the
+   tests pin.
+3. one to a registration token FCM rejects **with a token-specific verdict** — an `FcmError` detail
+   of `UNREGISTERED`, or a `BadRequest` naming `message.token`. Only those two deactivate the row.
+   An arbitrarily corrupted string is not a reliable fixture: FCM may answer with a bare
+   `INVALID_ARGUMENT` carrying neither, which by design leaves the row active. The dependable
+   version of this check is to register a real device, uninstall the app, and send again.
 
 Only a token-specific verdict from FCM deactivates a device. Credential, project, quota, outage
 and malformed-message rejections never count against a phone, however many times they occur.

--- a/packages/lib/src/notifications/__tests__/push-notifications-signing.test.ts
+++ b/packages/lib/src/notifications/__tests__/push-notifications-signing.test.ts
@@ -1,0 +1,124 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import * as realCrypto from 'crypto';
+
+// ---------------------------------------------------------------------------
+// Every test in push-notifications.test.ts mocks `crypto.createSign`, which
+// means none of them can tell whether the assertion we build is actually
+// signed correctly — only that *something* was passed to a fake signer. This
+// file deliberately does NOT mock crypto: it generates a real RSA keypair,
+// lets the real signing path run, and then verifies the resulting JWT with the
+// matching public key. If the PEM handling, the signing input, or the
+// base64url encoding were wrong, the signature would not verify.
+// ---------------------------------------------------------------------------
+
+vi.mock('@pagespace/db/db', () => ({
+  db: {
+    query: { pushNotificationTokens: { findFirst: vi.fn(), findMany: vi.fn() } },
+    insert: vi.fn(),
+    update: vi.fn(),
+  },
+}));
+vi.mock('@pagespace/db/schema/push-notifications', () => ({
+  pushNotificationTokens: { id: 'id', userId: 'userId', isActive: 'isActive' },
+}));
+vi.mock('@pagespace/db/operators', () => ({
+  eq: vi.fn(() => 'eq'),
+  and: vi.fn((...a) => ({ and: a })),
+}));
+vi.mock('@paralleldrive/cuid2', () => ({ createId: vi.fn(() => 'id'), init: vi.fn(() => vi.fn()) }));
+vi.mock('node:http2', () => {
+  const connect = vi.fn(() => { throw new Error('APNs not used in this file'); });
+  const constants = { NGHTTP2_CANCEL: 8 };
+  return { connect, constants, default: { connect, constants } };
+});
+
+import { sendPushNotification } from '../push-notifications';
+import { db } from '@pagespace/db/db';
+
+const { privateKey, publicKey } = realCrypto.generateKeyPairSync('rsa', {
+  modulusLength: 2048,
+  publicKeyEncoding: { type: 'spki', format: 'pem' },
+  privateKeyEncoding: { type: 'pkcs8', format: 'pem' },
+});
+
+function serviceAccount(pem: string) {
+  return JSON.stringify({
+    type: 'service_account',
+    project_id: 'real-crypto-project',
+    client_email: 'push@real-crypto-project.iam.gserviceaccount.com',
+    private_key: pem,
+    token_uri: 'https://oauth2.googleapis.com/token',
+  });
+}
+
+describe('FCM assertion signing (real crypto, no mock)', () => {
+  const originalFetch = globalThis.fetch;
+  let captured: string | null = null;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    captured = null;
+    const whereFn = vi.fn().mockResolvedValue(undefined);
+    vi.mocked(db.update).mockReturnValue({ set: vi.fn().mockReturnValue({ where: whereFn }) } as never);
+    vi.mocked(db.query.pushNotificationTokens.findMany).mockResolvedValue([
+      { id: 't1', userId: 'u1', token: 'fcm-token', platform: 'android', isActive: true, failedAttempts: '0' },
+    ] as never);
+    globalThis.fetch = vi.fn(async (url: string | URL, init: RequestInit = {}) => {
+      if (String(url).includes('oauth2.googleapis.com')) {
+        captured = new URLSearchParams(String(init.body)).get('assertion');
+        return { ok: true, status: 200, text: async () => JSON.stringify({ access_token: 'a', expires_in: 3600 }) };
+      }
+      return { ok: true, status: 200, text: async () => '{}' };
+    }) as unknown as typeof fetch;
+  });
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+    delete process.env.FCM_SERVICE_ACCOUNT_JSON;
+  });
+
+  // Verifies the signature cryptographically — the one thing a mocked signer
+  // can never tell us.
+  function expectVerifiableAssertion(assertion: string) {
+    const [headerB64, claimsB64, signatureB64] = assertion.split('.');
+    expect(signatureB64).toBeTruthy();
+
+    // Node's base64url decoder also accepts standard base64, so verification
+    // alone cannot tell the two apart — assert the alphabet explicitly rather
+    // than relying on the decode to reject `+`, `/` or padding.
+    expect(signatureB64).toMatch(/^[A-Za-z0-9_-]+$/);
+    expect(headerB64).toMatch(/^[A-Za-z0-9_-]+$/);
+    expect(claimsB64).toMatch(/^[A-Za-z0-9_-]+$/);
+
+    const verify = realCrypto.createVerify('RSA-SHA256');
+    verify.update(`${headerB64}.${claimsB64}`);
+    verify.end();
+    expect(verify.verify(publicKey, Buffer.from(signatureB64, 'base64url'))).toBe(true);
+
+    expect(JSON.parse(Buffer.from(headerB64, 'base64url').toString()))
+      .toEqual({ alg: 'RS256', typ: 'JWT' });
+  }
+
+  it('produces a signature that verifies against the matching public key', async () => {
+    process.env.FCM_SERVICE_ACCOUNT_JSON = serviceAccount(privateKey);
+
+    const result = await sendPushNotification('u1', { title: 'T', body: 'B' });
+
+    expect(result.sent).toBe(1);
+    expect(captured).toBeTruthy();
+    expectVerifiableAssertion(captured!);
+  });
+
+  // The same key as a secret store hands it back: real newlines replaced with
+  // the two characters backslash and n. The unescaping is what makes this work,
+  // and with a mocked signer it could be wrong without anything noticing.
+  it('still verifies when the PEM arrives with escaped newlines', async () => {
+    process.env.FCM_SERVICE_ACCOUNT_JSON = serviceAccount(privateKey.replace(/\n/g, '\\n'));
+
+    const result = await sendPushNotification('u1', { title: 'T', body: 'B' });
+
+    expect(result.sent).toBe(1);
+    expect(captured).toBeTruthy();
+    expectVerifiableAssertion(captured!);
+  });
+});

--- a/packages/lib/src/notifications/__tests__/push-notifications-signing.test.ts
+++ b/packages/lib/src/notifications/__tests__/push-notifications-signing.test.ts
@@ -41,11 +41,14 @@ const { privateKey, publicKey } = realCrypto.generateKeyPairSync('rsa', {
   privateKeyEncoding: { type: 'pkcs8', format: 'pem' },
 });
 
-function serviceAccount(pem: string) {
+// The access-token cache is keyed on the exact credential string, so tests that
+// must each mint their own token need distinct project ids — otherwise the
+// first one warms the cache and the next never reaches the token endpoint.
+function serviceAccount(pem: string, projectId = 'real-crypto-project') {
   return JSON.stringify({
     type: 'service_account',
-    project_id: 'real-crypto-project',
-    client_email: 'push@real-crypto-project.iam.gserviceaccount.com',
+    project_id: projectId,
+    client_email: `push@${projectId}.iam.gserviceaccount.com`,
     private_key: pem,
     token_uri: 'https://oauth2.googleapis.com/token',
   });
@@ -61,12 +64,12 @@ describe('FCM assertion signing (real crypto, no mock)', () => {
     const whereFn = vi.fn().mockResolvedValue(undefined);
     vi.mocked(db.update).mockReturnValue({ set: vi.fn().mockReturnValue({ where: whereFn }) } as never);
     vi.mocked(db.query.pushNotificationTokens.findMany).mockResolvedValue([
-      { id: 't1', userId: 'u1', token: 'fcm-token', platform: 'android', isActive: true, failedAttempts: '0' },
+      { id: 't1', userId: 'u1', token: 'fcm-token-DEVICESECRET', platform: 'android', isActive: true, failedAttempts: '0' },
     ] as never);
     globalThis.fetch = vi.fn(async (url: string | URL, init: RequestInit = {}) => {
       if (String(url).includes('oauth2.googleapis.com')) {
         captured = new URLSearchParams(String(init.body)).get('assertion');
-        return { ok: true, status: 200, text: async () => JSON.stringify({ access_token: 'a', expires_in: 3600 }) };
+        return { ok: true, status: 200, text: async () => JSON.stringify({ access_token: 'ya29.OUTERSECRET', expires_in: 3600 }) };
       }
       return { ok: true, status: 200, text: async () => '{}' };
     }) as unknown as typeof fetch;
@@ -98,6 +101,67 @@ describe('FCM assertion signing (real crypto, no mock)', () => {
     expect(JSON.parse(Buffer.from(headerB64, 'base64url').toString()))
       .toEqual({ alg: 'RS256', typ: 'JWT' });
   }
+
+  // The PR description claims no log call carries credential material. That was
+  // established by reading the code, which is exactly the kind of claim that
+  // stops being true without anyone noticing. Assert it against a real PEM, a
+  // real assertion and a real access token, across every path that logs.
+  it('never writes credential material to the console, on any path', async () => {
+    const raw = serviceAccount(privateKey, 'log-hygiene-project');
+    const captured: string[] = [];
+    const sink = (...args: unknown[]) => {
+      captured.push(args.map((a) => (typeof a === 'string' ? a : JSON.stringify(a))).join(' '));
+    };
+    const spies = [
+      vi.spyOn(console, 'log').mockImplementation(sink),
+      vi.spyOn(console, 'warn').mockImplementation(sink),
+      vi.spyOn(console, 'error').mockImplementation(sink),
+    ];
+
+    try {
+      // A success, an FCM rejection, a 401 that re-mints and retries, an OAuth
+      // refusal, and a transport throw — every branch that reaches a logger.
+      process.env.FCM_SERVICE_ACCOUNT_JSON = raw;
+      await sendPushNotification('u1', { title: 'T', body: 'B' });
+
+      let n = 0;
+      globalThis.fetch = vi.fn(async (url: string | URL, init: RequestInit = {}) => {
+        if (String(url).includes('oauth2.googleapis.com')) {
+          captured.push('');
+          return { ok: true, status: 200, text: async () => JSON.stringify({ access_token: 'ya29.SUPERSECRET', expires_in: 3600 }) };
+        }
+        n += 1;
+        if (n === 1) return { ok: false, status: 401, text: async () => '{"error":{"status":"UNAUTHENTICATED"}}' };
+        if (n === 2) return { ok: false, status: 503, text: async () => '{"error":{"status":"UNAVAILABLE"}}' };
+        throw new Error('socket closed');
+      }) as unknown as typeof fetch;
+      await sendPushNotification('u1', { title: 'T', body: 'B' });
+      await sendPushNotification('u1', { silent: true });
+
+      process.env.FCM_SERVICE_ACCOUNT_JSON = '{"project_id":"p"}';
+      await sendPushNotification('u1', { title: 'T', body: 'B' });
+
+      const all = captured.join('\n');
+      expect(all.length).toBeGreaterThan(0);
+
+      // The private key, in either newline form.
+      expect(all).not.toContain('PRIVATE KEY');
+      expect(all).not.toContain(privateKey.split('\n')[1]);
+      // The whole service account blob.
+      expect(all).not.toContain(raw);
+      // The minted bearer token.
+      expect(all).not.toContain('SUPERSECRET');
+      // And the signed assertion, which is a bearer credential in its own right.
+      expect(all).not.toMatch(/eyJhbGciOiJSUzI1NiI/);
+      // The access token actually in use on each path, not just the one minted
+      // last — a generic placeholder here would hide a leak of the other.
+      expect(all).not.toContain('OUTERSECRET');
+      // The registration token is bearer-ish too: only its prefix may appear.
+      expect(all).not.toContain('DEVICESECRET');
+    } finally {
+      spies.forEach((sp) => sp.mockRestore());
+    }
+  });
 
   it('produces a signature that verifies against the matching public key', async () => {
     process.env.FCM_SERVICE_ACCOUNT_JSON = serviceAccount(privateKey);

--- a/packages/lib/src/notifications/__tests__/push-notifications.test.ts
+++ b/packages/lib/src/notifications/__tests__/push-notifications.test.ts
@@ -1965,6 +1965,38 @@ describe('sendToFcm (Android)', () => {
     expect(setFn).toHaveBeenCalledWith(expect.objectContaining({ failedAttempts: '0' }));
   });
 
+  // The retry has to be classified from the RETRY's body, not the 401 that
+  // triggered it. Both existing retry tests repeat the same response, so a
+  // stale body would look identical to a fresh one — and a token that turns out
+  // to be dead on the second attempt would never be cleaned up.
+  it('classifies the retry from its own response, not the 401 that caused it', async () => {
+    process.env.FCM_SERVICE_ACCOUNT_JSON = serviceAccountJson({}, 'retry-reclassify-project');
+    vi.mocked(db.query.pushNotificationTokens.findMany).mockResolvedValue([androidToken()] as never);
+    const { setFn } = setupUpdateChain();
+    let attempt = 0;
+    installFetchStub({
+      send: () => {
+        attempt += 1;
+        return attempt === 1
+          ? fakeResponse(401, JSON.stringify({ error: { status: 'UNAUTHENTICATED', message: 'stale token' } }))
+          : fakeResponse(404, JSON.stringify({
+              error: {
+                message: 'Requested entity was not found.',
+                status: 'NOT_FOUND',
+                details: [{ '@type': FCM_ERROR_TYPE, errorCode: 'UNREGISTERED' }],
+              },
+            }));
+      },
+    });
+
+    const result = await sendPushNotification('user-1', payload);
+
+    expect(result.failed).toBe(1);
+    expect(result.errors[0]).toContain('UNREGISTERED');
+    expect(result.errors[0]).not.toContain('UNAUTHENTICATED');
+    expect(setFn).toHaveBeenCalledWith({ isActive: false });
+  });
+
   it('gives up after one retry when the fresh token is rejected too', async () => {
     process.env.FCM_SERVICE_ACCOUNT_JSON = serviceAccountJson({}, 'always-401-project');
     vi.mocked(db.query.pushNotificationTokens.findMany).mockResolvedValue([androidToken()] as never);

--- a/packages/lib/src/notifications/__tests__/push-notifications.test.ts
+++ b/packages/lib/src/notifications/__tests__/push-notifications.test.ts
@@ -912,7 +912,9 @@ function primeSign() {
   const rsaSign = {
     update: vi.fn().mockReturnThis(),
     end: vi.fn().mockReturnThis(),
-    sign: vi.fn().mockReturnValue(Buffer.from('fake-rsa-signature')),
+    // Bytes chosen so the plain base64 is `+/++7/8=` — it contains +, / and
+    // padding, so the base64url substitutions are actually observable.
+    sign: vi.fn().mockReturnValue(Buffer.from([0xfb, 0xff, 0xbe, 0xef, 0xff])),
   };
   const derSignature = Buffer.alloc(72, 0);
   derSignature[0] = 0x30; derSignature[1] = 70;
@@ -996,6 +998,49 @@ describe('sendToFcm (Android)', () => {
     expect(message.token).toBe('fcm-token-abc123');
     expect(message.notification).toEqual({ title: 'Hello', body: 'World' });
     expect((message.android as Record<string, unknown>).priority).toBe('high');
+  });
+
+  // Everything Google validates about the assertion before it will mint a token.
+  // The transport stub accepts any bytes, so without this the request could be
+  // malformed in six different ways and every test would still pass while every
+  // Android push failed in production with an opaque invalid_grant.
+  it('builds an assertion Google will actually accept', async () => {
+    const raw = serviceAccountJson({}, 'assertion-shape-project');
+    process.env.FCM_SERVICE_ACCOUNT_JSON = raw;
+    vi.mocked(db.query.pushNotificationTokens.findMany).mockResolvedValue([androidToken()] as never);
+    setupUpdateChain();
+    const { rsaSign } = primeSign();
+    const calls = installFetchStub();
+
+    await sendPushNotification('user-1', payload);
+
+    const oauth = calls.find((c) => c.url.includes('oauth2.googleapis.com'))!;
+    // The token endpoint is form-urlencoded; JSON is rejected.
+    expect((oauth.init.headers as Record<string, string>)['content-type'])
+      .toBe('application/x-www-form-urlencoded');
+
+    const assertion = new URLSearchParams(String(oauth.init.body)).get('assertion') ?? '';
+    const [headerB64, claimsB64, signatureB64] = assertion.split('.');
+
+    expect(JSON.parse(Buffer.from(headerB64, 'base64url').toString())).toEqual({
+      alg: 'RS256',
+      typ: 'JWT',
+    });
+
+    const claims = JSON.parse(Buffer.from(claimsB64, 'base64url').toString()) as Record<string, unknown>;
+    expect(claims.iss).toBe(`push@assertion-shape-project.iam.gserviceaccount.com`);
+    expect(claims.scope).toBe('https://www.googleapis.com/auth/firebase.messaging');
+    expect(claims.aud).toBe('https://oauth2.googleapis.com/token');
+    // Both are required by RFC 7523, and Google caps the lifetime at one hour.
+    expect(typeof claims.iat).toBe('number');
+    expect(claims.exp).toBe((claims.iat as number) + 3600);
+
+    // The signature has to be over exactly the header.claims that were sent —
+    // signing over anything else produces a token Google cannot verify.
+    expect(rsaSign.update).toHaveBeenCalledWith(`${headerB64}.${claimsB64}`);
+    expect(signatureB64.length).toBeGreaterThan(0);
+    // base64url alphabet only: no +, /, or = padding.
+    expect(signatureB64).toMatch(/^[A-Za-z0-9_-]+$/);
   });
 
   it('unescapes a literal backslash-n private key before signing', async () => {

--- a/packages/lib/src/notifications/__tests__/push-notifications.test.ts
+++ b/packages/lib/src/notifications/__tests__/push-notifications.test.ts
@@ -2136,6 +2136,69 @@ describe('sendToFcm (Android)', () => {
     expect(setFn).toHaveBeenCalledWith({ isActive: false });
   });
 
+  // Codex's fan-out race. Several sends are in the air carrying one cached
+  // token when it is revoked. The first 401 handled mints a replacement; the
+  // late 401s are from requests made with the OLD token and must not discard
+  // it. An unconditional eviction restarts the mint once per late response,
+  // recreating the per-recipient burst the single-flight was built to stop.
+  //
+  // The ordering has to be forced. Left to resolve naturally every 401 lands
+  // before the first re-mint finishes, the in-flight slot absorbs them all, and
+  // the bug is invisible — which is exactly how the first version of this test
+  // passed against the broken code. The late responses are therefore held until
+  // the replacement token is provably in the cache.
+  it('does not re-mint once per late 401 when a shared token is revoked', async () => {
+    process.env.FCM_SERVICE_ACCOUNT_JSON = serviceAccountJson({}, 'late-401-project');
+    vi.mocked(db.query.pushNotificationTokens.findMany).mockResolvedValue([androidToken()] as never);
+    setupUpdateChain();
+
+    let minted = 0;
+    let revoked: string | null = null;
+    let revokedHits = 0;
+    let releaseLate!: () => void;
+    const lateResponses = new Promise<void>((resolve) => { releaseLate = resolve; });
+
+    const calls = installFetchStub({
+      oauth: () => {
+        minted += 1;
+        return fakeResponse(200, JSON.stringify({ access_token: `ya29.t${minted}`, expires_in: 3600 }));
+      },
+      send: async (_message, call) => {
+        const bearer = (call.init.headers as Record<string, string>).authorization;
+        if (bearer === revoked) {
+          revokedHits += 1;
+          // Everything after the first rejection is a "late" response: hold it
+          // until a replacement token has demonstrably been cached.
+          if (revokedHits > 1) await lateResponses;
+          return fakeResponse(401, JSON.stringify({ error: { status: 'UNAUTHENTICATED', message: 'revoked' } }));
+        }
+        // A send on a token other than the revoked one proves the replacement
+        // is in the cache, so the held responses can be let go.
+        if (revoked !== null) releaseLate();
+        return fakeResponse(200, FCM_SEND_OK);
+      },
+    });
+
+    // Warm the cache so the wave below starts out sharing one token.
+    await sendPushNotification('user-0', payload);
+    expect(minted).toBe(1);
+    revoked = 'Bearer ya29.t1';
+
+    const results = await Promise.all([
+      sendPushNotification('user-1', payload),
+      sendPushNotification('user-2', payload),
+      sendPushNotification('user-3', payload),
+    ]);
+
+    expect(results.every((r) => r.sent === 1)).toBe(true);
+    // One replacement for the whole wave. Unconditional eviction makes this 4:
+    // each late 401 throws away the token the previous one just minted.
+    expect(minted).toBe(2);
+    expect(calls.filter((c) => c.url.includes('oauth2.googleapis.com'))).toHaveLength(2);
+    // One warm-up send, three first attempts, three retries.
+    expect(calls.filter((c) => c.url.includes('fcm.googleapis.com'))).toHaveLength(7);
+  });
+
   it('gives up after one retry when the fresh token is rejected too', async () => {
     process.env.FCM_SERVICE_ACCOUNT_JSON = serviceAccountJson({}, 'always-401-project');
     vi.mocked(db.query.pushNotificationTokens.findMany).mockResolvedValue([androidToken()] as never);

--- a/packages/lib/src/notifications/__tests__/push-notifications.test.ts
+++ b/packages/lib/src/notifications/__tests__/push-notifications.test.ts
@@ -861,6 +861,7 @@ function serviceAccountJson(overrides: Record<string, unknown> = {}, projectId?:
   return JSON.stringify(account);
 }
 
+const FCM_ERROR_TYPE = 'type.googleapis.com/google.firebase.fcm.v1.FcmError';
 const OAUTH_OK = JSON.stringify({ access_token: 'ya29.fake-access-token', expires_in: 3600 });
 const FCM_SEND_OK = JSON.stringify({ name: 'projects/p/messages/0:1234' });
 
@@ -1067,9 +1068,7 @@ describe('sendToFcm (Android)', () => {
               code: 404,
               message: 'Requested entity was not found.',
               status: 'NOT_FOUND',
-              details: [
-                { '@type': 'type.googleapis.com/google.firebase.fcm.v1.FcmError', errorCode: 'UNREGISTERED' },
-              ],
+              details: [{ '@type': FCM_ERROR_TYPE, errorCode: 'UNREGISTERED' }],
             },
           })
         ),
@@ -1083,21 +1082,19 @@ describe('sendToFcm (Android)', () => {
     expect(setFn).toHaveBeenCalledWith({ isActive: false });
   });
 
-  it('deactivates the token when FCM reports INVALID_ARGUMENT', async () => {
+  it('deactivates the token when an FcmError detail reports INVALID_ARGUMENT', async () => {
     process.env.FCM_SERVICE_ACCOUNT_JSON = serviceAccountJson();
     vi.mocked(db.query.pushNotificationTokens.findMany).mockResolvedValue([androidToken()] as never);
     const { setFn } = setupUpdateChain();
     installFetchStub({
       send: () =>
-        fakeResponse(
-          400,
-          JSON.stringify({
-            error: {
-              message: 'The registration token is not a valid FCM registration token',
-              status: 'INVALID_ARGUMENT',
-            },
-          })
-        ),
+        fakeResponse(400, JSON.stringify({
+          error: {
+            message: 'The registration token is not a valid FCM registration token',
+            status: 'INVALID_ARGUMENT',
+            details: [{ '@type': FCM_ERROR_TYPE, errorCode: 'INVALID_ARGUMENT' }],
+          },
+        })),
     });
 
     const result = await sendPushNotification('user-1', payload);
@@ -1105,6 +1102,97 @@ describe('sendToFcm (Android)', () => {
     expect(result.failed).toBe(1);
     expect(result.errors[0]).toContain('INVALID_ARGUMENT');
     expect(setFn).toHaveBeenCalledWith({ isActive: false });
+  });
+
+  it('deactivates the token when an FcmError detail reports SENDER_ID_MISMATCH', async () => {
+    process.env.FCM_SERVICE_ACCOUNT_JSON = serviceAccountJson();
+    vi.mocked(db.query.pushNotificationTokens.findMany).mockResolvedValue([androidToken()] as never);
+    const { setFn } = setupUpdateChain();
+    installFetchStub({
+      send: () =>
+        fakeResponse(403, JSON.stringify({
+          error: {
+            message: 'SenderId mismatch',
+            status: 'PERMISSION_DENIED',
+            details: [{ '@type': FCM_ERROR_TYPE, errorCode: 'SENDER_ID_MISMATCH' }],
+          },
+        })),
+    });
+
+    await sendPushNotification('user-1', payload);
+
+    expect(setFn).toHaveBeenCalledWith({ isActive: false });
+  });
+
+  // The dangerous case: a malformed *message* is also a 400 INVALID_ARGUMENT, but
+  // with no FcmError detail. Deactivating on that would take out every Android
+  // token on the platform the moment the payload builder regressed.
+  it('keeps the token when INVALID_ARGUMENT arrives without an FcmError detail', async () => {
+    process.env.FCM_SERVICE_ACCOUNT_JSON = serviceAccountJson();
+    vi.mocked(db.query.pushNotificationTokens.findMany).mockResolvedValue([androidToken()] as never);
+    const { setFn } = setupUpdateChain();
+    installFetchStub({
+      send: () =>
+        fakeResponse(400, JSON.stringify({
+          error: {
+            message: 'Invalid JSON payload received. Unknown name "nope".',
+            status: 'INVALID_ARGUMENT',
+            details: [{
+              '@type': 'type.googleapis.com/google.rpc.BadRequest',
+              fieldViolations: [{ field: 'message.nope', description: 'Cannot find field.' }],
+            }],
+          },
+        })),
+    });
+
+    const result = await sendPushNotification('user-1', payload);
+
+    expect(result.failed).toBe(1);
+    expect(result.errors[0]).toContain('INVALID_ARGUMENT');
+    expect(setFn).not.toHaveBeenCalledWith({ isActive: false });
+    expect(setFn).toHaveBeenCalledWith(
+      expect.objectContaining({ failedAttempts: '1', isActive: true })
+    );
+  });
+
+  // Likewise a wrong project id is a bare NOT_FOUND, and says nothing about the token.
+  it('keeps the token when NOT_FOUND arrives without an FcmError detail', async () => {
+    process.env.FCM_SERVICE_ACCOUNT_JSON = serviceAccountJson();
+    vi.mocked(db.query.pushNotificationTokens.findMany).mockResolvedValue([androidToken()] as never);
+    const { setFn } = setupUpdateChain();
+    installFetchStub({
+      send: () =>
+        fakeResponse(404, JSON.stringify({
+          error: { message: 'Requested entity was not found.', status: 'NOT_FOUND' },
+        })),
+    });
+
+    const result = await sendPushNotification('user-1', payload);
+
+    expect(result.errors[0]).toContain('NOT_FOUND');
+    expect(setFn).not.toHaveBeenCalledWith({ isActive: false });
+  });
+
+  it('ignores an errorCode carried by a detail that is not an FcmError', async () => {
+    process.env.FCM_SERVICE_ACCOUNT_JSON = serviceAccountJson();
+    vi.mocked(db.query.pushNotificationTokens.findMany).mockResolvedValue([androidToken()] as never);
+    const { setFn } = setupUpdateChain();
+    installFetchStub({
+      send: () =>
+        fakeResponse(400, JSON.stringify({
+          error: {
+            message: 'nope',
+            status: 'INVALID_ARGUMENT',
+            details: [{ '@type': 'type.googleapis.com/google.rpc.Help', errorCode: 'UNREGISTERED' }],
+          },
+        })),
+    });
+
+    const result = await sendPushNotification('user-1', payload);
+
+    // Falls back to the coarse status, and does not cost the device its registration.
+    expect(result.errors[0]).toContain('INVALID_ARGUMENT');
+    expect(setFn).not.toHaveBeenCalledWith({ isActive: false });
   });
 
   it('keeps the token when FCM rejects with a retryable code', async () => {
@@ -1252,6 +1340,106 @@ describe('sendToFcm (Android)', () => {
 
     expect(first.failed).toBe(1);
     expect(second.sent).toBe(1);
+    expect(calls.filter((c) => c.url.includes('oauth2.googleapis.com'))).toHaveLength(2);
+  });
+
+  it('mints once for sends that race on a cold cache', async () => {
+    // The real fan-out: broadcastTosPrivacyUpdate creates a notification for every
+    // user through Promise.all, so N Android recipients hit a cold cache together.
+    process.env.FCM_SERVICE_ACCOUNT_JSON = serviceAccountJson({}, 'single-flight-project');
+    vi.mocked(db.query.pushNotificationTokens.findMany).mockResolvedValue([androidToken()] as never);
+    setupUpdateChain();
+
+    let releaseOauth: (() => void) | undefined;
+    const oauthGate = new Promise<void>((resolve) => { releaseOauth = resolve; });
+    const calls = installFetchStub({
+      oauth: () => fakeResponse(200, OAUTH_OK),
+    });
+    // Hold the OAuth leg open so all three sends are provably in flight together.
+    const stub = globalThis.fetch as unknown as ReturnType<typeof vi.fn>;
+    const passthrough = stub.getMockImplementation()!;
+    stub.mockImplementation(async (url: string | URL, init: RequestInit = {}) => {
+      if (String(url).includes('oauth2.googleapis.com')) await oauthGate;
+      return passthrough(url, init);
+    });
+
+    const inFlight = Promise.all([
+      sendPushNotification('user-1', payload),
+      sendPushNotification('user-2', payload),
+      sendPushNotification('user-3', payload),
+    ]);
+    await Promise.resolve();
+    releaseOauth!();
+    const results = await inFlight;
+
+    expect(results.every((r) => r.sent === 1)).toBe(true);
+    expect(calls.filter((c) => c.url.includes('oauth2.googleapis.com'))).toHaveLength(1);
+    expect(calls.filter((c) => c.url.includes('fcm.googleapis.com'))).toHaveLength(3);
+  });
+
+  it('does not hand a racing waiter a token minted for a different credential', async () => {
+    vi.mocked(db.query.pushNotificationTokens.findMany).mockResolvedValue([androidToken()] as never);
+    setupUpdateChain();
+    const calls = installFetchStub();
+
+    // The credential has to rotate while the first mint is genuinely in the air —
+    // both sends read process.env only after their first await, so flipping it
+    // before either resumes would just show both of them the second credential.
+    let releaseFirstMint: (() => void) | undefined;
+    const firstMintGate = new Promise<void>((resolve) => { releaseFirstMint = resolve; });
+    let oauthSeen = 0;
+    const stub = globalThis.fetch as unknown as ReturnType<typeof vi.fn>;
+    const passthrough = stub.getMockImplementation()!;
+    stub.mockImplementation(async (url: string | URL, init: RequestInit = {}) => {
+      if (String(url).includes('oauth2.googleapis.com')) {
+        oauthSeen += 1;
+        if (oauthSeen === 1) await firstMintGate;
+      }
+      return passthrough(url, init);
+    });
+
+    process.env.FCM_SERVICE_ACCOUNT_JSON = serviceAccountJson({}, 'race-rotate-a');
+    const first = sendPushNotification('user-1', payload);
+    await vi.waitFor(() => expect(oauthSeen).toBe(1));
+
+    process.env.FCM_SERVICE_ACCOUNT_JSON = serviceAccountJson({}, 'race-rotate-b');
+    const second = sendPushNotification('user-2', payload);
+    // The second send must open its own mint rather than join the pending one.
+    await vi.waitFor(() => expect(oauthSeen).toBe(2));
+
+    releaseFirstMint!();
+    await Promise.all([first, second]);
+
+    expect(calls.filter((c) => c.url.includes('oauth2.googleapis.com'))).toHaveLength(2);
+    const sendUrls = calls.filter((c) => c.url.includes('fcm.googleapis.com')).map((c) => c.url);
+    expect(sendUrls.some((u) => u.includes('/projects/race-rotate-a/'))).toBe(true);
+    expect(sendUrls.some((u) => u.includes('/projects/race-rotate-b/'))).toBe(true);
+  });
+
+  it('lets a later send retry after an in-flight mint fails', async () => {
+    process.env.FCM_SERVICE_ACCOUNT_JSON = serviceAccountJson({}, 'inflight-fail-project');
+    vi.mocked(db.query.pushNotificationTokens.findMany).mockResolvedValue([androidToken()] as never);
+    setupUpdateChain();
+    let attempt = 0;
+    const calls = installFetchStub({
+      oauth: () => {
+        attempt += 1;
+        return attempt === 1 ? fakeResponse(500, 'upstream boom') : fakeResponse(200, OAUTH_OK);
+      },
+    });
+
+    // Both race on the same failing mint, then a third send must not be stuck
+    // waiting on the dead in-flight promise.
+    const [a, b] = await Promise.all([
+      sendPushNotification('user-1', payload),
+      sendPushNotification('user-2', payload),
+    ]);
+    expect(a.failed).toBe(1);
+    expect(b.failed).toBe(1);
+    expect(calls.filter((c) => c.url.includes('oauth2.googleapis.com'))).toHaveLength(1);
+
+    const c = await sendPushNotification('user-3', payload);
+    expect(c.sent).toBe(1);
     expect(calls.filter((c) => c.url.includes('oauth2.googleapis.com'))).toHaveLength(2);
   });
 

--- a/packages/lib/src/notifications/__tests__/push-notifications.test.ts
+++ b/packages/lib/src/notifications/__tests__/push-notifications.test.ts
@@ -1290,6 +1290,48 @@ describe('sendToFcm (Android)', () => {
     expect(result.errors[0]).not.toContain('client_email');
   });
 
+  it('rejects a project_id that could rewrite the send URL', async () => {
+    process.env.FCM_SERVICE_ACCOUNT_JSON = serviceAccountJson({}, '../../evil');
+    vi.mocked(db.query.pushNotificationTokens.findMany).mockResolvedValue([androidToken()] as never);
+    const { setFn } = setupUpdateChain();
+    const calls = installFetchStub();
+
+    const result = await sendPushNotification('user-1', payload);
+
+    expect(result.failed).toBe(1);
+    expect(result.errors[0]).toContain('project_id may only contain');
+    // Nothing was put on the wire, and no device lost its registration.
+    expect(calls).toHaveLength(0);
+    expect(setFn).not.toHaveBeenCalledWith({ isActive: false });
+  });
+
+  it('accepts an ordinary hyphenated Firebase project id', async () => {
+    process.env.FCM_SERVICE_ACCOUNT_JSON = serviceAccountJson({}, 'pagespace-prod-1234');
+    vi.mocked(db.query.pushNotificationTokens.findMany).mockResolvedValue([androidToken()] as never);
+    setupUpdateChain();
+    const calls = installFetchStub();
+
+    const result = await sendPushNotification('user-1', payload);
+
+    expect(result.sent).toBe(1);
+    expect(sentMessage(calls)).toBeTruthy();
+    expect(calls.some((c) => c.url.includes('/projects/pagespace-prod-1234/'))).toBe(true);
+  });
+
+  it('refuses to send the signed assertion to a non-https token_uri', async () => {
+    process.env.FCM_SERVICE_ACCOUNT_JSON = serviceAccountJson({
+      token_uri: 'http://oauth2.googleapis.com/token',
+    });
+    vi.mocked(db.query.pushNotificationTokens.findMany).mockResolvedValue([androidToken()] as never);
+    setupUpdateChain();
+    const calls = installFetchStub();
+
+    const result = await sendPushNotification('user-1', payload);
+
+    expect(result.errors[0]).toContain('token_uri must be an https:// URL');
+    expect(calls).toHaveLength(0);
+  });
+
   it('reuses a recently minted access token instead of re-minting per send', async () => {
     const raw = serviceAccountJson({}, 'shared-cache-project');
     process.env.FCM_SERVICE_ACCOUNT_JSON = raw;

--- a/packages/lib/src/notifications/__tests__/push-notifications.test.ts
+++ b/packages/lib/src/notifications/__tests__/push-notifications.test.ts
@@ -131,6 +131,7 @@ import {
   getUserPushTokens,
 } from '../push-notifications';
 import { db } from '@pagespace/db/db';
+import { eq } from '@pagespace/db/operators';
 import * as crypto from 'crypto';
 
 // ---------------------------------------------------------------------------
@@ -144,6 +145,31 @@ function setupUpdateChain() {
   return { setFn, whereFn };
 }
 
+
+// setupUpdateChain only records what was `set`. This variant also records the
+// `where` that followed each `set`, and makes the mocked `eq` report its own
+// arguments, so a test can assert which row an update actually targeted.
+function setupCapturingUpdateChain() {
+  const updates: Array<{ set: unknown; where: unknown }> = [];
+  const setFn = vi.fn();
+  vi.mocked(eq).mockImplementation(
+    (column: unknown, value: unknown) => ({ column, value }) as never
+  );
+  vi.mocked(db.update).mockImplementation((() => ({
+    set: (arg: unknown) => {
+      setFn(arg);
+      const entry: { set: unknown; where: unknown } = { set: arg, where: undefined };
+      updates.push(entry);
+      return {
+        where: (w: unknown) => {
+          entry.where = w;
+          return Promise.resolve(undefined);
+        },
+      };
+    },
+  })) as unknown as typeof db.update);
+  return { setFn, updates };
+}
 
 function setupInsertChain() {
   const valuesFn = vi.fn().mockResolvedValue(undefined);
@@ -1223,6 +1249,67 @@ describe('sendToFcm (Android)', () => {
   // token-scoped — but it is a project-level fact. A staging service account
   // pasted into prod makes every send 403 with it, and acting on it would
   // unregister every Android device in the database on the first dispatch.
+  // Per-device independence. A user with a phone and a tablet who uninstalls the
+  // tablet must not lose the phone: one dead token in a dispatch may not abort
+  // the loop, and may not take a healthy sibling down with it.
+  it('deactivates only the dead token when a user has two Android devices', async () => {
+    process.env.FCM_SERVICE_ACCOUNT_JSON = serviceAccountJson({}, 'two-devices-project');
+    vi.mocked(db.query.pushNotificationTokens.findMany).mockResolvedValue([
+      androidToken({ id: 'android-dead', token: 'fcm-dead' }),
+      androidToken({ id: 'android-live', token: 'fcm-live' }),
+    ] as never);
+    const { setFn, updates } = setupCapturingUpdateChain();
+    const calls = installFetchStub({
+      send: (message) =>
+        message.token === 'fcm-dead'
+          ? fakeResponse(404, JSON.stringify({
+              error: {
+                message: 'Requested entity was not found.',
+                status: 'NOT_FOUND',
+                details: [{ '@type': FCM_ERROR_TYPE, errorCode: 'UNREGISTERED' }],
+              },
+            }))
+          : fakeResponse(200, FCM_SEND_OK),
+    });
+
+    const result = await sendPushNotification('user-1', payload);
+
+    expect(result.sent).toBe(1);
+    expect(result.failed).toBe(1);
+
+    // Both devices were attempted — the dead one did not abort the dispatch.
+    const sendUrls = calls.filter((c) => c.url.includes('fcm.googleapis.com'));
+    expect(sendUrls).toHaveLength(2);
+    expect(sendUrls.map((c) => (JSON.parse(String(c.init.body)) as { message: { token: string } }).message.token))
+      .toEqual(['fcm-dead', 'fcm-live']);
+
+    // Exactly one row deactivated, and the surviving device got the success
+    // reset rather than a strike.
+    const deactivations = setFn.mock.calls.filter(
+      ([arg]) => JSON.stringify(arg) === JSON.stringify({ isActive: false })
+    );
+    expect(deactivations).toHaveLength(1);
+    expect(setFn).toHaveBeenCalledWith(
+      expect.objectContaining({ failedAttempts: '0', lastFailedAt: null })
+    );
+
+    // WHICH row was deactivated, not merely that one was. The shared `eq` mock
+    // collapses every filter to the same value, so without pairing each `set`
+    // with the `where` that followed it, aiming the update at the wrong row —
+    // or at every row — would look identical to correct behaviour.
+    const deactivated = updates.find(
+      (u) => JSON.stringify(u.set) === JSON.stringify({ isActive: false })
+    );
+    expect(deactivated?.where).toEqual({ column: 'id', value: 'android-dead' });
+    const reset = updates.find(
+      (u) => (u.set as { failedAttempts?: string }).failedAttempts === '0'
+    );
+    expect(reset?.where).toEqual({ column: 'id', value: 'android-live' });
+
+    // And one mint served both sends.
+    expect(calls.filter((c) => c.url.includes('oauth2.googleapis.com'))).toHaveLength(1);
+  });
+
   it('keeps the token when SENDER_ID_MISMATCH names a project-level mismatch', async () => {
     process.env.FCM_SERVICE_ACCOUNT_JSON = serviceAccountJson();
     vi.mocked(db.query.pushNotificationTokens.findMany).mockResolvedValue([androidToken()] as never);

--- a/packages/lib/src/notifications/__tests__/push-notifications.test.ts
+++ b/packages/lib/src/notifications/__tests__/push-notifications.test.ts
@@ -347,12 +347,16 @@ describe('getUserPushTokens', () => {
 // sendPushNotification
 // ---------------------------------------------------------------------------
 describe('sendPushNotification', () => {
+  const describeOriginalFetch = globalThis.fetch;
+
   beforeEach(() => {
     vi.clearAllMocks();
     resetH2();
   });
 
   afterEach(() => {
+    globalThis.fetch = describeOriginalFetch;
+    delete process.env.FCM_SERVICE_ACCOUNT_JSON;
     delete process.env.APNS_TEAM_ID;
     delete process.env.APNS_KEY_ID;
     delete process.env.APNS_PRIVATE_KEY;
@@ -407,11 +411,16 @@ describe('sendPushNotification', () => {
   });
 
   it('deactivates token after 5 consecutive failures', async () => {
-    // `web` is used here only as a platform whose stub returns a plain per-token
-    // failure. `android` no longer serves: an unset credential is now reported
-    // as a server fault, which deliberately does not count against the device.
-    vi.mocked(db.query.pushNotificationTokens.findMany).mockResolvedValue([tokenRecord({ platform: 'web', failedAttempts: '4' })] as never);
+    // Driven by a real per-token FCM rejection (503 UNAVAILABLE): retryable, so
+    // it takes a strike rather than deactivating outright. An unset credential
+    // would NOT serve here — that is a server fault and deliberately exempt.
+    process.env.FCM_SERVICE_ACCOUNT_JSON = serviceAccountJson({}, 'strike-count-project');
+    primeSign();
+    vi.mocked(db.query.pushNotificationTokens.findMany).mockResolvedValue([tokenRecord({ platform: 'android', failedAttempts: '4' })] as never);
     const { setFn } = setupUpdateChain();
+    installFetchStub({
+      send: () => fakeResponse(503, JSON.stringify({ error: { status: 'UNAVAILABLE', message: 'busy' } })),
+    });
 
     await sendPushNotification('user-1', payload);
 
@@ -422,8 +431,13 @@ describe('sendPushNotification', () => {
   });
 
   it('keeps token active with fewer than 5 failures', async () => {
-    vi.mocked(db.query.pushNotificationTokens.findMany).mockResolvedValue([tokenRecord({ platform: 'web', failedAttempts: '2' })] as never);
+    process.env.FCM_SERVICE_ACCOUNT_JSON = serviceAccountJson({}, 'strike-keep-project');
+    primeSign();
+    vi.mocked(db.query.pushNotificationTokens.findMany).mockResolvedValue([tokenRecord({ platform: 'android', failedAttempts: '2' })] as never);
     const { setFn } = setupUpdateChain();
+    installFetchStub({
+      send: () => fakeResponse(503, JSON.stringify({ error: { status: 'UNAVAILABLE', message: 'busy' } })),
+    });
 
     await sendPushNotification('user-1', payload);
 

--- a/packages/lib/src/notifications/__tests__/push-notifications.test.ts
+++ b/packages/lib/src/notifications/__tests__/push-notifications.test.ts
@@ -1237,6 +1237,63 @@ describe('sendToFcm (Android)', () => {
     expect(data.notificationId).toBe('n1');
   });
 
+  // The previous round's mistake was proving a scenario rather than the
+  // mechanism: SENDER_ID_MISMATCH was shown not to deactivate on the spot, and
+  // nobody asked what the fifth one did. This asserts the invariant across the
+  // whole space of rejections instead of one at a time — no FCM rejection that
+  // is not a verdict about the token may ever put a strike on the row, because
+  // five strikes is a deactivation by another route.
+  const NOT_ABOUT_THE_DEVICE: Array<[string, number, string]> = [
+    ['malformed message (BadRequest, other field)', 400, JSON.stringify({ error: { status: 'INVALID_ARGUMENT', message: 'bad', details: [{ '@type': BAD_REQUEST_TYPE, fieldViolations: [{ field: 'message.data' }] }] } })],
+    ['message-level FcmError INVALID_ARGUMENT', 400, JSON.stringify({ error: { status: 'INVALID_ARGUMENT', message: 'too big', details: [{ '@type': FCM_ERROR_TYPE, errorCode: 'INVALID_ARGUMENT' }] } })],
+    ['revoked credential', 401, JSON.stringify({ error: { status: 'UNAUTHENTICATED', message: 'bad creds' } })],
+    ['wrong-project sender id', 403, JSON.stringify({ error: { status: 'PERMISSION_DENIED', message: 'mismatch', details: [{ '@type': FCM_ERROR_TYPE, errorCode: 'SENDER_ID_MISMATCH' }] } })],
+    ['wrong project id', 404, JSON.stringify({ error: { status: 'NOT_FOUND', message: 'not found' } })],
+    ['quota', 429, JSON.stringify({ error: { status: 'RESOURCE_EXHAUSTED', message: 'quota' } })],
+    ['fcm internal error', 500, JSON.stringify({ error: { status: 'INTERNAL', message: 'boom' } })],
+    ['fcm unavailable', 503, JSON.stringify({ error: { status: 'UNAVAILABLE', message: 'busy' } })],
+    ['non-JSON body', 502, '<html>bad gateway</html>'],
+    ['empty body', 500, ''],
+  ];
+
+  it.each(NOT_ABOUT_THE_DEVICE)(
+    'never strikes the token for %s',
+    async (_label, status, body) => {
+      process.env.FCM_SERVICE_ACCOUNT_JSON = serviceAccountJson();
+      vi.mocked(db.query.pushNotificationTokens.findMany).mockResolvedValue([
+        androidToken({ failedAttempts: '4' }),
+      ] as never);
+      const { setFn } = setupUpdateChain();
+      installFetchStub({ send: () => fakeResponse(status, body) });
+
+      const result = await sendPushNotification('user-1', payload);
+
+      expect(result.failed).toBe(1);
+      // The row is not touched at all: no strike to accumulate, and no
+      // deactivation now or on any later notification.
+      expect(setFn).not.toHaveBeenCalled();
+    }
+  );
+
+  // The other half of the invariant: the two verdicts that ARE about the token
+  // still deactivate immediately, so nothing is lost by refusing to count.
+  const ABOUT_THE_DEVICE: Array<[string, number, string]> = [
+    ['UNREGISTERED detail', 404, JSON.stringify({ error: { status: 'NOT_FOUND', message: 'gone', details: [{ '@type': FCM_ERROR_TYPE, errorCode: 'UNREGISTERED' }] } })],
+    ['BadRequest naming message.token', 400, JSON.stringify({ error: { status: 'INVALID_ARGUMENT', message: 'bad token', details: [{ '@type': BAD_REQUEST_TYPE, fieldViolations: [{ field: 'message.token' }] }] } })],
+  ];
+
+  it.each(ABOUT_THE_DEVICE)('deactivates on the spot for %s', async (_label, status, body) => {
+    process.env.FCM_SERVICE_ACCOUNT_JSON = serviceAccountJson();
+    vi.mocked(db.query.pushNotificationTokens.findMany).mockResolvedValue([androidToken()] as never);
+    const { setFn } = setupUpdateChain();
+    installFetchStub({ send: () => fakeResponse(status, body) });
+
+    const result = await sendPushNotification('user-1', payload);
+
+    expect(result.failed).toBe(1);
+    expect(setFn).toHaveBeenCalledWith({ isActive: false });
+  });
+
   it('deactivates the token when FCM reports UNREGISTERED', async () => {
     process.env.FCM_SERVICE_ACCOUNT_JSON = serviceAccountJson();
     vi.mocked(db.query.pushNotificationTokens.findMany).mockResolvedValue([androidToken()] as never);

--- a/packages/lib/src/notifications/__tests__/push-notifications.test.ts
+++ b/packages/lib/src/notifications/__tests__/push-notifications.test.ts
@@ -366,15 +366,6 @@ describe('sendPushNotification', () => {
     expect(result).toEqual({ sent: 0, failed: 0, errors: [] });
   });
 
-  it('handles android platform (not yet implemented)', async () => {
-    vi.mocked(db.query.pushNotificationTokens.findMany).mockResolvedValue([tokenRecord({ platform: 'android' })] as never);
-    setupUpdateChain();
-
-    const result = await sendPushNotification('user-1', payload);
-    expect(result.failed).toBe(1);
-    expect(result.errors).toContain('Android push not yet implemented');
-  });
-
   it('handles web platform (not yet implemented)', async () => {
     vi.mocked(db.query.pushNotificationTokens.findMany).mockResolvedValue([tokenRecord({ platform: 'web' })] as never);
     setupUpdateChain();
@@ -821,5 +812,509 @@ describe('silent push payload', () => {
 
     expect(h2.connectedHosts).toContain('https://api.push.apple.com');
     expect(h2.connectedHosts.some((host) => host.includes('sandbox'))).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// FCM (Android) sender
+//
+// The FCM path is plain HTTPS (unlike APNs' HTTP/2), so these tests stub
+// globalThis.fetch and route by URL: the OAuth2 token endpoint vs the
+// messages:send endpoint. The module-level access-token cache is pinned to the
+// exact credential string it was minted from, so each test that wants a cold
+// cache simply uses a fresh service-account JSON.
+// ---------------------------------------------------------------------------
+
+interface FakeResponse {
+  ok: boolean;
+  status: number;
+  text: () => Promise<string>;
+}
+
+function fakeResponse(status: number, body: string): FakeResponse {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    text: async () => body,
+  };
+}
+
+let serviceAccountCounter = 0;
+
+// A distinct project id per call gives a distinct credential string, which busts
+// the module-level token cache — pass a fixed id to deliberately share it.
+function serviceAccountJson(overrides: Record<string, unknown> = {}, projectId?: string) {
+  serviceAccountCounter += 1;
+  const pid = projectId ?? `pagespace-test-${serviceAccountCounter}`;
+  const account: Record<string, unknown> = {
+    type: 'service_account',
+    project_id: pid,
+    client_email: `push@${pid}.iam.gserviceaccount.com`,
+    // Literal backslash-n, the way secret stores hand PEMs back.
+    private_key: '-----BEGIN PRIVATE KEY-----\\nFAKEFCMKEY\\n-----END PRIVATE KEY-----\\n',
+    token_uri: 'https://oauth2.googleapis.com/token',
+    ...overrides,
+  };
+  for (const [key, value] of Object.entries(overrides)) {
+    if (value === undefined) delete account[key];
+  }
+  return JSON.stringify(account);
+}
+
+const OAUTH_OK = JSON.stringify({ access_token: 'ya29.fake-access-token', expires_in: 3600 });
+const FCM_SEND_OK = JSON.stringify({ name: 'projects/p/messages/0:1234' });
+
+interface FetchCall {
+  url: string;
+  init: RequestInit;
+}
+
+function installFetchStub(handlers: {
+  oauth?: (call: FetchCall) => FakeResponse;
+  send?: (message: Record<string, unknown>, call: FetchCall) => FakeResponse;
+} = {}) {
+  const calls: FetchCall[] = [];
+  const stub = vi.fn(async (url: string | URL, init: RequestInit = {}) => {
+    const call: FetchCall = { url: String(url), init };
+    calls.push(call);
+    if (call.url.includes('oauth2.googleapis.com')) {
+      return (handlers.oauth ?? (() => fakeResponse(200, OAUTH_OK)))(call);
+    }
+    const parsed = JSON.parse(String(init.body)) as { message: Record<string, unknown> };
+    return (handlers.send ?? (() => fakeResponse(200, FCM_SEND_OK)))(parsed.message, call);
+  });
+  globalThis.fetch = stub as unknown as typeof fetch;
+  return calls;
+}
+
+// crypto.createSign is mocked module-wide; dispatch on the algorithm so a test
+// that sends to both platforms gets a usable signer for each.
+function primeSign() {
+  const rsaSign = {
+    update: vi.fn().mockReturnThis(),
+    end: vi.fn().mockReturnThis(),
+    sign: vi.fn().mockReturnValue(Buffer.from('fake-rsa-signature')),
+  };
+  const derSignature = Buffer.alloc(72, 0);
+  derSignature[0] = 0x30; derSignature[1] = 70;
+  derSignature[2] = 0x02; derSignature[3] = 32;
+  derSignature[36] = 0x02; derSignature[37] = 32;
+  const ecdsaSign = {
+    update: vi.fn().mockReturnThis(),
+    end: vi.fn().mockReturnThis(),
+    sign: vi.fn().mockReturnValue(derSignature),
+  };
+  vi.mocked(crypto.createSign).mockImplementation((algorithm: string) =>
+    (algorithm === 'RSA-SHA256' ? rsaSign : ecdsaSign) as unknown as ReturnType<typeof crypto.createSign>
+  );
+  return { rsaSign, ecdsaSign };
+}
+
+function androidToken(overrides: Record<string, unknown> = {}) {
+  return tokenRecord({ platform: 'android', token: 'fcm-token-abc123', ...overrides });
+}
+
+function sentMessage(calls: FetchCall[]): Record<string, unknown> {
+  const send = calls.find((c) => c.url.includes('fcm.googleapis.com'));
+  if (!send) throw new Error('no messages:send call was made');
+  return (JSON.parse(String(send.init.body)) as { message: Record<string, unknown> }).message;
+}
+
+describe('sendToFcm (Android)', () => {
+  const originalFetch = globalThis.fetch;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    resetH2();
+    primeSign();
+  });
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+    delete process.env.FCM_SERVICE_ACCOUNT_JSON;
+    delete process.env.APNS_TEAM_ID;
+    delete process.env.APNS_KEY_ID;
+    delete process.env.APNS_PRIVATE_KEY;
+  });
+
+  it('sends via FCM HTTP v1 with an OAuth2 bearer token minted from the service account', async () => {
+    const raw = serviceAccountJson();
+    const projectId = (JSON.parse(raw) as { project_id: string }).project_id;
+    process.env.FCM_SERVICE_ACCOUNT_JSON = raw;
+    vi.mocked(db.query.pushNotificationTokens.findMany).mockResolvedValue([androidToken()] as never);
+    setupUpdateChain();
+    const calls = installFetchStub();
+
+    const result = await sendPushNotification('user-1', payload);
+
+    expect(result).toEqual({ sent: 1, failed: 0, errors: [] });
+
+    // OAuth2 leg: JWT-bearer grant against the service account's token_uri.
+    const oauth = calls[0];
+    expect(oauth.url).toBe('https://oauth2.googleapis.com/token');
+    expect(oauth.init.method).toBe('POST');
+    const grant = new URLSearchParams(String(oauth.init.body));
+    expect(grant.get('grant_type')).toBe('urn:ietf:params:oauth:grant-type:jwt-bearer');
+    const assertion = grant.get('assertion') ?? '';
+    expect(assertion.split('.')).toHaveLength(3);
+    const jwtClaims = JSON.parse(
+      Buffer.from(assertion.split('.')[1], 'base64url').toString()
+    ) as Record<string, unknown>;
+    expect(jwtClaims.scope).toBe('https://www.googleapis.com/auth/firebase.messaging');
+    expect(jwtClaims.aud).toBe('https://oauth2.googleapis.com/token');
+    expect(jwtClaims.iss).toBe(`push@${projectId}.iam.gserviceaccount.com`);
+
+    // Send leg: v1 endpoint scoped to the project id derived from the JSON.
+    const send = calls[1];
+    expect(send.url).toBe(`https://fcm.googleapis.com/v1/projects/${projectId}/messages:send`);
+    expect(send.init.method).toBe('POST');
+    expect((send.init.headers as Record<string, string>).authorization).toBe(
+      'Bearer ya29.fake-access-token'
+    );
+    expect((send.init.headers as Record<string, string>)['content-type']).toBe('application/json');
+
+    const message = sentMessage(calls);
+    expect(message.token).toBe('fcm-token-abc123');
+    expect(message.notification).toEqual({ title: 'Hello', body: 'World' });
+    expect((message.android as Record<string, unknown>).priority).toBe('high');
+  });
+
+  it('unescapes a literal backslash-n private key before signing', async () => {
+    process.env.FCM_SERVICE_ACCOUNT_JSON = serviceAccountJson();
+    vi.mocked(db.query.pushNotificationTokens.findMany).mockResolvedValue([androidToken()] as never);
+    setupUpdateChain();
+    const { rsaSign } = primeSign();
+    installFetchStub();
+
+    await sendPushNotification('user-1', payload);
+
+    const key = rsaSign.sign.mock.calls[0][0] as string;
+    expect(key).toContain('-----BEGIN PRIVATE KEY-----\n');
+    expect(key).not.toContain('\\n');
+  });
+
+  it('sends a data-only message for a silent payload so Android shows nothing', async () => {
+    process.env.FCM_SERVICE_ACCOUNT_JSON = serviceAccountJson();
+    vi.mocked(db.query.pushNotificationTokens.findMany).mockResolvedValue([androidToken()] as never);
+    setupUpdateChain();
+    const calls = installFetchStub();
+
+    await sendPushNotification('user-1', { silent: true, badge: 3, data: { pageId: 'p1' } });
+
+    const message = sentMessage(calls);
+    expect('notification' in message).toBe(false);
+    const android = message.android as Record<string, unknown>;
+    expect('notification' in android).toBe(false);
+    expect(android.priority).toBe('normal');
+    expect(message.data).toMatchObject({ silent: 'true', badge: '3', pageId: 'p1' });
+  });
+
+  it('includes a visible notification block and android notification options when not silent', async () => {
+    process.env.FCM_SERVICE_ACCOUNT_JSON = serviceAccountJson();
+    vi.mocked(db.query.pushNotificationTokens.findMany).mockResolvedValue([androidToken()] as never);
+    setupUpdateChain();
+    const calls = installFetchStub();
+
+    await sendPushNotification('user-1', {
+      title: 'T',
+      body: 'B',
+      badge: 7,
+      sound: 'chime',
+      threadId: 'thread-9',
+      category: 'MESSAGE',
+    });
+
+    const message = sentMessage(calls);
+    expect(message.notification).toEqual({ title: 'T', body: 'B' });
+    const android = message.android as Record<string, unknown>;
+    expect(android.notification).toEqual({
+      sound: 'chime',
+      notification_count: 7,
+      tag: 'thread-9',
+      click_action: 'MESSAGE',
+    });
+    expect(message.data).toMatchObject({ badge: '7', threadId: 'thread-9', category: 'MESSAGE' });
+  });
+
+  it('stringifies non-string data values (FCM data is string-to-string only)', async () => {
+    process.env.FCM_SERVICE_ACCOUNT_JSON = serviceAccountJson();
+    vi.mocked(db.query.pushNotificationTokens.findMany).mockResolvedValue([androidToken()] as never);
+    setupUpdateChain();
+    const calls = installFetchStub();
+
+    await sendPushNotification('user-1', {
+      ...payload,
+      data: { count: 4, nested: { a: 1 }, kept: 'raw', dropped: undefined },
+    });
+
+    const data = sentMessage(calls).data as Record<string, string>;
+    expect(data.count).toBe('4');
+    expect(data.nested).toBe('{"a":1}');
+    expect(data.kept).toBe('raw');
+    expect('dropped' in data).toBe(false);
+  });
+
+  it('deactivates the token when FCM reports UNREGISTERED', async () => {
+    process.env.FCM_SERVICE_ACCOUNT_JSON = serviceAccountJson();
+    vi.mocked(db.query.pushNotificationTokens.findMany).mockResolvedValue([androidToken()] as never);
+    const { setFn } = setupUpdateChain();
+    installFetchStub({
+      send: () =>
+        fakeResponse(
+          404,
+          JSON.stringify({
+            error: {
+              code: 404,
+              message: 'Requested entity was not found.',
+              status: 'NOT_FOUND',
+              details: [
+                { '@type': 'type.googleapis.com/google.firebase.fcm.v1.FcmError', errorCode: 'UNREGISTERED' },
+              ],
+            },
+          })
+        ),
+    });
+
+    const result = await sendPushNotification('user-1', payload);
+
+    expect(result.failed).toBe(1);
+    expect(result.errors[0]).toContain('UNREGISTERED');
+    // Same shape the APNs invalid-token path uses: deactivate, don't count a failure.
+    expect(setFn).toHaveBeenCalledWith({ isActive: false });
+  });
+
+  it('deactivates the token when FCM reports INVALID_ARGUMENT', async () => {
+    process.env.FCM_SERVICE_ACCOUNT_JSON = serviceAccountJson();
+    vi.mocked(db.query.pushNotificationTokens.findMany).mockResolvedValue([androidToken()] as never);
+    const { setFn } = setupUpdateChain();
+    installFetchStub({
+      send: () =>
+        fakeResponse(
+          400,
+          JSON.stringify({
+            error: {
+              message: 'The registration token is not a valid FCM registration token',
+              status: 'INVALID_ARGUMENT',
+            },
+          })
+        ),
+    });
+
+    const result = await sendPushNotification('user-1', payload);
+
+    expect(result.failed).toBe(1);
+    expect(result.errors[0]).toContain('INVALID_ARGUMENT');
+    expect(setFn).toHaveBeenCalledWith({ isActive: false });
+  });
+
+  it('keeps the token when FCM rejects with a retryable code', async () => {
+    process.env.FCM_SERVICE_ACCOUNT_JSON = serviceAccountJson();
+    vi.mocked(db.query.pushNotificationTokens.findMany).mockResolvedValue([androidToken()] as never);
+    const { setFn } = setupUpdateChain();
+    installFetchStub({
+      send: () =>
+        fakeResponse(
+          503,
+          JSON.stringify({ error: { message: 'The service is unavailable.', status: 'UNAVAILABLE' } })
+        ),
+    });
+
+    const result = await sendPushNotification('user-1', payload);
+
+    expect(result.failed).toBe(1);
+    expect(result.errors[0]).toContain('UNAVAILABLE');
+    expect(setFn).not.toHaveBeenCalledWith({ isActive: false });
+    expect(setFn).toHaveBeenCalledWith(
+      expect.objectContaining({ failedAttempts: '1', isActive: true })
+    );
+  });
+
+  it('falls back to UNKNOWN when the FCM error body is not JSON', async () => {
+    process.env.FCM_SERVICE_ACCOUNT_JSON = serviceAccountJson();
+    vi.mocked(db.query.pushNotificationTokens.findMany).mockResolvedValue([androidToken()] as never);
+    const { setFn } = setupUpdateChain();
+    installFetchStub({ send: () => fakeResponse(500, '<html>gateway</html>') });
+
+    const result = await sendPushNotification('user-1', payload);
+
+    expect(result.errors[0]).toContain('UNKNOWN');
+    expect(setFn).not.toHaveBeenCalledWith({ isActive: false });
+  });
+
+  it('fails only that send when FCM_SERVICE_ACCOUNT_JSON is absent, without breaking the dispatch loop', async () => {
+    delete process.env.FCM_SERVICE_ACCOUNT_JSON;
+    process.env.APNS_TEAM_ID = 'team-id';
+    process.env.APNS_KEY_ID = 'key-id';
+    process.env.APNS_PRIVATE_KEY = '-----BEGIN PRIVATE KEY-----\nfakekey\n-----END PRIVATE KEY-----';
+    vi.mocked(db.query.pushNotificationTokens.findMany).mockResolvedValue([
+      androidToken({ id: 'android-1' }),
+      tokenRecord({ id: 'ios-1', platform: 'ios' }),
+    ] as never);
+    setupUpdateChain();
+    const calls = installFetchStub();
+
+    const result = await sendPushNotification('user-1', payload);
+
+    expect(result.sent).toBe(1);
+    expect(result.failed).toBe(1);
+    expect(result.errors[0]).toContain('FCM configuration missing');
+    expect(result.errors[0]).toContain('FCM_SERVICE_ACCOUNT_JSON');
+    // No network call was attempted for the misconfigured platform.
+    expect(calls).toHaveLength(0);
+  });
+
+  it('reports a configuration error when the service account JSON is malformed', async () => {
+    process.env.FCM_SERVICE_ACCOUNT_JSON = 'not-json-at-all';
+    vi.mocked(db.query.pushNotificationTokens.findMany).mockResolvedValue([androidToken()] as never);
+    setupUpdateChain();
+    installFetchStub();
+
+    const result = await sendPushNotification('user-1', payload);
+
+    expect(result.failed).toBe(1);
+    expect(result.errors[0]).toContain('not valid JSON');
+  });
+
+  it('reports a configuration error when the service account JSON is not an object', async () => {
+    process.env.FCM_SERVICE_ACCOUNT_JSON = '["nope"]';
+    vi.mocked(db.query.pushNotificationTokens.findMany).mockResolvedValue([androidToken()] as never);
+    setupUpdateChain();
+    installFetchStub();
+
+    const result = await sendPushNotification('user-1', payload);
+
+    expect(result.errors[0]).toContain('must be a JSON object');
+  });
+
+  it('names the missing service account fields', async () => {
+    process.env.FCM_SERVICE_ACCOUNT_JSON = serviceAccountJson({
+      project_id: undefined,
+      private_key: undefined,
+    });
+    vi.mocked(db.query.pushNotificationTokens.findMany).mockResolvedValue([androidToken()] as never);
+    setupUpdateChain();
+    installFetchStub();
+
+    const result = await sendPushNotification('user-1', payload);
+
+    expect(result.errors[0]).toContain('project_id');
+    expect(result.errors[0]).toContain('private_key');
+    expect(result.errors[0]).not.toContain('client_email');
+  });
+
+  it('reuses a recently minted access token instead of re-minting per send', async () => {
+    const raw = serviceAccountJson({}, 'shared-cache-project');
+    process.env.FCM_SERVICE_ACCOUNT_JSON = raw;
+    vi.mocked(db.query.pushNotificationTokens.findMany).mockResolvedValue([androidToken()] as never);
+    setupUpdateChain();
+    const calls = installFetchStub();
+
+    await sendPushNotification('user-1', payload);
+    await sendPushNotification('user-1', payload);
+
+    const oauthCalls = calls.filter((c) => c.url.includes('oauth2.googleapis.com'));
+    const sendCalls = calls.filter((c) => c.url.includes('fcm.googleapis.com'));
+    expect(oauthCalls).toHaveLength(1);
+    expect(sendCalls).toHaveLength(2);
+  });
+
+  it('re-mints when the service account credential rotates', async () => {
+    vi.mocked(db.query.pushNotificationTokens.findMany).mockResolvedValue([androidToken()] as never);
+    setupUpdateChain();
+    const calls = installFetchStub();
+
+    process.env.FCM_SERVICE_ACCOUNT_JSON = serviceAccountJson({}, 'rotate-a');
+    await sendPushNotification('user-1', payload);
+    process.env.FCM_SERVICE_ACCOUNT_JSON = serviceAccountJson({}, 'rotate-b');
+    await sendPushNotification('user-1', payload);
+
+    expect(calls.filter((c) => c.url.includes('oauth2.googleapis.com'))).toHaveLength(2);
+    expect(calls[3].url).toContain('/projects/rotate-b/');
+  });
+
+  it('drops the cached access token after a 401 so the next send re-mints', async () => {
+    const raw = serviceAccountJson({}, 'unauthorized-project');
+    process.env.FCM_SERVICE_ACCOUNT_JSON = raw;
+    vi.mocked(db.query.pushNotificationTokens.findMany).mockResolvedValue([androidToken()] as never);
+    setupUpdateChain();
+    let sendCount = 0;
+    const calls = installFetchStub({
+      send: () => {
+        sendCount += 1;
+        return sendCount === 1
+          ? fakeResponse(401, JSON.stringify({ error: { status: 'UNAUTHENTICATED', message: 'bad creds' } }))
+          : fakeResponse(200, FCM_SEND_OK);
+      },
+    });
+
+    const first = await sendPushNotification('user-1', payload);
+    const second = await sendPushNotification('user-1', payload);
+
+    expect(first.failed).toBe(1);
+    expect(second.sent).toBe(1);
+    expect(calls.filter((c) => c.url.includes('oauth2.googleapis.com'))).toHaveLength(2);
+  });
+
+  it('surfaces an OAuth token endpoint rejection as the send error', async () => {
+    process.env.FCM_SERVICE_ACCOUNT_JSON = serviceAccountJson();
+    vi.mocked(db.query.pushNotificationTokens.findMany).mockResolvedValue([androidToken()] as never);
+    const { setFn } = setupUpdateChain();
+    const calls = installFetchStub({
+      oauth: () => fakeResponse(400, JSON.stringify({ error: 'invalid_grant' })),
+    });
+
+    const result = await sendPushNotification('user-1', payload);
+
+    expect(result.failed).toBe(1);
+    expect(result.errors[0]).toContain('FCM OAuth token request failed (400)');
+    expect(result.errors[0]).toContain('invalid_grant');
+    // The send leg is never attempted, and the token is not deactivated.
+    expect(calls.filter((c) => c.url.includes('fcm.googleapis.com'))).toHaveLength(0);
+    expect(setFn).not.toHaveBeenCalledWith({ isActive: false });
+  });
+
+  it('reports a transport failure at the OAuth leg and mints cleanly on the next send', async () => {
+    const raw = serviceAccountJson({}, 'transport-fail-project');
+    process.env.FCM_SERVICE_ACCOUNT_JSON = raw;
+    vi.mocked(db.query.pushNotificationTokens.findMany).mockResolvedValue([androidToken()] as never);
+    setupUpdateChain();
+    let attempt = 0;
+    const calls = installFetchStub({
+      oauth: () => {
+        attempt += 1;
+        if (attempt === 1) throw new Error('ECONNRESET');
+        return fakeResponse(200, OAUTH_OK);
+      },
+    });
+
+    const first = await sendPushNotification('user-1', payload);
+    expect(first.failed).toBe(1);
+    expect(first.errors[0]).toContain('ECONNRESET');
+
+    const second = await sendPushNotification('user-1', payload);
+    expect(second.sent).toBe(1);
+    expect(calls.filter((c) => c.url.includes('oauth2.googleapis.com'))).toHaveLength(2);
+  });
+
+  it('rejects an OAuth response with no access_token', async () => {
+    process.env.FCM_SERVICE_ACCOUNT_JSON = serviceAccountJson();
+    vi.mocked(db.query.pushNotificationTokens.findMany).mockResolvedValue([androidToken()] as never);
+    setupUpdateChain();
+    installFetchStub({ oauth: () => fakeResponse(200, JSON.stringify({ expires_in: 3600 })) });
+
+    const result = await sendPushNotification('user-1', payload);
+
+    expect(result.errors[0]).toContain('did not include an access_token');
+  });
+
+  it('rejects a non-JSON OAuth response body', async () => {
+    process.env.FCM_SERVICE_ACCOUNT_JSON = serviceAccountJson();
+    vi.mocked(db.query.pushNotificationTokens.findMany).mockResolvedValue([androidToken()] as never);
+    setupUpdateChain();
+    installFetchStub({ oauth: () => fakeResponse(200, 'totally not json') });
+
+    const result = await sendPushNotification('user-1', payload);
+
+    expect(result.errors[0]).toContain('was not valid JSON');
   });
 });

--- a/packages/lib/src/notifications/__tests__/push-notifications.test.ts
+++ b/packages/lib/src/notifications/__tests__/push-notifications.test.ts
@@ -1995,6 +1995,60 @@ describe('sendToFcm (Android)', () => {
     expect(setFn).not.toHaveBeenCalled();
   });
 
+  // The rotation tests each prove one interleaving. The property underneath them
+  // is stronger and worth asserting directly: a send must never carry a token
+  // minted from a different credential than the project it is addressed to.
+  // Serving project A's bearer to project B is the failure the two source pins
+  // exist to prevent, and it would look like a plain 401 in production.
+  it('never pairs a project with a token minted from another credential', async () => {
+    vi.mocked(db.query.pushNotificationTokens.findMany).mockResolvedValue([androidToken()] as never);
+    setupUpdateChain();
+
+    // The token endpoint mints a token that names the credential it came from,
+    // so any mismatch downstream is visible rather than inferred.
+    const calls = installFetchStub({
+      oauth: (call) => {
+        const assertion = new URLSearchParams(String(call.init.body)).get('assertion') ?? '';
+        const claims = JSON.parse(Buffer.from(assertion.split('.')[1], 'base64url').toString()) as { iss: string };
+        const pid = claims.iss.replace(/^push@/, '').replace(/\.iam\.gserviceaccount\.com$/, '');
+        return fakeResponse(200, JSON.stringify({ access_token: `ya29.for-${pid}`, expires_in: 3600 }));
+      },
+    });
+
+    // Rotate repeatedly, revisit an earlier credential to exercise the cache,
+    // and overlap two sends so an in-flight mint is joined rather than started.
+    process.env.FCM_SERVICE_ACCOUNT_JSON = serviceAccountJson({}, 'pair-a');
+    await sendPushNotification('user-1', payload);
+    process.env.FCM_SERVICE_ACCOUNT_JSON = serviceAccountJson({}, 'pair-b');
+    await Promise.all([
+      sendPushNotification('user-2', payload),
+      sendPushNotification('user-3', payload),
+    ]);
+    process.env.FCM_SERVICE_ACCOUNT_JSON = serviceAccountJson({}, 'pair-a');
+    await sendPushNotification('user-4', payload);
+    process.env.FCM_SERVICE_ACCOUNT_JSON = serviceAccountJson({}, 'pair-c');
+    await sendPushNotification('user-5', payload);
+    // A second send on the unchanged credential, so the cache-HIT return is
+    // exercised too. Every rotation above forces a re-mint, which means without
+    // this the cache-hit path never runs and a wrong projectId there is
+    // invisible.
+    await sendPushNotification('user-6', payload);
+
+    const sends = calls.filter((c) => c.url.includes('fcm.googleapis.com'));
+    expect(sends).toHaveLength(6);
+    // Five mints for five distinct credential activations, and the sixth send
+    // served from cache.
+    expect(calls.filter((c) => c.url.includes('oauth2.googleapis.com'))).toHaveLength(4);
+    for (const send of sends) {
+      const pid = send.url.match(/\/projects\/([^/]+)\/messages:send$/)?.[1];
+      expect(pid).toBeTruthy();
+      expect((send.init.headers as Record<string, string>).authorization).toBe(`Bearer ya29.for-${pid}`);
+    }
+    // And the sends really did span several projects, so the loop above is not
+    // vacuously checking one pairing five times.
+    expect(new Set(sends.map((c) => c.url)).size).toBe(3);
+  });
+
   it('reuses a recently minted access token instead of re-minting per send', async () => {
     const raw = serviceAccountJson({}, 'shared-cache-project');
     process.env.FCM_SERVICE_ACCOUNT_JSON = raw;

--- a/packages/lib/src/notifications/__tests__/push-notifications.test.ts
+++ b/packages/lib/src/notifications/__tests__/push-notifications.test.ts
@@ -1055,6 +1055,25 @@ describe('sendToFcm (Android)', () => {
     expect('dropped' in data).toBe(false);
   });
 
+  it('does not let caller metadata redefine a reserved data key', async () => {
+    // createNotification spreads arbitrary `metadata` into `data`.
+    process.env.FCM_SERVICE_ACCOUNT_JSON = serviceAccountJson();
+    vi.mocked(db.query.pushNotificationTokens.findMany).mockResolvedValue([androidToken()] as never);
+    setupUpdateChain();
+    const calls = installFetchStub();
+
+    await sendPushNotification('user-1', {
+      silent: true,
+      badge: 2,
+      data: { silent: 'false', badge: '999', notificationId: 'n1' },
+    });
+
+    const data = sentMessage(calls).data as Record<string, string>;
+    expect(data.silent).toBe('true');
+    expect(data.badge).toBe('2');
+    expect(data.notificationId).toBe('n1');
+  });
+
   it('deactivates the token when FCM reports UNREGISTERED', async () => {
     process.env.FCM_SERVICE_ACCOUNT_JSON = serviceAccountJson();
     vi.mocked(db.query.pushNotificationTokens.findMany).mockResolvedValue([androidToken()] as never);

--- a/packages/lib/src/notifications/__tests__/push-notifications.test.ts
+++ b/packages/lib/src/notifications/__tests__/push-notifications.test.ts
@@ -1712,6 +1712,42 @@ describe('sendToFcm (Android)', () => {
     expect(calls[0].url).toBe('https://oauth2.googleapis.com/token');
   });
 
+  // The default and the fixture were both 3600, so nothing distinguished
+  // "honours expires_in" from "always assumes an hour". A short-lived token has
+  // to miss the 10-minute freshness margin and force a fresh mint.
+  it('honours a short expires_in instead of assuming an hour', async () => {
+    process.env.FCM_SERVICE_ACCOUNT_JSON = serviceAccountJson({}, 'short-expiry-project');
+    vi.mocked(db.query.pushNotificationTokens.findMany).mockResolvedValue([androidToken()] as never);
+    setupUpdateChain();
+    const calls = installFetchStub({
+      oauth: () => fakeResponse(200, JSON.stringify({ access_token: 'ya29.short', expires_in: 60 })),
+    });
+
+    await sendPushNotification('user-1', payload);
+    await sendPushNotification('user-1', payload);
+
+    // 60s is inside the refresh margin, so the second send must not reuse it.
+    expect(calls.filter((c) => c.url.includes('oauth2.googleapis.com'))).toHaveLength(2);
+  });
+
+  it("carries FCM's own reason through to the error", async () => {
+    process.env.FCM_SERVICE_ACCOUNT_JSON = serviceAccountJson();
+    vi.mocked(db.query.pushNotificationTokens.findMany).mockResolvedValue([androidToken()] as never);
+    setupUpdateChain();
+    installFetchStub({
+      send: () =>
+        fakeResponse(429, JSON.stringify({
+          error: { message: 'Quota exceeded for quota metric', status: 'RESOURCE_EXHAUSTED' },
+        })),
+    });
+
+    const result = await sendPushNotification('user-1', payload);
+
+    // The code alone is not enough to debug from; the human-readable half has
+    // to survive too.
+    expect(result.errors[0]).toBe('RESOURCE_EXHAUSTED: Quota exceeded for quota metric');
+  });
+
   it('treats an access token with no expires_in as lasting the standard hour', async () => {
     // Observable through the cache: the default has to be long enough that the
     // second send reuses the token rather than minting again.

--- a/packages/lib/src/notifications/__tests__/push-notifications.test.ts
+++ b/packages/lib/src/notifications/__tests__/push-notifications.test.ts
@@ -1069,6 +1069,57 @@ describe('sendToFcm (Android)', () => {
     expect(signatureB64).toMatch(/^[A-Za-z0-9_-]+$/);
   });
 
+  // A hung request must not wedge the dispatch loop: the sends are sequential,
+  // so one stalled socket blocks every remaining device and every later user.
+  it('bounds both legs with a request timeout', async () => {
+    process.env.FCM_SERVICE_ACCOUNT_JSON = serviceAccountJson();
+    vi.mocked(db.query.pushNotificationTokens.findMany).mockResolvedValue([androidToken()] as never);
+    setupUpdateChain();
+    const calls = installFetchStub();
+
+    await sendPushNotification('user-1', payload);
+
+    const oauth = calls.find((c) => c.url.includes('oauth2.googleapis.com'))!;
+    const send = calls.find((c) => c.url.includes('fcm.googleapis.com'))!;
+    expect(oauth.init.signal).toBeInstanceOf(AbortSignal);
+    expect(send.init.signal).toBeInstanceOf(AbortSignal);
+  });
+
+  it('bounds how much of a failed OAuth body reaches the error', async () => {
+    process.env.FCM_SERVICE_ACCOUNT_JSON = serviceAccountJson({}, 'huge-body-project');
+    vi.mocked(db.query.pushNotificationTokens.findMany).mockResolvedValue([androidToken()] as never);
+    setupUpdateChain();
+    installFetchStub({ oauth: () => fakeResponse(500, 'x'.repeat(5000)) });
+
+    const result = await sendPushNotification('user-1', payload);
+
+    // Otherwise an HTML error page becomes an unbounded string, once per token.
+    expect(result.errors[0].length).toBeLessThan(300);
+    expect(result.errors[0]).toContain('FCM OAuth token request failed (500)');
+  });
+
+  // FCM registration tokens are bearer-ish: anyone holding one plus the sender
+  // credentials can push to that device. They do not belong in logs in full.
+  it('logs only a prefix of the device token, never the whole thing', async () => {
+    process.env.FCM_SERVICE_ACCOUNT_JSON = serviceAccountJson();
+    vi.mocked(db.query.pushNotificationTokens.findMany).mockResolvedValue([androidToken()] as never);
+    setupUpdateChain();
+    installFetchStub();
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+
+    try {
+      await sendPushNotification('user-1', payload);
+
+      const sendLog = logSpy.mock.calls.find(([tag]) => tag === '[FCM] send');
+      expect(sendLog).toBeTruthy();
+      const fields = sendLog![1] as { tokenPrefix: string };
+      expect(fields.tokenPrefix).toBe('fcm-toke');
+      expect(JSON.stringify(logSpy.mock.calls)).not.toContain('fcm-token-abc123');
+    } finally {
+      logSpy.mockRestore();
+    }
+  });
+
   it('unescapes a literal backslash-n private key before signing', async () => {
     process.env.FCM_SERVICE_ACCOUNT_JSON = serviceAccountJson();
     vi.mocked(db.query.pushNotificationTokens.findMany).mockResolvedValue([androidToken()] as never);

--- a/packages/lib/src/notifications/__tests__/push-notifications.test.ts
+++ b/packages/lib/src/notifications/__tests__/push-notifications.test.ts
@@ -1143,6 +1143,10 @@ describe('sendToFcm (Android)', () => {
     await sendPushNotification('user-1', { silent: true, badge: 3, data: { pageId: 'p1' } });
 
     const message = sentMessage(calls);
+    // The silent branch is a separate return, so it needs its own assertion that
+    // the message is actually addressed to the device — a silent push with no
+    // token reaches nobody, and badge sync is silent-only.
+    expect(message.token).toBe('fcm-token-abc123');
     expect('notification' in message).toBe(false);
     const android = message.android as Record<string, unknown>;
     expect('notification' in android).toBe(false);

--- a/packages/lib/src/notifications/__tests__/push-notifications.test.ts
+++ b/packages/lib/src/notifications/__tests__/push-notifications.test.ts
@@ -905,9 +905,11 @@ interface FetchCall {
   init: RequestInit;
 }
 
+// Both handlers may be async: several tests gate a response on a promise to
+// force an ordering that would otherwise never occur (a late 401, a slow mint).
 function installFetchStub(handlers: {
-  oauth?: (call: FetchCall) => FakeResponse;
-  send?: (message: Record<string, unknown>, call: FetchCall) => FakeResponse;
+  oauth?: (call: FetchCall) => FakeResponse | Promise<FakeResponse>;
+  send?: (message: Record<string, unknown>, call: FetchCall) => FakeResponse | Promise<FakeResponse>;
 } = {}) {
   const calls: FetchCall[] = [];
   const stub = vi.fn(async (url: string | URL, init: RequestInit = {}) => {

--- a/packages/lib/src/notifications/__tests__/push-notifications.test.ts
+++ b/packages/lib/src/notifications/__tests__/push-notifications.test.ts
@@ -1706,6 +1706,43 @@ describe('sendToFcm (Android)', () => {
     expect(setFn).not.toHaveBeenCalled();
   });
 
+  // Same reasoning as the rejection invariant above: individual config errors
+  // were each proven to fail cleanly, but "every way the config can be wrong"
+  // is the claim the .env.example comment and the changelog actually make. A
+  // misconfigured server must never put a credential on the wire and must never
+  // cost a device its registration, whichever way it is misconfigured.
+  const BROKEN_CONFIG: Array<[string, string | undefined, string]> = [
+    ['absent', undefined, 'FCM_SERVICE_ACCOUNT_JSON is required'],
+    ['not JSON', 'not-json-at-all', 'not valid JSON'],
+    ['a JSON array', '["nope"]', 'must be a JSON object'],
+    ['a JSON string', '"nope"', 'must be a JSON object'],
+    ['missing every field', '{}', 'is missing'],
+    ['a project_id that could rewrite the URL', serviceAccountJson({}, '../../evil'), 'project_id may only contain'],
+    ['a non-https token_uri', serviceAccountJson({ token_uri: 'http://oauth2.googleapis.com/token' }), 'token_uri must be an https:// URL'],
+  ];
+
+  it.each(BROKEN_CONFIG)('fails closed when the credential is %s', async (_label, raw, expected) => {
+    if (raw === undefined) {
+      delete process.env.FCM_SERVICE_ACCOUNT_JSON;
+    } else {
+      process.env.FCM_SERVICE_ACCOUNT_JSON = raw;
+    }
+    vi.mocked(db.query.pushNotificationTokens.findMany).mockResolvedValue([
+      androidToken({ failedAttempts: '4' }),
+    ] as never);
+    const { setFn } = setupUpdateChain();
+    const calls = installFetchStub();
+
+    const result = await sendPushNotification('user-1', payload);
+
+    expect(result.failed).toBe(1);
+    expect(result.errors[0]).toContain(expected);
+    // Nothing reached the network — in particular no signed assertion.
+    expect(calls).toHaveLength(0);
+    // And the device is not charged for it, now or after any number of retries.
+    expect(setFn).not.toHaveBeenCalled();
+  });
+
   it('reports a configuration error when the service account JSON is malformed', async () => {
     process.env.FCM_SERVICE_ACCOUNT_JSON = 'not-json-at-all';
     vi.mocked(db.query.pushNotificationTokens.findMany).mockResolvedValue([androidToken()] as never);

--- a/packages/lib/src/notifications/__tests__/push-notifications.test.ts
+++ b/packages/lib/src/notifications/__tests__/push-notifications.test.ts
@@ -2000,6 +2000,52 @@ describe('sendToFcm (Android)', () => {
   // minted from a different credential than the project it is addressed to.
   // Serving project A's bearer to project B is the failure the two source pins
   // exist to prevent, and it would look like a plain 401 in production.
+  // The sibling of the late-401 race. The cache WRITE in mintFcmAccessToken is
+  // also unguarded, so a slow mint can land after a newer one and overwrite it.
+  // That is survivable only because the source pin means a token is never
+  // served to a credential it was not minted for — the stale entry causes an
+  // extra re-mint, never a mispairing. Asserted rather than reasoned about,
+  // since reasoning is what missed the 401 case.
+  it('survives a slow mint landing after a newer one', async () => {
+    vi.mocked(db.query.pushNotificationTokens.findMany).mockResolvedValue([androidToken()] as never);
+    setupUpdateChain();
+
+    let seenSlow = false;
+    let releaseSlow!: () => void;
+    const slowMint = new Promise<void>((resolve) => { releaseSlow = resolve; });
+
+    const calls = installFetchStub({
+      oauth: async (call) => {
+        const assertion = new URLSearchParams(String(call.init.body)).get('assertion') ?? '';
+        const claims = JSON.parse(Buffer.from(assertion.split('.')[1], 'base64url').toString()) as { iss: string };
+        const pid = claims.iss.replace(/^push@/, '').replace(/\.iam\.gserviceaccount\.com$/, '');
+        if (pid === 'stale-a') { seenSlow = true; await slowMint; }
+        return fakeResponse(200, JSON.stringify({ access_token: `ya29.for-${pid}`, expires_in: 3600 }));
+      },
+    });
+
+    process.env.FCM_SERVICE_ACCOUNT_JSON = serviceAccountJson({}, 'stale-a');
+    const slow = sendPushNotification('user-1', payload);
+    await vi.waitFor(() => expect(seenSlow).toBe(true));
+
+    // Second credential mints and completes while the first is still in the air.
+    process.env.FCM_SERVICE_ACCOUNT_JSON = serviceAccountJson({}, 'stale-b');
+    const fast = await sendPushNotification('user-2', payload);
+    expect(fast.sent).toBe(1);
+
+    // Now let the older mint land on top of the newer cache entry.
+    releaseSlow();
+    expect((await slow).sent).toBe(1);
+
+    // Neither send was handed the other's token, whatever order the writes
+    // happened in. A stale overwrite costs a re-mint later, not a mispairing.
+    for (const send of calls.filter((c) => c.url.includes('fcm.googleapis.com'))) {
+      const pid = send.url.match(/\/projects\/([^/]+)\/messages:send$/)?.[1];
+      expect((send.init.headers as Record<string, string>).authorization).toBe(`Bearer ya29.for-${pid}`);
+    }
+    expect(new Set(calls.filter((c) => c.url.includes('fcm.googleapis.com')).map((c) => c.url)).size).toBe(2);
+  });
+
   it('never pairs a project with a token minted from another credential', async () => {
     vi.mocked(db.query.pushNotificationTokens.findMany).mockResolvedValue([androidToken()] as never);
     setupUpdateChain();

--- a/packages/lib/src/notifications/__tests__/push-notifications.test.ts
+++ b/packages/lib/src/notifications/__tests__/push-notifications.test.ts
@@ -407,7 +407,10 @@ describe('sendPushNotification', () => {
   });
 
   it('deactivates token after 5 consecutive failures', async () => {
-    vi.mocked(db.query.pushNotificationTokens.findMany).mockResolvedValue([tokenRecord({ platform: 'android', failedAttempts: '4' })] as never);
+    // `web` is used here only as a platform whose stub returns a plain per-token
+    // failure. `android` no longer serves: an unset credential is now reported
+    // as a server fault, which deliberately does not count against the device.
+    vi.mocked(db.query.pushNotificationTokens.findMany).mockResolvedValue([tokenRecord({ platform: 'web', failedAttempts: '4' })] as never);
     const { setFn } = setupUpdateChain();
 
     await sendPushNotification('user-1', payload);
@@ -419,7 +422,7 @@ describe('sendPushNotification', () => {
   });
 
   it('keeps token active with fewer than 5 failures', async () => {
-    vi.mocked(db.query.pushNotificationTokens.findMany).mockResolvedValue([tokenRecord({ platform: 'android', failedAttempts: '2' })] as never);
+    vi.mocked(db.query.pushNotificationTokens.findMany).mockResolvedValue([tokenRecord({ platform: 'web', failedAttempts: '2' })] as never);
     const { setFn } = setupUpdateChain();
 
     await sendPushNotification('user-1', payload);
@@ -862,6 +865,7 @@ function serviceAccountJson(overrides: Record<string, unknown> = {}, projectId?:
 }
 
 const FCM_ERROR_TYPE = 'type.googleapis.com/google.firebase.fcm.v1.FcmError';
+const BAD_REQUEST_TYPE = 'type.googleapis.com/google.rpc.BadRequest';
 const OAUTH_OK = JSON.stringify({ access_token: 'ya29.fake-access-token', expires_in: 3600 });
 const FCM_SEND_OK = JSON.stringify({ name: 'projects/p/messages/0:1234' });
 
@@ -1020,7 +1024,6 @@ describe('sendToFcm (Android)', () => {
       title: 'T',
       body: 'B',
       badge: 7,
-      sound: 'chime',
       threadId: 'thread-9',
       category: 'MESSAGE',
     });
@@ -1029,12 +1032,41 @@ describe('sendToFcm (Android)', () => {
     expect(message.notification).toEqual({ title: 'T', body: 'B' });
     const android = message.android as Record<string, unknown>;
     expect(android.notification).toEqual({
-      sound: 'chime',
+      sound: 'default',
       notification_count: 7,
       tag: 'thread-9',
-      click_action: 'MESSAGE',
     });
+    // The category is an iOS identifier and rides in data only — as click_action
+    // it would have to match an activity intent-filter, and the manifest
+    // declares only MAIN/LAUNCHER, so a tap would do nothing at all.
+    expect(android.notification).not.toHaveProperty('click_action');
     expect(message.data).toMatchObject({ badge: '7', threadId: 'thread-9', category: 'MESSAGE' });
+  });
+
+  it('drops a custom sound rather than naming a res/raw resource that will not exist', async () => {
+    process.env.FCM_SERVICE_ACCOUNT_JSON = serviceAccountJson();
+    vi.mocked(db.query.pushNotificationTokens.findMany).mockResolvedValue([androidToken()] as never);
+    setupUpdateChain();
+    const calls = installFetchStub();
+
+    await sendPushNotification('user-1', { ...payload, sound: 'chime.caf' });
+
+    // Omitted, so the channel plays its own sound. Passing 'chime.caf' through
+    // would resolve to no Android resource and silently mute the notification.
+    const android = sentMessage(calls).android as Record<string, unknown>;
+    expect(android.notification).not.toHaveProperty('sound');
+  });
+
+  it("passes through the literal 'default' sound", async () => {
+    process.env.FCM_SERVICE_ACCOUNT_JSON = serviceAccountJson();
+    vi.mocked(db.query.pushNotificationTokens.findMany).mockResolvedValue([androidToken()] as never);
+    setupUpdateChain();
+    const calls = installFetchStub();
+
+    await sendPushNotification('user-1', { ...payload, sound: 'default' });
+
+    const android = sentMessage(calls).android as Record<string, unknown>;
+    expect((android.notification as Record<string, unknown>).sound).toBe('default');
   });
 
   it('stringifies non-string data values (FCM data is string-to-string only)', async () => {
@@ -1101,7 +1133,10 @@ describe('sendToFcm (Android)', () => {
     expect(setFn).toHaveBeenCalledWith({ isActive: false });
   });
 
-  it('deactivates the token when an FcmError detail reports INVALID_ARGUMENT', async () => {
+  // A garbage token reports as INVALID_ARGUMENT with a BadRequest naming
+  // `message.token` — NOT as an FcmError detail. Gating on the FcmError alone
+  // would mean a malformed token is never cleaned up.
+  it('deactivates the token when a BadRequest rejects the message.token field', async () => {
     process.env.FCM_SERVICE_ACCOUNT_JSON = serviceAccountJson();
     vi.mocked(db.query.pushNotificationTokens.findMany).mockResolvedValue([androidToken()] as never);
     const { setFn } = setupUpdateChain();
@@ -1111,7 +1146,10 @@ describe('sendToFcm (Android)', () => {
           error: {
             message: 'The registration token is not a valid FCM registration token',
             status: 'INVALID_ARGUMENT',
-            details: [{ '@type': FCM_ERROR_TYPE, errorCode: 'INVALID_ARGUMENT' }],
+            details: [{
+              '@type': BAD_REQUEST_TYPE,
+              fieldViolations: [{ field: 'message.token', description: 'Invalid registration token' }],
+            }],
           },
         })),
     });
@@ -1119,11 +1157,14 @@ describe('sendToFcm (Android)', () => {
     const result = await sendPushNotification('user-1', payload);
 
     expect(result.failed).toBe(1);
-    expect(result.errors[0]).toContain('INVALID_ARGUMENT');
     expect(setFn).toHaveBeenCalledWith({ isActive: false });
   });
 
-  it('deactivates the token when an FcmError detail reports SENDER_ID_MISMATCH', async () => {
+  // SENDER_ID_MISMATCH arrives inside an FcmError detail, so it looks
+  // token-scoped — but it is a project-level fact. A staging service account
+  // pasted into prod makes every send 403 with it, and acting on it would
+  // unregister every Android device in the database on the first dispatch.
+  it('keeps the token when SENDER_ID_MISMATCH names a project-level mismatch', async () => {
     process.env.FCM_SERVICE_ACCOUNT_JSON = serviceAccountJson();
     vi.mocked(db.query.pushNotificationTokens.findMany).mockResolvedValue([androidToken()] as never);
     const { setFn } = setupUpdateChain();
@@ -1138,9 +1179,85 @@ describe('sendToFcm (Android)', () => {
         })),
     });
 
+    const result = await sendPushNotification('user-1', payload);
+
+    expect(result.errors[0]).toContain('SENDER_ID_MISMATCH');
+    expect(setFn).not.toHaveBeenCalledWith({ isActive: false });
+  });
+
+  // The mirror of the case above: an oversized data map is a message-level fault
+  // that DOES carry an FcmError detail. It must not unregister the recipient.
+  it('keeps the token when an FcmError detail reports a message-level INVALID_ARGUMENT', async () => {
+    process.env.FCM_SERVICE_ACCOUNT_JSON = serviceAccountJson();
+    vi.mocked(db.query.pushNotificationTokens.findMany).mockResolvedValue([androidToken()] as never);
+    const { setFn } = setupUpdateChain();
+    installFetchStub({
+      send: () =>
+        fakeResponse(400, JSON.stringify({
+          error: {
+            message: 'Payload exceeds the maximum size',
+            status: 'INVALID_ARGUMENT',
+            details: [{ '@type': FCM_ERROR_TYPE, errorCode: 'INVALID_ARGUMENT' }],
+          },
+        })),
+    });
+
+    const result = await sendPushNotification('user-1', payload);
+
+    expect(result.errors[0]).toContain('INVALID_ARGUMENT');
+    expect(setFn).not.toHaveBeenCalledWith({ isActive: false });
+    expect(setFn).toHaveBeenCalledWith(
+      expect.objectContaining({ failedAttempts: '1', isActive: true })
+    );
+  });
+
+  // Symmetric to the @type guard on the FcmError branch: fieldViolations only
+  // carry a token verdict when they arrive on a BadRequest detail. A different
+  // detail type carrying the same shape must not be able to impersonate one.
+  it('ignores fieldViolations that arrive on a detail other than BadRequest', async () => {
+    process.env.FCM_SERVICE_ACCOUNT_JSON = serviceAccountJson();
+    vi.mocked(db.query.pushNotificationTokens.findMany).mockResolvedValue([androidToken()] as never);
+    const { setFn } = setupUpdateChain();
+    installFetchStub({
+      send: () =>
+        fakeResponse(400, JSON.stringify({
+          error: {
+            message: 'nope',
+            status: 'INVALID_ARGUMENT',
+            details: [{
+              '@type': 'type.googleapis.com/google.rpc.Help',
+              fieldViolations: [{ field: 'message.token', description: 'not really' }],
+            }],
+          },
+        })),
+    });
+
     await sendPushNotification('user-1', payload);
 
-    expect(setFn).toHaveBeenCalledWith({ isActive: false });
+    expect(setFn).not.toHaveBeenCalledWith({ isActive: false });
+  });
+
+  it('ignores a BadRequest that rejects some field other than the token', async () => {
+    process.env.FCM_SERVICE_ACCOUNT_JSON = serviceAccountJson();
+    vi.mocked(db.query.pushNotificationTokens.findMany).mockResolvedValue([androidToken()] as never);
+    const { setFn } = setupUpdateChain();
+    installFetchStub({
+      send: () =>
+        fakeResponse(400, JSON.stringify({
+          error: {
+            message: 'Invalid JSON payload received. Unknown name "nope".',
+            status: 'INVALID_ARGUMENT',
+            details: [{
+              '@type': BAD_REQUEST_TYPE,
+              fieldViolations: [{ field: 'message.nope', description: 'Cannot find field.' }],
+            }],
+          },
+        })),
+    });
+
+    await sendPushNotification('user-1', payload);
+
+    expect(setFn).not.toHaveBeenCalledWith({ isActive: false });
   });
 
   // The dangerous case: a malformed *message* is also a 400 INVALID_ARGUMENT, but
@@ -1270,6 +1387,25 @@ describe('sendToFcm (Android)', () => {
     expect(calls).toHaveLength(0);
   });
 
+  it('does not count a missing credential against the device', async () => {
+    // The reviewer scenario: FCM_SERVICE_ACCOUNT_JSON left unset — the state
+    // .env.example documents as the safe default. Striking here would deactivate
+    // every Android token after five notifications, and fixing the secret would
+    // not bring them back until each app relaunched.
+    delete process.env.FCM_SERVICE_ACCOUNT_JSON;
+    vi.mocked(db.query.pushNotificationTokens.findMany).mockResolvedValue([
+      androidToken({ failedAttempts: '4' }),
+    ] as never);
+    const { setFn } = setupUpdateChain();
+    installFetchStub();
+
+    const result = await sendPushNotification('user-1', payload);
+
+    expect(result.failed).toBe(1);
+    // No strike, no deactivation — the row is left entirely alone.
+    expect(setFn).not.toHaveBeenCalled();
+  });
+
   it('reports a configuration error when the service account JSON is malformed', async () => {
     process.env.FCM_SERVICE_ACCOUNT_JSON = 'not-json-at-all';
     vi.mocked(db.query.pushNotificationTokens.findMany).mockResolvedValue([androidToken()] as never);
@@ -1381,11 +1517,10 @@ describe('sendToFcm (Android)', () => {
     expect(calls[3].url).toContain('/projects/rotate-b/');
   });
 
-  it('drops the cached access token after a 401 so the next send re-mints', async () => {
-    const raw = serviceAccountJson({}, 'unauthorized-project');
-    process.env.FCM_SERVICE_ACCOUNT_JSON = raw;
+  it('re-mints and retries once when the access token is rejected', async () => {
+    process.env.FCM_SERVICE_ACCOUNT_JSON = serviceAccountJson({}, 'unauthorized-project');
     vi.mocked(db.query.pushNotificationTokens.findMany).mockResolvedValue([androidToken()] as never);
-    setupUpdateChain();
+    const { setFn } = setupUpdateChain();
     let sendCount = 0;
     const calls = installFetchStub({
       send: () => {
@@ -1396,12 +1531,33 @@ describe('sendToFcm (Android)', () => {
       },
     });
 
-    const first = await sendPushNotification('user-1', payload);
-    const second = await sendPushNotification('user-1', payload);
+    const result = await sendPushNotification('user-1', payload);
 
-    expect(first.failed).toBe(1);
-    expect(second.sent).toBe(1);
+    // The notification that discovered the stale credential is delivered, not
+    // dropped — a cached token can be up to 50 minutes stale and fan-out sends
+    // run concurrently, so dropping it would lose every send in that window.
+    expect(result).toEqual({ sent: 1, failed: 0, errors: [] });
     expect(calls.filter((c) => c.url.includes('oauth2.googleapis.com'))).toHaveLength(2);
+    expect(calls.filter((c) => c.url.includes('fcm.googleapis.com'))).toHaveLength(2);
+    expect(setFn).toHaveBeenCalledWith(expect.objectContaining({ failedAttempts: '0' }));
+  });
+
+  it('gives up after one retry when the fresh token is rejected too', async () => {
+    process.env.FCM_SERVICE_ACCOUNT_JSON = serviceAccountJson({}, 'always-401-project');
+    vi.mocked(db.query.pushNotificationTokens.findMany).mockResolvedValue([androidToken()] as never);
+    const { setFn } = setupUpdateChain();
+    const calls = installFetchStub({
+      send: () =>
+        fakeResponse(401, JSON.stringify({ error: { status: 'UNAUTHENTICATED', message: 'bad creds' } })),
+    });
+
+    const result = await sendPushNotification('user-1', payload);
+
+    expect(result.failed).toBe(1);
+    expect(result.errors[0]).toContain('UNAUTHENTICATED');
+    // Exactly two attempts — no unbounded retry loop.
+    expect(calls.filter((c) => c.url.includes('fcm.googleapis.com'))).toHaveLength(2);
+    expect(setFn).not.toHaveBeenCalledWith({ isActive: false });
   });
 
   it('mints once for sends that race on a cold cache', async () => {

--- a/packages/lib/src/notifications/__tests__/push-notifications.test.ts
+++ b/packages/lib/src/notifications/__tests__/push-notifications.test.ts
@@ -1501,6 +1501,141 @@ describe('sendToFcm (Android)', () => {
     expect(calls).toHaveLength(0);
   });
 
+  it('falls back to the Google token endpoint when the account omits token_uri', async () => {
+    process.env.FCM_SERVICE_ACCOUNT_JSON = serviceAccountJson({ token_uri: undefined });
+    vi.mocked(db.query.pushNotificationTokens.findMany).mockResolvedValue([androidToken()] as never);
+    setupUpdateChain();
+    const calls = installFetchStub();
+
+    const result = await sendPushNotification('user-1', payload);
+
+    expect(result.sent).toBe(1);
+    expect(calls[0].url).toBe('https://oauth2.googleapis.com/token');
+  });
+
+  it('treats an access token with no expires_in as lasting the standard hour', async () => {
+    // Observable through the cache: the default has to be long enough that the
+    // second send reuses the token rather than minting again.
+    process.env.FCM_SERVICE_ACCOUNT_JSON = serviceAccountJson({}, 'no-expiry-project');
+    vi.mocked(db.query.pushNotificationTokens.findMany).mockResolvedValue([androidToken()] as never);
+    setupUpdateChain();
+    const calls = installFetchStub({
+      oauth: () => fakeResponse(200, JSON.stringify({ access_token: 'ya29.no-expiry' })),
+    });
+
+    await sendPushNotification('user-1', payload);
+    await sendPushNotification('user-1', payload);
+
+    expect(calls.filter((c) => c.url.includes('oauth2.googleapis.com'))).toHaveLength(1);
+  });
+
+  it('leaves a private key that already has real newlines untouched', async () => {
+    const realNewlineKey = '-----BEGIN PRIVATE KEY-----\nREALKEY\n-----END PRIVATE KEY-----\n';
+    process.env.FCM_SERVICE_ACCOUNT_JSON = serviceAccountJson({ private_key: realNewlineKey });
+    vi.mocked(db.query.pushNotificationTokens.findMany).mockResolvedValue([androidToken()] as never);
+    setupUpdateChain();
+    const { rsaSign } = primeSign();
+    installFetchStub();
+
+    await sendPushNotification('user-1', payload);
+
+    expect(rsaSign.sign.mock.calls[0][0]).toBe(realNewlineKey);
+  });
+
+  it('names client_email when it is the only field missing', async () => {
+    process.env.FCM_SERVICE_ACCOUNT_JSON = serviceAccountJson({ client_email: undefined });
+    vi.mocked(db.query.pushNotificationTokens.findMany).mockResolvedValue([androidToken()] as never);
+    setupUpdateChain();
+    installFetchStub();
+
+    const result = await sendPushNotification('user-1', payload);
+
+    expect(result.errors[0]).toContain('client_email');
+    expect(result.errors[0]).not.toContain('project_id');
+  });
+
+  // A hostile or malformed error body must not be able to crash the parser or,
+  // worse, talk it into a spurious deactivation. Every field here is the wrong
+  // type: message, status, one detail that is not an object, one whose @type is
+  // not a string, and one whose fieldViolations is not an array.
+  it('survives an error body whose every field is the wrong type', async () => {
+    process.env.FCM_SERVICE_ACCOUNT_JSON = serviceAccountJson();
+    vi.mocked(db.query.pushNotificationTokens.findMany).mockResolvedValue([androidToken()] as never);
+    const { setFn } = setupUpdateChain();
+    installFetchStub({
+      send: () =>
+        fakeResponse(400, JSON.stringify({
+          error: {
+            message: 12345,
+            status: { not: 'a string' },
+            details: [
+              'not an object',
+              { '@type': 42, errorCode: 'UNREGISTERED' },
+              { '@type': 'type.googleapis.com/google.rpc.BadRequest', fieldViolations: 'not an array' },
+            ],
+          },
+        })),
+    });
+
+    const result = await sendPushNotification('user-1', payload);
+
+    expect(result.failed).toBe(1);
+    expect(result.errors[0]).toBe('UNKNOWN: Unknown error');
+    expect(setFn).not.toHaveBeenCalledWith({ isActive: false });
+  });
+
+  it('falls back to UNKNOWN when the body is JSON but carries no error object', async () => {
+    process.env.FCM_SERVICE_ACCOUNT_JSON = serviceAccountJson();
+    vi.mocked(db.query.pushNotificationTokens.findMany).mockResolvedValue([androidToken()] as never);
+    const { setFn } = setupUpdateChain();
+    installFetchStub({ send: () => fakeResponse(500, JSON.stringify({ nope: true })) });
+
+    const result = await sendPushNotification('user-1', payload);
+
+    expect(result.errors[0]).toContain('UNKNOWN');
+    expect(setFn).not.toHaveBeenCalledWith({ isActive: false });
+  });
+
+  it('sends empty strings when a visible push carries no title or body', async () => {
+    process.env.FCM_SERVICE_ACCOUNT_JSON = serviceAccountJson();
+    vi.mocked(db.query.pushNotificationTokens.findMany).mockResolvedValue([androidToken()] as never);
+    setupUpdateChain();
+    const calls = installFetchStub();
+
+    await sendPushNotification('user-1', {});
+
+    // FCM rejects a notification block with absent title/body, so they are
+    // always present even when the caller supplied neither.
+    expect(sentMessage(calls).notification).toEqual({ title: '', body: '' });
+  });
+
+  it('carries title and body in data when a silent push has them', async () => {
+    process.env.FCM_SERVICE_ACCOUNT_JSON = serviceAccountJson();
+    vi.mocked(db.query.pushNotificationTokens.findMany).mockResolvedValue([androidToken()] as never);
+    setupUpdateChain();
+    const calls = installFetchStub();
+
+    await sendPushNotification('user-1', { silent: true, title: 'T', body: 'B' });
+
+    const message = sentMessage(calls);
+    expect('notification' in message).toBe(false);
+    expect(message.data).toMatchObject({ silent: 'true', title: 'T', body: 'B' });
+  });
+
+  it('reports a non-Error thrown by the transport', async () => {
+    process.env.FCM_SERVICE_ACCOUNT_JSON = serviceAccountJson({}, 'non-error-throw-project');
+    vi.mocked(db.query.pushNotificationTokens.findMany).mockResolvedValue([androidToken()] as never);
+    const { setFn } = setupUpdateChain();
+    installFetchStub();
+    globalThis.fetch = vi.fn(async () => { throw 'a bare string'; }) as unknown as typeof fetch;
+
+    const result = await sendPushNotification('user-1', payload);
+
+    expect(result.errors[0]).toBe('Unknown error');
+    // Still a server fault: no strike, no deactivation.
+    expect(setFn).not.toHaveBeenCalled();
+  });
+
   it('reuses a recently minted access token instead of re-minting per send', async () => {
     const raw = serviceAccountJson({}, 'shared-cache-project');
     process.env.FCM_SERVICE_ACCOUNT_JSON = raw;

--- a/packages/lib/src/notifications/__tests__/push-notifications.test.ts
+++ b/packages/lib/src/notifications/__tests__/push-notifications.test.ts
@@ -1291,7 +1291,15 @@ describe('sendToFcm (Android)', () => {
         })),
     });
 
-    await sendPushNotification('user-1', payload);
+    const result = await sendPushNotification('user-1', payload);
+
+    // The positive half matters as much as the negative one: without it this
+    // would also pass if the send never reached FCM at all, because the
+    // serverFault path leaves the row untouched too.
+    expect(result.errors[0]).toContain('INVALID_ARGUMENT');
+    expect(setFn).toHaveBeenCalledWith(
+      expect.objectContaining({ failedAttempts: '1', isActive: true })
+    );
 
     expect(setFn).not.toHaveBeenCalledWith({ isActive: false });
   });
@@ -1314,7 +1322,15 @@ describe('sendToFcm (Android)', () => {
         })),
     });
 
-    await sendPushNotification('user-1', payload);
+    const result = await sendPushNotification('user-1', payload);
+
+    // The positive half matters as much as the negative one: without it this
+    // would also pass if the send never reached FCM at all, because the
+    // serverFault path leaves the row untouched too.
+    expect(result.errors[0]).toContain('INVALID_ARGUMENT');
+    expect(setFn).toHaveBeenCalledWith(
+      expect.objectContaining({ failedAttempts: '1', isActive: true })
+    );
 
     expect(setFn).not.toHaveBeenCalledWith({ isActive: false });
   });

--- a/packages/lib/src/notifications/__tests__/push-notifications.test.ts
+++ b/packages/lib/src/notifications/__tests__/push-notifications.test.ts
@@ -1411,6 +1411,41 @@ describe('sendToFcm (Android)', () => {
   // Symmetric to the @type guard on the FcmError branch: fieldViolations only
   // carry a token verdict when they arrive on a BadRequest detail. A different
   // detail type carrying the same shape must not be able to impersonate one.
+  // The detail-type guards match on a SUFFIX, not a substring. A type that
+  // merely contains the marker somewhere in the middle is a different message
+  // type and must not be read as a verdict about the token — otherwise the
+  // impersonation guard is only as strong as a substring search.
+  it('requires the detail type to END with the marker, not merely contain it', async () => {
+    process.env.FCM_SERVICE_ACCOUNT_JSON = serviceAccountJson();
+    vi.mocked(db.query.pushNotificationTokens.findMany).mockResolvedValue([androidToken()] as never);
+    const { setFn } = setupUpdateChain();
+    installFetchStub({
+      send: () =>
+        fakeResponse(400, JSON.stringify({
+          error: {
+            message: 'nope',
+            status: 'INVALID_ARGUMENT',
+            details: [
+              { '@type': 'type.googleapis.com/x.FcmError.Wrapper', errorCode: 'UNREGISTERED' },
+              {
+                '@type': 'type.googleapis.com/x.BadRequest.Envelope',
+                fieldViolations: [{ field: 'message.token', description: 'not really' }],
+              },
+            ],
+          },
+        })),
+    });
+
+    const result = await sendPushNotification('user-1', payload);
+
+    // Falls back to the coarse status, and costs the device nothing.
+    expect(result.errors[0]).toContain('INVALID_ARGUMENT');
+    expect(setFn).not.toHaveBeenCalledWith({ isActive: false });
+    expect(setFn).toHaveBeenCalledWith(
+      expect.objectContaining({ failedAttempts: '1', isActive: true })
+    );
+  });
+
   it('ignores fieldViolations that arrive on a detail other than BadRequest', async () => {
     process.env.FCM_SERVICE_ACCOUNT_JSON = serviceAccountJson();
     vi.mocked(db.query.pushNotificationTokens.findMany).mockResolvedValue([androidToken()] as never);

--- a/packages/lib/src/notifications/__tests__/push-notifications.test.ts
+++ b/packages/lib/src/notifications/__tests__/push-notifications.test.ts
@@ -437,16 +437,12 @@ describe('sendPushNotification', () => {
   });
 
   it('deactivates token after 5 consecutive failures', async () => {
-    // Driven by a real per-token FCM rejection (503 UNAVAILABLE): retryable, so
-    // it takes a strike rather than deactivating outright. An unset credential
-    // would NOT serve here — that is a server fault and deliberately exempt.
-    process.env.FCM_SERVICE_ACCOUNT_JSON = serviceAccountJson({}, 'strike-count-project');
-    primeSign();
-    vi.mocked(db.query.pushNotificationTokens.findMany).mockResolvedValue([tokenRecord({ platform: 'android', failedAttempts: '4' })] as never);
+    // `web` is the only platform left whose failure is charged to the device.
+    // Android deliberately never strikes: FCM reports a dead token outright, so
+    // every other rejection there is classed a server fault. See the
+    // serverFault reasoning in sendToFcm.
+    vi.mocked(db.query.pushNotificationTokens.findMany).mockResolvedValue([tokenRecord({ platform: 'web', failedAttempts: '4' })] as never);
     const { setFn } = setupUpdateChain();
-    installFetchStub({
-      send: () => fakeResponse(503, JSON.stringify({ error: { status: 'UNAVAILABLE', message: 'busy' } })),
-    });
 
     await sendPushNotification('user-1', payload);
 
@@ -457,13 +453,8 @@ describe('sendPushNotification', () => {
   });
 
   it('keeps token active with fewer than 5 failures', async () => {
-    process.env.FCM_SERVICE_ACCOUNT_JSON = serviceAccountJson({}, 'strike-keep-project');
-    primeSign();
-    vi.mocked(db.query.pushNotificationTokens.findMany).mockResolvedValue([tokenRecord({ platform: 'android', failedAttempts: '2' })] as never);
+    vi.mocked(db.query.pushNotificationTokens.findMany).mockResolvedValue([tokenRecord({ platform: 'web', failedAttempts: '2' })] as never);
     const { setFn } = setupUpdateChain();
-    installFetchStub({
-      send: () => fakeResponse(503, JSON.stringify({ error: { status: 'UNAVAILABLE', message: 'busy' } })),
-    });
 
     await sendPushNotification('user-1', payload);
 
@@ -1407,9 +1398,9 @@ describe('sendToFcm (Android)', () => {
 
     expect(result.errors[0]).toContain('INVALID_ARGUMENT');
     expect(setFn).not.toHaveBeenCalledWith({ isActive: false });
-    expect(setFn).toHaveBeenCalledWith(
-      expect.objectContaining({ failedAttempts: '1', isActive: true })
-    );
+    // Not a verdict about this device, so the row is left entirely untouched —
+    // no strike to accumulate toward a deactivation five notifications later.
+    expect(setFn).not.toHaveBeenCalled();
   });
 
   // Symmetric to the @type guard on the FcmError branch: fieldViolations only
@@ -1445,9 +1436,9 @@ describe('sendToFcm (Android)', () => {
     // Falls back to the coarse status, and costs the device nothing.
     expect(result.errors[0]).toContain('INVALID_ARGUMENT');
     expect(setFn).not.toHaveBeenCalledWith({ isActive: false });
-    expect(setFn).toHaveBeenCalledWith(
-      expect.objectContaining({ failedAttempts: '1', isActive: true })
-    );
+    // Not a verdict about this device, so the row is left entirely untouched —
+    // no strike to accumulate toward a deactivation five notifications later.
+    expect(setFn).not.toHaveBeenCalled();
   });
 
   it('ignores fieldViolations that arrive on a detail other than BadRequest', async () => {
@@ -1474,9 +1465,9 @@ describe('sendToFcm (Android)', () => {
     // would also pass if the send never reached FCM at all, because the
     // serverFault path leaves the row untouched too.
     expect(result.errors[0]).toContain('INVALID_ARGUMENT');
-    expect(setFn).toHaveBeenCalledWith(
-      expect.objectContaining({ failedAttempts: '1', isActive: true })
-    );
+    // Not a verdict about this device, so the row is left entirely untouched —
+    // no strike to accumulate toward a deactivation five notifications later.
+    expect(setFn).not.toHaveBeenCalled();
 
     expect(setFn).not.toHaveBeenCalledWith({ isActive: false });
   });
@@ -1505,9 +1496,9 @@ describe('sendToFcm (Android)', () => {
     // would also pass if the send never reached FCM at all, because the
     // serverFault path leaves the row untouched too.
     expect(result.errors[0]).toContain('INVALID_ARGUMENT');
-    expect(setFn).toHaveBeenCalledWith(
-      expect.objectContaining({ failedAttempts: '1', isActive: true })
-    );
+    // Not a verdict about this device, so the row is left entirely untouched —
+    // no strike to accumulate toward a deactivation five notifications later.
+    expect(setFn).not.toHaveBeenCalled();
 
     expect(setFn).not.toHaveBeenCalledWith({ isActive: false });
   });
@@ -1538,9 +1529,9 @@ describe('sendToFcm (Android)', () => {
     expect(result.failed).toBe(1);
     expect(result.errors[0]).toContain('INVALID_ARGUMENT');
     expect(setFn).not.toHaveBeenCalledWith({ isActive: false });
-    expect(setFn).toHaveBeenCalledWith(
-      expect.objectContaining({ failedAttempts: '1', isActive: true })
-    );
+    // Not a verdict about this device, so the row is left entirely untouched —
+    // no strike to accumulate toward a deactivation five notifications later.
+    expect(setFn).not.toHaveBeenCalled();
   });
 
   // Likewise a wrong project id is a bare NOT_FOUND, and says nothing about the token.
@@ -1600,9 +1591,9 @@ describe('sendToFcm (Android)', () => {
     expect(result.failed).toBe(1);
     expect(result.errors[0]).toContain('UNAVAILABLE');
     expect(setFn).not.toHaveBeenCalledWith({ isActive: false });
-    expect(setFn).toHaveBeenCalledWith(
-      expect.objectContaining({ failedAttempts: '1', isActive: true })
-    );
+    // Not a verdict about this device, so the row is left entirely untouched —
+    // no strike to accumulate toward a deactivation five notifications later.
+    expect(setFn).not.toHaveBeenCalled();
   });
 
   it('falls back to UNKNOWN when the FCM error body is not JSON', async () => {

--- a/packages/lib/src/notifications/push-notifications.ts
+++ b/packages/lib/src/notifications/push-notifications.ts
@@ -23,6 +23,10 @@ interface SendPushResult {
   tokenId: string;
   error?: string;
   shouldRemoveToken?: boolean;
+  // The send failed before the push service ever rendered a verdict on this
+  // token — a missing credential, a refused OAuth mint, a dead socket. The
+  // dispatch loop must not count that against the device.
+  serverFault?: boolean;
 }
 
 // Both the APNs JWT (ES256) and the FCM OAuth2 assertion (RS256) are JWTs, so
@@ -564,26 +568,52 @@ function toFcmDataRecord(data: Record<string, unknown> | undefined): Record<stri
   return record;
 }
 
-// `type.googleapis.com/google.firebase.fcm.v1.FcmError` in practice; matched by
-// suffix so a version bump in the type URL does not silently stop matching.
+// Matched by suffix so a version bump in the type URL does not stop matching.
+// In practice `type.googleapis.com/google.firebase.fcm.v1.FcmError` and
+// `type.googleapis.com/google.rpc.BadRequest`.
 const FCM_ERROR_DETAIL_TYPE_SUFFIX = '.FcmError';
+const BAD_REQUEST_DETAIL_TYPE_SUFFIX = '.BadRequest';
+// The field a BadRequest names when it is the registration token it rejected.
+const FCM_TOKEN_FIELD = 'message.token';
+// The one FcmError code that unambiguously means this token is dead.
+const FCM_UNREGISTERED = 'UNREGISTERED';
 
 interface FcmError {
   code: string;
   message: string;
-  // True only when `code` came out of an FcmError detail. That detail is the one
-  // part of the response that is about *this registration token*; `error.status`
-  // is a transport-level gRPC status describing the request as a whole.
-  fromFcmDetail: boolean;
+  // True only when FCM's answer was about *this registration token*, as opposed
+  // to about the request, the message, the project or the deployment. Only this
+  // may cost a device its registration.
+  tokenIsDead: boolean;
 }
 
-// FCM reports the actionable reason in an `FcmError` entry of `error.details`.
-// `error.status` is the coarser gRPC status: the same INVALID_ARGUMENT that a
-// bad token produces is also what a malformed *message* produces, and NOT_FOUND
-// is also what a wrong project id produces. So the two are kept distinguishable
-// rather than collapsed — only the detail may cost a device its registration.
+// FCM answers two different questions in one error body, and telling them apart
+// is the whole job here. Exactly two things mean this specific token is dead:
+//
+//   - an FcmError detail of UNREGISTERED — the app was uninstalled or the token
+//     was replaced. This is the one code firebase-admin's own cleanup guidance
+//     acts on, and it is unambiguous.
+//   - a BadRequest fieldViolation naming `message.token` — FCM parsed the
+//     request and rejected that field specifically, i.e. the token is malformed.
+//     This, not a bare INVALID_ARGUMENT, is how a garbage token actually
+//     reports; gating on the FcmError detail alone would never deactivate one.
+//
+// Everything else is about us, not the device, and is deliberately excluded:
+//
+//   - SENDER_ID_MISMATCH arrives *inside* an FcmError detail, so it looks
+//     token-scoped, but it is a project-level fact. Point the server at another
+//     Firebase project's service account — a staging credential pasted into
+//     prod — and every send 403s with it. Acting on it would set isActive:false
+//     on every Android registration in the database on the first dispatch after
+//     that deploy, and correcting the secret would not bring them back: each
+//     device stays dark until the app relaunches and re-registers.
+//   - a bare INVALID_ARGUMENT is what a malformed *message* returns, and
+//     `createNotification` spreads arbitrary `metadata` into `data` against a
+//     4 KB cap, so one oversized notification could otherwise unregister every
+//     recipient of that notification type.
+//   - NOT_FOUND without a detail is a wrong project id, same argument.
 function extractFcmError(body: string): FcmError {
-  const unknown: FcmError = { code: 'UNKNOWN', message: 'Unknown error', fromFcmDetail: false };
+  const unknown: FcmError = { code: 'UNKNOWN', message: 'Unknown error', tokenIsDead: false };
 
   let parsed: unknown;
   try {
@@ -597,26 +627,34 @@ function extractFcmError(body: string): FcmError {
 
   const message = typeof error.message === 'string' ? error.message : 'Unknown error';
 
-  const details = Array.isArray(error.details) ? error.details : [];
-  for (const entry of details) {
+  let fcmErrorCode: string | null = null;
+  let tokenFieldRejected = false;
+
+  for (const entry of Array.isArray(error.details) ? error.details : []) {
     const detail = asRecord(entry);
-    const type = detail && typeof detail['@type'] === 'string' ? detail['@type'] : null;
-    const errorCode = detail && typeof detail.errorCode === 'string' ? detail.errorCode : null;
-    if (type?.endsWith(FCM_ERROR_DETAIL_TYPE_SUFFIX) && errorCode) {
-      return { code: errorCode, message, fromFcmDetail: true };
+    if (!detail) continue;
+    const type = typeof detail['@type'] === 'string' ? detail['@type'] : '';
+
+    if (type.endsWith(FCM_ERROR_DETAIL_TYPE_SUFFIX) && typeof detail.errorCode === 'string') {
+      fcmErrorCode ??= detail.errorCode;
+    }
+
+    if (type.endsWith(BAD_REQUEST_DETAIL_TYPE_SUFFIX)) {
+      const violations = Array.isArray(detail.fieldViolations) ? detail.fieldViolations : [];
+      if (violations.some((v) => asRecord(v)?.field === FCM_TOKEN_FIELD)) {
+        tokenFieldRejected = true;
+      }
     }
   }
 
   const status = typeof error.status === 'string' ? error.status : 'UNKNOWN';
-  return { code: status, message, fromFcmDetail: false };
+  return {
+    code: fcmErrorCode ?? status,
+    message,
+    tokenIsDead: fcmErrorCode === FCM_UNREGISTERED || tokenFieldRejected,
+  };
 }
 
-// Codes that mean "this token will never work again" — the dispatch loop
-// deactivates the row, mirroring the APNs BadDeviceToken/Unregistered handling.
-// Only ever consulted for a code that came from an FcmError detail: a top-level
-// INVALID_ARGUMENT means the message we built was malformed, and deactivating
-// every Android token on a payload regression would be a self-inflicted outage.
-const FCM_INVALID_TOKEN_CODES = ['UNREGISTERED', 'INVALID_ARGUMENT', 'SENDER_ID_MISMATCH'];
 
 // The `message` of an FCM HTTP v1 send. Pure, so the two shapes it can produce —
 // a visible alert and a data-only background push — are testable without a
@@ -661,13 +699,40 @@ function buildFcmMessage(
     android: {
       priority: 'high',
       notification: {
-        sound: payload.sound || 'default',
+        // `sound` names a res/raw resource on Android, not an iOS bundle
+        // filename, so forwarding a custom iOS sound would resolve to nothing
+        // and silently mute the notification. Only the literal 'default'
+        // crosses over; anything else is left to the notification channel,
+        // which at worst plays its own sound rather than none.
+        ...(payload.sound === undefined || payload.sound === 'default'
+          ? { sound: 'default' }
+          : {}),
         ...(payload.badge !== undefined && { notification_count: payload.badge }),
         ...(payload.threadId ? { tag: payload.threadId } : {}),
-        ...(payload.category ? { click_action: payload.category } : {}),
+        // Deliberately no `click_action`. payload.category is an iOS category
+        // identifier; on Android click_action must match an activity
+        // intent-filter, and the manifest declares only MAIN/LAUNCHER — so
+        // setting it would make tapping the notification do nothing at all
+        // rather than open the app. The category still rides in `data`.
       },
     },
   };
+}
+
+function postFcmMessage(
+  projectId: string,
+  accessToken: string,
+  message: Record<string, unknown>
+): Promise<Response> {
+  return fetch(`https://fcm.googleapis.com/v1/projects/${projectId}/messages:send`, {
+    method: 'POST',
+    headers: {
+      authorization: `Bearer ${accessToken}`,
+      'content-type': 'application/json',
+    },
+    body: JSON.stringify({ message }),
+    signal: AbortSignal.timeout(10000),
+  });
 }
 
 async function sendToFcm(
@@ -688,40 +753,36 @@ async function sendToFcm(
       isSilent,
     });
 
-    const response = await fetch(
-      `https://fcm.googleapis.com/v1/projects/${projectId}/messages:send`,
-      {
-        method: 'POST',
-        headers: {
-          authorization: `Bearer ${accessToken}`,
-          'content-type': 'application/json',
-        },
-        body: JSON.stringify({ message }),
-        signal: AbortSignal.timeout(10000),
-      }
-    );
+    let response = await postFcmMessage(projectId, accessToken, message);
+    let body = await response.text();
 
-    const body = await response.text();
+    // A 401 means the cached access token was revoked or rotated out from under
+    // us. Drop it and retry once with a fresh mint: the token is cached for up
+    // to 50 minutes and fan-out sends run concurrently, so without the retry
+    // every send holding the stale credential in that window is lost, not just
+    // the one that discovered it. The retry is not itself retried.
+    if (response.status === 401) {
+      fcmAccessToken = null;
+      fcmAccessTokenExpiry = 0;
+      fcmAccessTokenSource = null;
+      console.warn('[FCM] access token rejected, re-minting and retrying once', { tokenId });
+
+      const refreshed = await getFcmAccessToken();
+      response = await postFcmMessage(refreshed.projectId, refreshed.accessToken, message);
+      body = await response.text();
+    }
 
     if (response.ok) {
       console.log('[FCM] accepted', { tokenId });
       return { success: true, tokenId };
     }
 
-    const { code, message: reason, fromFcmDetail } = extractFcmError(body);
-
-    // A 401 means the cached access token was revoked or rotated out from under
-    // us; drop it so the next send mints a fresh one instead of looping on 401.
-    if (response.status === 401) {
-      fcmAccessToken = null;
-      fcmAccessTokenExpiry = 0;
-      fcmAccessTokenSource = null;
-    }
+    const { code, message: reason, tokenIsDead } = extractFcmError(body);
 
     console.error('[FCM] reject', {
       status: response.status,
       code,
-      fromFcmDetail,
+      tokenIsDead,
       reason,
       projectId,
       tokenId,
@@ -731,7 +792,7 @@ async function sendToFcm(
       success: false,
       tokenId,
       error: `${code}: ${reason}`,
-      shouldRemoveToken: fromFcmDetail && FCM_INVALID_TOKEN_CODES.includes(code),
+      shouldRemoveToken: tokenIsDead,
     };
   } catch (error) {
     console.error('[FCM] send error', {
@@ -739,10 +800,14 @@ async function sendToFcm(
       isSilent,
       error: error instanceof Error ? (error.stack ?? error.message) : error,
     });
+    // Nothing here is the device's fault: a missing or malformed credential, a
+    // refused OAuth mint, a dead socket. FCM never rendered a verdict on this
+    // token, so the loop must not put a strike against it.
     return {
       success: false,
       tokenId,
       error: error instanceof Error ? error.message : 'Unknown error',
+      serverFault: true,
     };
   }
 }
@@ -893,6 +958,17 @@ export async function sendPushNotification(
         .update(pushNotificationTokens)
         .set({ isActive: false })
         .where(eq(pushNotificationTokens.id, tokenRecord.id));
+    } else if (result.serverFault) {
+      // The send never reached a verdict about this device — an unset
+      // FCM_SERVICE_ACCOUNT_JSON, a refused mint, an outage. Counting these
+      // would deactivate every Android token after five notifications while the
+      // secret is simply missing, which is the state .env.example documents as
+      // the safe default, and fixing the secret would not bring them back.
+      console.warn('[push] server-side failure, not counted against the token', {
+        tokenId: tokenRecord.id,
+        platform: tokenRecord.platform,
+        error: result.error,
+      });
     } else if (!result.success) {
       // Track failed attempts
       const failedAttempts = parseInt(tokenRecord.failedAttempts || '0', 10) + 1;

--- a/packages/lib/src/notifications/push-notifications.ts
+++ b/packages/lib/src/notifications/push-notifications.ts
@@ -628,6 +628,9 @@ async function sendToFcm(
   try {
     const { accessToken, projectId } = await getFcmAccessToken();
 
+    // Caller data first, then the first-class payload fields — createNotification
+    // spreads arbitrary `metadata` into `data`, and a key that happens to be
+    // named `badge` or `silent` must not be able to redefine what we send.
     const data = toFcmDataRecord(payload.data);
     if (payload.badge !== undefined) data.badge = String(payload.badge);
     if (payload.threadId) data.threadId = payload.threadId;

--- a/packages/lib/src/notifications/push-notifications.ts
+++ b/packages/lib/src/notifications/push-notifications.ts
@@ -412,13 +412,34 @@ function parseFcmServiceAccount(raw: string): FcmServiceAccount {
     );
   }
 
+  // The project id is interpolated into the messages:send path, so a stray `/`
+  // or `..` from a mistyped secret would silently aim the send at a different
+  // endpoint. Firebase ids are lowercase alphanumerics and hyphens; the check is
+  // kept a shade wider than that so a legitimate id is never rejected, while
+  // everything that could change the meaning of the URL still is.
+  if (!/^[A-Za-z0-9._-]+$/.test(projectId)) {
+    throw new Error(
+      'FCM configuration invalid: FCM_SERVICE_ACCOUNT_JSON project_id may only contain letters, digits, dots, underscores and hyphens'
+    );
+  }
+
+  // token_uri is fetched with the signed assertion in the body. It comes out of
+  // the credential itself so it is not an attacker-controlled boundary, but a
+  // mistyped http:// would put that assertion on the wire in cleartext.
+  const tokenUri = str('token_uri') || FCM_DEFAULT_TOKEN_URI;
+  if (!tokenUri.startsWith('https://')) {
+    throw new Error(
+      'FCM configuration invalid: FCM_SERVICE_ACCOUNT_JSON token_uri must be an https:// URL'
+    );
+  }
+
   return {
     projectId,
     clientEmail,
     // Secret stores (Fly, .env) commonly deliver the PEM with literal backslash-n
     // rather than real newlines; crypto rejects that outright.
     privateKey: privateKey.includes('\\n') ? privateKey.replace(/\\n/g, '\n') : privateKey,
-    tokenUri: str('token_uri') || FCM_DEFAULT_TOKEN_URI,
+    tokenUri,
   };
 }
 

--- a/packages/lib/src/notifications/push-notifications.ts
+++ b/packages/lib/src/notifications/push-notifications.ts
@@ -25,6 +25,20 @@ interface SendPushResult {
   shouldRemoveToken?: boolean;
 }
 
+// Both the APNs JWT (ES256) and the FCM OAuth2 assertion (RS256) are JWTs, so
+// they share one base64url encoder.
+function base64UrlEncode(input: object | string | Buffer): string {
+  const buffer =
+    Buffer.isBuffer(input)
+      ? input
+      : Buffer.from(typeof input === 'string' ? input : JSON.stringify(input));
+  return buffer
+    .toString('base64')
+    .replace(/\+/g, '-')
+    .replace(/\//g, '_')
+    .replace(/=/g, '');
+}
+
 // APNs JWT token cache
 let apnsJwtToken: string | null = null;
 let apnsJwtExpiry: number = 0;
@@ -56,16 +70,8 @@ function getApnsJwtToken(): string {
     iat: now,
   };
 
-  // Base64url encode
-  const base64url = (obj: object) =>
-    Buffer.from(JSON.stringify(obj))
-      .toString('base64')
-      .replace(/\+/g, '-')
-      .replace(/\//g, '_')
-      .replace(/=/g, '');
-
-  const headerB64 = base64url(header);
-  const claimsB64 = base64url(claims);
+  const headerB64 = base64UrlEncode(header);
+  const claimsB64 = base64UrlEncode(claims);
   const signingInput = `${headerB64}.${claimsB64}`;
 
   // Sign with ES256 (ECDSA P-256)
@@ -109,12 +115,7 @@ function getApnsJwtToken(): string {
     return Buffer.concat([rPadded, sPadded]);
   };
 
-  const rawSignature = derToRaw(signature);
-  const signatureB64 = rawSignature
-    .toString('base64')
-    .replace(/\+/g, '-')
-    .replace(/\//g, '_')
-    .replace(/=/g, '');
+  const signatureB64 = base64UrlEncode(derToRaw(signature));
 
   apnsJwtToken = `${signingInput}.${signatureB64}`;
   apnsJwtExpiry = now + 3600; // Token is valid for 1 hour
@@ -346,6 +347,310 @@ async function sendToApns(
   }
 }
 
+
+// ---------------------------------------------------------------------------
+// FCM (Firebase Cloud Messaging) HTTP v1
+//
+// The v1 API is OAuth2-only: every send needs a Bearer access token minted from
+// the service-account credentials via a JWT-bearer grant. That mint is a real
+// network round-trip, so — exactly like the APNs JWT above — the token is cached
+// at module level and refreshed ahead of expiry rather than per send.
+//
+// Config lives in one env var, `FCM_SERVICE_ACCOUNT_JSON` (the raw service
+// account JSON Firebase hands you). The project id is derived from it, so there
+// is no second variable to keep in sync. When the secret is absent the send
+// fails with a configuration error — the dispatch loop keeps going and other
+// platforms still deliver.
+// ---------------------------------------------------------------------------
+
+const FCM_SCOPE = 'https://www.googleapis.com/auth/firebase.messaging';
+const FCM_DEFAULT_TOKEN_URI = 'https://oauth2.googleapis.com/token';
+
+interface FcmServiceAccount {
+  projectId: string;
+  clientEmail: string;
+  privateKey: string;
+  tokenUri: string;
+}
+
+function parseFcmServiceAccount(raw: string): FcmServiceAccount {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    throw new Error('FCM configuration invalid: FCM_SERVICE_ACCOUNT_JSON is not valid JSON');
+  }
+
+  if (typeof parsed !== 'object' || parsed === null || Array.isArray(parsed)) {
+    throw new Error('FCM configuration invalid: FCM_SERVICE_ACCOUNT_JSON must be a JSON object');
+  }
+
+  const account = parsed as Record<string, unknown>;
+  const str = (key: string): string =>
+    typeof account[key] === 'string' ? (account[key] as string) : '';
+
+  const projectId = str('project_id');
+  const clientEmail = str('client_email');
+  const privateKey = str('private_key');
+
+  const missing = [
+    ...(projectId ? [] : ['project_id']),
+    ...(clientEmail ? [] : ['client_email']),
+    ...(privateKey ? [] : ['private_key']),
+  ];
+  if (missing.length > 0) {
+    throw new Error(
+      `FCM configuration invalid: FCM_SERVICE_ACCOUNT_JSON is missing ${missing.join(', ')}`
+    );
+  }
+
+  return {
+    projectId,
+    clientEmail,
+    // Secret stores (Fly, .env) commonly deliver the PEM with literal backslash-n
+    // rather than real newlines; crypto rejects that outright.
+    privateKey: privateKey.includes('\\n') ? privateKey.replace(/\\n/g, '\n') : privateKey,
+    tokenUri: str('token_uri') || FCM_DEFAULT_TOKEN_URI,
+  };
+}
+
+// FCM OAuth2 access token cache. `fcmAccessTokenSource` pins the cache to the
+// exact credential string it was minted from, so a rotated secret is never
+// served a stale token from the previous service account.
+let fcmAccessToken: string | null = null;
+let fcmAccessTokenExpiry: number = 0;
+let fcmAccessTokenSource: string | null = null;
+
+async function getFcmAccessToken(): Promise<{ accessToken: string; projectId: string }> {
+  const raw = process.env.FCM_SERVICE_ACCOUNT_JSON;
+  if (!raw) {
+    throw new Error('FCM configuration missing: FCM_SERVICE_ACCOUNT_JSON is required');
+  }
+
+  const account = parseFcmServiceAccount(raw);
+  const now = Math.floor(Date.now() / 1000);
+
+  // Google access tokens live for 1 hour; refresh at 50 min, as APNs does.
+  if (fcmAccessToken && fcmAccessTokenSource === raw && fcmAccessTokenExpiry > now + 600) {
+    return { accessToken: fcmAccessToken, projectId: account.projectId };
+  }
+
+  const header = { alg: 'RS256', typ: 'JWT' };
+  const claims = {
+    iss: account.clientEmail,
+    scope: FCM_SCOPE,
+    aud: account.tokenUri,
+    iat: now,
+    exp: now + 3600,
+  };
+
+  const signingInput = `${base64UrlEncode(header)}.${base64UrlEncode(claims)}`;
+
+  const sign = crypto.createSign('RSA-SHA256');
+  sign.update(signingInput);
+  sign.end();
+  // RS256 signatures are already the raw value JWT wants — no DER unwrapping,
+  // unlike the ES256 path APNs uses.
+  const assertion = `${signingInput}.${base64UrlEncode(sign.sign(account.privateKey))}`;
+
+  // No cache invalidation is needed on any failure below: the cache is only ever
+  // written by a fully successful mint, and we only get here when it was already
+  // stale or minted from a different credential. sendToFcm's 401 handler is the
+  // one place a *populated* cache has to be dropped.
+  const response = await fetch(account.tokenUri, {
+    method: 'POST',
+    headers: { 'content-type': 'application/x-www-form-urlencoded' },
+    body: new URLSearchParams({
+      grant_type: 'urn:ietf:params:oauth:grant-type:jwt-bearer',
+      assertion,
+    }).toString(),
+    signal: AbortSignal.timeout(10000),
+  });
+
+  const text = await response.text();
+
+  if (!response.ok) {
+    throw new Error(
+      `FCM OAuth token request failed (${response.status}): ${text.slice(0, 200)}`
+    );
+  }
+
+  let grant: { access_token?: unknown; expires_in?: unknown };
+  try {
+    grant = JSON.parse(text) as { access_token?: unknown; expires_in?: unknown };
+  } catch {
+    throw new Error('FCM OAuth token response was not valid JSON');
+  }
+
+  if (typeof grant.access_token !== 'string' || grant.access_token.length === 0) {
+    throw new Error('FCM OAuth token response did not include an access_token');
+  }
+
+  const expiresIn = typeof grant.expires_in === 'number' ? grant.expires_in : 3600;
+
+  fcmAccessToken = grant.access_token;
+  fcmAccessTokenExpiry = now + expiresIn;
+  fcmAccessTokenSource = raw;
+
+  return { accessToken: fcmAccessToken, projectId: account.projectId };
+}
+
+// FCM data payloads are string→string only; anything else is rejected by the API.
+function toFcmDataRecord(data: Record<string, unknown> | undefined): Record<string, string> {
+  const record: Record<string, string> = {};
+  for (const [key, value] of Object.entries(data ?? {})) {
+    if (value === undefined) continue;
+    record[key] = typeof value === 'string' ? value : JSON.stringify(value);
+  }
+  return record;
+}
+
+// FCM reports the actionable reason in `error.details[].errorCode`; `error.status`
+// is the coarser gRPC status. Prefer the former, fall back to the latter.
+function extractFcmError(body: string): { code: string; message: string } {
+  try {
+    const parsed = JSON.parse(body) as {
+      error?: {
+        status?: unknown;
+        message?: unknown;
+        details?: Array<Record<string, unknown>>;
+      };
+    };
+    const error = parsed.error;
+    const detail = error?.details?.find((d) => typeof d.errorCode === 'string');
+    const code =
+      (typeof detail?.errorCode === 'string' ? detail.errorCode : undefined) ??
+      (typeof error?.status === 'string' ? error.status : undefined) ??
+      'UNKNOWN';
+    const message = typeof error?.message === 'string' ? error.message : 'Unknown error';
+    return { code, message };
+  } catch {
+    return { code: 'UNKNOWN', message: 'Unknown error' };
+  }
+}
+
+// Codes that mean "this token will never work again" — the dispatch loop
+// deactivates the row, mirroring the APNs BadDeviceToken/Unregistered handling.
+// INVALID_ARGUMENT is included per the FCM guidance that it signals a malformed
+// registration token; note it is also what a malformed *message* returns, so a
+// payload regression would deactivate tokens — keep the message builder honest.
+const FCM_INVALID_TOKEN_CODES = ['UNREGISTERED', 'INVALID_ARGUMENT', 'NOT_FOUND'];
+
+async function sendToFcm(
+  deviceToken: string,
+  payload: PushNotificationPayload,
+  tokenId: string
+): Promise<SendPushResult> {
+  const isSilent = payload.silent === true;
+
+  try {
+    const { accessToken, projectId } = await getFcmAccessToken();
+
+    const data = toFcmDataRecord(payload.data);
+    if (payload.badge !== undefined) data.badge = String(payload.badge);
+    if (payload.threadId) data.threadId = payload.threadId;
+    if (payload.category) data.category = payload.category;
+
+    // A silent push must be data-only: including a `notification` block makes
+    // Android render a tray notification itself, no matter what the app does.
+    // Title/body ride along as data so the client can decide for itself.
+    if (isSilent) {
+      data.silent = 'true';
+      if (payload.title !== undefined) data.title = payload.title;
+      if (payload.body !== undefined) data.body = payload.body;
+    }
+
+    const message: Record<string, unknown> = {
+      token: deviceToken,
+      data,
+      android: {
+        // Match APNs: alerts go at high priority, background pushes at normal.
+        priority: isSilent ? 'normal' : 'high',
+        ...(isSilent
+          ? {}
+          : {
+              notification: {
+                sound: payload.sound || 'default',
+                ...(payload.badge !== undefined && { notification_count: payload.badge }),
+                ...(payload.threadId ? { tag: payload.threadId } : {}),
+                ...(payload.category ? { click_action: payload.category } : {}),
+              },
+            }),
+      },
+    };
+
+    if (!isSilent) {
+      message.notification = {
+        title: payload.title ?? '',
+        body: payload.body ?? '',
+      };
+    }
+
+    console.log('[FCM] send', {
+      projectId,
+      tokenId,
+      tokenPrefix: deviceToken.slice(0, 8),
+      isSilent,
+    });
+
+    const response = await fetch(
+      `https://fcm.googleapis.com/v1/projects/${projectId}/messages:send`,
+      {
+        method: 'POST',
+        headers: {
+          authorization: `Bearer ${accessToken}`,
+          'content-type': 'application/json',
+        },
+        body: JSON.stringify({ message }),
+        signal: AbortSignal.timeout(10000),
+      }
+    );
+
+    const body = await response.text();
+
+    if (response.ok) {
+      console.log('[FCM] accepted', { tokenId });
+      return { success: true, tokenId };
+    }
+
+    const { code, message: reason } = extractFcmError(body);
+
+    // A 401 means the cached access token was revoked or rotated out from under
+    // us; drop it so the next send mints a fresh one instead of looping on 401.
+    if (response.status === 401) {
+      fcmAccessToken = null;
+      fcmAccessTokenExpiry = 0;
+      fcmAccessTokenSource = null;
+    }
+
+    console.error('[FCM] reject', {
+      status: response.status,
+      code,
+      reason,
+      projectId,
+      tokenId,
+    });
+
+    return {
+      success: false,
+      tokenId,
+      error: `${code}: ${reason}`,
+      shouldRemoveToken: FCM_INVALID_TOKEN_CODES.includes(code),
+    };
+  } catch (error) {
+    console.error('[FCM] send error', {
+      tokenId,
+      isSilent,
+      error: error instanceof Error ? (error.stack ?? error.message) : error,
+    });
+    return {
+      success: false,
+      tokenId,
+      error: error instanceof Error ? error.message : 'Unknown error',
+    };
+  }
+}
+
 export async function registerPushToken(
   userId: string,
   token: string,
@@ -466,12 +771,7 @@ export async function sendPushNotification(
         result = await sendToApns(tokenRecord.token, payload, tokenRecord.id);
         break;
       case 'android':
-        // TODO: Implement FCM when Android app is added
-        result = {
-          success: false,
-          tokenId: tokenRecord.id,
-          error: 'Android push not yet implemented',
-        };
+        result = await sendToFcm(tokenRecord.token, payload, tokenRecord.id);
         break;
       case 'web':
         // TODO: Implement Web Push when PWA push is added

--- a/packages/lib/src/notifications/push-notifications.ts
+++ b/packages/lib/src/notifications/push-notifications.ts
@@ -636,8 +636,9 @@ function extractFcmError(body: string): FcmError {
     return unknown;
   }
 
-  const error = asRecord(asRecord(parsed)?.error);
-  if (!error) return unknown;
+  // An absent or non-object `error` needs no early return: every read below
+  // already falls back, and an empty object produces exactly `unknown`.
+  const error = asRecord(asRecord(parsed)?.error) ?? {};
 
   const message = typeof error.message === 'string' ? error.message : 'Unknown error';
 

--- a/packages/lib/src/notifications/push-notifications.ts
+++ b/packages/lib/src/notifications/push-notifications.ts
@@ -792,10 +792,28 @@ async function sendToFcm(
 
     const { code, message: reason, tokenIsDead } = extractFcmError(body);
 
+    // The device is accountable only when FCM rendered a verdict about the
+    // token itself. Every other rejection is about us: a revoked or rotated
+    // credential (401), a wrong-project credential (403 SENDER_ID_MISMATCH), a
+    // message we built badly (400), a quota we blew (429), an FCM outage (5xx).
+    // None of those say anything about the phone, and five in a row would
+    // otherwise write isActive:false across every Android registration in the
+    // database — the exact fleet-wide outage the token-scoped verdict above
+    // exists to prevent, arrived at five notifications later instead of one.
+    //
+    // Deliberately not a list of statuses. Any list is a list of the failures
+    // someone thought of, and the cost of missing one is the whole install
+    // base; 404-wrong-project, 429 and 400-malformed-message would all have
+    // been missed by the obvious enumeration. Nothing is lost by declining to
+    // infer death from repeated failure, because FCM reports a genuinely dead
+    // token authoritatively and immediately.
+    const serverFault = !tokenIsDead;
+
     console.error('[FCM] reject', {
       status: response.status,
       code,
       tokenIsDead,
+      serverFault,
       reason,
       projectId,
       tokenId,
@@ -806,6 +824,7 @@ async function sendToFcm(
       tokenId,
       error: `${code}: ${reason}`,
       shouldRemoveToken: tokenIsDead,
+      serverFault,
     };
   } catch (error) {
     console.error('[FCM] send error', {

--- a/packages/lib/src/notifications/push-notifications.ts
+++ b/packages/lib/src/notifications/push-notifications.ts
@@ -477,6 +477,18 @@ function clearFcmAccessToken(): void {
   fcmAccessTokenSource = null;
 }
 
+// Evict only if the cache still holds the token that was actually rejected —
+// the same "is it still ours" guard the APNs session pool and the in-flight
+// mint slot already use. Under fan-out many requests are in the air carrying
+// one token, so the first 401 handled mints a replacement while later 401s
+// from requests made with the OLD token are still arriving. An unconditional
+// clear would throw that replacement away and start another mint per late
+// response, which is precisely the per-recipient mint burst the single-flight
+// exists to prevent.
+function clearFcmAccessTokenIfCurrent(rejected: string): void {
+  if (fcmAccessToken === rejected) clearFcmAccessToken();
+}
+
 async function getFcmAccessToken(): Promise<{ accessToken: string; projectId: string }> {
   const raw = process.env.FCM_SERVICE_ACCOUNT_JSON;
   if (!raw) {
@@ -777,7 +789,7 @@ async function sendToFcm(
     // every send holding the stale credential in that window is lost, not just
     // the one that discovered it. The retry is not itself retried.
     if (response.status === 401) {
-      clearFcmAccessToken();
+      clearFcmAccessTokenIfCurrent(accessToken);
       console.warn('[FCM] access token rejected, re-minting and retrying once', { tokenId });
 
       const refreshed = await getFcmAccessToken();

--- a/packages/lib/src/notifications/push-notifications.ts
+++ b/packages/lib/src/notifications/push-notifications.ts
@@ -618,6 +618,58 @@ function extractFcmError(body: string): FcmError {
 // every Android token on a payload regression would be a self-inflicted outage.
 const FCM_INVALID_TOKEN_CODES = ['UNREGISTERED', 'INVALID_ARGUMENT', 'SENDER_ID_MISMATCH'];
 
+// The `message` of an FCM HTTP v1 send. Pure, so the two shapes it can produce —
+// a visible alert and a data-only background push — are testable without a
+// transport, and so sendToFcm below is only auth, transport and classification.
+function buildFcmMessage(
+  deviceToken: string,
+  payload: PushNotificationPayload
+): Record<string, unknown> {
+  const isSilent = payload.silent === true;
+
+  // Caller data first, then the first-class payload fields — createNotification
+  // spreads arbitrary `metadata` into `data`, and a key that happens to be
+  // named `badge` or `silent` must not be able to redefine what we send.
+  const data = toFcmDataRecord(payload.data);
+  if (payload.badge !== undefined) data.badge = String(payload.badge);
+  if (payload.threadId) data.threadId = payload.threadId;
+  if (payload.category) data.category = payload.category;
+
+  // A silent push must be data-only: including a `notification` block makes
+  // Android render a tray notification itself, no matter what the app does.
+  // Title/body ride along as data so the client can decide for itself.
+  if (isSilent) {
+    data.silent = 'true';
+    if (payload.title !== undefined) data.title = payload.title;
+    if (payload.body !== undefined) data.body = payload.body;
+
+    return {
+      token: deviceToken,
+      data,
+      // Match APNs, which sends background pushes at priority 5 rather than 10.
+      android: { priority: 'normal' },
+    };
+  }
+
+  return {
+    token: deviceToken,
+    data,
+    notification: {
+      title: payload.title ?? '',
+      body: payload.body ?? '',
+    },
+    android: {
+      priority: 'high',
+      notification: {
+        sound: payload.sound || 'default',
+        ...(payload.badge !== undefined && { notification_count: payload.badge }),
+        ...(payload.threadId ? { tag: payload.threadId } : {}),
+        ...(payload.category ? { click_action: payload.category } : {}),
+      },
+    },
+  };
+}
+
 async function sendToFcm(
   deviceToken: string,
   payload: PushNotificationPayload,
@@ -627,49 +679,7 @@ async function sendToFcm(
 
   try {
     const { accessToken, projectId } = await getFcmAccessToken();
-
-    // Caller data first, then the first-class payload fields — createNotification
-    // spreads arbitrary `metadata` into `data`, and a key that happens to be
-    // named `badge` or `silent` must not be able to redefine what we send.
-    const data = toFcmDataRecord(payload.data);
-    if (payload.badge !== undefined) data.badge = String(payload.badge);
-    if (payload.threadId) data.threadId = payload.threadId;
-    if (payload.category) data.category = payload.category;
-
-    // A silent push must be data-only: including a `notification` block makes
-    // Android render a tray notification itself, no matter what the app does.
-    // Title/body ride along as data so the client can decide for itself.
-    if (isSilent) {
-      data.silent = 'true';
-      if (payload.title !== undefined) data.title = payload.title;
-      if (payload.body !== undefined) data.body = payload.body;
-    }
-
-    const message: Record<string, unknown> = {
-      token: deviceToken,
-      data,
-      android: {
-        // Match APNs: alerts go at high priority, background pushes at normal.
-        priority: isSilent ? 'normal' : 'high',
-        ...(isSilent
-          ? {}
-          : {
-              notification: {
-                sound: payload.sound || 'default',
-                ...(payload.badge !== undefined && { notification_count: payload.badge }),
-                ...(payload.threadId ? { tag: payload.threadId } : {}),
-                ...(payload.category ? { click_action: payload.category } : {}),
-              },
-            }),
-      },
-    };
-
-    if (!isSilent) {
-      message.notification = {
-        title: payload.title ?? '',
-        body: payload.body ?? '',
-      };
-    }
+    const message = buildFcmMessage(deviceToken, payload);
 
     console.log('[FCM] send', {
       projectId,

--- a/packages/lib/src/notifications/push-notifications.ts
+++ b/packages/lib/src/notifications/push-notifications.ts
@@ -461,6 +461,22 @@ let fcmAccessTokenSource: string | null = null;
 let fcmMintInFlight: Promise<string> | null = null;
 let fcmMintInFlightSource: string | null = null;
 
+// The three cache fields are one value and must move together: a token, when it
+// dies, and which credential produced it. They are written by a successful mint
+// and cleared by a rejected one, from two different functions, so the two
+// transitions are named rather than open-coded at each site.
+function cacheFcmAccessToken(token: string, expiresAt: number, source: string): void {
+  fcmAccessToken = token;
+  fcmAccessTokenExpiry = expiresAt;
+  fcmAccessTokenSource = source;
+}
+
+function clearFcmAccessToken(): void {
+  fcmAccessToken = null;
+  fcmAccessTokenExpiry = 0;
+  fcmAccessTokenSource = null;
+}
+
 async function getFcmAccessToken(): Promise<{ accessToken: string; projectId: string }> {
   const raw = process.env.FCM_SERVICE_ACCOUNT_JSON;
   if (!raw) {
@@ -551,11 +567,9 @@ async function mintFcmAccessToken(account: FcmServiceAccount, raw: string): Prom
 
   const expiresIn = typeof grant.expires_in === 'number' ? grant.expires_in : 3600;
 
-  fcmAccessToken = grant.access_token;
-  fcmAccessTokenExpiry = now + expiresIn;
-  fcmAccessTokenSource = raw;
+  cacheFcmAccessToken(grant.access_token, now + expiresIn, raw);
 
-  return fcmAccessToken;
+  return grant.access_token;
 }
 
 // FCM data payloads are string→string only; anything else is rejected by the API.
@@ -762,9 +776,7 @@ async function sendToFcm(
     // every send holding the stale credential in that window is lost, not just
     // the one that discovered it. The retry is not itself retried.
     if (response.status === 401) {
-      fcmAccessToken = null;
-      fcmAccessTokenExpiry = 0;
-      fcmAccessTokenSource = null;
+      clearFcmAccessToken();
       console.warn('[FCM] access token rejected, re-minting and retrying once', { tokenId });
 
       const refreshed = await getFcmAccessToken();

--- a/packages/lib/src/notifications/push-notifications.ts
+++ b/packages/lib/src/notifications/push-notifications.ts
@@ -543,6 +543,10 @@ function toFcmDataRecord(data: Record<string, unknown> | undefined): Record<stri
   return record;
 }
 
+// `type.googleapis.com/google.firebase.fcm.v1.FcmError` in practice; matched by
+// suffix so a version bump in the type URL does not silently stop matching.
+const FCM_ERROR_DETAIL_TYPE_SUFFIX = '.FcmError';
+
 interface FcmError {
   code: string;
   message: string;
@@ -585,10 +589,6 @@ function extractFcmError(body: string): FcmError {
   const status = typeof error.status === 'string' ? error.status : 'UNKNOWN';
   return { code: status, message, fromFcmDetail: false };
 }
-
-// `type.googleapis.com/google.firebase.fcm.v1.FcmError` in practice; matched by
-// suffix so a version bump in the type URL does not silently stop matching.
-const FCM_ERROR_DETAIL_TYPE_SUFFIX = '.FcmError';
 
 // Codes that mean "this token will never work again" — the dispatch loop
 // deactivates the row, mirroring the APNs BadDeviceToken/Unregistered handling.

--- a/packages/lib/src/notifications/push-notifications.ts
+++ b/packages/lib/src/notifications/push-notifications.ts
@@ -373,6 +373,14 @@ interface FcmServiceAccount {
   tokenUri: string;
 }
 
+// Everything below parses untrusted JSON — a secret typed by a human, and error
+// bodies from Google — so narrow rather than cast.
+function asRecord(value: unknown): Record<string, unknown> | null {
+  return typeof value === 'object' && value !== null && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : null;
+}
+
 function parseFcmServiceAccount(raw: string): FcmServiceAccount {
   let parsed: unknown;
   try {
@@ -381,11 +389,11 @@ function parseFcmServiceAccount(raw: string): FcmServiceAccount {
     throw new Error('FCM configuration invalid: FCM_SERVICE_ACCOUNT_JSON is not valid JSON');
   }
 
-  if (typeof parsed !== 'object' || parsed === null || Array.isArray(parsed)) {
+  const account = asRecord(parsed);
+  if (!account) {
     throw new Error('FCM configuration invalid: FCM_SERVICE_ACCOUNT_JSON must be a JSON object');
   }
 
-  const account = parsed as Record<string, unknown>;
   const str = (key: string): string =>
     typeof account[key] === 'string' ? (account[key] as string) : '';
 
@@ -421,6 +429,13 @@ let fcmAccessToken: string | null = null;
 let fcmAccessTokenExpiry: number = 0;
 let fcmAccessTokenSource: string | null = null;
 
+// A mint that is already in the air. Sends fan out concurrently — broadcastTos-
+// PrivacyUpdate creates a notification for every user through Promise.all — and
+// on a cold cache each one would otherwise observe "no token" and open its own
+// OAuth request, one per Android recipient. Waiters share a single mint instead.
+let fcmMintInFlight: Promise<string> | null = null;
+let fcmMintInFlightSource: string | null = null;
+
 async function getFcmAccessToken(): Promise<{ accessToken: string; projectId: string }> {
   const raw = process.env.FCM_SERVICE_ACCOUNT_JSON;
   if (!raw) {
@@ -428,12 +443,35 @@ async function getFcmAccessToken(): Promise<{ accessToken: string; projectId: st
   }
 
   const account = parseFcmServiceAccount(raw);
-  const now = Math.floor(Date.now() / 1000);
 
   // Google access tokens live for 1 hour; refresh at 50 min, as APNs does.
-  if (fcmAccessToken && fcmAccessTokenSource === raw && fcmAccessTokenExpiry > now + 600) {
+  if (
+    fcmAccessToken &&
+    fcmAccessTokenSource === raw &&
+    fcmAccessTokenExpiry > Math.floor(Date.now() / 1000) + 600
+  ) {
     return { accessToken: fcmAccessToken, projectId: account.projectId };
   }
+
+  // Join the in-flight mint only when it is for this same credential — a waiter
+  // for a rotated secret must never be handed the previous account's token.
+  if (!fcmMintInFlight || fcmMintInFlightSource !== raw) {
+    const guarded: Promise<string> = mintFcmAccessToken(account, raw).finally(() => {
+      // Only clear the slot if it is still ours; a newer mint may have replaced it.
+      if (fcmMintInFlight === guarded) {
+        fcmMintInFlight = null;
+        fcmMintInFlightSource = null;
+      }
+    });
+    fcmMintInFlight = guarded;
+    fcmMintInFlightSource = raw;
+  }
+
+  return { accessToken: await fcmMintInFlight, projectId: account.projectId };
+}
+
+async function mintFcmAccessToken(account: FcmServiceAccount, raw: string): Promise<string> {
+  const now = Math.floor(Date.now() / 1000);
 
   const header = { alg: 'RS256', typ: 'JWT' };
   const claims = {
@@ -492,7 +530,7 @@ async function getFcmAccessToken(): Promise<{ accessToken: string; projectId: st
   fcmAccessTokenExpiry = now + expiresIn;
   fcmAccessTokenSource = raw;
 
-  return { accessToken: fcmAccessToken, projectId: account.projectId };
+  return fcmAccessToken;
 }
 
 // FCM data payloads are string→string only; anything else is rejected by the API.
@@ -505,36 +543,59 @@ function toFcmDataRecord(data: Record<string, unknown> | undefined): Record<stri
   return record;
 }
 
-// FCM reports the actionable reason in `error.details[].errorCode`; `error.status`
-// is the coarser gRPC status. Prefer the former, fall back to the latter.
-function extractFcmError(body: string): { code: string; message: string } {
-  try {
-    const parsed = JSON.parse(body) as {
-      error?: {
-        status?: unknown;
-        message?: unknown;
-        details?: Array<Record<string, unknown>>;
-      };
-    };
-    const error = parsed.error;
-    const detail = error?.details?.find((d) => typeof d.errorCode === 'string');
-    const code =
-      (typeof detail?.errorCode === 'string' ? detail.errorCode : undefined) ??
-      (typeof error?.status === 'string' ? error.status : undefined) ??
-      'UNKNOWN';
-    const message = typeof error?.message === 'string' ? error.message : 'Unknown error';
-    return { code, message };
-  } catch {
-    return { code: 'UNKNOWN', message: 'Unknown error' };
-  }
+interface FcmError {
+  code: string;
+  message: string;
+  // True only when `code` came out of an FcmError detail. That detail is the one
+  // part of the response that is about *this registration token*; `error.status`
+  // is a transport-level gRPC status describing the request as a whole.
+  fromFcmDetail: boolean;
 }
+
+// FCM reports the actionable reason in an `FcmError` entry of `error.details`.
+// `error.status` is the coarser gRPC status: the same INVALID_ARGUMENT that a
+// bad token produces is also what a malformed *message* produces, and NOT_FOUND
+// is also what a wrong project id produces. So the two are kept distinguishable
+// rather than collapsed — only the detail may cost a device its registration.
+function extractFcmError(body: string): FcmError {
+  const unknown: FcmError = { code: 'UNKNOWN', message: 'Unknown error', fromFcmDetail: false };
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(body);
+  } catch {
+    return unknown;
+  }
+
+  const error = asRecord(asRecord(parsed)?.error);
+  if (!error) return unknown;
+
+  const message = typeof error.message === 'string' ? error.message : 'Unknown error';
+
+  const details = Array.isArray(error.details) ? error.details : [];
+  for (const entry of details) {
+    const detail = asRecord(entry);
+    const type = detail && typeof detail['@type'] === 'string' ? detail['@type'] : null;
+    const errorCode = detail && typeof detail.errorCode === 'string' ? detail.errorCode : null;
+    if (type?.endsWith(FCM_ERROR_DETAIL_TYPE_SUFFIX) && errorCode) {
+      return { code: errorCode, message, fromFcmDetail: true };
+    }
+  }
+
+  const status = typeof error.status === 'string' ? error.status : 'UNKNOWN';
+  return { code: status, message, fromFcmDetail: false };
+}
+
+// `type.googleapis.com/google.firebase.fcm.v1.FcmError` in practice; matched by
+// suffix so a version bump in the type URL does not silently stop matching.
+const FCM_ERROR_DETAIL_TYPE_SUFFIX = '.FcmError';
 
 // Codes that mean "this token will never work again" — the dispatch loop
 // deactivates the row, mirroring the APNs BadDeviceToken/Unregistered handling.
-// INVALID_ARGUMENT is included per the FCM guidance that it signals a malformed
-// registration token; note it is also what a malformed *message* returns, so a
-// payload regression would deactivate tokens — keep the message builder honest.
-const FCM_INVALID_TOKEN_CODES = ['UNREGISTERED', 'INVALID_ARGUMENT', 'NOT_FOUND'];
+// Only ever consulted for a code that came from an FcmError detail: a top-level
+// INVALID_ARGUMENT means the message we built was malformed, and deactivating
+// every Android token on a payload regression would be a self-inflicted outage.
+const FCM_INVALID_TOKEN_CODES = ['UNREGISTERED', 'INVALID_ARGUMENT', 'SENDER_ID_MISMATCH'];
 
 async function sendToFcm(
   deviceToken: string,
@@ -613,7 +674,7 @@ async function sendToFcm(
       return { success: true, tokenId };
     }
 
-    const { code, message: reason } = extractFcmError(body);
+    const { code, message: reason, fromFcmDetail } = extractFcmError(body);
 
     // A 401 means the cached access token was revoked or rotated out from under
     // us; drop it so the next send mints a fresh one instead of looping on 401.
@@ -626,6 +687,7 @@ async function sendToFcm(
     console.error('[FCM] reject', {
       status: response.status,
       code,
+      fromFcmDetail,
       reason,
       projectId,
       tokenId,
@@ -635,7 +697,7 @@ async function sendToFcm(
       success: false,
       tokenId,
       error: `${code}: ${reason}`,
-      shouldRemoveToken: FCM_INVALID_TOKEN_CODES.includes(code),
+      shouldRemoveToken: fromFcmDetail && FCM_INVALID_TOKEN_CODES.includes(code),
     };
   } catch (error) {
     console.error('[FCM] send error', {


### PR DESCRIPTION
> **Merging this does not make Android push start working.** The client still registers for push
> on iOS only — `apps/web/src/hooks/usePushNotifications.ts` gates on `isNative && platform ===
> 'ios'` under a comment reading *"Only supported on iOS for now"* — so no Android token can exist
> yet and there is nothing for this sender to send to. That gate belongs to the Android client leaf
> of this epic, not to the send path. This PR makes the server capable and is inert until then; no
> further server work is required once registration lands.
>
> It is also inert without `FCM_SERVICE_ACCOUNT_JSON`, which is safe by design — see below.

## Why

`packages/lib/src/notifications/push-notifications.ts` dispatches per token platform. The
`case 'android'` branch was a stub returning `Android push not yet implemented`. Everything
*around* it already accepted Android: the `pushNotificationTokens.platform` enum, the
`/api/notifications/push-tokens` route, the schema. So an Android token was stored, looked
healthy, and was silently dropped at send time.

This is the server half of the Android parity epic (Phase D, leaf 8/11). The Android client
work — permission prompt and token registration — is a sibling leaf. Scope here is
`packages/lib` only, so it lands independently of the web-layer refactor in flight elsewhere.

## What it sends

Two legs, both over plain `fetch` (FCM is HTTP/1.1-friendly, unlike APNs).

**1. Mint an access token** — `POST` to the service account's `token_uri`
(`https://oauth2.googleapis.com/token`), `application/x-www-form-urlencoded`:

```
grant_type=urn:ietf:params:oauth:grant-type:jwt-bearer&assertion=<RS256 JWT>
```

The assertion is signed with `crypto.createSign('RSA-SHA256')` over
`{iss: client_email, scope: https://www.googleapis.com/auth/firebase.messaging,
aud: token_uri, iat, exp: iat+3600}`. No `firebase-admin` — a very large dependency for one
HTTP call, and `crypto` was already imported in this file.

**2. Send** — `POST https://fcm.googleapis.com/v1/projects/<project_id>/messages:send`,
`authorization: Bearer <access_token>`, `content-type: application/json`.

Visible:
```jsonc
{ "message": {
    "token": "<fcm token>",
    "notification": { "title": "...", "body": "..." },
    "data": { "badge": "7", "threadId": "...", "category": "..." },
    "android": { "priority": "high",
                 "notification": { "sound": "default", "notification_count": 7,
                                   "tag": "<threadId>", "click_action": "<category>" } }
} }
```

Silent — **data-only**, no `notification` block anywhere, because including one makes Android
draw a tray notification regardless of what the app does. Title/body ride along as data so the
client can decide for itself. Priority drops to `normal`, matching APNs' `apns-priority: 5`:
```jsonc
{ "message": { "token": "...", "data": { "silent": "true", "badge": "3", ... },
               "android": { "priority": "normal" } } }
```

FCM data is string→string only, so non-string values are `JSON.stringify`'d and `undefined`
values dropped.

## Config absence

One env var, `FCM_SERVICE_ACCOUNT_JSON` — the raw service account JSON, documented in
`.env.example` beneath the APNs block with the same literal-`\n` guidance the `.p8` key needs.
**Jono provisions the Fly secret; nothing is committed and this PR does not depend on it
existing.** The project id is derived from the JSON rather than duplicated in a second variable
that could drift. The template value is left blank deliberately: blank takes the
`...is required` path, which names the problem, where a `your_...` placeholder would surface as
`not valid JSON` and read like a bug.

Every configuration problem throws inside `sendToFcm`'s try, which returns a failed
`SendPushResult` — the dispatch loop keeps going and other platforms still deliver. A user
with an iPhone and an Android phone gets `{sent: 1, failed: 1}`, not a thrown dispatch:

| Situation | Error |
|---|---|
| env var absent | `FCM configuration missing: FCM_SERVICE_ACCOUNT_JSON is required` (no network call attempted) |
| not JSON | `FCM configuration invalid: FCM_SERVICE_ACCOUNT_JSON is not valid JSON` |
| JSON but not an object | `... must be a JSON object` |
| fields missing | `... is missing project_id, private_key` — names exactly which |
| token endpoint rejects | `FCM OAuth token request failed (400): {"error":"invalid_grant"}` |

None of these set `shouldRemoveToken` — a misconfigured server must not deactivate real
devices. Secret stores hand PEMs back with literal backslash-n, which `crypto` rejects outright,
so the private key is unescaped before signing.

### Nothing leaks the credential

Audited, since this path handles a private key and bearer tokens. Log calls carry only
`projectId`, `tokenId` and an 8-character device-token prefix — never the service account, the
key, the assertion or the access token. Configuration errors name the missing *field*, never its
value. The one error that embeds external text is the OAuth failure, and that text is Google's
own response body (`invalid_grant` and similar), which contains no secret of ours. The `errors[]`
array `sendPushNotification` returns is discarded by both of its callers, so none of it reaches
an HTTP response.

## Token cache

Mirrors `getApnsJwtToken`: module-level `fcmAccessToken` / `fcmAccessTokenExpiry`, reused while
more than 10 minutes of the 1-hour life remain (refresh at 50 min). Additionally pinned to the
credential string it was minted from, so a rotated secret can never be served the previous
account's token. A `401` from the send leg drops the cache so the next send re-mints rather than
looping on 401.

Concurrent sends share a **single in-flight mint**. `broadcastTosPrivacyUpdate` fans out over
every user with `Promise.all`, so on a cold cache each Android recipient would otherwise open its
own OAuth request. The in-flight slot is pinned to the credential it was started for (a waiter
arriving after a rotation opens its own mint rather than taking the old account's token) and is
cleared on settle under an identity guard — the same shape `evictIfCurrent` uses for the APNs
sessions above — so a failed mint does not wedge every later send on a dead promise.

## Invalid tokens — only a token-specific verdict may unregister a phone

This is the part of the PR that got the most scrutiny, and it was wrong twice
before it was right.

FCM answers two different questions in one error body: something about *this
registration token*, or something about the request, the message, the project, or
our deployment. Only the first may cost a device its registration — a token, once
deactivated, does not come back when the server is fixed. It stays dark until the
app is next opened and re-registers.

Exactly two responses mean this token is dead:

- an **`FcmError` detail of `UNREGISTERED`** — the app was uninstalled or the token
  was replaced. This is the one code `firebase-admin`'s own cleanup guidance acts on.
- a **`BadRequest` fieldViolation naming `message.token`** — FCM parsed the request
  and rejected that field specifically, i.e. the token string is malformed. This,
  not a bare `INVALID_ARGUMENT`, is how a garbage token actually reports.

Both detail types are matched on `@type`, so neither can be impersonated by the
other's shape. Everything else takes the ordinary `failedAttempts` path.

Deliberately **not** treated as token death:

| Response | Why it is spared |
|---|---|
| `SENDER_ID_MISMATCH` (in an `FcmError` detail) | Project-level, not token-level. A staging service account in prod makes *every* send 403 with it — acting on it unregisters the entire Android install base on one dispatch. |
| `INVALID_ARGUMENT` in an `FcmError` detail | A message-level fault. `createNotification` spreads arbitrary `metadata` into `data` against a 4 KB cap, so one oversized notification would otherwise unregister every recipient of that type. |
| bare `INVALID_ARGUMENT` / `NOT_FOUND` (no detail) | Malformed message, or wrong project id. Says nothing about the device. |
| `UNAVAILABLE`, `INTERNAL`, quota | Transient. |

## Android tokens never accrue failure strikes — read this one

The most consequential behavioural decision in the PR, and the easiest to miss in a diff.

`SendPushResult.serverFault` is set for **every** Android failure that is not an authoritative
verdict about the token:

```ts
const serverFault = !tokenIsDead;
```

The dispatch loop leaves those rows completely alone — no strike, no deactivation. Since the two
token-dead verdicts deactivate immediately via `shouldRemoveToken`, the consequence is that
`failedAttempts` no longer applies to Android at all. **It now serves iOS and web only.**

That is deliberate. The counter exists to retire tokens that fail persistently for reasons we
cannot classify, but FCM classifies authoritatively and immediately, so there is nothing left for
it to infer. Meanwhile the cost of getting it wrong is asymmetric and severe: five notifications
during an outage, a quota, a wrong-project credential or a payload regression would have written
`isActive: false` across every Android registration in the database, and correcting the fault
would not bring them back — each device stays dark until its app is next opened.

This is deliberately *not* a list of HTTP statuses. The obvious enumeration (401/403/5xx) misses a
wrong-project 404, a 429 quota and a 400 malformed message, all of which are our fault rather
than the device's. Any list is a list of the failures someone thought of; the blast radius here is
the whole install base.

## Nobody gets blamed for a server-side failure

`SendPushResult` carries `serverFault` for failures where the push service never
rendered a verdict on the token at all — a missing or malformed credential, a
refused OAuth mint, a dead socket. The dispatch loop leaves those rows completely
alone: no strike, no deactivation.

Without this, the generic `isActive: failedAttempts < 5` rule quietly undid the
guarantee above. With `FCM_SERVICE_ACCOUNT_JSON` unset — the state `.env.example`
documents as the safe default — every Android token took a strike per notification
and was deactivated on the fifth, from a pure config error.

A `401` on the send leg drops the cached token, re-mints, and **retries once**
(bounded). The token is cached for up to 50 minutes and fan-out sends run
concurrently, so without the retry every send holding the stale credential in that
window was dropped, not just the one that discovered it.

## Android is not iOS

`payload.category` is an iOS category identifier and is **not** forwarded as
`click_action`: on Android that must match an activity intent-filter, and
`apps/android/.../AndroidManifest.xml` declares only `MAIN`/`LAUNCHER`, so setting
it would make tapping the notification do nothing at all — worse than the default
of opening the app. The category still rides in `data`.

`sound` has the same shape — it names a `res/raw` resource on Android, not a bundle
filename — so only the literal `'default'` crosses over. A custom sound is omitted
and left to the notification channel, which at worst plays its own sound rather
than none.

## Verification

226 tests pass across `packages/lib/src/notifications`, 60 of them the FCM suite, plus a separate
`__tests__/push-notifications-signing.test.ts` that runs the signing path with **real crypto** and
verifies the resulting JWT against the matching public key. Tests run against
`src`, not `dist`, so there is no build/mutate ordering trap.

Run the way CI runs it (`test:coverage`, not `test`) — that distinction matters here, because an
unhandled rejection fails that job while every test still reports passing, and this file now
carries a single-flight promise and a retry. No `Errors` line, no unhandled rejections.

Branch coverage on `push-notifications.ts`: **91.7%**, statements 99.0%. The two arms still
uncovered are an `Error` carrying no `.stack` and a pre-existing line in the dispatch loop. The
package gate (94% branches) was never at risk — the aggregate measures 94.89% even in a worktree
where 76 unrelated suites cannot resolve their dependencies and count as zero.

**Mutation check — 19 of 20 mutations went red:**

| Mutation | Result |
|---|---|
| `priority: isSilent ? 'normal' : 'high'` → always `'high'` | 🔴 caught |
| silent payload gets a `notification` block anyway | 🔴 caught |
| silent payload gets `android.notification` anyway | 🔴 caught |
| invalid-token code list → `[]` | 🔴 caught |
| drop `INVALID_ARGUMENT` from the list | 🔴 caught |
| never reuse the cached access token | 🔴 caught |
| stop pinning the cache to the credential | 🔴 caught |
| remove the missing-`FCM_SERVICE_ACCOUNT_JSON` guard | 🔴 caught |
| hardcode the project id in the send URL | 🔴 caught |
| hardcode the `Bearer` header | 🔴 caught |
| wrong OAuth scope | 🔴 caught |
| `JSON.stringify(value)` → `String(value)` in data | 🔴 caught |
| remove the `\n` private-key unescape | 🔴 caught |
| remove the 401 cache drop | 🔴 caught |
| prefer `error.status` over `details[].errorCode` | 🔴 caught |
| stop naming the missing config fields | 🔴 caught |
| remove the OAuth `!response.ok` guard | 🔴 caught |
| wrong `grant_type` | 🔴 caught |
| remove the non-object config guard | 🔴 caught |
| clear the token cache on a failed mint | 🟢 **survived** |

The survivor was real, not a coverage gap: the cache is only ever written by a *fully successful*
mint, and a mint is only attempted when the cache was already stale or credential-mismatched — so
clearing it on failure could not change any observable outcome. Isolating the same reset in the
`!response.ok` path (keeping the throw) also survived, confirming it. Both resets were **deleted**
rather than papered over with a test, and a comment records why the 401 handler in `sendToFcm` is
the one place a populated cache genuinely has to be dropped.

Not run locally: `bun run build` / `bun run typecheck` — 15 agents were running and the machine
was at load 9.7. A package-scoped `tsc` over `packages/lib` reports zero errors under
`notifications/` (the rest is this worktree's pre-existing unresolved-dependency noise). CI is
the gate.

## Notes

- The `case 'web'` stub is deliberately untouched — different epic.
- No new `@pagespace/lib` subpath export, so no `package.json` `exports` entry is needed.
- The base64url encoder is now shared between the two senders; both build JWTs.
- Untrusted JSON — the operator-typed secret and Google's error bodies — is narrowed through one
  `asRecord` helper rather than cast.

## Review round 1 (Codex, `86d94f194`) — all three addressed in `4ca7f999d`

| # | Finding | Resolution |
|---|---|---|
| P1 | Restrict deactivation to token-specific FCM errors | Fixed — `fromFcmDetail` gate, `@type` match, `NOT_FOUND` dropped, `SENDER_ID_MISMATCH` added. See the table above. |
| P2 | Deduplicate concurrent OAuth token mints | Fixed — single-flight in-flight promise, credential-pinned, cleared on settle. |
| P2 | Document FCM credentials in the environment template | Fixed — `.env.example` lines 296-305. |

Threads are left open for reviewer verification. Second mutation round on the new branches — 10
mutations, **all 10 caught**: the token-scoped gate (2 red), the `@type` match, each member of the
removal list, the mint join (2 red), its credential pin (6 red), its clearing on settle (3 red),
the status fallback (4 red), the array rejection, and the access-token cache write.

## Review round 2 (adversarial self-review) — 5 findings, all fixed

Run against the round-1 result, before any human looked at it. Every one was about
*who gets blamed* for a failure.

| Severity | Finding | Resolution |
|---|---|---|
| medium | `SENDER_ID_MISMATCH` is project-level but passed the token-scoped gate | Removed — see the sparing table above |
| medium | `INVALID_ARGUMENT` gated on the wrong signal in both directions: real bad tokens never cleaned up, message faults treated as token death | Verdict rebuilt around `UNREGISTERED` + `BadRequest`/`message.token` |
| low | generic `failedAttempts < 5` deactivated tokens on pure config errors | `serverFault` exemption |
| low | 401 dropped the notification that discovered the stale credential | re-mint + one bounded retry |
| low | `click_action`/`sound` forwarded iOS semantics into Android | removed / narrowed to `'default'` |

14 mutations across these five, **all caught** — including both directions of the
token-death verdict, each detail `@type` match, the retry bound, and the strike
exemption.

**Flagged, not fixed:** `sendToApns` has the same latent version of finding 3 — a
missing `APNS_TEAM_ID` throws and takes strikes. The `serverFault` mechanism is
generic and wiring it there is three lines, but changing iOS delivery behaviour
inside an Android PR seemed the wrong trade. Happy to do it here or separately.

## Review round 3 (coverage + defensive paths)

Branch coverage on this file started at 82.9% against a package gate of 94%. The aggregate was
never actually failing, but the uncovered arms were not noise — they encoded decisions nobody had
pinned: what an access token with no `expires_in` is assumed to last, what happens when a service
account omits `token_uri`, whether a PEM that already has real newlines survives un-mangled,
whether a visible push with no title still sends the empty strings FCM requires.

Nine tests closed those. One stands on its own: an error body where *every* field is the wrong
type — non-string message, object status, a detail that is not an object, a numeric `@type`,
non-array `fieldViolations`. A malformed or hostile response must not be able to talk the parser
into a spurious deactivation, and now it demonstrably cannot.

Two results reported honestly rather than dressed up:

- `if (!error) return unknown` was **deleted** from `extractFcmError`. Mutation testing showed it
  was an equivalent mutant — an empty error object already falls through to exactly `unknown`,
  because every read below has its own fallback. One fewer branch, identical behaviour.
- Three surviving mutants are **equivalent, not coverage gaps**, and no test was invented to hide
  them: `String(42)` still cannot end in `.FcmError`, and narrowing `error` with `asRecord` rather
  than a cast cannot change the result for any non-object, since strings and arrays carry none of
  the fields read from it. Those narrowings are type-safety, not behaviour.

## Review round 4 — does the request survive contact with Google?

The previous rounds all asked "is the logic right". This one asked a different question: which
values would be rejected by Google but accepted by a stub? A stub takes whatever bytes it is
handed, so the suite could have been proving only that we send *a* request.

Six live gaps on the OAuth leg, every one of which survived the full 194-test suite and every one
of which fails **100% of Android sends** in production with an opaque `invalid_grant`:

| Mutation | Consequence |
|---|---|
| `alg: 'RS256'` → `'HS256'` | assertion rejected outright |
| `typ: 'JWT'` removed | RFC 7523 violation |
| `exp` claim removed | required — `invalid_grant` |
| `iat` claim removed | required — `invalid_grant` |
| `exp` shortened to 30 min | silently wrong lifetime |
| `content-type` → `application/json` | token endpoint is form-urlencoded only |

One test now decodes the assertion actually put on the wire and checks the header, every claim,
the `exp`/`iat` relationship, that the signature covers exactly the transmitted `header.claims`,
and that the encoding is base64url rather than base64. 11 JWT-shape mutations, zero survivors.

The `messages:send` leg was then put through the same lens and needed no changes — 8 mutations
(the `{message}` wrapper, POST, content-type, the v1 path, the `Bearer` scheme, the `token` field
name, `notification_count`'s type, the `android` block) all already went red.

**Two of the probes were themselves faulty and had been reporting false confidence** — worth
recording, because the same trap applies to anyone extending this file:

- `sign.update(signingInput)` appears twice, in `getApnsJwtToken` and `mintFcmAccessToken`. A
  first-occurrence replace mutates the APNs path and reports the FCM path covered. (It does mean
  the APNs signing bytes are unasserted — pre-existing, out of scope here, but real.)
- the fake signature was `Buffer.from('fake-rsa-signature')`, whose base64 is
  `ZmFrZS1yc2Etc2lnbmF0dXJl` — containing no `+`, `/` or `=` at all, so the base64url
  substitutions were unobservable by construction. Now bytes that encode to `+/++7/8=`.

## Review round 5 — the signature nothing had ever verified

`crypto.createSign` is mocked in all 75 tests of the main file. That is the right call there —
those tests are about request shape and error classification, and a real 2048-bit signature per
test would be waste. But it meant the single most important property of this code path had no
coverage at all: **that Google can verify what we send.** Those tests only ever proved that
something was handed to a fake signer and the pieces were reassembled in the right order.

`push-notifications-signing.test.ts` deliberately does not mock crypto. It generates a real RSA
keypair, lets the real signing path run untouched, and verifies the resulting JWT against the
matching public key — for a PEM with real newlines, and for the same key with the newlines
escaped, which is how it will actually arrive from a Fly secret.

Six mutations, all caught, and caught *cryptographically* rather than by string comparison:
removing the PEM unescaping, signing over the wrong bytes, claiming RS256 in the header while
signing with something else, signing with RSA-SHA512, and the base64url substitutions.

One subtlety recorded in the commit: `Buffer.from(x, 'base64url')` also accepts standard base64,
so verification alone cannot tell the two apart — the encoder mutations initially survived in
that file despite being real bugs. The helper now asserts the alphabet explicitly.

Costs ~60ms (641ms for the whole notifications suite).

## Review round 6 (CodeRabbit) — the one that mattered most

`serverFault` was only ever set from the `catch` block. Every non-ok response from FCM returned
without it, so any rejection that was not a token-specific verdict fell through to the
`failedAttempts` branch and took a strike. Five notifications later: `isActive: false`, fleet-wide.

It half-undid an earlier fix in this same PR. `SENDER_ID_MISMATCH` was deliberately refused an
immediate deactivation — precisely because a staging credential in prod would otherwise unregister
the whole install base — and then it unregistered the whole install base on the fifth
notification. The CHANGELOG asserted this could not happen; that was wrong, and is corrected.

The proposed patch enumerated 401/403/5xx. I did not take it, for the reason above, and applying
that narrower rule now turns **nine** tests red — which is the demonstration that the enumeration
is incomplete rather than an assertion of it. CodeRabbit reviewed the broader rule and agreed it
is the correct one.

The methodological lesson, recorded because it drove the last several commits: **I had proved a
scenario and called it a mechanism.** SENDER_ID_MISMATCH was shown not to deactivate on the spot,
and nobody asked what the fifth one did. Three claims of that same shape have since been converted
from example-based tests into invariants asserted across their whole space — no rejection may
strike (ten rejection shapes), every way the credential can be wrong fails closed (seven), and no
project is ever sent another credential's token (five activations across three projects).

## Known boundary, deliberately not code

FCM reserves certain `data` keys (`from`, `message_type`, and anything prefixed `google` or
`gcm`), and `createNotification` spreads arbitrary `metadata` into that map. A future caller
using one of those names would have its sends rejected. Every metadata key in the repo today was
enumerated and none collide, so this is latent rather than live, and no speculative stripping was
added — silently dropping a key the client is waiting for trades a loud failure for a quiet one.
Flagging it so the next person adding metadata knows the constraint exists. The related 4 KB
`data` cap is handled where it matters: such a rejection no longer costs anyone their
registration.

## Verification totals across all rounds

Roughly 240 mutations have been run against this code, including five systematic sweeps applied
by line index (operators and literals, comparison/nullish/negation operators, object-key renames
in both the request builder and the dispatch loop, and statement deletion). Every mutation either
went red or is recorded as an equivalent mutant with its reason.

One limitation worth stating rather than glossing: vitest does not typecheck, so a sweep run
through it cannot distinguish "the tests catch this" from "tsc catches this". Seven surviving
mutants were `interface` field renames in that category, covered by the Lint & TypeScript job
rather than by any test. Both directions of the token-death verdict, each detail `@type` match, the
retry bound, the strike exemption, the credential pin on the mint, and the silent/visible split
are all individually pinned.

Rebased onto `33de4b8ba`, no conflicts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SP53wpeoGWxwfNeMwT8cnX
