### PR TITLE
fix(sheets): quote-aware reference shifting and bounded conditional evaluation (#2492 regressions)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -224,6 +224,18 @@ All notable user-facing changes to PageSpace are documented here. Format follows
 
 ### Fixed
 
+- **Pasting a formula no longer corrupts quoted text inside it** — copying a formula like
+  `=IF(A2>0,"q1","")` down a row used to also rewrite the quoted string, turning `"q1"` into
+  `"Q2"`: the reference-shifting logic behind paste and conditional-format rules didn't know the
+  difference between a cell reference and a letters-and-digits run sitting inside a string literal.
+  It now leaves anything inside quotes untouched, both on paste and when a conditional-format
+  formula rule is evaluated per cell. Separately, a sheet with a very large or pathological set of
+  conditional-format rules could make typing, saving, or rendering the sheet hang — evaluation work
+  is now capped in total across every rule and range combined, on top of the existing per-range
+  limit, and rule count itself is capped where a sheet is written. Saving a sheet also no longer
+  evaluates conditional formats at all, since the save format never reads that result — cutting
+  needless work on every keystroke.
+
 - **A charge that fails to record is retried instead of silently dropped** — usage metering used to
   report success whether or not it had actually written anything. If the database write for a usage
   record failed, the failure was logged and then swallowed: the meter above it saw a normal result,

--- a/apps/web/src/components/layout/middle-content/page-views/sheet/core/__tests__/clipboard.test.ts
+++ b/apps/web/src/components/layout/middle-content/page-views/sheet/core/__tests__/clipboard.test.ts
@@ -258,6 +258,23 @@ describe('computePasteCells', () => {
     });
   });
 
