### PR TITLE
fix(backfill): 200 concurrent writes against a one-connection pool

### DIFF
--- a/apps/web/src/lib/editor/__tests__/content-mode-backfill.test.ts
+++ b/apps/web/src/lib/editor/__tests__/content-mode-backfill.test.ts
@@ -10,6 +10,12 @@
  * (id, revisionAfterApply) pairs back — never a page edited since.
  */
 import { describe, it, expect, vi, beforeEach } from 'vitest';
+// Without this, `assert(...)` resolves to chai's global truthy assert via
+// vitest globals — `assert({ actual: 1, expected: 999 })` PASSES, because a
+// non-empty object is truthy. Every riteway-shaped assertion in this file was
+// vacuous until this import existed, which is how a 200-way `Promise.all`
+// against a one-connection pool shipped with 22 green tests.
+import { assert } from '@/lib/ai/core/__tests__/riteway';
 
 const { gtCursors, classifyMock } = vi.hoisted(() => ({
   gtCursors: [] as unknown[],
@@ -364,5 +370,59 @@ describe('parseBackfillArgs', () => {
   it('refuses --apply and --revert together', () => {
     const result = parseBackfillArgs(['--apply', '--out', 'x.json', '--revert', 'y.json']);
     expect(result.ok).toBe(false);
+  });
+
+  it('given a batch of mislabelled pages, never has more than one write in flight', async () => {
+    // The regression this guards. These scripts run on `getMigrationPool()`,
+    // which is deliberately `max: 1` so a backfill cannot starve the
+    // deployment it runs against. The batch used to write via `Promise.all`,
+    // putting up to 200 writes in flight against that one connection — a
+    // self-deadlock that killed the first real production run with
+    // `timeout exceeded when trying to connect`, before a single row was
+    // corrected. Concurrency here is not a speed-up; it is the bug.
+    let inFlight = 0;
+    let maxInFlight = 0;
+    let revision = 100;
+    const update = vi.fn(() => ({
+      set: () => ({
+        where: (cond: { and: Array<{ eq: [unknown, unknown] }> }) => ({
+          returning: async () => {
+            inFlight += 1;
+            maxInFlight = Math.max(maxInFlight, inFlight);
+            // Yield, so a concurrent implementation genuinely overlaps here.
+            await new Promise((resolve) => setTimeout(resolve, 0));
+            inFlight -= 1;
+            revision += 1;
+            return [{ id: cond.and[0].eq[1], revision }];
+          },
+        }),
+      }),
+    }));
+
+    const select = selectReturning([
+      [
+        markdownPage('p1'),
+        markdownPage('p2'),
+        markdownPage('p3'),
+        markdownPage('p4'),
+        markdownPage('p5'),
+      ],
+      [],
+    ]);
+
+    const result = await planAndApplyBackfill(fakeDb(select, update), { apply: true });
+
+    assert({
+      given: 'a batch of five mislabelled pages on a one-connection pool',
+      should: 'never exceed one write in flight',
+      actual: maxInFlight,
+      expected: 1,
+    });
+    assert({
+      given: 'sequential writes',
+      should: 'still correct every page in the batch',
+      actual: result.corrected.length,
+      expected: 5,
+    });
   });
 });

--- a/apps/web/src/lib/editor/content-mode-backfill.ts
+++ b/apps/web/src/lib/editor/content-mode-backfill.ts
@@ -14,6 +14,18 @@ import { pages } from '@pagespace/db/schema/core';
 import type { getMigrationDb } from '@pagespace/db/db';
 import { createDomWorkspace, classifyDocumentContent } from './document-content-format';
 
+/**
+ * Run thunks one at a time. See the call site for why this is sequential:
+ * these scripts hold a one-connection pool by design, so any concurrency here
+ * deadlocks rather than speeds anything up.
+ */
+async function sequentially(tasks: Array<() => Promise<void>>): Promise<void> {
+  for (const task of tasks) {
+    await task();
+  }
+}
+
+
 export type BackfillDb = ReturnType<typeof getMigrationDb>;
 
 const DEFAULT_BATCH_SIZE = 200;
@@ -111,12 +123,24 @@ export async function planAndApplyBackfill(
       if (!apply) {
         summary.corrected.push(...mislabelled.map((page) => ({ id: page.id, revisionAfterApply: page.revision + 1 })));
       } else if (mislabelled.length > 0) {
-        // Each page's compare-and-swap only touches its own row, so the
-        // batch's writes run concurrently rather than one round trip at a
-        // time — up to `batchSize` (200) in flight per batch.
+        // Written SEQUENTIALLY, and that is not a missed optimisation.
+        //
+        // This ran as `Promise.all` over the batch — up to `batchSize` (200)
+        // writes in flight — until the first real run against production died
+        // on `timeout exceeded when trying to connect` before it corrected a
+        // single row. The scripts that call this use `getMigrationPool()`,
+        // which is deliberately `max: 1` (packages/db/src/db.ts:117) so a
+        // long-running backfill cannot starve the deployment it is running
+        // against. Two hundred concurrent writes against a one-connection pool
+        // is a self-deadlock: the first takes the connection, the other 199
+        // wait for one that cannot free until they stop waiting.
+        //
+        // Do not "restore" the concurrency without also giving these scripts a
+        // pool that can serve it — the concurrency was never the thing making
+        // this fast, and the pool bound is the thing keeping production safe.
         const batchCorrected: CorrectedPage[] = [];
-        await Promise.all(
-          mislabelled.map(async (page) => {
+        await sequentially(
+          mislabelled.map((page) => async () => {
             // Compare-and-swap on the exact content read: a page edited
             // between the select and this write must not be relabelled
             // against content this run never actually classified. updatedAt


### PR DESCRIPTION
The mislabelled-`contentMode` backfill from #2511 has never corrected a row. Its first real run against production died on `timeout exceeded when trying to connect` before writing anything.

Found while running it as the Phase E gate. **Production was left untouched** — verified zero rows modified; it failed on the first batch.

## The deadlock

Each batch wrote via `Promise.all` over up to `batchSize` (200) pages. The scripts that call this use `getMigrationPool()`, which is deliberately `max: 1` (`packages/db/src/db.ts:117`) so a long-running backfill cannot starve the deployment it runs against.

Two hundred concurrent writes against a one-connection pool is a self-deadlock: the first write takes the connection, the other 199 wait for one that cannot free until they stop waiting. The code comment claimed *"up to `batchSize` (200) in flight per batch"* — written against a pool that serves one.

Writes are sequential now. The comment says why, so the concurrency is not "restored" later without also giving these scripts a pool that can serve it. It was never the thing making this fast; the pool bound is the thing keeping production safe.

## Why 22 green tests did not catch it

This was **the only one of 193** riteway-style test files in the repo using `assert({ given, should, actual, expected })` **without importing `assert`**. It resolved to chai's global truthy `assert` via vitest globals, where `assert(someObject)` merely checks the object is truthy.

Verified directly — this passes:

```ts
assert({ given: 'a lie', should: 'fail', actual: 1, expected: 999 });
```

So every assertion in the file was vacuous, and no possible bug in the runner could have failed it.

The import is added, with a comment on why its absence was invisible. The other 192 files import a real `assert` and are unaffected — I checked rather than assumed.

## New guard

A test asserts no more than one write is ever in flight, by counting concurrent entries into the mocked `returning()`.

**Mutation-checked:** restoring `Promise.all` turns it red. Worth noting it did **not** go red before the `assert` import was fixed — the first mutation run passed with `maxInFlight = 5` against `expected: 1`, which is what exposed the vacuous assert in the first place.

## Validation

- `bun run --filter web test -- src/lib/editor/__tests__/content-mode-backfill.test.ts` — 23 passed
- `bun run typecheck` (monorepo root) — 17/17

## After this merges

The backfill still needs running — the Phase E gate is **not** cleared. Dry run against production currently reports `Would correct: 3173 of 3765 scanned`, which I reconciled against the census's 3,003: the extra ~168 are markdown pages containing unescaped angle brackets (`ActionResult<void>`, `<task-id>`) that the census's cruder SQL regex counted as HTML. The script's parser-based classifier is the more correct of the two.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed content-mode backfills that could stall when correcting multiple pages.
  - Corrections now complete reliably while preserving safeguards against conflicting updates.
  - Ensured all affected pages are corrected without exceeding the supported number of simultaneous writes.

- **Tests**
  - Added regression coverage confirming batch corrections complete successfully with controlled write concurrency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->