### PR TITLE
feat(sandbox): sprites service-surface spike findings + typed SDK seam (dark)

### DIFF
--- a/docs/spikes/2026-08-dev-preview-sprite-services-spike.md
+++ b/docs/spikes/2026-08-dev-preview-sprite-services-spike.md
@@ -38,7 +38,8 @@
 
 ## 1. Setup (verified)
 
-- Token recipe: `flyctl tokens create org -o personal -x 2h`, strip the `FlyV1 ` prefix,
+- Token recipe: `flyctl tokens create org -o personal -x 2h`, strip the leading `FlyV1` (plus
+  its trailing space) prefix,
   `SpritesClient.createToken(macaroon, 'personal')` → a `personal…`-prefixed Sprites token
   (114 chars). The 2h expiry is real — a later run failed `APIError: unauthorized` until
   re-minted.

--- a/docs/spikes/2026-08-dev-preview-sprite-services-spike.md
+++ b/docs/spikes/2026-08-dev-preview-sprite-services-spike.md
@@ -1,0 +1,196 @@
+# Spike: Sprites Services surface against a live Sprite (dev-server preview)
+
+> **Date:** 2026-08-29/30 · **SDK:** `@fly/sprites@0.0.1-rc37` · **API:** `https://api.sprites.dev`
+> **Why:** the dev-preview workstream (same-origin authenticated proxy to a dev server in a
+> sandbox) rests on the SDK's Services surface (`createService`/`httpPort`/`SpriteInfo.url`/
+> `urlSettings`), which had **never been verified against a live Sprite** — the old design doc
+> (`docs/sprites/services-adoption-design.md`, OBSOLETE) said so itself in §7.
+> **Method:** four throwaway Sprites driven end-to-end with a real org-minted token
+> (`flyctl tokens create org` → `SpritesClient.createToken`), every one deleted in a `finally`
+> and the deletion verified (`getSprite` → `sprite not found`). Every claim below is marked
+> **verified** (observed on the wire) or **assumed** (docs/types only, not observed).
+
+## TL;DR — what changed under the design doc
+
+1. **The Services CRUD surface works exactly as the SDK types say.** `createService` (PUT,
+   auto-starts, NDJSON log stream), `listServices`, `getService`, `startService`,
+   `stopService`, `deleteService`, `signalService` — all real, all verified. **Part B (the
+   typed seam) is buildable.**
+2. **`httpPort` is accepted, stored, and DOES NOTHING to URL routing.** The sprite URL is a
+   proxy to **port 8080, always**. A service bound to `httpPort: 8000` is unreachable via the
+   URL (the request *hangs* — no 502); any plain process listening on 8080 — service or not —
+   is served. Start-on-request never fired. The docs' "requests route to the service's port"
+   and "the proxy starts it first" are **not the shipped behavior**.
+3. **No one-http-port-per-Sprite scarcity.** A second service with its own `httpPort` was
+   accepted without a 409. The design doc's P1 ("visibility is a property of the single
+   HTTP-port slot") loses its enforcement mechanism — but also its urgency, since `httpPort`
+   doesn't route anything. The real slot is **port 8080 itself**.
+4. **URL auth (`auth: 'sprite'`) is real and org-token-friendly**: `Authorization: Bearer
+   <sprites-token>` → 200 in ~56ms. No/invalid token → **302 to an SSO flow**
+   (`https://sprites.dev/auth/sprite?return_url=…`), not a 401. `auth: 'public'` works and is
+   flipped live by `updateURLSettings`. The zero-trust architecture (our proxy adds the org
+   token; the URL stays `auth: 'sprite'`) is **confirmed viable** — with the 8080 caveat.
+5. **`port_opened` frames are real but TTY-only**; `port_closed` was **never observed**.
+   `stopService` leaves the service in `status: 'failed'` (`"exited with code 143"`), not
+   `'stopped'`.
+
+---
+
+## 1. Setup (verified)
+
+- Token recipe: `flyctl tokens create org -o personal -x 2h`, strip the `FlyV1 ` prefix,
+  `SpritesClient.createToken(macaroon, 'personal')` → a `personal…`-prefixed Sprites token
+  (114 chars). The 2h expiry is real — a later run failed `APIError: unauthorized` until
+  re-minted.
+- Sprite image: `python3`, `node`, `bun` all present under `/.sprite/bin`; no `busybox`/`nc`.
+  Kernel `6.12.105-fly` x86_64.
+- `createSprite` returns `status: 'cold'`, an `id` (`sprite-<uuid>`), a `url`
+  (`https://<name>-<org>.sprites.app`) and `urlSettings` **immediately** — no service needed
+  for the URL to exist.
+
+## 2. `SpriteInfo.url` + `urlSettings` (verified)
+
+- Shape: `url: "https://ps-spike-preview-mtf27zhe-bskrl.sprites.app"`,
+  `urlSettings: { auth: 'sprite', private_access: 'admins' }`. Note **`private_access` is not
+  in the SDK's `URLSettings` type** (`{ auth?: string }`) — the wire shape is a superset.
+- Default is `auth: 'sprite'` (private). Behavior at the URL, service running on its port:
+
+  | Request | Result |
+  |---|---|
+  | No `Authorization` | **302** → `https://sprites.dev/auth/sprite?return_url=<signed>` (browser SSO), not 401 |
+  | `Bearer <garbage>` | **302** to the same SSO flow (invalid ≡ absent) |
+  | Raw Fly org token (`FlyV1 fm2_…`) as `Authorization` | **302** (Fly macaroons are NOT accepted at the URL) |
+  | `Bearer <sprites-token>` | **200**, ~56ms — the minted org-scoped Sprites token IS the credential |
+
+- `updateURLSettings({ auth: 'public' })` → next `getSprite` shows `{ auth: 'public' }` and
+  the URL serves with no auth. `{ auth: 'sprite' }` restores the 302-for-anonymous behavior.
+  Both verified live, effective immediately.
+- **Consequence for the proxy task:** the same-origin proxy authenticates to the sprite URL
+  with the `SPRITES_API_TOKEN` bearer header. A browser can never open the URL directly
+  (it gets the SSO flow for an org it isn't in), which is exactly the v1 posture.
+
+## 3. URL routing: **always port 8080** (verified — the headline surprise)
+
+Run 3, distinct marker files per port, URL set `public` to remove auth noise:
+
+| State inside the Sprite | `GET <sprite url>/` |
+|---|---|
+| Service `httpPort: 8000` **running**, nothing on 8080 | **hangs** — 25s+ timeout, no 502, no answer |
+| Same, plus a plain (non-service) `python3 -m http.server 8080` | **200 `MARKER-8080-PLAIN`** — the 8080 process, not the service |
+| Service stopped, 8080 process still up | 200 `MARKER-8080-PLAIN` |
+| Service restarted via `startService` | still 200 `MARKER-8080-PLAIN` |
+
+- The `httpPort` field on a service is persisted (comes back in `listServices`) but has **no
+  observable routing effect**.
+- **Start-on-request does not exist** in shipped behavior: with the service stopped, requests
+  to the URL neither started it nor changed its state (checked before/after; state stayed
+  `failed`). With *nothing* on 8080 the request hangs until client timeout — there is no
+  fast failure to detect "no server" from outside.
+- **Assumed** (not verified): 8080 is the documented default Sprite HTTP port; the docs'
+  service-port routing may arrive in a later platform release. Re-verify before building
+  anything on `httpPort`.
+- **Consequence:** a previewable dev server must be reachable **on port 8080 in the Sprite**
+  (bind it there, or relay to it). "Which service owns the preview" is a fact about port
+  8080, not about any service row — the design doc's P1 conclusion survives with 8080
+  substituted for "the httpPort slot".
+
+## 4. Services lifecycle (verified)
+
+- **`createService(name, {cmd, args, httpPort}, duration?)`** is a PUT
+  (`/v1/sprites/{name}/services/{svc}`) that **auto-starts** the service and returns an
+  NDJSON `ServiceLogStream`. With `duration: '5s'` the stream carried
+  `{type:'started'}` … `{type:'complete', log_files:{combined|stdout|stderr:
+  '/.sprite/logs/services/<name>.log'}}` (~5s apart — the stream stays open for the
+  monitoring window). Note the wire field is **`log_files`** (snake_case); the SDK's
+  `ServiceLogEvent` type says `logFiles` — **the type lies**, consume defensively.
+- **`listServices()`** → `[{name, cmd, args, needs: [], httpPort?, state: {name, status,
+  pid, started_at, next_restart_at}}]`. **`getService(name)`** → same but `needs: null`
+  (list normalizes to `[]`, get returns the raw `null` — another types-vs-wire wobble; the
+  `state` timestamps are snake_case strings, not the camelCase of the SDK's `ServiceState`).
+- **State machine observed:** running → (`stopService`) → **`failed`** with
+  `error: "exited with code 143"` — the runtime records the SIGTERM exit as a failure; the
+  documented sticky-'stopped' state was never observed. → (`startService`) → `running` with
+  a fresh pid. Stop **is** sticky in effect (nothing restarted it), but code that matches
+  `status === 'stopped'` will never fire; treat `failed` + our own stopped-intent flag as
+  the real signal.
+- **`stopService`** stream: `stopping` → `stopped (exit_code: 143)` → `complete`. (The
+  *stream event* says `stopped`; the *persisted state* says `failed`.)
+- **Duplicate `httpPort`:** second service with `httpPort` on another port → accepted,
+  started, no 409. Both listed as `running`.
+- **`deleteService`** → 204; service gone from `listServices`.
+- **Destroy with services defined:** `deleteSprite` succeeds normally; `getSprite` after →
+  `APIError: sprite not found` (404). Services need no separate teardown.
+- **Hibernate/wake:** see §6.
+
+## 5. `port_opened` / `port_closed` exec-WS frames (verified)
+
+- A dev server binding a port inside a **TTY session** (`createSession(..., {tty: true})` —
+  the exact shape the realtime terminal uses) produces a TEXT control frame on that
+  session's own WebSocket: `{"type":"port_opened","port":8124,"address":"10.0.0.1","pid":383}`
+  — matching the SDK's `PortNotification` type. It arrives interleaved with `session_info`
+  and `exit` frames via the SDK's `message` event, which our `SpriteCommandLike`
+  already models (`on('message')`) and our consumers currently ignore.
+- A **plain `spawn` (no TTY)** running the same server produced **zero** frames — in two
+  separate runs. The SDK forwards every TEXT frame regardless of TTY (websocket.js emits
+  `message` for any string payload), so the filter is **server-side**: the runtime only
+  notifies TTY/session channels. Port detection must therefore hook the PTY path
+  (realtime terminal), not the batch exec path.
+- **`port_closed` was never observed** — killing the server and waiting (2s, then 8s in a
+  second run, plus a post-exit listen window) produced no frame. Do not build teardown
+  logic on `port_closed`; treat it as best-effort if it ever arrives.
+
+## 6. Hibernation vs services (run 4, verified)
+
+- A Sprite with a **running** service still pauses: status went `running` → `warm` within
+  ~60–80s of idle (polled at 20s intervals). "Services don't block pause" is real.
+- While paused (`warm`), `listServices` still answers (it's a control-plane read) and reports
+  the frozen truth: `status: 'running'`, same pid.
+- **An inbound URL request wakes the paused VM** — the fetch itself timed out (nothing on
+  8080, §3) but the next `getSprite` showed `running`. Billing consequence for the proxy
+  task confirmed: any proxied request is a wake, so wake-through-the-proxy must consult the
+  same code-exec gate posture as session ensure.
+- **Warm wake resumes the service process mid-flight**: same pid (22) before and after the
+  pause — no restart, no state change. (Cold-boot restart behavior — the docs' "starts every
+  service fresh" — was NOT observed in this spike's window: **assumed**, unverified.)
+
+## 7. What this means for the seam (Part B) and downstream tasks
+
+- **Safe to type and thread now** (verified operations only): `listServices`, `getService`,
+  `createService`, `startService`, `stopService`, `deleteService`, `url`, `urlSettings`,
+  `updateURLSettings` — plus surfacing `port_opened`/`port_closed` frames to a
+  caller-provided listener on the exec WS (data only; TTY sessions are where they occur).
+- **Do NOT build on** (diverges from docs/types): `httpPort` as a routing mechanism;
+  start-on-request; the one-http-port 409; `status === 'stopped'`; `ServiceLogEvent.logFiles`
+  (wire is `log_files`); `URLSettings` as an exact shape (wire adds `private_access`).
+- **Decision for the proxy task** (flagged, not resolved here): the preview path is
+  "our proxy + Bearer sprites-token → `https://<sprite>.sprites.app` → whatever listens on
+  8080". Getting the user's dev server onto 8080 (run it there? in-sprite relay? revisit
+  when platform ships httpPort routing?) is that task's call — posted as
+  `[Q-preview-spike]`.
+
+## Appendix: raw evidence
+
+Scratch scripts (`spike-services{,-2,-3,-4}.mjs`) and full logs lived in the session
+scratchpad; sprites `ps-spike-preview-mtf27zhe`, `ps-spike2-mtf9pca8`, `ps-spike3-mtf9s2gb`,
+`ps-spike4-…` all verified deleted. Key raw shapes:
+
+```jsonc
+// getService('devserver') while running
+{ "name": "devserver", "cmd": "python3",
+  "args": ["-m", "http.server", "8000", "--directory", "/srv-spike"],
+  "needs": null,
+  "state": { "name": "devserver", "status": "running", "pid": 26,
+             "started_at": "2026-08-30T00:17:15.307030906Z",
+             "next_restart_at": "0001-01-01T00:00:00Z" } }
+
+// after stopService
+{ "state": { "status": "failed", "error": "exited with code 143", ... } }
+
+// TTY-session control frames while a server binds/dies
+{ "type": "session_info", "session_id": "58", "command": "sh", "tty": true, ... }
+{ "type": "port_opened", "port": 8124, "address": "10.0.0.1", "pid": 383 }
+{ "type": "exit", "exit_code": 0 }   // no port_closed, ever
+
+// anonymous request to a private (auth: 'sprite') URL
+// 302 Location: https://sprites.dev/auth/sprite?return_url=<signed-token>
+```

--- a/docs/spikes/2026-08-dev-preview-sprite-services-spike.md
+++ b/docs/spikes/2026-08-dev-preview-sprite-services-spike.md
@@ -169,6 +169,41 @@ Run 3, distinct marker files per port, URL set `public` to remove auth noise:
   when platform ships httpPort routing?) is that task's call — posted as
   `[Q-preview-spike]`.
 
+## 8. Addendum (2026-08-31): docs say httpPort/409/start-on-request ARE real — re-verified, they are NOT live
+
+The published docs (`docs.sprites.dev/concepts/services`, fetched directly) are unambiguous and
+internally consistent: *"The proxy routes incoming requests to port 8080 by default. Services with
+`--http-port` override this routing target."*; a second `--http-port` service *"fails with `409:
+another service already has an HTTP port configured`"*; and *"If the service isn't running when a
+request arrives, the proxy starts it first, then forwards the request."* This directly contradicts
+§2–3 above. Rather than take either the docs or the original spike on faith, ran one more decisive
+test designed to rule out the two most likely explanations for the discrepancy:
+
+- **Not an SDK bug**: every service-lifecycle call in this run was a hand-rolled `fetch()` — not
+  `@fly/sprites` — hitting the exact endpoints/body shapes read directly out of the SDK's own
+  source (`PUT /v1/sprites/{name}/services/{name}`, body `{cmd, args, httpPort}`;
+  `PUT /v1/sprites/{name}` with `{url_settings: {auth}}`), so there is no daylight between "what the
+  SDK sends" and "what this test sent."
+- **Not propagation delay**: polled the sprite URL every 15s for **5 minutes** after creating the
+  httpPort service (20 attempts) — every single attempt was a bare timeout, never a 502, never a
+  200. Same pattern for start-on-request: polled for 3 minutes after stopping the service (12
+  attempts) — never auto-started, service stayed `status: 'failed'` throughout.
+- **Not stale tooling**: the fresh sprite created for this run reported `"version":"0.0.1-rc48"` —
+  newer than both the pinned SDK (`0.0.1-rc37`) and the locally installed `sprite` CLI (`rc43`). The
+  live platform itself, on its current version, does not exhibit the documented behavior.
+- **New detail on the 409 claim**: retried the second-httpPort create three times. The retries
+  don't even attempt-and-reject — they return `200` with `{"message":"Service already running with
+  that command, use POST /v1/services/second/restart if you want to restart it"}`, i.e. the API
+  treats a repeat of the identical request as an idempotent no-op, never as a conflict to reject.
+
+**Conclusion — upgraded from "assumed" to "verified, repeatedly, two independent runs, raw API, long
+polling windows": `httpPort` routing, the one-http-port 409, and start-on-request are documented
+platform behavior that is NOT live on the API/runtime version this org can reach as of 2026-08-31.**
+This is not a criticism of the SDK or this driver — it is a live platform/documentation gap, and
+should be re-checked before anyone builds the proxy task against the assumption that it works. The
+findings in §2–3 (URL always proxies port 8080; no scarcity; no start-on-request) stand as the
+operative behavior to design against today.
+
 ## Appendix: raw evidence
 
 Scratch scripts (`spike-services{,-2,-3,-4}.mjs`) and full logs lived in the session

--- a/docs/spikes/2026-08-dev-preview-sprite-services-spike.md
+++ b/docs/spikes/2026-08-dev-preview-sprite-services-spike.md
@@ -204,6 +204,58 @@ should be re-checked before anyone builds the proxy task against the assumption 
 findings in §2–3 (URL always proxies port 8080; no scarcity; no start-on-request) stand as the
 operative behavior to design against today.
 
+## 9. Addendum (2026-08-31): ruled out "wrong config on our end"; discovered a better port-detection endpoint; found no hidden per-port routing
+
+Before trusting either the docs or §8's re-verification, checked whether the gap could be explained
+by something wrong with how PageSpace's own account is set up, rather than a platform/docs gap:
+
+- **Not the wrong org**: `flyctl orgs list` shows exactly one org on this account (`2Wits`/`personal`).
+  `flyctl apps list` confirms every production app (`pagespace-web`, `pagespace-realtime`, etc.) is
+  owned by that exact same org — there is no separate, better-provisioned "company" Sprites org this
+  spike missed.
+- **Not the wrong token shape**: production's `resolveSpritesToken()` reads `SPRITES_API_TOKEN` into
+  `new SpritesClient(token)` — the identical bearer-token shape minted here via
+  `SpritesClient.createToken(macaroon, 'personal')`.
+- **Not a billing/plan gate**: production apps are actively deployed and billed under this org, which
+  rules out "unpaid trial account" as an explanation. No plan/beta/tier language appears anywhere in
+  the docs for the services/httpPort/ports features.
+- **Not stale docs vs. a newer platform**: `docs.sprites.dev/api/` resolves to `/api/v001-rc48/` —
+  the exact runtime version (`0.0.1-rc48`) every freshly-created sprite in this investigation
+  reported. The docs being read are documentation for the exact version being tested.
+- **Not an ongoing platform incident**: Fly's own status page (`status.flyio.net`) shows no open or
+  recent incident touching Sprites HTTP routing/services/proxy — the one Sprites-related incident in
+  the last month (sprite deletion jobs failing, 2026-08-30 21:18–22:05 UTC) is unrelated and outside
+  every test window here.
+
+Also discovered a previously-missed API surface — `docs.sprites.dev/api/v001-rc48/ports/` documents
+`WSS /v1/sprites/{name}/ports/watch`: *"Watch for port open/close events across all processes in the
+sprite namespace. On connect, sends a snapshot of all currently listening ports as a `port_list`
+message, then streams incremental `port_opened`/`port_closed` events."* The SDK does not wrap this
+endpoint at all (grepped the dist — zero references). Tested it directly:
+
+- **Correction to §5's finding**: `port_opened`/`port_closed` are NOT TTY-session-only. §5 concluded
+  this from the exec-WS's own `message` channel, which genuinely is TTY-only (verified: a plain
+  `spawn()` produced zero frames there). But the dedicated `ports/watch` WS saw a `port_opened` +
+  `port_closed` pair for a **plain non-TTY `spawn()`** process within ~1.5s of it binding the port —
+  a strictly more general, more reliable detection channel than the one wired into this PR's seam.
+  **If/when the dev-server-detection decision core gets built, it should watch `ports/watch`, not
+  the exec-WS message channel** — this seam's `onPortEvent` (TTY-only) should be treated as
+  superseded, not extended.
+- **The docs' example message is misleading**: the docs example shows
+  `"address": "https://my-sprite.sprites.dev:3000"` (a routable per-port URL), which would have been
+  a completely different — and much simpler — path to a working preview (watch for the port, hit its
+  own URL directly, no Services/httpPort involved at all). The ACTUAL wire response only ever
+  contained `"address": "10.0.0.1"` — the sprite's internal IP, matching exactly what the exec-WS
+  channel already showed in §5 of the original spike. **There is no hidden per-port public URL.**
+  `ports/watch` is a notification-only channel; it does not make a port externally reachable.
+
+**Net effect on the open question**: the "wrong config" and "secret per-port URL" hypotheses are
+both ruled out. The httpPort/409/start-on-request gap from §8 stands, now with corroborating context
+(matching API version, no incident, no plan gate) rather than a plausible alternate explanation. The
+one channel genuinely not checkable from here: an account-level feature flag invisible to `flyctl`,
+the `sprite` CLI, and the public docs — only Fly support or a Sprites account dashboard could confirm
+or rule that out.
+
 ## Appendix: raw evidence
 
 Scratch scripts (`spike-services{,-2,-3,-4}.mjs`) and full logs lived in the session

--- a/packages/lib/src/services/agent-workspaces/__tests__/fakes.ts
+++ b/packages/lib/src/services/agent-workspaces/__tests__/fakes.ts
@@ -328,6 +328,7 @@ export function makeHandle(
     onData: () => {},
     onExit: () => {},
     onError: () => {},
+    onPortEvent: () => {},
     kill: () => {},
   };
   return {
@@ -354,6 +355,16 @@ export function makeHandle(
     listStreams: async (): Promise<SandboxStreamSessionInfo[]> => [],
     killSession: async () => {},
     createCheckpoint: async () => {},
+    services: {
+      create: async () => {},
+      list: async () => [],
+      get: async () => null,
+      start: async () => {},
+      stop: async () => {},
+      remove: async () => {},
+    },
+    urlInfo: async () => ({ url: null, auth: 'unknown' }),
+    setUrlAuth: async () => {},
   };
 }
 

--- a/packages/lib/src/services/sandbox/__tests__/machine-diff.test.ts
+++ b/packages/lib/src/services/sandbox/__tests__/machine-diff.test.ts
@@ -85,6 +85,16 @@ function makeHandle(files: Record<string, string>): { handle: SandboxHandle; rea
     },
     listStreams: async () => [],
     killSession: async () => {},
+    services: {
+      create: async () => {},
+      list: async () => [],
+      get: async () => null,
+      start: async () => {},
+      stop: async () => {},
+      remove: async () => {},
+    },
+    urlInfo: async () => ({ url: null, auth: 'unknown' }),
+    setUrlAuth: async () => {},
   };
   return { handle, reads };
 }

