### PR TITLE
fix(billing): trackUsage reports persistence outcome — meters no longer advance past lost charges

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -205,6 +205,18 @@ All notable user-facing changes to PageSpace are documented here. Format follows
 
 ### Fixed
 
+- **A charge that fails to record is retried instead of silently dropped** — usage metering used to
+  report success whether or not it had actually written anything. If the database write for a usage
+  record failed, the failure was logged and then swallowed: the meter above it saw a normal result,
+  moved its billing marker past the window it had just tried to charge for, and that spend was gone
+  for good — with no record left behind for the nightly reconciliation to find. It affected every
+  running meter: sandbox storage, terminal sessions, and published-app runtime. Metering now reports
+  whether the record was actually written, and a meter that hears "no" leaves its window open so the
+  next cycle bills the whole span again — safe precisely because nothing was written the first time.
+  The reverse case is handled just as deliberately: when the record IS written but the ledger entry
+  is deferred to the reconciliation job, the window closes normally, because reopening it would
+  charge you twice for the same span.
+
 - **A custom domain stuck on SSL now tells you which DNS record to add** — when a certificate is
   waiting on an ownership record, domain settings name it outright: the `_fly-ownership` TXT record,
   where it goes, and every value that satisfies it — Fly accepts an app-scoped or an org-scoped

--- a/apps/realtime/src/terminal/__tests__/shell-handler.test.ts
+++ b/apps/realtime/src/terminal/__tests__/shell-handler.test.ts
@@ -121,6 +121,14 @@ function makeAuthSuccess(over: Partial<{
   };
 }
 