+  it('shifts the reference but leaves quoted string literals untouched on an internal formulas paste', () => {
+    const result = computePasteCells({
+      previous: sheet({}),
+      table: table([['=IF(A2>0,"q1","")']]),
+      start: { row: 1, column: 0 },
+      pasteMode: 'formulas',
+      isInternalPaste: true,
+      copyStart: { row: 0, column: 0 },
+    });
+    assert({
+      given: 'an internal formulas paste one row down of a formula with a quoted string literal',
+      should: 'shift the reference and leave the literal untouched, including its case',
+      actual: result.cells.A2,
+      expected: '=IF(A3>0,"q1","")',
+    });
+  });
+
   it('skips formula values in values mode, leaving the target untouched', () => {
     const result = computePasteCells({
       previous: sheet({ A1: 'keep' }),

--- a/packages/lib/src/__tests__/sheet-conditional.test.ts
+++ b/packages/lib/src/__tests__/sheet-conditional.test.ts
@@ -670,13 +670,16 @@ describe('parseConditionalRules', () => {
     // The array path is bounded by collecting incrementally, but the
     // TOML-bag map path (`{"0": rule, "1": rule, ...}`) has to sort every
     // candidate key before it can even start parsing, so "stop once enough
-    // valid ones are found" isn't available for this branch specifically —
-    // `Object.keys` must always fully enumerate. What CAN be (and is)
-    // bounded is everything after that: a Proxy counts property-value reads
-    // on the stored object (the step that would otherwise touch all of a
-    // huge object's rule payloads, not just the ones that make the cut) to
-    // prove the fix actually stops those at the bound rather than merely
-    // trimming the final output.
+    // valid ones are found" isn't available for this branch specifically.
+    // Key enumeration itself is bounded with a `for...in` loop that breaks
+    // once `MAX_CONDITIONAL_RULE_MAP_KEYS_SCANNED` keys are collected —
+    // unlike `Object.keys`, which always materializes every own key into an
+    // array before anything else can run. A `Proxy` can't observe that part
+    // (its `ownKeys` trap must hand back the complete key list atomically
+    // either way), but it can observe the step after: property-value reads
+    // on the stored object, which is what would otherwise touch every one
+    // of a huge object's rule payloads rather than just the ones that make
+    // the cut.
     const raw: Record<string, unknown> = {};
     for (let i = 0; i < MAX_CONDITIONAL_RULE_MAP_KEYS_SCANNED * 3; i++) {
       raw[String(i)] = rule(`r${i}`);
@@ -697,6 +700,36 @@ describe('parseConditionalRules', () => {
     // Bounded by MAX_CONDITIONAL_RULE_MAP_KEYS_SCANNED, not by the object's
     // real size (3x larger here).
     expect(valueReads).toBeLessThan(MAX_CONDITIONAL_RULE_MAP_KEYS_SCANNED * 2);
+  });
+
+  it('collects keys via bounded iteration rather than materializing the full key list first', () => {
+    // A plain object, not a Proxy: exercises the real `for...in` early break
+    // this fix relies on, rather than downstream effects of it. Correctness
+    // check — the ordering/cap guarantees hold the same way for a genuinely
+    // large object as they do for the smaller ones above.
+    const raw: Record<string, unknown> = {};
+    const total = MAX_CONDITIONAL_RULE_MAP_KEYS_SCANNED * 5;
+    for (let i = 0; i < total; i++) {
+      raw[String(i)] = rule(`r${i}`);
+    }
+
+    const parsed = parseConditionalRules(raw);
+
+    expect(parsed).toHaveLength(MAX_CONDITIONAL_RULES);
+    expect(parsed?.[0].id).toBe('r0');
+    expect(parsed?.[parsed.length - 1].id).toBe(`r${MAX_CONDITIONAL_RULES - 1}`);
+  });
+
+  it('ignores an inherited enumerable property, matching Object.keys semantics', () => {
+    // `for...in` walks the prototype chain; `Object.keys` does not. The
+    // `hasOwnProperty` filter is what keeps the two equivalent here.
+    const proto = { '99': rule('inherited') };
+    const own = Object.create(proto);
+    own['0'] = rule('own');
+
+    const parsed = parseConditionalRules(own);
+
+    expect(parsed?.map((r) => r.id)).toEqual(['own']);
   });
 });
 

--- a/packages/lib/src/__tests__/sheet-conditional.test.ts
+++ b/packages/lib/src/__tests__/sheet-conditional.test.ts
@@ -1,6 +1,8 @@
 import { describe, it, expect } from 'vitest';
 import {
   MAX_CONDITIONAL_RANGE_CELLS,
+  MAX_CONDITIONAL_RULES,
+  MAX_CONDITIONAL_TOTAL_CELLS,
   addressesOfRange,
   parseConditionalRule,
   parseConditionalRules,
@@ -411,6 +413,71 @@ describe('data bars', () => {
     const result = evaluateConditionalFormats([bar], contextOf({ A1: 1, A2: 'text' }));
     expect(result.bars.A2).toBeUndefined();
   });
+
+  it('honors an explicit positive `number` min anchor rather than forcing the baseline to zero', () => {
+    // All-positive data with a configured min of 50: the baseline should sit
+    // at 50, not silently clamp to 0 and compress every bar toward the low end.
+    const explicitMin: ConditionalRule = {
+      id: 'b2',
+      kind: 'dataBar',
+      ranges: ['A1:A3'],
+      color: '#3b82f6',
+      min: { type: 'number', value: 50 },
+      max: { type: 'number', value: 100 },
+    };
+    const result = evaluateConditionalFormats(
+      [explicitMin],
+      contextOf({ A1: 50, A2: 75, A3: 100 })
+    );
+    expect(result.bars.A1.fraction).toBe(0);
+    expect(result.bars.A2.fraction).toBeCloseTo(0.5);
+    expect(result.bars.A3.fraction).toBe(1);
+  });
+
+  it('still clamps the default auto min anchor to zero for all-positive data', () => {
+    const result = evaluateConditionalFormats([bar], contextOf({ A1: 50, A2: 75, A3: 100 }));
+    // Auto anchor (no explicit `min`) measures from 0, not from the smallest
+    // value (50) — otherwise A1 would render as an empty bar.
+    expect(result.bars.A1.fraction).toBeCloseTo(0.5);
+  });
+});
+
+describe('aggregate cell budget across all rules combined', () => {
+  it('bounds total conditional evaluation work at MAX_CONDITIONAL_TOTAL_CELLS, even split across rules and ranges each individually under MAX_CONDITIONAL_RANGE_CELLS', () => {
+    // Four ranges of exactly MAX_CONDITIONAL_RANGE_CELLS each, in one rule,
+    // exhaust the whole aggregate budget on their own.
+    const bigRule: ConditionalRule = {
+      id: 'big',
+      kind: 'cell',
+      ranges: ['A1:A500000', 'B1:B500000', 'C1:C500000', 'D1:D500000'],
+      condition: { operator: 'isNotEmpty' },
+      format: { bold: true },
+    };
+    const extraRule: ConditionalRule = {
+      id: 'extra',
+      kind: 'cell',
+      ranges: ['E1'],
+      condition: { operator: 'isNotEmpty' },
+      format: { italic: true },
+    };
+    expect(
+      bigRule.ranges.reduce((sum, r) => sum + addressesOfRange(r).length, 0)
+    ).toBe(MAX_CONDITIONAL_TOTAL_CELLS);
+
+    const context: ConditionalContext = {
+      valueAt: () => 'x',
+      isError: () => false,
+      evaluateFormula: () => '',
+    };
+    const result = evaluateConditionalFormats([bigRule, extraRule], context);
+
+    expect(result.formats.A1).toEqual({ bold: true });
+    expect(result.formats.D500000).toEqual({ bold: true });
+    // The aggregate budget was fully spent by `bigRule`, so `extraRule` —
+    // despite covering just one cell, well under any per-range cap —
+    // contributes nothing.
+    expect(result.formats.E1).toBeUndefined();
+  }, 20000);
 });
 
 describe('mixColors', () => {
@@ -527,6 +594,14 @@ describe('parseConditionalRules', () => {
     expect(parseConditionalRules([{ junk: true }])).toBeUndefined();
     expect(parseConditionalRules(undefined)).toBeUndefined();
     expect(parseConditionalRules('nope')).toBeUndefined();
+  });
+
+  it('caps the rule count at MAX_CONDITIONAL_RULES, an API write cannot exceed the parse boundary', () => {
+    const many = Array.from({ length: MAX_CONDITIONAL_RULES + 50 }, (_, i) => rule(`r${i}`));
+    const parsed = parseConditionalRules(many);
+    expect(parsed).toHaveLength(MAX_CONDITIONAL_RULES);
+    expect(parsed?.[0].id).toBe('r0');
+    expect(parsed?.[parsed.length - 1].id).toBe(`r${MAX_CONDITIONAL_RULES - 1}`);
   });
 });
 

--- a/packages/lib/src/__tests__/sheet-conditional.test.ts
+++ b/packages/lib/src/__tests__/sheet-conditional.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect } from 'vitest';
 import {
   MAX_CONDITIONAL_RANGE_CELLS,
   MAX_CONDITIONAL_RANGES_PER_RULE,
+  MAX_CONDITIONAL_RULE_MAP_KEYS_SCANNED,
   MAX_CONDITIONAL_RULES,
   MAX_CONDITIONAL_TOTAL_CELLS,
   addressesOfRange,
@@ -663,6 +664,39 @@ describe('parseConditionalRules', () => {
 
     expect(parsed).toHaveLength(MAX_CONDITIONAL_RULES);
     expect(indexReads).toBeLessThan(MAX_CONDITIONAL_RULES * 2);
+  });
+
+  it('bounds the numerically-keyed map path too, before the sort that reconstructs order', () => {
+    // The array path is bounded by collecting incrementally, but the
+    // TOML-bag map path (`{"0": rule, "1": rule, ...}`) has to sort every
+    // candidate key before it can even start parsing, so "stop once enough
+    // valid ones are found" isn't available for this branch specifically —
+    // `Object.keys` must always fully enumerate. What CAN be (and is)
+    // bounded is everything after that: a Proxy counts property-value reads
+    // on the stored object (the step that would otherwise touch all of a
+    // huge object's rule payloads, not just the ones that make the cut) to
+    // prove the fix actually stops those at the bound rather than merely
+    // trimming the final output.
+    const raw: Record<string, unknown> = {};
+    for (let i = 0; i < MAX_CONDITIONAL_RULE_MAP_KEYS_SCANNED * 3; i++) {
+      raw[String(i)] = rule(`r${i}`);
+    }
+    let valueReads = 0;
+    const tracked = new Proxy(raw, {
+      get(target, prop, receiver) {
+        if (typeof prop === 'string' && /^\d+$/.test(prop)) valueReads += 1;
+        return Reflect.get(target, prop, receiver);
+      },
+    });
+
+    const parsed = parseConditionalRules(tracked);
+
+    expect(parsed).toHaveLength(MAX_CONDITIONAL_RULES);
+    expect(parsed?.[0].id).toBe('r0');
+    expect(parsed?.[parsed.length - 1].id).toBe(`r${MAX_CONDITIONAL_RULES - 1}`);
+    // Bounded by MAX_CONDITIONAL_RULE_MAP_KEYS_SCANNED, not by the object's
+    // real size (3x larger here).
+    expect(valueReads).toBeLessThan(MAX_CONDITIONAL_RULE_MAP_KEYS_SCANNED * 2);
   });
 });
 

--- a/packages/lib/src/__tests__/sheet-conditional.test.ts
+++ b/packages/lib/src/__tests__/sheet-conditional.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from 'vitest';
 import {
   MAX_CONDITIONAL_RANGE_CELLS,
+  MAX_CONDITIONAL_RANGES_PER_RULE,
   MAX_CONDITIONAL_RULES,
   MAX_CONDITIONAL_TOTAL_CELLS,
   addressesOfRange,
@@ -640,6 +641,66 @@ describe('parseConditionalRules', () => {
     expect(parsed).toHaveLength(MAX_CONDITIONAL_RULES);
     expect(parsed?.[0].id).toBe('r0');
     expect(parsed?.[parsed.length - 1].id).toBe(`r${MAX_CONDITIONAL_RULES - 1}`);
+  });
+
+  it('stops parsing once MAX_CONDITIONAL_RULES valid rules are collected, rather than parsing every entry first', () => {
+    // A `.map(parse).filter(valid).slice(cap)` pipeline parses every entry
+    // before the cap ever applies — unbounded CPU on an unbounded array. A
+    // Proxy counts index reads during `parseConditionalRules`' own iteration
+    // (untouched by this array's `.length` or the `Array.from` that built
+    // it) to prove the fix actually stops early rather than merely trimming
+    // the output.
+    const raw = Array.from({ length: MAX_CONDITIONAL_RULES * 10 }, (_, i) => rule(`r${i}`));
+    let indexReads = 0;
+    const tracked = new Proxy(raw, {
+      get(target, prop, receiver) {
+        if (typeof prop === 'string' && /^\d+$/.test(prop)) indexReads += 1;
+        return Reflect.get(target, prop, receiver);
+      },
+    });
+
+    const parsed = parseConditionalRules(tracked);
+
+    expect(parsed).toHaveLength(MAX_CONDITIONAL_RULES);
+    expect(indexReads).toBeLessThan(MAX_CONDITIONAL_RULES * 2);
+  });
+});
+
+describe('conditional rule ranges: per-rule entry cap', () => {
+  it('caps the number of range entries one rule holds at MAX_CONDITIONAL_RANGES_PER_RULE', () => {
+    // `addressesOfRange` returns [] for an invalid or oversized range, so a
+    // `ranges` array padded with an unbounded number of such entries would
+    // otherwise cost unbounded CPU (one parse/decode per entry) without the
+    // per-cell budget ever tripping, since nothing is ever consumed from it.
+    const many = Array.from({ length: MAX_CONDITIONAL_RANGES_PER_RULE + 500 }, (_, i) => `A${i + 1}`);
+    const parsed = parseConditionalRule({
+      id: 'r',
+      kind: 'cell',
+      ranges: many,
+      condition: { operator: 'isNotEmpty' },
+      format: { bold: true },
+    });
+    expect(parsed?.ranges).toHaveLength(MAX_CONDITIONAL_RANGES_PER_RULE);
+    expect(parsed?.ranges[0]).toBe('A1');
+    expect(parsed?.ranges[MAX_CONDITIONAL_RANGES_PER_RULE - 1]).toBe(`A${MAX_CONDITIONAL_RANGES_PER_RULE}`);
+  });
+});
+
+describe('addressesOfRange: maxCount', () => {
+  it('stops enumerating at maxCount rather than building the full range and trimming it after', () => {
+    // A range within MAX_CONDITIONAL_RANGE_CELLS on its own, asked for far
+    // fewer addresses than it actually has.
+    expect(addressesOfRange('A1:A100', 3)).toEqual(['A1', 'A2', 'A3']);
+  });
+
+  it('still rejects a range over MAX_CONDITIONAL_RANGE_CELLS wholesale, regardless of maxCount', () => {
+    // maxCount only ever narrows; it must never let an otherwise-oversized
+    // range through just because the caller asked for a small maxCount.
+    expect(addressesOfRange('A1:ZZ500001', 1)).toEqual([]);
+  });
+
+  it('defaults to MAX_CONDITIONAL_RANGE_CELLS, unchanged from before this parameter existed', () => {
+    expect(addressesOfRange('A1:SF1000')).toHaveLength(MAX_CONDITIONAL_RANGE_CELLS);
   });
 });
 

--- a/packages/lib/src/__tests__/sheet-conditional.test.ts
+++ b/packages/lib/src/__tests__/sheet-conditional.test.ts
@@ -478,6 +478,44 @@ describe('aggregate cell budget across all rules combined', () => {
     // contributes nothing.
     expect(result.formats.E1).toBeUndefined();
   }, 20000);
+
+  it('bounds a single rule holding many individually-valid ranges, without expanding them all before applying the budget', () => {
+    // `rule.ranges` is API-writable jsonb with no cap on entry count: one
+    // rule can hold far more ranges than four. Ten ranges of
+    // MAX_CONDITIONAL_RANGE_CELLS each (5,000,000 combined) sum to well past
+    // the 2,000,000 aggregate budget — flat-mapping every range before
+    // slicing to the budget would transiently allocate all 5,000,000
+    // addresses (and previously crashed outright: spreading that many
+    // elements onto `Array.prototype.push` blows the engine's call-stack
+    // argument limit). `expandRangesWithinBudget` must stop consuming
+    // ranges as soon as the budget is spent instead.
+    const manyRangesRule: ConditionalRule = {
+      id: 'many',
+      kind: 'cell',
+      ranges: Array.from({ length: 10 }, (_, i) => {
+        const col = String.fromCharCode(65 + i); // A..J
+        return `${col}1:${col}500000`;
+      }),
+      condition: { operator: 'isNotEmpty' },
+      format: { bold: true },
+    };
+
+    const context: ConditionalContext = {
+      valueAt: () => 'x',
+      isError: () => false,
+      evaluateFormula: () => '',
+    };
+
+    expect(() => evaluateConditionalFormats([manyRangesRule], context)).not.toThrow();
+    const result = evaluateConditionalFormats([manyRangesRule], context);
+
+    // First four ranges (A..D) exhaust the budget exactly, as in the test
+    // above; nothing from range five (E) onward is painted.
+    expect(result.formats.A1).toEqual({ bold: true });
+    expect(result.formats.D500000).toEqual({ bold: true });
+    expect(result.formats.E1).toBeUndefined();
+    expect(result.formats.J1).toBeUndefined();
+  }, 20000);
 });
 
 describe('mixColors', () => {

--- a/packages/lib/src/__tests__/sheet-sparse-equivalence.test.ts
+++ b/packages/lib/src/__tests__/sheet-sparse-equivalence.test.ts
@@ -213,3 +213,61 @@ describe('sparse evaluation', () => {
     expect(sparse.byAddress.A1.dependents).toEqual(['B1', 'C1']);
   });
 });