--- a/packages/lib/src/services/sandbox/__tests__/machine-fs.test.ts
+++ b/packages/lib/src/services/sandbox/__tests__/machine-fs.test.ts
@@ -35,6 +35,16 @@ function makeHandle(overrides: {
     },
     listStreams: async () => [],
     killSession: async () => {},
+    services: {
+      create: async () => {},
+      list: async () => [],
+      get: async () => null,
+      start: async () => {},
+      stop: async () => {},
+      remove: async () => {},
+    },
+    urlInfo: async () => ({ url: null, auth: 'unknown' }),
+    setUrlAuth: async () => {},
   };
 }
 

--- a/packages/lib/src/services/sandbox/sandbox-client/__tests__/sandbox-host-adapter.test.ts
+++ b/packages/lib/src/services/sandbox/sandbox-client/__tests__/sandbox-host-adapter.test.ts
@@ -19,6 +19,16 @@ function fakeHandle(over: Partial<SandboxHandle> = {}): SandboxHandle {
     },
     listStreams: async () => [],
     killSession: async () => {},
+    services: {
+      create: async () => {},
+      list: async () => [],
+      get: async () => null,
+      start: async () => {},
+      stop: async () => {},
+      remove: async () => {},
+    },
+    urlInfo: async () => ({ url: null, auth: 'unknown' }),
+    setUrlAuth: async () => {},
     ...over,
   };
 }