+/**
+ * A settle that landed durably. `trackUsage` no longer resolves with `void`: it
+ * reports whether the `ai_usage_logs` row was written, and the heartbeat keeps its
+ * billing window OPEN when it was not — so a stub that resolves with nothing is a
+ * stub that claims a LOST charge.
+ */
+const PERSISTED_SETTLE = { persisted: true, creditsSettled: true } as const;
+
 function makeBilling(over: Partial<{
   gate: ReturnType<typeof vi.fn>;
   trackUsage: ReturnType<typeof vi.fn>;
@@ -128,7 +136,7 @@ function makeBilling(over: Partial<{
 }> = {}) {
   return {
     gate: vi.fn().mockResolvedValue({ allowed: true, holdId: 'hold-1' }),
-    trackUsage: vi.fn().mockResolvedValue(undefined),
+    trackUsage: vi.fn().mockResolvedValue(PERSISTED_SETTLE),
     releaseHold: vi.fn().mockResolvedValue(undefined),
     ...over,
   };
@@ -1850,7 +1858,7 @@ describe('buildShellHandlers', () => {
         const billing = makeBilling({
           trackUsage: vi.fn()
             .mockRejectedValueOnce(new Error('db blip'))
-            .mockResolvedValue(undefined),
+            .mockResolvedValue(PERSISTED_SETTLE),
         });
         const { onConnect } = buildShellHandlers({ sessionMap, openShell, checkAuth, socket, persistSpriteExecId, billing });
         await onConnect(validPayload);
@@ -1868,12 +1876,60 @@ describe('buildShellHandlers', () => {
         expect(retry.activeSeconds).toBeCloseTo((2 * SETTLE_HEARTBEAT_MS) / 1000, 0);
       });
 
+      // ── The persistence CONTRACT ────────────────────────────────────────────
+      // The settle reaches `AIMonitoring.trackUsage`, which never throws. Before it
+      // reported an outcome, a settle whose `ai_usage_logs` write failed RESOLVED —
+      // so the rollback above, written for exactly this failure, was unreachable on
+      // the real path and the window was silently rebased over lost spend.
+
+      it('given a heartbeat settle that resolves WITHOUT persisting, restores the window and hold so the next heartbeat retries the FULL window', async () => {
+        const billing = makeBilling({
+          trackUsage: vi.fn()
+            .mockResolvedValueOnce({ persisted: false, creditsSettled: false })
+            .mockResolvedValue(PERSISTED_SETTLE),
+        });
+        const { onConnect } = buildShellHandlers({ sessionMap, openShell, checkAuth, socket, persistSpriteExecId, billing });
+        await onConnect(validPayload);
+
+        await vi.advanceTimersByTimeAsync(SETTLE_HEARTBEAT_MS); // settle resolves, unpersisted
+        expect(billing.trackUsage).toHaveBeenCalledTimes(1);
+        expect(billing.gate).toHaveBeenCalledTimes(1); // connect only — no fresh hold stacked
+        expect(shell.kill).not.toHaveBeenCalled();     // fail-open: session stays alive
+        expect(sessionMap.getByKey('shell:shl-1')).toMatchObject({ holdId: 'hold-1' }); // hold restored
+
+        await vi.advanceTimersByTimeAsync(SETTLE_HEARTBEAT_MS); // retries the whole window
+        expect(billing.trackUsage).toHaveBeenCalledTimes(2);
+        const retry = billing.trackUsage.mock.calls[1][0];
+        expect(retry.holdId).toBe('hold-1');
+        expect(retry.activeSeconds).toBeCloseTo((2 * SETTLE_HEARTBEAT_MS) / 1000, 0);
+      });
+
+      it('given a PERSISTED settle whose ledger settle was deferred, rebases the window normally (the backfill cron owns that charge)', async () => {
+        // Rolling back here would re-bill a window the credit backfill cron is
+        // already collecting from the usage row — a double-charge caused by trying
+        // to prevent a lost one.
+        const billing = makeBilling({
+          trackUsage: vi.fn().mockResolvedValue({ persisted: true, creditsSettled: false }),
+        });
+        const { onConnect } = buildShellHandlers({ sessionMap, openShell, checkAuth, socket, persistSpriteExecId, billing });
+        await onConnect(validPayload);
+
+        await vi.advanceTimersByTimeAsync(SETTLE_HEARTBEAT_MS);
+        expect(billing.gate).toHaveBeenCalledTimes(2); // connect + the post-settle re-hold
+        expect(sessionMap.getByKey('shell:shl-1')).toMatchObject({ holdId: 'hold-1' });
+
+        await vi.advanceTimersByTimeAsync(SETTLE_HEARTBEAT_MS);
+        // The window was rebased, so the second settle bills ONE heartbeat, not two.
+        const second = billing.trackUsage.mock.calls[1][0];
+        expect(second.activeSeconds).toBeCloseTo(SETTLE_HEARTBEAT_MS / 1000, 0);
+      });
+
       it('given the session is torn down while a heartbeat settle is FAILING, retries the pre-heartbeat window once instead of dropping it', async () => {
         let rejectSettle: (e: Error) => void = () => {};
         const billing = makeBilling({
           trackUsage: vi.fn()
             .mockImplementationOnce(() => new Promise((_, rej) => { rejectSettle = rej; })) // heartbeat settle hangs, then fails
-            .mockResolvedValue(undefined),
+            .mockResolvedValue(PERSISTED_SETTLE),
         });
         const { onConnect } = buildShellHandlers({ sessionMap, openShell, checkAuth, socket, persistSpriteExecId, billing });
         await onConnect(validPayload);
@@ -2004,9 +2060,9 @@ describe('buildShellHandlers', () => {
         // Mirror of the failing-settle race: the settle lands fine, but by then the
         // terminal is gone. Asking the gate for the next window's hold would
         // reserve credit for a session nobody will ever settle or release.
-        const settle = deferred<void>();
+        const settle = deferred<typeof PERSISTED_SETTLE>();
         const billing = makeBilling({
-          trackUsage: vi.fn().mockImplementationOnce(() => settle.promise).mockResolvedValue(undefined),
+          trackUsage: vi.fn().mockImplementationOnce(() => settle.promise).mockResolvedValue(PERSISTED_SETTLE),
         });
         const { onConnect } = buildShellHandlers({ sessionMap, openShell, checkAuth, socket, persistSpriteExecId, billing });
         await onConnect(validPayload);
@@ -2014,7 +2070,7 @@ describe('buildShellHandlers', () => {
         await vi.advanceTimersByTimeAsync(SETTLE_HEARTBEAT_MS); // heartbeat: settle in flight
         const onExitArg = openShell.mock.calls[0][0].onExit as (exitCode: number) => void;
         onExitArg(0);          // terminal closes while the settle is still running
-        settle.resolve();      // ...and the settle then SUCCEEDS
+        settle.resolve(PERSISTED_SETTLE); // ...and the settle then SUCCEEDS
         await vi.advanceTimersByTimeAsync(0);
 
         // Only the connect-time gate ran: no hold was taken out for a dead session.
@@ -2054,8 +2110,13 @@ describe('buildShellHandlers', () => {
         const billing = makeBilling({
           trackUsage: vi
             .fn()
-            .mockImplementationOnce(() => new Promise<void>((resolve) => { resolveSettle = () => resolve(undefined); }))
-            .mockResolvedValue(undefined),
+            .mockImplementationOnce(
+              () =>
+                new Promise<typeof PERSISTED_SETTLE>((resolve) => {
+                  resolveSettle = () => resolve(PERSISTED_SETTLE);
+                }),
+            )
+            .mockResolvedValue(PERSISTED_SETTLE),
         });
         const { onConnect } = buildShellHandlers({ sessionMap, openShell, checkAuth, socket, persistSpriteExecId, billing });
         await onConnect(validPayload);

--- a/apps/realtime/src/terminal/__tests__/shell-handler.test.ts
+++ b/apps/realtime/src/terminal/__tests__/shell-handler.test.ts
@@ -1,4 +1,19 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+/**
+ * The realtime logger, mocked so the two UNRECOVERABLE-charge paths can be
+ * asserted rather than merely executed: a settle that resolves without persisting
+ * has no window left to reopen (teardown, and the crash-compensating attempt), so
+ * the ERROR it emits IS the whole observable behaviour.
+ */
+const mockRealtimeLogger = vi.hoisted(() => ({
+  debug: vi.fn(),
+  info: vi.fn(),
+  warn: vi.fn(),
+  error: vi.fn(),
+}));
+vi.mock('@pagespace/lib/logging/logger-config', () => ({ loggers: { realtime: mockRealtimeLogger } }));
+
 import { buildShellHandlers, MAX_INPUT_BYTES, SETTLE_HEARTBEAT_MS, resolveShellCommand, planConnect, ensureShellSession, connectFailureMessage, armIdleReap, planColdTailPersist, latestActivityAt } from '../shell-handler';
 import { createTerminalSessionMap, DETACHED_IDLE_MS } from '../terminal-session-map';
 import type { ShellCheckAuthFn, OpenShellFn, SocketLike } from '../shell-handler';
@@ -1947,6 +1962,52 @@ describe('buildShellHandlers', () => {
         expect(compensating[compensating.length - 1].activeSeconds).toBeCloseTo(SETTLE_HEARTBEAT_MS / 1000, 0);
         // Total billed across all successful-looking calls still sums to the window (tail ≈ 0).
         expect(calls.reduce((s, c) => s + c.activeSeconds, 0)).toBeCloseTo((2 * SETTLE_HEARTBEAT_MS) / 1000, 0);
+      });
+
+      it('given the COMPENSATING settle also resolves without persisting, says plainly that the window is unrecoverable', async () => {
+        // The compensating attempt is the LAST thing that will ever touch this
+        // window — the session is already gone, so there is no next heartbeat and
+        // no watermark to hold. Its outcome is therefore read and logged rather
+        // than dropped: this is the exact moment the charge becomes unrecoverable.
+        let rejectSettle: (e: Error) => void = () => {};
+        const billing = makeBilling({
+          trackUsage: vi.fn()
+            .mockImplementationOnce(() => new Promise((_, rej) => { rejectSettle = rej; }))
+            .mockResolvedValue({ persisted: false, creditsSettled: false }),
+        });
+        const { onConnect } = buildShellHandlers({ sessionMap, openShell, checkAuth, socket, persistSpriteExecId, billing });
+        await onConnect(validPayload);
+
+        await vi.advanceTimersByTimeAsync(SETTLE_HEARTBEAT_MS);
+        const onExitArg = openShell.mock.calls[0][0].onExit as (exitCode: number) => void;
+        onExitArg(0);
+        rejectSettle(new Error('db blip'));
+        await vi.advanceTimersByTimeAsync(0);
+
+        const messages = mockRealtimeLogger.error.mock.calls.map((c) => String(c[0]));
+        expect(messages).toContain(
+          'Shell compensating settle did not persist a usage row — this window is unbilled and unrecoverable',
+        );
+      });
+
+      it('given the TEARDOWN settle resolves without persisting, says plainly that the window is unrecoverable', async () => {
+        // Teardown has no next tick to retry on, so — as above — the log is the
+        // whole observable behaviour, and it must not be the one silent path.
+        const billing = makeBilling({
+          trackUsage: vi.fn().mockResolvedValue({ persisted: false, creditsSettled: false }),
+        });
+        const { onConnect } = buildShellHandlers({ sessionMap, openShell, checkAuth, socket, persistSpriteExecId, billing });
+        await onConnect(validPayload);
+
+        const onExitArg = openShell.mock.calls[0][0].onExit as (exitCode: number) => void;
+        onExitArg(0); // teardown settles the tail
+        await vi.advanceTimersByTimeAsync(0);
+
+        const messages = mockRealtimeLogger.error.mock.calls.map((c) => String(c[0]));
+        expect(messages).toContain(
+          'Shell session final settle did not persist a usage row — this window is unbilled and unrecoverable',
+        );
+        expect(sessionMap.getByKey('shell:shl-1')).toBeUndefined(); // teardown still completed
       });
 
       it('given a gate infra error at a heartbeat, keeps the session alive (fail-open) rather than killing a live PTY', async () => {

--- a/apps/realtime/src/terminal/shell-handler.ts
+++ b/apps/realtime/src/terminal/shell-handler.ts
@@ -631,6 +631,11 @@ async function settleAccruedWindow(
       // will ever retry THIS window. One compensating best-effort attempt —
       // the same fire-and-forget guarantee the end-settle itself has. If it
       // also fails, the hold expires via TTL and the window is lost.
+      //
+      // This is the LAST attempt anything will make on this window, so its
+      // outcome is read and logged rather than dropped: a compensating settle
+      // that resolves without persisting is the exact moment the window becomes
+      // unrecoverable, and it must not be the one silent site in the file.
       void billing
         .trackUsage({
           payerId,
@@ -638,6 +643,15 @@ async function settleAccruedWindow(
           activeSeconds,
           driveId: session.driveId,
           workspaceId: session.workspaceId,
+        })
+        .then((compensating) => {
+          if (!compensating.persisted) {
+            loggers.realtime.error(
+              'Shell compensating settle did not persist a usage row — this window is unbilled and unrecoverable',
+              new Error('shell compensating settle was not persisted'),
+              { sessionKey, activeSeconds },
+            );
+          }
         })
         .catch(() => {});
     }

--- a/apps/realtime/src/terminal/shell-handler.ts
+++ b/apps/realtime/src/terminal/shell-handler.ts
@@ -365,6 +365,12 @@ function endShellSession(
   }
   if (deps.billing && session.payerId && session.connectedAt !== undefined) {
     const activeSeconds = Math.max(0, (Date.now() - session.connectedAt) / 1000);
+    // Fire-and-forget by necessity: teardown has no next tick to retry on, so this
+    // is the last chance to bill the tail and there is nothing to keep open. The
+    // outcome is still READ rather than dropped — a settle that resolved without
+    // persisting is spend nothing downstream can recover (the backfill cron reads
+    // `ai_usage_logs`), and that deserves to be said in the log at the one moment
+    // anyone could act on it.
     void deps.billing
       .trackUsage({
         payerId: session.payerId,
@@ -372,6 +378,15 @@ function endShellSession(
         activeSeconds,
         driveId: session.driveId,
         workspaceId: session.workspaceId,
+      })
+      .then((settle) => {
+        if (!settle.persisted) {
+          loggers.realtime.error(
+            'Shell session final settle did not persist a usage row — this window is unbilled and unrecoverable',
+            new Error('shell final settle was not persisted'),
+            { sessionKey, activeSeconds },
+          );
+        }
       })
       .catch((error) => {
         loggers.realtime.error('Shell session billing settle failed', error instanceof Error ? error : new Error(String(error)), {
@@ -576,13 +591,31 @@ async function settleAccruedWindow(
   session.holdId = undefined;
   const activeSeconds = Math.max(0, (session.connectedAt - windowStart) / 1000);
   try {
-    await billing.trackUsage({
+    const settle = await billing.trackUsage({
       payerId,
       holdId,
       activeSeconds,
       driveId: session.driveId,
       workspaceId: session.workspaceId,
     });
+    // A settle that RESOLVED WITHOUT PERSISTING is the failure this function's
+    // rollback was written for but could never see: no `ai_usage_logs` row exists,
+    // so nothing — not the ledger, not the backfill cron, which reads that table —
+    // will ever bill this window. Take the same path as a throw, so the rebase is
+    // rolled back and the window is retried at the next heartbeat.
+    //
+    // NOT keyed on `creditsSettled`: a persisted row whose ledger claim was
+    // deferred is already owned by the backfill cron, and retrying the window for
+    // it would bill the payer twice for the same seconds.
+    if (!settle.persisted) {
+      throw new Error('shell heartbeat settle was not persisted');
+    }
+    if (!settle.creditsSettled) {
+      loggers.realtime.warn(
+        'Shell heartbeat settle persisted but its ledger settle was deferred to the backfill cron',
+        { sessionKey },
+      );
+    }
   } catch (error) {
     loggers.realtime.error('Shell heartbeat settle failed', error instanceof Error ? error : new Error(String(error)), {
       sessionKey,

--- a/apps/realtime/src/voice/__tests__/call-metering.test.ts
+++ b/apps/realtime/src/voice/__tests__/call-metering.test.ts
@@ -81,7 +81,9 @@ function harness(over: Partial<CallMeterOptions> = {}) {
     reason: 'ok' as const,
     holdId: `hold-${++holdCounter}`,
   }));
-  const track = vi.fn(async () => {});
+  // `trackUsage` reports whether the usage row landed; a stub resolving with
+  // nothing would claim a LOST window, which the meter now treats as a failed settle.
+  const track = vi.fn(async () => ({ persisted: true, creditsSettled: true }));
   const release = vi.fn(async () => {});
   const limits: { reason: MeterStopReason; message: string }[] = [];
   let clock = 1_000;

--- a/apps/realtime/src/voice/__tests__/call-metering.test.ts
+++ b/apps/realtime/src/voice/__tests__/call-metering.test.ts
@@ -482,6 +482,38 @@ describe('startCallMeter — stopping', () => {
     expect(h.gate).toHaveBeenCalledTimes(2);
   });
 
+  it('given a settle that RESOLVES WITHOUT PERSISTING, should treat it as a failed settle and keep the call up', async () => {
+    // `trackUsage` never throws, so before it reported an outcome this was the
+    // failure the catch above could not see: the settle resolved, the window was
+    // consumed, and no `ai_usage_logs` row existed for anything to recover from.
+    // A live call has no window to reopen — the honest response is to return the
+    // reservation, log the window as unbilled, and let the user keep talking.
+    const { options, h } = harness({
+      track: (async () => ({ persisted: false, creditsSettled: false })) as unknown as CallMeterOptions['track'],
+    });
+    const meter = await startedMeter(options);
+
+    meter.record(usage());
+    await meter.settle();
+
+    expect(h.release).toHaveBeenCalledWith('hold-1');
+    expect(h.gate).toHaveBeenCalledTimes(2); // re-held for the next window
+    expect(h.limits).toEqual([]); // the call was NOT taken down
+  });
+
+  it('given a PERSISTED settle whose ledger settle was deferred, should treat it as a normal settle (the backfill cron owns that charge)', async () => {
+    const { options, h } = harness({
+      track: (async () => ({ persisted: true, creditsSettled: false })) as unknown as CallMeterOptions['track'],
+    });
+    const meter = await startedMeter(options);
+
+    meter.record(usage());
+    await meter.settle();
+
+    // `trackUsage` took ownership of the hold, so nothing is released here.
+    expect(h.release).not.toHaveBeenCalled();
+  });
+
   it('should clear every timer so a stopped call cannot fire a limit', async () => {
     const { options, h } = harness();
     const meter = await startedMeter(options);

--- a/apps/realtime/src/voice/call-metering.ts
+++ b/apps/realtime/src/voice/call-metering.ts
@@ -193,7 +193,7 @@ export const startCallMeter = async (
       holdId = undefined;
 
       try {
-        await track({
+        const settle = await track({
           userId,
           provider: 'openai_voice',
           model,
@@ -216,6 +216,18 @@ export const startCallMeter = async (
             audioOutputTokens: usage.output_token_details?.audio_tokens ?? 0,
           },
         });
+        // A settle that RESOLVED WITHOUT PERSISTING is the failure this catch was
+        // written for but could never see: no `ai_usage_logs` row exists, so nothing
+        // downstream (the backfill cron reads that table) will ever bill this
+        // window. `pending` was already consumed above and a live call has no
+        // window to reopen, so the honest response is the same one a throw gets —
+        // return the reservation and say plainly that this window is unbilled.
+        //
+        // NOT keyed on `creditsSettled`: a persisted row whose ledger claim was
+        // deferred is already owned by the backfill cron.
+        if (!settle.persisted) {
+          throw new Error('realtime voice settle was not persisted');
+        }
       } catch (error) {
         // A failed settle must not take the call down — the user is mid-sentence.
         loggers.realtime.error(

--- a/apps/web/src/app/api/ai/global/[id]/messages/__tests__/credit-gate.test.ts
+++ b/apps/web/src/app/api/ai/global/[id]/messages/__tests__/credit-gate.test.ts
@@ -531,7 +531,11 @@ describe('POST /api/ai/global/[id]/messages — usage logging durability (R4)', 
     // within a bounded number of flushes. This is what makes the guarantee testable
     // — a synchronous mock + "was it called" assertion would pass either way.
     let resolveTrack!: () => void;
-    vi.mocked(AIMonitoring.trackUsage).mockReturnValueOnce(new Promise<void>((res) => { resolveTrack = res; }));
+    vi.mocked(AIMonitoring.trackUsage).mockReturnValueOnce(
+      new Promise((res) => {
+        resolveTrack = () => res({ persisted: true, creditsSettled: true });
+      }),
+    );
 
     await POST(makeRequest(), makeContext());
     await captured.createUIMessageStreamOptions.execute?.({ write: vi.fn() });

--- a/apps/web/src/app/api/ai/page-agents/consult/__tests__/conversation-continuity.test.ts
+++ b/apps/web/src/app/api/ai/page-agents/consult/__tests__/conversation-continuity.test.ts
@@ -120,6 +120,14 @@ vi.mock('@pagespace/lib/billing/credit-gate', () => ({
 
 vi.mock('@pagespace/lib/monitoring/ai-monitoring', () => ({
   AIMonitoring: { trackUsage: vi.fn(), trackToolUsage: vi.fn() },
+  // A pure-telemetry call site: the route hands the tracking promise to a NAMED
+  // discard rather than leaving it to float, so the mocked module must provide it.
+  discardUsageOutcome: (tracking: Promise<unknown>) => {
+    void Promise.resolve(tracking).then(
+      () => undefined,
+      () => undefined,
+    );
+  },
 }));
 
 vi.mock('@/lib/ai/core/provider-factory', () => ({

--- a/apps/web/src/app/api/ai/page-agents/consult/__tests__/conversation-listing-index.test.ts
+++ b/apps/web/src/app/api/ai/page-agents/consult/__tests__/conversation-listing-index.test.ts
@@ -101,6 +101,14 @@ vi.mock('@pagespace/lib/billing/credit-gate', () => ({
 
 vi.mock('@pagespace/lib/monitoring/ai-monitoring', () => ({
   AIMonitoring: { trackUsage: vi.fn(), trackToolUsage: vi.fn() },
+  // A pure-telemetry call site: the route hands the tracking promise to a NAMED
+  // discard rather than leaving it to float, so the mocked module must provide it.
+  discardUsageOutcome: (tracking: Promise<unknown>) => {
+    void Promise.resolve(tracking).then(
+      () => undefined,
+      () => undefined,
+    );
+  },
 }));
 
 vi.mock('@/lib/ai/core/provider-factory', () => ({

--- a/apps/web/src/app/api/ai/page-agents/consult/__tests__/credit-gate.test.ts
+++ b/apps/web/src/app/api/ai/page-agents/consult/__tests__/credit-gate.test.ts
@@ -84,6 +84,14 @@ vi.mock('@pagespace/lib/billing/credit-gate', () => ({
 
 vi.mock('@pagespace/lib/monitoring/ai-monitoring', () => ({
   AIMonitoring: { trackUsage: vi.fn(), trackToolUsage: vi.fn() },
+  // A pure-telemetry call site: the route hands the tracking promise to a NAMED
+  // discard rather than leaving it to float, so the mocked module must provide it.
+  discardUsageOutcome: (tracking: Promise<unknown>) => {
+    void Promise.resolve(tracking).then(
+      () => undefined,
+      () => undefined,
+    );
+  },
 }));
 
 vi.mock('@/lib/ai/core/provider-factory', () => ({

--- a/apps/web/src/app/api/ai/page-agents/consult/__tests__/mcp-scope-tool-filtering.test.ts
+++ b/apps/web/src/app/api/ai/page-agents/consult/__tests__/mcp-scope-tool-filtering.test.ts
@@ -84,6 +84,14 @@ vi.mock('@pagespace/lib/billing/credit-gate', () => ({
 
 vi.mock('@pagespace/lib/monitoring/ai-monitoring', () => ({
   AIMonitoring: { trackUsage: vi.fn(), trackToolUsage: vi.fn() },
+  // A pure-telemetry call site: the route hands the tracking promise to a NAMED
+  // discard rather than leaving it to float, so the mocked module must provide it.
+  discardUsageOutcome: (tracking: Promise<unknown>) => {
+    void Promise.resolve(tracking).then(
+      () => undefined,
+      () => undefined,
+    );
+  },
 }));
 
 vi.mock('@/lib/ai/core/provider-factory', () => ({

--- a/apps/web/src/app/api/ai/page-agents/consult/__tests__/recent-history-ordering.test.ts
+++ b/apps/web/src/app/api/ai/page-agents/consult/__tests__/recent-history-ordering.test.ts
@@ -111,6 +111,14 @@ vi.mock('@pagespace/lib/billing/credit-gate', () => ({
 
 vi.mock('@pagespace/lib/monitoring/ai-monitoring', () => ({
   AIMonitoring: { trackUsage: vi.fn(), trackToolUsage: vi.fn() },
+  // A pure-telemetry call site: the route hands the tracking promise to a NAMED
+  // discard rather than leaving it to float, so the mocked module must provide it.
+  discardUsageOutcome: (tracking: Promise<unknown>) => {
+    void Promise.resolve(tracking).then(
+      () => undefined,
+      () => undefined,
+    );
+  },
 }));
 
 vi.mock('@/lib/ai/core/provider-factory', () => ({

--- a/apps/web/src/app/api/ai/page-agents/consult/__tests__/sandbox-switch.test.ts
+++ b/apps/web/src/app/api/ai/page-agents/consult/__tests__/sandbox-switch.test.ts
@@ -89,6 +89,14 @@ vi.mock('@pagespace/lib/billing/credit-gate', () => ({
 
 vi.mock('@pagespace/lib/monitoring/ai-monitoring', () => ({
   AIMonitoring: { trackUsage: vi.fn(), trackToolUsage: vi.fn() },
+  // A pure-telemetry call site: the route hands the tracking promise to a NAMED
+  // discard rather than leaving it to float, so the mocked module must provide it.
+  discardUsageOutcome: (tracking: Promise<unknown>) => {
+    void Promise.resolve(tracking).then(
+      () => undefined,
+      () => undefined,
+    );
+  },
 }));
 
 vi.mock('@/lib/ai/core/provider-factory', () => ({

--- a/apps/web/src/app/api/ai/page-agents/consult/__tests__/step-cap-parity.test.ts
+++ b/apps/web/src/app/api/ai/page-agents/consult/__tests__/step-cap-parity.test.ts
@@ -94,6 +94,14 @@ vi.mock('@pagespace/lib/billing/credit-gate', () => ({
 
 vi.mock('@pagespace/lib/monitoring/ai-monitoring', () => ({
   AIMonitoring: { trackUsage: vi.fn(), trackToolUsage: vi.fn() },
+  // A pure-telemetry call site: the route hands the tracking promise to a NAMED
+  // discard rather than leaving it to float, so the mocked module must provide it.
+  discardUsageOutcome: (tracking: Promise<unknown>) => {
+    void Promise.resolve(tracking).then(
+      () => undefined,
+      () => undefined,
+    );
+  },
 }));
 
 vi.mock('@/lib/ai/core/provider-factory', () => ({

--- a/apps/web/src/app/api/ai/page-agents/consult/route.ts
+++ b/apps/web/src/app/api/ai/page-agents/consult/route.ts
@@ -4,7 +4,7 @@ import { finishTool, FINISH_TOOL_NAME } from '@/lib/ai/tools/finish-tool';
 import { mergeToolSets } from '@/lib/ai/core/tool-utils';
 import { filterToolsForMcpScope, filterToolsForImageGen, filterToolsForSandboxEnablement } from '@/lib/ai/core/tool-filtering';
 import { authenticateRequestWithOptions, isAuthError, isMCPAuthResult, checkMCPPageScope, getAllowedDriveIds, isScopedMCPAuth, canPrincipalViewPage } from '@/lib/auth';
-import { AIMonitoring } from '@pagespace/lib/monitoring/ai-monitoring';
+import { AIMonitoring, discardUsageOutcome } from '@pagespace/lib/monitoring/ai-monitoring';
 
 const AUTH_OPTIONS = { allow: ['session', 'mcp'] as const, requireCSRF: true };
 import { createAIProvider, isProviderError, type ProviderRequest } from '@/lib/ai/core/provider-factory';
@@ -658,7 +658,7 @@ export async function POST(request: Request) {
       // enabled); use totalUsage so every round-trip is billed, not just the
       // final step.
       const usage = result.totalUsage;
-      AIMonitoring.trackUsage({
+      discardUsageOutcome(AIMonitoring.trackUsage({
         userId,
         provider: resolvedProvider,
         model: resolvedModelName,
@@ -670,7 +670,7 @@ export async function POST(request: Request) {
         driveId: agent.driveId,
         success: true,
         holdId,
-      });
+      }));
       // trackUsage owns the hold release from here.
       holdHandedOff = true;
     } catch (aiError) {

--- a/apps/web/src/app/api/pulse/cron/__tests__/pii-decrypt-dedup.test.ts
+++ b/apps/web/src/app/api/pulse/cron/__tests__/pii-decrypt-dedup.test.ts
@@ -81,6 +81,14 @@ vi.mock('@pagespace/lib/services/page-content-store', () => ({
 
 vi.mock('@pagespace/lib/monitoring/ai-monitoring', () => ({
   AIMonitoring: { trackUsage: vi.fn() },
+  // These are pure-telemetry call sites: they hand the tracking promise to a NAMED
+  // discard rather than leaving it to float, so the mocked module has to provide it.
+  discardUsageOutcome: (tracking: Promise<unknown>) => {
+    void Promise.resolve(tracking).then(
+      () => undefined,
+      () => undefined,
+    );
+  },
   extractOpenRouterCostDollars: vi.fn(() => 0),
   extractOpenRouterGenerationIds: vi.fn(() => []),
 }));

--- a/apps/web/src/app/api/pulse/cron/__tests__/task-trash-filter.test.ts
+++ b/apps/web/src/app/api/pulse/cron/__tests__/task-trash-filter.test.ts
@@ -89,6 +89,14 @@ vi.mock('@pagespace/lib/services/page-content-store', () => ({
 
 vi.mock('@pagespace/lib/monitoring/ai-monitoring', () => ({
   AIMonitoring: { trackUsage: vi.fn() },
+  // These are pure-telemetry call sites: they hand the tracking promise to a NAMED
+  // discard rather than leaving it to float, so the mocked module has to provide it.
+  discardUsageOutcome: (tracking: Promise<unknown>) => {
+    void Promise.resolve(tracking).then(
+      () => undefined,
+      () => undefined,
+    );
+  },
   extractOpenRouterCostDollars: vi.fn(() => 0),
   extractOpenRouterGenerationIds: vi.fn(() => []),
 }));

--- a/apps/web/src/app/api/pulse/cron/route.ts
+++ b/apps/web/src/app/api/pulse/cron/route.ts
@@ -33,7 +33,7 @@ import {
 import { readPageContent } from '@pagespace/lib/services/page-content-store';
 import { accessiblePageIds } from '@pagespace/lib/permissions/accessible-page-ids';
 import { loggers } from '@pagespace/lib/logging/logger-config';
-import { AIMonitoring, extractOpenRouterCostDollars, extractOpenRouterGenerationIds } from '@pagespace/lib/monitoring/ai-monitoring';
+import { AIMonitoring, discardUsageOutcome, extractOpenRouterCostDollars, extractOpenRouterGenerationIds } from '@pagespace/lib/monitoring/ai-monitoring';
 import { canConsumeAI } from '@pagespace/lib/billing/credit-gate';
 import { releaseHold } from '@pagespace/lib/billing/credit-consume';
 import type { SubscriptionTier } from '@pagespace/lib/services/subscription-utils';
@@ -923,7 +923,7 @@ What would be genuinely useful or interesting to say right now? Maybe it's an ob
   // Track AI usage. Passing holdId hands the reservation to trackUsage, which settles
   // it atomically with the debit (or releases it if there was nothing billable).
   const usage = result.usage;
-  AIMonitoring.trackUsage({
+  discardUsageOutcome(AIMonitoring.trackUsage({
     userId,
     provider: providerResult.provider,
     model: providerResult.modelName,
@@ -937,7 +937,7 @@ What would be genuinely useful or interesting to say right now? Maybe it's an ob
     openrouterGenerationIds: extractOpenRouterGenerationIds(result.steps),
     holdId,
     success: true,
-  });
+  }));
   // The hold is now owned by trackUsage — keep the caller's finally from releasing it.
   markHandedOff();
 

--- a/apps/web/src/app/api/pulse/generate/__tests__/task-trash-filter.test.ts
+++ b/apps/web/src/app/api/pulse/generate/__tests__/task-trash-filter.test.ts
@@ -92,6 +92,14 @@ vi.mock('@pagespace/lib/services/page-content-store', () => ({
 
 vi.mock('@pagespace/lib/monitoring/ai-monitoring', () => ({
   AIMonitoring: { trackUsage: vi.fn() },
+  // These are pure-telemetry call sites: they hand the tracking promise to a NAMED
+  // discard rather than leaving it to float, so the mocked module has to provide it.
+  discardUsageOutcome: (tracking: Promise<unknown>) => {
+    void Promise.resolve(tracking).then(
+      () => undefined,
+      () => undefined,
+    );
+  },
   extractOpenRouterCostDollars: vi.fn(() => 0),
   extractOpenRouterGenerationIds: vi.fn(() => []),
 }));

--- a/apps/web/src/app/api/pulse/generate/route.ts
+++ b/apps/web/src/app/api/pulse/generate/route.ts
@@ -33,7 +33,7 @@ import {
 import { readPageContent } from '@pagespace/lib/services/page-content-store';
 import { accessiblePageIds } from '@pagespace/lib/permissions/accessible-page-ids';
 import { loggers } from '@pagespace/lib/logging/logger-config';
-import { AIMonitoring, extractOpenRouterCostDollars, extractOpenRouterGenerationIds } from '@pagespace/lib/monitoring/ai-monitoring';
+import { AIMonitoring, discardUsageOutcome, extractOpenRouterCostDollars, extractOpenRouterGenerationIds } from '@pagespace/lib/monitoring/ai-monitoring';
 import { canConsumeAI } from '@pagespace/lib/billing/credit-gate';
 import { MAX_CHAT_INFLIGHT } from '@pagespace/lib/billing/credit-pricing';
 import { releaseHold } from '@pagespace/lib/billing/credit-consume';
@@ -747,7 +747,7 @@ What would be genuinely useful or interesting to say right now? Maybe it's an ob
 
     // Track AI usage
     const usage = result.usage;
-    AIMonitoring.trackUsage({
+    discardUsageOutcome(AIMonitoring.trackUsage({
       userId,
       provider: providerResult.provider,
       model: providerResult.modelName,
@@ -761,7 +761,7 @@ What would be genuinely useful or interesting to say right now? Maybe it's an ob
       openrouterGenerationIds: extractOpenRouterGenerationIds(result.steps),
       success: true,
       holdId,
-    });
+    }));
     // trackUsage owns the hold release from here.
     holdHandedOff = true;
 

--- a/apps/web/src/lib/ai/tools/__tests__/image-generation-tools.test.ts
+++ b/apps/web/src/lib/ai/tools/__tests__/image-generation-tools.test.ts
@@ -5,7 +5,12 @@ import type { ToolExecutionContext } from '@/lib/ai/core/types';
 // --- module mocks (no real billing / OpenRouter / S3 / DB) ---
 const canConsumeAI = vi.fn<(...a: unknown[]) => unknown>();
 const releaseHold = vi.fn<(...a: unknown[]) => Promise<void>>(async () => {});
-const trackUsage = vi.fn<(...a: unknown[]) => Promise<void>>(async () => {});
+// `trackUsage` reports whether the usage row landed (`UsageTrackingOutcome`); a
+// stub resolving with nothing would claim a LOST charge on every image call.
+const PERSISTED_SETTLE = { persisted: true, creditsSettled: true } as const;
+const trackUsage = vi.fn<(...a: unknown[]) => Promise<typeof PERSISTED_SETTLE>>(
+  async () => PERSISTED_SETTLE,
+);
 const generateImageBytes = vi.fn<(...a: unknown[]) => unknown>();
 const createImageFilePage = vi.fn<(...a: unknown[]) => unknown>();
 
@@ -85,7 +90,7 @@ beforeEach(() => {
   releaseHold.mockReset();
   releaseHold.mockResolvedValue(undefined);
   trackUsage.mockReset();
-  trackUsage.mockResolvedValue(undefined);
+  trackUsage.mockResolvedValue(PERSISTED_SETTLE);
   generateImageBytes.mockReset();
   createImageFilePage.mockReset();
   dbState.role = 'user';

--- a/apps/web/src/lib/ai/tools/image-generation-tools.ts
+++ b/apps/web/src/lib/ai/tools/image-generation-tools.ts
@@ -212,7 +212,7 @@ restricted to app administrators.`,
         error?: string;
       }) => {
         const resolved = resolveImageCost(args.providerCostDollars);
-        await AIMonitoring.trackUsage({
+        const settle = await AIMonitoring.trackUsage({
           userId,
           provider: 'openrouter',
           model,
@@ -234,22 +234,40 @@ restricted to app administrators.`,
           },
         }).catch((metErr) => {
           // Defensive only — currently UNREACHABLE: trackAIUsage wraps its whole body in a
-          // logging try/catch and never rejects (it logs the swallowed failure at ERROR
-          // itself, which is where an unbilled generation actually surfaces). Kept so a
-          // future change that lets it throw can't silently fail the user's request.
+          // logging try/catch and never rejects. It REPORTS its failures instead (see the
+          // `persisted` check below), which is what an unbilled generation surfaces as.
+          // Kept so a future change that lets it throw can't silently fail the request.
           imageLogger.error('Failed to record image usage', metErr as Error, {
             userId: maskIdentifier(userId),
             model,
             costDollars: resolved.costDollars,
             generationIds: args.generationIds,
           });
+          return { persisted: false, creditsSettled: false };
         });
 
-        // Belt-and-braces hold cleanup. trackAIUsage SWALLOWS its own errors (every branch
-        // is wrapped in a logging try/catch), so a rejection is NOT a reliable signal that
-        // the settle landed: if `writeAiUsage` throws, the throw is caught internally and
-        // the settle/release branches below it never run, leaving the hold neither settled
-        // nor released — it would strand the user's reserved credits until TTL expiry.
+        // An image generation is a ONE-SHOT charge: there is no window, no watermark and
+        // no next tick, so a lost usage row cannot be retried — it can only be reported.
+        // Say so at the one place that knows the user-facing context (which model, whose
+        // generation) rather than leaving only the seam's own log.
+        if (!settle.persisted) {
+          imageLogger.error(
+            'Image generation usage was not persisted — this spend is unbilled and unrecoverable',
+            new Error('image settle was not persisted'),
+            {
+              userId: maskIdentifier(userId),
+              model,
+              costDollars: resolved.costDollars,
+              generationIds: args.generationIds,
+            },
+          );
+        }
+
+        // Belt-and-braces hold cleanup. `trackAIUsage` never rejects, and it now disposes
+        // of the reservation on every one of its own exits — settled against by
+        // consumeCredits, or released when the usage row could not be written. So this is
+        // no longer covering a stranded hold; it stays as a cheap idempotent backstop for a
+        // path that ends without either.
         //
         // Deleting the hold here is safe and idempotent: consumeCredits already removes it
         // inside its settle transaction (and in the zero-charge branch), so on the happy path

--- a/apps/web/src/lib/integrations/zoom/extract-action-items.ts
+++ b/apps/web/src/lib/integrations/zoom/extract-action-items.ts
@@ -1,7 +1,7 @@
 import { generateText } from 'ai';
 import { createAIProvider, isProviderError } from '@/lib/ai/core/provider-factory';
 import { loggers } from '@pagespace/lib/logging/logger-config';
-import { AIMonitoring } from '@pagespace/lib/monitoring/ai-monitoring';
+import { AIMonitoring, discardUsageOutcome } from '@pagespace/lib/monitoring/ai-monitoring';
 import type { ActionItem } from './build-document';
 
 const SYSTEM_PROMPT =
@@ -28,7 +28,7 @@ export async function extractActionItems(
       maxOutputTokens: 512,
     });
 
-    AIMonitoring.trackUsage({
+    discardUsageOutcome(AIMonitoring.trackUsage({
       userId,
       provider: provider.provider,
       model: provider.modelName,
@@ -40,7 +40,7 @@ export async function extractActionItems(
         : undefined,
       success: true,
       metadata: { feature: 'zoom_action_items' },
-    });
+    }));
 
     const jsonText = result.text.trim().replace(/^```json\s*/i, '').replace(/\s*```$/, '');
     const parsed = JSON.parse(jsonText);

--- a/apps/web/src/lib/integrations/zoom/generate-summary.ts
+++ b/apps/web/src/lib/integrations/zoom/generate-summary.ts
@@ -1,7 +1,7 @@
 import { generateText } from 'ai';
 import { createAIProvider, isProviderError } from '@/lib/ai/core/provider-factory';
 import { loggers } from '@pagespace/lib/logging/logger-config';
-import { AIMonitoring } from '@pagespace/lib/monitoring/ai-monitoring';
+import { AIMonitoring, discardUsageOutcome } from '@pagespace/lib/monitoring/ai-monitoring';
 
 const SYSTEM_PROMPT =
   'Summarize this meeting transcript in 3–5 bullet points. Focus on decisions made and key outcomes. Be concise.';
@@ -24,7 +24,7 @@ export async function generateTranscriptSummary(
       maxOutputTokens: 512,
     });
 
-    AIMonitoring.trackUsage({
+    discardUsageOutcome(AIMonitoring.trackUsage({
       userId,
       provider: provider.provider,
       model: provider.modelName,
@@ -36,7 +36,7 @@ export async function generateTranscriptSummary(
         : undefined,
       success: true,
       metadata: { feature: 'zoom_summary' },
-    });
+    }));
 
     return result.text.trim();
   } catch (err) {

--- a/apps/web/src/lib/memory/__tests__/compaction-service.test.ts
+++ b/apps/web/src/lib/memory/__tests__/compaction-service.test.ts
@@ -45,6 +45,14 @@ vi.mock('@/lib/ai/core/ai-providers-config', () => ({
 }));
 vi.mock('@pagespace/lib/monitoring/ai-monitoring', () => ({
   AIMonitoring: { trackUsage: vi.fn() },
+  // These are pure-telemetry call sites: they hand the tracking promise to a NAMED
+  // discard rather than leaving it to float, so the mocked module has to provide it.
+  discardUsageOutcome: (tracking: Promise<unknown>) => {
+    void Promise.resolve(tracking).then(
+      () => undefined,
+      () => undefined,
+    );
+  },
 }));
 vi.mock('@pagespace/lib/logging/logger-config', () => ({
   loggers: { api: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() } },

--- a/apps/web/src/lib/memory/__tests__/discovery-service.test.ts
+++ b/apps/web/src/lib/memory/__tests__/discovery-service.test.ts
@@ -65,6 +65,14 @@ vi.mock('@/lib/ai/core/ai-providers-config', () => ({
 }));
 vi.mock('@pagespace/lib/monitoring/ai-monitoring', () => ({
   AIMonitoring: { trackUsage: vi.fn() },
+  // These are pure-telemetry call sites: they hand the tracking promise to a NAMED
+  // discard rather than leaving it to float, so the mocked module has to provide it.
+  discardUsageOutcome: (tracking: Promise<unknown>) => {
+    void Promise.resolve(tracking).then(
+      () => undefined,
+      () => undefined,
+    );
+  },
 }));
 vi.mock('@pagespace/lib/logging/logger-config', () => ({
   loggers: { api: { info: vi.fn(), debug: vi.fn(), warn: vi.fn(), error: vi.fn() } },

--- a/apps/web/src/lib/memory/__tests__/integration-service.test.ts
+++ b/apps/web/src/lib/memory/__tests__/integration-service.test.ts
@@ -40,6 +40,14 @@ vi.mock('@/lib/ai/core/ai-providers-config', () => ({
 }));
 vi.mock('@pagespace/lib/monitoring/ai-monitoring', () => ({
   AIMonitoring: { trackUsage: vi.fn() },
+  // These are pure-telemetry call sites: they hand the tracking promise to a NAMED
+  // discard rather than leaving it to float, so the mocked module has to provide it.
+  discardUsageOutcome: (tracking: Promise<unknown>) => {
+    void Promise.resolve(tracking).then(
+      () => undefined,
+      () => undefined,
+    );
+  },
 }));
 vi.mock('@pagespace/lib/logging/logger-config', () => ({
   loggers: { api: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() } },

--- a/apps/web/src/lib/memory/compaction-service.ts
+++ b/apps/web/src/lib/memory/compaction-service.ts
@@ -12,7 +12,7 @@ import { generateText } from 'ai';
 import { createAIProvider, isProviderError } from '@/lib/ai/core/provider-factory';
 import { BACKGROUND_HEAVY_PROVIDER, BACKGROUND_HEAVY_MODEL } from '@/lib/ai/core/ai-providers-config';
 import { loggers } from '@pagespace/lib/logging/logger-config';
-import { AIMonitoring } from '@pagespace/lib/monitoring/ai-monitoring';
+import { AIMonitoring, discardUsageOutcome } from '@pagespace/lib/monitoring/ai-monitoring';
 import { getCurrentPersonalizationPages, updatePersonalizationPage } from './integration-service';
 
 import { MAX_FIELD_LENGTH, compactionTarget, type MemoryField } from './budgets';
@@ -131,7 +131,7 @@ Compact this by deleting anything that does not change AI behaviour. Output only
       maxRetries: 2,
     });
 
-    AIMonitoring.trackUsage({
+    discardUsageOutcome(AIMonitoring.trackUsage({
       userId,
       provider: providerResult.provider,
       model: providerResult.modelName,
@@ -143,7 +143,7 @@ Compact this by deleting anything that does not change AI behaviour. Output only
         : undefined,
       success: true,
       metadata: { feature: 'memory_compaction', field },
-    });
+    }));
 
     const compactedContent = result.text.trim();
 

--- a/apps/web/src/lib/memory/discovery-service.ts
+++ b/apps/web/src/lib/memory/discovery-service.ts
@@ -18,7 +18,7 @@ import { conversations, messages } from '@pagespace/db/schema/conversations';
 import { createAIProvider, isProviderError } from '@/lib/ai/core/provider-factory';
 import { BACKGROUND_HEAVY_PROVIDER, BACKGROUND_HEAVY_MODEL } from '@/lib/ai/core/ai-providers-config';
 import { loggers } from '@pagespace/lib/logging/logger-config';
-import { AIMonitoring } from '@pagespace/lib/monitoring/ai-monitoring';
+import { AIMonitoring, discardUsageOutcome } from '@pagespace/lib/monitoring/ai-monitoring';
 import { z } from 'zod';
 
 export type MemoryField = 'bio' | 'writingStyle' | 'rules';
@@ -336,7 +336,7 @@ async function runDiscoveryPass(
       maxRetries: 2,
     });
 
-    AIMonitoring.trackUsage({
+    discardUsageOutcome(AIMonitoring.trackUsage({
       userId,
       provider: providerResult.provider,
       model: providerResult.modelName,
@@ -348,7 +348,7 @@ async function runDiscoveryPass(
         : undefined,
       success: true,
       metadata: { feature: 'memory_discovery', pass: passName },
-    });
+    }));
 
     // Resolve each cited index to the real message timestamp. The transcript is
     // chronological, so index 0 is the OLDEST message in the window, and an

--- a/apps/web/src/lib/memory/integration-service.ts
+++ b/apps/web/src/lib/memory/integration-service.ts
@@ -30,7 +30,7 @@ import { generateText } from 'ai';
 import { createAIProvider, isProviderError } from '@/lib/ai/core/provider-factory';
 import { BACKGROUND_HEAVY_PROVIDER, BACKGROUND_HEAVY_MODEL } from '@/lib/ai/core/ai-providers-config';
 import { loggers } from '@pagespace/lib/logging/logger-config';
-import { AIMonitoring } from '@pagespace/lib/monitoring/ai-monitoring';
+import { AIMonitoring, discardUsageOutcome } from '@pagespace/lib/monitoring/ai-monitoring';
 import { readMemoryPages } from '@pagespace/lib/memory/memory-pages';
 import {
   applyPageMutation,
@@ -345,7 +345,7 @@ Return JSON with the full new content for each field that should change. Use nul
       maxRetries: 2,
     });
 
-    AIMonitoring.trackUsage({
+    discardUsageOutcome(AIMonitoring.trackUsage({
       userId,
       provider: providerResult.provider,
       model: providerResult.modelName,
@@ -357,7 +357,7 @@ Return JSON with the full new content for each field that should change. Use nul
         : undefined,
       success: true,
       metadata: { feature: 'memory_integration' },
-    });
+    }));
 
     const text = result.text.trim();
     const jsonMatch = text.match(/```(?:json)?\s*([\s\S]*?)\s*```/);

--- a/packages/lib/src/billing/__tests__/credit-consume.test.ts
+++ b/packages/lib/src/billing/__tests__/credit-consume.test.ts
@@ -287,10 +287,81 @@ describe('consumeCredits', () => {
   it('does not throw and leaves the row pending when the decrement transaction fails', async () => {
     mockDb.insert.mockReturnValue(claimReturning([{ id: 'led_1' }]));
     mockDb.transaction.mockRejectedValueOnce(new Error('tx boom'));
+    // Never THROWS — but it no longer resolves as though nothing happened either:
+    // `deferred` is what says the backfill cron still owes this charge.
     await expect(
       consumeCredits({ aiUsageLogId: 'aul_1', userId: 'u1', costDollars: 1 }),
-    ).resolves.toBeUndefined();
+    ).resolves.toBe('deferred');
     expect(mockAiLogger.debug).toHaveBeenCalled();
+  });
+
+  // ── The reported STATUS ─────────────────────────────────────────────────────
+  // `consumeCredits` never throws, and it used to resolve `void`, so a caller could
+  // not tell a completed settle from one the cron still owes. Callers use the
+  // status to LOG and to COUNT — never to re-bill a window, because `deferred` is a
+  // charge the backfill cron is about to collect from the usage row.
+
+  it('reports settled when the decrement commits', async () => {
+    mockDb.insert.mockReturnValue(claimReturning([{ id: 'led_1' }]));
+    mockDb.transaction.mockImplementation(async (cb: (tx: unknown) => Promise<void>) => {
+      const noopWhere = vi.fn().mockResolvedValue(undefined);
+      await cb({
+        select: () => ({ from: () => ({ where: () => ({ for: () => Promise.resolve([{ monthlyRemainingCents: 1000, topupRemainingCents: 0, pendingMillicents: 0 }]) }) }) }),
+        update: vi.fn().mockReturnValue({ set: () => ({ where: noopWhere }) }),
+      });
+    });
+    expect(await consumeCredits({ aiUsageLogId: 'aul_ok', userId: 'u1', costDollars: 1 })).toBe('settled');
+  });
+
+  it('reports deferred when the transaction COMMITS but decremented nothing (no balance row yet)', async () => {
+    // `decrementAndSettle` returns early for a user with no balance row, deliberately
+    // leaving the ledger row 'pending' — a resolved transaction that settled nothing.
+    // This is the case a `void` return could never express.
+    mockDb.insert.mockReturnValue(claimReturning([{ id: 'led_1' }]));
+    mockDb.transaction.mockImplementation(async (cb: (tx: unknown) => Promise<void>) => {
+      await cb({
+        select: () => ({ from: () => ({ where: () => ({ for: () => Promise.resolve([]) }) }) }),
+        update: vi.fn(),
+      });
+    });
+    expect(await consumeCredits({ aiUsageLogId: 'aul_nobal', userId: 'u1', costDollars: 1 })).toBe('deferred');
+  });
+
+  it('reports deferred when the ledger CLAIM itself fails (no row for the pending sweep, orphan sweep owns it)', async () => {
+    mockDb.insert.mockReturnValue({
+      values: vi.fn().mockReturnValue({
+        onConflictDoNothing: vi.fn().mockReturnValue({
+          returning: vi.fn().mockRejectedValue(new Error('claim boom')),
+        }),
+      }),
+    });
+    expect(await consumeCredits({ aiUsageLogId: 'aul_claim', userId: 'u1', costDollars: 1 })).toBe('deferred');
+  });
+
+  it('reports settled for a billing-disabled deployment and for an already-claimed duplicate', async () => {
+    mockIsBillingEnabled.mockReturnValue(false);
+    expect(await consumeCredits({ aiUsageLogId: 'aul_off', userId: 'u1', costDollars: 1 })).toBe('settled');
+
+    mockIsBillingEnabled.mockReturnValue(true);
+    mockDb.insert.mockReturnValue(claimReturning([])); // conflict -> already consumed
+    expect(await consumeCredits({ aiUsageLogId: 'aul_dup2', userId: 'u1', costDollars: 1 })).toBe('settled');
+  });
+
+  it('reports unbillable for a cost that is not a finite non-negative number', async () => {
+    // Neither settled nor recoverable: there is nothing for a cron to finish, which
+    // is exactly why it is not folded into `deferred`.
+    expect(await consumeCredits({ aiUsageLogId: 'aul_bad', userId: 'u1', costDollars: Number.NaN })).toBe('unbillable');
+  });
+
+  it('reports settled for a zero-charge call and deferred when marking it skipped fails', async () => {
+    mockDb.insert.mockReturnValue(claimReturning([{ id: 'led_zero' }]));
+    const where = vi.fn().mockResolvedValue(undefined);
+    mockDb.update.mockReturnValue({ set: () => ({ where }) });
+    expect(await consumeCredits({ aiUsageLogId: 'aul_free2', userId: 'u1', costDollars: 0 })).toBe('settled');
+
+    mockDb.insert.mockReturnValue(claimReturning([{ id: 'led_zero2' }]));
+    mockDb.update.mockReturnValue({ set: () => ({ where: vi.fn().mockRejectedValue(new Error('boom')) }) });
+    expect(await consumeCredits({ aiUsageLogId: 'aul_free3', userId: 'u1', costDollars: 0 })).toBe('deferred');
   });
 
   it('releases the gate hold inside the settle transaction when a holdId is threaded through', async () => {

--- a/packages/lib/src/billing/credit-consume.ts
+++ b/packages/lib/src/billing/credit-consume.ts
@@ -12,6 +12,10 @@
  *   - Safe: never throws into the AI request. A failed decrement leaves the
  *     ledger row 'pending' for the backfill cron (settlePendingLedgerRow); a
  *     failed claim leaves no row, and the cron's orphan sweep reconciles it.
+ *   - Honest: never-throwing is not the same as always-succeeding, so the outcome
+ *     is REPORTED instead of swallowed — see {@link CreditSettleStatus}. Callers
+ *     use it to log and to count; they must NOT use a `deferred` to re-bill the
+ *     window, because the backfill cron is about to settle exactly that charge.
  */
 
 import { db } from '@pagespace/db/db';
@@ -70,6 +74,10 @@ type Tx = Parameters<Parameters<typeof db.transaction>[0]>[0];
  * If no balance row exists yet, the ledger row is left untouched ('pending') so the
  * reconcile cron settles it once a balance is created. Shared by consumeCredits and
  * settlePendingLedgerRow.
+ *
+ * Returns whether the decrement actually landed. `false` is the balance-less case
+ * above — a resolved transaction that settled NOTHING, which is exactly the shape
+ * `consumeCredits` must not report to its caller as a completed settle.
  */
 async function decrementAndSettle(
   tx: Tx,
@@ -78,7 +86,7 @@ async function decrementAndSettle(
   chargeMc: number,
   aiUsageLogId: string | null,
   holdId: string | null = null,
-): Promise<void> {
+): Promise<boolean> {
   const rows = await tx
     .select()
     .from(creditBalances)
@@ -97,7 +105,7 @@ async function decrementAndSettle(
   // Leave the ledger row 'pending' so the reconcile cron retries once a balance
   // exists — never mark a call 'applied' without decrementing it, which would
   // silently drop the charge and hide it from both backfill sweeps.
-  if (!bal) return;
+  if (!bal) return false;
 
   // Rollover: the carry balance is always spendable, even after the monthly period
   // ends. The gate no longer zeroes expired paid monthly, and settle must match:
@@ -165,10 +173,30 @@ async function decrementAndSettle(
   if (holdId) {
     await tx.delete(creditHolds).where(eq(creditHolds.id, holdId));
   }
+  return true;
 }
 
-export async function consumeCredits(input: ConsumeCreditsInput): Promise<void> {
-  if (!isBillingEnabled()) return; // tenant/onprem are unlimited
+/**
+ * What one `consumeCredits` call did with the charge — the honest answer to
+ * "is this call's money accounted for?", which `Promise<void>` could not give.
+ *
+ *  - `settled`    the charge is accounted for: decremented, or deliberately not
+ *                 owed (a $0 call recorded as 'skipped', a duplicate claim that
+ *                 was already consumed, or a deployment where billing is off).
+ *  - `deferred`   a write did not land and the ledger row is left for
+ *                 `credit-backfill.ts` to recover — the pending sweep if a row was
+ *                 claimed, the orphan sweep if it was not. NOT a lost charge, and
+ *                 nothing upstream should re-bill the window on it: the sweep will
+ *                 settle it, and re-billing would charge the payer twice.
+ *  - `unbillable` the cost was not a finite non-negative number, so there is
+ *                 nothing to settle and nothing to recover. A programming/upstream
+ *                 error, reported rather than folded into `deferred` so it cannot
+ *                 be mistaken for work a cron will finish.
+ */
+export type CreditSettleStatus = 'settled' | 'deferred' | 'unbillable';
+
+export async function consumeCredits(input: ConsumeCreditsInput): Promise<CreditSettleStatus> {
+  if (!isBillingEnabled()) return 'settled'; // tenant/onprem are unlimited
 
   // Guard a malformed cost before it can produce a bogus ledger claim. A
   // non-finite or negative cost is a programming/upstream error, not a billable
@@ -179,7 +207,7 @@ export async function consumeCredits(input: ConsumeCreditsInput): Promise<void> 
       costDollars: input.costDollars,
       aiUsageLogId: input.aiUsageLogId,
     });
-    return;
+    return 'unbillable';
   }
 
   // The precise charge in millicents (sub-cent accurate). The whole-cent `amountCents`
@@ -217,7 +245,7 @@ export async function consumeCredits(input: ConsumeCreditsInput): Promise<void> 
         where: sql`${creditLedger.aiUsageLogId} IS NOT NULL AND ${creditLedger.entryType} = 'usage'`,
       })
       .returning({ id: creditLedger.id });
-    if (claimed.length === 0) return; // already consumed — idempotent no-op
+    if (claimed.length === 0) return 'settled'; // already consumed — idempotent no-op
     ledgerId = claimed[0].id;
   } catch (error) {
     // No ledger row persisted; the cron's orphan sweep will reconcile.
@@ -225,7 +253,7 @@ export async function consumeCredits(input: ConsumeCreditsInput): Promise<void> 
       error: (error as Error).message,
       aiUsageLogId: input.aiUsageLogId,
     });
-    return;
+    return 'deferred';
   }
 
   // A zero-charge call (free/local model, or a tool-only analytics log carrying
@@ -236,6 +264,7 @@ export async function consumeCredits(input: ConsumeCreditsInput): Promise<void> 
   // it. NOTE: a sub-cent call has chargeMc > 0 and is NOT skipped here — it goes
   // through the transaction so its fraction accrues into pendingMillicents.
   if (chargeMc === 0) {
+    let zeroChargeSettled = true;
     try {
       await db
         .update(creditLedger)
@@ -253,19 +282,38 @@ export async function consumeCredits(input: ConsumeCreditsInput): Promise<void> 
         });
       }
     } catch (error) {
+      // The claim row exists but never reached a terminal status, so the backfill
+      // cron's pending sweep owns it from here.
+      zeroChargeSettled = false;
       loggers.ai.debug('credit zero-charge settle failed', {
         error: (error as Error).message,
         aiUsageLogId: input.aiUsageLogId,
       });
     }
-    return;
+    return zeroChargeSettled ? 'settled' : 'deferred';
   }
 
   // 2. Decrement the balance and settle the ledger row, atomically.
+  // Captured from INSIDE the callback rather than read off the transaction's return
+  // value: what we need to know is whether the decrement ran, and a driver/mock that
+  // does not pass the callback's result back through would silently turn every
+  // successful settle into a `deferred`.
+  let applied = false;
   try {
-    await db.transaction((tx) =>
-      decrementAndSettle(tx, ledgerId, input.userId, chargeMc, input.aiUsageLogId, input.holdId ?? null),
-    );
+    await db.transaction(async (tx) => {
+      applied = await decrementAndSettle(
+        tx,
+        ledgerId,
+        input.userId,
+        chargeMc,
+        input.aiUsageLogId,
+        input.holdId ?? null,
+      );
+    });
+    // A committed transaction that decremented NOTHING (no balance row yet) left
+    // the ledger row 'pending' on purpose — report it as deferred rather than as a
+    // settle, or the meters above would treat a charge the cron still owes as done.
+    if (!applied) return 'deferred';
     // The debit + hold release committed: push the user's fresh balance so the navbar
     // reflects this call's spend live (no refresh). Best-effort, never blocks the call.
     void emitCreditsUpdated(input.userId, {
@@ -278,7 +326,9 @@ export async function consumeCredits(input: ConsumeCreditsInput): Promise<void> 
       error: (error as Error).message,
       aiUsageLogId: input.aiUsageLogId,
     });
+    return 'deferred';
   }
+  return 'settled';
 }
 
 /**

--- a/packages/lib/src/monitoring/__tests__/ai-monitoring.test.ts
+++ b/packages/lib/src/monitoring/__tests__/ai-monitoring.test.ts
@@ -296,8 +296,12 @@ describe('getContextWindow', () => {
 describe('trackAIUsage', () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    mockWriteAiUsage.mockResolvedValue(undefined);
-    mockConsumeCredits.mockResolvedValue(undefined);
+    // The DEFAULT is a write that lands and a settle that completes. `writeAiUsage`
+    // resolves `string | null` and a null is a LOST usage row — the one
+    // unrecoverable outcome in this function — so a default of `undefined` would
+    // have every unrelated test exercising the failure path.
+    mockWriteAiUsage.mockResolvedValue('aul_default');
+    mockConsumeCredits.mockResolvedValue('settled');
     mockReleaseHold.mockResolvedValue(undefined);
   });
 
@@ -475,6 +479,97 @@ describe('trackAIUsage', () => {
     await trackAIUsage({ userId: 'user-1', provider: 'openai', model: 'gpt-4o', inputTokens: 10, outputTokens: 10 });
     await new Promise(resolve => setTimeout(resolve, 0));
     expect(mockConsumeCredits).not.toHaveBeenCalled();
+  });
+
+  // ── The persistence CONTRACT ────────────────────────────────────────────────
+  // `trackAIUsage` used to resolve `void` whatever happened below it, so no caller
+  // could tell a committed charge from a lost one and every meter that advances a
+  // watermark after awaiting it could close a window over spend that never landed.
+
+  it('reports a persisted, settled charge on the happy path', async () => {
+    mockWriteAiUsage.mockResolvedValueOnce('aul_ok');
+    mockConsumeCredits.mockResolvedValueOnce('settled');
+    const outcome = await trackAIUsage({
+      userId: 'user-1',
+      provider: 'anthropic',
+      model: 'claude-3-5-sonnet-20241022',
+      inputTokens: 1000,
+      outputTokens: 500,
+    });
+    expect(outcome).toEqual({ persisted: true, creditsSettled: true });
+  });
+
+  it('reports persisted:false when the usage row was NOT written — the one unrecoverable outcome', async () => {
+    // `writeAiUsage` catches its own failure and resolves null. With no
+    // `ai_usage_logs` row the credit backfill cron's orphan sweep, which reads that
+    // table, can never find this charge: it is gone unless a meter re-bills the window.
+    mockWriteAiUsage.mockResolvedValueOnce(null);
+    const outcome = await trackAIUsage({
+      userId: 'user-1',
+      provider: 'anthropic',
+      model: 'claude-3-5-sonnet-20241022',
+      inputTokens: 1000,
+      outputTokens: 500,
+      holdId: 'hold_lost',
+    });
+    expect(outcome).toEqual({ persisted: false, creditsSettled: false });
+    expect(mockAiLogger.error).toHaveBeenCalled();
+    // The reservation is returned rather than left to pin the payer's spendable
+    // balance until its TTL — nothing downstream will ever settle it.
+    expect(mockReleaseHold).toHaveBeenCalledWith('hold_lost');
+  });
+
+  it('reports persisted:false when the usage write THROWS', async () => {
+    mockWriteAiUsage.mockRejectedValueOnce(new Error('db down'));
+    const outcome = await trackAIUsage({
+      userId: 'user-1',
+      provider: 'anthropic',
+      model: 'claude-3-5-sonnet-20241022',
+      inputTokens: 1000,
+      outputTokens: 500,
+    });
+    expect(outcome).toEqual({ persisted: false, creditsSettled: false });
+  });
+
+  it('reports persisted:true with creditsSettled:false when the ledger settle was DEFERRED', async () => {
+    // Deferred is not lost: the usage row exists, so credit-backfill.ts settles this
+    // charge on its next sweep. Meters must therefore NOT hold a watermark on this —
+    // doing so would bill the payer twice for one span.
+    mockWriteAiUsage.mockResolvedValueOnce('aul_deferred');
+    mockConsumeCredits.mockResolvedValueOnce('deferred');
+    const outcome = await trackAIUsage({
+      userId: 'user-1',
+      provider: 'anthropic',
+      model: 'claude-3-5-sonnet-20241022',
+      inputTokens: 1000,
+      outputTokens: 500,
+    });
+    expect(outcome).toEqual({ persisted: true, creditsSettled: false });
+  });
+
+  it('reports a settled outcome for a metering-exempt provider — nothing was owed', async () => {
+    mockWriteAiUsage.mockResolvedValueOnce('aul_exempt');
+    const outcome = await trackAIUsage({
+      userId: 'user-1',
+      provider: 'glm',
+      model: 'glm-4.7',
+      inputTokens: 1000,
+      outputTokens: 500,
+    });
+    expect(outcome).toEqual({ persisted: true, creditsSettled: true });
+    expect(mockConsumeCredits).not.toHaveBeenCalled();
+  });
+
+  it('reports a settled outcome for a token-less failure — deliberately unbilled, not lost', async () => {
+    mockWriteAiUsage.mockResolvedValueOnce('aul_nobill');
+    const outcome = await trackAIUsage({
+      userId: 'user-1',
+      provider: 'openai',
+      model: 'gpt-4o',
+      success: false,
+      error: 'pre-generation failure',
+    });
+    expect(outcome).toEqual({ persisted: true, creditsSettled: true });
   });
 
   it('should call writeAiUsage with computed cost and totals', async () => {

--- a/packages/lib/src/monitoring/ai-monitoring.ts
+++ b/packages/lib/src/monitoring/ai-monitoring.ts
@@ -937,8 +937,16 @@ export function discardUsageOutcome(tracking: Promise<UsageTrackingOutcome>): vo
   );
 }
 
-/** Nothing was written and nothing was billed — every failure path's outcome. */
-const USAGE_TRACKING_LOST: UsageTrackingOutcome = { persisted: false, creditsSettled: false };
+/**
+ * Nothing was confirmed written and nothing was billed — every failure path's
+ * outcome. FROZEN because this one object is handed to every caller on every
+ * failure: an unfrozen shared literal is one careless `outcome.persisted = true`
+ * away from making a meter believe every later failure succeeded.
+ */
+const USAGE_TRACKING_LOST: UsageTrackingOutcome = Object.freeze({
+  persisted: false,
+  creditsSettled: false,
+});
 
 /**
  * Track AI usage with automatic cost calculation.

--- a/packages/lib/src/monitoring/ai-monitoring.ts
+++ b/packages/lib/src/monitoring/ai-monitoring.ts
@@ -881,9 +881,73 @@ export interface AIUsageData {
 }
 
 /**
- * Track AI usage with automatic cost calculation
+ * What one `trackAIUsage` call durably achieved. The seam used to return
+ * `Promise<void>` and swallow every failure below it, so no caller could tell a
+ * committed charge from a lost one — and every meter that advances a watermark
+ * after awaiting it (the sandbox storage reconcile, the realtime shell settle, the
+ * published-app awake meter) could close a window over a charge that never landed.
+ *
+ * READ {@link UsageTrackingOutcome.persisted} FIRST: it is the load-bearing field,
+ * and {@link UsageTrackingOutcome.creditsSettled} is deliberately NOT a second one.
  */
-export async function trackAIUsage(data: AIUsageData): Promise<void> {
+export interface UsageTrackingOutcome {
+  /**
+   * The `ai_usage_logs` row for this call is durably written.
+   *
+   * THIS is what a meter gates its watermark/window on, because this row is what
+   * every recovery path keys off: `credit-backfill.ts` sweeps usage rows that have
+   * no ledger entry and re-runs the charge. With the row, a charge is at worst
+   * late. Without it there is nothing to recover from and the spend is gone for
+   * good — the provider already billed us and nobody will ever bill the payer.
+   *
+   * False means: keep the window OPEN. Nothing was written, so the next tick
+   * re-bills the same span and cannot double-charge for it.
+   */
+  persisted: boolean;
+  /**
+   * The credit settle completed IN-LINE — or there was legitimately nothing to
+   * settle (a metering-exempt provider, a token-less failure, a $0 call, or a
+   * deployment with billing off).
+   *
+   * NOT a watermark gate, and gating on it would be a bug in the opposite
+   * direction. `consumeCredits` reports `deferred` for a claim/settle that did not
+   * land, and the backfill cron then settles that very charge from the usage row —
+   * so a meter that held its window open on `creditsSettled === false` would bill
+   * the payer a second time for a span the cron is already collecting. Reported so
+   * failures are visible in logs and counters, nothing more.
+   */
+  creditsSettled: boolean;
+}
+
+/**
+ * Explicitly drop a tracking outcome, for a call site that is pure telemetry and
+ * has no window, watermark or hold to keep open on a failure. Named rather than
+ * implicit so "this call ignores the outcome" is a decision visible in the diff,
+ * not the absence of one — and so a future meter added at such a site is not
+ * silently born with the old swallow. `trackAIUsage` already logs the failure at
+ * ERROR; this only stops the promise floating.
+ */
+export function discardUsageOutcome(tracking: Promise<UsageTrackingOutcome>): void {
+  // `Promise.resolve` rather than `tracking.then` directly: the only job here is to
+  // stop the promise floating, and it must not itself become a new way for a call
+  // site to blow up on something it has explicitly declared it does not care about.
+  void Promise.resolve(tracking).then(
+    () => undefined,
+    () => undefined,
+  );
+}
+
+/** Nothing was written and nothing was billed — every failure path's outcome. */
+const USAGE_TRACKING_LOST: UsageTrackingOutcome = { persisted: false, creditsSettled: false };
+
+/**
+ * Track AI usage with automatic cost calculation.
+ *
+ * Never throws (an AI request must not die because a monitoring write did), but it
+ * no longer hides that: the {@link UsageTrackingOutcome} it resolves with says
+ * whether the usage row landed and whether the charge settled.
+ */
+export async function trackAIUsage(data: AIUsageData): Promise<UsageTrackingOutcome> {
   try {
     // Calculate tokens if not provided
     let { inputTokens, outputTokens, totalTokens } = data;
@@ -1004,6 +1068,29 @@ export async function trackAIUsage(data: AIUsageData): Promise<void> {
         },
         reconcileStatus,
       });
+      // `writeAiUsage` CATCHES its own failure and returns null rather than
+      // throwing, so a null id here is a lost usage row — the one unrecoverable
+      // outcome in this function, since the backfill cron's orphan sweep reads
+      // `ai_usage_logs` and therefore has nothing to find. Report it instead of
+      // falling through to the hold release as if nothing had gone wrong.
+      if (!aiUsageLogId) {
+        // A metering-exempt provider never owed anything, so the lost row costs
+        // observability rather than revenue — say which, so an operator reading the
+        // log is not sent hunting for money that was never going to be charged.
+        const exempt = isMeteringExempt(data.provider);
+        loggers.ai.error(
+          exempt
+            ? 'AI usage row was NOT persisted (metering-exempt provider) — observability only, nothing was owed'
+            : 'AI usage row was NOT persisted — this spend is unbilled and unrecoverable',
+          new Error('writeAiUsage returned no id'),
+          { model: data.model, provider: data.provider, source: data.source, holdId: data.holdId },
+        );
+        // The gate's reservation would otherwise sit against the payer's spendable
+        // balance until its TTL, and nothing downstream will ever settle it.
+        if (data.holdId) await releaseHold(data.holdId);
+        return { persisted: false, creditsSettled: exempt };
+      }
+
       // Bill when real tokens were consumed, regardless of success. A token-less
       // failure (pre-generation error) carries 0 tokens and is skipped; a
       // zero-charge call still reaches consumeCredits, which settles it as
@@ -1014,8 +1101,17 @@ export async function trackAIUsage(data: AIUsageData): Promise<void> {
         // shared credit pool. The gate is normally skipped for this provider so no
         // hold exists; release one defensively if a caller placed it anyway.
         if (data.holdId) await releaseHold(data.holdId);
-      } else if (aiUsageLogId && (success || (totalTokens ?? 0) > 0)) {
-        await consumeCredits({
+        // Nothing was owed, so nothing is outstanding: a settle that was never
+        // meant to happen is `creditsSettled: true`, not a silent false that would
+        // read as a failure in every meter's log.
+        return { persisted: true, creditsSettled: true };
+      }
+
+      if (success || (totalTokens ?? 0) > 0) {
+        // `consumeCredits` never throws; the `.catch` here is belt-and-braces for a
+        // future rejection, and its outcome — not the mere fact that it resolved —
+        // is what `creditsSettled` reports.
+        const settle = await consumeCredits({
           aiUsageLogId,
           userId: data.userId,
           costDollars: cost,
@@ -1025,32 +1121,53 @@ export async function trackAIUsage(data: AIUsageData): Promise<void> {
           conversationId: data.conversationId,
           pageId: data.pageId,
           markupBpsOverride: data.markupBpsOverride,
-        })
-          .catch((error) => {
-            loggers.ai.debug('credit consume failed', { error: (error as Error).message });
+        }).catch((error) => {
+          loggers.ai.debug('credit consume failed', { error: (error as Error).message });
+          return 'deferred' as const;
+        });
+        if (settle !== 'settled') {
+          // The usage row IS written, so the backfill cron owns this charge from
+          // here (pending sweep for a claimed row, orphan sweep for an unclaimed
+          // one). Logged at WARN, not ERROR: late is not lost.
+          loggers.ai.warn('credit settle did not complete in-line; left to the backfill cron', {
+            aiUsageLogId,
+            status: settle,
+            model: data.model,
+            provider: data.provider,
+            source: data.source,
           });
-      } else if (data.holdId) {
+        }
+        return { persisted: true, creditsSettled: settle === 'settled' };
+      }
+
+      if (data.holdId) {
         // Token-less failure (pre-generation error): nothing to bill, but the gate
         // already placed a hold. Release it now instead of leaving it to the cron.
         await releaseHold(data.holdId);
       }
+      // Deliberately unbilled (a pre-generation failure that burned no tokens) —
+      // an outcome, not a loss.
+      return { persisted: true, creditsSettled: true };
     } catch (error) {
-      // This swallow is the ONLY thing standing between a failed usage write and a silent
-      // billing gap: if writeAiUsage (or the settle below it) throws, the provider has
-      // already charged us but no ai_usage_logs row exists — so nothing debits the user and
-      // the orphan sweep, which keys off ai_usage_logs, can never find it. Log at ERROR (not
-      // debug) so unbilled spend is visible instead of disappearing into a debug channel.
+      // A throw here means the provider has already charged us but no ai_usage_logs
+      // row exists — so nothing debits the user and the orphan sweep, which keys off
+      // ai_usage_logs, can never find it. Logged at ERROR (not debug) so unbilled
+      // spend is visible instead of disappearing into a debug channel, and — unlike
+      // before — REPORTED to the caller, so a meter can keep its window open over it
+      // instead of advancing a watermark past a charge that never landed.
       loggers.ai.error('AI usage tracking failed — spend may be UNBILLED', error as Error, {
         model: data.model,
         provider: data.provider,
         source: data.source,
         holdId: data.holdId,
       });
+      return USAGE_TRACKING_LOST;
     }
   } catch (error) {
     loggers.ai.debug('AI usage calculation failed', { 
       error: (error as Error).message 
     });
+    return USAGE_TRACKING_LOST;
   }
 }
 
@@ -1072,11 +1189,12 @@ export interface AIToolUsage {
   pageId?: string;
 }
 
-export function trackAIToolUsage(data: AIToolUsage): Promise<void> {
+export function trackAIToolUsage(data: AIToolUsage): Promise<UsageTrackingOutcome> {
   // Return (not just call) trackAIUsage so the same durability guarantee applies
   // here: a caller that `await`s trackAIToolUsage waits for the tool-analytics log
   // (and its zero-charge ledger settlement) to persist before returning, instead
-  // of resolving immediately and risking a dropped write on a serverless freeze.
+  // of resolving immediately and risking a dropped write on a serverless freeze —
+  // and receives the same {@link UsageTrackingOutcome} it would from trackAIUsage.
   return trackAIUsage({
     userId: data.userId,
     provider: data.provider,

--- a/packages/lib/src/services/app-hosting/__tests__/app-billing.test.ts
+++ b/packages/lib/src/services/app-hosting/__tests__/app-billing.test.ts
@@ -132,6 +132,18 @@ describe('defaultAppBillingDeps.trackUsage', () => {
       publishedAppId: 'app-1',
     });
 
+  it('RETURNS the credit seam’s persistence outcome verbatim — the callers gate their awake window on it', async () => {
+    // The whole point of the seam: a resolved settle is not a settled one. If this
+    // binding dropped the outcome (an `async` wrapper that awaits and returns
+    // nothing, which is what it used to be), every hosting caller would be back to
+    // closing windows over lost charges with no way to tell.
+    mockTrackUsage.mockResolvedValueOnce({ persisted: false, creditsSettled: false });
+    expect(await settle()).toEqual({ persisted: false, creditsSettled: false });
+
+    mockTrackUsage.mockResolvedValueOnce({ persisted: true, creditsSettled: true });
+    expect(await settle()).toEqual({ persisted: true, creditsSettled: true });
+  });
+
   it('attributes the charge to the payer, the drive, and the published app', async () => {
     await settle();
 

--- a/packages/lib/src/services/app-hosting/__tests__/app-lifecycle-metering.test.ts
+++ b/packages/lib/src/services/app-hosting/__tests__/app-lifecycle-metering.test.ts
@@ -88,7 +88,7 @@ function makeDeps(over: Partial<AppLifecycleMeteringDeps> = {}): {
   stopMachine: ReturnType<typeof vi.fn>;
 } {
   const gate = vi.fn(async () => ({ allowed: true, holdId: 'hold-1' }));
-  const trackUsage = vi.fn(async () => {});
+  const trackUsage = vi.fn(async () => ({ persisted: true, creditsSettled: true }));
   const releaseHold = vi.fn(async () => {});
   const startMachine = vi.fn(async () => {});
   const stopMachine = vi.fn(async () => {});
@@ -342,6 +342,50 @@ describe('stopPublishedApp', () => {
         clearedWatermark: 'awakeBilledThrough' in written,
       },
       expected: { status: 'stopped', clearedWatermark: false },
+    });
+  });
+
+  // ── The persistence CONTRACT (issue: trackUsage must report its outcome) ────
+  // The default binding runs through `AIMonitoring.trackUsage`, which never throws.
+  // Before it reported an outcome, a settle whose `ai_usage_logs` write failed
+  // RESOLVED — so the test above covered only a deps-level throw and the app's last
+  // awake window was silently closed over lost spend on the real path.
+
+  it('given a settle that resolves WITHOUT persisting, should close the STATUS but keep the window open for a retry', async () => {
+    const { deps, trackUsage } = makeDeps();
+    trackUsage.mockResolvedValue({ persisted: false, creditsSettled: false });
+    seed(running());
+
+    const result = await stopPublishedApp('app-1', 'idle', deps);
+
+    expect(result).toMatchObject({ outcome: 'stopped', billedSeconds: 0 });
+    const written = mockDb.__state.updateSets[0];
+    assert({
+      given: 'a settle that resolved but wrote no usage row',
+      should: 'move the status without clearing the billing watermark',
+      actual: { status: written.status, clearedWatermark: 'awakeBilledThrough' in written },
+      expected: { status: 'stopped', clearedWatermark: false },
+    });
+  });
+
+  it('given a PERSISTED settle whose ledger settle was deferred, should still CLOSE the window (the backfill cron owns that charge)', async () => {
+    // Reopening the window here would re-bill a span the credit backfill cron is
+    // already collecting from the usage row.
+    const { deps, trackUsage } = makeDeps();
+    trackUsage.mockResolvedValue({ persisted: true, creditsSettled: false });
+    seed(running());
+
+    const result = await stopPublishedApp('app-1', 'idle', deps);
+
+    const written = mockDb.__state.updateSets[0];
+    assert({
+      given: 'a persisted settle whose ledger claim was deferred to the backfill cron',
+      should: 'bill the span and close the window exactly as a fully settled charge would',
+      actual: {
+        billedSeconds: result.outcome === 'stopped' ? result.billedSeconds : -1,
+        clearedWatermark: 'awakeBilledThrough' in written,
+      },
+      expected: { billedSeconds: 3600, clearedWatermark: true },
     });
   });
 

--- a/packages/lib/src/services/app-hosting/__tests__/app-lifecycle-metering.test.ts
+++ b/packages/lib/src/services/app-hosting/__tests__/app-lifecycle-metering.test.ts
@@ -238,6 +238,97 @@ describe('wakePublishedApp', () => {
   });
 });
 
+describe('wakePublishedApp — the abandoned tail a failed close left behind', () => {
+  // `closeStatusOnly` preserves `awakeBilledThrough` when a final settle does not
+  // land, but the awake meter reads `status = 'running'` rows ONLY, so nothing
+  // revisits a stopped row — and the wake's own UPDATE resets that watermark to
+  // `wokenAt`. Without this step the preserved span is silently discarded at the
+  // next wake, which makes the failed-settle path's "the window stays open"
+  // promise false exactly where it matters most.
+
+  const abandoned = () =>
+    appRow({
+      status: 'stopped',
+      awakeBilledThrough: new Date('2026-08-20T10:00:00.000Z'),
+      lastStopAt: new Date('2026-08-20T10:10:00.000Z'),
+      awakeHoldId: 'hold-stranded',
+    });
+
+  it('bills the stranded span at the boundary the window REALLY ended on, not up to now', async () => {
+    const { deps, trackUsage } = makeDeps();
+    seed(abandoned(), [[appRow({ status: 'running' })]]);
+
+    await wakePublishedApp('app-1', deps);
+
+    // 10:00 -> 10:10 is 600s. Billing to `now` (12:00) would charge 7200s — two
+    // hours of a machine that was STOPPED.
+    expect(trackUsage).toHaveBeenCalledWith({
+      payerId: 'payer-1',
+      holdId: 'hold-stranded',
+      activeSeconds: 600,
+      driveId: 'drive-1',
+      publishedAppId: 'app-1',
+    });
+  });
+
+  it('does NOT bill a tail on a live (running) row — that is an open window, not an abandoned one', async () => {
+    const { deps, trackUsage } = makeDeps();
+    seed(
+      appRow({
+        status: 'running',
+        awakeBilledThrough: new Date('2026-08-20T10:00:00.000Z'),
+        lastStopAt: new Date('2026-08-20T10:10:00.000Z'),
+      }),
+      [[appRow({ status: 'running' })]],
+    );
+
+    await wakePublishedApp('app-1', deps);
+
+    expect(trackUsage).not.toHaveBeenCalled();
+  });
+
+  it('returns the stranded reservation when the tail prices to nothing', async () => {
+    const { deps, trackUsage, releaseHold } = makeDeps();
+    seed(
+      appRow({
+        status: 'stopped',
+        awakeBilledThrough: new Date('2026-08-20T10:10:00.000Z'),
+        lastStopAt: new Date('2026-08-20T10:10:00.000Z'), // zero-length window
+        awakeHoldId: 'hold-stranded',
+      }),
+      [[appRow({ status: 'running' })]],
+    );
+
+    await wakePublishedApp('app-1', deps);
+
+    expect(trackUsage).not.toHaveBeenCalled();
+    expect(releaseHold).toHaveBeenCalledWith('hold-stranded');
+  });
+
+  it('NEVER blocks the wake, even when the tail settle fails outright', async () => {
+    // A billing failure must not leave an app unservable. The span is lost at this
+    // point — two independent failures at two separate moments — and said so.
+    const { deps, trackUsage, startMachine } = makeDeps();
+    trackUsage.mockRejectedValue(new Error('ledger down'));
+    seed(abandoned(), [[appRow({ status: 'running' })]]);
+
+    const result = await wakePublishedApp('app-1', deps);
+
+    expect(startMachine).toHaveBeenCalled();
+    expect(result.outcome).toBe('woken');
+  });
+
+  it('does not bill anyone when the gate REFUSES — a parked wake moves no money', async () => {
+    const { deps, gate, trackUsage } = makeDeps();
+    gate.mockResolvedValue({ allowed: false, reason: 'insufficient_credits' });
+    seed(abandoned());
+
+    await wakePublishedApp('app-1', deps);
+
+    expect(trackUsage).not.toHaveBeenCalled();
+  });
+});
+
 describe('stopPublishedApp', () => {
   const running = () =>
     appRow({ status: 'running', lastWakeAt: WOKEN_AT, awakeBilledThrough: WOKEN_AT, awakeHoldId: 'hold-1' });

--- a/packages/lib/src/services/app-hosting/__tests__/awake-meter.test.ts
+++ b/packages/lib/src/services/app-hosting/__tests__/awake-meter.test.ts
@@ -26,7 +26,10 @@ function runningApp(over: Partial<PublishedApp> = {}): PublishedApp {
 }
 
 function makeDeps(over: Partial<AwakeMeterDeps> = {}) {
-  const trackUsage = vi.fn<AppBillingDeps['trackUsage']>(async () => {});
+  const trackUsage = vi.fn<AppBillingDeps['trackUsage']>(async () => ({
+    persisted: true,
+    creditsSettled: true,
+  }));
   // Typed to the seam rather than inferred from this one happy-path literal, so a
   // test can hand it a refusal (which carries `reason` and no `holdId`).
   const gate = vi.fn<AppBillingDeps['gate']>(async () => ({ allowed: true, holdId: 'hold-next' }));
@@ -101,6 +104,54 @@ describe('meterAwakePublishedApps — the ordinary settle', () => {
       publishedAppId: 'app-1',
       billedThrough: NOW,
       holdId: 'hold-next',
+    });
+  });
+
+  // ── The persistence CONTRACT (issue: trackUsage must report its outcome) ────
+  // `billing.trackUsage` reaches `AIMonitoring.trackUsage`, which never throws.
+  // Before it reported an outcome, a settle whose `ai_usage_logs` write failed
+  // RESOLVED — so this meter counted it `settled`, advanced the watermark, and
+  // closed the window over spend nothing would ever bill. Flip `persisted` and the
+  // watermark must HOLD; restore it and it must advance.
+
+  it('given a settle that resolves WITHOUT persisting, HOLDS the watermark so the next tick re-bills the span', async () => {
+    const { deps, writeSettle, gate } = makeDeps();
+    deps.billing.trackUsage = async () => ({ persisted: false, creditsSettled: false });
+
+    const run = await meter(deps);
+
+    assert({
+      given: 'an awake settle that resolved but wrote no usage row',
+      should: 'count it failed, bill no seconds, and move no watermark',
+      actual: {
+        settled: run.settled,
+        failed: run.failed,
+        seconds: run.totalAwakeSeconds,
+        advances: writeSettle.mock.calls.length,
+      },
+      expected: { settled: 0, failed: 1, seconds: 0, advances: 0 },
+    });
+    // Not `settledButUnadvanced`: that name means money moved and only the
+    // watermark write failed — the opposite situation, and the opposite remedy.
+    expect(run.settledButUnadvanced).toBe(0);
+    // The re-gate is skipped with the advance: this tick made no window to reserve.
+    expect(gate).not.toHaveBeenCalled();
+  });
+
+  it('given a PERSISTED settle whose ledger settle was deferred, still ADVANCES the watermark (the backfill cron owns that charge)', async () => {
+    // Holding the window open here would re-bill a span the credit backfill cron is
+    // already collecting from the usage row — a double-charge caused by trying to
+    // prevent a lost one.
+    const { deps, writeSettle } = makeDeps();
+    deps.billing.trackUsage = async () => ({ persisted: true, creditsSettled: false });
+
+    const run = await meter(deps);
+
+    assert({
+      given: 'a persisted settle whose ledger claim was deferred to the backfill cron',
+      should: 'settle and close the window exactly as a fully settled charge would',
+      actual: { settled: run.settled, failed: run.failed, advances: writeSettle.mock.calls.length },
+      expected: { settled: 1, failed: 0, advances: 1 },
     });
   });
 
@@ -302,6 +353,7 @@ describe('meterAwakePublishedApps — attribution and isolation', () => {
   it('ISOLATES one bad row — the rest of the fleet is still billed', async () => {
     const trackUsage = vi.fn(async (input: { publishedAppId: string }) => {
       if (input.publishedAppId === 'app-bad') throw new Error('boom');
+      return { persisted: true, creditsSettled: true };
     });
     const { deps } = makeDeps({
       listRunningApps: async () => [

--- a/packages/lib/src/services/app-hosting/app-billing.ts
+++ b/packages/lib/src/services/app-hosting/app-billing.ts
@@ -36,7 +36,7 @@ import {
   PUBLISHED_APP_WAKE_HOLD_ESTIMATE_CENTS,
 } from '../../billing/credit-pricing';
 import { resolveEnvPayerId, lookupDriveOwnerId } from '../../billing/sandbox-payer';
-import { AIMonitoring } from '../../monitoring/ai-monitoring';
+import { AIMonitoring, type UsageTrackingOutcome } from '../../monitoring/ai-monitoring';
 import { calculateMachineCostDollars, PUBLISHED_APP_GUEST_SHAPE } from '../../monitoring/machine-pricing';
 import { toSubscriptionTier, type SubscriptionTier } from '../../billing/subscription-tiers';
 import { PUBLISHED_APP_AWAKE_MODEL } from '../../monitoring/usage-source';
@@ -59,19 +59,11 @@ export interface AppBillingDeps {
    * Settles accrued awake-seconds against the wake's hold. Called by every
    * heartbeat and once more at the stop boundary.
    *
-   * CAVEAT, and it is a real one: the default binding goes through
-   * `AIMonitoring.trackUsage`, which CATCHES its own persistence failures — a
-   * failed `writeAiUsage`, or a `consumeCredits` that rejects — logs them, and
-   * resolves normally. So a resolved call here is NOT proof that a usage row or a
-   * ledger claim exists, and the callers' "a failed settle leaves the window open
-   * for the next tick" behaviour only covers a settle that actually throws.
-   *
-   * This is a property of the shared credit pipeline rather than of hosting —
-   * every meter in the repo that calls `trackUsage` inherits it, the sandbox
-   * storage reconcile included — so it is deliberately NOT worked around here
-   * with a second, hosting-only write path. Fixing it means giving
-   * `trackUsage` a durable-persistence result, which is a change with a
-   * platform-wide blast radius and belongs in its own PR.
+   * REPORTS ITS OUTCOME rather than resolving regardless: a resolved call is not
+   * a settled one, and `UsageTrackingOutcome.persisted` is what says whether this
+   * app's usage row landed. The callers close the awake window only on a persisted
+   * settle — on a lost one the window stays open and the next tick re-bills the
+   * whole span, which is safe precisely because nothing was written.
    */
   trackUsage: (input: {
     payerId: string;
@@ -79,7 +71,7 @@ export interface AppBillingDeps {
     activeSeconds: number;
     driveId: string;
     publishedAppId: string;
-  }) => Promise<void>;
+  }) => Promise<UsageTrackingOutcome>;
   /** Releases a reservation without billing — every exit that never settles. */
   releaseHold: (holdId: string) => Promise<void>;
 }
@@ -127,8 +119,9 @@ export const defaultAppBillingDeps: AppBillingDeps = {
     };
   },
 
-  async trackUsage({ payerId, holdId, activeSeconds, driveId, publishedAppId }) {
-    await AIMonitoring.trackUsage({
+  trackUsage({ payerId, holdId, activeSeconds, driveId, publishedAppId }) {
+    // Returned, not awaited-and-discarded — the outcome IS the contract here.
+    return AIMonitoring.trackUsage({
       userId: payerId,
       // The substrate, named where substrate names belong — in the usage row's
       // provider field, not in the payer resolution or the billed unit above it.

--- a/packages/lib/src/services/app-hosting/app-lifecycle-metering.ts
+++ b/packages/lib/src/services/app-hosting/app-lifecycle-metering.ts
@@ -140,6 +140,13 @@ export async function wakePublishedApp(
     return { outcome: 'parked', reason: gate.reason ?? 'insufficient_credits' };
   }
 
+  // A previous stop whose final settle did not land left its window on the row.
+  // The UPDATE below resets `awakeBilledThrough` to `wokenAt`, so this is the last
+  // moment that span can be billed — settle it at the boundary it really ended on.
+  // Runs after the gate so a wake that is about to be refused does not bill, and
+  // before the start so it cannot be confused with this wake's own window.
+  await settleAbandonedTail(row, deps);
+
   try {
     await deps.startMachine(row.flyAppName, row.machineId);
   } catch (error) {
@@ -409,9 +416,85 @@ async function settleAndClose(
 }
 
 /**
+ * Settle a tail that a FAILED close left behind on a non-running row, at the wake
+ * that is about to overwrite it.
+ *
+ * `closeStatusOnly` preserves `awakeBilledThrough` when a final settle does not
+ * land — but nothing consumed it: the awake meter reads `status = 'running'` rows
+ * only, so a stopped row is never revisited, and the wake below resets the
+ * watermark to `wokenAt`. The preserved span was therefore silently discarded at
+ * the next wake, which is the moment this runs instead.
+ *
+ * The billed span is [`awakeBilledThrough`, `lastStopAt`] — the window as it really
+ * ended. Emphatically NOT up to `now`: the machine was down in between, and billing
+ * that gap would charge the payer for a stopped app.
+ *
+ * Never blocks the wake. If this settle also fails to persist, the span is finally
+ * lost and said so at ERROR — two independent failures at two separate moments,
+ * against losing it on the first. A `parked` app that is never woken again keeps
+ * its tail on the row unbilled; recovering that needs a sweep over non-running
+ * rows, which is follow-up work rather than a wake's job.
+ */
+async function settleAbandonedTail(
+  row: PublishedApp,
+  deps: AppLifecycleMeteringDeps,
+): Promise<void> {
+  if (row.status === 'running') return; // a live window, not an abandoned tail
+  if (row.awakeBilledThrough === null || row.lastStopAt === null) return;
+
+  const plan = planAwakeSettle({ billedThrough: row.awakeBilledThrough, now: row.lastStopAt });
+  if (plan.action !== 'settle') {
+    // Nothing billable was stranded; return the reservation the failed close kept.
+    if (row.awakeHoldId) await deps.billing.releaseHold(row.awakeHoldId);
+    return;
+  }
+
+  const payerId = await deps.billing.resolvePayerId({ driveId: row.driveId });
+  if (!payerId) {
+    // Unresolvable drive — never substitute a payer. The tail stays on the row and
+    // the wake below overwrites it, so this IS the loss; say so rather than warn.
+    loggers.ai.error(
+      'Published-app abandoned tail could not be billed: the owning drive did not resolve — this span is lost',
+      new Error('abandoned tail payer unresolved'),
+      { publishedAppId: row.id, driveId: row.driveId, activeSeconds: plan.activeSeconds },
+    );
+    return;
+  }
+
+  try {
+    const settle = await deps.billing.trackUsage({
+      payerId,
+      holdId: row.awakeHoldId ?? undefined,
+      activeSeconds: plan.activeSeconds,
+      driveId: row.driveId,
+      publishedAppId: row.id,
+    });
+    if (!settle.persisted) {
+      loggers.ai.error(
+        'Published-app abandoned tail did not persist on the retry either — this span is lost',
+        new Error('abandoned tail settle was not persisted'),
+        { publishedAppId: row.id, driveId: row.driveId, activeSeconds: plan.activeSeconds },
+      );
+    }
+  } catch (error) {
+    loggers.ai.error(
+      'Published-app abandoned tail settle threw on the retry — this span is lost',
+      error instanceof Error ? error : new Error(String(error)),
+      { publishedAppId: row.id, driveId: row.driveId, activeSeconds: plan.activeSeconds },
+    );
+  }
+}
+
+/**
  * Close the STATUS without closing the billing window — the failed-settle path.
- * `awakeBilledThrough` deliberately survives, so the unbilled span is retried
- * instead of being forgiven, while the row stops claiming to be running.
+ * `awakeBilledThrough` deliberately survives so the unbilled span is not forgiven
+ * at the moment of failure, while the row stops claiming to be running.
+ *
+ * It is NOT retried by the awake meter: that meter reads `status = 'running'` rows
+ * only, so this row is now invisible to it. The preserved span is settled by
+ * `settleAbandonedTail` at the next wake — the next moment anything touches the row
+ * — before the wake resets the watermark. A row that is never woken again keeps its
+ * tail unbilled; a sweep over non-running rows would close that, and is follow-up.
  */
 async function closeStatusOnly(
   row: PublishedApp,

--- a/packages/lib/src/services/app-hosting/app-lifecycle-metering.ts
+++ b/packages/lib/src/services/app-hosting/app-lifecycle-metering.ts
@@ -332,9 +332,15 @@ async function settleAndClose(
       // is a deps-level or transport failure. A settle that RESOLVES WITHOUT
       // PERSISTING is the shape `AIMonitoring.trackUsage` used to hide behind
       // `Promise<void>`: it now reports `persisted: false`, and it means no
-      // `ai_usage_logs` row exists — so not even the credit backfill cron, which
-      // reads that table, can recover the charge. Retrying the window is the only
-      // thing that can, and retrying is safe precisely because nothing was written.
+      // `ai_usage_logs` row is CONFIRMED to exist — so not even the credit backfill
+      // cron, which reads that table, can be relied on to recover the charge.
+      // Retrying the window is the only thing that can.
+      //
+      // "Not confirmed", not "not written": a connection dropped at the commit
+      // boundary reports a failed write over a row that committed, and the retry
+      // then bills the span twice. Bounded at ONE duplicate span, and strictly
+      // better than losing the window on every genuine failure; the deterministic
+      // per-window idempotency key that would close it is a filed follow-up.
       //
       // Deliberately NOT keyed on `creditsSettled`: a persisted row whose ledger
       // claim was deferred is already owned by the backfill cron, and reopening the

--- a/packages/lib/src/services/app-hosting/app-lifecycle-metering.ts
+++ b/packages/lib/src/services/app-hosting/app-lifecycle-metering.ts
@@ -288,7 +288,10 @@ async function parkPublishedApp(row: PublishedApp, reason: string): Promise<void
 
 export interface SettleAndCloseResult {
   billedSeconds: number;
-  /** The settle threw. The window is left OPEN so the next tick retries it rather than losing it. */
+  /**
+   * The settle did not land — it threw, or it resolved without persisting a usage
+   * row. The window is left OPEN so the next tick retries it rather than losing it.
+   */
   failed: boolean;
 }
 
@@ -303,6 +306,9 @@ export interface SettleAndCloseResult {
  * The hold is disposed of exactly once, whichever way the window ends: settled
  * against by `trackUsage` when there are seconds to bill, released otherwise. A
  * hold left behind would suppress the payer's spendable balance for its whole TTL.
+ * (`trackUsage` returns the reservation itself on a settle that does not persist,
+ * so the retried window is settled unreserved on the next tick — one tick of
+ * unreserved spend, against losing the window outright.)
  */
 async function settleAndClose(
   row: PublishedApp,
@@ -316,35 +322,58 @@ async function settleAndClose(
   if (plan.action === 'settle') {
     const payerId = await deps.billing.resolvePayerId({ driveId: row.driveId });
     if (payerId) {
+      // The window is NOT closed on a failed settle: leaving it open means the next
+      // heartbeat retries the whole span, where closing it would silently lose the
+      // app's last awake window. The status still moves either way — the machine
+      // really did stop, and leaving a `running` row over it would be worse than a
+      // window that gets retried.
+      //
+      // TWO failure shapes reach that path, and only one of them used to. A THROW
+      // is a deps-level or transport failure. A settle that RESOLVES WITHOUT
+      // PERSISTING is the shape `AIMonitoring.trackUsage` used to hide behind
+      // `Promise<void>`: it now reports `persisted: false`, and it means no
+      // `ai_usage_logs` row exists — so not even the credit backfill cron, which
+      // reads that table, can recover the charge. Retrying the window is the only
+      // thing that can, and retrying is safe precisely because nothing was written.
+      //
+      // Deliberately NOT keyed on `creditsSettled`: a persisted row whose ledger
+      // claim was deferred is already owned by the backfill cron, and reopening the
+      // window for it would bill the payer twice for the same span.
+      let settled = false;
       try {
-        await deps.billing.trackUsage({
+        const settle = await deps.billing.trackUsage({
           payerId,
           holdId: row.awakeHoldId ?? undefined,
           activeSeconds: plan.activeSeconds,
           driveId: row.driveId,
           publishedAppId: row.id,
         });
-        billedSeconds = plan.activeSeconds;
+        settled = settle.persisted;
+        if (settled && !settle.creditsSettled) {
+          loggers.ai.warn(
+            'Published-app final settle persisted but its ledger settle was deferred to the backfill cron',
+            { publishedAppId: row.id, driveId: row.driveId },
+          );
+        }
+        if (!settled) {
+          loggers.ai.error(
+            'Published-app final settle did not persist a usage row — the awake window stays open for the next tick to retry',
+            new Error('final settle was not persisted'),
+            { publishedAppId: row.id, driveId: row.driveId, activeSeconds: plan.activeSeconds },
+          );
+        }
       } catch (error) {
-        // The window is NOT closed on a failed settle: leaving it open means the
-        // next heartbeat retries the whole span, where closing it would silently
-        // lose the app's last awake window. The status still moves below — the
-        // machine really did stop, and leaving a `running` row over it would be
-        // worse than a window that gets retried.
-        //
-        // Reached only when the settle actually THROWS. The default binding runs
-        // through `AIMonitoring.trackUsage`, which swallows its own persistence
-        // failures and resolves — see the caveat on `AppBillingDeps.trackUsage`.
-        // So this covers a deps-level or transport failure, not a lost ledger
-        // write, and it is not the whole guarantee the shape suggests.
         loggers.ai.error(
           'Published-app final settle failed — the awake window stays open for the next tick to retry',
           error instanceof Error ? error : new Error(String(error)),
           { publishedAppId: row.id, driveId: row.driveId, activeSeconds: plan.activeSeconds },
         );
+      }
+      if (!settled) {
         await closeStatusOnly(row, nextStatus, stampedStopAt);
         return { billedSeconds: 0, failed: true };
       }
+      billedSeconds = plan.activeSeconds;
     } else {
       // Unresolvable drive: skip the charge rather than misattribute it, exactly
       // as the storage reconcile does. The hold is still released below — it

--- a/packages/lib/src/services/app-hosting/awake-meter.ts
+++ b/packages/lib/src/services/app-hosting/awake-meter.ts
@@ -371,11 +371,17 @@ async function meterOneApp(
     publishedAppId: row.id,
   });
   if (!settle.persisted) {
-    // The settle resolved but wrote NO usage row, so nothing — not the ledger, not
-    // the backfill cron, which reads `ai_usage_logs` — will ever bill this span.
-    // Leave the watermark alone: the window stays open and the next tick re-bills
-    // the whole span. Safe to retry because nothing was written, and the only
-    // alternative is losing the charge outright. The re-gate below is skipped with
+    // The settle resolved but reported NO persisted usage row, so nothing — not the
+    // ledger, not the backfill cron, which reads `ai_usage_logs` — will ever bill
+    // this span. Leave the watermark alone: the window stays open and the next tick
+    // re-bills the whole span, and the only alternative is losing the charge
+    // outright.
+    //
+    // "Nothing was CONFIRMED written", not "nothing was written": a connection
+    // dropped at the commit boundary reports a failed write over a row that
+    // committed, and the retry then bills the span twice. Bounded at ONE duplicate
+    // span; the deterministic per-window idempotency key that would close it is a
+    // filed follow-up. The re-gate below is skipped with
     // it — the seam already returned this wake's reservation on its way out, so the
     // next tick settles the retried span unreserved and re-gates after it. That is
     // one tick of unreserved spend, bounded by the settle cadence, and strictly

--- a/packages/lib/src/services/app-hosting/awake-meter.ts
+++ b/packages/lib/src/services/app-hosting/awake-meter.ts
@@ -192,7 +192,16 @@ export interface MeterAwakeResult {
   unresolvedPayer: number;
   /** Rows stopped and parked because the payer ran out of credits at the re-gate. */
   parked: number;
-  /** Rows where something threw. Isolated; the window is left open so the span is retried. */
+  /**
+   * Rows where the span was NOT billed — something threw, or the settle resolved
+   * without persisting a usage row. Isolated either way; the window is left open so
+   * the span is retried on the next tick, which is safe precisely because nothing
+   * was written.
+   *
+   * The non-persisted case used to be invisible: `trackUsage` returned
+   * `Promise<void>` and swallowed its own failures, so a lost charge was counted as
+   * `settled` and its watermark advanced over it.
+   */
   failed: number;
   /** Settles whose span exceeded {@link MAX_AWAKE_SETTLE_SPAN_MS} and was shortened — expected to be ZERO in steady state. */
   clamped: number;
@@ -354,13 +363,48 @@ async function meterOneApp(
     return;
   }
 
-  await deps.billing.trackUsage({
+  const settle = await deps.billing.trackUsage({
     payerId,
     holdId: row.awakeHoldId ?? undefined,
     activeSeconds: plan.activeSeconds,
     driveId: row.driveId,
     publishedAppId: row.id,
   });
+  if (!settle.persisted) {
+    // The settle resolved but wrote NO usage row, so nothing — not the ledger, not
+    // the backfill cron, which reads `ai_usage_logs` — will ever bill this span.
+    // Leave the watermark alone: the window stays open and the next tick re-bills
+    // the whole span. Safe to retry because nothing was written, and the only
+    // alternative is losing the charge outright. The re-gate below is skipped with
+    // it — the seam already returned this wake's reservation on its way out, so the
+    // next tick settles the retried span unreserved and re-gates after it. That is
+    // one tick of unreserved spend, bounded by the settle cadence, and strictly
+    // better than closing the window over a charge nobody will ever make.
+    //
+    // Counted as `failed` rather than thrown: this function is run under the
+    // meter's advisory lock and a throw here would be caught by the per-row guard
+    // anyway — a counted failure keeps the tick's accounting honest without
+    // pretending an exception happened.
+    //
+    // NOT gated on `creditsSettled`: a persisted row whose ledger settle was
+    // deferred is already owned by the backfill cron, and re-billing the window for
+    // it would charge the payer twice.
+    result.failed += 1;
+    loggers.ai.error(
+      'Published-app awake settle did not persist a usage row — the window stays open and is retried next tick',
+      new Error('awake settle was not persisted'),
+      { publishedAppId: row.id, driveId: row.driveId, activeSeconds: plan.activeSeconds },
+    );
+    return;
+  }
+  if (!settle.creditsSettled) {
+    // Late, not lost: the usage row exists, so `credit-backfill.ts` collects this
+    // charge on its next sweep. The window still closes below.
+    loggers.ai.warn(
+      'Published-app awake settle persisted but its ledger settle was deferred to the backfill cron',
+      { publishedAppId: row.id, driveId: row.driveId },
+    );
+  }
   result.settled += 1;
   result.totalAwakeSeconds += plan.activeSeconds;
   if (plan.clamped) result.clamped += 1;

--- a/packages/lib/src/services/sandbox/__tests__/git-tool-runners.test.ts
+++ b/packages/lib/src/services/sandbox/__tests__/git-tool-runners.test.ts
@@ -478,6 +478,7 @@ function makeBilling(over: Partial<NonNullable<SandboxRunDeps['billing']>> = {})
     },
     trackUsage: async (input) => {
       trackUsageCalls.push(input);
+      return { persisted: true, creditsSettled: true };
     },
     releaseHold: async (holdId) => {
       releaseHoldCalls.push(holdId);

--- a/packages/lib/src/services/sandbox/__tests__/sandbox-billing.test.ts
+++ b/packages/lib/src/services/sandbox/__tests__/sandbox-billing.test.ts
@@ -152,6 +152,18 @@ describe('defaultSandboxBillingDeps.gate', () => {
 });
 
 describe('defaultSandboxBillingDeps.trackUsage', () => {
+  it('RETURNS the credit seam’s persistence outcome verbatim — the shell heartbeat gates its billing window on it', async () => {
+    mockTrackUsage.mockResolvedValueOnce({ persisted: false, creditsSettled: false });
+    expect(
+      await defaultSandboxBillingDeps.trackUsage({ payerId: 'owner-1', holdId: 'hold-1', activeSeconds: 3600 }),
+    ).toEqual({ persisted: false, creditsSettled: false });
+
+    mockTrackUsage.mockResolvedValueOnce({ persisted: true, creditsSettled: true });
+    expect(
+      await defaultSandboxBillingDeps.trackUsage({ payerId: 'owner-1', holdId: 'hold-1', activeSeconds: 3600 }),
+    ).toEqual({ persisted: true, creditsSettled: true });
+  });
+
   it("bills source:'terminal' with the real active-window cost and threads the holdId through", async () => {
     mockTrackUsage.mockResolvedValue(undefined);
 

--- a/packages/lib/src/services/sandbox/__tests__/sandbox-storage-billing.integration.test.ts
+++ b/packages/lib/src/services/sandbox/__tests__/sandbox-storage-billing.integration.test.ts
@@ -108,6 +108,7 @@ function realDepsCapturingCharges(over: Partial<ReconcileSandboxStorageDeps> = {
         ),
       chargeStorage: async (input) => {
         charges.push(input);
+        return { persisted: true, creditsSettled: true };
       },
       now: () => NOW,
       ...over,

--- a/packages/lib/src/services/sandbox/__tests__/sandbox-storage-billing.test.ts
+++ b/packages/lib/src/services/sandbox/__tests__/sandbox-storage-billing.test.ts
@@ -147,6 +147,27 @@ describe('defaultReconcileSandboxStorageDeps.lookupDriveOwnerId', () => {
 });
 
 describe('defaultReconcileSandboxStorageDeps.chargeStorage', () => {
+  it('RETURNS the credit seam’s persistence outcome verbatim — the reconcile gates its watermark on it', async () => {
+    // A resolved charge is not a landed one. If this binding dropped the outcome
+    // (an `async` wrapper that awaits and returns nothing, which is what it used to
+    // be), the reconcile would be back to advancing watermarks over lost charges.
+    const charge = () =>
+      defaultReconcileSandboxStorageDeps.chargeStorage({
+        payerId: 'owner-1',
+        driveId: 'drive-1',
+        subjectKind: 'session',
+        subjectId: 'ws-1',
+        costDollars: 0.01,
+        gbMonths: 0.5,
+      });
+
+    mockTrackUsage.mockResolvedValueOnce({ persisted: false, creditsSettled: false });
+    expect(await charge()).toEqual({ persisted: false, creditsSettled: false });
+
+    mockTrackUsage.mockResolvedValueOnce({ persisted: true, creditsSettled: true });
+    expect(await charge()).toEqual({ persisted: true, creditsSettled: true });
+  });
+
   it("bills source:'terminal' with no holdId (background reconcile charge)", async () => {
     mockTrackUsage.mockResolvedValue(undefined);
 
@@ -447,7 +468,7 @@ describe('reconcileSandboxStorageSerialized', () => {
       listDriveEnvSprites: vi.fn(async () => []),
       listPublishedAppRootfs: vi.fn(async () => []),
       lookupDriveOwnerId: vi.fn(async () => null),
-      chargeStorage: vi.fn(async () => {}),
+      chargeStorage: vi.fn(async () => ({ persisted: true, creditsSettled: true })),
       advanceAgentSessionWatermark: vi.fn(async () => 'advanced' as const),
       advanceDriveEnvWatermark: vi.fn(async () => 'advanced' as const),
       advancePublishedAppWatermark: vi.fn(async () => 'advanced' as const),

--- a/packages/lib/src/services/sandbox/__tests__/sandbox-storage-reconcile.test.ts
+++ b/packages/lib/src/services/sandbox/__tests__/sandbox-storage-reconcile.test.ts
@@ -150,6 +150,9 @@ function makeDeps(over: Partial<ReconcileSandboxStorageDeps> = {}): {
     lookupDriveOwnerId: async () => 'owner-1',
     chargeStorage: async (input) => {
       chargeCalls.push(input);
+      // The real seam reports whether the usage row landed; the happy-path stub
+      // says it did, and the tests that care override this.
+      return { persisted: true, creditsSettled: true };
     },
     // `'advanced'` = the row was written with the value we asked for. The real
     // writers are monotonic and answer `'superseded'` when a provision already
@@ -324,12 +327,63 @@ describe('reconcileSandboxStorage', () => {
     expect(agentSessionAdvanceCalls.map((c) => c.workspaceId)).toEqual(['fine']);
   });
 
+  // ── The persistence CONTRACT (issue: trackUsage must report its outcome) ────
+  // `chargeStorage` reaches `AIMonitoring.trackUsage`, which never throws. Before it
+  // reported an outcome, a charge whose `ai_usage_logs` write failed RESOLVED — so
+  // this loop counted it `charged`, advanced the watermark, and closed the window
+  // over spend that nothing would ever bill. These two tests are the mutation proof:
+  // flip `persisted` and the watermark must HOLD; restore it and it must advance.
+
+  it('given a charge that resolves WITHOUT persisting, HOLDS the watermark so the next run re-bills the window', async () => {
+    const { deps, agentSessionAdvanceCalls } = makeDeps({
+      listAgentSessionSprites: async () => [agentSession({ workspaceId: 'session-lost' })],
+      chargeStorage: async () => ({ persisted: false, creditsSettled: false }),
+    });
+
+    const result = await reconcileSandboxStorage(deps);
+
+    assert({
+      given: 'a storage charge that resolved but wrote no usage row',
+      should: 'count it failed, bill nothing, and leave the watermark untouched',
+      actual: {
+        charged: result.charged,
+        failed: result.failed,
+        totalCostDollars: result.totalCostDollars,
+        advances: agentSessionAdvanceCalls.length,
+      },
+      expected: { charged: 0, failed: 1, totalCostDollars: 0, advances: 0 },
+    });
+    // Not `chargedButUnadvanced`: that means money moved and only the watermark
+    // write failed, which is the opposite situation and the opposite remedy.
+    expect(result.chargedButUnadvanced).toBe(0);
+  });
+
+  it('given a PERSISTED charge whose ledger settle was deferred, still ADVANCES the watermark (the backfill cron owns that charge)', async () => {
+    // The inverse guard, and it matters as much: holding the window open here would
+    // re-bill a span the credit backfill cron is already collecting from the usage
+    // row — a double-charge caused by trying to prevent a lost one.
+    const { deps, agentSessionAdvanceCalls } = makeDeps({
+      listAgentSessionSprites: async () => [agentSession({ workspaceId: 'session-deferred' })],
+      chargeStorage: async () => ({ persisted: true, creditsSettled: false }),
+    });
+
+    const result = await reconcileSandboxStorage(deps);
+
+    assert({
+      given: 'a persisted charge whose ledger settle was deferred to the backfill cron',
+      should: 'count it charged and close the window exactly as a fully settled charge would',
+      actual: { charged: result.charged, failed: result.failed, advances: agentSessionAdvanceCalls.length },
+      expected: { charged: 1, failed: 0, advances: 1 },
+    });
+  });
+
   it('given chargeStorage ITSELF throws, bills nothing for that row (no double-count) and never attempts its watermark advance', async () => {
     const { deps, chargeCalls, agentSessionAdvanceCalls } = makeDeps({
       listAgentSessionSprites: async () => [agentSession({ workspaceId: 'boom' }), agentSession({ workspaceId: 'fine' })],
       chargeStorage: async (input) => {
         if (input.subjectId === 'boom') throw new Error('credit ledger unreachable');
         chargeCalls.push(input);
+        return { persisted: true, creditsSettled: true };
       },
     });
 
@@ -589,6 +643,7 @@ describe('reconcileSandboxStorage', () => {
       chargeStorage: async (input) => {
         if (input.subjectId === 'env-boom') throw new Error('credit ledger unreachable');
         chargeCalls.push(input);
+        return { persisted: true, creditsSettled: true };
       },
     });
 

--- a/packages/lib/src/services/sandbox/__tests__/tool-runners.test.ts
+++ b/packages/lib/src/services/sandbox/__tests__/tool-runners.test.ts
@@ -1457,8 +1457,11 @@ describe('runBashInSandbox — machine billing (Terminal Epic 3)', () => {
 
     await runBashInSandbox({ command: 'echo hi', ctx: makeCtx(), deps });
 
-    // The usage row exists, so the backfill cron owns both the charge and the
-    // hold's disposal — releasing it here would under-reserve that pending debit.
+    // The usage row exists, so the backfill cron owns the CHARGE and will settle it
+    // from that row; releasing the hold here would under-reserve that pending debit.
+    // The hold itself is disposed of by whichever lands first — the cron's settle
+    // transaction, or its own TTL expiry (the cron sweeps expired holds; it does not
+    // dispose of live ones).
     expect(releaseHoldCalls).toEqual([]);
   });
 

--- a/packages/lib/src/services/sandbox/__tests__/tool-runners.test.ts
+++ b/packages/lib/src/services/sandbox/__tests__/tool-runners.test.ts
@@ -1295,6 +1295,7 @@ function makeBilling(over: Partial<SandboxRunDeps['billing']> = {}): {
     },
     trackUsage: async (input) => {
       trackUsageCalls.push(input);
+      return { persisted: true, creditsSettled: true };
     },
     releaseHold: async (holdId) => {
       releaseHoldCalls.push(holdId);
@@ -1399,6 +1400,65 @@ describe('runBashInSandbox — machine billing (Terminal Epic 3)', () => {
     expect(trackUsageCalls).toEqual([
       { payerId: 'owner-42', holdId: 'hold-1', activeSeconds: 5, pageId: undefined, driveId: 'd1', workspaceId: 'ws-1' },
     ]);
+    expect(releaseHoldCalls).toEqual([]);
+  });
+
+  it('given a settle that resolves WITHOUT persisting, RETURNS the hold instead of handing it off', async () => {
+    // A one-shot run has no window to reopen, so the honest response to a lost
+    // charge is to stop pretending the credit pipeline owns the reservation:
+    // `trackUsage` wrote nothing, so nothing downstream will ever settle or delete
+    // the hold, and leaving it would suppress the payer's spendable until its TTL.
+    const clock = makeMutableClock(new Date('2026-06-01T12:00:00.000Z').getTime());
+    const sandbox = makeSandbox({
+      runCommand: async () => {
+        clock.advance(5000);
+        return { exitCode: 0, stdout: 'ok', stderr: '' };
+      },
+    });
+    let settleAttempts = 0;
+    const { billing, releaseHoldCalls } = makeBilling({
+      trackUsage: async () => {
+        settleAttempts += 1;
+        return { persisted: false, creditsSettled: false };
+      },
+    });
+    const { deps } = makeDeps({
+      billing,
+      resolveBillingSession: makeBillingSession({ ownerId: 'owner-42', driveId: 'd1', workspaceId: 'ws-1' }),
+      reconnect: async () => sandbox,
+      now: clock.now,
+    });
+
+    const result = await runBashInSandbox({ command: 'echo hi', ctx: makeCtx(), deps });
+
+    // The user's command still succeeds — billing never fails a run.
+    expect(result).toMatchObject({ success: true });
+    expect(settleAttempts).toBe(1);
+    expect(releaseHoldCalls).toEqual(['hold-1']);
+  });
+
+  it('given a PERSISTED settle whose ledger settle was deferred, still hands the hold off to the credit pipeline', async () => {
+    const clock = makeMutableClock(new Date('2026-06-01T12:00:00.000Z').getTime());
+    const sandbox = makeSandbox({
+      runCommand: async () => {
+        clock.advance(5000);
+        return { exitCode: 0, stdout: 'ok', stderr: '' };
+      },
+    });
+    const { billing, releaseHoldCalls } = makeBilling({
+      trackUsage: async () => ({ persisted: true, creditsSettled: false }),
+    });
+    const { deps } = makeDeps({
+      billing,
+      resolveBillingSession: makeBillingSession({ ownerId: 'owner-42', driveId: 'd1', workspaceId: 'ws-1' }),
+      reconnect: async () => sandbox,
+      now: clock.now,
+    });
+
+    await runBashInSandbox({ command: 'echo hi', ctx: makeCtx(), deps });
+
+    // The usage row exists, so the backfill cron owns both the charge and the
+    // hold's disposal — releasing it here would under-reserve that pending debit.
     expect(releaseHoldCalls).toEqual([]);
   });
 

--- a/packages/lib/src/services/sandbox/sandbox-billing.ts
+++ b/packages/lib/src/services/sandbox/sandbox-billing.ts
@@ -68,8 +68,10 @@ export const defaultSandboxBillingDeps: SandboxBillingDeps = {
     return { allowed: result.allowed, holdId: result.holdId, reason: result.allowed ? undefined : result.reason };
   },
 
-  async trackUsage({ payerId, holdId, activeSeconds, pageId, driveId, workspaceId }) {
-    await AIMonitoring.trackUsage({
+  trackUsage({ payerId, holdId, activeSeconds, pageId, driveId, workspaceId }) {
+    // Returned, not awaited-and-discarded: the seam's whole point is that the
+    // caller learns whether the charge is durable (see `UsageTrackingOutcome`).
+    return AIMonitoring.trackUsage({
       userId: payerId,
       provider: 'sprites',
       model: 'terminal-machine',

--- a/packages/lib/src/services/sandbox/sandbox-storage-billing.ts
+++ b/packages/lib/src/services/sandbox/sandbox-storage-billing.ts
@@ -178,18 +178,14 @@ export const defaultReconcileSandboxStorageDeps: ReconcileSandboxStorageDeps = {
   lookupDriveOwnerId,
 
   /**
-   * NOTE ON FAILURE: this cannot report one. `AIMonitoring.trackUsage` returns
-   * `Promise<void>` and swallows its own errors into a
-   * `'AI usage tracking failed — spend may be UNBILLED'` log rather than
-   * rejecting, so a credit-ledger outage looks identical to a successful charge
-   * from here — the reconcile counts it as `charged`, advances the watermark, and
-   * the window is closed for good. That swallow is deliberate upstream (a throw
-   * there would break user-facing generation), so it is not this PR's to undo;
-   * the consequence is documented on `ReconcileSandboxStorageResult.charged` and
-   * tracked in issue #2444.
+   * REPORTS ITS FAILURE. `AIMonitoring.trackUsage` still never throws (a throw
+   * there would break user-facing generation), but it now resolves with a
+   * `UsageTrackingOutcome` saying whether the `ai_usage_logs` row landed — so a
+   * credit-ledger outage no longer looks identical to a successful charge, and the
+   * reconcile can hold the watermark instead of closing the window over lost spend.
    */
-  async chargeStorage({ payerId, driveId, subjectKind, subjectId, costDollars, gbMonths }) {
-    await AIMonitoring.trackUsage({
+  chargeStorage({ payerId, driveId, subjectKind, subjectId, costDollars, gbMonths }) {
+    return AIMonitoring.trackUsage({
       userId: payerId,
       provider: 'sprites',
       // The billed unit, named in the meter line itself. Sessions keep the

--- a/packages/lib/src/services/sandbox/sandbox-storage-reconcile.ts
+++ b/packages/lib/src/services/sandbox/sandbox-storage-reconcile.ts
@@ -147,6 +147,7 @@ import { calculateMachineStorageCostDollars } from '../../monitoring/machine-pri
 import { resolveEnvPayerId } from '../../billing/sandbox-payer';
 import { storageBillingTarget, type StorageSubject } from './sandbox-storage-attribution';
 import { loggers } from '../../logging/logger-config';
+import type { UsageTrackingOutcome } from '../../monitoring/ai-monitoring';
 
 const MS_PER_DAY = 24 * 60 * 60 * 1000;
 /** A billing month, for prorating the monthly storage rate over an elapsed span. Not tied to any subscription's actual renewal cycle — storage accrual is metered independently of it. */
@@ -395,7 +396,7 @@ export interface ReconcileSandboxStorageDeps {
     subjectId: string;
     costDollars: number;
     gbMonths: number;
-  }) => Promise<void>;
+  }) => Promise<UsageTrackingOutcome>;
   /**
    * Persists the new watermark for an `agent_workspaces` Sprite, on the ROW
    * ITSELF — the per-row watermark the design calls for, no separate tracking
@@ -421,31 +422,30 @@ export interface ReconcileSandboxStorageDeps {
 export interface ReconcileSandboxStorageResult {
   processed: number;
   /**
-   * Rows where `chargeStorage` RESOLVED — regardless of whether the watermark
-   * then advanced. Always reflected in `totalCostDollars`.
+   * Rows whose charge was DURABLY WRITTEN — the `ai_usage_logs` row exists, so the
+   * charge is either already settled or owned by the backfill cron. Regardless of
+   * whether the watermark then advanced. Always reflected in `totalCostDollars`.
    *
-   * "Resolved", not "the money moved", and the distinction is not pedantry: the
-   * production binding hands the charge to `AIMonitoring.trackUsage`, which
-   * returns `Promise<void>` and swallows its own failures into a
-   * `'AI usage tracking failed — spend may be UNBILLED'` log rather than
-   * rejecting. So with those deps this counter — and `totalCostDollars` — count
-   * charges SUBMITTED, and `failed` can only ever catch the steps BEFORE the
-   * charge. That log is the authoritative signal for a charge that did not land;
-   * tracked as a platform gap in issue #2444.
+   * This used to count charges SUBMITTED rather than landed, because
+   * `AIMonitoring.trackUsage` returned `Promise<void>` and swallowed its own
+   * failures. It now reports a {@link UsageTrackingOutcome}, so a charge that did
+   * not persist is counted under `failed` and its window is left open — this
+   * counter means what its name says again.
    */
   charged: number;
   /** Rows with a positive accrual whose owner could not be resolved — left unbilled (watermark untouched) for a future run to retry. */
   skipped: number;
   /**
-   * Rows where NOTHING was billed because something threw before or during the
-   * charge — the payer lookup, the accrual computation, `chargeStorage` itself,
-   * or (on a row whose window prices to $0) its watermark advance, which sits in
-   * the same guarded block. Isolated per row so one bad row doesn't abort the batch.
+   * Rows where NOTHING was billed — because something threw before or during the
+   * charge (the payer lookup, the accrual computation, `chargeStorage` itself, or,
+   * on a row whose window prices to $0, its watermark advance, which sits in the
+   * same guarded block) OR because the charge resolved WITHOUT persisting a usage
+   * row. Isolated per row so one bad row doesn't abort the batch.
    *
-   * With the PRODUCTION binding the `chargeStorage` case is unreachable: that dep
-   * cannot reject (see `charged`). So in production this counts pre-charge
-   * failures only, and a test injecting a throwing `chargeStorage` is what
-   * exercises the rest.
+   * The non-persisted case is the one that used to be invisible: `chargeStorage`
+   * cannot reject with the production binding, so before `trackUsage` reported an
+   * outcome a lost charge was counted as `charged` and its watermark advanced over
+   * it. Both shapes now land here, and both leave the window open for the next run.
    *
    * Distinct from {@link ReconcileSandboxStorageResult.chargedButUnadvanced},
    * which means the opposite: money DID move and only the watermark write
@@ -583,10 +583,11 @@ export interface ReconcileSandboxStorageResult {
    */
   failedSources: StorageSubjectKind[];
   /**
-   * Total charged this run — accumulated the moment `chargeStorage` resolves,
-   * never gated on the watermark advance that follows it. See `charged` for why
-   * this is "charged", not "collected": with the production binding a charge that
-   * silently failed still lands here.
+   * Total charged this run — accumulated the moment `chargeStorage` reports a
+   * PERSISTED charge, never gated on the watermark advance that follows it. See
+   * `charged` for why this is "charged", not "collected": a persisted charge whose
+   * ledger settle was deferred to the backfill cron still lands here, because the
+   * cron will collect it.
    */
   totalCostDollars: number;
 }
@@ -966,11 +967,12 @@ export async function reconcileSandboxStorage(
 
     // The charge itself — isolated from the watermark advance below so the
     // two outcomes ("nothing was billed" vs "billed, but the watermark write
-    // failed") are never conflated. `charged`/`totalCostDollars` move the
-    // moment this resolves; whether that means money REACHED the ledger depends
-    // on the binding, and the production one cannot say (see `charged`'s doc).
+    // failed") are never conflated. `charged`/`totalCostDollars` move only on a
+    // charge that PERSISTED: a resolved call is not a settled one, and treating it
+    // as one is what used to close a window over spend that never reached a row.
+    let settle: UsageTrackingOutcome;
     try {
-      await deps.chargeStorage({
+      settle = await deps.chargeStorage({
         payerId: resolved.ownerId,
         driveId: attributionDriveId,
         subjectKind: subject.kind,
@@ -990,8 +992,36 @@ export async function reconcileSandboxStorage(
       );
       continue;
     }
+    if (!settle.persisted) {
+      // The charge resolved but wrote NO usage row, so there is nothing for the
+      // credit backfill cron to recover from — the spend is lost unless this window
+      // is billed again. Leave the watermark exactly where it was: the next run
+      // re-bills the whole span, and it cannot double-charge because nothing was
+      // written. Counted as `failed` — the same outcome as a throw, which is what
+      // this branch would have been if the seam could throw.
+      //
+      // Deliberately NOT gated on `creditsSettled`: a persisted row whose ledger
+      // claim was deferred is already owned by the backfill cron, and holding the
+      // window open for it would bill the payer twice for the same span.
+      billingByKind[subject.kind].failed += 1;
+      loggers.ai.error(
+        'Sandbox storage reconcile: chargeStorage did not persist a usage row — the window is left open for the next run',
+        new Error('storage charge was not persisted'),
+        { driveId: attributionDriveId, subjectKind: subject.kind, subjectId: subject.subjectId },
+      );
+      continue;
+    }
     totalCostDollars += resolved.costDollars;
     billingByKind[subject.kind].charged += 1;
+    if (!settle.creditsSettled) {
+      // Late, not lost: the usage row exists, so `credit-backfill.ts` settles this
+      // charge on its next sweep. Reported at WARN so a persistent count is visible
+      // without being read as revenue loss.
+      loggers.ai.warn(
+        'Sandbox storage reconcile: charge persisted but its ledger settle was deferred to the backfill cron',
+        { driveId: attributionDriveId, subjectKind: subject.kind, subjectId: subject.subjectId },
+      );
+    }
 
     try {
       // The window is only actually closed once the charge landed AND the

--- a/packages/lib/src/services/sandbox/sandbox-storage-reconcile.ts
+++ b/packages/lib/src/services/sandbox/sandbox-storage-reconcile.ts
@@ -993,12 +993,20 @@ export async function reconcileSandboxStorage(
       continue;
     }
     if (!settle.persisted) {
-      // The charge resolved but wrote NO usage row, so there is nothing for the
-      // credit backfill cron to recover from — the spend is lost unless this window
-      // is billed again. Leave the watermark exactly where it was: the next run
-      // re-bills the whole span, and it cannot double-charge because nothing was
-      // written. Counted as `failed` — the same outcome as a throw, which is what
-      // this branch would have been if the seam could throw.
+      // The charge resolved but reported NO persisted usage row, so there is
+      // nothing for the credit backfill cron to recover from — the spend is lost
+      // unless this window is billed again. Leave the watermark exactly where it
+      // was: the next run re-bills the whole span. Counted as `failed` — the same
+      // outcome as a throw, which is what this branch would have been if the seam
+      // could throw.
+      //
+      // "Nothing was CONFIRMED written", not "nothing was written", and the
+      // difference is the honest bound on this retry. A connection dropped at the
+      // commit boundary reports a failed write over a row that committed, and the
+      // retry then bills the span twice. That is bounded at ONE duplicate span and
+      // is strictly better than the alternative it replaces (losing the charge on
+      // every genuine failure); closing it properly needs a deterministic
+      // idempotency key per meter window, which is filed as a follow-up.
       //
       // Deliberately NOT gated on `creditsSettled`: a persisted row whose ledger
       // claim was deferred is already owned by the backfill cron, and holding the

--- a/packages/lib/src/services/sandbox/tool-runners.ts
+++ b/packages/lib/src/services/sandbox/tool-runners.ts
@@ -46,6 +46,7 @@ import {
 import { getValidatedEnv } from '../../config/env-validation';
 import type { ExecutableSandbox, SandboxRunResult } from './sandbox-client/types';
 import type { CodeExecutionAuditInput, CodeExecutionAnomaly } from './audit';
+import type { UsageTrackingOutcome } from '../../monitoring/ai-monitoring';
 
 /** Largest file body a single `writeFile` may submit, in bytes. */
 export const MAX_WRITE_BYTES = 1024 * 1024;
@@ -128,6 +129,12 @@ export interface SandboxBillingDeps {
    * agent page; `driveId` is the realtime shell bridge's session-level
    * attribution (a session is drive-scoped, not page-anchored) — a caller
    * sets whichever one its own model has, never both.
+   *
+   * REPORTS ITS OUTCOME: resolving is not the same as settling.
+   * `UsageTrackingOutcome.persisted` says whether the usage row landed, and the
+   * realtime shell's heartbeat keeps its billing window OPEN when it did not.
+   * A one-shot run (this file) has no window to keep, so it only disposes of the
+   * hold correctly and lets the seam's own ERROR log stand.
    */
   trackUsage: (input: {
     payerId: string;
@@ -139,7 +146,7 @@ export interface SandboxBillingDeps {
     driveId?: string;
     /** The `agent_workspaces.id` this run belongs to — first-class attribution, mirroring `driveId`. */
     workspaceId?: string;
-  }) => Promise<void>;
+  }) => Promise<UsageTrackingOutcome>;
   /** Releases a hold without billing. Called on every exit that never reaches `trackUsage`. */
   releaseHold: (holdId: string) => Promise<void>;
 }
@@ -610,9 +617,8 @@ export async function withMachineBilling<S>(
   try {
     const result = await run();
     if (result.success) {
-      handedOff = true;
       const activeSeconds = Math.max(0, (deps.now().getTime() - startedAt) / 1000);
-      await billing.trackUsage({
+      const settle = await billing.trackUsage({
         payerId,
         holdId,
         activeSeconds,
@@ -622,6 +628,18 @@ export async function withMachineBilling<S>(
         driveId: billingSession.driveId ?? undefined,
         workspaceId: billingSession.workspaceId,
       });
+      // The hand-off is what the settle ACHIEVED, not what it was asked to do. A
+      // settle that persisted owns the reservation from here (the credit pipeline
+      // deletes it inside the decrement, or the backfill cron settles the row and
+      // the hold expires on its TTL). A settle that did not persist wrote nothing
+      // and owns nothing, so the `finally` below returns the reservation instead of
+      // leaving it to suppress the payer's spendable balance for its whole TTL.
+      // Idempotent either way: releasing an already-deleted hold deletes zero rows.
+      //
+      // A one-shot run has no window to reopen — there is no next tick for a
+      // finished command — so the lost charge is reported by the seam's own ERROR
+      // log and not retried here.
+      handedOff = settle.persisted;
     }
     return result;
   } finally {


### PR DESCRIPTION
## The defect

`AIMonitoring.trackUsage` resolved `Promise<void>` whatever happened beneath it.

- `writeAiUsage` **catches its own failure and returns `null`** rather than throwing. A null id fell straight through to `else if (data.holdId) await releaseHold(...)` — hold released, nothing billed, call resolved normally.
- `consumeCredits` likewise never throws; the `.catch()` on it was decorative.

So no caller could distinguish a committed charge from a lost one. Every meter that advances a watermark **after awaiting it** could close a window over spend nothing would ever bill:

| meter | what it advanced past a lost charge |
|---|---|
| `sandbox-storage-reconcile` | the per-row `storageLastBilledAt` watermark |
| `awake-meter` (published apps) | `awakeBilledThrough` + the re-gate |
| `app-lifecycle-metering` (stop/park) | the app's last awake window |
| realtime `shell-handler` heartbeat | the session's billing-window rebase |

Their "a failed settle leaves the window open for the next tick" catches were **unreachable for this failure mode** — the seam could not throw. Surfaced by review on #2493, which documented the un-guarantee in caveats rather than working around it.

## The contract

One change on the shared seam:

```ts
export interface UsageTrackingOutcome {
  persisted: boolean;      // the ai_usage_logs row is durably written
  creditsSettled: boolean; // the ledger settle completed in-line
}
```

### `persisted` is the load-bearing field, and the only watermark gate

The `ai_usage_logs` row is what **every** recovery path keys off: `credit-backfill.ts` sweeps usage rows with no ledger entry (`cost > 0`, past a 5-minute grace) and re-runs the charge, and sweeps ledger rows stuck `pending` and re-settles them. With the row, a charge is at worst *late*. Without it there is nothing to recover from and the spend is gone — the provider already billed us.

### `creditsSettled` is deliberately NOT a second gate

This is the part worth reviewing closely, because the obvious reading is wrong. `consumeCredits` widens from `Promise<void>` to a typed `CreditSettleStatus` (`'settled' | 'deferred' | 'unbillable'`) so the field is honest rather than a swallow one level down. But a **`deferred` charge is already owned by the backfill cron**. A meter that held its window open on `creditsSettled === false` would re-bill a span the cron is about to collect — a double-charge caused by trying to prevent a lost one.

So every meter guards on `persisted` and *logs* `creditsSettled`. Both directions are tested, per meter.

## The sweep

Every awaiting caller now honours the outcome, and every meter keeps its never-throws property (failures are **counted**, not thrown, so a cron's advisory lock is unaffected):

- **storage reconcile** — a non-persisted charge counts `failed` (not `charged`), adds nothing to `totalCostDollars`, and leaves the watermark untouched.
- **awake meter** — counts `failed`, holds the watermark, and skips the re-gate with it (the seam already returned the wake's reservation on its way out; the retried span settles unreserved on the next tick, bounded by the settle cadence).
- **app-lifecycle `settleAndClose`** — the status still moves (the machine really did stop) but `awakeBilledThrough` survives, so the next tick retries the span. The old catch only covered a deps-level throw; this is the shape it was actually written for.
- **realtime shell heartbeat** — takes the same path as a throw: rolls the rebase back and restores the hold so the next heartbeat retries the FULL window.
- **realtime voice call meter** — same path as a throw; the window has no reopen, so the reservation is returned and the log says plainly that it is unbilled.
- **`withMachineBilling`** — `handedOff` is now what the settle *achieved*, so a lost charge RETURNS the hold instead of leaving it to pin the payer's spendable until TTL.
- **pure-telemetry sites** (pulse ×2, memory ×3, zoom ×2) — hand the promise to a named `discardUsageOutcome` rather than leaving it to float, so ignoring the outcome is a decision visible in the diff.

Also removed: #2493's caveat on `AppBillingDeps.trackUsage`, the settle-catch comment in `app-lifecycle-metering`, the "NOTE ON FAILURE: this cannot report one" block on `chargeStorage`, the `ReconcileSandboxStorageResult.charged`/`failed` caveats (and the `#2444` pointer), and the now-false "trackAIUsage SWALLOWS its own errors" comments in `image-generation-tools`.

## Follow-up review round

Two rounds of review landed on this, and one of them found a hole in the PR's own promise rather than a nit.

**The awake tail a failed close stranded.** `closeStatusOnly` preserves `awakeBilledThrough` when a final settle does not land, and its comment claimed the span "is retried". Nothing retried it: `defaultAwakeMeterDeps.listRunningApps` selects `status = 'running'` rows only, so a stopped/parked row is never revisited, and `wakePublishedApp` then resets `awakeBilledThrough` to `wokenAt` unconditionally — discarding the span. Pre-existing (the path was written for a settle that *throws*, which is rare), but this PR routes the far more common non-persisted settle down it too, so the promise had to become true rather than quieter.

`settleAbandonedTail` now runs at the next wake — the last moment that span can be billed. It bills `[awakeBilledThrough, lastStopAt]`, the window as it *really* ended, **not** up to `now`, which would charge the payer for the hours the machine was stopped. After the gate (a wake about to be refused moves no money), before the start (so it cannot be confused with this wake's own window), returning the stranded reservation when the tail prices to nothing, and never blocking the wake — a billing failure must not leave an app unservable, so a tail that fails again is lost and logged at ERROR. Two more mutation proofs: skipping the tail settle → RED; billing it to `now` → RED.

**Still open, and documented in-code rather than implied away:** a `parked` app never woken again keeps its tail unbilled. Closing that needs a sweep over non-running rows — follow-up, not a wake's job.

Also from review: the last unadorned `trackUsage` call site (`consult/route.ts`) now uses the named discard; the realtime shell's crash-compensating settle reads and logs `persisted` instead of being the one silent site; the three "nothing was written, so the retry cannot double-charge" comments now say "nothing was **CONFIRMED** written" (a connection dropped at the commit boundary means the retry *can* double-charge — the honest bound is one duplicate span, and the deterministic per-window idempotency key that closes it is filed as a follow-up); `USAGE_TRACKING_LOST` is frozen.

## Mutation proof

Each guard was inverted in turn and its suite re-run — **all six went red**, then were restored:

| mutation | suite |
|---|---|
| reconcile `if (!settle.persisted)` → `if (false)` | ✅ RED |
| awake meter `if (!settle.persisted)` → `if (false)` | ✅ RED |
| lifecycle `settled = settle.persisted` → `= true` | ✅ RED |
| shell heartbeat persisted-guard → `if (false)` | ✅ RED |
| `writeAiUsage`-null branch → report `{persisted: true}` | ✅ RED |
| `creditsSettled: settle === 'settled'` → `: true` | ✅ RED |
| skip `settleAbandonedTail` at the wake | ✅ RED |
| bill the abandoned tail to `now` instead of `lastStopAt` | ✅ RED |

The chain is proved end to end: **break `writeAiUsage`** in the harness (`mockResolvedValueOnce(null)`) → `trackAIUsage` reports `persisted: false` *and* releases the stray hold; **break `consumeCredits`** (`'deferred'`) → `creditsSettled: false` with `persisted: true`; the three deps bindings pass the outcome through **verbatim** (asserted in `app-billing`, `sandbox-billing`, `sandbox-storage-billing`); each meter then holds or advances accordingly.

## Gates

- `bun run typecheck` — 17/17 tasks ✅
- `bun run lint` — 15/15 ✅ (pre-existing warnings only)
- `bun run knip:check` — 4 issues, all within baseline (4) ✅
- `bun run test:unit` — lib **10,942 passed**, web **19,129 passed** ✅ (against a migrated test Postgres; the one remaining failure, `gdpr-eraser.integration.test.ts`, needs `ADMIN_DATABASE_URL`, which CI provides)
- `bun run test:security` — all suites green ✅
- `test:coverage` (what CI actually runs) — lib, web and realtime all within threshold; realtime branch coverage had dipped to 97.96% because the two unrecoverable-charge paths were executed by no test, and is now 98.02% ✅
- realtime `shell-handler` + `call-metering` — 205 passed ✅

## Not in scope

No new meter, no schema change, no behaviour change on any successful path. `consumeCredits` still never throws — it only *reports*.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SvinMdzyuUqHrTnWTPypW7
