### PR TITLE
Backfill mislabelled contentMode markdown pages (Phase B gate)

### DIFF
--- a/.pu-reports/pu-mp-contentmode-backfill.md
+++ b/.pu-reports/pu-mp-contentmode-backfill.md
@@ -65,27 +65,102 @@ boundary-heuristic failure case reproduced directly.
 included — a restored page is seeded like any other) is classified individually; a page that
 cannot be classified confidently is skipped and reported by id + error-type, never corrected.
 
-**Reversible.** Only `contentMode` changes — `content`, `revision`, `updatedAt` are untouched
-(`updatedAt` pinned to its prior value, so this reads as a label correction, not a user edit, in
-the UI or GDPR export). Every corrected page id is written to `--out <path>` as a JSON array;
-`--revert <path>` reads that file back and flips exactly those ids to `'html'` again, guarded so a
-page a user has since re-saved through the real markdown migration (i.e. no longer `'markdown'`)
-is left alone rather than forced.
+**Reversible.** `content` is never touched. `contentMode` flips, `updatedAt` is pinned to its prior
+value (so this reads as a label correction, not a user edit, in the UI or GDPR export), and
+`revision` is bumped by 1 on every write (see "Review round" below for why). Every corrected page
+is written to `--out <path>` as `{ id, revisionAfterApply }` objects, **incrementally after each
+batch commits**; `--revert <path>` reads that file back and flips exactly those pages to `'html'`
+again, requiring both `contentMode='markdown'` AND the exact recorded `revisionAfterApply` — a page
+genuinely edited since (through the real markdown migration or otherwise; every ordinary save bumps
+`revision`) no longer matches and is reported as skipped rather than having that edit discarded.
 
 **Dry-run is the default.** `--apply` refuses to run without `--out <path>`, so the correction can
 never be un-reversible for want of a log. Compare-and-swap on the exact `content`/`contentMode`
 read guards every write against a page edited between the select and the write; a concurrently
 modified row is skipped and reported, never clobbered. Per-batch writes run concurrently
-(`Promise.all`, capped at the 200-row batch size); the revert path is one batched
-`UPDATE ... WHERE id = ANY(...) RETURNING id`.
+(`Promise.all`, capped at the 200-row batch size); the revert path is one batched UPDATE whose WHERE
+clause pins each id to its own expected revision (`or(and(id=X, revision=rX), and(id=Y,
+revision=rY), ...)` — a single `inArray` on ids alongside a separate `inArray` on revisions would
+cross-match any id against any revision in the list, not the specific pairing this guard needs).
 
 **Never prints document content.** Every log line is page ids, counts, and JS error *names* only.
 
-Tests: `apps/web/src/lib/editor/__tests__/content-mode-backfill.test.ts` (17 cases) — dry-run vs.
+Tests: `apps/web/src/lib/editor/__tests__/content-mode-backfill.test.ts` (22 cases) — dry-run vs.
 apply, correctly-labelled pages left alone, empty pages left alone, low-confidence classification
 skipped and reported, concurrent-modification skip, cursor pagination termination, updatedAt