--- a/packages/lib/src/services/sandbox/sandbox-client/__tests__/sprite-sandbox-host.test.ts
+++ b/packages/lib/src/services/sandbox/sandbox-client/__tests__/sprite-sandbox-host.test.ts
@@ -836,5 +836,70 @@ describe('createSpriteSandboxHost', () => {
 
       expect(events).toEqual([{ type: 'port_opened', port: 5173 }, { type: 'port_closed', port: 5173 }]);
     });
+
+    it('given a SECOND onPortEvent subscriber, should deliver live events to BOTH — matching onData/onExit/onError fan-out, not silently orphaning the first', async () => {
+      const session = fakeSessionCommand();
+      const { sdk } = makeSdk({ getSprite: async () => fakeSprite({ createSession: session.createSession }) });
+      const client = createSpritesSandboxClient({ sdk });
+      const host = createSpriteSandboxHost({ sdk, client });
+      const handle = await host.provision({ name: 'k', substrate: { kind: 'sprite' }, options });
+      const stream = await handle.stream({});
+
+      const first: unknown[] = [];
+      const second: unknown[] = [];
+      stream.onPortEvent((event) => first.push(event));
+      stream.onPortEvent((event) => second.push(event));
+      session.emitMessage({ type: 'port_opened', port: 8000 });
+
+      expect(first).toEqual([{ type: 'port_opened', port: 8000 }]);
+      expect(second).toEqual([{ type: 'port_opened', port: 8000 }]);
+    });
+
+    it('given a pre-subscribe buffered event, a second (later) subscriber should NOT receive it again — only the first subscriber drains the backlog', async () => {
+      const session = fakeSessionCommand({ autoSpawn: false });
+      const { sdk } = makeSdk({ getSprite: async () => fakeSprite({ createSession: session.createSession }) });
+      const client = createSpritesSandboxClient({ sdk });
+      const host = createSpriteSandboxHost({ sdk, client });
+      const handle = await host.provision({ name: 'k', substrate: { kind: 'sprite' }, options });
+
+      const streamPromise = handle.stream({});
+      await new Promise((resolve) => setTimeout(resolve, 0));
+      session.emitMessage({ type: 'port_opened', port: 5173 });
+      session.emitSpawn();
+      const stream = await streamPromise;
+
+      const first: unknown[] = [];
+      const second: unknown[] = [];
+      stream.onPortEvent((event) => first.push(event));
+      stream.onPortEvent((event) => second.push(event));
+
+      expect(first).toEqual([{ type: 'port_opened', port: 5173 }]);
+      expect(second).toEqual([]);
+    });
+
+    it('given more port events than the buffer cap while nobody has subscribed, should drop the oldest rather than grow unbounded', async () => {
+      const session = fakeSessionCommand({ autoSpawn: false });
+      const { sdk } = makeSdk({ getSprite: async () => fakeSprite({ createSession: session.createSession }) });
+      const client = createSpritesSandboxClient({ sdk });
+      const host = createSpriteSandboxHost({ sdk, client });
+      const handle = await host.provision({ name: 'k', substrate: { kind: 'sprite' }, options });
+
+      const streamPromise = handle.stream({});
+      await new Promise((resolve) => setTimeout(resolve, 0));
+      // 70 events, well past the 64-entry cap, before anyone subscribes.
+      for (let port = 0; port < 70; port += 1) {
+        session.emitMessage({ type: 'port_opened', port });
+      }
+      session.emitSpawn();
+      const stream = await streamPromise;
+
+      const events: Array<{ port: number }> = [];
+      stream.onPortEvent((event) => events.push(event as { port: number }));
+
+      expect(events.length).toBe(64);
+      // The oldest (lowest ports) were dropped; the tail survives, in order.
+      expect(events[0]).toEqual({ type: 'port_opened', port: 6 });
+      expect(events[events.length - 1]).toEqual({ type: 'port_opened', port: 69 });
+    });
   });
 });

--- a/packages/lib/src/services/sandbox/sandbox-client/__tests__/sprite-sandbox-host.test.ts
+++ b/packages/lib/src/services/sandbox/sandbox-client/__tests__/sprite-sandbox-host.test.ts
@@ -901,5 +901,50 @@ describe('createSpriteSandboxHost', () => {
       expect(events[0]).toEqual({ type: 'port_opened', port: 6 });
       expect(events[events.length - 1]).toEqual({ type: 'port_opened', port: 69 });
     });
+
+    it('given a replay callback that itself calls onPortEvent (a nested subscribe), the nested listener should get NO backlog replay of its own and the outer listener should still see the full backlog exactly once', async () => {
+      // CodeRabbit review, PR #2520: with the naive "replay, then check
+      // listeners.length, then push" ordering, a subscribe triggered
+      // synchronously from inside a replay callback would see
+      // listeners.length === 0 (the outer subscribe hadn't pushed yet) and
+      // replay the SAME backlog again to the nested listener — while also
+      // mutating `buffered.length` mid-iteration out from under the outer
+      // loop. Register-then-drain-atomically fixes both.
+      const session = fakeSessionCommand({ autoSpawn: false });
+      const { sdk } = makeSdk({ getSprite: async () => fakeSprite({ createSession: session.createSession }) });
+      const client = createSpritesSandboxClient({ sdk });
+      const host = createSpriteSandboxHost({ sdk, client });
+      const handle = await host.provision({ name: 'k', substrate: { kind: 'sprite' }, options });
+
+      const streamPromise = handle.stream({});
+      await new Promise((resolve) => setTimeout(resolve, 0));
+      session.emitMessage({ type: 'port_opened', port: 3000 });
+      session.emitMessage({ type: 'port_opened', port: 3001 });
+      session.emitSpawn();
+      const stream = await streamPromise;
+
+      const outer: unknown[] = [];
+      const nested: unknown[] = [];
+      let nestedSubscribed = false;
+      stream.onPortEvent((event) => {
+        outer.push(event);
+        if (!nestedSubscribed) {
+          nestedSubscribed = true;
+          stream.onPortEvent((e) => nested.push(e));
+        }
+      });
+
+      expect(outer).toEqual([{ type: 'port_opened', port: 3000 }, { type: 'port_opened', port: 3001 }]);
+      expect(nested).toEqual([]);
+
+      // A live event after both are subscribed reaches both.
+      session.emitMessage({ type: 'port_closed', port: 3000 });
+      expect(outer).toEqual([
+        { type: 'port_opened', port: 3000 },
+        { type: 'port_opened', port: 3001 },
+        { type: 'port_closed', port: 3000 },
+      ]);
+      expect(nested).toEqual([{ type: 'port_closed', port: 3000 }]);
+    });
   });
 });

--- a/packages/lib/src/services/sandbox/sandbox-client/__tests__/sprite-sandbox-host.test.ts
+++ b/packages/lib/src/services/sandbox/sandbox-client/__tests__/sprite-sandbox-host.test.ts
@@ -65,6 +65,7 @@ function fakeCommand(
     emitStdout: (chunk: string) => stdout.emit('data', chunk),
     emitStderr: (chunk: string) => stderr.emit('data', chunk),
     emitExit: (code: number) => events.emit('exit', code),
+    emitMessage: (message: unknown) => events.emit('message', message),
   };
 }
 
@@ -80,7 +81,22 @@ function fakeSprite(over: Partial<SpriteInstanceLike> = {}): SpriteInstanceLike 
     createCheckpoint: async () => ({ processAll: async () => {}, close: () => {} }),
     destroy: async () => {},
     killSession: async () => {},
+    updateURLSettings: async () => {},
+    listServices: async () => [],
+    createService: async () => fakeServiceLogStream(),
+    startService: async () => fakeServiceLogStream(),
+    stopService: async () => fakeServiceLogStream(),
+    deleteService: async () => {},
     ...over,
+  };
+}
+
+function fakeServiceLogStream(events: Array<{ type: string; data?: string }> = []) {
+  return {
+    processAll: async (handler: (event: { type: string; data?: string }) => void | Promise<void>) => {
+      for (const event of events) await handler(event);
+    },
+    close: () => {},
   };
 }
 