+
+describe('sparse evaluation: conditional formats', () => {
+  const withRule = (): SheetData => {
+    const sheet = sheetWith({ A1: '1', B1: '2' }, 5, 5);
+    sheet.conditionalFormats = [
+      { id: 'r1', kind: 'dataBar', ranges: ['A1:E5'], color: '#3b82f6' },
+    ];
+    return sheet;
+  };
+
+  it('backfills blank cells a rule covers and reports bars/formats by default', () => {
+    const sparse = evaluateSheetSparse(withRule());
+    // C1 holds nothing but is inside the rule's range, so it must be
+    // materialized for the rule to have anything to evaluate against.
+    expect(sparse.byAddress.C1).toBeDefined();
+    expect(sparse.bars?.A1).toBeDefined();
+    expect(sparse.bars?.B1).toBeDefined();
+  });
+
+  it('skips conditional-format evaluation and the blank-cell backfill entirely when asked', () => {
+    // `serializeSheetContent` reads `conditionalFormats` straight off the raw
+    // `SheetData`, never off this evaluation, so this work is pure waste there
+    // — and unbounded, a hot-path freeze risk on every keystroke.
+    const sparse = evaluateSheetSparse(withRule(), { skipConditionalFormats: true });
+    expect(sparse.byAddress.C1).toBeUndefined();
+    expect(sparse.bars).toBeUndefined();
+  });
+
+  it('does not paint a rule-covered cell that falls outside the sheet rectangle, agreeing with the dense walk', () => {
+    // `evaluateSheet` only ever seeds addresses inside rowCount x columnCount,
+    // so a rule range reaching past it paints nothing there. The blank-cell
+    // backfill used to reach past the rectangle too, so the two disagreed —
+    // same sheet, different look in editor (sparse) vs. export (dense).
+    const sheet = sheetWith({ A1: '1' }, 3, 3);
+    sheet.conditionalFormats = [
+      {
+        id: 'r1',
+        kind: 'cell',
+        ranges: ['A1:E5'],
+        condition: { operator: 'isNotEmpty' },
+        format: { bold: true },
+      },
+    ];
+
+    const sparse = evaluateSheetSparse(sheet);
+    const dense = evaluateSheet(sheet);
+
+    // D4/E5 are outside the 3x3 rectangle but inside the rule's A1:E5 range.
+    expect(sparse.byAddress.D4).toBeUndefined();
+    expect(sparse.byAddress.E5).toBeUndefined();
+    expect(dense.byAddress.D4).toBeUndefined();
+    expect(dense.byAddress.E5).toBeUndefined();
+
+    // A cell inside the rectangle is still painted by both.
+    expect(sparse.byAddress.A1?.format).toEqual({ bold: true });
+    expect(dense.byAddress.A1?.format).toEqual({ bold: true });
+  });
+});

--- a/packages/lib/src/__tests__/sheet.test.ts
+++ b/packages/lib/src/__tests__/sheet.test.ts
@@ -342,6 +342,40 @@ describe('adjustFormulaReferences', () => {
     expect(adjusted).toBe(formula);
     expect(elapsedMs).toBeLessThan(1000);
   });