-pinning, batched revert (including a mixed reverted/already-changed result and the empty-list
-no-op), and every `parseBackfillArgs` branch.
+pinning, the revision bump using a SQL increment expression (not a stale JS-side value),
+`onBatchCorrected` firing once per batch with only that batch's corrections (and never in dry-run,
+and never for a batch that corrected nothing), batched revert (including the per-row revision
+pairing, a mixed reverted/already-changed result, and the empty-list no-op), and every
+`parseBackfillArgs` branch.
+
+## Review round (CodeRabbit + Codex, PR #2511) — findings and what changed
+
+Both automated reviewers converged independently on the same two P1/Major findings, plus one more
+each. All were verified against the actual source (not taken on faith) before acting.
+
+1. **Increment `revision` when relabelling live pages (Codex, P1).** Verified: `applyPageMutation`
+   (the normal save path) never reads or writes `contentMode`, and a raw `contentMode` flip with no
+   revision bump leaves a client session that had the page open under the old mode with a still-valid
+   `expectedRevision`. Its next ordinary save would then land content under the label that no longer
+   matches what it actually wrote — recreating, in the opposite direction, the exact mismatch this
+   migration exists to fix. **Fix:** the apply write now also sets `revision = revision + 1` (a SQL
+   expression, not a stale read value, so it's correct even under concurrent writes). This forces
+   the existing `PageRevisionMismatchError` / 409 "modified elsewhere" path on that client's next
+   save — the codebase's already-established mechanism for exactly this class of staleness.
+
+   Considered and rejected: routing through `applyPageMutation` (as the existing
+   `convert-content-mode` API route does) to also get realtime broadcast and a `page_versions`
+   snapshot. Rejected because that route's job is a genuine content *conversion* (turndown/marked)
+   for a single page a user requested — running it here would mean creating ~3,003 broadcast events
+   and version-snapshot rows for a correction that changes zero bytes of content, and worse, its
+   markdown-mode conversion path feeds content through `marked.parse()` assuming real HTML input —
+   exactly the lossy path this whole backfill exists to avoid, since our population's content is
+   already raw markdown text. The revision bump alone eliminates the actual data-corruption risk
+   (silent wrong-mode writes); it does not eliminate a stale client needing to refresh, which Codex's
+   own alternative ("or require the backfill to run while writes are quiesced") already accepts as
+   within tolerance for a one-time migration.
+
+2. **Guard `--revert` against edits made after apply (Codex P1 + CodeRabbit Major).** Verified: the
+   original revert only checked `contentMode='markdown'`, so a page a user had genuinely edited
+   after the backfill (content changed, but `contentMode` legitimately stays `'markdown'`) would
+   still match and get forced back to `'html'`, discarding the edit and recreating the exact
+   mislabelling this PR fixes. **Fix:** solved by the same revision bump above — `--revert` now
+   requires the page to still be at the exact `revisionAfterApply` this run recorded, and any
+   ordinary save since (which always bumps revision) makes that page fail the guard and be reported
+   as skipped. (CodeRabbit's suggested alternative, a separate content-digest column, would add a
+   new persisted field for a check the existing revision counter already answers precisely.)
+
+3. **Persist the revert manifest incrementally, not only once at the end (Codex P1 + CodeRabbit
+   Major).** Verified: `--out` was written exactly once, after the entire run. A process killed
+   partway through a multi-thousand-row run would leave every already-committed correction with no
+   record to revert it by. **Fix:** `planAndApplyBackfill` gained an `onBatchCorrected` callback,
+   invoked after each batch's writes commit; the CLI wrapper appends to the manifest and rewrites
+   `--out` after every batch. This bounds exposure to at most one in-flight batch (200 rows) instead
+   of the whole run. Not implemented as a true write-ahead-log/transactional-audit-record (what
+   CodeRabbit's "Heavy lift" label suggests) — that is disproportionate engineering for a one-time,
+   human-operated migration script of this size; per-batch durability resolves the actual risk named
+   (an unrecoverable partial run) without it.
+
+4. **`HTML_ELEMENT_NAMES` was missing `search` (CodeRabbit Minor).** Verified empirically (not just
+   via the review's own citation): happy-dom parses `<search>` as a real `search`-tagged element
+   (confirmed with a throwaway probe script), and `search` was absent from the set, so
+   `<search>only content</search>` misclassified as `markdown-source` and would have relabelled a
+   genuinely-HTML page. **Fix:** added `search` to the set, plus a regression test asserting a bare
+   `<search>` element (no nested known element) classifies as `html`. Mutation-checked: removing it
+   again made the new test fail as expected.
+
+5. **Nitpick — rename `priorUpdatedAt` to `PRIOR_UPDATED_AT` (CodeRabbit Trivial).** Declined, with
+   evidence: the exact precedent this test's pattern was modeled on
+   (`scripts/__tests__/backfill-legacy-ciphertext-reencrypt.test.ts:100`) uses camelCase
+   `priorUpdatedAt` for the identical fixture; this repo's own style guide
+   (`.claude/rules/javascript/javascript.mdc`) states "Avoid ALL_CAPS for constants... there's no
+   need for a hard distinction between constants and variables"; and a scan of top-level `Date`
+   fixtures across `apps/web/src/**/__tests__/*.test.ts` shows a genuine mix of both conventions in
+   active use. No change made.
+
+All four substantive findings were fixed and mutation-checked (broke the mechanism, confirmed the
+relevant new/updated test went red, restored, confirmed green). See "Mutation checks" below.
 
 ## 3. Re-running markdown construct detection at the corrected population
 
@@ -122,6 +197,20 @@ restored, confirmed green again.
   predicates → 3 tests failed (all three `revertBackfill` result-shape tests) → restored, 17 tests
   green.
 
+Review-round fixes, each mutation-checked the same way:
+
+- `document-content-format.ts`: removed `search` from `HTML_ELEMENT_NAMES` → the new `<search>`
+  regression test failed as expected → restored, 8 tests green.
+- `content-mode-backfill.ts`, revert per-row guard: dropped the revision pairing from the `or(...)`
+  branches (`or(...corrections.map(c => eq(pages.id, c.id)))`, i.e. matching on id alone) → the new
+  "builds the WHERE clause as a per-row pairing" test failed as expected → restored, 21 tests green.
+- `content-mode-backfill.ts`, `onBatchCorrected` guard: dropped the `batchCorrected.length > 0`
+  check before invoking the callback → initially passed against the existing test (which used a page
+  that was never mislabelled at all, so the guarded branch was never reached) — caught as a gap in
+  my own test, not the code; added a second case (a mislabelled page whose write loses the
+  compare-and-swap, so `batchCorrected` stays empty even though the batch had mislabelled pages) →
+  the mutation now correctly fails that test → restored, 22 tests green.
+
 ## Gates
 
 Worktree was rebuilt clean before gating (`bun install`; `@pagespace/db` and `@pagespace/lib` dist
@@ -148,6 +237,12 @@ builds; `apps/web` prod build) per repo convention.
   - `apps/web`: **1,253/1,254 files, 19,263/19,269 tests** (1 file/6 tests skipped, pre-existing,
     unrelated).
   - None of the excluded/skipped tests touch this diff's files.
+- Review-round fixes were re-gated after every change: `bun run typecheck` (root, forced past a
+  stale turbo cache) 17/17, `bun run lint` 15/15, `bun run knip:check` within baseline, and the full
+  `apps/web` test suite re-run clean (this round's changes are scoped entirely to
+  `apps/web/src/lib/editor/` and `apps/web/scripts/`, so a full `apps/web` run is the right-sized
+  re-verification rather than repeating the full isolated-Postgres monorepo run for an untouched
+  set of packages).
 
 ## What command to run against production
 
@@ -157,10 +252,12 @@ builds; `apps/web` prod build) per repo convention.
 # 1. Dry run first. Sanity-check the reported count against the census's 3,003.
 cd apps/web && bun run backfill:content-mode
 
-# 2. Apply, with the ids log kept somewhere durable.
+# 2. Apply, with the ids log kept somewhere durable. The file is written
+#    incrementally as each batch commits, not just once at the end.
 bun run backfill:content-mode -- --apply --out mislabelled-content-mode-backfill-<date>.json
 
-# Revert path, if ever needed:
+# Revert path, if ever needed — flips back only pages still at the exact
+# revision the apply run left them at (an edit since is left alone):
 bun run backfill:content-mode -- --revert mislabelled-content-mode-backfill-<date>.json
 ```
 

--- a/.pu-reports/pu-mp-contentmode-backfill.md
+++ b/.pu-reports/pu-mp-contentmode-backfill.md
@@ -1,0 +1,185 @@
+# Backfill the 3,003 mislabelled markdown documents
+
+Branch: `pu/mp-contentmode-backfill` · Board task: `sdnmolb83k4h2u04009r9kt0`
+
+## What this is
+
+`pages.contentMode='html'` claims a page is HTML. The collab content census measured 3,003
+DOCUMENT pages (of 3,488 non-empty html-mode pages) that parse to **zero real HTML elements** —
+they hold markdown source under the wrong label. `htmlToYDoc` on markdown source succeeds without
+throwing and returns one paragraph of raw markdown as literal text: every heading, list, code
+fence and table is destroyed, permanently, the moment that content is seeded into a Y.Doc. This is
+the hard gate on Phase E (seeding) that the epic named.
+
+This PR ships the classifier and the backfill script. **It does not run the backfill against
+production** — see "What to run" below.
+
+## 1. The classifier
+
+`apps/web/src/lib/editor/document-content-format.ts` — `classifyDocumentContent(content,
+workspace)` classifies stored content as `'empty' | 'html' | 'markdown-source' | 'unknown'`
+(confidence-gated) **by parsing the content**, never by trusting `contentMode`.
+
+**`detectPageContentFormat` (packages/lib) was evaluated and not reused.** It decides `html` from
+a boundary heuristic (`trimmed.startsWith('<') && trimmed.endsWith('>')`) with no DOM parse and no
+markdown category. `# heading\n\nsome text ending in >` satisfies that heuristic and would be
+misclassified `html` despite containing zero real elements — exactly the failure mode this backfill
+exists to catch. It remains correct for its own callers (diffing/version-snapshot format detection
+across html/json/tiptap/text), where a wrong markdown-vs-text guess has no data-loss consequence;
+nothing about it was changed.
+
+Instead, the classifier parses content with the same DOM-inspection method the collab content
+census used to measure the 3,003-page population — the only method proven against production data
+(`hasRealHtmlElement`, moved out of `census/constructs.ts` into this permanent module together with
+`HTML_ELEMENT_NAMES`/`UNESCAPED_ANGLE_BRACKET_KEY`, since the census itself is TEMPORARY BY DESIGN
+and slated for deletion once `COLLAB_SCHEMA_VERSION` v1 freezes — a future Phase E seed-guard needs
+to keep importing this classifier after that deletion). `census/constructs.ts` keeps its own richer
+`DomWorkspace` (needed for its round-trip diffing) and imports only the two shared primitives.
+
+A parse failure classifies as `{ confident: false }` rather than guessing — callers must skip and
+report these, never act on them.
+
+Tests: `apps/web/src/lib/editor/__tests__/document-content-format.test.ts` (7 cases), including the
+exact trap (`ActionResult<void>` in prose must not read as HTML) and the `detectPageContentFormat`
+boundary-heuristic failure case reproduced directly.
+
+## 2. The backfill script
+
+`apps/web/scripts/backfill-mislabelled-content-mode.ts` (thin CLI wrapper) +
+`apps/web/src/lib/editor/content-mode-backfill.ts` (testable core, same script/core split as
+`collab-content-census.ts` vs. `census/`).
+
+**Choice recorded: corrects the LABEL, never the content.** `contentMode` is flipped to
+`'markdown'`; the markdown source itself is never touched or converted to HTML. Two reasons:
+
+1. Converting would run the exact lossy markdown-through-an-HTML-parser path the census exists to
+   warn about — it succeeds without throwing and comes back as prose, which is the whole trap.
+   Relabelling makes zero content changes, so there is nothing to verify per page beyond the
+   classification itself.
+2. Phase K already scopes a dedicated markdown migration onto the real editing surface once the
+   schema freezes. Relabelling is what puts these 3,003 pages into that correctly-scoped
+   population, matching the plan's own framing ("Phase K's real population is roughly four times
+   the label count").
+
+**Verification per page, not aggregate.** Every `contentMode='html'` DOCUMENT page (trashed
+included — a restored page is seeded like any other) is classified individually; a page that
+cannot be classified confidently is skipped and reported by id + error-type, never corrected.
+
+**Reversible.** Only `contentMode` changes — `content`, `revision`, `updatedAt` are untouched
+(`updatedAt` pinned to its prior value, so this reads as a label correction, not a user edit, in
+the UI or GDPR export). Every corrected page id is written to `--out <path>` as a JSON array;
+`--revert <path>` reads that file back and flips exactly those ids to `'html'` again, guarded so a
+page a user has since re-saved through the real markdown migration (i.e. no longer `'markdown'`)
+is left alone rather than forced.
+
+**Dry-run is the default.** `--apply` refuses to run without `--out <path>`, so the correction can
+never be un-reversible for want of a log. Compare-and-swap on the exact `content`/`contentMode`
+read guards every write against a page edited between the select and the write; a concurrently
+modified row is skipped and reported, never clobbered. Per-batch writes run concurrently
+(`Promise.all`, capped at the 200-row batch size); the revert path is one batched
+`UPDATE ... WHERE id = ANY(...) RETURNING id`.
+
+**Never prints document content.** Every log line is page ids, counts, and JS error *names* only.
+
+Tests: `apps/web/src/lib/editor/__tests__/content-mode-backfill.test.ts` (17 cases) — dry-run vs.
+apply, correctly-labelled pages left alone, empty pages left alone, low-confidence classification
+skipped and reported, concurrent-modification skip, cursor pagination termination, updatedAt
+pinning, batched revert (including a mixed reverted/already-changed result and the empty-list
+no-op), and every `parseBackfillArgs` branch.
+
+## 3. Re-running markdown construct detection at the corrected population
+
+**Not done in this PR.** The leaf's acceptance criteria (per the task page) scope this PR to the
+classifier + backfill script; re-running `collab-content-census.ts`'s markdown-construct detection
+across the corrected ~4,000-page population is a follow-up run against production, using the
+already-existing census script, once this backfill has actually executed. Flagging this explicitly
+rather than silently narrowing scope.
+
+## 4. Phase E hard-precondition guard — not yet wired, and correctly so
+
+The task page's requirement ("a seed that encounters markdown source in an html-mode page must
+refuse, not proceed") describes a precondition Phase E's seed code must enforce. **Phase E doesn't
+exist in the codebase yet** (per the plan: "Then the schema construction leaves... in the recorded
+Phase B order" — schema freeze and Phase E are both still ahead). There is no seed function to gate.
+What this PR does instead: places the classifier in a permanent module
+(`document-content-format.ts`) specifically so that when Phase E's seed path is built, it imports
+`classifyDocumentContent` from here and refuses on `'markdown-source'`/`'unknown'` results — the
+guard's *mechanism* exists now; its *call site* doesn't exist to wire it into yet.
+
+## Mutation checks
+
+Every test file was mutation-checked: broke the mechanism, confirmed the relevant tests went red,
+restored, confirmed green again.
+
+- `document-content-format.ts`: `hasRealHtmlElement`'s tag-match branch flipped to always return
+  `false` → 4 tests failed (`classifies real HTML markup as html`, `classifies markdown embedding
+  real raw HTML as html`, plus the corresponding backfill-core tests that depend on real HTML being
+  recognized) → restored, 22 tests green.
+- `content-mode-backfill.ts`, concurrent-modification path: made the `rowCount === 0` branch push
+  to `corrected` instead of `skippedConcurrentModification` → 1 test failed (`a row modified
+  concurrently between select and write is skipped, not clobbered`) → restored, 17 tests green.
+- `content-mode-backfill.ts`, batched revert: swapped `reverted`/`skippedAlreadyChanged` filter
+  predicates → 3 tests failed (all three `revertBackfill` result-shape tests) → restored, 17 tests
+  green.
+
+## Gates
+
+Worktree was rebuilt clean before gating (`bun install`; `@pagespace/db` and `@pagespace/lib` dist
+builds; `apps/web` prod build) per repo convention.
+
+- `bun run typecheck` (monorepo root): **17/17 tasks successful.**
+- `bun run lint` (monorepo root): **15/15 tasks successful** (only pre-existing warnings unrelated
+  to this diff).
+- `bun run knip:check`: **within baseline** (4/4, no new issues).
+- Full test suite, run against a dedicated isolated Postgres (the fixed-name shared test container
+  used by `scripts/test-with-db.sh` is shared across every concurrent worktree/session on this
+  machine and was being torn down and rebuilt mid-run by other sessions throughout — chasing that
+  down cost real time before it was conclusively ruled unrelated to this diff):
+  - `packages/db`: **45/45 files, 664/664 tests.**
+  - `packages/lib`: **494/495 files, 11,264/11,264 tests** — the one excluded file
+    (`gdpr-eraser.integration.test.ts`) is self-documented as requiring a **separate, dedicated
+    scratch Postgres** (never the app DB) via `ADMIN_DATABASE_URL`; CI provisions that, this
+    verification run did not.
+  - `apps/processor`: **66/69 files, 1,163/1,163 tests** — the 3 excluded files need the same
+    separate `ADMIN_DATABASE_URL` scratch DB (one of them literally names its own throwaway
+    database, `pagespace_main_siem_it` — this is also what explains the stray scratch databases
+    observed sitting in the shared container).
+  - `apps/realtime`: **33/33 files, 1,146/1,146 tests.**
+  - `apps/web`: **1,253/1,254 files, 19,263/19,269 tests** (1 file/6 tests skipped, pre-existing,
+    unrelated).
+  - None of the excluded/skipped tests touch this diff's files.
+
+## What command to run against production
+
+**Do not run this yourself — the orchestrator holds the production credential.**
+
+```bash
+# 1. Dry run first. Sanity-check the reported count against the census's 3,003.
+cd apps/web && bun run backfill:content-mode
+
+# 2. Apply, with the ids log kept somewhere durable.
+bun run backfill:content-mode -- --apply --out mislabelled-content-mode-backfill-<date>.json
+
+# Revert path, if ever needed:
+bun run backfill:content-mode -- --revert mislabelled-content-mode-backfill-<date>.json
+```
+
+## Files changed
+
+- `apps/web/src/lib/editor/document-content-format.ts` (new) — the classifier.
+- `apps/web/src/lib/editor/content-mode-backfill.ts` (new) — the backfill's testable core.
+- `apps/web/scripts/backfill-mislabelled-content-mode.ts` (new) — CLI entry point.
+- `apps/web/src/lib/editor/__tests__/document-content-format.test.ts` (new).
+- `apps/web/src/lib/editor/__tests__/content-mode-backfill.test.ts` (new).
+- `apps/web/src/lib/editor/census/constructs.ts` — refactored to import
+  `HTML_ELEMENT_NAMES`/`UNESCAPED_ANGLE_BRACKET_KEY` from the new permanent module instead of
+  owning a second copy; its own richer `DomWorkspace`/`createDomWorkspace` (needed for round-trip
+  diffing) is unchanged and stays local. All 7 existing census test files still pass unmodified
+  (131 tests).
+- `apps/web/package.json` — added `backfill:content-mode` script.
+
+## Board status
+
+Leaving task `sdnmolb83k4h2u04009r9kt0` `in_progress` — it completes on merge, which is the
+orchestrator's call, per instructions. (Also noting: PageSpace MCP tools are not connected in this
+`pu` worktree session, so I could not read/write the board directly from here regardless.)

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -10,6 +10,7 @@
     "typecheck": "tsc --noEmit",
     "prepare": "next-ws patch --yes",
     "census": "bun --tsconfig-override scripts/tsconfig.census.json scripts/collab-content-census.ts",
+    "backfill:content-mode": "bun scripts/backfill-mislabelled-content-mode.ts",
     "test": "vitest run",
     "test:coverage": "vitest run --coverage"
   },

--- a/apps/web/scripts/backfill-mislabelled-content-mode.ts
+++ b/apps/web/scripts/backfill-mislabelled-content-mode.ts
@@ -1,0 +1,142 @@
+/**
+ * Backfill: correct `contentMode` for DOCUMENT pages storing markdown source
+ * under `contentMode='html'` (multiplayer epic, Phase B gate).
+ *
+ * The collab content census (`collab-content-census.ts`) measured 3,003 such
+ * pages against production: they begin `# `, their HTML tag histogram is
+ * empty, and `contentMode` says `html` anyway. `htmlToYDoc` on markdown
+ * source yields ONE paragraph containing the raw markdown as literal text —
+ * every heading, list, code fence and table collapses into prose. Today that
+ * is a rendering bug you can still fix by correcting the column; once it is a
+ * Y.Doc it IS the document, permanently. This script is the fix, and it is a
+ * hard gate on Phase E (seeding): nothing may seed a Y.Doc from one of these
+ * pages until the label is correct.
+ *
+ * CHOICE RECORDED: this backfill corrects the LABEL (`contentMode` ->
+ * 'markdown'), never the content. It does not convert the markdown source to
+ * HTML. Two reasons:
+ *   1. Converting would run the exact lossy markdown-through-an-HTML-parser
+ *      path the census exists to warn about — the trap is that it succeeds
+ *      without throwing and comes back as prose. Relabelling makes zero
+ *      content changes, so there is nothing to verify per page beyond the
+ *      classification itself.
+ *   2. Phase K already scopes a dedicated markdown migration onto the real
+ *      editing surface once `COLLAB_SCHEMA_VERSION` v1 is frozen. Relabelling
+ *      is what puts these 3,003 pages into that correctly-scoped population
+ *      instead of quietly resizing it after the fact.
+ *
+ * Classification is by content inspection (`classifyDocumentContent`, in
+ * `../src/lib/editor/document-content-format.ts`), never by trusting
+ * `contentMode` — see that module for why `detectPageContentFormat` in
+ * packages/lib was not reused. A page that cannot be parsed confidently is
+ * skipped and reported, never guessed at.
+ *
+ * NEVER PRINTS DOCUMENT CONTENT. Page ids and counts only, matching the
+ * census's own rule — this runs against production user data.
+ *
+ * Reversible: only `contentMode` changes, `content`/`revision`/`updatedAt`
+ * are untouched (updatedAt is pinned to its prior value so this correction
+ * does not read as a user edit in the UI or GDPR export). Every corrected
+ * page id is written to `--out <path>` as a JSON array, and `--revert <path>`
+ * reads that file back and flips exactly those ids to 'html' again (guarded:
+ * only pages still `contentMode='markdown'` are touched, so a page a user
+ * has since re-saved through the real markdown migration is left alone).
+ *
+ * Dry-run is the default and only reports counts + ids; `--apply` requires
+ * `--out <path>` so the correction is never un-reversible for want of a log.
+ *
+ * Usage:
+ *   bun scripts/backfill-mislabelled-content-mode.ts                         # dry run (default, safe)
+ *   bun scripts/backfill-mislabelled-content-mode.ts --apply --out ids.json  # live write
+ *   bun scripts/backfill-mislabelled-content-mode.ts --revert ids.json       # undo a prior --apply
+ *
+ * Lives under apps/web/scripts/ (not repo-root scripts/) for the same reason
+ * collab-content-census.ts does: the classifier needs apps/web's happy-dom
+ * dependency, which the root workspace cannot resolve.
+ *
+ * Its testable logic (`planAndApplyBackfill`, `revertBackfill`,
+ * `parseBackfillArgs`) lives in `../src/lib/editor/content-mode-backfill.ts`
+ * so it runs under apps/web's ordinary vitest config — this file is a thin
+ * argv/stdout/file-IO wrapper, untested itself, same split
+ * collab-content-census.ts uses against src/lib/editor/census/.
+ *
+ * DO NOT run this against production yourself — the orchestrator holds the
+ * production credential. Dry-run against production first, sanity-check the
+ * reported count against the census's 3,003, then --apply with --out set to
+ * a path that will actually be kept.
+ */
+
+import { readFile, writeFile } from 'node:fs/promises';
+import { getMigrationDb, getMigrationPool } from '@pagespace/db/db';
+import {
+  parseBackfillArgs,
+  planAndApplyBackfill,
+  revertBackfill,
+} from '../src/lib/editor/content-mode-backfill';
+
+async function main(): Promise<void> {
+  const parsed = parseBackfillArgs(process.argv.slice(2));
+  if (!parsed.ok) {
+    console.error(`❌ ${parsed.error}`);
+    process.exit(1);
+  }
+
+  const db = getMigrationDb();
+  const { args } = parsed;
+
+  try {
+    if (args.mode === 'revert') {
+      const raw: unknown = JSON.parse(await readFile(args.revertPath!, 'utf8'));
+      if (!Array.isArray(raw) || !raw.every((id) => typeof id === 'string')) {
+        throw new Error(`${args.revertPath} must contain a JSON array of page id strings`);
+      }
+      const result = await revertBackfill(db, raw);
+      console.log(
+        `Revert complete. attempted: ${result.attempted}, reverted: ${result.reverted.length}, ` +
+          `already changed since (skipped): ${result.skippedAlreadyChanged.length}`,
+      );
+      if (result.skippedAlreadyChanged.length > 0) {
+        console.log(`  skipped ids: ${result.skippedAlreadyChanged.join(' ')}`);
+      }
+      return;
+    }
+
+    const apply = args.mode === 'apply';
+    console.log(`${apply ? '' : '[DRY RUN] '}Scanning contentMode='html' DOCUMENT pages...`);
+    const summary = await planAndApplyBackfill(db, { apply });
+
+    console.log(
+      `${apply ? 'Corrected' : 'Would correct'}: ${summary.corrected.length} of ${summary.scanned} scanned. ` +
+        `Skipped (unparseable): ${summary.skippedUnparseable.length}. ` +
+        `Skipped (concurrent modification): ${summary.skippedConcurrentModification.length}.`,
+    );
+    if (summary.corrected.length > 0) {
+      console.log(`  page ids: ${summary.corrected.join(' ')}`);
+    }
+    if (summary.skippedUnparseable.length > 0) {
+      console.log(
+        `  unparseable page ids: ${summary.skippedUnparseable.map((s) => `${s.id}(${s.reason})`).join(' ')}`,
+      );
+    }
+    if (summary.skippedConcurrentModification.length > 0) {
+      console.log(`  concurrently-modified page ids: ${summary.skippedConcurrentModification.join(' ')}`);
+    }
+
+    if (apply) {
+      await writeFile(args.outPath!, JSON.stringify(summary.corrected, null, 2));
+      console.log(`Wrote ${summary.corrected.length} corrected page ids to ${args.outPath} — keep this to revert.`);
+    }
+  } finally {
+    await getMigrationPool().end();
+  }
+}
+
+// No import.meta.main guard: nothing imports this file (it is a CLI entry
+// point, same as collab-content-census.ts), and import.meta.main is a Bun-ism
+// the tsconfig ImportMeta type here doesn't declare.
+try {
+  await main();
+} catch (err) {
+  console.error('❌ Backfill failed:', err);
+  process.exit(1);
+}

--- a/apps/web/scripts/backfill-mislabelled-content-mode.ts
+++ b/apps/web/scripts/backfill-mislabelled-content-mode.ts
@@ -34,21 +34,32 @@
  * NEVER PRINTS DOCUMENT CONTENT. Page ids and counts only, matching the
  * census's own rule — this runs against production user data.
  *
- * Reversible: only `contentMode` changes, `content`/`revision`/`updatedAt`
- * are untouched (updatedAt is pinned to its prior value so this correction
- * does not read as a user edit in the UI or GDPR export). Every corrected
- * page id is written to `--out <path>` as a JSON array, and `--revert <path>`
- * reads that file back and flips exactly those ids to 'html' again (guarded:
- * only pages still `contentMode='markdown'` are touched, so a page a user
- * has since re-saved through the real markdown migration is left alone).
+ * Reversible: `content` is never touched. `contentMode` flips, `updatedAt` is
+ * pinned to its prior value (so this reads as a label correction, not a user
+ * edit, in the UI or GDPR export), and `revision` is bumped by 1 — a page
+ * open in an editor session before the backfill ran still holds the OLD
+ * `expectedRevision`, so its next ordinary save now gets the existing 409
+ * "modified elsewhere" path instead of silently landing HTML content under
+ * the now-corrected `contentMode='markdown'` label (see PR #2511 review).
+ *
+ * Every corrected page is written to `--out <path>` as a JSON array of
+ * `{ id, revisionAfterApply }`, **incrementally after each batch commits**
+ * (not only once at the end) — a process killed partway through a
+ * multi-thousand-row run still leaves a manifest covering everything already
+ * committed. `--revert <path>` reads that file back and flips exactly those
+ * pages to `'html'` again, requiring BOTH `contentMode='markdown'` AND the
+ * exact `revisionAfterApply` this run recorded: `applyPageMutation` bumps
+ * `revision` on every ordinary save, so a page a user has genuinely edited
+ * since (through the real markdown migration or otherwise) no longer matches
+ * and is reported as skipped rather than having that edit discarded.
  *
  * Dry-run is the default and only reports counts + ids; `--apply` requires
  * `--out <path>` so the correction is never un-reversible for want of a log.
  *
  * Usage:
- *   bun scripts/backfill-mislabelled-content-mode.ts                         # dry run (default, safe)
- *   bun scripts/backfill-mislabelled-content-mode.ts --apply --out ids.json  # live write
- *   bun scripts/backfill-mislabelled-content-mode.ts --revert ids.json       # undo a prior --apply
+ *   bun scripts/backfill-mislabelled-content-mode.ts                            # dry run (default, safe)
+ *   bun scripts/backfill-mislabelled-content-mode.ts --apply --out backfill.json # live write
+ *   bun scripts/backfill-mislabelled-content-mode.ts --revert backfill.json      # undo a prior --apply
  *
  * Lives under apps/web/scripts/ (not repo-root scripts/) for the same reason
  * collab-content-census.ts does: the classifier needs apps/web's happy-dom
@@ -72,7 +83,21 @@ import {
   parseBackfillArgs,
   planAndApplyBackfill,
   revertBackfill,
+  type CorrectedPage,
 } from '../src/lib/editor/content-mode-backfill';
+
+function isCorrectedPageArray(value: unknown): value is CorrectedPage[] {
+  return (
+    Array.isArray(value) &&
+    value.every(
+      (entry) =>
+        entry !== null &&
+        typeof entry === 'object' &&
+        typeof (entry as CorrectedPage).id === 'string' &&
+        typeof (entry as CorrectedPage).revisionAfterApply === 'number',
+    )
+  );
+}
 
 async function main(): Promise<void> {
   const parsed = parseBackfillArgs(process.argv.slice(2));
@@ -87,8 +112,8 @@ async function main(): Promise<void> {
   try {
     if (args.mode === 'revert') {
       const raw: unknown = JSON.parse(await readFile(args.revertPath!, 'utf8'));
-      if (!Array.isArray(raw) || !raw.every((id) => typeof id === 'string')) {
-        throw new Error(`${args.revertPath} must contain a JSON array of page id strings`);
+      if (!isCorrectedPageArray(raw)) {
+        throw new Error(`${args.revertPath} must contain a JSON array of { id, revisionAfterApply } objects`);
       }
       const result = await revertBackfill(db, raw);
       console.log(
@@ -103,7 +128,21 @@ async function main(): Promise<void> {
 
     const apply = args.mode === 'apply';
     console.log(`${apply ? '' : '[DRY RUN] '}Scanning contentMode='html' DOCUMENT pages...`);
-    const summary = await planAndApplyBackfill(db, { apply });
+
+    // Rewritten after every batch commits (apply mode only), so the file on
+    // disk is always a true, current record of what has actually been
+    // corrected — a crash mid-run loses at most the in-flight batch, never
+    // the whole run's manifest.
+    const manifest: CorrectedPage[] = [];
+    const summary = await planAndApplyBackfill(db, {
+      apply,
+      onBatchCorrected: apply
+        ? async (batchCorrected) => {
+            manifest.push(...batchCorrected);
+            await writeFile(args.outPath!, JSON.stringify(manifest, null, 2));
+          }
+        : undefined,
+    });
 
     console.log(
       `${apply ? 'Corrected' : 'Would correct'}: ${summary.corrected.length} of ${summary.scanned} scanned. ` +
@@ -111,7 +150,7 @@ async function main(): Promise<void> {
         `Skipped (concurrent modification): ${summary.skippedConcurrentModification.length}.`,
     );
     if (summary.corrected.length > 0) {
-      console.log(`  page ids: ${summary.corrected.join(' ')}`);
+      console.log(`  page ids: ${summary.corrected.map((c) => c.id).join(' ')}`);
     }
     if (summary.skippedUnparseable.length > 0) {
       console.log(
@@ -123,8 +162,7 @@ async function main(): Promise<void> {
     }
 
     if (apply) {
-      await writeFile(args.outPath!, JSON.stringify(summary.corrected, null, 2));
-      console.log(`Wrote ${summary.corrected.length} corrected page ids to ${args.outPath} — keep this to revert.`);
+      console.log(`Wrote ${manifest.length} corrected page ids to ${args.outPath} — keep this to revert.`);
     }
   } finally {
     await getMigrationPool().end();

--- a/apps/web/src/lib/editor/__tests__/content-mode-backfill.test.ts
+++ b/apps/web/src/lib/editor/__tests__/content-mode-backfill.test.ts
@@ -1,0 +1,253 @@
+/**
+ * Tests for the mislabelled-`contentMode` backfill's imperative shell.
+ * Classification itself is unit-tested in document-content-format.test.ts;
+ * here we verify the runner's loop: dry-run writes nothing, apply corrects
+ * only tagless html-mode pages, a page that fails to classify confidently is
+ * skipped and reported rather than guessed at, a concurrently-modified row
+ * is skipped rather than clobbered, pagination advances and terminates,
+ * updatedAt is pinned, and revert flips exactly the given ids back.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const { gtCursors, classifyMock } = vi.hoisted(() => ({
+  gtCursors: [] as unknown[],
+  classifyMock: vi.fn(),
+}));
+
+vi.mock('@pagespace/db/schema/core', () => ({
+  pages: { id: 'id', type: 'type', content: 'content', contentMode: 'contentMode', updatedAt: 'updatedAt' },
+}));
+vi.mock('@pagespace/db/operators', () => ({
+  eq: (col: unknown, value: unknown) => ({ eq: [col, value] }),
+  gt: (_col: unknown, cursor: unknown) => {
+    gtCursors.push(cursor);
+    return {};
+  },
+  asc: () => ({}),
+  and: (...conds: unknown[]) => ({ and: conds }),
+  inArray: (col: unknown, values: unknown) => ({ inArray: [col, values] }),
+}));
+vi.mock('../document-content-format', async () => {
+  const actual = await vi.importActual<typeof import('../document-content-format')>('../document-content-format');
+  // Delegate to the real classifier by default; individual tests override
+  // with mockReturnValueOnce. Wired here (not in a beforeEach) so nothing in
+  // the test file needs its own reference to the real, unmocked function.
+  classifyMock.mockImplementation(actual.classifyDocumentContent);
+  return { ...actual, classifyDocumentContent: classifyMock };
+});
+
+import {
+  planAndApplyBackfill,
+  revertBackfill,
+  parseBackfillArgs,
+  type BackfillDb,
+} from '../content-mode-backfill';
+
+/** Chainable select stub terminating on .limit(); returns successive batches. */
+function selectReturning(batches: unknown[][]) {
+  let call = 0;
+  return vi.fn(() => {
+    const rows = batches[call] ?? [];
+    call += 1;
+    const stub: Record<string, unknown> = {};
+    for (const m of ['from', 'where', 'orderBy']) stub[m] = () => stub;
+    stub['limit'] = () => Promise.resolve(rows);
+    return stub;
+  });
+}
+
+function captureUpdate({ rowCount = 1 }: { rowCount?: number } = {}) {
+  const sets: Array<Record<string, unknown>> = [];
+  const update = vi.fn(() => ({
+    set: (v: Record<string, unknown>) => {
+      sets.push(v);
+      return { where: () => Promise.resolve({ rowCount }) };
+    },
+  }));
+  return { update, sets };
+}
+
+function fakeDb(select: ReturnType<typeof selectReturning>, update: ReturnType<typeof captureUpdate>['update']) {
+  return { select, update } as unknown as BackfillDb;
+}
+
+const priorUpdatedAt = new Date('2026-01-15T12:00:00Z');
+const markdownPage = (id: string) => ({
+  id,
+  content: '# Heading\n\nSome *emphasis* and a list:\n\n- one\n- two',
+  contentMode: 'html' as const,
+  updatedAt: priorUpdatedAt,
+});
+const htmlPage = (id: string) => ({
+  id,
+  content: '<p>real <strong>html</strong></p>',
+  contentMode: 'html' as const,
+  updatedAt: priorUpdatedAt,
+});
+const emptyPage = (id: string) => ({ id, content: '   ', contentMode: 'html' as const, updatedAt: priorUpdatedAt });
+
+beforeEach(() => {
+  gtCursors.length = 0;
+});
+
+describe('planAndApplyBackfill', () => {
+  it('dry run: reports tagless html-mode pages as to-be-corrected and writes nothing', async () => {
+    const select = selectReturning([[markdownPage('p1'), htmlPage('p2'), emptyPage('p3')], []]);
+    const { update, sets } = captureUpdate();
+    const result = await planAndApplyBackfill(fakeDb(select, update), { apply: false });
+
+    expect(result).toEqual({
+      scanned: 3,
+      corrected: ['p1'],
+      skippedUnparseable: [],
+      skippedConcurrentModification: [],
+    });
+    expect(update).not.toHaveBeenCalled();
+    expect(sets).toHaveLength(0);
+  });
+
+  it('apply: corrects contentMode to markdown for a tagless page, pinning updatedAt, leaving content untouched', async () => {
+    const select = selectReturning([[markdownPage('p1')], []]);
+    const { update, sets } = captureUpdate();
+    const result = await planAndApplyBackfill(fakeDb(select, update), { apply: true });
+
+    expect(result.corrected).toEqual(['p1']);
+    expect(sets).toHaveLength(1);
+    expect(sets[0].contentMode).toBe('markdown');
+    expect(sets[0].updatedAt).toBe(priorUpdatedAt);
+    expect(sets[0].content).toBeUndefined();
+  });
+
+  it('leaves genuinely html-mode pages alone', async () => {
+    const select = selectReturning([[htmlPage('p1')], []]);
+    const { update } = captureUpdate();
+    const result = await planAndApplyBackfill(fakeDb(select, update), { apply: true });
+
+    expect(result).toEqual({ scanned: 1, corrected: [], skippedUnparseable: [], skippedConcurrentModification: [] });
+    expect(update).not.toHaveBeenCalled();
+  });
+
+  it('leaves empty pages alone', async () => {
+    const select = selectReturning([[emptyPage('p1')], []]);
+    const { update } = captureUpdate();
+    const result = await planAndApplyBackfill(fakeDb(select, update), { apply: true });
+
+    expect(result.corrected).toEqual([]);
+    expect(update).not.toHaveBeenCalled();
+  });
+
+  it('a page that cannot be classified confidently is skipped and reported, never guessed at', async () => {
+    classifyMock.mockReturnValueOnce({ format: 'unknown', confident: false, reason: 'RangeError' });
+    const select = selectReturning([[markdownPage('p1')], []]);
+    const { update } = captureUpdate();
+    const result = await planAndApplyBackfill(fakeDb(select, update), { apply: true });
+
+    expect(result).toEqual({
+      scanned: 1,
+      corrected: [],
+      skippedUnparseable: [{ id: 'p1', reason: 'RangeError' }],
+      skippedConcurrentModification: [],
+    });
+    expect(update).not.toHaveBeenCalled();
+  });
+
+  it('a row modified concurrently between select and write is skipped, not clobbered', async () => {
+    const select = selectReturning([[markdownPage('p1')], []]);
+    const { update } = captureUpdate({ rowCount: 0 });
+    const result = await planAndApplyBackfill(fakeDb(select, update), { apply: true });
+
+    expect(result).toEqual({
+      scanned: 1,
+      corrected: [],
+      skippedUnparseable: [],
+      skippedConcurrentModification: ['p1'],
+    });
+  });
+
+  it('paginates by advancing the ascending-id cursor to each batch\'s last id and terminates', async () => {
+    const select = selectReturning([[markdownPage('p1')], [markdownPage('p2')], []]);
+    const { update, sets } = captureUpdate();
+    const result = await planAndApplyBackfill(fakeDb(select, update), { apply: true, batchSize: 1 });
+
+    expect(result.corrected).toEqual(['p1', 'p2']);
+    expect(sets).toHaveLength(2);
+    expect(select).toHaveBeenCalledTimes(3);
+    expect(gtCursors).toEqual(['p1', 'p2']);
+  });
+});
+
+/** Batched update stub: `.returning()` resolves with the rows the WHERE clause matched. */
+function captureBatchedUpdate(returnedIds: string[]) {
+  const sets: Array<Record<string, unknown>> = [];
+  const update = vi.fn(() => ({
+    set: (v: Record<string, unknown>) => {
+      sets.push(v);
+      return { where: () => ({ returning: () => Promise.resolve(returnedIds.map((id) => ({ id }))) }) };
+    },
+  }));
+  return { update, sets };
+}
+
+describe('revertBackfill', () => {
+  it('flips the given ids back to html when still markdown, in one batched update', async () => {
+    const { update } = captureBatchedUpdate(['p1', 'p2']);
+    const result = await revertBackfill({ update } as unknown as BackfillDb, ['p1', 'p2']);
+    expect(result).toEqual({ attempted: 2, reverted: ['p1', 'p2'], skippedAlreadyChanged: [] });
+    expect(update).toHaveBeenCalledTimes(1);
+  });
+
+  it('skips ids no longer contentMode=markdown rather than forcing them', async () => {
+    const { update } = captureBatchedUpdate([]);
+    const result = await revertBackfill({ update } as unknown as BackfillDb, ['p1']);
+    expect(result).toEqual({ attempted: 1, reverted: [], skippedAlreadyChanged: ['p1'] });
+  });
+
+  it('reports a mix of reverted and already-changed ids from one batch', async () => {
+    const { update } = captureBatchedUpdate(['p1']);
+    const result = await revertBackfill({ update } as unknown as BackfillDb, ['p1', 'p2']);
+    expect(result).toEqual({ attempted: 2, reverted: ['p1'], skippedAlreadyChanged: ['p2'] });
+  });
+
+  it('is a no-op for an empty id list, without querying the database', async () => {
+    const { update } = captureBatchedUpdate([]);
+    const result = await revertBackfill({ update } as unknown as BackfillDb, []);
+    expect(result).toEqual({ attempted: 0, reverted: [], skippedAlreadyChanged: [] });
+    expect(update).not.toHaveBeenCalled();
+  });
+});
+
+describe('parseBackfillArgs', () => {
+  it('defaults to dry-run', () => {
+    expect(parseBackfillArgs([])).toEqual({ ok: true, args: { mode: 'dry-run' } });
+  });
+
+  it('refuses --apply without --out: the correction must stay reversible', () => {
+    const result = parseBackfillArgs(['--apply']);
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.error).toContain('--out');
+  });
+
+  it('accepts --apply --out <path>', () => {
+    expect(parseBackfillArgs(['--apply', '--out', 'ids.json'])).toEqual({
+      ok: true,
+      args: { mode: 'apply', outPath: 'ids.json' },
+    });
+  });
+
+  it('accepts --revert <path>', () => {
+    expect(parseBackfillArgs(['--revert', 'ids.json'])).toEqual({
+      ok: true,
+      args: { mode: 'revert', revertPath: 'ids.json' },
+    });
+  });
+
+  it('refuses --revert without a path', () => {
+    const result = parseBackfillArgs(['--revert']);
+    expect(result.ok).toBe(false);
+  });
+
+  it('refuses --apply and --revert together', () => {
+    const result = parseBackfillArgs(['--apply', '--out', 'x.json', '--revert', 'y.json']);
+    expect(result.ok).toBe(false);
+  });
+});

--- a/apps/web/src/lib/editor/__tests__/content-mode-backfill.test.ts
+++ b/apps/web/src/lib/editor/__tests__/content-mode-backfill.test.ts
@@ -2,10 +2,12 @@
  * Tests for the mislabelled-`contentMode` backfill's imperative shell.
  * Classification itself is unit-tested in document-content-format.test.ts;
  * here we verify the runner's loop: dry-run writes nothing, apply corrects
- * only tagless html-mode pages, a page that fails to classify confidently is
- * skipped and reported rather than guessed at, a concurrently-modified row
- * is skipped rather than clobbered, pagination advances and terminates,
- * updatedAt is pinned, and revert flips exactly the given ids back.
+ * only tagless html-mode pages and bumps revision, a page that fails to
+ * classify confidently is skipped and reported rather than guessed at, a
+ * concurrently-modified row is skipped rather than clobbered, pagination
+ * advances and terminates, onBatchCorrected fires per batch in apply mode
+ * only, updatedAt is pinned, and revert flips exactly the given
+ * (id, revisionAfterApply) pairs back — never a page edited since.
  */
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 
@@ -15,7 +17,14 @@ const { gtCursors, classifyMock } = vi.hoisted(() => ({
 }));
 
 vi.mock('@pagespace/db/schema/core', () => ({
-  pages: { id: 'id', type: 'type', content: 'content', contentMode: 'contentMode', updatedAt: 'updatedAt' },
+  pages: {
+    id: 'id',
+    type: 'type',
+    content: 'content',
+    contentMode: 'contentMode',
+    updatedAt: 'updatedAt',
+    revision: 'revision',
+  },
 }));
 vi.mock('@pagespace/db/operators', () => ({
   eq: (col: unknown, value: unknown) => ({ eq: [col, value] }),
@@ -25,7 +34,8 @@ vi.mock('@pagespace/db/operators', () => ({
   },
   asc: () => ({}),
   and: (...conds: unknown[]) => ({ and: conds }),
-  inArray: (col: unknown, values: unknown) => ({ inArray: [col, values] }),
+  or: (...conds: unknown[]) => ({ or: conds }),
+  sql: (strings: TemplateStringsArray, ...values: unknown[]) => ({ __sql: true, strings, values }),
 }));
 vi.mock('../document-content-format', async () => {
   const actual = await vi.importActual<typeof import('../document-content-format')>('../document-content-format');
@@ -41,6 +51,7 @@ import {
   revertBackfill,
   parseBackfillArgs,
   type BackfillDb,
+  type CorrectedPage,
 } from '../content-mode-backfill';
 
 /** Chainable select stub terminating on .limit(); returns successive batches. */
@@ -56,12 +67,29 @@ function selectReturning(batches: unknown[][]) {
   });
 }
 
-function captureUpdate({ rowCount = 1 }: { rowCount?: number } = {}) {
+/**
+ * Chainable update stub for the apply-mode compare-and-swap: `.returning()`
+ * resolves with one row (a fresh, incrementing `revision`, proving the write
+ * used the SQL increment expression rather than a static value) when
+ * `succeeds`, or an empty array (the concurrent-modification case) when not.
+ * The row's `id` is read back out of the mocked `and(eq(pages.id, ...), ...)`
+ * WHERE condition so it always matches the page actually being updated.
+ */
+function captureUpdate({ succeeds = true }: { succeeds?: boolean } = {}) {
   const sets: Array<Record<string, unknown>> = [];
+  let revision = 100;
   const update = vi.fn(() => ({
     set: (v: Record<string, unknown>) => {
       sets.push(v);
-      return { where: () => Promise.resolve({ rowCount }) };
+      return {
+        where: (cond: { and: Array<{ eq: [unknown, unknown] }> }) => ({
+          returning: () => {
+            if (!succeeds) return Promise.resolve([]);
+            revision += 1;
+            return Promise.resolve([{ id: cond.and[0].eq[1], revision }]);
+          },
+        }),
+      };
     },
   }));
   return { update, sets };
@@ -72,33 +100,41 @@ function fakeDb(select: ReturnType<typeof selectReturning>, update: ReturnType<t
 }
 
 const priorUpdatedAt = new Date('2026-01-15T12:00:00Z');
-const markdownPage = (id: string) => ({
+const markdownPage = (id: string, revision = 5) => ({
   id,
   content: '# Heading\n\nSome *emphasis* and a list:\n\n- one\n- two',
   contentMode: 'html' as const,
   updatedAt: priorUpdatedAt,
+  revision,
 });
 const htmlPage = (id: string) => ({
   id,
   content: '<p>real <strong>html</strong></p>',
   contentMode: 'html' as const,
   updatedAt: priorUpdatedAt,
+  revision: 5,
 });
-const emptyPage = (id: string) => ({ id, content: '   ', contentMode: 'html' as const, updatedAt: priorUpdatedAt });
+const emptyPage = (id: string) => ({
+  id,
+  content: '   ',
+  contentMode: 'html' as const,
+  updatedAt: priorUpdatedAt,
+  revision: 5,
+});
 
 beforeEach(() => {
   gtCursors.length = 0;
 });
 
 describe('planAndApplyBackfill', () => {
-  it('dry run: reports tagless html-mode pages as to-be-corrected and writes nothing', async () => {
+  it('dry run: reports tagless html-mode pages as to-be-corrected (previewing the post-apply revision) and writes nothing', async () => {
     const select = selectReturning([[markdownPage('p1'), htmlPage('p2'), emptyPage('p3')], []]);
     const { update, sets } = captureUpdate();
     const result = await planAndApplyBackfill(fakeDb(select, update), { apply: false });
 
     expect(result).toEqual({
       scanned: 3,
-      corrected: ['p1'],
+      corrected: [{ id: 'p1', revisionAfterApply: 6 }],
       skippedUnparseable: [],
       skippedConcurrentModification: [],
     });
@@ -106,16 +142,17 @@ describe('planAndApplyBackfill', () => {
     expect(sets).toHaveLength(0);
   });
 
-  it('apply: corrects contentMode to markdown for a tagless page, pinning updatedAt, leaving content untouched', async () => {
+  it('apply: corrects contentMode to markdown for a tagless page, bumps revision via a SQL expression (not a static value), pins updatedAt, and leaves content untouched', async () => {
     const select = selectReturning([[markdownPage('p1')], []]);
     const { update, sets } = captureUpdate();
     const result = await planAndApplyBackfill(fakeDb(select, update), { apply: true });
 
-    expect(result.corrected).toEqual(['p1']);
+    expect(result.corrected).toEqual([{ id: 'p1', revisionAfterApply: 101 }]);
     expect(sets).toHaveLength(1);
     expect(sets[0].contentMode).toBe('markdown');
     expect(sets[0].updatedAt).toBe(priorUpdatedAt);
     expect(sets[0].content).toBeUndefined();
+    expect(sets[0].revision).toEqual(expect.objectContaining({ __sql: true }));
   });
 
   it('leaves genuinely html-mode pages alone', async () => {
@@ -153,7 +190,7 @@ describe('planAndApplyBackfill', () => {
 
   it('a row modified concurrently between select and write is skipped, not clobbered', async () => {
     const select = selectReturning([[markdownPage('p1')], []]);
-    const { update } = captureUpdate({ rowCount: 0 });
+    const { update } = captureUpdate({ succeeds: false });
     const result = await planAndApplyBackfill(fakeDb(select, update), { apply: true });
 
     expect(result).toEqual({
@@ -169,46 +206,124 @@ describe('planAndApplyBackfill', () => {
     const { update, sets } = captureUpdate();
     const result = await planAndApplyBackfill(fakeDb(select, update), { apply: true, batchSize: 1 });
 
-    expect(result.corrected).toEqual(['p1', 'p2']);
+    expect(result.corrected).toEqual([
+      { id: 'p1', revisionAfterApply: 101 },
+      { id: 'p2', revisionAfterApply: 102 },
+    ]);
     expect(sets).toHaveLength(2);
     expect(select).toHaveBeenCalledTimes(3);
     expect(gtCursors).toEqual(['p1', 'p2']);
   });
+
+  it('invokes onBatchCorrected once per batch, with only that batch\'s corrected pages, so a crash mid-run leaves a manifest of everything already committed', async () => {
+    const select = selectReturning([[markdownPage('p1')], [markdownPage('p2'), htmlPage('p3')], []]);
+    const { update } = captureUpdate();
+    const onBatchCorrected = vi.fn();
+    await planAndApplyBackfill(fakeDb(select, update), { apply: true, batchSize: 2, onBatchCorrected });
+
+    expect(onBatchCorrected).toHaveBeenCalledTimes(2);
+    expect(onBatchCorrected).toHaveBeenNthCalledWith(1, [{ id: 'p1', revisionAfterApply: 101 }]);
+    expect(onBatchCorrected).toHaveBeenNthCalledWith(2, [{ id: 'p2', revisionAfterApply: 102 }]);
+  });
+
+  it('never invokes onBatchCorrected in dry-run mode — nothing was written', async () => {
+    const select = selectReturning([[markdownPage('p1')], []]);
+    const { update } = captureUpdate();
+    const onBatchCorrected = vi.fn();
+    await planAndApplyBackfill(fakeDb(select, update), { apply: false, onBatchCorrected });
+
+    expect(onBatchCorrected).not.toHaveBeenCalled();
+  });
+
+  it('does not invoke onBatchCorrected for a batch with no mislabelled pages', async () => {
+    const select = selectReturning([[htmlPage('p1')], []]);
+    const { update } = captureUpdate();
+    const onBatchCorrected = vi.fn();
+    await planAndApplyBackfill(fakeDb(select, update), { apply: true, onBatchCorrected });
+
+    expect(onBatchCorrected).not.toHaveBeenCalled();
+  });
+
+  it('does not invoke onBatchCorrected when a mislabelled batch corrects nothing (every write lost the compare-and-swap)', async () => {
+    const select = selectReturning([[markdownPage('p1')], []]);
+    const { update } = captureUpdate({ succeeds: false });
+    const onBatchCorrected = vi.fn();
+    await planAndApplyBackfill(fakeDb(select, update), { apply: true, onBatchCorrected });
+
+    expect(onBatchCorrected).not.toHaveBeenCalled();
+  });
 });
 
-/** Batched update stub: `.returning()` resolves with the rows the WHERE clause matched. */
+/**
+ * Chainable batched-update stub for revert: `.where()` captures the
+ * condition it was called with (so a test can assert the per-row revision
+ * pairing was actually built), and `.returning()` resolves with the rows the
+ * test says the WHERE clause matched.
+ */
 function captureBatchedUpdate(returnedIds: string[]) {
   const sets: Array<Record<string, unknown>> = [];
+  const whereConditions: unknown[] = [];
   const update = vi.fn(() => ({
     set: (v: Record<string, unknown>) => {
       sets.push(v);
-      return { where: () => ({ returning: () => Promise.resolve(returnedIds.map((id) => ({ id }))) }) };
+      return {
+        where: (cond: unknown) => {
+          whereConditions.push(cond);
+          return { returning: () => Promise.resolve(returnedIds.map((id) => ({ id }))) };
+        },
+      };
     },
   }));
-  return { update, sets };
+  return { update, sets, whereConditions };
 }
 
+const correction = (id: string, revisionAfterApply: number): CorrectedPage => ({ id, revisionAfterApply });
+
 describe('revertBackfill', () => {
-  it('flips the given ids back to html when still markdown, in one batched update', async () => {
-    const { update } = captureBatchedUpdate(['p1', 'p2']);
-    const result = await revertBackfill({ update } as unknown as BackfillDb, ['p1', 'p2']);
+  it('flips the given pages back to html when still markdown at the recorded revision, in one batched update, bumping revision again', async () => {
+    const { update, sets } = captureBatchedUpdate(['p1', 'p2']);
+    const result = await revertBackfill(
+      { update } as unknown as BackfillDb,
+      [correction('p1', 6), correction('p2', 9)],
+    );
     expect(result).toEqual({ attempted: 2, reverted: ['p1', 'p2'], skippedAlreadyChanged: [] });
     expect(update).toHaveBeenCalledTimes(1);
+    expect(sets[0].contentMode).toBe('html');
+    expect(sets[0].revision).toEqual(expect.objectContaining({ __sql: true }));
   });
 
-  it('skips ids no longer contentMode=markdown rather than forcing them', async () => {
+  it('builds the WHERE clause as a per-row (id, revision) pairing, not a cross-product of ids and revisions', async () => {
+    const stub = captureBatchedUpdate(['p1']);
+    await revertBackfill({ update: stub.update } as unknown as BackfillDb, [correction('p1', 6), correction('p2', 9)]);
+
+    expect(stub.whereConditions).toHaveLength(1);
+    const [cond] = stub.whereConditions as [{ and: [{ eq: [unknown, string] }, { or: Array<{ and: unknown[] }> }] }];
+    expect(cond.and[0].eq).toEqual(['contentMode', 'markdown']);
+    const orBranches = cond.and[1].or;
+    expect(orBranches).toHaveLength(2);
+    expect((orBranches[0] as { and: Array<{ eq: unknown[] }> }).and).toEqual([
+      { eq: ['id', 'p1'] },
+      { eq: ['revision', 6] },
+    ]);
+    expect((orBranches[1] as { and: Array<{ eq: unknown[] }> }).and).toEqual([
+      { eq: ['id', 'p2'] },
+      { eq: ['revision', 9] },
+    ]);
+  });
+
+  it('skips a page no longer at the recorded revision — edited since the backfill — rather than discarding that edit', async () => {
     const { update } = captureBatchedUpdate([]);
-    const result = await revertBackfill({ update } as unknown as BackfillDb, ['p1']);
+    const result = await revertBackfill({ update } as unknown as BackfillDb, [correction('p1', 6)]);
     expect(result).toEqual({ attempted: 1, reverted: [], skippedAlreadyChanged: ['p1'] });
   });
 
-  it('reports a mix of reverted and already-changed ids from one batch', async () => {
+  it('reports a mix of reverted and already-changed pages from one batch', async () => {
     const { update } = captureBatchedUpdate(['p1']);
-    const result = await revertBackfill({ update } as unknown as BackfillDb, ['p1', 'p2']);
+    const result = await revertBackfill({ update } as unknown as BackfillDb, [correction('p1', 6), correction('p2', 9)]);
     expect(result).toEqual({ attempted: 2, reverted: ['p1'], skippedAlreadyChanged: ['p2'] });
   });
 
-  it('is a no-op for an empty id list, without querying the database', async () => {
+  it('is a no-op for an empty list, without querying the database', async () => {
     const { update } = captureBatchedUpdate([]);
     const result = await revertBackfill({ update } as unknown as BackfillDb, []);
     expect(result).toEqual({ attempted: 0, reverted: [], skippedAlreadyChanged: [] });

--- a/apps/web/src/lib/editor/__tests__/document-content-format.test.ts
+++ b/apps/web/src/lib/editor/__tests__/document-content-format.test.ts
@@ -1,0 +1,59 @@
+import { describe, it, expect, afterAll } from 'vitest';
+import { classifyDocumentContent, createDomWorkspace } from '../document-content-format';
+
+const workspace = createDomWorkspace();
+afterAll(() => workspace.close());
+
+const classify = (content: string) => classifyDocumentContent(content, workspace);
+
+describe('classifyDocumentContent', () => {
+  it('classifies whitespace-only content as empty', () => {
+    expect(classify('')).toEqual({ format: 'empty', confident: true });
+    expect(classify('   \n\t')).toEqual({ format: 'empty', confident: true });
+  });
+
+  it('classifies real HTML markup as html', () => {
+    expect(classify('<p>hello <strong>world</strong></p>')).toEqual({ format: 'html', confident: true });
+  });
+
+  it('classifies markdown source with no HTML tags as markdown-source', () => {
+    const markdown = '# Heading\n\nSome *emphasis* and a [link](https://example.com).\n\n- one\n- two';
+    expect(classify(markdown)).toEqual({ format: 'markdown-source', confident: true });
+  });
+
+  it('does not mistake an unescaped generic for HTML', () => {
+    // The exact trap the mislabelled population fell into: prose containing
+    // ActionResult<void> parses to a phantom, non-real "element" under a naive
+    // DOM scan. It must still classify as markdown-source, not html.
+    expect(classify('# Notes\n\nReturns `ActionResult<void>` from the handler.')).toEqual({
+      format: 'markdown-source',
+      confident: true,
+    });
+  });
+
+  it('does not misclassify markdown ending in a stray angle bracket as html', () => {
+    // This is exactly the boundary heuristic `detectPageContentFormat` uses
+    // (startsWith('<') && endsWith('>')) failing: content that merely ends
+    // with '>' is not HTML.
+    const markdown = '# Title\n\nSome text that happens to end with a caret >';
+    expect(classify(markdown)).toEqual({ format: 'markdown-source', confident: true });
+  });
+
+  it('classifies markdown embedding real raw HTML as html, since it does contain a real element', () => {
+    expect(classify('# Title\n\n<div>raw html block</div>')).toEqual({ format: 'html', confident: true });
+  });
+
+  it('reports low confidence rather than guessing when parsing throws', () => {
+    const throwingWorkspace = {
+      parse(): never {
+        throw new TypeError('boom');
+      },
+      close() {},
+    };
+    expect(classifyDocumentContent('# unparseable', throwingWorkspace as never)).toEqual({
+      format: 'unknown',
+      confident: false,
+      reason: 'TypeError',
+    });
+  });
+});

--- a/apps/web/src/lib/editor/__tests__/document-content-format.test.ts
+++ b/apps/web/src/lib/editor/__tests__/document-content-format.test.ts
@@ -43,6 +43,14 @@ describe('classifyDocumentContent', () => {
     expect(classify('# Title\n\n<div>raw html block</div>')).toEqual({ format: 'html', confident: true });
   });
 
+  it('classifies a bare <search> element as html, with no nested known element required', () => {
+    // <search> is a real HTML5 element (WHATWG grouping content) happy-dom
+    // parses as its own tag rather than falling into the unescaped-angle-
+    // bracket bucket. A page consisting only of one is still real HTML and
+    // must not be misclassified markdown-source.
+    expect(classify('<search>find stuff</search>')).toEqual({ format: 'html', confident: true });
+  });
+
   it('reports low confidence rather than guessing when parsing throws', () => {
     const throwingWorkspace = {
       parse(): never {

--- a/apps/web/src/lib/editor/census/constructs.ts
+++ b/apps/web/src/lib/editor/census/constructs.ts
@@ -1,4 +1,7 @@
 import { Window } from 'happy-dom';
+import { HTML_ELEMENT_NAMES, UNESCAPED_ANGLE_BRACKET_KEY } from '../document-content-format';
+
+export { UNESCAPED_ANGLE_BRACKET_KEY };
 
 /**
  * Every structural construct a stored HTML document contains, in a form that
@@ -28,6 +31,13 @@ export interface DocumentConstructs {
  * `generateHTML` rebuild the schema and stand up a fresh window on every call —
  * ~2.5ms per document of setup the census would pay tens of thousands of times.
  * `round-trip.test.ts` pins the two paths to the same output.
+ *
+ * This is a SEPARATE happy-dom window from `document-content-format.ts`'s:
+ * that module's own workspace type only exposes `tagName`/`querySelectorAll`
+ * (all its classifier needs), and it is meant to outlive this census — which
+ * is TEMPORARY BY DESIGN — so it does not carry the richer shape
+ * (`empty()`, `document`, `textContent`, attribute readers) only this file's
+ * round-trip diffing needs.
  */
 export interface DomWorkspace {
   /** Parses stored markup into a detached element. */
@@ -56,37 +66,6 @@ export interface DomElement {
   getAttribute(name: string): string | null;
   /** Recursive: measuring a table means asking it for its own rows. */
   querySelectorAll(selector: string): Iterable<DomElement>;
-}
-
-/**
- * Attributes whose VALUE is the construct rather than the attribute itself.
- * `data-type="taskList"` is the whole of TipTap's task-list markup — a bare
- * `attr:data-type` row would merge it with every other TipTap node that
- * round-trips fine.
- */
-const VALUE_BEARING_ATTRIBUTES = new Set(['data-type']);
-
-/**
- * Inline `style` is reported per CSS property (`style:text-align`), not as one
- * `attr:style`. `text-align` is a v1 schema candidate; `color` already has a
- * home in `textStyle`. Merging them would make the census unable to tell the
- * question apart from the answer.
- */
-function styleProperties(styleAttribute: string): string[] {
-  return styleAttribute
-    .split(';')
-    .map((declaration) => declaration.split(':')[0].trim().toLowerCase())
-    .filter((property) => property.length > 0);
-}
-
-function attributeKeys(name: string, value: string): string[] {
-  if (name === 'style') {
-    return styleProperties(value).map((property) => `style:${property}`);
-  }
-  if (VALUE_BEARING_ATTRIBUTES.has(name)) {
-    return [`attr:${name}=${value}`];
-  }
-  return [`attr:${name}`];
 }
 
 /**
@@ -126,31 +105,35 @@ export function createDomWorkspace(): DomWorkspace {
 }
 
 /**
- * Real HTML element names. Anything outside this set that the parser produced is
- * not markup the author wrote — it is an unescaped `<` in prose or a code
- * sample. Documents here are full of `ActionResult<void>`, `Set<string>` and
- * CLI placeholders like `<task-id>`, and happy-dom turns every one of them into
- * an element. Reported individually they produced ~200 phantom rows that buried
- * the real findings; the census is meant to answer "what must v1 represent",
- * and the answer is never `<actionresult<void>`.
- *
- * They are still counted, under one key, because the phenomenon is worth
- * knowing: it means stored HTML contains unescaped angle brackets.
+ * Attributes whose VALUE is the construct rather than the attribute itself.
+ * `data-type="taskList"` is the whole of TipTap's task-list markup — a bare
+ * `attr:data-type` row would merge it with every other TipTap node that
+ * round-trips fine.
  */
-const HTML_ELEMENT_NAMES = new Set<string>([
-  'a','abbr','address','area','article','aside','audio','b','base','bdi','bdo','blockquote','body',
-  'br','button','canvas','caption','cite','code','col','colgroup','data','datalist','dd','del',
-  'details','dfn','dialog','div','dl','dt','em','embed','fieldset','figcaption','figure','footer',
-  'form','h1','h2','h3','h4','h5','h6','head','header','hgroup','hr','html','i','iframe','img',
-  'input','ins','kbd','label','legend','li','link','main','map','mark','menu','meta','meter','nav',
-  'noscript','object','ol','optgroup','option','output','p','param','picture','pre','progress','q',
-  'rp','rt','ruby','s','samp','script','section','select','slot','small','source','span','strong',
-  'style','sub','summary','sup','table','tbody','td','template','textarea','tfoot','th','thead',
-  'time','title','tr','track','u','ul','var','video','wbr','svg','math',
-]);
+const VALUE_BEARING_ATTRIBUTES = new Set(['data-type']);
 
-/** Single bucket for parser artefacts of unescaped `<` in text. */
-export const UNESCAPED_ANGLE_BRACKET_KEY = 'text:unescaped-angle-bracket';
+/**
+ * Inline `style` is reported per CSS property (`style:text-align`), not as one
+ * `attr:style`. `text-align` is a v1 schema candidate; `color` already has a
+ * home in `textStyle`. Merging them would make the census unable to tell the
+ * question apart from the answer.
+ */
+function styleProperties(styleAttribute: string): string[] {
+  return styleAttribute
+    .split(';')
+    .map((declaration) => declaration.split(':')[0].trim().toLowerCase())
+    .filter((property) => property.length > 0);
+}
+
+function attributeKeys(name: string, value: string): string[] {
+  if (name === 'style') {
+    return styleProperties(value).map((property) => `style:${property}`);
+  }
+  if (VALUE_BEARING_ATTRIBUTES.has(name)) {
+    return [`attr:${name}=${value}`];
+  }
+  return [`attr:${name}`];
+}
 
 export function collectConstructs(container: DomElement): DocumentConstructs {
   const elements = new Set<string>();

--- a/apps/web/src/lib/editor/content-mode-backfill.ts
+++ b/apps/web/src/lib/editor/content-mode-backfill.ts
@@ -9,7 +9,7 @@
  * See the script's own header for the full rationale (why relabel rather
  * than convert, why this is reversible, why dry-run is the default).
  */
-import { and, asc, eq, gt, inArray } from '@pagespace/db/operators';
+import { and, asc, eq, gt, or, sql } from '@pagespace/db/operators';
 import { pages } from '@pagespace/db/schema/core';
 import type { getMigrationDb } from '@pagespace/db/db';
 import { createDomWorkspace, classifyDocumentContent } from './document-content-format';
@@ -18,11 +18,39 @@ export type BackfillDb = ReturnType<typeof getMigrationDb>;
 
 const DEFAULT_BATCH_SIZE = 200;
 
+/**
+ * A corrected page, as recorded in the `--out` manifest. `revisionAfterApply`
+ * is what makes `--revert` safe: `applyPageMutation` bumps `revision` on
+ * every ordinary save, so a page a user edits after this backfill runs will
+ * have moved past this value by the time anyone reverts — the revert compare-
+ * and-swap requires an exact match and leaves that page alone rather than
+ * discarding the user's edit.
+ */
+export interface CorrectedPage {
+  id: string;
+  revisionAfterApply: number;
+}
+
 export interface BackfillSummary {
   scanned: number;
-  corrected: string[];
+  corrected: CorrectedPage[];
   skippedUnparseable: Array<{ id: string; reason: string }>;
   skippedConcurrentModification: string[];
+}
+
+export interface PlanAndApplyOptions {
+  apply: boolean;
+  batchSize?: number;
+  /**
+   * Invoked once per batch, after that batch's writes have committed, with
+   * exactly the pages this batch corrected. The CLI wrapper uses this to
+   * durably persist the `--out` manifest incrementally rather than only once
+   * at the very end — without it, a process killed partway through a
+   * multi-thousand-row run would leave already-corrected pages with no
+   * record to revert them by. Never called in dry-run mode (nothing was
+   * written) or for an empty batch.
+   */
+  onBatchCorrected?: (corrected: CorrectedPage[]) => Promise<void> | void;
 }
 
 /**
@@ -33,7 +61,7 @@ export interface BackfillSummary {
  */
 export async function planAndApplyBackfill(
   db: BackfillDb,
-  { apply, batchSize = DEFAULT_BATCH_SIZE }: { apply: boolean; batchSize?: number },
+  { apply, batchSize = DEFAULT_BATCH_SIZE, onBatchCorrected }: PlanAndApplyOptions,
 ): Promise<BackfillSummary> {
   const workspace = createDomWorkspace();
   const summary: BackfillSummary = {
@@ -47,7 +75,13 @@ export async function planAndApplyBackfill(
     let after: string | null = null;
     for (;;) {
       const batch = await db
-        .select({ id: pages.id, content: pages.content, contentMode: pages.contentMode, updatedAt: pages.updatedAt })
+        .select({
+          id: pages.id,
+          content: pages.content,
+          contentMode: pages.contentMode,
+          updatedAt: pages.updatedAt,
+          revision: pages.revision,
+        })
         .from(pages)
         .where(
           and(
@@ -75,30 +109,41 @@ export async function planAndApplyBackfill(
       }
 
       if (!apply) {
-        summary.corrected.push(...mislabelled.map((page) => page.id));
-      } else {
+        summary.corrected.push(...mislabelled.map((page) => ({ id: page.id, revisionAfterApply: page.revision + 1 })));
+      } else if (mislabelled.length > 0) {
         // Each page's compare-and-swap only touches its own row, so the
         // batch's writes run concurrently rather than one round trip at a
         // time — up to `batchSize` (200) in flight per batch.
+        const batchCorrected: CorrectedPage[] = [];
         await Promise.all(
           mislabelled.map(async (page) => {
             // Compare-and-swap on the exact content read: a page edited
             // between the select and this write must not be relabelled
             // against content this run never actually classified. updatedAt
             // is pinned to its prior value — this is a label correction, not
-            // a user edit.
-            const written = await db
+            // a user edit. `revision` is bumped (atomically, via the SQL
+            // expression, not the stale JS-side value) so a client session
+            // that already had this page open under the old `contentMode`
+            // gets a 409 on its next save instead of silently writing content
+            // that no longer matches the label — see PR #2511 review.
+            const [written] = await db
               .update(pages)
-              .set({ contentMode: 'markdown', updatedAt: page.updatedAt })
-              .where(and(eq(pages.id, page.id), eq(pages.content, page.content), eq(pages.contentMode, 'html')));
+              .set({ contentMode: 'markdown', updatedAt: page.updatedAt, revision: sql`${pages.revision} + 1` })
+              .where(and(eq(pages.id, page.id), eq(pages.content, page.content), eq(pages.contentMode, 'html')))
+              .returning({ id: pages.id, revision: pages.revision });
 
-            if (written.rowCount === 0) {
+            if (!written) {
               summary.skippedConcurrentModification.push(page.id);
             } else {
-              summary.corrected.push(page.id);
+              batchCorrected.push({ id: written.id, revisionAfterApply: written.revision });
             }
           }),
         );
+
+        summary.corrected.push(...batchCorrected);
+        if (batchCorrected.length > 0 && onBatchCorrected) {
+          await onBatchCorrected(batchCorrected);
+        }
       }
 
       after = batch[batch.length - 1].id;
@@ -116,27 +161,40 @@ export interface RevertSummary {
   skippedAlreadyChanged: string[];
 }
 
-/** Flips exactly the given page ids back to `contentMode='html'`, and only if still 'markdown'. */
-export async function revertBackfill(db: BackfillDb, pageIds: string[]): Promise<RevertSummary> {
-  if (pageIds.length === 0) {
+/**
+ * Flips exactly the given pages back to `contentMode='html'` — only a page
+ * still `contentMode='markdown'` **at the exact revision this backfill left
+ * it at** is touched. A page edited since (by a real user save, which always
+ * bumps `revision`) no longer matches and is reported as skipped rather than
+ * forced, so a revert can never discard a genuine edit.
+ */
+export async function revertBackfill(db: BackfillDb, corrections: CorrectedPage[]): Promise<RevertSummary> {
+  if (corrections.length === 0) {
     return { attempted: 0, reverted: [], skippedAlreadyChanged: [] };
   }
 
-  // One batched UPDATE rather than one round trip per id: `RETURNING id`
-  // reports exactly which of the given ids were still 'markdown' (and so
-  // actually flipped), so a page a user has since re-saved through the real
-  // markdown migration is reported as skipped rather than clobbered.
+  // One batched UPDATE rather than one round trip per id: the per-row OR
+  // branch pins EACH id to its own expected revision (a single inArray on ids
+  // plus a separate inArray on revisions would cross-match any id against any
+  // revision in the list, not the specific pairing this guard requires).
+  // `RETURNING id` reports exactly which pages were still at that revision
+  // and so actually flipped.
   const written = await db
     .update(pages)
-    .set({ contentMode: 'html' })
-    .where(and(inArray(pages.id, pageIds), eq(pages.contentMode, 'markdown')))
+    .set({ contentMode: 'html', revision: sql`${pages.revision} + 1` })
+    .where(
+      and(
+        eq(pages.contentMode, 'markdown'),
+        or(...corrections.map((c) => and(eq(pages.id, c.id), eq(pages.revision, c.revisionAfterApply)))),
+      ),
+    )
     .returning({ id: pages.id });
 
   const reverted = new Set(written.map((row) => row.id));
   return {
-    attempted: pageIds.length,
-    reverted: pageIds.filter((id) => reverted.has(id)),
-    skippedAlreadyChanged: pageIds.filter((id) => !reverted.has(id)),
+    attempted: corrections.length,
+    reverted: corrections.map((c) => c.id).filter((id) => reverted.has(id)),
+    skippedAlreadyChanged: corrections.map((c) => c.id).filter((id) => !reverted.has(id)),
   };
 }
 

--- a/apps/web/src/lib/editor/content-mode-backfill.ts
+++ b/apps/web/src/lib/editor/content-mode-backfill.ts
@@ -1,0 +1,180 @@
+/**
+ * Core logic for the mislabelled-`contentMode` backfill
+ * (`apps/web/scripts/backfill-mislabelled-content-mode.ts`). Pure/imperative
+ * shell split out of the CLI script so it lives under `src/**` and is
+ * exercised by `apps/web`'s ordinary vitest config — the script file itself
+ * is a thin argv/stdout wrapper, same split as `collab-content-census.ts`
+ * vs. `src/lib/editor/census/`.
+ *
+ * See the script's own header for the full rationale (why relabel rather
+ * than convert, why this is reversible, why dry-run is the default).
+ */
+import { and, asc, eq, gt, inArray } from '@pagespace/db/operators';
+import { pages } from '@pagespace/db/schema/core';
+import type { getMigrationDb } from '@pagespace/db/db';
+import { createDomWorkspace, classifyDocumentContent } from './document-content-format';
+
+export type BackfillDb = ReturnType<typeof getMigrationDb>;
+
+const DEFAULT_BATCH_SIZE = 200;
+
+export interface BackfillSummary {
+  scanned: number;
+  corrected: string[];
+  skippedUnparseable: Array<{ id: string; reason: string }>;
+  skippedConcurrentModification: string[];
+}
+
+/**
+ * Scans every `contentMode='html'` DOCUMENT page (trashed included — a
+ * restored page is seeded like any other, so its label matters just as
+ * much), classifies its stored content by inspection, and either reports
+ * (dry run) or corrects (`apply`) the ones holding markdown source.
+ */
+export async function planAndApplyBackfill(
+  db: BackfillDb,
+  { apply, batchSize = DEFAULT_BATCH_SIZE }: { apply: boolean; batchSize?: number },
+): Promise<BackfillSummary> {
+  const workspace = createDomWorkspace();
+  const summary: BackfillSummary = {
+    scanned: 0,
+    corrected: [],
+    skippedUnparseable: [],
+    skippedConcurrentModification: [],
+  };
+
+  try {
+    let after: string | null = null;
+    for (;;) {
+      const batch = await db
+        .select({ id: pages.id, content: pages.content, contentMode: pages.contentMode, updatedAt: pages.updatedAt })
+        .from(pages)
+        .where(
+          and(
+            eq(pages.type, 'DOCUMENT'),
+            eq(pages.contentMode, 'html'),
+            after === null ? undefined : gt(pages.id, after),
+          ),
+        )
+        .orderBy(asc(pages.id))
+        .limit(batchSize);
+
+      if (batch.length === 0) break;
+
+      const mislabelled: (typeof batch)[number][] = [];
+      for (const page of batch) {
+        summary.scanned += 1;
+        const classification = classifyDocumentContent(page.content, workspace);
+
+        if (!classification.confident) {
+          summary.skippedUnparseable.push({ id: page.id, reason: classification.reason });
+        } else if (classification.format === 'markdown-source') {
+          mislabelled.push(page);
+        }
+        // 'empty' or genuinely 'html' — correctly labelled, nothing to do.
+      }
+
+      if (!apply) {
+        summary.corrected.push(...mislabelled.map((page) => page.id));
+      } else {
+        // Each page's compare-and-swap only touches its own row, so the
+        // batch's writes run concurrently rather than one round trip at a
+        // time — up to `batchSize` (200) in flight per batch.
+        await Promise.all(
+          mislabelled.map(async (page) => {
+            // Compare-and-swap on the exact content read: a page edited
+            // between the select and this write must not be relabelled
+            // against content this run never actually classified. updatedAt
+            // is pinned to its prior value — this is a label correction, not
+            // a user edit.
+            const written = await db
+              .update(pages)
+              .set({ contentMode: 'markdown', updatedAt: page.updatedAt })
+              .where(and(eq(pages.id, page.id), eq(pages.content, page.content), eq(pages.contentMode, 'html')));
+
+            if (written.rowCount === 0) {
+              summary.skippedConcurrentModification.push(page.id);
+            } else {
+              summary.corrected.push(page.id);
+            }
+          }),
+        );
+      }
+
+      after = batch[batch.length - 1].id;
+    }
+  } finally {
+    workspace.close();
+  }
+
+  return summary;
+}
+
+export interface RevertSummary {
+  attempted: number;
+  reverted: string[];
+  skippedAlreadyChanged: string[];
+}
+
+/** Flips exactly the given page ids back to `contentMode='html'`, and only if still 'markdown'. */
+export async function revertBackfill(db: BackfillDb, pageIds: string[]): Promise<RevertSummary> {
+  if (pageIds.length === 0) {
+    return { attempted: 0, reverted: [], skippedAlreadyChanged: [] };
+  }
+
+  // One batched UPDATE rather than one round trip per id: `RETURNING id`
+  // reports exactly which of the given ids were still 'markdown' (and so
+  // actually flipped), so a page a user has since re-saved through the real
+  // markdown migration is reported as skipped rather than clobbered.
+  const written = await db
+    .update(pages)
+    .set({ contentMode: 'html' })
+    .where(and(inArray(pages.id, pageIds), eq(pages.contentMode, 'markdown')))
+    .returning({ id: pages.id });
+
+  const reverted = new Set(written.map((row) => row.id));
+  return {
+    attempted: pageIds.length,
+    reverted: pageIds.filter((id) => reverted.has(id)),
+    skippedAlreadyChanged: pageIds.filter((id) => !reverted.has(id)),
+  };
+}
+
+export interface BackfillArgs {
+  mode: 'dry-run' | 'apply' | 'revert';
+  outPath?: string;
+  revertPath?: string;
+}
+
+export type ParseArgsResult = { ok: true; args: BackfillArgs } | { ok: false; error: string };
+
+export function parseBackfillArgs(argv: string[]): ParseArgsResult {
+  const apply = argv.includes('--apply');
+  const revertIndex = argv.indexOf('--revert');
+  const outIndex = argv.indexOf('--out');
+
+  if (apply && revertIndex >= 0) {
+    return { ok: false, error: 'Pass either --apply or --revert, not both.' };
+  }
+
+  if (revertIndex >= 0) {
+    const revertPath = argv[revertIndex + 1];
+    if (!revertPath) return { ok: false, error: '--revert requires a path to the ids file --apply --out produced.' };
+    return { ok: true, args: { mode: 'revert', revertPath } };
+  }
+
+  if (apply) {
+    const outPath = outIndex >= 0 ? argv[outIndex + 1] : undefined;
+    if (!outPath) {
+      return {
+        ok: false,
+        error:
+          'Refusing --apply without --out <path>: this correction must stay reversible, and reversing it needs ' +
+          'the exact list of page ids this run touched. Pass --out <path> to write that list.',
+      };
+    }
+    return { ok: true, args: { mode: 'apply', outPath } };
+  }
+
+  return { ok: true, args: { mode: 'dry-run' } };
+}

--- a/apps/web/src/lib/editor/document-content-format.ts
+++ b/apps/web/src/lib/editor/document-content-format.ts
@@ -17,9 +17,9 @@ export const HTML_ELEMENT_NAMES = new Set<string>([
   'form','h1','h2','h3','h4','h5','h6','head','header','hgroup','hr','html','i','iframe','img',
   'input','ins','kbd','label','legend','li','link','main','map','mark','menu','meta','meter','nav',
   'noscript','object','ol','optgroup','option','output','p','param','picture','pre','progress','q',
-  'rp','rt','ruby','s','samp','script','section','select','slot','small','source','span','strong',
-  'style','sub','summary','sup','table','tbody','td','template','textarea','tfoot','th','thead',
-  'time','title','tr','track','u','ul','var','video','wbr','svg','math',
+  'rp','rt','ruby','s','samp','script','search','section','select','slot','small','source','span',
+  'strong','style','sub','summary','sup','table','tbody','td','template','textarea','tfoot','th',
+  'thead','time','title','tr','track','u','ul','var','video','wbr','svg','math',
 ]);
 
 /** Single marker for parser artefacts of unescaped `<` in text. */

--- a/apps/web/src/lib/editor/document-content-format.ts
+++ b/apps/web/src/lib/editor/document-content-format.ts
@@ -1,0 +1,138 @@
+import { Window } from 'happy-dom';
+
+/**
+ * Real HTML element names. Anything outside this set that a parser produced is
+ * not markup the author wrote — it is an unescaped `<` in prose or a code
+ * sample (`ActionResult<void>`, `<task-id>`), which every happy-dom parse
+ * turns into an element of its own. Moved here (out of
+ * `census/constructs.ts`, which this repo is going to delete once
+ * `COLLAB_SCHEMA_VERSION` v1 is frozen) because the mislabelled-content-mode
+ * backfill needs the exact same "does this contain real HTML" answer the
+ * census measured, and needs it to survive after the census is gone.
+ */
+export const HTML_ELEMENT_NAMES = new Set<string>([
+  'a','abbr','address','area','article','aside','audio','b','base','bdi','bdo','blockquote','body',
+  'br','button','canvas','caption','cite','code','col','colgroup','data','datalist','dd','del',
+  'details','dfn','dialog','div','dl','dt','em','embed','fieldset','figcaption','figure','footer',
+  'form','h1','h2','h3','h4','h5','h6','head','header','hgroup','hr','html','i','iframe','img',
+  'input','ins','kbd','label','legend','li','link','main','map','mark','menu','meta','meter','nav',
+  'noscript','object','ol','optgroup','option','output','p','param','picture','pre','progress','q',
+  'rp','rt','ruby','s','samp','script','section','select','slot','small','source','span','strong',
+  'style','sub','summary','sup','table','tbody','td','template','textarea','tfoot','th','thead',
+  'time','title','tr','track','u','ul','var','video','wbr','svg','math',
+]);
+
+/** Single marker for parser artefacts of unescaped `<` in text. */
+export const UNESCAPED_ANGLE_BRACKET_KEY = 'text:unescaped-angle-bracket';
+
+/**
+ * The narrow slice of a parsed element this module actually reads. Kept to
+ * exactly `tagName` + `querySelectorAll` on purpose: `census/constructs.ts`
+ * needs a much richer shape (`empty()`, `document`, `textContent`, attribute
+ * readers) for its own round-trip diffing, but that module is TEMPORARY BY
+ * DESIGN (deleted once `COLLAB_SCHEMA_VERSION` v1 freezes) and this one is
+ * meant to outlive it — a future Phase E seed-guard imports this module, not
+ * the census. Widening this interface to fit the census's needs would bake
+ * census-only requirements into the file that is supposed to survive census
+ * deletion. `census/constructs.ts` owns its own richer workspace/window and
+ * imports only `HTML_ELEMENT_NAMES`/`UNESCAPED_ANGLE_BRACKET_KEY` from here.
+ */
+export interface DomElement {
+  tagName: string;
+  querySelectorAll(selector: string): Iterable<DomElement>;
+}
+
+export interface DomWorkspace {
+  /** Parses stored markup into a detached element. */
+  parse(html: string): DomElement;
+  close(): void;
+}
+
+/**
+ * happy-dom rather than jsdom: it is the DOM `@tiptap/html@3` declares as its
+ * peer, so "does this content contain a real HTML element" is answered by the
+ * same parser the editor's own server-side round trip uses.
+ */
+export function createDomWorkspace(): DomWorkspace {
+  const window = new Window({
+    settings: {
+      disableJavaScriptEvaluation: true,
+      disableJavaScriptFileLoading: true,
+      disableCSSFileLoading: true,
+      disableIframePageLoading: true,
+      disableComputedStyleRendering: true,
+    },
+  });
+
+  return {
+    parse(html: string): DomElement {
+      const container = window.document.createElement('div') as unknown as DomElement & { innerHTML: string };
+      container.innerHTML = html;
+      return container;
+    },
+    close(): void {
+      // close() aborts the window's async tasks on its way out; abort() as well
+      // would just be the older, narrower half of the same call.
+      void window.happyDOM.close();
+    },
+  };
+}
+
+/**
+ * Whether a parsed document contains any element the author actually wrote,
+ * as opposed to happy-dom's parse of an unescaped `<` in prose or a code
+ * sample turning `ActionResult<void>` into an `<actionresult>` "element".
+ */
+export function hasRealHtmlElement(container: DomElement): boolean {
+  for (const element of container.querySelectorAll('*')) {
+    if (HTML_ELEMENT_NAMES.has(element.tagName.toLowerCase())) return true;
+  }
+  return false;
+}
+
+export type ClassifyContentResult =
+  | { format: 'empty'; confident: true }
+  | { format: 'html'; confident: true }
+  | { format: 'markdown-source'; confident: true }
+  /** The content could not be parsed at all — never guess, report and skip. */
+  | { format: 'unknown'; confident: false; reason: string };
+
+/**
+ * Classifies stored `pages.content` as `html` or `markdown-source` **by
+ * inspecting the content**, never by trusting `contentMode` — that column is
+ * exactly what this classifier exists to check.
+ *
+ * `packages/lib`'s `detectPageContentFormat` was evaluated for this and is
+ * NOT reused: it decides `html` from a boundary heuristic
+ * (`trimmed.startsWith('<') && trimmed.endsWith('>')`) with no DOM parse and
+ * no markdown category — `# heading\n\nmore text with a stray >` would
+ * satisfy that heuristic and be misclassified `html` despite containing zero
+ * real elements, which is precisely the failure mode this backfill exists to
+ * catch. It remains correct for its own callers (content-format detection
+ * for diffing and version snapshotting across html/json/tiptap/text), where
+ * being wrong about markdown-vs-text has no data-loss consequence. This
+ * classifier instead parses the content with the same DOM the collab content
+ * census used to measure the 3,003-page population (`hasRealHtmlElement`
+ * above), because that is the only method proven against production data.
+ *
+ * A parse failure classifies as `{ confident: false }` rather than guessing a
+ * format — per-page callers must skip and report these, not act on them.
+ */
+export function classifyDocumentContent(content: string, workspace: DomWorkspace): ClassifyContentResult {
+  if (!/\S/.test(content)) {
+    return { format: 'empty', confident: true };
+  }
+
+  try {
+    const container = workspace.parse(content);
+    return hasRealHtmlElement(container)
+      ? { format: 'html', confident: true }
+      : { format: 'markdown-source', confident: true };
+  } catch (error) {
+    return {
+      format: 'unknown',
+      confident: false,
+      reason: error instanceof Error ? error.name : 'unknown',
+    };
+  }
+}


### PR DESCRIPTION
## Summary
- Adds `classifyDocumentContent` — a DOM-inspection classifier (`apps/web/src/lib/editor/document-content-format.ts`) that decides `html` vs `markdown-source` **by inspecting content**, never by trusting `contentMode`. Evaluates and documents why `detectPageContentFormat` (packages/lib) isn't reused for this (boundary heuristic, no DOM parse, false-positives exactly on the population this backfill targets).
- Adds the backfill script (`apps/web/scripts/backfill-mislabelled-content-mode.ts` + testable core in `content-mode-backfill.ts`): corrects `contentMode` to `'markdown'` for the ~3,003 pages the census found holding markdown source under `contentMode='html'`. Relabels rather than converts (converting would re-run the exact lossy path the census warns about). Dry-run by default, `--apply` requires `--out <path>`, fully reversible via `--revert`.
- Refactors `census/constructs.ts` to import shared primitives from the new permanent module instead of duplicating them, keeping the census's own richer workspace type local (it's temporary-by-design; the classifier is meant to outlive it).

**Does not run against production.** See `.pu-reports/pu-mp-contentmode-backfill.md` for the exact command, full rationale, and gate results.

## Test plan
- [x] `bun run typecheck` — 17/17 tasks
- [x] `bun run lint` — 15/15 tasks
- [x] `bun run knip:check` — within baseline
- [x] Full test suite (isolated Postgres, to avoid the shared test-container race across concurrent worktrees): packages/db 45/45 (664 tests), packages/lib 494/495 (11,264 tests — 1 file needs a separate scratch admin DB, CI-only), apps/processor 66/69 (1,163 tests — same scratch-DB pattern), apps/realtime 33/33 (1,146 tests), apps/web 1,253/1,254 (19,263 tests)
- [x] Every new test mutation-checked (broke the mechanism, confirmed red, restored) — see report for specifics
- [ ] Orchestrator: dry-run against production, sanity-check count against the census's 3,003, then `--apply --out <path>`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KJFBYv6VdnyEtcHEbQ4HK7

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added content-format detection to distinguish empty, HTML, Markdown source, and unrecognized document content.
  - Added a content-mode backfill tool with dry-run, apply, and reversible revert modes.
  - Added safeguards to skip pages that changed during processing or cannot be confidently classified.
  - Added progress reporting, batching, and verification for large-scale corrections.

- **Tests**
  - Added coverage for content classification, backfill behavior, concurrent changes, pagination, reversion, and command validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->