@@ -527,5 +543,241 @@ describe('createSpriteSandboxHost', () => {
 
     const stream = await handle.stream({});
     expect(() => stream.write('x')).toThrow(/not interactive/);
+  });
+
+  describe('services + url (dev-preview seam)', () => {
+    it('given services.create, should PUT via createService and drain its startup log stream before resolving', async () => {
+      let created: { name: string; config: unknown; duration: unknown } | undefined;
+      const { sdk } = makeSdk({
+        getSprite: async () => fakeSprite({
+          createService: async (name, config, duration) => {
+            created = { name, config, duration };
+            return fakeServiceLogStream([{ type: 'started' }, { type: 'complete' }]);
+          },
+        }),
+      });
+      const client = createSpritesSandboxClient({ sdk });
+      const host = createSpriteSandboxHost({ sdk, client });
+      const handle = await host.provision({ name: 'k', substrate: { kind: 'sprite' }, options });
+
+      await handle.services.create({ name: 'devserver', command: 'python3', args: ['-m', 'http.server'], httpPort: 8000 });
+
+      expect(created).toEqual({
+        name: 'devserver',
+        config: { cmd: 'python3', args: ['-m', 'http.server'], httpPort: 8000 },
+        duration: '5s',
+      });
+    });
+
+    it('given services.create, should reject when the startup log stream reports an error event', async () => {
+      const { sdk } = makeSdk({
+        getSprite: async () => fakeSprite({
+          createService: async () => fakeServiceLogStream([{ type: 'error', data: 'boom' }]),
+        }),
+      });
+      const client = createSpritesSandboxClient({ sdk });
+      const host = createSpriteSandboxHost({ sdk, client });
+      const handle = await host.provision({ name: 'k', substrate: { kind: 'sprite' }, options });
+
+      await expect(handle.services.create({ name: 'devserver', command: 'python3' })).rejects.toThrow(/boom/);
+    });
+
+    it('given services.list, should normalize a Sprite service record onto the provider-neutral shape', async () => {
+      const { sdk } = makeSdk({
+        getSprite: async () => fakeSprite({
+          listServices: async () => [
+            {
+              name: 'devserver',
+              cmd: 'python3',
+              args: ['-m', 'http.server'],
+              needs: null,
+              httpPort: 8000,
+              state: { name: 'devserver', status: 'running', pid: 26 },
+            },
+          ],
+        }),
+      });
+      const client = createSpritesSandboxClient({ sdk });
+      const host = createSpriteSandboxHost({ sdk, client });
+      const handle = await host.provision({ name: 'k', substrate: { kind: 'sprite' }, options });
+
+      await expect(handle.services.list()).resolves.toEqual([
+        { name: 'devserver', command: 'python3', args: ['-m', 'http.server'], httpPort: 8000, status: 'running', pid: 26 },
+      ]);
+    });
+
+    it('given services.list, should normalize an unrecognized status string to "unknown" rather than leak it', async () => {
+      const { sdk } = makeSdk({
+        getSprite: async () => fakeSprite({
+          listServices: async () => [
+            { name: 'x', cmd: 'x', args: [], state: { name: 'x', status: 'crashlooping' as never } },
+          ],
+        }),
+      });
+      const client = createSpritesSandboxClient({ sdk });
+      const host = createSpriteSandboxHost({ sdk, client });
+      const handle = await host.provision({ name: 'k', substrate: { kind: 'sprite' }, options });
+
+      const [service] = await handle.services.list();
+      expect(service?.status).toBe('unknown');
+    });
+
+    it('given services.get for a name present in the listing, should return its normalized record', async () => {
+      const { sdk } = makeSdk({
+        getSprite: async () => fakeSprite({
+          listServices: async () => [
+            { name: 'devserver', cmd: 'python3', args: [], state: { name: 'devserver', status: 'running' } },
+          ],
+        }),
+      });
+      const client = createSpritesSandboxClient({ sdk });
+      const host = createSpriteSandboxHost({ sdk, client });
+      const handle = await host.provision({ name: 'k', substrate: { kind: 'sprite' }, options });
+
+      await expect(handle.services.get('devserver')).resolves.toMatchObject({ name: 'devserver', status: 'running' });
+    });
+
+    it('given services.get for a name absent from the listing, should return null', async () => {
+      const { sdk } = makeSdk({ getSprite: async () => fakeSprite({ listServices: async () => [] }) });
+      const client = createSpritesSandboxClient({ sdk });
+      const host = createSpriteSandboxHost({ sdk, client });
+      const handle = await host.provision({ name: 'k', substrate: { kind: 'sprite' }, options });
+
+      await expect(handle.services.get('missing')).resolves.toBeNull();
+    });
+
+    it('given services.stop, should record a "failed" status verbatim — Sprite records a stop as a failed exit, not "stopped"', async () => {
+      const { sdk } = makeSdk({
+        getSprite: async () => fakeSprite({
+          stopService: async () => fakeServiceLogStream([{ type: 'stopping' }, { type: 'stopped' }]),
+          listServices: async () => [
+            { name: 'devserver', cmd: 'python3', args: [], state: { name: 'devserver', status: 'failed', error: 'exited with code 143' } },
+          ],
+        }),
+      });
+      const client = createSpritesSandboxClient({ sdk });
+      const host = createSpriteSandboxHost({ sdk, client });
+      const handle = await host.provision({ name: 'k', substrate: { kind: 'sprite' }, options });
+
+      await handle.services.stop('devserver');
+      await expect(handle.services.get('devserver')).resolves.toMatchObject({ status: 'failed', error: 'exited with code 143' });
+    });
+
+    it('given services.start, should call startService and drain its stream', async () => {
+      let started: string | undefined;
+      const { sdk } = makeSdk({
+        getSprite: async () => fakeSprite({
+          startService: async (name) => { started = name; return fakeServiceLogStream([{ type: 'started' }]); },
+        }),
+      });
+      const client = createSpritesSandboxClient({ sdk });
+      const host = createSpriteSandboxHost({ sdk, client });
+      const handle = await host.provision({ name: 'k', substrate: { kind: 'sprite' }, options });
+
+      await handle.services.start('devserver');
+      expect(started).toBe('devserver');
+    });
+
+    it('given services.remove, should call deleteService', async () => {
+      let removed: string | undefined;
+      const { sdk } = makeSdk({
+        getSprite: async () => fakeSprite({ deleteService: async (name) => { removed = name; } }),
+      });
+      const client = createSpritesSandboxClient({ sdk });
+      const host = createSpriteSandboxHost({ sdk, client });
+      const handle = await host.provision({ name: 'k', substrate: { kind: 'sprite' }, options });
+
+      await handle.services.remove('devserver');
+      expect(removed).toBe('devserver');
+    });
+
+    it('given urlInfo, should report the sprite url + normalized auth mode', async () => {
+      const { sdk } = makeSdk({
+        getSprite: async () => fakeSprite({ url: 'https://x.sprites.app', urlSettings: { auth: 'sprite' } }),
+      });
+      const client = createSpritesSandboxClient({ sdk });
+      const host = createSpriteSandboxHost({ sdk, client });
+      const handle = await host.provision({ name: 'k', substrate: { kind: 'sprite' }, options });
+
+      await expect(handle.urlInfo()).resolves.toEqual({ url: 'https://x.sprites.app', auth: 'sprite' });
+    });
+
+    it('given urlInfo, should normalize an absent/unrecognized auth mode to "unknown" — never default to a proven-private claim', async () => {
+      const { sdk } = makeSdk({ getSprite: async () => fakeSprite({ url: 'https://x.sprites.app', urlSettings: undefined }) });
+      const client = createSpritesSandboxClient({ sdk });
+      const host = createSpriteSandboxHost({ sdk, client });
+      const handle = await host.provision({ name: 'k', substrate: { kind: 'sprite' }, options });
+
+      await expect(handle.urlInfo()).resolves.toEqual({ url: 'https://x.sprites.app', auth: 'unknown' });
+    });
+
+    it('given urlInfo on a sprite reporting no url, should return url: null', async () => {
+      const { sdk } = makeSdk({ getSprite: async () => fakeSprite({ url: undefined }) });
+      const client = createSpritesSandboxClient({ sdk });
+      const host = createSpriteSandboxHost({ sdk, client });
+      const handle = await host.provision({ name: 'k', substrate: { kind: 'sprite' }, options });
+
+      await expect(handle.urlInfo()).resolves.toEqual({ url: null, auth: 'unknown' });
+    });
+
+    it('given setUrlAuth, should call updateURLSettings with the requested mode', async () => {
+      let settings: { auth: string } | undefined;
+      const { sdk } = makeSdk({
+        getSprite: async () => fakeSprite({ updateURLSettings: async (s) => { settings = s; } }),
+      });
+      const client = createSpritesSandboxClient({ sdk });
+      const host = createSpriteSandboxHost({ sdk, client });
+      const handle = await host.provision({ name: 'k', substrate: { kind: 'sprite' }, options });
+
+      await handle.setUrlAuth('public');
+      expect(settings).toEqual({ auth: 'public' });
+    });
+  });
+
+  describe('onPortEvent (port_opened/port_closed frames)', () => {
+    // fakeCommand's 'spawn' auto-fires on a setTimeout(0) registered at
+    // CONSTRUCTION time — building it before `host.provision()` (which itself
+    // awaits) would fire 'spawn' before `awaitStreamOpen`'s listener attaches,
+    // and the stream would never open. So `createSession` builds a FRESH
+    // command at call time (the pattern every other test in this file uses)
+    // and stashes it in `cmdRef` so the test can emit on it afterwards.
+    function fakeSessionCommand() {
+      let cmdRef: ReturnType<typeof fakeCommand> | undefined;
+      const createSession = () => {
+        cmdRef = fakeCommand({ autoExit: false });
+        return cmdRef.command;
+      };
+      return { createSession, emitMessage: (message: unknown) => cmdRef?.emitMessage(message) };
+    }
+
+    it('given a port_opened control frame on the stream, should deliver it to a subscribed listener', async () => {
+      const session = fakeSessionCommand();
+      const { sdk } = makeSdk({ getSprite: async () => fakeSprite({ createSession: session.createSession }) });
+      const client = createSpritesSandboxClient({ sdk });
+      const host = createSpriteSandboxHost({ sdk, client });
+      const handle = await host.provision({ name: 'k', substrate: { kind: 'sprite' }, options });
+      const stream = await handle.stream({});
+
+      const events: unknown[] = [];
+      stream.onPortEvent((event) => events.push(event));
+      session.emitMessage({ type: 'port_opened', port: 8124, address: '10.0.0.1', pid: 383 });
+
+      expect(events).toEqual([{ type: 'port_opened', port: 8124, address: '10.0.0.1', pid: 383 }]);
+    });
+
+    it('given a non-port control frame (e.g. session_info), should not invoke the port-event listener', async () => {
+      const session = fakeSessionCommand();
+      const { sdk } = makeSdk({ getSprite: async () => fakeSprite({ createSession: session.createSession }) });
+      const client = createSpritesSandboxClient({ sdk });
+      const host = createSpriteSandboxHost({ sdk, client });
+      const handle = await host.provision({ name: 'k', substrate: { kind: 'sprite' }, options });
+      const stream = await handle.stream({});
+
+      const events: unknown[] = [];
+      stream.onPortEvent((event) => events.push(event));
+      session.emitMessage({ type: 'session_info', session_id: '1' });
+
+      expect(events).toEqual([]);
+    });
   });
 });

--- a/packages/lib/src/services/sandbox/sandbox-client/__tests__/sprite-sandbox-host.test.ts
+++ b/packages/lib/src/services/sandbox/sandbox-client/__tests__/sprite-sandbox-host.test.ts
@@ -66,6 +66,7 @@ function fakeCommand(
     emitStderr: (chunk: string) => stderr.emit('data', chunk),
     emitExit: (code: number) => events.emit('exit', code),
     emitMessage: (message: unknown) => events.emit('message', message),
+    emitSpawn: () => events.emit('spawn'),
   };
 }
 
