### PR TITLE
Sync admin's OpenRouter provider list, add CHANGELOG entry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -235,6 +235,15 @@ All notable user-facing changes to PageSpace are documented here. Format follows
   in the table, on kanban cards and on the narrow-screen cards. Previously none of them said, and
   the only hint was a count inside the expanded row.
 
+### Changed
+
+- **The default AI model is now Z.ai's GLM-5.3 Flash** — cheaper per token and a larger context
+  window than the previous default (OpenAI's GPT-5.6 Luna), and still on the free-tier allowlist.
+  New accounts pick it up automatically; anyone with an explicit model already selected keeps that
+  choice. Also refreshed the whole OpenRouter model catalog: many new models and providers are now
+  selectable (a lot more vendor choice), pricing and context-window figures were corrected against
+  OpenRouter's live data, and a handful of models OpenRouter no longer serves were removed.
+
 ### Fixed
 
 - **Every pane in an AI page's split grid now offers Chat/History/Settings from its own bar** — the

--- a/apps/admin/src/lib/monitoring-queries.ts
+++ b/apps/admin/src/lib/monitoring-queries.ts
@@ -510,9 +510,17 @@ export function computeMarginPct(realCostCents: number, chargedCents: number): n
 }
 
 // Cloud vendors route through OpenRouter; local providers use their own backends.
+// Hand-kept in sync with CLOUD_VENDOR_PROVIDERS in
+// apps/web/src/lib/ai/core/ai-providers-config.ts (admin can't import the web
+// app's module) — a vendor added there without updating here miscounts real
+// OpenRouter cost as 'estimate' in margin/revenue analytics.
 const CLOUD_VENDOR_PROVIDERS = new Set<string>([
   'openai', 'anthropic', 'google', 'xai', 'deepseek', 'qwen', 'mistral',
-  'moonshot', 'minimax', 'meta', 'bytedance', 'ai21', 'inception', 'writer',
+  'moonshot', 'minimax', 'meta', 'bytedance', 'inception', 'writer', 'zai',
+  'aion-labs', 'amazon', 'arcee-ai', 'cohere', 'dots-studio', 'ibm-granite',
+  'inclusionai', 'kwaipilot', 'liquid', 'meituan', 'nex-agi', 'nvidia',
+  'poolside', 'rekaai', 'relace', 'sakana', 'sao10k', 'stepfun', 'tencent',
+  'thedrummer', 'thinkingmachines', 'upstage', 'xiaomi',
 ]);
 
 function getBackendProvider(uiProvider: string): string {


### PR DESCRIPTION
## Context
This is a follow-up to #2516 (Refresh OpenRouter models, fix pricing drift, default to GLM-5.3 Flash), which merged while this commit was in flight — it got pushed to the now-closed branch a few minutes after the merge landed, so it's stranded and needs its own PR.

## Summary
- `apps/admin/src/lib/monitoring-queries.ts` hand-maintains its own copy of `CLOUD_VENDOR_PROVIDERS` (admin can't import the web app's module) to decide whether a provider's cost is "real" (OpenRouter-priced) or "estimate" in margin/revenue analytics. It still listed the now-removed `ai21` and never had `zai` at all — meaning every zai/GLM user's spend was already being misclassified as "estimate" before #2516, and now that `zai` is the default provider for new users (per #2516), that misclassification applies to the majority of the user base going forward. Synced it with the real list plus the 23 new provider keys `#2516` added.
- Adds the `CHANGELOG.md` entry the repo's `CLAUDE.md` calls for on user-visible changes: the new default model and the catalog refresh from #2516.

Found via a proactive `/code-review` pass on #2516 after its two CI-flagged review comments were fixed; both findings below were independently verified against source and the live OpenRouter API before landing.

## Test plan
- [x] `bun run --filter admin typecheck` — passes
- [x] No test references `CLOUD_VENDOR_PROVIDERS`/`getBackendProvider` in `apps/admin`, so nothing to update there

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>

https://claude.ai/code/session_01HNG1kzFqRXDQg38CYZT5C1