+
+  it('shifts a reference outside a string literal but leaves the literal alone', () => {
+    expect(adjustFormulaReferences('=IF(a2>0,"q1","")', 1, 0)).toBe('=IF(A3>0,"q1","")');
+  });
+
+  it('does not shift or reletter a lowercase-looking cell ref inside a string', () => {
+    expect(adjustFormulaReferences('=IF(A2>0,"a1","")', 1, 0)).toBe('=IF(A3>0,"a1","")');
+  });
+
+  it('leaves sheet-name-shaped and date-shaped literals untouched', () => {
+    expect(adjustFormulaReferences('=A1&"sheet2"', 1, 0)).toBe('=A2&"sheet2"');
+    expect(adjustFormulaReferences('=A1&"Q4 2026"', 1, 0)).toBe('=A2&"Q4 2026"');
+  });
+
+  it('leaves a ref-shaped literal untouched when it is the entire formula body', () => {
+    expect(adjustFormulaReferences('="A1"', 1, 1)).toBe('="A1"');
+  });
+
+  it('shifts refs on both sides of a string literal', () => {
+    expect(adjustFormulaReferences('=A1&"b2"&C1', 1, 0)).toBe('=A2&"b2"&C2');
+  });
+
+  it('handles a ref immediately adjacent to a quote', () => {
+    expect(adjustFormulaReferences('=CONCATENATE(A1,"x")', 1, 0)).toBe('=CONCATENATE(A2,"x")');
+    expect(adjustFormulaReferences('="x"&A1', 1, 0)).toBe('="x"&A2');
+  });
+
+  it('copies an unterminated trailing string literal through unchanged', () => {
+    expect(adjustFormulaReferences('=A1&"unterminated a2', 1, 0)).toBe('=A2&"unterminated a2');
+  });
+
+  it('does not shift a ref inside a second string literal after a real ref', () => {
+    expect(adjustFormulaReferences('=IF(A1="b2","c3","d4")', 1, 0)).toBe('=IF(A2="b2","c3","d4")');
+  });
 });
 
 describe('sheet sanitisation', () => {

--- a/packages/lib/src/__tests__/sheet.test.ts
+++ b/packages/lib/src/__tests__/sheet.test.ts
@@ -376,6 +376,27 @@ describe('adjustFormulaReferences', () => {
   it('does not shift a ref inside a second string literal after a real ref', () => {
     expect(adjustFormulaReferences('=IF(A1="b2","c3","d4")', 1, 0)).toBe('=IF(A2="b2","c3","d4")');
   });
+
+  it('shifts a real reference following a page-reference label containing an unmatched quote', () => {
+    // A page-reference label can hold any character, including a bare `"` —
+    // the tokenizer (`parser.ts`) scans `@[...]` verbatim up to the closing
+    // `]` with no quote-awareness at all. Misreading that quote as the start
+    // of a string literal used to swallow the rest of the formula, including
+    // the real trailing reference — leaving `A1` unshifted instead of `A2`.
+    expect(adjustFormulaReferences('=@[Budget "Q1]:A1', 1, 0)).toBe('=@[Budget "Q1]:A2');
+  });
+
+  it('leaves a page-reference label with a balanced pair of quotes untouched and still shifts the trailing ref', () => {
+    expect(adjustFormulaReferences('=@[Budget "Q1"]:A1', 1, 0)).toBe('=@[Budget "Q1"]:A2');
+  });
+
+  it('shifts a real reference following a page reference with an identifier suffix', () => {
+    expect(adjustFormulaReferences('=@[Budget](pg_1:page):A1', 1, 0)).toBe('=@[Budget](pg_1:page):A2');
+  });
+
+  it('does not let a string literal after a page reference bleed into the reference scan', () => {
+    expect(adjustFormulaReferences('=@[Budget]:A1&"x2"', 1, 0)).toBe('=@[Budget]:A2&"x2"');
+  });
 });
 
 describe('sheet sanitisation', () => {

--- a/packages/lib/src/sheets/address.ts
+++ b/packages/lib/src/sheets/address.ts
@@ -172,6 +172,24 @@ export function adjustFormulaReferences(
 
   while (index < formula.length) {
     const start = index;
+
+    // String literals: the tokenizer (`parser.ts`) has no escape convention —
+    // a `"` always closes the string — so mirror that exactly and copy the
+    // span verbatim. Otherwise a letters+digits run inside a quoted literal
+    // (e.g. `"q1"`) gets mistaken for a cell reference and shifted/uppercased.
+    if (formula.charCodeAt(index) === 34 /* " */) {
+      let end = index + 1;
+      while (end < formula.length && formula.charCodeAt(end) !== 34) {
+        end += 1;
+      }
+      if (end < formula.length) {
+        end += 1; // include closing quote
+      }
+      result += formula.slice(start, end);
+      index = end;
+      continue;
+    }
+
     let colDollar = '';
     let rowDollar = '';
 

--- a/packages/lib/src/sheets/address.ts
+++ b/packages/lib/src/sheets/address.ts
@@ -173,6 +173,35 @@ export function adjustFormulaReferences(
   while (index < formula.length) {
     const start = index;
 
+    // Page references `@[Label](id:type)?:A1`: the label can hold any
+    // character at all, including a `"` — the tokenizer (`parser.ts`) scans
+    // it verbatim up to the closing `]` with no quote-awareness. Detected
+    // and consumed as one span before the string-literal check below, so a
+    // quote inside a label (e.g. `@[Budget "Q1]:A1`) is never misread as the
+    // start of a string literal — which would otherwise swallow everything
+    // after it, including a real reference that needs to shift.
+    if (formula.charCodeAt(index) === 64 /* @ */ && formula[index + 1] === '[') {
+      let end = index + 2;
+      while (end < formula.length && formula[end] !== ']') {
+        end += 1;
+      }
+      if (end < formula.length) {
+        end += 1; // include closing ]
+        if (formula[end] === '(') {
+          let metaEnd = end + 1;
+          while (metaEnd < formula.length && formula[metaEnd] !== ')') {
+            metaEnd += 1;
+          }
+          if (metaEnd < formula.length) {
+            end = metaEnd + 1; // include closing )
+          }
+        }
+      }
+      result += formula.slice(start, end);
+      index = end;
+      continue;
+    }
+
     // String literals: the tokenizer (`parser.ts`) has no escape convention —
     // a `"` always closes the string — so mirror that exactly and copy the
     // span verbatim. Otherwise a letters+digits run inside a quoted literal

--- a/packages/lib/src/sheets/conditional.ts
+++ b/packages/lib/src/sheets/conditional.ts
@@ -140,6 +140,31 @@ const EMPTY: ConditionalResult = { formats: {}, bars: {} };
  */
 export const MAX_CONDITIONAL_RANGE_CELLS = 500_000;
 
+/**
+ * The most rules a sheet's conditional-format list may hold.
+ *
+ * `MAX_CONDITIONAL_RANGE_CELLS` bounds one range; nothing bounded the rule
+ * count itself, and rules are stored as API-writable jsonb — so a write with
+ * thousands of rules (each individually under the per-range cap) passed
+ * through untouched and made every render/save re-walk all of them. Enforced
+ * at the parse boundary (`parseConditionalRules`), where every stored value
+ * — API write or load — passes through.
+ */
+export const MAX_CONDITIONAL_RULES = 200;
+
+/**
+ * The most cells conditional-format evaluation may cover in total, across
+ * every rule and every range of a sheet combined.
+ *
+ * `MAX_CONDITIONAL_RANGE_CELLS` only bounds one range at a time; a rule list
+ * with many rules, or many ranges per rule, each individually under that cap,
+ * could still sum to unbounded work — and a `formula` rule shifts, tokenizes,
+ * parses and evaluates a formula per covered cell, making that work
+ * expensive per cell rather than cheap. This is the aggregate ceiling that
+ * catches what the per-range cap alone cannot.
+ */
+export const MAX_CONDITIONAL_TOTAL_CELLS = 2_000_000;
+
 /** Every address of an `A1:B2` range, or of a bare `A1`. Invalid ranges yield none. */
 export function addressesOfRange(range: string): string[] {
   const normalized = range.trim().toUpperCase();
@@ -412,12 +437,23 @@ export function evaluateConditionalFormats(
     formats[address] = { ...(formats[address] ?? {}), ...format };
   };
 
+  // Aggregate budget across every rule and range combined — see
+  // `MAX_CONDITIONAL_TOTAL_CELLS`. Decremented as ranges are consumed below;
+  // once it hits zero, remaining rules/ranges contribute nothing further,
+  // the same treatment an individually-oversized range already gets.
+  let remainingCellBudget = MAX_CONDITIONAL_TOTAL_CELLS;
+
   for (const rule of rules) {
-    const addresses = rule.ranges.flatMap((range) => addressesOfRange(range));
+    if (remainingCellBudget <= 0) break;
+
+    const addresses = rule.ranges
+      .flatMap((range) => addressesOfRange(range))
+      .slice(0, remainingCellBudget);
     if (addresses.length === 0) continue;
 
     switch (rule.kind) {
       case 'cell': {
+        remainingCellBudget -= addresses.length;
         for (const address of addresses) {
           if (matchesCondition(context.valueAt(address), context.isError(address), rule.condition)) {
             contribute(address, rule.format);
@@ -428,10 +464,15 @@ export function evaluateConditionalFormats(
 
       case 'formula': {
         for (const range of rule.ranges) {
+          if (remainingCellBudget <= 0) break;
+
           const anchor = rangeAnchor(range);
           if (!anchor) continue;
 
-          for (const address of addressesOfRange(range)) {
+          const rangeAddresses = addressesOfRange(range).slice(0, remainingCellBudget);
+          remainingCellBudget -= rangeAddresses.length;
+
+          for (const address of rangeAddresses) {
             const { row, column } = decodeCellAddress(address);
             // Relative references shift from the range's top-left, so one rule
             // written against the first cell reads correctly for all of them.
@@ -455,6 +496,7 @@ export function evaluateConditionalFormats(
       }
 
       case 'colorScale': {
+        remainingCellBudget -= addresses.length;
         const sorted = numbersIn(addresses, context).sort((a, b) => a - b);
         if (sorted.length === 0) break;
 
@@ -487,10 +529,17 @@ export function evaluateConditionalFormats(
       }
 
       case 'dataBar': {
+        remainingCellBudget -= addresses.length;
         const sorted = numbersIn(addresses, context).sort((a, b) => a - b);
         if (sorted.length === 0) break;
 
-        const low = Math.min(0, anchorValue(rule.min, sorted, 'min'));
+        // Excel's baseline-at-zero default only applies to the auto anchor —
+        // an explicit anchor (e.g. a positive `number`/`percent`/`percentile`
+        // min) must be honored as the user configured it, not forced ≤0.
+        const low =
+          rule.min && rule.min.type !== 'min'
+            ? anchorValue(rule.min, sorted, 'min')
+            : Math.min(0, anchorValue(rule.min, sorted, 'min'));
         const high = anchorValue(rule.max, sorted, 'max');
         const span = high - low;
 
@@ -647,5 +696,11 @@ export function parseConditionalRules(value: unknown): ConditionalRule[] | undef
     .map((entry) => parseConditionalRule(entry))
     .filter((rule): rule is ConditionalRule => rule !== null);
 
-  return rules.length > 0 ? rules : undefined;
+  // Capped here — the API write door every stored rule set passes through —
+  // rather than at evaluation time, so an oversized write never round-trips
+  // back out any larger than what will actually be evaluated. See
+  // `MAX_CONDITIONAL_RULES`.
+  const capped = rules.slice(0, MAX_CONDITIONAL_RULES);
+
+  return capped.length > 0 ? capped : undefined;
 }

--- a/packages/lib/src/sheets/conditional.ts
+++ b/packages/lib/src/sheets/conditional.ts
@@ -180,6 +180,26 @@ export const MAX_CONDITIONAL_RULES = 200;
 export const MAX_CONDITIONAL_RANGES_PER_RULE = 1_000;
 
 /**
+ * The most keys of the numerically-keyed rule-storage map that
+ * `parseConditionalRules` will look at, before it even knows which ones are
+ * valid.
+ *
+ * The TOML bag stores rules as `{ "0": rule, "1": rule, ... }` rather than
+ * an array, and `Object.keys` on it is unbounded the same way an array of
+ * rules is — but unlike the array path (bounded by collecting incrementally
+ * and stopping at `MAX_CONDITIONAL_RULES`), reconstructing rule order here
+ * needs a `.sort()` over every candidate key *before* any of them can be
+ * parsed or discarded, so there is no "stop once enough valid ones are
+ * found" option for this step specifically. Bounding the raw key list first
+ * keeps that sort (and the map/filter around it) cheap regardless of how
+ * large the stored object is. Ten times `MAX_CONDITIONAL_RULES`: enough
+ * headroom that a realistic document — where every key is the canonical,
+ * already-ascending form `sheetDataToSheetDoc` writes — never loses a rule
+ * to this bound before the per-rule cap would have dropped it anyway.
+ */
+export const MAX_CONDITIONAL_RULE_MAP_KEYS_SCANNED = MAX_CONDITIONAL_RULES * 10;
+
+/**
  * The most cells conditional-format evaluation may cover in total, across
  * every rule and every range of a sheet combined.
  *
@@ -771,6 +791,7 @@ export function parseConditionalRules(value: unknown): ConditionalRule[] | undef
     entries = value;
   } else if (isObject(value)) {
     entries = Object.keys(value)
+      .slice(0, MAX_CONDITIONAL_RULE_MAP_KEYS_SCANNED)
       .map((key) => ({ key, index: Number(key) }))
       .filter(({ index }) => Number.isFinite(index))
       .sort((a, b) => a.index - b.index)

--- a/packages/lib/src/sheets/conditional.ts
+++ b/packages/lib/src/sheets/conditional.ts
@@ -165,6 +165,46 @@ export const MAX_CONDITIONAL_RULES = 200;
  */
 export const MAX_CONDITIONAL_TOTAL_CELLS = 2_000_000;
 
+/**
+ * Expand a list of ranges to addresses, one range at a time, never
+ * materializing more than `remainingBudget` combined — even transiently.
+ *
+ * `rule.ranges` is API-writable jsonb with no cap on entry count: a rule can
+ * hold an unbounded number of ranges that are each individually valid and
+ * under `MAX_CONDITIONAL_RANGE_CELLS` on their own. Expanding all of them
+ * with `flatMap` before applying an aggregate budget via `.slice()` would
+ * still allocate unbounded memory — the slice only trims the *result*, after
+ * the allocation that was supposed to be prevented already happened. Walking
+ * ranges one at a time and stopping as soon as the budget is spent bounds
+ * peak memory to one range's worth (≤ `MAX_CONDITIONAL_RANGE_CELLS`) beyond
+ * the budget, not the sum of every range in the list.
+ */
+export function expandRangesWithinBudget(
+  ranges: readonly string[],
+  remainingBudget: number
+): { addresses: string[]; consumed: number } {
+  // `.concat()`, not `.push(...take)`: spreading a few-hundred-thousand-
+  // element array as call arguments blows the engine's argument-count limit
+  // ("Maximum call stack size exceeded") well before it reaches
+  // `MAX_CONDITIONAL_RANGE_CELLS`.
+  let addresses: string[] = [];
+  let consumed = 0;
+
+  for (const range of ranges) {
+    if (consumed >= remainingBudget) break;
+
+    const rangeAddresses = addressesOfRange(range);
+    if (rangeAddresses.length === 0) continue;
+
+    const available = remainingBudget - consumed;
+    const take = rangeAddresses.length > available ? rangeAddresses.slice(0, available) : rangeAddresses;
+    addresses = addresses.concat(take);
+    consumed += take.length;
+  }
+
+  return { addresses, consumed };
+}
+
 /** Every address of an `A1:B2` range, or of a bare `A1`. Invalid ranges yield none. */
 export function addressesOfRange(range: string): string[] {
   const normalized = range.trim().toUpperCase();
@@ -446,14 +486,55 @@ export function evaluateConditionalFormats(
   for (const rule of rules) {
     if (remainingCellBudget <= 0) break;
 
-    const addresses = rule.ranges
-      .flatMap((range) => addressesOfRange(range))
-      .slice(0, remainingCellBudget);
+    // `formula` needs each range's own anchor for relative-reference shifting,
+    // so it walks `rule.ranges` itself below rather than through the shared
+    // expansion — which also means it never allocates the address list this
+    // computes, since it wouldn't use it.
+    if (rule.kind === 'formula') {
+      for (const range of rule.ranges) {
+        if (remainingCellBudget <= 0) break;
+
+        const anchor = rangeAnchor(range);
+        if (!anchor) continue;
+
+        const rangeAddresses = addressesOfRange(range).slice(0, remainingCellBudget);
+        remainingCellBudget -= rangeAddresses.length;
+
+        for (const address of rangeAddresses) {
+          const { row, column } = decodeCellAddress(address);
+          // Relative references shift from the range's top-left, so one rule
+          // written against the first cell reads correctly for all of them.
+          const shifted = adjustFormulaReferences(
+            rule.formula,
+            row - anchor.row,
+            column - anchor.column
+          );
+          let result: SheetPrimitive;
+          try {
+            result = context.evaluateFormula(shifted);
+          } catch {
+            // A rule that cannot be evaluated must not take the sheet down
+            // with it; it simply does not match.
+            continue;
+          }
+          if (isTruthy(result)) contribute(address, rule.format);
+        }
+      }
+      continue;
+    }
+
+    // Ranges are expanded one at a time, stopping as soon as the budget is
+    // spent — see `expandRangesWithinBudget`. A rule may hold an unbounded
+    // number of ranges (jsonb, no cap on array length), each individually
+    // valid and under `MAX_CONDITIONAL_RANGE_CELLS` on its own; flat-mapping
+    // all of them before slicing to the budget would still allocate
+    // unbounded memory before the cap ever took effect.
+    const { addresses, consumed } = expandRangesWithinBudget(rule.ranges, remainingCellBudget);
+    remainingCellBudget -= consumed;
     if (addresses.length === 0) continue;
 
     switch (rule.kind) {
       case 'cell': {
-        remainingCellBudget -= addresses.length;
         for (const address of addresses) {
           if (matchesCondition(context.valueAt(address), context.isError(address), rule.condition)) {
             contribute(address, rule.format);
@@ -462,41 +543,7 @@ export function evaluateConditionalFormats(
         break;
       }
 
-      case 'formula': {
-        for (const range of rule.ranges) {
-          if (remainingCellBudget <= 0) break;
-
-          const anchor = rangeAnchor(range);
-          if (!anchor) continue;
-
-          const rangeAddresses = addressesOfRange(range).slice(0, remainingCellBudget);
-          remainingCellBudget -= rangeAddresses.length;
-
-          for (const address of rangeAddresses) {
-            const { row, column } = decodeCellAddress(address);
-            // Relative references shift from the range's top-left, so one rule
-            // written against the first cell reads correctly for all of them.
-            const shifted = adjustFormulaReferences(
-              rule.formula,
-              row - anchor.row,
-              column - anchor.column
-            );
-            let result: SheetPrimitive;
-            try {
-              result = context.evaluateFormula(shifted);
-            } catch {
-              // A rule that cannot be evaluated must not take the sheet down
-              // with it; it simply does not match.
-              continue;
-            }
-            if (isTruthy(result)) contribute(address, rule.format);
-          }
-        }
-        break;
-      }
-
       case 'colorScale': {
-        remainingCellBudget -= addresses.length;
         const sorted = numbersIn(addresses, context).sort((a, b) => a - b);
         if (sorted.length === 0) break;
 
@@ -529,7 +576,6 @@ export function evaluateConditionalFormats(
       }
 
       case 'dataBar': {
-        remainingCellBudget -= addresses.length;
         const sorted = numbersIn(addresses, context).sort((a, b) => a - b);
         if (sorted.length === 0) break;
 

--- a/packages/lib/src/sheets/conditional.ts
+++ b/packages/lib/src/sheets/conditional.ts
@@ -149,8 +149,35 @@ export const MAX_CONDITIONAL_RANGE_CELLS = 500_000;
  * through untouched and made every render/save re-walk all of them. Enforced
  * at the parse boundary (`parseConditionalRules`), where every stored value
  * — API write or load — passes through.
+ *
+ * That "API write or load" is deliberate, not incidental: bounding
+ * evaluation work requires the cap to apply everywhere a stored value is
+ * parsed, not only on fresh writes. The cost is the same one
+ * `MAX_CONDITIONAL_RANGE_CELLS` already accepts for an individually
+ * oversized range — a sheet that already has more rules than the cap (not
+ * achievable through this codebase today, since conditional formatting
+ * shipped with no rule-count limit at all until this constant existed) would
+ * have the excess silently dropped on load, and a subsequent save persists
+ * that truncation. Generous enough (200) that reaching it is not a realistic
+ * accident.
  */
 export const MAX_CONDITIONAL_RULES = 200;
+
+/**
+ * The most range entries one rule's `ranges` array may hold.
+ *
+ * `expandRangesWithinBudget` stops as soon as the cell budget is spent — but
+ * an invalid or individually-oversized range (e.g. `A1:A500001`, one past
+ * `MAX_CONDITIONAL_RANGE_CELLS`) contributes zero cells via `addressesOfRange`,
+ * so the budget never decreases for it. A `ranges` array padded with an
+ * unbounded number of such entries would still cost real, unbounded CPU —
+ * one `addressesOfRange` call (parse, decode, bounds-check) per entry — with
+ * the per-cell budget never tripping. Capped at the same parse boundary as
+ * `MAX_CONDITIONAL_RULES`, in `readRanges`, so this can never reach the
+ * evaluator at all. Generous against real use: a rule needing more than a
+ * thousand disjoint ranges is not a realistic layout.
+ */
+export const MAX_CONDITIONAL_RANGES_PER_RULE = 1_000;
 
 /**
  * The most cells conditional-format evaluation may cover in total, across
@@ -167,25 +194,26 @@ export const MAX_CONDITIONAL_TOTAL_CELLS = 2_000_000;
 
 /**
  * Expand a list of ranges to addresses, one range at a time, never
- * materializing more than `remainingBudget` combined — even transiently.
+ * materializing more than `remainingBudget` combined.
  *
  * `rule.ranges` is API-writable jsonb with no cap on entry count: a rule can
  * hold an unbounded number of ranges that are each individually valid and
  * under `MAX_CONDITIONAL_RANGE_CELLS` on their own. Expanding all of them
  * with `flatMap` before applying an aggregate budget via `.slice()` would
  * still allocate unbounded memory — the slice only trims the *result*, after
- * the allocation that was supposed to be prevented already happened. Walking
- * ranges one at a time and stopping as soon as the budget is spent bounds
- * peak memory to one range's worth (≤ `MAX_CONDITIONAL_RANGE_CELLS`) beyond
- * the budget, not the sum of every range in the list.
+ * the allocation that was supposed to be prevented already happened.
+ * Walking ranges one at a time, and asking `addressesOfRange` to stop at the
+ * remaining budget rather than enumerating a whole range and slicing it down
+ * afterward, keeps the true peak at `remainingBudget` — not `remainingBudget`
+ * plus whatever one oversized range would have enumerated before trimming.
  */
 export function expandRangesWithinBudget(
   ranges: readonly string[],
   remainingBudget: number
 ): { addresses: string[]; consumed: number } {
-  // `.concat()`, not `.push(...take)`: spreading a few-hundred-thousand-
-  // element array as call arguments blows the engine's argument-count limit
-  // ("Maximum call stack size exceeded") well before it reaches
+  // `.concat()`, not `.push(...rangeAddresses)`: spreading a few-hundred-
+  // thousand-element array as call arguments blows the engine's argument-
+  // count limit ("Maximum call stack size exceeded") well before it reaches
   // `MAX_CONDITIONAL_RANGE_CELLS`.
   let addresses: string[] = [];
   let consumed = 0;
@@ -193,20 +221,28 @@ export function expandRangesWithinBudget(
   for (const range of ranges) {
     if (consumed >= remainingBudget) break;
 
-    const rangeAddresses = addressesOfRange(range);
+    const rangeAddresses = addressesOfRange(range, remainingBudget - consumed);
     if (rangeAddresses.length === 0) continue;
 
-    const available = remainingBudget - consumed;
-    const take = rangeAddresses.length > available ? rangeAddresses.slice(0, available) : rangeAddresses;
-    addresses = addresses.concat(take);
-    consumed += take.length;
+    addresses = addresses.concat(rangeAddresses);
+    consumed += rangeAddresses.length;
   }
 
   return { addresses, consumed };
 }
 
-/** Every address of an `A1:B2` range, or of a bare `A1`. Invalid ranges yield none. */
-export function addressesOfRange(range: string): string[] {
+/**
+ * Every address of an `A1:B2` range, or of a bare `A1`. Invalid ranges yield
+ * none.
+ *
+ * `maxCount` stops enumeration early — after that many addresses, not after
+ * building the whole range and trimming it — so a caller with a small
+ * remaining budget can ask for a small array outright instead of paying for
+ * a large one it will immediately discard most of. It only ever narrows: a
+ * range over `MAX_CONDITIONAL_RANGE_CELLS` is still rejected wholesale
+ * regardless of `maxCount`, unchanged from before this parameter existed.
+ */
+export function addressesOfRange(range: string, maxCount: number = MAX_CONDITIONAL_RANGE_CELLS): string[] {
   const normalized = range.trim().toUpperCase();
   const [rawStart, rawEnd, ...extra] = normalized.split(':');
   if (!rawStart || extra.length > 0) return [];
@@ -242,8 +278,9 @@ export function addressesOfRange(range: string): string[] {
   }
 
   const addresses: string[] = [];
-  for (let row = rowStart; row <= rowEnd; row++) {
+  outer: for (let row = rowStart; row <= rowEnd; row++) {
     for (let column = columnStart; column <= columnEnd; column++) {
+      if (addresses.length >= maxCount) break outer;
       addresses.push(encodeCellAddress(row, column));
     }
   }
@@ -497,7 +534,7 @@ export function evaluateConditionalFormats(
         const anchor = rangeAnchor(range);
         if (!anchor) continue;
 
-        const rangeAddresses = addressesOfRange(range).slice(0, remainingCellBudget);
+        const rangeAddresses = addressesOfRange(range, remainingCellBudget);
         remainingCellBudget -= rangeAddresses.length;
 
         for (const address of rangeAddresses) {
@@ -623,7 +660,11 @@ const isObject = (value: unknown): value is Record<string, unknown> =>
 
 const readRanges = (value: unknown): string[] | null => {
   if (!Array.isArray(value)) return null;
-  const ranges = value.filter((entry): entry is string => typeof entry === 'string' && entry.trim() !== '');
+  // Sliced before filtering, not after: the point is to bound how many
+  // entries get inspected at all, not just how many end up valid.
+  const ranges = value
+    .slice(0, MAX_CONDITIONAL_RANGES_PER_RULE)
+    .filter((entry): entry is string => typeof entry === 'string' && entry.trim() !== '');
   return ranges.length > 0 ? ranges : null;
 };
 
@@ -738,15 +779,17 @@ export function parseConditionalRules(value: unknown): ConditionalRule[] | undef
     return undefined;
   }
 
-  const rules = entries
-    .map((entry) => parseConditionalRule(entry))
-    .filter((rule): rule is ConditionalRule => rule !== null);
+  // Collected incrementally and capped here — the API write door every
+  // stored rule set passes through — rather than parsing every entry before
+  // slicing: `entries` can be unbounded (API-writable jsonb), and parsing
+  // one is real work. Stops as soon as `MAX_CONDITIONAL_RULES` valid rules
+  // are collected instead of parsing the rest for nothing.
+  const rules: ConditionalRule[] = [];
+  for (const entry of entries) {
+    if (rules.length >= MAX_CONDITIONAL_RULES) break;
+    const rule = parseConditionalRule(entry);
+    if (rule) rules.push(rule);
+  }
 
-  // Capped here — the API write door every stored rule set passes through —
-  // rather than at evaluation time, so an oversized write never round-trips
-  // back out any larger than what will actually be evaluated. See
-  // `MAX_CONDITIONAL_RULES`.
-  const capped = rules.slice(0, MAX_CONDITIONAL_RULES);
-
-  return capped.length > 0 ? capped : undefined;
+  return rules.length > 0 ? rules : undefined;
 }

--- a/packages/lib/src/sheets/conditional.ts
+++ b/packages/lib/src/sheets/conditional.ts
@@ -790,8 +790,22 @@ export function parseConditionalRules(value: unknown): ConditionalRule[] | undef
   if (Array.isArray(value)) {
     entries = value;
   } else if (isObject(value)) {
-    entries = Object.keys(value)
-      .slice(0, MAX_CONDITIONAL_RULE_MAP_KEYS_SCANNED)
+    // `for...in` with an early break, not `Object.keys(value).slice(...)`:
+    // `Object.keys` has no way to stop partway through — it always
+    // enumerates and allocates an array for every own key first, so a
+    // `.slice()` afterward bounds everything downstream of it but not the
+    // enumeration itself. `for...in` visits keys one at a time and can stop
+    // as soon as the bound is reached. It also walks inherited enumerable
+    // properties, unlike `Object.keys`, so `hasOwnProperty` filters those
+    // out to keep the same own-keys-only semantics.
+    const keys: string[] = [];
+    for (const key in value) {
+      if (!Object.prototype.hasOwnProperty.call(value, key)) continue;
+      keys.push(key);
+      if (keys.length >= MAX_CONDITIONAL_RULE_MAP_KEYS_SCANNED) break;
+    }
+
+    entries = keys
       .map((key) => ({ key, index: Number(key) }))
       .filter(({ index }) => Number.isFinite(index))
       .sort((a, b) => a.index - b.index)

--- a/packages/lib/src/sheets/evaluation.ts
+++ b/packages/lib/src/sheets/evaluation.ts
@@ -24,7 +24,8 @@ import { tokenize, FormulaParser } from './parser';
 import { evaluateFunction, flattenValue, coerceNumber, formatDisplayValue } from './functions';
 import { applyNumberFormat, resolveCellFormat } from './format';
 import {
-  addressesOfRange,
+  MAX_CONDITIONAL_TOTAL_CELLS,
+  expandRangesWithinBudget,
   evaluateConditionalFormats,
   type DataBarFill,
 } from './conditional';
@@ -512,11 +513,35 @@ function evaluateExpression(
   return flattenValue(evaluated)[0];
 }
 
-/** Every address any rule covers, so a rule over blank cells still paints. */
+/**
+ * Every address any rule covers, so a rule over blank cells still paints.
+ *
+ * Bounded by the same aggregate cap `evaluateConditionalFormats` enforces
+ * (`MAX_CONDITIONAL_TOTAL_CELLS`), expanded one range at a time via
+ * `expandRangesWithinBudget` rather than flat-mapped up front: a rule can
+ * hold an unbounded number of ranges, each individually valid and under
+ * `MAX_CONDITIONAL_RANGE_CELLS` on its own, and this result feeds the
+ * blank-cell backfill below — materializing it unbounded would defeat the
+ * budget before evaluation ever got a chance to apply it.
+ */
 export function conditionalAddresses(sheet: SheetData): string[] {
   const rules = sheet.conditionalFormats;
   if (!rules || rules.length === 0) return [];
-  return rules.flatMap((rule) => rule.ranges.flatMap((range) => addressesOfRange(range)));
+
+  // `.concat()`, not `.push(...ruleAddresses)`: spreading a large array as
+  // call arguments blows the engine's argument-count limit well before it
+  // reaches `MAX_CONDITIONAL_TOTAL_CELLS`.
+  let addresses: string[] = [];
+  let remainingBudget = MAX_CONDITIONAL_TOTAL_CELLS;
+
+  for (const rule of rules) {
+    if (remainingBudget <= 0) break;
+    const { addresses: ruleAddresses, consumed } = expandRangesWithinBudget(rule.ranges, remainingBudget);
+    addresses = addresses.concat(ruleAddresses);
+    remainingBudget -= consumed;
+  }
+
+  return addresses;
 }
 
 /**

--- a/packages/lib/src/sheets/evaluation.ts
+++ b/packages/lib/src/sheets/evaluation.ts
@@ -19,7 +19,7 @@ import type {
   SheetDocDependencyRecord,
 } from './types';
 import { LOCAL_PAGE_KEY } from './constants';
-import { encodeCellAddress, expandRange, numberRegex, columnLabelOf } from './address';
+import { encodeCellAddress, decodeCellAddress, expandRange, numberRegex, columnLabelOf } from './address';
 import { tokenize, FormulaParser } from './parser';
 import { evaluateFunction, flattenValue, coerceNumber, formatDisplayValue } from './functions';
 import { applyNumberFormat, resolveCellFormat } from './format';
@@ -793,14 +793,29 @@ export function evaluateSheetSparse(
     };
   }
 
+  if (options.skipConditionalFormats) {
+    return { byAddress, dependencies };
+  }
+
   // A rule can cover cells that hold nothing — "highlight the blanks", or a
   // coloured band across an empty row. Those have no entry here, and without
   // one the rule would be stored correctly and paint nothing, which is exactly
   // how a blank cell's own formatting was once invisible.
+  //
+  // Bounded to the sheet's own rectangle to agree with `evaluateSheet`: the
+  // dense walk only ever seeds addresses inside `rowCount x columnCount`, so
+  // a rule range reaching past it paints nothing there — unlike a real
+  // formula cell stored past the rectangle (which both paths intentionally
+  // keep; see `serializeSheetContent`'s comment), a blank backfilled purely
+  // to satisfy a rule has no content to preserve, so there is no reason for
+  // the two evaluators to disagree here.
+  const sparseRowCount = Math.max(1, sheet.rowCount);
+  const sparseColumnCount = Math.max(1, sheet.columnCount);
   for (const address of conditionalAddresses(sheet)) {
-    if (!byAddress[address] && isLocalAddress(address)) {
-      byAddress[address] = evaluateCellInternal(address, pageKey, env, new Set());
-    }
+    if (byAddress[address] || !isLocalAddress(address)) continue;
+    const { row, column } = decodeCellAddress(address);
+    if (row < 0 || row >= sparseRowCount || column < 0 || column >= sparseColumnCount) continue;
+    byAddress[address] = evaluateCellInternal(address, pageKey, env, new Set());
   }
 
   const bars = applyConditionalFormats(sheet, byAddress, pageKey, env);

--- a/packages/lib/src/sheets/io.ts
+++ b/packages/lib/src/sheets/io.ts
@@ -184,7 +184,11 @@ export function serializeSheetContent(
   // edges. It additionally emits an edge to a referenced address *outside*
   // rowCount x columnCount, which the dense walk could never see —  the same
   // reason an out-of-rectangle cell now survives a save at all.
-  const evaluation = evaluateSheetSparse(sanitized);
+  // `sheetDataToSheetDoc` reads `conditionalFormats` straight off `sanitized`,
+  // never off the evaluation result, so evaluating rules (and backfilling the
+  // blank cells they cover) here is pure waste — and, unbounded, a hot-path
+  // freeze risk on every keystroke.
+  const evaluation = evaluateSheetSparse(sanitized, { skipConditionalFormats: true });
   const doc = sheetDataToSheetDoc(sanitized, evaluation, options);
   return stringifySheetDoc(doc);
 }

--- a/packages/lib/src/sheets/types.ts
+++ b/packages/lib/src/sheets/types.ts
@@ -178,6 +178,15 @@ export interface SheetEvaluationOptions {
   resolveExternalReference?: (
     reference: SheetExternalReferenceToken
   ) => SheetExternalReferenceResolution | null | undefined;
+  /**
+   * Skip conditional-format evaluation (and the blank-cell backfill it needs)
+   * in `evaluateSheetSparse`. `sheetDataToSheetDoc` — the only consumer on the
+   * serialize path (`serializeSheetContent`) — reads `conditionalFormats`
+   * straight off the raw `SheetData`, never off the evaluation result, so
+   * that work is pure waste on every save/keystroke there. Renderers (the
+   * editor, the AI sheet-view tool) still need it and must leave this unset.
+   */
+  skipConditionalFormats?: boolean;
 }
 
 export interface SheetEvaluationCell {


### PR DESCRIPTION
## Summary

Fixes the two HIGH-severity regressions shipped in #2492 (sheets conditional formatting), plus two LOWs from the same PR/files while touching them.

- **HIGH — data corruption on paste**: `adjustFormulaReferences` (`packages/lib/src/sheets/address.ts`) was widened in #2492 to match lowercase cell refs, but the scanner had no awareness of quoted string literals. Any `letters+digits` run inside a quoted string (`"q1"`, `"sheet2"`) got shifted and uppercased on paste and on conditional-format formula-rule evaluation. Fixed by making the scanner quote-aware: it now copies a `"..."` span verbatim, matching the tokenizer's own no-escape-convention string handling in `parser.ts`.

- **HIGH — unbounded conditional-format evaluation, hot-path freeze risk**: `MAX_CONDITIONAL_RANGE_CELLS` only capped one range; rule count and ranges-per-rule were unbounded and API-writable via jsonb, and a `formula` rule shifts+tokenizes+parses+evaluates per covered cell. Fixed with:
  - `MAX_CONDITIONAL_TOTAL_CELLS` (2,000,000): an aggregate budget across every rule × range combined, enforced inside `evaluateConditionalFormats`.
  - `MAX_CONDITIONAL_RULES` (200): a rule-count cap enforced at `parseConditionalRules`, the parse boundary every stored rule set (API write or load) passes through.
  - `serializeSheetContent` (`io.ts`) now passes `skipConditionalFormats: true` to `evaluateSheetSparse` — verified `sheetDataToSheetDoc` reads `conditionalFormats` straight off the raw `SheetData`, never off the evaluation result, and neither the blank-cell backfill nor `bars` is consumed on that path, so evaluating them there was pure waste. The render memo (`SheetView.tsx`) and the AI sheet-view tool (`sheet-view.ts`) are untouched and still evaluate normally — now under the new aggregate budget automatically.

- **LOW — data-bar baseline ignored an explicit positive min anchor**: `Math.min(0, anchorValue(rule.min, ...))` forced the baseline to ≤0 even when the rule configured an explicit `number`/`percent`/`percentile` min above zero. Now only the auto (`min`) anchor gets the Excel-style zero-baseline default; an explicit anchor is honored as configured.

- **LOW — sparse vs. dense evaluators disagreed on out-of-rectangle rule coverage**: the sparse path's blank-cell backfill (for "highlight the blanks" rules) reached past the sheet's `rowCount x columnCount` rectangle; the dense walk (used for exports/published pages) never does, since it only ever seeds addresses inside the rectangle. Picked the dense behavior: the sparse backfill is now bounded to the rectangle too, so editor and export agree. (Out-of-rectangle *real* formula cells are untouched — that's a separate, intentional sparse-path behavior documented in `serializeSheetContent`.)

## Review follow-up — five rounds of CodeRabbit/Codex, each closing one more layer of the same budget chain

- **Round 1 (`90625c66`)**: aggregate budget was applied via `.flatMap(...).slice(budget)`, which still materializes every range before the slice trims it — `rule.ranges` has no entry-count cap. Fixed with `expandRangesWithinBudget`, walking ranges one at a time and stopping as soon as the shared budget is spent, used by both `evaluateConditionalFormats` and the sparse render path's `conditionalAddresses`. (Caught mid-fix: `array.push(...largeArray)` overflows the call stack on a large range — switched to `.concat()`.) Also fixed a page-reference label containing an unmatched `"` (`@[Budget "]:A1`) being misread by the new quote guard as an unterminated string, swallowing a real trailing reference.

- **Round 2 (`b0c476cd`)**: an invalid/oversized range contributes zero cells, so a `ranges` array padded with an unbounded run of such entries never tripped the cell budget — one `addressesOfRange` call per entry regardless. Fixed with `MAX_CONDITIONAL_RANGES_PER_RULE` (1,000), enforced in `readRanges` at the same parse boundary as `MAX_CONDITIONAL_RULES`. Also tightened `addressesOfRange` to accept a `maxCount` and stop enumerating there rather than building a whole range and slicing after — eliminating a transient per-range overshoot the aggregate budget's own docstring had overclaimed didn't exist.

- **Round 3 (`c65c615b`)**: `parseConditionalRules`'s array path parsed every entry (`.map().filter()`) before slicing to `MAX_CONDITIONAL_RULES` — unbounded parse work on an unbounded array. Rewritten as an incremental collect-and-break loop.

- **Round 4 (`187b40f9`)**: the numerically-keyed map path (`{"0": rule, "1": rule, ...}`, the TOML-bag storage shape) still ran `Object.keys(value).map().filter().sort().map()` over every key before the capped loop started. Bounded with `MAX_CONDITIONAL_RULE_MAP_KEYS_SCANNED` (10× the rule cap) via a `for...in` loop that breaks early — actually stopping enumeration rather than trimming its result.

- **Round 5**: independently verified (Node benchmark, not taken on faith) that `for...in` with an early break still costs something proportional to object size in V8 — confirmed directionally, though the magnitude in my own measurement was much smaller than initially reported. Concluded this residual is a payload-size question (reaching it requires a single jsonb field carrying 100k–1M+ keys, tens of MB of raw JSON) rather than a computation-bounding one solvable in plain JS at this layer — see the thread for the full reasoning and benchmark numbers. Flagged as a possible follow-up (a request-body/jsonb size cap) rather than taken on unscoped here.

Every round: fixed, mutation-checked (line-index edit → new test goes red → revert), tests added, CI re-verified green before moving to the next.

## Test plan

- [x] `bun run --filter @pagespace/lib test -- sheet` — 747/747 pass (19 files)
- [x] `bun run --filter web test -- page-views/sheet` — 310/310 pass, including a new paste-corruption regression test in `clipboard.test.ts`
- [x] Mutation-checked every fix by line-index edit — each mutation drove the relevant new test(s) red, then reverted
- [x] `bunx tsc --noEmit` clean in both `packages/lib` and `apps/web`
- [x] Changelog updated (user-visible paste-corruption fix)
- [x] CI green on the final commit: Lint & TypeScript Check, Unit Tests, E2E

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SVgX1drFsmJmfAb8aEyQ5U

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Formula references now shift correctly during paste without altering quoted text.
  * Conditional formatting honors explicit data-bar minimums and applies consistently to blank cells within valid sheet ranges.
  * Saves avoid redundant conditional-format evaluation for improved performance.

* **Performance & Reliability**
  * Conditional formatting is capped at 200 rules and 2,000,000 evaluated cells per sheet to prevent excessive processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
