### PR TITLE
fix(notifications): an APNs config failure must not retire an iPhone

### DIFF
--- a/packages/lib/src/notifications/__tests__/push-notifications.test.ts
+++ b/packages/lib/src/notifications/__tests__/push-notifications.test.ts
@@ -414,7 +414,29 @@ describe('sendPushNotification', () => {
     expect(result.errors[0]).toContain('Unknown platform: blackberry');
   });
 
-  it('increments failedAttempts on iOS failure', async () => {
+  // The iOS half of the serverFault rule. A missing APNS_TEAM_ID throws before
+  // APNs is ever asked about the token, so it says nothing about the device —
+  // and unlike Android, iOS push is live with real registrations, so striking
+  // here would deactivate the whole install base after five notifications.
+  it('does not count a missing APNs credential against the device', async () => {
+    delete process.env.APNS_TEAM_ID;
+    delete process.env.APNS_KEY_ID;
+    delete process.env.APNS_PRIVATE_KEY;
+    vi.mocked(db.query.pushNotificationTokens.findMany).mockResolvedValue([
+      tokenRecord({ platform: 'ios', failedAttempts: '4' }),
+    ] as never);
+    const { setFn } = setupUpdateChain();
+
+    const result = await sendPushNotification('user-1', payload);
+
+    expect(result.failed).toBe(1);
+    expect(result.errors[0]).toContain('APNs configuration missing');
+    // The row is left entirely alone: no strike to accumulate toward a
+    // deactivation five notifications later.
+    expect(setFn).not.toHaveBeenCalled();
+  });
+
+  it('does not charge the device for an APNs signing failure', async () => {
     process.env.APNS_TEAM_ID = 'team-id';
     process.env.APNS_KEY_ID = 'key-id';
     process.env.APNS_PRIVATE_KEY = '-----BEGIN PRIVATE KEY-----\nMIGHAgEAMBMGByqGSM49AgEGCCqGSM49AwEHBG0wawIBAQQg...\n-----END PRIVATE KEY-----';
@@ -433,7 +455,9 @@ describe('sendPushNotification', () => {
 
     const result = await sendPushNotification('user-1', payload);
     expect(result.failed).toBe(1);
-    expect(db.update).toHaveBeenCalled();
+    // A signing failure is our key being broken, not the device's registration
+    // being bad, so the row is left alone rather than charged a strike.
+    expect(db.update).not.toHaveBeenCalled();
   });
 
   it('deactivates token after 5 consecutive failures', async () => {
@@ -560,12 +584,11 @@ describe('sendPushNotification', () => {
 
     expect(result.failed).toBe(1);
     expect(result.errors).toContain('fetch failed');
-    // Transport errors must NOT deactivate the token (it may be fine); the
-    // failedAttempts counter increments instead of a direct isActive:false.
-    expect(setFn).toHaveBeenCalledWith(expect.objectContaining({
-      failedAttempts: '1',
-      isActive: true,
-    }));
+    // Transport errors must not cost the token anything. Not deactivating it on
+    // the spot is only half of that: a strike per stalled send deactivates it on
+    // the fifth, which is the same outcome reached slowly. APNs never rendered a
+    // verdict here, so the row is untouched.
+    expect(setFn).not.toHaveBeenCalled();
     // The poisoned session must be closed (not just uncached) so its HTTP/2
     // socket is released and doesn't leak on repeated stalls.
     expect(h2.sessionCloseCount).toBeGreaterThan(0);

--- a/packages/lib/src/notifications/push-notifications.ts
+++ b/packages/lib/src/notifications/push-notifications.ts
@@ -343,10 +343,17 @@ async function sendToApns(
       error: error instanceof Error ? (error.stack ?? error.message) : error,
       ...(code ? { code } : {}),
     });
+    // Nothing here is the device's fault: a missing or malformed APNs
+    // credential, a signing failure, a dead HTTP/2 session. APNs never rendered
+    // a verdict on this token, so the dispatch loop must not put a strike
+    // against it — five of those would write isActive:false across every iOS
+    // registration while APNS_TEAM_ID is simply unset, and fixing the secret
+    // would not bring them back. Mirrors the FCM path.
     return {
       success: false,
       tokenId,
       error: error instanceof Error ? error.message : 'Unknown error',
+      serverFault: true,
     };
   }
 }


### PR DESCRIPTION
The iOS twin of the bug CodeRabbit found on #2501, which that PR fixed for FCM and left behind for APNs.

## The bug

`sendToApns`'s catch returns `{success, tokenId, error}` with no `serverFault`, so every failure it handles falls through to the `failedAttempts` branch in the dispatch loop and takes a strike. Five notifications with `APNS_TEAM_ID` unset — or five stalled HTTP/2 sends during an outage — writes `isActive: false` across **every iOS registration**. Correcting the secret does not bring them back; each device stays dark until its app is next opened.

Verified against master rather than inferred:

- `getApnsJwtToken` throws `"APNs configuration missing: APNS_TEAM_ID, APNS_KEY_ID, and APNS_PRIVATE_KEY are required"` (line 63)
- the catch returns without `serverFault`
- so the loop's `serverFault` branch is unreachable from the APNs path

## Why this is the more serious half

#2501 fixed the identical defect for FCM, where it **could not fire yet** — Android is dormant until its client leaf registers a token. **iOS push is live in production with real registrations.** The bug that was theoretical for Android is live for iPhones.

## The fix

`serverFault: true` in the catch, mirroring FCM. APNs never rendered a verdict on the token, so the device is not accountable.

## Two existing tests encoded the old behaviour

Both drove *server-side* failures and asserted a strike: a crypto signing failure, and an HTTP/2 stream error. The transport one is the more telling — its comment already read *"Transport errors must NOT deactivate the token (it may be fine); the failedAttempts counter increments instead"*. That was half true. The counter it endorsed deactivates on the fifth, so the protection it describes only held for one send.

That is the same shape as the `SENDER_ID_MISMATCH` half-fix on #2501: refusing the immediate deactivation while leaving the slow one in place.

The session-close assertion in that test (`h2.sessionCloseCount > 0`, guarding against leaked HTTP/2 sockets) is unrelated and preserved.

## Deliberately narrow

Only the catch block. Extending the rule to non-ok APNs responses — a 429, a 500 — is the same argument and probably right, but it changes strike semantics for **live iOS traffic** on a path I cannot exercise against real APNs. That deserves its own decision rather than riding along here. Flagging it rather than doing it.

## Verification

229 tests pass; 202 TypeScript errors, matching baseline exactly; lint clean. Two mutations red, including reverting the fix itself.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SP53wpeoGWxwfNeMwT8cnX