@@ -741,16 +742,20 @@ describe('createSpriteSandboxHost', () => {
     // and the stream would never open. So `createSession` builds a FRESH
     // command at call time (the pattern every other test in this file uses)
     // and stashes it in `cmdRef` so the test can emit on it afterwards.
-    function fakeSessionCommand() {
+    function fakeSessionCommand(over: Partial<Parameters<typeof fakeCommand>[0]> = {}) {
       let cmdRef: ReturnType<typeof fakeCommand> | undefined;
       const createSession = () => {
-        cmdRef = fakeCommand({ autoExit: false });
+        cmdRef = fakeCommand({ autoExit: false, ...over });
         return cmdRef.command;
       };
-      return { createSession, emitMessage: (message: unknown) => cmdRef?.emitMessage(message) };
+      return {
+        createSession,
+        emitMessage: (message: unknown) => cmdRef?.emitMessage(message),
+        emitSpawn: () => cmdRef?.emitSpawn(),
+      };
     }
 
-    it('given a port_opened control frame on the stream, should deliver it to a subscribed listener', async () => {
+    it('given a port_opened control frame delivered AFTER the caller subscribes, should deliver it live', async () => {
       const session = fakeSessionCommand();
       const { sdk } = makeSdk({ getSprite: async () => fakeSprite({ createSession: session.createSession }) });
       const client = createSpritesSandboxClient({ sdk });
@@ -778,6 +783,58 @@ describe('createSpriteSandboxHost', () => {
       session.emitMessage({ type: 'session_info', session_id: '1' });
 
       expect(events).toEqual([]);
+    });
+
+    it('given a port_opened frame that arrives BEFORE the caller can call onPortEvent (a fast dev server racing stream() itself), should still deliver it — buffered, not dropped', async () => {
+      // Codex review, PR #2520: EventEmitter never replays a past event to a
+      // late subscriber. A caller can only call `onPortEvent` AFTER `stream()`
+      // resolves, but the server can emit `port_opened` the instant the
+      // process binds a port — which can be before `stream()` even returns.
+      // Manual spawn control (autoSpawn: false) lets this test put the frame
+      // in exactly that window: after the command exists (so
+      // `bufferPortEvents` has attached its listener) but before `spawn`
+      // fires (so `stream()` has not yet resolved, and the caller could not
+      // possibly have called `onPortEvent` yet).
+      const session = fakeSessionCommand({ autoSpawn: false });
+      const { sdk } = makeSdk({ getSprite: async () => fakeSprite({ createSession: session.createSession }) });
+      const client = createSpritesSandboxClient({ sdk });
+      const host = createSpriteSandboxHost({ sdk, client });
+      const handle = await host.provision({ name: 'k', substrate: { kind: 'sprite' }, options });
+
+      const streamPromise = handle.stream({});
+      // Flush the microtasks up through `sdk.getSprite` resolving and
+      // `sprite.createSession(...)` running synchronously after it — enough
+      // for `bufferPortEvents` to have attached its `message` listener, but
+      // `awaitStreamOpen` is still waiting (spawn is manual in this test).
+      await new Promise((resolve) => setTimeout(resolve, 0));
+      session.emitMessage({ type: 'port_opened', port: 5173, address: '10.0.0.1', pid: 500 });
+      session.emitSpawn();
+      const stream = await streamPromise;
+
+      const events: unknown[] = [];
+      stream.onPortEvent((event) => events.push(event));
+
+      expect(events).toEqual([{ type: 'port_opened', port: 5173, address: '10.0.0.1', pid: 500 }]);
+    });
+
+    it('given both a buffered pre-subscribe event and a later live one, should deliver both in order without duplication', async () => {
+      const session = fakeSessionCommand({ autoSpawn: false });
+      const { sdk } = makeSdk({ getSprite: async () => fakeSprite({ createSession: session.createSession }) });
+      const client = createSpritesSandboxClient({ sdk });
+      const host = createSpriteSandboxHost({ sdk, client });
+      const handle = await host.provision({ name: 'k', substrate: { kind: 'sprite' }, options });
+
+      const streamPromise = handle.stream({});
+      await new Promise((resolve) => setTimeout(resolve, 0));
+      session.emitMessage({ type: 'port_opened', port: 5173 });
+      session.emitSpawn();
+      const stream = await streamPromise;
+
+      const events: unknown[] = [];
+      stream.onPortEvent((event) => events.push(event));
+      session.emitMessage({ type: 'port_closed', port: 5173 });
+
+      expect(events).toEqual([{ type: 'port_opened', port: 5173 }, { type: 'port_closed', port: 5173 }]);
     });
   });
 });

--- a/packages/lib/src/services/sandbox/sandbox-client/__tests__/sprites.test.ts
+++ b/packages/lib/src/services/sandbox/sandbox-client/__tests__/sprites.test.ts
@@ -23,7 +23,14 @@ import { SandboxProvisionError } from '../../sandbox-options';
 import { SANDBOX_EGRESS_ALLOWLIST } from '../../execution-policy';
 import { hashSandboxEgressPolicy, egressLockdownToken } from '../../egress-lockdown';
 import { SANDBOX_ROOT } from '../../sandbox-paths';
-import { parentDir, fsRecoveryExec, spawnWithSelfHealingCwd } from '../sprites';
+import {
+  parentDir,
+  fsRecoveryExec,
+  spawnWithSelfHealingCwd,
+  readPortNotification,
+  serviceLogErrorMessage,
+  drainServiceLogStream,
+} from '../sprites';
 
 const options = { egressAllowlist: SANDBOX_EGRESS_ALLOWLIST };
 
@@ -158,6 +165,12 @@ function fakeSprite(
     createCheckpoint: async () => fakeCheckpointStream(),
     destroy: async () => {},
     killSession: async () => {},
+    updateURLSettings: async () => {},
+    listServices: async () => [],
+    createService: async () => ({ processAll: async () => {}, close: () => {} }),
+    startService: async () => ({ processAll: async () => {}, close: () => {} }),
+    stopService: async () => ({ processAll: async () => {}, close: () => {} }),
+    deleteService: async () => {},
     ...over,
   };
 }
@@ -291,6 +304,81 @@ describe('fsRecoveryExec (pure)', () => {
     should: 'keep it a positional arg, so it can never be evaluated as script',
     actual: fsRecoveryExec(['/workspace/$(touch pwned)'])[1],
     expected: ['-c', 'mkdir -p "$@" 2>/dev/null || :', 'sh', '/workspace/$(touch pwned)'],
+  });
+});
+
+describe('readPortNotification (pure)', () => {
+  it('given a well-formed port_opened frame, should parse it', () => {
+    expect(readPortNotification({ type: 'port_opened', port: 8124, address: '10.0.0.1', pid: 383 })).toEqual({
+      type: 'port_opened',
+      port: 8124,
+      address: '10.0.0.1',
+      pid: 383,
+    });
+  });
+
+  it('given a port_closed frame with no address/pid, should parse the required fields only', () => {
+    expect(readPortNotification({ type: 'port_closed', port: 3000 })).toEqual({ type: 'port_closed', port: 3000 });
+  });
+
+  it('given a session_info frame, should return undefined — not every control frame is a port event', () => {
+    expect(readPortNotification({ type: 'session_info', session_id: '1' })).toBeUndefined();
+  });
+
+  it('given a frame with a non-numeric port, should return undefined rather than trust the wire', () => {
+    expect(readPortNotification({ type: 'port_opened', port: '8124' })).toBeUndefined();
+  });
+
+  it('given a non-object message, should return undefined', () => {
+    expect(readPortNotification('raw text output')).toBeUndefined();
+    expect(readPortNotification(null)).toBeUndefined();
+  });
+});
+
+describe('serviceLogErrorMessage (pure)', () => {
+  it('given a non-error event, should return undefined', () => {
+    expect(serviceLogErrorMessage({ type: 'started' })).toBeUndefined();
+    expect(serviceLogErrorMessage({ type: 'complete' })).toBeUndefined();
+  });
+
+  it('given an error event with data, should return the data', () => {
+    expect(serviceLogErrorMessage({ type: 'error', data: 'boom' })).toBe('boom');
+  });
+
+  it('given an error event with no data, should fall back to a generic message', () => {
+    expect(serviceLogErrorMessage({ type: 'error' })).toBe('service log stream reported an error');
+  });
+});
+
+describe('drainServiceLogStream (pure-ish: fake stream, no network)', () => {
+  function fakeStream(events: Array<{ type: string; data?: string }>) {
+    let closed = false;
+    return {
+      processAll: async (handler: (event: { type: string; data?: string }) => void | Promise<void>) => {
+        for (const event of events) await handler(event);
+      },
+      close: () => { closed = true; },
+      wasClosed: () => closed,
+    };
+  }
+
+  it('given a stream with no error event, should resolve', async () => {
+    const stream = fakeStream([{ type: 'started' }, { type: 'complete' }]);
+    await expect(drainServiceLogStream(stream)).resolves.toBeUndefined();
+  });
+
+  it('given a stream with an error event, should reject with its message', async () => {
+    const stream = fakeStream([{ type: 'started' }, { type: 'error', data: 'port already bound' }]);
+    await expect(drainServiceLogStream(stream)).rejects.toThrow(/port already bound/);
+  });
+
+  it('given a stream whose processAll never settles (close() does not force it to), should still reject on timeout rather than hang forever', async () => {
+    const stream = {
+      processAll: () => new Promise<void>(() => {}), // never resolves, even after close()
+      close: vi.fn(),
+    };
+    await expect(drainServiceLogStream(stream, 5)).rejects.toThrow(/timed out/);
+    expect(stream.close).toHaveBeenCalled();
   });
 });
 

--- a/packages/lib/src/services/sandbox/sandbox-client/__tests__/wake-retry.test.ts
+++ b/packages/lib/src/services/sandbox/sandbox-client/__tests__/wake-retry.test.ts
@@ -188,6 +188,12 @@ function fakeSprite(name: string): SpriteInstanceLike {
     createCheckpoint: async () => { throw new Error('not used'); },
     destroy: async () => {},
     killSession: async () => {},
+    updateURLSettings: async () => {},
+    listServices: async () => [],
+    createService: async () => { throw new Error('not used'); },
+    startService: async () => { throw new Error('not used'); },
+    stopService: async () => { throw new Error('not used'); },
+    deleteService: async () => {},
   };
 }
 

--- a/packages/lib/src/services/sandbox/sandbox-client/sprite-sandbox-host.ts
+++ b/packages/lib/src/services/sandbox/sandbox-client/sprite-sandbox-host.ts
@@ -21,6 +21,7 @@ import {
   SandboxStreamOpenTimeoutError,
   type SandboxHandle,
   type SandboxHost,
+  type SandboxPortEvent,
   type SandboxServiceInfo,
   type SandboxServiceStatus,
   type SandboxServicesApi,
@@ -198,7 +199,59 @@ function wrapSpriteServices(getSprite: () => Promise<SpriteInstanceLike>): Sandb
   };
 }
 
