### PR TITLE
Always show the pane bar's tab strip on the host pane

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -224,6 +224,13 @@ All notable user-facing changes to PageSpace are documented here. Format follows
 
 ### Fixed
 
+- **Every pane in an AI page's split grid now offers Chat/History/Settings from its own bar** — the
+  "host" pane (the one showing the same conversation the page's own header already tracks) used to
+  collapse to a bare name label with no way to reach History or Settings from that pane, unlike
+  every other pane in the grid. It now carries the same tab strip. Deleting the page's own hosted
+  conversation from that newly-reachable History tab now correctly hands the page a replacement
+  conversation instead of leaving it silently pointed at one that no longer exists — including when
+  a session end happens to land at the same moment.
 - **An agent locked down by `update_agent_config` can be unlocked again, and `pagespace keys` tells
   you the real fix** — restricting an agent's tools to an empty list had no way back through the
   tool itself: the field that means "no restrictions" is `null`, and the schema only accepted an

--- a/apps/web/src/components/agents/panes/AgentPanes.tsx
+++ b/apps/web/src/components/agents/panes/AgentPanes.tsx
@@ -1276,6 +1276,16 @@ export default function AgentPanes({
    * a pane in the same place, showing the picker — the simplest safe recovery,
    * with the user explicitly picking what is next rather than a guessed
    * replacement.
+   *
+   * If the deleted id IS `hostConversationId`, the hosting `AgentPageView` is
+   * tracking it as its own `current` conversation — unbinding the grid node
+   * alone leaves that page-level state pointed at a conversation that no
+   * longer exists, with nothing to notice (review finding: the host pane's
+   * bar didn't used to carry a tab strip at all, so this delete path was
+   * unreachable for the host's own conversation before it gained one).
+   * `onConversationClosed` is the SAME event a manual pane close already
+   * reports, and `AgentPageView`'s handler mints a replacement for exactly
+   * this case when `next` is null — reusing it here needs no new plumbing.
    */
   const handleHistoryDeleteConversation = useCallback(
     (deletedConversationId: string) => {
@@ -1298,8 +1308,11 @@ export default function AgentPanes({
           unbindPane(sessionId, node.id);
         }
       }
+      if (deletedConversationId === hostConversationId) {
+        onConversationClosed?.({ conversationId: deletedConversationId, next: null, nextAgentPageId: null });
+      }
     },
-    [sessionId, unbindPane, mutate],
+    [sessionId, unbindPane, mutate, hostConversationId, onConversationClosed],
   );
 
   /**

--- a/apps/web/src/components/agents/panes/AgentPanes.tsx
+++ b/apps/web/src/components/agents/panes/AgentPanes.tsx
@@ -721,6 +721,17 @@ export default function AgentPanes({
    * Synchronous now, and nothing awaits it — so no rebind branch, no catch, no
    * toast on the success path.
    */
+  // Shared by every producer of the "closed, nothing replaced it" event —
+  // a manual pane close and a History delete of the page's own hosted
+  // conversation both report it identically, so the shape can't drift
+  // between them the way two independently-typed literals could.
+  const notifyConversationClosedWithNoReplacement = useCallback(
+    (conversationId: string) => {
+      onConversationClosed?.({ conversationId, next: null, nextAgentPageId: null });
+    },
+    [onConversationClosed],
+  );
+
   const closeChatPane = useCallback(
     (nodeId: string, conversationId: string) => {
       // `closePane` drops the node, and the node IS the membership — so the
@@ -729,9 +740,9 @@ export default function AgentPanes({
       // second listing it kept in step; there is one source now, and this line
       // wrote to it.
       closePane(sessionId, nodeId);
-      onConversationClosed?.({ conversationId, next: null, nextAgentPageId: null });
+      notifyConversationClosedWithNoReplacement(conversationId);
     },
-    [sessionId, closePane, onConversationClosed],
+    [sessionId, closePane, notifyConversationClosedWithNoReplacement],
   );
 
   const handleClosePane = useCallback(
@@ -1308,7 +1319,7 @@ export default function AgentPanes({
       // would silently skip the one notification this whole method exists to
       // send in exactly that race (caught in review).
       if (deletedConversationId === hostConversationId) {
-        onConversationClosed?.({ conversationId: deletedConversationId, next: null, nextAgentPageId: null });
+        notifyConversationClosedWithNoReplacement(deletedConversationId);
       }
       // Read fresh at call time: this always runs after the DELETE's own round
       // trip, during which the user could have already repurposed a node.
@@ -1320,7 +1331,7 @@ export default function AgentPanes({
         }
       }
     },
-    [sessionId, unbindPane, mutate, hostConversationId, onConversationClosed],
+    [sessionId, unbindPane, mutate, hostConversationId, notifyConversationClosedWithNoReplacement],
   );
 
   /**

--- a/apps/web/src/components/agents/panes/AgentPanes.tsx
+++ b/apps/web/src/components/agents/panes/AgentPanes.tsx
@@ -1299,6 +1299,17 @@ export default function AgentPanes({
       // Instant-freshness nudge, unconditional — the canonical row is gone from
       // the listing regardless of whether any node here is showing it.
       void mutate(isAgentWorkspacesKey);
+      // Ahead of the `live` check below, and deliberately not inside it: this
+      // notifies the HOSTING PAGE, not this grid — it doesn't depend on the
+      // workspace still being in the store. A concurrent session-end (the
+      // sidebar's own end-session path, independent of this grid's own
+      // `confirmEndSession`) can forget the workspace before this callback's
+      // own DELETE round trip resolves; gating this behind `if (!live) return`
+      // would silently skip the one notification this whole method exists to
+      // send in exactly that race (caught in review).
+      if (deletedConversationId === hostConversationId) {
+        onConversationClosed?.({ conversationId: deletedConversationId, next: null, nextAgentPageId: null });
+      }
       // Read fresh at call time: this always runs after the DELETE's own round
       // trip, during which the user could have already repurposed a node.
       const live = useAgentWorkspaceStore.getState().workspaces[sessionId];
@@ -1307,9 +1318,6 @@ export default function AgentPanes({
         if (node.target?.kind === 'chat' && node.target.id === deletedConversationId) {
           unbindPane(sessionId, node.id);
         }
-      }
-      if (deletedConversationId === hostConversationId) {
-        onConversationClosed?.({ conversationId: deletedConversationId, next: null, nextAgentPageId: null });
       }
     },
     [sessionId, unbindPane, mutate, hostConversationId, onConversationClosed],

--- a/apps/web/src/components/agents/panes/AgentPanes.tsx
+++ b/apps/web/src/components/agents/panes/AgentPanes.tsx
@@ -1801,16 +1801,16 @@ function ChatPane({
       <PaneBar
         isActive={isActive}
         identity={
-          isHostIdentity ? (
-            // This pane shows the SAME conversation the hosting AI_CHAT page's
-            // own header already identifies — a second selector and tab strip
-            // would be duplicate chrome for the identical thing. Matched by
-            // CONVERSATION, not agent: a split pane pointed at the same agent but
-            // a DIFFERENT conversation keeps its full selector, since that is its
-            // only in-grid way to be managed.
-            <PaneSessionIdentity name={agent?.title ?? title} />
-          ) : (
-            <div className="flex min-w-0 flex-1 items-center gap-0.5">
+          <div className="flex min-w-0 flex-1 items-center gap-0.5">
+            {isHostIdentity ? (
+              // This pane shows the SAME conversation the hosting AI_CHAT
+              // page's own header already identifies — a second agent
+              // selector would be duplicate chrome for switching an agent
+              // this pane can't actually leave. The tab strip is NOT
+              // dropped though: Chat/History/Settings still has to be
+              // reachable from every pane's own bar, host included.
+              <PaneSessionIdentity name={agent?.title ?? title} />
+            ) : (
               <AISelector
                 selectedAgent={agentPageId === null ? null : agent}
                 onSelectAgent={(next) => onSelectAgent(next?.id ?? null)}
@@ -1820,15 +1820,15 @@ function ChatPane({
                 disabled={disabledAgentSwitch}
                 className="h-6 min-w-0 flex-1 justify-start gap-1 px-1.5 py-0 text-xs font-medium"
               />
-              <PaneChatTabStrip
-                activeTab={activeTab}
-                onSelectTab={setActiveTab}
-                // The Assistant (agentPageId null) has no page, so no Settings.
-                showSettings={agentPageId !== null}
-                agentTitle={agent?.title ?? 'Agent'}
-              />
-            </div>
-          )
+            )}
+            <PaneChatTabStrip
+              activeTab={activeTab}
+              onSelectTab={setActiveTab}
+              // The Assistant (agentPageId null) has no page, so no Settings.
+              showSettings={agentPageId !== null}
+              agentTitle={agent?.title ?? 'Agent'}
+            />
+          </div>
         }
         actions={
           <>

--- a/apps/web/src/components/agents/panes/__tests__/AgentPanes.test.tsx
+++ b/apps/web/src/components/agents/panes/__tests__/AgentPanes.test.tsx
@@ -1566,6 +1566,62 @@ describe('AgentPanes — a History delete', () => {
     expect(onConversationClosed).not.toHaveBeenCalled();
   });
 
+  it('still notifies the host recovery path even if the workspace was forgotten while the DELETE was in flight (session-end race)', async () => {
+    // The notification does not depend on the workspace still being in the
+    // store — a concurrent session-end (the sidebar's own independent
+    // end-session path) can forget it before this DELETE's own round trip
+    // resolves. Simulated by holding the DELETE pending, forgetting the
+    // workspace while it's in flight, then letting it resolve.
+    mockSessionConversations([{ conversationId: 'conv-1', agentPageId: 'agent-1' }]);
+    let resolveDelete!: (value: { ok: boolean; json: () => Promise<unknown> }) => void;
+    const base = mockFetchWithAuth.getMockImplementation()!;
+    mockFetchWithAuth.mockImplementation(async (url: string, init?: { method?: string }) => {
+      if (url === '/api/ai/page-agents/agent-1/conversations' && init?.method !== 'DELETE') {
+        return jsonOk({
+          conversations: [
+            {
+              id: 'conv-1',
+              title: 'First chat',
+              preview: '',
+              createdAt: new Date('2026-01-01').toISOString(),
+              updatedAt: new Date('2026-01-01').toISOString(),
+              messageCount: 1,
+              sessionId: 'ses-1',
+              isOwner: true,
+              lastMessage: { role: 'user', timestamp: new Date('2026-01-01').toISOString() },
+            },
+          ],
+        });
+      }
+      if (init?.method === 'DELETE') return new Promise((resolve) => (resolveDelete = resolve));
+      return base(url, init);
+    });
+    seat([rootNode, chatNode('n1', WS, 0, 'conv-1')]);
+    const onConversationClosed = vi.fn();
+    const user = userEvent.setup();
+    renderPanes({ hostConversationId: 'conv-1', onConversationClosed });
+
+    await screen.findByTestId('pane-chat');
+    await user.click(await screen.findByRole('tab', { name: /history/i }));
+    await user.click(await screen.findByText('delete-conv-1'));
+
+    // The DELETE is pending — a concurrent session-end (unrelated to this
+    // delete) forgets the workspace before the delete's own round trip
+    // resolves.
+    useAgentWorkspaceStore.getState().forgetWorkspace(WS);
+    expect(useAgentWorkspaceStore.getState().workspaces[WS]).toBeUndefined();
+
+    resolveDelete({ ok: true, json: async () => ({}) });
+
+    await waitFor(() =>
+      expect(onConversationClosed).toHaveBeenCalledWith({
+        conversationId: 'conv-1',
+        next: null,
+        nextAgentPageId: null,
+      }),
+    );
+  });
+
   it('does NOT touch any pane when the delete is refused', async () => {
     mockSessionConversations([{ conversationId: 'conv-1', agentPageId: 'agent-1' }]);
     mockFetchWithAuth.mockImplementation(async (url: string, init?: { method?: string }) => {

--- a/apps/web/src/components/agents/panes/__tests__/AgentPanes.test.tsx
+++ b/apps/web/src/components/agents/panes/__tests__/AgentPanes.test.tsx
@@ -1515,6 +1515,57 @@ describe('AgentPanes — a History delete', () => {
     expect(panesNow().some((node) => node.target === null)).toBe(true);
   });
 
+  /**
+   * The host pane's bar carries a History tab now (it didn't used to — see
+   * the identity-slot fix above), so deleting the page's OWN hosted
+   * conversation from inside the grid is reachable for the first time.
+   * Unbinding the node alone would leave `AgentPageView`'s `current` state
+   * pointed at a conversation that no longer exists, with nothing to notice
+   * (review finding — chatgpt-codex-connector). This reuses the SAME
+   * `onConversationClosed` event a manual pane close already reports, which
+   * `AgentPageView`'s handler already turns into a `mintReplacementForCurrent`
+   * when `next` is null — no new recovery path, just routing this delete
+   * through the existing one.
+   */
+  it("notifies the host recovery path when the DELETED conversation is the page's own hosted one", async () => {
+    mockSessionConversations([{ conversationId: 'conv-1', agentPageId: 'agent-1' }]);
+    mockAgentHistory();
+    seat([rootNode, chatNode('n1', WS, 0, 'conv-1')]);
+    const onConversationClosed = vi.fn();
+    const user = userEvent.setup();
+    renderPanes({ hostConversationId: 'conv-1', onConversationClosed });
+
+    await screen.findByTestId('pane-chat');
+    await user.click(await screen.findByRole('tab', { name: /history/i }));
+    await user.click(await screen.findByText('delete-conv-1'));
+
+    await waitFor(() =>
+      expect(onConversationClosed).toHaveBeenCalledWith({
+        conversationId: 'conv-1',
+        next: null,
+        nextAgentPageId: null,
+      }),
+    );
+  });
+
+  it("does NOT notify the host recovery path for a delete that ISN'T the hosted conversation", async () => {
+    mockSessionConversations([{ conversationId: 'conv-1', agentPageId: 'agent-1' }]);
+    mockAgentHistory();
+    seat([rootNode, chatNode('n1', WS, 0, 'conv-1')]);
+    const onConversationClosed = vi.fn();
+    const user = userEvent.setup();
+    // Hosted conversation is a DIFFERENT one — this pane's own delete is a
+    // split pane's own history, not the page's tracked conversation.
+    renderPanes({ hostConversationId: 'conv-2', onConversationClosed });
+
+    await screen.findByTestId('pane-chat');
+    await user.click(await screen.findByRole('tab', { name: /history/i }));
+    await user.click(await screen.findByText('delete-conv-1'));
+
+    await waitFor(() => expect(nodeShowingChat('conv-1')).toBeUndefined());
+    expect(onConversationClosed).not.toHaveBeenCalled();
+  });
+
   it('does NOT touch any pane when the delete is refused', async () => {
     mockSessionConversations([{ conversationId: 'conv-1', agentPageId: 'agent-1' }]);
     mockFetchWithAuth.mockImplementation(async (url: string, init?: { method?: string }) => {


### PR DESCRIPTION
## Summary
- In the AI-page split grid (`AgentPanes.tsx`), the "host" pane (the one mirroring the AI page's own hosted conversation) collapsed to a bare identity label with no `PaneChatTabStrip` — the one pane in a grid that couldn't reach History or Settings from its own bar.
- It now keeps the plain identity label (no duplicate agent-switcher — this pane can't leave its bound agent) but always renders the Chat/History/Settings tab strip alongside it, matching every other pane in the grid. Split/close and the inline Save button were already unconditional for this pane.
- Follow-up (review findings): the newly-reachable History tab on the host pane made it possible for the first time to delete the page's own hosted conversation from inside the grid. `handleHistoryDeleteConversation` now notifies `AgentPageView`'s existing recovery path (`onConversationClosed` → `mintReplacementForCurrent`) when that happens, including when a concurrent session-end forgets the workspace mid-delete. The "closed, no replacement" event payload was also factored into one shared helper so the two call sites that report it can't drift.

## Scope note
This lands only the safe half of the original ask. Reducing the page-level `AgentPageView` header (dropping the Chat/History/Settings pills + pinned Save button) was investigated but reverted: those page-level tabs drive a distinct capability for a session-bound grid — browsing *all* of an agent's past conversations and switching which one the page hosts — with no per-pane equivalent (a per-pane History pick only rebinds that one grid node, not the page's own tracked conversation). Removing them broke ~20-29 existing tests covering that real behavior, so that part was left as-is pending a follow-up decision.

## Test plan
- [x] `bun run --filter web test -- panes/__tests__/AgentPanes AgentPageView` (103 passing, including host-delete recovery + session-end race coverage)
- [x] `bun run typecheck` (monorepo-wide, 17/17 packages)
- [x] CI green: Unit Tests, E2E, Lint & TypeScript Check
- [ ] Manually verify in the app: open an AI page with a session-bound split grid, confirm the host pane's bar shows the Chat/History/Settings tab strip, and confirm deleting the hosted conversation from that tab recovers correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SKUXirLLextXHov7qD8a4n

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Chat panes now consistently display the Chat, History, and Settings tabs, including when showing the same conversation as the main page.
  - Preserved the session identity label for conversations linked to the main page.
  - Retained conversation selection and tab navigation for other chat panes.
  - Deleting the main page's hosted conversation from History now correctly provides a replacement conversation, including when the session ends at the same time.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