-function wrapSpriteStream(command: SpriteCommandLike): SandboxStream {
+/**
+ * Buffers port_opened/port_closed notifications on `command`'s message
+ * channel from the moment THIS is called, replaying anything buffered to
+ * the first `subscribe` call and forwarding live afterward.
+ *
+ * Necessary because a caller cannot subscribe to `onPortEvent` before
+ * `stream()` resolves and hands back the `SandboxStream` — but a fast dev
+ * server can bind its port and emit `port_opened` inside that very window
+ * (spawn -> stream open confirmed -> caller receives the handle -> caller
+ * calls `onPortEvent`). Unlike terminal scrollback (which the server
+ * replays on attach — see `readSessionInfoId`'s doc), a missed port event
+ * is gone for good: the spike found no server-side replay for it (docs/
+ * spikes/2026-08-dev-preview-sprite-services-spike.md §5). So the listener
+ * for the underlying `message` event is attached unconditionally, as early
+ * as the command handle exists — not deferred to the first `onPortEvent`
+ * call, which is what `EventEmitter`'s no-replay semantics would otherwise
+ * silently drop. (Flagged by Codex review on PR #2520.)
+ */
+function bufferPortEvents(command: SpriteCommandLike): {
+  subscribe(listener: (event: SandboxPortEvent) => void): void;
+} {
+  const buffered: SandboxPortEvent[] = [];
+  let listener: ((event: SandboxPortEvent) => void) | undefined;
+  command.on('message', (message) => {
+    // Same `message` event `readSessionInfoId` reads — the SDK re-emits every
+    // TEXT control frame there. Port frames only actually arrive on TTY
+    // sessions (server-side filter — see `SpritePortNotification`), which is
+    // what every SandboxStream is. Non-port frames parse to undefined and
+    // are dropped; nothing here classifies or acts, per the seam contract.
+    const event = readPortNotification(message);
+    if (event === undefined) return;
+    if (listener) {
+      listener(event);
+    } else {
+      buffered.push(event);
+    }
+  });
+  return {
+    subscribe(l) {
+      listener = l;
+      // Replay what arrived before anyone was listening, then clear — a
+      // second `subscribe` call is not a supported use of this seam (one
+      // caller-provided listener per stream, matching onData/onExit/onError).
+      for (const event of buffered) l(event);
+      buffered.length = 0;
+    },
+  };
+}
+
+function wrapSpriteStream(
+  command: SpriteCommandLike,
+  portEvents: { subscribe(listener: (event: SandboxPortEvent) => void): void },
+): SandboxStream {
   return {
     write(data) {
       if (!command.stdin) {
@@ -223,15 +276,7 @@ function wrapSpriteStream(command: SpriteCommandLike): SandboxStream {
       command.on('error', listener);
     },
     onPortEvent(listener) {
-      // Same `message` event `readSessionInfoId` reads — the SDK re-emits every
-      // TEXT control frame there. Port frames only actually arrive on TTY
-      // sessions (server-side filter — see `SpritePortNotification`), which is
-      // what every SandboxStream is. Non-port frames parse to undefined and
-      // are dropped; nothing here classifies or acts, per the seam contract.
-      command.on('message', (message) => {
-        const event = readPortNotification(message);
-        if (event !== undefined) listener(event);
-      });
+      portEvents.subscribe(listener);
     },
     kill(signal) {
       command.kill(signal);
@@ -302,8 +347,12 @@ function wrapSpriteHandle({
                   rows: args.rows,
                 },
               );
+        // Start buffering port events IMMEDIATELY — before awaiting the open
+        // confirmation, let alone before the caller can call `onPortEvent`.
+        // See `bufferPortEvents`'s doc for why this can't wait.
+        const portEvents = bufferPortEvents(command);
         await awaitStreamOpen(command, streamOpenTimeoutMs);
-        return wrapSpriteStream(command);
+        return wrapSpriteStream(command, portEvents);
       };
 
       // Retry ONLY the attach. Re-opening an attach is idempotent — it targets a

--- a/packages/lib/src/services/sandbox/sandbox-client/sprite-sandbox-host.ts
+++ b/packages/lib/src/services/sandbox/sandbox-client/sprite-sandbox-host.ts
@@ -217,11 +217,24 @@ function wrapSpriteServices(getSprite: () => Promise<SpriteInstanceLike>): Sandb
  * call, which is what `EventEmitter`'s no-replay semantics would otherwise
  * silently drop. (Flagged by Codex review on PR #2520.)
  */
+// Cap on the pre-subscribe buffer in `bufferPortEvents` — see its doc. A
+// stream nobody ever calls `onPortEvent` on (true of every caller today —
+// this seam is dark) must not accumulate port events for its entire
+// lifetime; drop the oldest once this many are queued. Generous for any
+// realistic single-process port lifecycle (repeated crash-restart loops
+// included) while still bounding memory on an hours-long PTY session.
+const PORT_EVENT_BUFFER_CAP = 64;
+
 function bufferPortEvents(command: SpriteCommandLike): {
   subscribe(listener: (event: SandboxPortEvent) => void): void;
 } {
   const buffered: SandboxPortEvent[] = [];
-  let listener: ((event: SandboxPortEvent) => void) | undefined;
+  // A LIST, not a single slot: `onData`/`onExit`/`onError` above all attach a
+  // fresh listener to the underlying EventEmitter on every call, so two
+  // subscribers coexist (fan-out) rather than the second silently replacing
+  // the first. `onPortEvent` must match that shape — a caller has no way to
+  // know a second subscribe would otherwise orphan the first with no error.
+  const listeners: Array<(event: SandboxPortEvent) => void> = [];
   command.on('message', (message) => {
     // Same `message` event `readSessionInfoId` reads — the SDK re-emits every
     // TEXT control frame there. Port frames only actually arrive on TTY
@@ -230,20 +243,23 @@ function bufferPortEvents(command: SpriteCommandLike): {
     // are dropped; nothing here classifies or acts, per the seam contract.
     const event = readPortNotification(message);
     if (event === undefined) return;
-    if (listener) {
-      listener(event);
+    if (listeners.length > 0) {
+      for (const l of listeners) l(event);
     } else {
       buffered.push(event);
+      if (buffered.length > PORT_EVENT_BUFFER_CAP) buffered.shift();
     }
   });
   return {
     subscribe(l) {
-      listener = l;
-      // Replay what arrived before anyone was listening, then clear — a
-      // second `subscribe` call is not a supported use of this seam (one
-      // caller-provided listener per stream, matching onData/onExit/onError).
+      // Replay what arrived before ANY subscriber existed — only the FIRST
+      // subscribe drains and clears the buffer; once at least one listener
+      // is attached, every event forwards live to all of them and the
+      // buffer never accumulates again. A subscriber joining after that
+      // point gets live events only, same as joining any other pub/sub late.
       for (const event of buffered) l(event);
-      buffered.length = 0;
+      if (listeners.length === 0) buffered.length = 0;
+      listeners.push(l);
     },
   };
 }
@@ -389,9 +405,24 @@ function wrapSpriteHandle({
 
     // Dev-preview seam (dark until the proxy/decision-core tasks consume it):
     // the service lifecycle + URL info verified live by
-    // docs/spikes/2026-08-dev-preview-sprite-services-spike.md. Same
-    // getSprite-per-call pattern as stream/listStreams/killSession above — the
-    // per-connect handle cache collapses the reads.
+    // docs/spikes/2026-08-dev-preview-sprite-services-spike.md.
+    //
+    // Same getSprite-PER-CALL pattern as stream/listStreams/killSession
+    // above — no local caching or wake-retry wrapping here, matching those
+    // pre-existing methods exactly (this is not a new gap this seam
+    // introduces). `apps/realtime` wraps its `sdk` in
+    // `createSpriteHandleCache` (sprites.ts) before reaching this file, which
+    // collapses same-connect reads to one round trip; `apps/web`'s
+    // `sprites-client.ts` does NOT, so a caller chaining several of these
+    // calls there pays one control-plane read per call. Fixing that is
+    // production SDK-factory wiring, out of scope for this dark seam —
+    // whoever wires the first real caller should either request the cache be
+    // added to the web factory or accept the N+1 cost. Wake-retry is the same
+    // story: a hibernated sprite may need `withWakeRetry` around these calls
+    // once a real caller exists, but the correct retry POSTURE depends on
+    // that caller (see the container doc's note on the code-exec gate for
+    // wake-through-the-proxy) — copying `withWakeRetry` here blind would be a
+    // guess, not a verified behavior.
     services: wrapSpriteServices(() => sdk.getSprite(exec.sandboxId)),
 
     async urlInfo(): Promise<SandboxUrlInfo> {

--- a/packages/lib/src/services/sandbox/sandbox-client/sprite-sandbox-host.ts
+++ b/packages/lib/src/services/sandbox/sandbox-client/sprite-sandbox-host.ts
@@ -252,14 +252,19 @@ function bufferPortEvents(command: SpriteCommandLike): {
   });
   return {
     subscribe(l) {
-      // Replay what arrived before ANY subscriber existed — only the FIRST
-      // subscribe drains and clears the buffer; once at least one listener
-      // is attached, every event forwards live to all of them and the
-      // buffer never accumulates again. A subscriber joining after that
-      // point gets live events only, same as joining any other pub/sub late.
-      for (const event of buffered) l(event);
-      if (listeners.length === 0) buffered.length = 0;
+      // Register BEFORE replaying, and drain the buffer atomically (splice
+      // into a local array, not a bare loop over `buffered`) — a replay
+      // callback that itself calls `onPortEvent` synchronously (a nested
+      // subscribe) must see `listeners` already non-empty and an already
+      // -emptied `buffered`, or it would replay the same backlog a second
+      // time to the nested listener while truncating the outer replay loop
+      // out from under itself (mutating `buffered.length` mid-iteration).
+      // CodeRabbit review on PR #2520.
+      const isFirstSubscriber = listeners.length === 0;
       listeners.push(l);
+      if (!isFirstSubscriber) return;
+      const backlog = buffered.splice(0);
+      for (const event of backlog) l(event);
     },
   };
 }

--- a/packages/lib/src/services/sandbox/sandbox-client/sprite-sandbox-host.ts
+++ b/packages/lib/src/services/sandbox/sandbox-client/sprite-sandbox-host.ts
@@ -21,16 +21,26 @@ import {
   SandboxStreamOpenTimeoutError,
   type SandboxHandle,
   type SandboxHost,
+  type SandboxServiceInfo,
+  type SandboxServiceStatus,
+  type SandboxServicesApi,
   type SandboxStream,
   type SandboxStreamSessionInfo,
+  type SandboxUrlAuth,
+  type SandboxUrlInfo,
 } from '../sandbox-host';
 import type { ExecSandboxClient, ExecutableSandbox } from './types';
 import {
   withWakeRetry,
   asPreOpenDrop,
+  drainServiceLogStream,
   isSpriteGoneStatus,
+  readPortNotification,
   spawnWithSelfHealingCwd,
+  SERVICE_LOG_MONITOR_WINDOW,
   type SpriteCommandLike,
+  type SpriteInstanceLike,
+  type SpriteServiceRecordLike,
   type SpritesSdk,
 } from './sprites';
 import { SANDBOX_ROOT } from '../sandbox-paths';
@@ -103,6 +113,91 @@ function awaitStreamOpen(command: SpriteCommandLike, timeoutMs: number): Promise
 // wall-clock cap. Bounded by kill frequency, and not fixable here without an SDK
 // change.
 
+/** The Sprite wire statuses this seam recognizes. Anything else — a future
+ *  SDK/runtime addition — normalizes to 'unknown' rather than leaking an
+ *  unvalidated string through the provider-neutral type. */
+const KNOWN_SERVICE_STATUSES: readonly SandboxServiceStatus[] = [
+  'stopped',
+  'starting',
+  'running',
+  'stopping',
+  'failed',
+];
+
+/**
+ * Pure: map a Sprite service record onto the provider-neutral shape.
+ * A record with no `state` at all (never observed live, but the SDK types it
+ * optional) is 'unknown', not a guess.
+ */
+export function normalizeSpriteService(record: SpriteServiceRecordLike): SandboxServiceInfo {
+  const status = record.state?.status;
+  return {
+    name: record.name,
+    command: record.cmd,
+    args: record.args,
+    ...(record.httpPort !== undefined ? { httpPort: record.httpPort } : {}),
+    status: status !== undefined && (KNOWN_SERVICE_STATUSES as readonly string[]).includes(status)
+      ? status
+      : 'unknown',
+    ...(record.state?.pid !== undefined ? { pid: record.state.pid } : {}),
+    ...(record.state?.error !== undefined ? { error: record.state.error } : {}),
+  };
+}
+
+/**
+ * Pure: map the wire's URL auth string onto the closed union. The wire returns
+ * a superset of the SDK types (`private_access` rides alongside `auth` —
+ * verified), so only the two modes the platform verifies map through; anything
+ * else — including an absent value — is 'unknown', which consumers must treat
+ * as NOT proven private (see `SandboxUrlAuth`).
+ */
+export function normalizeSpriteUrlAuth(auth: string | undefined): SandboxUrlAuth {
+  return auth === 'public' || auth === 'sprite' ? auth : 'unknown';
+}
+
+function wrapSpriteServices(getSprite: () => Promise<SpriteInstanceLike>): SandboxServicesApi {
+  return {
+    async create({ name, command, args, httpPort }) {
+      const sprite = await getSprite();
+      // The PUT auto-starts the service and hands back its startup log stream;
+      // resolving before that stream completes would report success for an
+      // operation still in flight (and leak the response body's reader).
+      await drainServiceLogStream(
+        await sprite.createService(
+          name,
+          { cmd: command, ...(args !== undefined ? { args } : {}), ...(httpPort !== undefined ? { httpPort } : {}) },
+          SERVICE_LOG_MONITOR_WINDOW,
+        ),
+      );
+    },
+    async list() {
+      const sprite = await getSprite();
+      return (await sprite.listServices()).map(normalizeSpriteService);
+    },
+    async get(name) {
+      // Derived from list rather than the SDK's getService: the SDK rejects a
+      // miss with an untyped `Error('Service not found: …')` that message-match
+      // classification would have to fish out — an absent row from the listing
+      // is the same answer without the fragility.
+      const sprite = await getSprite();
+      const record = (await sprite.listServices()).find((s) => s.name === name);
+      return record !== undefined ? normalizeSpriteService(record) : null;
+    },
+    async start(name) {
+      const sprite = await getSprite();
+      await drainServiceLogStream(await sprite.startService(name, SERVICE_LOG_MONITOR_WINDOW));
+    },
+    async stop(name) {
+      const sprite = await getSprite();
+      await drainServiceLogStream(await sprite.stopService(name));
+    },
+    async remove(name) {
+      const sprite = await getSprite();
+      await sprite.deleteService(name);
+    },
+  };
+}
+
 function wrapSpriteStream(command: SpriteCommandLike): SandboxStream {
   return {
     write(data) {
@@ -126,6 +221,17 @@ function wrapSpriteStream(command: SpriteCommandLike): SandboxStream {
     },
     onError(listener) {
       command.on('error', listener);
+    },
+    onPortEvent(listener) {
+      // Same `message` event `readSessionInfoId` reads — the SDK re-emits every
+      // TEXT control frame there. Port frames only actually arrive on TTY
+      // sessions (server-side filter — see `SpritePortNotification`), which is
+      // what every SandboxStream is. Non-port frames parse to undefined and
+      // are dropped; nothing here classifies or acts, per the seam contract.
+      command.on('message', (message) => {
+        const event = readPortNotification(message);
+        if (event !== undefined) listener(event);
+      });
     },
     kill(signal) {
       command.kill(signal);
@@ -230,6 +336,26 @@ function wrapSpriteHandle({
     async killSession(sessionId: string): Promise<void> {
       const sprite = await sdk.getSprite(exec.sandboxId);
       await sprite.killSession(sessionId);
+    },
+
+    // Dev-preview seam (dark until the proxy/decision-core tasks consume it):
+    // the service lifecycle + URL info verified live by
+    // docs/spikes/2026-08-dev-preview-sprite-services-spike.md. Same
+    // getSprite-per-call pattern as stream/listStreams/killSession above — the
+    // per-connect handle cache collapses the reads.
+    services: wrapSpriteServices(() => sdk.getSprite(exec.sandboxId)),
+
+    async urlInfo(): Promise<SandboxUrlInfo> {
+      const sprite = await sdk.getSprite(exec.sandboxId);
+      return {
+        url: sprite.url ?? null,
+        auth: normalizeSpriteUrlAuth(sprite.urlSettings?.auth),
+      };
+    },
+
+    async setUrlAuth(auth): Promise<void> {
+      const sprite = await sdk.getSprite(exec.sandboxId);
+      await sprite.updateURLSettings({ auth });
     },
   };
 }

--- a/packages/lib/src/services/sandbox/sandbox-client/sprites.ts
+++ b/packages/lib/src/services/sandbox/sandbox-client/sprites.ts
@@ -241,6 +241,46 @@ export function readSessionInfoId(message: unknown): string | undefined {
 }
 
 /**
+ * A `port_opened` / `port_closed` control frame from an exec session's
+ * WebSocket, parsed from the same `message` event stream `readSessionInfoId`
+ * reads (the RC SDK ships no typed frame union, so the wire shape is validated
+ * defensively rather than trusted).
+ *
+ * Live-verified (docs/spikes/2026-08-dev-preview-sprite-services-spike.md §5):
+ * the runtime emits `port_opened` when a process binds a port inside a TTY
+ * session — `{"type":"port_opened","port":8124,"address":"10.0.0.1","pid":383}`
+ * — and emits NOTHING on a plain non-TTY `spawn` running the same server (the
+ * filter is server-side; the SDK forwards every TEXT frame regardless of TTY).
+ * `port_closed` is typed by the SDK but was never observed on the wire, so
+ * treat it as best-effort if it ever arrives: never build teardown logic on it.
+ */
+export interface SpritePortNotification {
+  type: 'port_opened' | 'port_closed';
+  port: number;
+  address?: string;
+  pid?: number;
+}
+
+/**
+ * Pure: parse a port notification from an exec-WS `message` frame, or
+ * undefined for every other frame (`session_info`, resize acks, raw text) and
+ * for a malformed port payload. Data only — what a caller DOES about a port
+ * opening (classification, exposure) is deliberately not this layer's job.
+ */
+export function readPortNotification(message: unknown): SpritePortNotification | undefined {
+  if (typeof message !== 'object' || message === null) return undefined;
+  const frame = message as { type?: unknown; port?: unknown; address?: unknown; pid?: unknown };
+  if (frame.type !== 'port_opened' && frame.type !== 'port_closed') return undefined;
+  if (typeof frame.port !== 'number' || !Number.isInteger(frame.port)) return undefined;
+  return {
+    type: frame.type,
+    port: frame.port,
+    ...(typeof frame.address === 'string' ? { address: frame.address } : {}),
+    ...(typeof frame.pid === 'number' ? { pid: frame.pid } : {}),
+  };
+}
+
+/**
  * The subset of the SDK's checkpoint/restore progress stream the driver
  * consumes — mirrors the real `CheckpointStream`/`RestoreStream` (both expose
  * `processAll`). Messages are `{type: 'info'|'stdout'|'stderr'|'error', data?,
@@ -258,6 +298,167 @@ export interface SpriteCheckpointStreamLike {
   /** Close the stream — called on a timeout so a stalled read doesn't hold the
    *  underlying connection open past the point we've given up waiting on it. */
   close(): void;
+}
+
+/**
+ * A service's runtime status, as the services API reports it. The full union
+ * comes from the SDK's `ServiceState` type; live-verified transitions
+ * (docs/spikes/2026-08-dev-preview-sprite-services-spike.md §4):
+ * `running` (fresh create auto-starts), and — the trap — `stopService` lands in
+ * **`failed`** (`error: "exited with code 143"`, the runtime recording its own
+ * SIGTERM as a crash), NOT the documented sticky `stopped`, which was never
+ * observed. Code must not treat `status === 'stopped'` as "the user stopped
+ * it"; stopped-intent has to be tracked by the caller.
+ */
+export type SpriteServiceStatus = 'stopped' | 'starting' | 'running' | 'stopping' | 'failed';
+
+/** The state slice of a service record the driver consumes. Only fields
+ *  verified on the wire AND declared by the SDK are typed here — the wire's
+ *  timestamps are snake_case (`started_at`) while the SDK types camelCase, so
+ *  neither spelling is trustworthy and both are deliberately omitted. */
+export interface SpriteServiceStateLike {
+  status: SpriteServiceStatus;
+  pid?: number;
+  /** e.g. `"exited with code 143"` after a stop — see {@link SpriteServiceStatus}. */
+  error?: string;
+}
+
+/**
+ * A service as reported by GET `/v1/sprites/{name}/services`. `needs` is
+ * `[]` from the list endpoint but `null` from the get-one endpoint (verified),
+ * so it is typed to tolerate both.
+ *
+ * `httpPort` is persisted and echoed back but — live-verified, the spike's
+ * headline finding — has NO routing effect: the sprite URL always proxies to
+ * port 8080, regardless of any service's `httpPort`, and start-on-request does
+ * not exist in shipped behavior. Do not build routing decisions on this field.
+ */
+export interface SpriteServiceRecordLike {
+  name: string;
+  cmd: string;
+  args: string[];
+  needs?: string[] | null;
+  httpPort?: number;
+  state?: SpriteServiceStateLike;
+}
+
+/** Request body for PUT `/v1/sprites/{name}/services/{svc}` (create-or-update). */
+export interface SpriteServiceRequestLike {
+  cmd: string;
+  args?: string[];
+  needs?: string[];
+  httpPort?: number;
+}
+
+/**
+ * One NDJSON event from a service create/start/stop log stream. Only `type` is
+ * load-bearing here; the SDK's `ServiceLogEvent` types richer fields but the
+ * wire diverges from them (verified: the completion event carries `log_files`,
+ * snake_case, where the SDK types `logFiles`), so nothing else is trusted.
+ */
+export interface SpriteServiceLogEventLike {
+  type: string;
+  data?: string;
+}
+
+/** The service-operation NDJSON stream subset the driver consumes — same
+ *  shape/contract as {@link SpriteCheckpointStreamLike}. */
+export interface SpriteServiceLogStreamLike {
+  processAll(handler: (event: SpriteServiceLogEventLike) => void | Promise<void>): Promise<void>;
+  close(): void;
+}
+
+/**
+ * Sprite-URL auth modes accepted by `updateURLSettings` (both live-verified):
+ * `'sprite'` (the default — anonymous/invalid/raw-Fly-token requests get a 302
+ * to an interactive SSO flow at sprites.dev, NOT a 401; `Bearer
+ * <org-minted sprites token>` gets through) and `'public'` (no auth at all).
+ * v1 preview policy keeps every sprite on `'sprite'` — 'public' exists on this
+ * seam because the platform verifies it, but exposure decisions belong to the
+ * (future) decision core and its permission gate, never to this driver.
+ */
+export type SpriteUrlAuth = 'public' | 'sprite';
+
+/** URL auth settings as read back from the API. `auth` is typed open (string)
+ *  because the wire returns a superset of the SDK's `URLSettings` — verified:
+ *  `{ auth: 'sprite', private_access: 'admins' }`. */
+export interface SpriteUrlSettingsLike {
+  auth?: string;
+}
+
+/**
+ * Pure: the failure text of an `error`-type service log event, or undefined
+ * for every other event. Mirrors {@link checkpointStreamErrorMessage}. The
+ * `error` event type is declared by the SDK but was not observed live
+ * (verified events: `started`/`complete`/`stopping`/`stopped`), so this is a
+ * defensive net, not a load-bearing path.
+ */
+export function serviceLogErrorMessage(event: SpriteServiceLogEventLike): string | undefined {
+  if (event.type !== 'error') return undefined;
+  return event.data ?? 'service log stream reported an error';
+}
+
+/**
+ * The monitoring window passed to createService/startService. The stream stays
+ * open for this long after the operation lands (verified: `started` →
+ * `complete` arrive ~`duration` apart), so it is kept short — it is latency on
+ * every create/start. '5s' is the value every live spike run used.
+ */
+export const SERVICE_LOG_MONITOR_WINDOW = '5s';
+
+/** Wall-clock cap on draining a service log stream — the SDK exposes no
+ *  timeout of its own, and every other network op in this driver is bounded. */
+const SERVICE_STREAM_TIMEOUT_MS = 30_000;
+
+/**
+ * Drain a service create/start/stop log stream to completion, bounded, and
+ * surface the first `error`-type event as a rejection. The events themselves
+ * are discarded: the wire's completion payload diverges from the SDK types
+ * (see {@link SpriteServiceLogEventLike}) and no caller consumes it yet.
+ */
+export function drainServiceLogStream(
+  stream: SpriteServiceLogStreamLike,
+  timeoutMs: number = SERVICE_STREAM_TIMEOUT_MS,
+): Promise<void> {
+  let settled = false;
+  return new Promise<void>((resolve, reject) => {
+    const timer = setTimeout(() => {
+      if (settled) return;
+      settled = true;
+      try {
+        stream.close();
+      } catch {
+        // Best-effort cleanup only; the timeout error below is what propagates.
+      }
+      reject(new Error(`Sprite service operation timed out after ${timeoutMs}ms`));
+    }, timeoutMs);
+
+    let streamError: string | undefined;
+    stream
+      .processAll((event) => {
+        if (streamError === undefined) {
+          streamError = serviceLogErrorMessage(event);
+        }
+      })
+      .then(
+        () => {
+          if (settled) return;
+          settled = true;
+          clearTimeout(timer);
+          if (streamError !== undefined) {
+            reject(new Error(`Sprite service operation failed: ${streamError}`));
+          } else {
+            resolve();
+          }
+        },
+        (error) => {
+          if (settled) return;
+          settled = true;
+          clearTimeout(timer);
+          reject(error);
+        },
+      );
+  });
 }
 
 /** The Sprite instance subset the driver consumes. */
@@ -332,6 +533,44 @@ export interface SpriteInstanceLike {
    * gone — see {@link killSpriteSession}.
    */
   killSession(sessionId: string): Promise<void>;
+  /**
+   * The sprite's URL (`https://<name>-<org>.sprites.app`), hydrated from the
+   * API response like {@link id} — present from creation, no service required.
+   * Live-verified: the URL is a proxy to **port 8080 in the sprite, always** —
+   * a service's `httpPort` does not rewire it (see
+   * {@link SpriteServiceRecordLike}) — and a request to it WAKES a paused
+   * sprite even when nothing is listening (the request then hangs, no 502).
+   * Optional for the same reason `id` is: the RC SDK types it optional, and a
+   * build that stops reporting it must degrade to "no URL known".
+   */
+  readonly url?: string;
+  /** URL auth settings hydrated alongside {@link url}. Default `auth: 'sprite'`. */
+  readonly urlSettings?: SpriteUrlSettingsLike;
+  /** Update the sprite URL's auth mode (PATCH, effective immediately — verified). */
+  updateURLSettings(settings: { auth: SpriteUrlAuth }): Promise<void>;
+  /** List the sprite's services with their runtime state. */
+  listServices(): Promise<SpriteServiceRecordLike[]>;
+  /**
+   * Create-or-update a service (PUT — idempotent on the name). AUTO-STARTS the
+   * process and returns the startup log stream; the caller must drain it
+   * (see {@link drainServiceLogStream}). `duration` is the monitoring window
+   * the stream stays open for.
+   */
+  createService(
+    name: string,
+    config: SpriteServiceRequestLike,
+    duration?: string,
+  ): Promise<SpriteServiceLogStreamLike>;
+  /** Start a stopped/failed service. Returns the same kind of log stream. */
+  startService(name: string, duration?: string): Promise<SpriteServiceLogStreamLike>;
+  /**
+   * Stop a service (SIGTERM, then `timeout` before escalation). Sticky in
+   * effect — nothing restarts it — but the recorded state is `failed`, not
+   * `stopped`; see {@link SpriteServiceStatus}.
+   */
+  stopService(name: string, timeout?: string): Promise<SpriteServiceLogStreamLike>;
+  /** Remove a service definition (404s→rejects on an unknown name — verified 204 on success). */
+  deleteService(name: string): Promise<void>;
 }
 
 /** The injectable Sprites SDK statics. Defaults to the real `@fly/sprites`. */

--- a/packages/lib/src/services/sandbox/sandbox-host.ts
+++ b/packages/lib/src/services/sandbox/sandbox-host.ts
@@ -80,6 +80,26 @@ export class SandboxStreamOpenTimeoutError extends Error {
 }
 
 /**
+ * A port lifecycle notification observed on a machine's interactive stream —
+ * a process inside the sandbox bound (or released) a TCP port. Data only:
+ * whether that port is a dev server, whether it should be exposed, and what to
+ * tell the user are all decisions for a consumer (the dev-preview decision
+ * core), never for the transport that reports it.
+ *
+ * Provider caveats (Sprite, live-verified — see
+ * docs/spikes/2026-08-dev-preview-sprite-services-spike.md §5): notifications
+ * arrive only on TTY streams (a non-TTY exec running the same server emits
+ * nothing), and `port_closed` has never been observed on the wire — treat it
+ * as best-effort, never as a teardown signal.
+ */
+export interface SandboxPortEvent {
+  type: 'port_opened' | 'port_closed';
+  port: number;
+  address?: string;
+  pid?: number;
+}
+
+/**
  * A live interactive (PTY) stream on a machine. Deliberately minimal — bounded
  * reconnect/keepalive orchestration (see `apps/realtime/src/terminal/sprites-shell.ts`)
  * is caller-side policy, not part of this seam: a caller reconnects by calling
@@ -91,6 +111,12 @@ export interface SandboxStream {
   onData(listener: (chunk: Buffer) => void): void;
   onExit(listener: (code: number) => void): void;
   onError(listener: (error: unknown) => void): void;
+  /**
+   * Subscribe to port open/close notifications on this stream (see
+   * {@link SandboxPortEvent} for what arrives and the provider caveats).
+   * Purely additive data: a caller that never subscribes sees no change.
+   */
+  onPortEvent(listener: (event: SandboxPortEvent) => void): void;
   kill(signal?: string): void;
 }
 
@@ -114,6 +140,82 @@ export class SandboxSpriteReplacedError extends Error {
     );
     this.name = 'SandboxSpriteReplacedError';
   }
+}
+
+/**
+ * A machine service's runtime status, provider-neutral. Mirrors the Sprite
+ * wire union plus `'unknown'` for a status string a future backend/SDK bump
+ * reports that this seam does not recognize — normalized at the driver edge
+ * (never a lie, never a crash).
+ *
+ * Semantics caveat (live-verified): on Sprite, an explicit stop records
+ * `'failed'` ("exited with code 143"), and the documented sticky `'stopped'`
+ * was never observed — so status alone cannot distinguish "the user stopped
+ * this" from "this crashed". Stopped-intent is the caller's to persist (the
+ * old design doc's `stoppedByUser`, unchanged by the rebuild).
+ */
+export type SandboxServiceStatus = 'stopped' | 'starting' | 'running' | 'stopping' | 'failed' | 'unknown';
+
+/** A runtime-managed service on a machine, with its current state. */
+export interface SandboxServiceInfo {
+  name: string;
+  command: string;
+  args: string[];
+  /**
+   * The port the service DECLARED. Live-verified to have NO routing effect on
+   * Sprite today (the machine URL always proxies to port 8080) — carried as
+   * data for display/bookkeeping, never as proof of reachability.
+   */
+  httpPort?: number;
+  status: SandboxServiceStatus;
+  pid?: number;
+  /** Failure text when status is `failed` — including after an explicit stop. */
+  error?: string;
+}
+
+/** Arguments for creating (or updating — create is idempotent on `name`) a service. */
+export interface CreateSandboxServiceArgs {
+  name: string;
+  command: string;
+  args?: string[];
+  httpPort?: number;
+}
+
+/**
+ * Auth mode on the machine's inbound URL. `'sprite'` = platform-authenticated
+ * (org token only; anonymous requests get an SSO redirect); `'public'` = no
+ * auth; `'unknown'` = the backend reported a mode this seam does not
+ * recognize — consumers MUST treat it as "not proven private" (fail closed),
+ * never as private-by-default.
+ */
+export type SandboxUrlAuth = 'public' | 'sprite' | 'unknown';
+
+/** The machine's inbound URL and its auth mode. `url: null` when the backend
+ *  reports none. */
+export interface SandboxUrlInfo {
+  url: string | null;
+  auth: SandboxUrlAuth;
+}
+
+/**
+ * Runtime-managed services on a machine (dev servers — the preview workstream;
+ * agent terminals stay exec sessions, per the standing design decision).
+ * Verified operations only; every mutation resolves after the backend's own
+ * operation log stream completes, so a resolved promise means the operation
+ * landed, not merely that a request was accepted.
+ */
+export interface SandboxServicesApi {
+  /** Create-or-update AND auto-start the service (backend behavior — verified). */
+  create(args: CreateSandboxServiceArgs): Promise<void>;
+  list(): Promise<SandboxServiceInfo[]>;
+  /** null for a name the machine has no service under (derived from list —
+   *  the backend's get-by-name rejects with an untyped error on a miss). */
+  get(name: string): Promise<SandboxServiceInfo | null>;
+  start(name: string): Promise<void>;
+  /** Sticky stop — nothing restarts it. See {@link SandboxServiceStatus} for
+   *  the `failed`-not-`stopped` state it records. */
+  stop(name: string): Promise<void>;
+  remove(name: string): Promise<void>;
 }
 
 /** A provisioned/attached machine session — the full surface a caller drives. */
@@ -163,6 +265,27 @@ export interface SandboxHandle {
    * genuinely cannot support checkpoints is introduced.
    */
   createCheckpoint(comment: string): Promise<void>;
+  /**
+   * Runtime-managed services on this machine — see {@link SandboxServicesApi}.
+   * Required, not optional, for the same reason `createCheckpoint` is: one
+   * backend exists, and an optional-with-fallback would guard a hypothetical.
+   */
+  services: SandboxServicesApi;
+  /**
+   * The machine's inbound URL + auth mode, as last read from the control
+   * plane. On the Sprite backend the fields ride the (per-connect cached)
+   * sprite handle, so a `setUrlAuth` in the same connect may not be reflected
+   * until the next attach — read it BEFORE mutating, or re-attach to confirm.
+   */
+  urlInfo(): Promise<SandboxUrlInfo>;
+  /**
+   * Set the machine URL's auth mode. This is a CAPABILITY, not a policy:
+   * v1 preview keeps every machine on `'sprite'` (org-token-only), and the
+   * decision to ever go `'public'` belongs to a permission-gated decision
+   * core, not to any caller of this seam directly. `'unknown'` is
+   * deliberately not accepted here — only the two modes the platform verifies.
+   */
+  setUrlAuth(auth: 'public' | 'sprite'): Promise<void>;
 }
 
 /**


### PR DESCRIPTION
## Summary

**Part A — live spike** (task page `jir7n8yx70hva5lab4ub7sgk`): drove four real throwaway Sprites through the `@fly/sprites@0.0.1-rc37` Services surface — createService/list/get/start/stop/delete, `SpriteInfo.url` + `urlSettings`, the one-http-port scarcity claim, hibernate/wake behavior, and `port_opened`/`port_closed` exec-WS frames. Every sprite deleted in a `finally` and deletion verified. Full findings: `docs/spikes/2026-08-dev-preview-sprite-services-spike.md`.

**Headline finding:** a service's `httpPort` does **not** control URL routing. The sprite URL always proxies to port 8080 in the VM regardless of any service's declared port — confirmed with distinct marker files per port across three runs (service on 8000 alone: request hangs, no 502, no start-on-request; plain process on 8080: served). There's also no one-http-port-per-Sprite 409 (a second `httpPort` service was silently accepted). URL auth is solid: anonymous/bad creds → 302 SSO redirect (not 401); `Bearer <org-minted sprites token>` → 200; `updateURLSettings` flips public/private live. Hibernation: a running service does not block pause; an inbound URL request DOES wake a paused sprite even when nothing answers; warm wake resumed the service with the same pid, no restart observed.

**Part B — typed SDK seam** (built since Part A confirmed the CRUD surface works): 
- `SpriteInstanceLike` gains `createService`/`listServices`/`getService`/`startService`/`stopService`/`deleteService`/`updateURLSettings`/`url`/`urlSettings`, typed against **verified wire shapes**, not the SDK's own types where they diverge (e.g. `log_files` vs `logFiles`, `needs: null` vs `[]`, the extra `private_access` field).
- `SandboxHost`/`SandboxHandle` (the provider-neutral seam) gain a `services`/`urlInfo`/`setUrlAuth` surface, normalizing Sprite's wire statuses onto a closed union (unrecognized status → `'unknown'`, never a leaked string).
- `SandboxStream` gains `onPortEvent` — surfaces `port_opened`/`port_closed` control frames (previously discarded) to a caller-provided listener, fanned out to multiple subscribers (matching `onData`/`onExit`/`onError`), with a bounded pre-subscribe buffer so a fast dev server's port event isn't lost in the window before a caller can subscribe. Data only, no classification.

**Dark**: nothing calls this yet. It's inert until the decision-core/proxy/UI tasks in the dev-preview container consume it. `[Q-preview-spike]` posted on the coordination page flags the httpPort finding for whoever designs the proxy, since it changes the routing assumption the old design doc made.

## Review response

Three rounds of fixes since the initial push, each mutation-verified (reverted, confirmed the new test fails, restored):

1. **Codex (P2):** `port_opened`/`port_closed` frames could arrive before a caller had any chance to call `onPortEvent` (the window between spawn and `stream()` resolving). Fixed with a buffer that attaches its listener immediately and replays to the first subscriber.
2. **Self-review (proactive `/code-review high` pass):** the buffer had no cap (unbounded growth on a long-lived stream nobody ever subscribes to) and a second `onPortEvent` call silently overwrote the first instead of fanning out like its siblings. Fixed both; also corrected an overclaiming comment about handle caching (the uncached `getSprite`-per-call pattern in the new services/url methods matches the pre-existing `listStreams`/`killSession` methods exactly — not a new gap, documented as a caveat for the first real caller instead).
3. **CodeRabbit:** the register-then-replay ordering had a race where a replay callback that itself called `onPortEvent` (nested subscribe) would see stale state and both duplicate the backlog to the nested listener and truncate the outer replay mid-iteration. Fixed by registering the listener and atomically draining the buffer before invoking any replay callback.

6 CodeRabbit/Codex findings on unrelated, already-merged code (PR #2516/#2517's AI-provider-catalog changes, surfaced by a broad review scope) were correctly identified as out of scope and not touched.

## Test plan
- [x] `bun run --filter @pagespace/lib test -- sandbox/sandbox-client/__tests__/sprites.test.ts` — 109/109
- [x] `bun run --filter @pagespace/lib test -- sandbox/sandbox-client/__tests__/sprite-sandbox-host.test.ts` — 47/47 (services CRUD, urlInfo/setUrlAuth, onPortEvent buffering/fan-out/cap/nested-subscribe)
- [x] `bun run --filter @pagespace/lib test` — ~11k passed (pre-existing Postgres-integration-test failures only — no test DB in this worktree — none in sandbox/sprites code)
- [x] `bun run --filter realtime test` — 1146/1146
- [x] `bun run typecheck` (full monorepo, 17/17 tasks) and `bun run --filter @pagespace/lib lint` — clean, re-run after every push
- [x] `bun run knip:check` — within baseline (4)
- [x] All 4 spike sprites confirmed deleted (`getSprite` → `sprite not found`)
- [x] CI: 11/11 checks green, MERGEABLE/CLEAN against master, three consecutive stable re-scans

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019zHhK3daRmjHpH42i2WBQy

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added runtime service management for creating, listing, starting, stopping, and removing services.
  - Added service status reporting and startup/error handling.
  - Added URL authentication controls for public or authenticated access.
  - Added port event notifications for interactive streams, including buffered events received before subscription.
- **Documentation**
  - Added a development preview covering service behavior, URL access, authentication, hibernation, and port requirements.
- **Tests**
  - Expanded coverage for service workflows, URL settings, port events, stream handling, and error conditions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
