### PR TITLE
feat(web): find friends/collaborators by name when inviting to a drive

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ All notable user-facing changes to PageSpace are documented here. Format follows
 
 ### Added
 
+- **You can find friends and collaborators by name when inviting them to a drive** — the invite
+  member search now surfaces people you already have a relationship with — anyone you share a drive
+  with, or an accepted connection — by their display name or username, even when their profile is
+  private. Previously a private profile could only be reached by typing their exact email address.
+  Strangers with private profiles stay hidden, and no email is ever revealed by a name match, so this
+  opens no new way to discover people you don't already know.
+
 - **You can publish a drive Environment to a live URL** — the Environments UI now has a Publish
   action, and the resulting app pane lives on the environment itself rather than in a separate
   dashboard. Publishing snapshots the environment's filesystem, creates its hosting row and Fly app

--- a/apps/web/src/app/api/users/search/__tests__/route.test.ts
+++ b/apps/web/src/app/api/users/search/__tests__/route.test.ts
@@ -79,6 +79,7 @@ vi.mock('@pagespace/db/operators', () => ({
   or: vi.fn((...args: unknown[]) => ({ _or: true, args })),
   ilike: vi.fn((col: unknown, val: unknown) => ({ _ilike: true, col, val })),
   isNotNull: vi.fn((col: unknown) => ({ _isNotNull: true, col })),
+  inArray: vi.fn((col: unknown, vals: unknown) => ({ _inArray: true, col, vals })),
 }));
 vi.mock('@pagespace/db/schema/auth', () => ({
   users: {
@@ -103,7 +104,12 @@ vi.mock('@/lib/utils/query-params', () => ({
   parseBoundedIntParam: vi.fn((_raw: string | null, opts: { defaultValue: number }) => opts.defaultValue),
 }));
 
+vi.mock('@/lib/users/visibility', () => ({
+  getRelatedUserIds: vi.fn(),
+}));
+
 import { GET } from '../route';
+import { getRelatedUserIds } from '@/lib/users/visibility';
 import { loggers } from '@pagespace/lib/logging/logger-config'
 import { auditRequest } from '@pagespace/lib/audit/audit-log';
 import { verifyAuth } from '@/lib/auth';
@@ -150,6 +156,50 @@ function setupDbChains(
   });
 }
 
+const relatedSelectChain = {
+  limit: vi.fn(),
+  where: vi.fn(),
+  leftJoin: vi.fn(),
+  from: vi.fn(),
+};
+
+// When the caller HAS related ids, the route issues an extra select for the
+// related-profiles branch between the public-profile and email queries:
+//   1. public profiles  2. related profiles  3. email  4. profile lookup
+function setupDbChainsWithRelated(
+  relatedResults: unknown[] = [],
+  profileResults: unknown[] = [],
+  emailResults: unknown[] = [],
+  profileLookupResults: unknown[] = [],
+) {
+  profileSelectChain.limit.mockResolvedValue(profileResults);
+  profileSelectChain.where.mockReturnValue({ limit: profileSelectChain.limit });
+  profileSelectChain.leftJoin.mockReturnValue({ where: profileSelectChain.where });
+  profileSelectChain.from.mockReturnValue({ leftJoin: profileSelectChain.leftJoin });
+
+  relatedSelectChain.limit.mockResolvedValue(relatedResults);
+  relatedSelectChain.where.mockReturnValue({ limit: relatedSelectChain.limit });
+  relatedSelectChain.leftJoin.mockReturnValue({ where: relatedSelectChain.where });
+  relatedSelectChain.from.mockReturnValue({ leftJoin: relatedSelectChain.leftJoin });
+
+  emailSelectChain.limit.mockResolvedValue(emailResults);
+  emailSelectChain.where.mockReturnValue({ limit: emailSelectChain.limit });
+  emailSelectChain.from.mockReturnValue({ where: emailSelectChain.where });
+
+  profileLookupChain.limit.mockResolvedValue(profileLookupResults);
+  profileLookupChain.where.mockReturnValue({ limit: profileLookupChain.limit });
+  profileLookupChain.from.mockReturnValue({ where: profileLookupChain.where });
+
+  let selectCallCount = 0;
+  vi.mocked(db.select).mockImplementation((..._args: unknown[]) => {
+    selectCallCount++;
+    if (selectCallCount === 1) return { from: profileSelectChain.from } as never;
+    if (selectCallCount === 2) return { from: relatedSelectChain.from } as never;
+    if (selectCallCount === 3) return { from: emailSelectChain.from } as never;
+    return { from: profileLookupChain.from } as never;
+  });
+}
+
 // ============================================================================
 // GET /api/users/search
 // ============================================================================
@@ -163,6 +213,9 @@ describe('GET /api/users/search', () => {
       hasSessionBearerToken: false,
     });
     vi.mocked(checkDistributedRateLimit).mockResolvedValue({ allowed: true });
+    // Default: caller has no relationships, so the related-profiles branch issues
+    // no query and the existing profile→email→lookup select ordering is unchanged.
+    vi.mocked(getRelatedUserIds).mockResolvedValue([]);
     setupDbChains();
   });
 
@@ -381,6 +434,78 @@ describe('GET /api/users/search', () => {
 
       expect(response.status).toBe(200);
       expect(body.users).toHaveLength(2);
+    });
+  });
+
+  describe('related profiles (find friends/collaborators by name)', () => {
+    it('finds a PRIVATE friend/collaborator by name when the caller is related to them', async () => {
+      // The related branch returns a row that would NOT appear in the public
+      // profile query (isPublic = false). It must still surface by name.
+      vi.mocked(getRelatedUserIds).mockResolvedValue(['friend_1']);
+      const relatedResults = [
+        {
+          userId: 'friend_1',
+          username: 'privfriend',
+          displayName: 'Private Friend',
+          bio: 'hidden bio',
+          avatarUrl: null,
+        },
+      ];
+      setupDbChainsWithRelated(relatedResults, [], []);
+
+      const request = new Request('https://example.com/api/users/search?q=priv');
+      const response = await GET(request);
+      const body = await response.json();
+
+      expect(response.status).toBe(200);
+      expect(body.users).toHaveLength(1);
+      expect(body.users[0]).toEqual({
+        userId: 'friend_1',
+        username: 'privfriend',
+        displayName: 'Private Friend',
+        bio: 'hidden bio',
+        avatarUrl: null,
+      });
+      // Same public-profile shape — the related branch NEVER carries an email.
+      expect(body.users[0]).not.toHaveProperty('email');
+      // The related query must scope to the caller's related ids and NOT gate on
+      // isPublic (that is the whole point of the branch).
+      const relatedWhere = relatedSelectChain.where.mock.calls;
+      expect(relatedWhere.length).toBeGreaterThan(0);
+    });
+
+    it('does NOT issue the related query when the caller has no relationships', async () => {
+      vi.mocked(getRelatedUserIds).mockResolvedValue([]);
+      setupDbChains([], []);
+
+      const request = new Request('https://example.com/api/users/search?q=priv');
+      const response = await GET(request);
+      const body = await response.json();
+
+      expect(response.status).toBe(200);
+      expect(body.users).toEqual([]);
+      // Only the public-profile and email selects ran (2), not a related select.
+      expect(vi.mocked(db.select)).toHaveBeenCalledTimes(2);
+    });
+
+    it('de-dupes a user who is both a public match and a related match (related wins position)', async () => {
+      vi.mocked(getRelatedUserIds).mockResolvedValue(['shared_1']);
+      const relatedResults = [
+        { userId: 'shared_1', username: 'shared', displayName: 'Shared User', bio: null, avatarUrl: null },
+      ];
+      const profileResults = [
+        { userId: 'shared_1', username: 'shared', displayName: 'Shared User', bio: null, avatarUrl: null, email: 'x@y.com' },
+      ];
+      setupDbChainsWithRelated(relatedResults, profileResults, []);
+
+      const request = new Request('https://example.com/api/users/search?q=shared');
+      const response = await GET(request);
+      const body = await response.json();
+
+      expect(response.status).toBe(200);
+      expect(body.users).toHaveLength(1);
+      expect(body.users[0].userId).toBe('shared_1');
+      expect(body.users[0]).not.toHaveProperty('email');
     });
   });
 

--- a/apps/web/src/app/api/users/search/__tests__/route.test.ts
+++ b/apps/web/src/app/api/users/search/__tests__/route.test.ts
@@ -105,16 +105,17 @@ vi.mock('@/lib/utils/query-params', () => ({
 }));
 
 vi.mock('@/lib/users/visibility', () => ({
-  getRelatedUserIds: vi.fn(),
+  searchRelatedProfilesByName: vi.fn(),
 }));
 
 import { GET } from '../route';
-import { getRelatedUserIds } from '@/lib/users/visibility';
+import { searchRelatedProfilesByName } from '@/lib/users/visibility';
 import { loggers } from '@pagespace/lib/logging/logger-config'
 import { auditRequest } from '@pagespace/lib/audit/audit-log';
 import { verifyAuth } from '@/lib/auth';
 import { db } from '@pagespace/db/db';
 import { and, isNotNull } from '@pagespace/db/operators';
+import { parseBoundedIntParam } from '@/lib/utils/query-params';
 import { checkDistributedRateLimit } from '@pagespace/lib/security/distributed-rate-limit';
 
 // ============================================================================
@@ -156,49 +157,9 @@ function setupDbChains(
   });
 }
 
-const relatedSelectChain = {
-  limit: vi.fn(),
-  where: vi.fn(),
-  leftJoin: vi.fn(),
-  from: vi.fn(),
-};
-
-// When the caller HAS related ids, the route issues an extra select for the
-// related-profiles branch between the public-profile and email queries:
-//   1. public profiles  2. related profiles  3. email  4. profile lookup
-function setupDbChainsWithRelated(
-  relatedResults: unknown[] = [],
-  profileResults: unknown[] = [],
-  emailResults: unknown[] = [],
-  profileLookupResults: unknown[] = [],
-) {
-  profileSelectChain.limit.mockResolvedValue(profileResults);
-  profileSelectChain.where.mockReturnValue({ limit: profileSelectChain.limit });
-  profileSelectChain.leftJoin.mockReturnValue({ where: profileSelectChain.where });
-  profileSelectChain.from.mockReturnValue({ leftJoin: profileSelectChain.leftJoin });
-
-  relatedSelectChain.limit.mockResolvedValue(relatedResults);
-  relatedSelectChain.where.mockReturnValue({ limit: relatedSelectChain.limit });
-  relatedSelectChain.leftJoin.mockReturnValue({ where: relatedSelectChain.where });
-  relatedSelectChain.from.mockReturnValue({ leftJoin: relatedSelectChain.leftJoin });
-
-  emailSelectChain.limit.mockResolvedValue(emailResults);
-  emailSelectChain.where.mockReturnValue({ limit: emailSelectChain.limit });
-  emailSelectChain.from.mockReturnValue({ where: emailSelectChain.where });
-
-  profileLookupChain.limit.mockResolvedValue(profileLookupResults);
-  profileLookupChain.where.mockReturnValue({ limit: profileLookupChain.limit });
-  profileLookupChain.from.mockReturnValue({ where: profileLookupChain.where });
-
-  let selectCallCount = 0;
-  vi.mocked(db.select).mockImplementation((..._args: unknown[]) => {
-    selectCallCount++;
-    if (selectCallCount === 1) return { from: profileSelectChain.from } as never;
-    if (selectCallCount === 2) return { from: relatedSelectChain.from } as never;
-    if (selectCallCount === 3) return { from: emailSelectChain.from } as never;
-    return { from: profileLookupChain.from } as never;
-  });
-}
+// The related-profiles branch is delegated to `searchRelatedProfilesByName`
+// (mocked here), so it issues no `db.select` of its own — the route's own select
+// order stays: 1. public profiles  2. email  3. profile lookup.
 
 // ============================================================================
 // GET /api/users/search
@@ -213,9 +174,9 @@ describe('GET /api/users/search', () => {
       hasSessionBearerToken: false,
     });
     vi.mocked(checkDistributedRateLimit).mockResolvedValue({ allowed: true });
-    // Default: caller has no relationships, so the related-profiles branch issues
-    // no query and the existing profile→email→lookup select ordering is unchanged.
-    vi.mocked(getRelatedUserIds).mockResolvedValue([]);
+    // Default: no related matches; tests that exercise the related branch set a
+    // return value on this mock. It never issues a db.select of its own.
+    vi.mocked(searchRelatedProfilesByName).mockResolvedValue([]);
     setupDbChains();
   });
 
@@ -438,11 +399,10 @@ describe('GET /api/users/search', () => {
   });
 
   describe('related profiles (find friends/collaborators by name)', () => {
-    it('finds a PRIVATE friend/collaborator by name when the caller is related to them', async () => {
-      // The related branch returns a row that would NOT appear in the public
-      // profile query (isPublic = false). It must still surface by name.
-      vi.mocked(getRelatedUserIds).mockResolvedValue(['friend_1']);
-      const relatedResults = [
+    it('finds a PRIVATE friend/collaborator by name via the related branch', async () => {
+      // searchRelatedProfilesByName returns a row that would NOT appear in the
+      // public profile query (isPublic = false). It must still surface by name.
+      vi.mocked(searchRelatedProfilesByName).mockResolvedValue([
         {
           userId: 'friend_1',
           username: 'privfriend',
@@ -450,8 +410,8 @@ describe('GET /api/users/search', () => {
           bio: 'hidden bio',
           avatarUrl: null,
         },
-      ];
-      setupDbChainsWithRelated(relatedResults, [], []);
+      ]);
+      setupDbChains([], []);
 
       const request = new Request('https://example.com/api/users/search?q=priv');
       const response = await GET(request);
@@ -468,35 +428,30 @@ describe('GET /api/users/search', () => {
       });
       // Same public-profile shape — the related branch NEVER carries an email.
       expect(body.users[0]).not.toHaveProperty('email');
-      // The related query must scope to the caller's related ids and NOT gate on
-      // isPublic (that is the whole point of the branch).
-      const relatedWhere = relatedSelectChain.where.mock.calls;
-      expect(relatedWhere.length).toBeGreaterThan(0);
+      // The route delegates the relationship scoping to the helper, passing the
+      // caller id, an escaped LIKE pattern, and the result limit.
+      expect(searchRelatedProfilesByName).toHaveBeenCalledWith('user_123', '%priv%', 10);
     });
 
-    it('does NOT issue the related query when the caller has no relationships', async () => {
-      vi.mocked(getRelatedUserIds).mockResolvedValue([]);
+    it('passes a LIKE-escaped pattern to the related branch so wildcards are literal', async () => {
+      vi.mocked(searchRelatedProfilesByName).mockResolvedValue([]);
       setupDbChains([], []);
 
-      const request = new Request('https://example.com/api/users/search?q=priv');
-      const response = await GET(request);
-      const body = await response.json();
+      const request = new Request('https://example.com/api/users/search?q=' + encodeURIComponent('%%'));
+      await GET(request);
 
-      expect(response.status).toBe(200);
-      expect(body.users).toEqual([]);
-      // Only the public-profile and email selects ran (2), not a related select.
-      expect(vi.mocked(db.select)).toHaveBeenCalledTimes(2);
+      // `%%` must be escaped to `\%\%`, not passed through as a match-all wildcard.
+      expect(searchRelatedProfilesByName).toHaveBeenCalledWith('user_123', '%\\%\\%%', 10);
     });
 
-    it('de-dupes a user who is both a public match and a related match (related wins position)', async () => {
-      vi.mocked(getRelatedUserIds).mockResolvedValue(['shared_1']);
-      const relatedResults = [
+    it('de-dupes a user who is both a public match and a related match', async () => {
+      vi.mocked(searchRelatedProfilesByName).mockResolvedValue([
         { userId: 'shared_1', username: 'shared', displayName: 'Shared User', bio: null, avatarUrl: null },
-      ];
+      ]);
       const profileResults = [
         { userId: 'shared_1', username: 'shared', displayName: 'Shared User', bio: null, avatarUrl: null, email: 'x@y.com' },
       ];
-      setupDbChainsWithRelated(relatedResults, profileResults, []);
+      setupDbChains(profileResults, []);
 
       const request = new Request('https://example.com/api/users/search?q=shared');
       const response = await GET(request);
@@ -506,6 +461,31 @@ describe('GET /api/users/search', () => {
       expect(body.users).toHaveLength(1);
       expect(body.users[0].userId).toBe('shared_1');
       expect(body.users[0]).not.toHaveProperty('email');
+    });
+
+    it('preserves the exact-email match ahead of name matches (email-first, survives the limit)', async () => {
+      // A related and a public name match, plus an exact-email match for a THIRD
+      // user. With limit=1 the email match must win (highest intent).
+      vi.mocked(parseBoundedIntParam).mockReturnValueOnce(1);
+      vi.mocked(searchRelatedProfilesByName).mockResolvedValue([
+        { userId: 'rel', username: 'rel', displayName: 'Related One', bio: null, avatarUrl: null },
+      ]);
+      const profileResults = [
+        { userId: 'pub', username: 'pub', displayName: 'Public One', bio: null, avatarUrl: null },
+      ];
+      const emailResults = [
+        { userId: 'mail', email: 'exact@example.com', name: 'Exact Mail' },
+      ];
+      setupDbChains(profileResults, emailResults, []);
+
+      const request = new Request('https://example.com/api/users/search?q=exact@example.com');
+      const response = await GET(request);
+      const body = await response.json();
+
+      expect(response.status).toBe(200);
+      expect(body.users).toHaveLength(1);
+      expect(body.users[0].userId).toBe('mail');
+      expect(body.users[0].email).toBe('exact@example.com');
     });
   });
 

--- a/apps/web/src/app/api/users/search/route.ts
+++ b/apps/web/src/app/api/users/search/route.ts
@@ -1,6 +1,6 @@
 import { NextResponse } from 'next/server';
 import { db } from '@pagespace/db/db'
-import { eq, and, or, ilike, isNotNull } from '@pagespace/db/operators'
+import { eq, and, or, ilike, isNotNull, inArray } from '@pagespace/db/operators'
 import { users } from '@pagespace/db/schema/auth'
 import { userProfiles } from '@pagespace/db/schema/members';
 import { verifyAuth } from '@/lib/auth';
@@ -16,6 +16,7 @@ import {
   buildPublicProfileResult,
   buildExactEmailMatchResult,
 } from '@/lib/users/enumeration-safe';
+import { getRelatedUserIds } from '@/lib/users/visibility';
 
 export async function GET(request: Request) {
   try {
@@ -63,6 +64,13 @@ export async function GET(request: Request) {
     // match must never carry an email — that is not part of the public-profile
     // model. Only the exact-email-match branch below (where the caller already
     // supplied the full address) may surface an email.
+    //
+    // The related-profiles branch further down applies the same name match to
+    // people the caller already shares context with (accepted connections /
+    // shared-drive co-members) WITHOUT the isPublic gate, so a private friend or
+    // collaborator is findable by name. That opens no new enumeration surface:
+    // you can only find, by name, someone you already have a relationship with,
+    // and that branch carries no email either.
     const profileResults = await db.select({
       userId: userProfiles.userId,
       username: userProfiles.username,
@@ -84,6 +92,34 @@ export async function GET(request: Request) {
     )
     .limit(limit);
 
+    // Related profiles: name-match people the caller already shares context with
+    // (accepted connections / shared-drive co-members), regardless of isPublic.
+    // The emailVerified gate stays to keep temp/magic-link accounts invisible,
+    // and no email is selected (same public-profile shape, preserving M3).
+    const relatedIds = await getRelatedUserIds(user.id);
+    const relatedResults = relatedIds.length > 0
+      ? await db.select({
+          userId: userProfiles.userId,
+          username: userProfiles.username,
+          displayName: userProfiles.displayName,
+          bio: userProfiles.bio,
+          avatarUrl: userProfiles.avatarUrl,
+        })
+        .from(userProfiles)
+        .leftJoin(users, eq(userProfiles.userId, users.id))
+        .where(
+          and(
+            inArray(userProfiles.userId, relatedIds),
+            isNotNull(users.emailVerified),
+            or(
+              ilike(userProfiles.username, searchPattern),
+              ilike(userProfiles.displayName, searchPattern)
+            )
+          )
+        )
+        .limit(limit)
+      : [];
+
     // Also search by email (exact match for privacy).
     // emailVerified IS NOT NULL is the gate that closes Review C1: an admin
     // searching `bob@example.com` while bob holds only a pending invite from
@@ -104,9 +140,17 @@ export async function GET(request: Request) {
     // Combine results, avoiding duplicates
     const userMap = new Map<string, ReturnType<typeof buildPublicProfileResult>>();
 
-    // Add profile results — public-profile shape, no email (M3).
-    for (const result of profileResults) {
+    // Add related profiles first — known people are the likely intended targets,
+    // so they surface at the top of the (limited) combined list.
+    for (const result of relatedResults) {
       userMap.set(result.userId, buildPublicProfileResult(result));
+    }
+
+    // Add public profile results — public-profile shape, no email (M3).
+    for (const result of profileResults) {
+      if (!userMap.has(result.userId)) {
+        userMap.set(result.userId, buildPublicProfileResult(result));
+      }
     }
 
     // Add email results if not already in map. These are exact-email matches,
@@ -142,7 +186,9 @@ export async function GET(request: Request) {
       }
     }
 
-    const userResults = Array.from(userMap.values());
+    // Related-first insertion order is preserved by Map; cap the merged list so
+    // the combined branches still respect `limit`.
+    const userResults = Array.from(userMap.values()).slice(0, limit);
 
     auditRequest(request, { eventType: 'data.read', userId: user.id, resourceType: 'user_search', resourceId: user.id, details: { queryLength: query.length, resultCount: userResults.length } });
 

--- a/apps/web/src/app/api/users/search/route.ts
+++ b/apps/web/src/app/api/users/search/route.ts
@@ -1,12 +1,13 @@
 import { NextResponse } from 'next/server';
 import { db } from '@pagespace/db/db'
-import { eq, and, or, ilike, isNotNull, inArray } from '@pagespace/db/operators'
+import { eq, and, or, ilike, isNotNull } from '@pagespace/db/operators'
 import { users } from '@pagespace/db/schema/auth'
 import { userProfiles } from '@pagespace/db/schema/members';
 import { verifyAuth } from '@/lib/auth';
 import { loggers } from '@pagespace/lib/logging/logger-config';
 import { auditRequest } from '@pagespace/lib/audit/audit-log';
 import { userEmailMatch, decryptUserRows } from '@pagespace/lib/auth/user-repository';
+import { escapeLikePattern } from '@pagespace/lib/db/like-pattern';
 import { parseBoundedIntParam } from '@/lib/utils/query-params';
 import {
   checkDistributedRateLimit,
@@ -16,7 +17,7 @@ import {
   buildPublicProfileResult,
   buildExactEmailMatchResult,
 } from '@/lib/users/enumeration-safe';
-import { getRelatedUserIds } from '@/lib/users/visibility';
+import { searchRelatedProfilesByName } from '@/lib/users/visibility';
 
 export async function GET(request: Request) {
   try {
@@ -52,8 +53,12 @@ export async function GET(request: Request) {
     }
 
     // Search for users by username, display name, or email
-    // Only search public profiles or exact email matches
-    const searchPattern = `%${query}%`;
+    // Only search public profiles or exact email matches.
+    // Escape LIKE metacharacters (`%`, `_`, `\`) so a query like `%%` is matched
+    // literally instead of becoming a wildcard that would dump every related
+    // private profile (CWE-200) — the related branch below intentionally drops
+    // the isPublic gate, so an unescaped wildcard there is an info-disclosure.
+    const searchPattern = `%${escapeLikePattern(query)}%`;
 
     // First, search in user profiles (public only).
     // The inner join on users + isNotNull(emailVerified) excludes temp users
@@ -93,32 +98,11 @@ export async function GET(request: Request) {
     .limit(limit);
 
     // Related profiles: name-match people the caller already shares context with
-    // (accepted connections / shared-drive co-members), regardless of isPublic.
-    // The emailVerified gate stays to keep temp/magic-link accounts invisible,
-    // and no email is selected (same public-profile shape, preserving M3).
-    const relatedIds = await getRelatedUserIds(user.id);
-    const relatedResults = relatedIds.length > 0
-      ? await db.select({
-          userId: userProfiles.userId,
-          username: userProfiles.username,
-          displayName: userProfiles.displayName,
-          bio: userProfiles.bio,
-          avatarUrl: userProfiles.avatarUrl,
-        })
-        .from(userProfiles)
-        .leftJoin(users, eq(userProfiles.userId, users.id))
-        .where(
-          and(
-            inArray(userProfiles.userId, relatedIds),
-            isNotNull(users.emailVerified),
-            or(
-              ilike(userProfiles.username, searchPattern),
-              ilike(userProfiles.displayName, searchPattern)
-            )
-          )
-        )
-        .limit(limit)
-      : [];
+    // (accepted connections / shared-drive co-members/owners), regardless of
+    // isPublic. Bounded in the database (name predicate + limit applied there,
+    // relationship via correlated EXISTS), so cost scales with matches, not with
+    // total drive membership. Carries no email (same public-profile shape, M3).
+    const relatedResults = await searchRelatedProfilesByName(user.id, searchPattern, limit);
 
     // Also search by email (exact match for privacy).
     // emailVerified IS NOT NULL is the gate that closes Review C1: an admin
@@ -137,26 +121,16 @@ export async function GET(request: Request) {
     // Decrypt PII at the edge so the exact-email match surfaces plaintext name/email.
     const emailResults = await decryptUserRows(emailRows);
 
-    // Combine results, avoiding duplicates
+    // Combine results, avoiding duplicates. Insertion order matters: the final
+    // list is truncated to `limit`, so higher-intent matches go in first.
     const userMap = new Map<string, ReturnType<typeof buildPublicProfileResult>>();
 
-    // Add related profiles first — known people are the likely intended targets,
-    // so they surface at the top of the (limited) combined list.
-    for (const result of relatedResults) {
-      userMap.set(result.userId, buildPublicProfileResult(result));
-    }
-
-    // Add public profile results — public-profile shape, no email (M3).
-    for (const result of profileResults) {
-      if (!userMap.has(result.userId)) {
-        userMap.set(result.userId, buildPublicProfileResult(result));
-      }
-    }
-
-    // Add email results if not already in map. These are exact-email matches,
-    // so the caller already knows the address and the result may carry it.
-    // Defense in depth: even if the DB layer returns an unverified row,
-    // drop it here so search can never surface a temp user.
+    // Exact-email matches first — the caller typed a full address, so this is the
+    // strongest signal and must never be pushed out of the list by the slice
+    // below (nor overwritten by a later, less precise name match that carries no
+    // email). These are the only results that may surface an email.
+    // Defense in depth: even if the DB layer returns an unverified row, drop it
+    // here so search can never surface a temp user.
     for (const result of emailResults) {
       if (result.emailVerified === null) continue;
       if (!userMap.has(result.userId)) {
@@ -186,8 +160,23 @@ export async function GET(request: Request) {
       }
     }
 
-    // Related-first insertion order is preserved by Map; cap the merged list so
-    // the combined branches still respect `limit`.
+    // Then related profiles — known people are the likely intended targets, so
+    // they rank above anonymous public matches. Public-profile shape, no email.
+    for (const result of relatedResults) {
+      if (!userMap.has(result.userId)) {
+        userMap.set(result.userId, buildPublicProfileResult(result));
+      }
+    }
+
+    // Finally public profile results — public-profile shape, no email (M3).
+    for (const result of profileResults) {
+      if (!userMap.has(result.userId)) {
+        userMap.set(result.userId, buildPublicProfileResult(result));
+      }
+    }
+
+    // Map preserves insertion order (email → related → public); cap the merged
+    // list so the combined branches still respect `limit`.
     const userResults = Array.from(userMap.values()).slice(0, limit);
 
     auditRequest(request, { eventType: 'data.read', userId: user.id, resourceType: 'user_search', resourceId: user.id, details: { queryLength: query.length, resultCount: userResults.length } });

--- a/apps/web/src/lib/users/__tests__/visibility.test.ts
+++ b/apps/web/src/lib/users/__tests__/visibility.test.ts
@@ -36,9 +36,9 @@ vi.mock('@pagespace/db/schema/social', () => ({
   },
 }));
 
-import { callerCanViewUser } from '../visibility';
+import { callerCanViewUser, getRelatedUserIds } from '../visibility';
 import { db } from '@pagespace/db/db';
-import { isNotNull } from '@pagespace/db/operators';
+import { eq, isNotNull } from '@pagespace/db/operators';
 
 function queueSelectResults(results: unknown[][]) {
   let i = 0;
@@ -127,6 +127,83 @@ describe('callerCanViewUser', () => {
     await callerCanViewUser('u1', 'u2');
     // Both the caller's member-drive lookup and the target shared-membership
     // lookup must compose the acceptedAt gate.
+    expect(isNotNull).toHaveBeenCalledWith('driveMembers.acceptedAt');
+  });
+});
+
+// ============================================================================
+// getRelatedUserIds — the set form used by /api/users/search so a private
+// friend/collaborator is findable by name. Query order per invocation:
+//   1. accepted connections (either direction)
+//   2. caller's owned drives   (getUserDriveIds)
+//   3. caller's member drives  (getUserDriveIds)
+//   4. co-members of the caller's drives
+//   5. owners of the caller's drives
+// ============================================================================
+describe('getRelatedUserIds', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('returns the other side of accepted connections in both directions', async () => {
+    queueSelectResults([
+      [
+        { user1Id: 'u1', user2Id: 'u2' }, // caller is user1 → partner u2
+        { user1Id: 'u3', user2Id: 'u1' }, // caller is user2 → partner u3
+      ],
+      [], // owns no drives
+      [], // member of no drives
+    ]);
+    const ids = await getRelatedUserIds('u1');
+    expect(ids.sort()).toEqual(['u2', 'u3']);
+  });
+
+  it('includes accepted co-members and owners of the caller\'s drives', async () => {
+    queueSelectResults([
+      [], // no connections
+      [{ id: 'drive_a' }], // caller owns drive_a
+      [], // member of none
+      [{ userId: 'u2' }, { userId: 'u3' }], // co-members
+      [{ ownerId: 'u4' }], // owners of shared drives
+    ]);
+    const ids = await getRelatedUserIds('u1');
+    expect(ids.sort()).toEqual(['u2', 'u3', 'u4']);
+  });
+
+  it('excludes the caller themselves and de-dupes', async () => {
+    queueSelectResults([
+      [{ user1Id: 'u1', user2Id: 'u2' }], // partner u2
+      [{ id: 'drive_a' }], // caller owns drive_a
+      [], // member of none
+      [{ userId: 'u1' }, { userId: 'u2' }], // caller appears as its own member row + dup u2
+      [{ ownerId: 'u1' }], // caller owns the shared drive
+    ]);
+    const ids = await getRelatedUserIds('u1');
+    expect(ids).toEqual(['u2']);
+  });
+
+  it('short-circuits drive lookups when the caller has no drives', async () => {
+    queueSelectResults([
+      [], // no connections
+      [], // owns none
+      [], // member of none
+    ]);
+    expect(await getRelatedUserIds('u1')).toEqual([]);
+    // 1 connections select + 2 drive-id selects; the co-member/owner reads are skipped.
+    expect(db.select).toHaveBeenCalledTimes(3);
+  });
+
+  it('gates on accepted status so pending/blocked relationships are excluded', async () => {
+    queueSelectResults([
+      [], // connections
+      [{ id: 'drive_a' }], // owns drive_a
+      [], // member of none
+      [], // co-members
+      [], // owners
+    ]);
+    await getRelatedUserIds('u1');
+    // Connections restricted to ACCEPTED; drive co-members gated on acceptedAt.
+    expect(eq).toHaveBeenCalledWith('connections.status', 'ACCEPTED');
     expect(isNotNull).toHaveBeenCalledWith('driveMembers.acceptedAt');
   });
 });

--- a/apps/web/src/lib/users/__tests__/visibility.test.ts
+++ b/apps/web/src/lib/users/__tests__/visibility.test.ts
@@ -15,10 +15,14 @@ import { describe, it, expect, beforeEach, vi } from 'vitest';
 vi.mock('@pagespace/db/db', () => ({ db: { select: vi.fn() } }));
 vi.mock('@pagespace/db/operators', () => ({
   eq: vi.fn(),
+  ne: vi.fn(),
   and: vi.fn(),
   or: vi.fn(),
   inArray: vi.fn(),
   isNotNull: vi.fn(),
+  ilike: vi.fn(),
+  exists: vi.fn(),
+  sql: vi.fn(),
 }));
 vi.mock('@pagespace/db/schema/core', () => ({ drives: { id: 'drives.id', ownerId: 'drives.ownerId' } }));
 vi.mock('@pagespace/db/schema/members', () => ({
@@ -27,6 +31,16 @@ vi.mock('@pagespace/db/schema/members', () => ({
     driveId: 'driveMembers.driveId',
     acceptedAt: 'driveMembers.acceptedAt',
   },
+  userProfiles: {
+    userId: 'userProfiles.userId',
+    username: 'userProfiles.username',
+    displayName: 'userProfiles.displayName',
+    bio: 'userProfiles.bio',
+    avatarUrl: 'userProfiles.avatarUrl',
+  },
+}));
+vi.mock('@pagespace/db/schema/auth', () => ({
+  users: { id: 'users.id', emailVerified: 'users.emailVerified' },
 }));
 vi.mock('@pagespace/db/schema/social', () => ({
   connections: {
@@ -36,9 +50,9 @@ vi.mock('@pagespace/db/schema/social', () => ({
   },
 }));
 
-import { callerCanViewUser, getRelatedUserIds } from '../visibility';
+import { callerCanViewUser, searchRelatedProfilesByName } from '../visibility';
 import { db } from '@pagespace/db/db';
-import { eq, isNotNull } from '@pagespace/db/operators';
+import { eq, ne, isNotNull, ilike, exists } from '@pagespace/db/operators';
 
 function queueSelectResults(results: unknown[][]) {
   let i = 0;
@@ -50,6 +64,8 @@ function queueSelectResults(results: unknown[][]) {
     terminal.limit = () => Promise.resolve(result);
     const chain = {
       from: () => chain,
+      innerJoin: () => chain,
+      leftJoin: () => chain,
       where: () => terminal,
       limit: () => Promise.resolve(result),
     };
@@ -132,78 +148,66 @@ describe('callerCanViewUser', () => {
 });
 
 // ============================================================================
-// getRelatedUserIds — the set form used by /api/users/search so a private
-// friend/collaborator is findable by name. Query order per invocation:
-//   1. accepted connections (either direction)
-//   2. caller's owned drives   (getUserDriveIds)
-//   3. caller's member drives  (getUserDriveIds)
-//   4. co-members of the caller's drives
-//   5. owners of the caller's drives
+// searchRelatedProfilesByName — name-matches private-or-public profiles the
+// caller already shares context with, used by /api/users/search so a private
+// friend/collaborator is findable by name. The relationship is expressed as
+// correlated EXISTS subqueries, so db.select() is issued in this order:
+//   1. caller's owned drives          (getUserDriveIds)
+//   2. caller's member drives         (getUserDriveIds)
+//   3. connectedToCaller EXISTS subquery (always built)
+//   4. co-member EXISTS subquery      (only when the caller has drives)
+//   5. owner EXISTS subquery          (only when the caller has drives)
+//   6. the main userProfiles query    (its result is what's returned)
 // ============================================================================
-describe('getRelatedUserIds', () => {
+describe('searchRelatedProfilesByName', () => {
   beforeEach(() => {
     vi.clearAllMocks();
   });
 
-  it('returns the other side of accepted connections in both directions', async () => {
+  const PATTERN = '%bob%';
+  const friend = { userId: 'friend', username: 'bobby', displayName: 'Bob', bio: null, avatarUrl: null };
+
+  it('returns the profiles matched by the bounded relationship query', async () => {
     queueSelectResults([
-      [
-        { user1Id: 'u1', user2Id: 'u2' }, // caller is user1 → partner u2
-        { user1Id: 'u3', user2Id: 'u1' }, // caller is user2 → partner u3
-      ],
-      [], // owns no drives
-      [], // member of no drives
+      [{ id: 'drive_a' }], // owned
+      [], // member
+      [], // connectedToCaller EXISTS subquery
+      [], // co-member EXISTS subquery
+      [], // owner EXISTS subquery
+      [friend], // main query
     ]);
-    const ids = await getRelatedUserIds('u1');
-    expect(ids.sort()).toEqual(['u2', 'u3']);
+    const rows = await searchRelatedProfilesByName('u1', PATTERN, 10);
+    expect(rows).toEqual([friend]);
   });
 
-  it('includes accepted co-members and owners of the caller\'s drives', async () => {
-    queueSelectResults([
-      [], // no connections
-      [{ id: 'drive_a' }], // caller owns drive_a
-      [], // member of none
-      [{ userId: 'u2' }, { userId: 'u3' }], // co-members
-      [{ ownerId: 'u4' }], // owners of shared drives
-    ]);
-    const ids = await getRelatedUserIds('u1');
-    expect(ids.sort()).toEqual(['u2', 'u3', 'u4']);
-  });
-
-  it('excludes the caller themselves and de-dupes', async () => {
-    queueSelectResults([
-      [{ user1Id: 'u1', user2Id: 'u2' }], // partner u2
-      [{ id: 'drive_a' }], // caller owns drive_a
-      [], // member of none
-      [{ userId: 'u1' }, { userId: 'u2' }], // caller appears as its own member row + dup u2
-      [{ ownerId: 'u1' }], // caller owns the shared drive
-    ]);
-    const ids = await getRelatedUserIds('u1');
-    expect(ids).toEqual(['u2']);
-  });
-
-  it('short-circuits drive lookups when the caller has no drives', async () => {
-    queueSelectResults([
-      [], // no connections
-      [], // owns none
-      [], // member of none
-    ]);
-    expect(await getRelatedUserIds('u1')).toEqual([]);
-    // 1 connections select + 2 drive-id selects; the co-member/owner reads are skipped.
-    expect(db.select).toHaveBeenCalledTimes(3);
-  });
-
-  it('gates on accepted status so pending/blocked relationships are excluded', async () => {
-    queueSelectResults([
-      [], // connections
-      [{ id: 'drive_a' }], // owns drive_a
-      [], // member of none
-      [], // co-members
-      [], // owners
-    ]);
-    await getRelatedUserIds('u1');
-    // Connections restricted to ACCEPTED; drive co-members gated on acceptedAt.
+  it('composes the relationship, name, and safety gates', async () => {
+    queueSelectResults([[{ id: 'drive_a' }], [], [], [], [], []]);
+    await searchRelatedProfilesByName('u1', PATTERN, 10);
+    // Accepted connections only; drive co-membership gated on acceptedAt.
     expect(eq).toHaveBeenCalledWith('connections.status', 'ACCEPTED');
     expect(isNotNull).toHaveBeenCalledWith('driveMembers.acceptedAt');
+    // Temp/magic-link accounts excluded; caller never matches themselves.
+    expect(isNotNull).toHaveBeenCalledWith('users.emailVerified');
+    expect(ne).toHaveBeenCalledWith('userProfiles.userId', 'u1');
+    // Name predicate applied on both username and display name.
+    expect(ilike).toHaveBeenCalledWith('userProfiles.username', PATTERN);
+    expect(ilike).toHaveBeenCalledWith('userProfiles.displayName', PATTERN);
+    // connection + co-member + owner relationship subqueries.
+    expect(exists).toHaveBeenCalledTimes(3);
+  });
+
+  it('uses only the connection relationship when the caller has no drives', async () => {
+    queueSelectResults([
+      [], // owned — none
+      [], // member — none
+      [], // connectedToCaller EXISTS subquery
+      [friend], // main query
+    ]);
+    const rows = await searchRelatedProfilesByName('u1', PATTERN, 10);
+    expect(rows).toEqual([friend]);
+    // No drive-based EXISTS subqueries are built.
+    expect(exists).toHaveBeenCalledTimes(1);
+    // owned + member + connection subquery + main.
+    expect(db.select).toHaveBeenCalledTimes(4);
   });
 });

--- a/apps/web/src/lib/users/visibility.ts
+++ b/apps/web/src/lib/users/visibility.ts
@@ -9,10 +9,12 @@
  */
 
 import { db } from '@pagespace/db/db';
-import { eq, and, or, inArray, isNotNull } from '@pagespace/db/operators';
+import { eq, ne, and, or, inArray, isNotNull, ilike, exists, sql } from '@pagespace/db/operators';
 import { drives } from '@pagespace/db/schema/core';
-import { driveMembers } from '@pagespace/db/schema/members';
+import { driveMembers, userProfiles } from '@pagespace/db/schema/members';
+import { users } from '@pagespace/db/schema/auth';
 import { connections } from '@pagespace/db/schema/social';
+import type { PublicProfileRow } from './enumeration-safe';
 
 /**
  * Drive ids the user owns or is an ACCEPTED member of.
@@ -85,58 +87,94 @@ export async function callerCanViewUser(
 }
 
 /**
- * The set of users the caller already shares context with: accepted connections
- * (either direction) and co-members/owners of any drive the caller owns or is an
- * accepted member of. Excludes the caller themselves.
+ * Name-match verified user profiles the caller already shares context with —
+ * accepted connections (either direction) and accepted co-members/owners of any
+ * drive the caller owns or is an accepted member of — regardless of the profile's
+ * `isPublic` flag. Excludes the caller themselves and temp/magic-link accounts
+ * (emailVerified IS NULL). `usernamePattern` must already be a LIKE-escaped
+ * `%…%` pattern.
  *
- * This is the set form of {@link callerCanViewUser}. The search endpoint uses it
- * to let already-known people surface by name even when their profile is private
- * — you can only find, by name, someone you already have a relationship with, so
- * it opens no new enumeration surface. Same `acceptedAt` gate applies: a pending,
+ * This is the search counterpart of {@link callerCanViewUser}: it lets an
+ * already-known person surface by name even when their profile is private — you
+ * can only find, by name, someone you already have a relationship with, so it
+ * opens no new enumeration surface. Same `acceptedAt` gate applies: a pending,
  * unaccepted invite is not an established relationship.
+ *
+ * The relationship is expressed as correlated EXISTS subqueries against
+ * userProfiles rather than by materializing every collaborator id in the app and
+ * expanding it into an IN list: the name predicate and LIMIT are applied inside
+ * the database, so cost scales with the number of MATCHES (bounded by `limit`),
+ * not with the total membership of the caller's drives. The only set carried in
+ * memory is the caller's own drive ids, which is inherently bounded.
  */
-export async function getRelatedUserIds(callerId: string): Promise<string[]> {
-  const related = new Set<string>();
+export async function searchRelatedProfilesByName(
+  callerId: string,
+  usernamePattern: string,
+  limit: number,
+): Promise<PublicProfileRow[]> {
+  const callerDriveIds = await getUserDriveIds(callerId);
 
-  // Accepted connections and the caller's own drive ids are independent lookups;
-  // run them together to keep this off the critical path of a per-keystroke
-  // typeahead search.
-  const [acceptedConnections, callerDriveIds] = await Promise.all([
+  // Accepted connection with the caller, either direction.
+  const connectedToCaller = exists(
     db
-      .select({ user1Id: connections.user1Id, user2Id: connections.user2Id })
+      .select({ one: sql`1` })
       .from(connections)
       .where(
         and(
           eq(connections.status, 'ACCEPTED'),
-          or(eq(connections.user1Id, callerId), eq(connections.user2Id, callerId)),
-        ),
-      ),
-    getUserDriveIds(callerId),
-  ]);
-  for (const row of acceptedConnections) {
-    related.add(row.user1Id === callerId ? row.user2Id : row.user1Id);
-  }
-
-  if (callerDriveIds.length > 0) {
-    const [coMembers, owners] = await Promise.all([
-      db
-        .select({ userId: driveMembers.userId })
-        .from(driveMembers)
-        .where(
-          and(
-            inArray(driveMembers.driveId, callerDriveIds),
-            isNotNull(driveMembers.acceptedAt),
+          or(
+            and(eq(connections.user1Id, callerId), eq(connections.user2Id, userProfiles.userId)),
+            and(eq(connections.user2Id, callerId), eq(connections.user1Id, userProfiles.userId)),
           ),
         ),
-      db
-        .select({ ownerId: drives.ownerId })
-        .from(drives)
-        .where(inArray(drives.id, callerDriveIds)),
-    ]);
-    for (const row of coMembers) related.add(row.userId);
-    for (const row of owners) related.add(row.ownerId);
+      ),
+  );
+
+  const relationshipPredicates = [connectedToCaller];
+  if (callerDriveIds.length > 0) {
+    // Accepted member of one of the caller's drives.
+    relationshipPredicates.push(
+      exists(
+        db
+          .select({ one: sql`1` })
+          .from(driveMembers)
+          .where(
+            and(
+              eq(driveMembers.userId, userProfiles.userId),
+              isNotNull(driveMembers.acceptedAt),
+              inArray(driveMembers.driveId, callerDriveIds),
+            ),
+          ),
+      ),
+    );
+    // Owner of one of the caller's drives.
+    relationshipPredicates.push(
+      exists(
+        db
+          .select({ one: sql`1` })
+          .from(drives)
+          .where(and(eq(drives.ownerId, userProfiles.userId), inArray(drives.id, callerDriveIds))),
+      ),
+    );
   }
 
-  related.delete(callerId);
-  return Array.from(related);
+  return db
+    .select({
+      userId: userProfiles.userId,
+      username: userProfiles.username,
+      displayName: userProfiles.displayName,
+      bio: userProfiles.bio,
+      avatarUrl: userProfiles.avatarUrl,
+    })
+    .from(userProfiles)
+    .innerJoin(users, eq(userProfiles.userId, users.id))
+    .where(
+      and(
+        ne(userProfiles.userId, callerId),
+        isNotNull(users.emailVerified),
+        or(ilike(userProfiles.username, usernamePattern), ilike(userProfiles.displayName, usernamePattern)),
+        or(...relationshipPredicates),
+      ),
+    )
+    .limit(limit);
 }

--- a/apps/web/src/lib/users/visibility.ts
+++ b/apps/web/src/lib/users/visibility.ts
@@ -83,3 +83,55 @@ export async function callerCanViewUser(
     .limit(1);
   return sharedOwnership.length > 0;
 }
+
+/**
+ * The set of users the caller already shares context with: accepted connections
+ * (either direction) and co-members/owners of any drive the caller owns or is an
+ * accepted member of. Excludes the caller themselves.
+ *
+ * This is the set form of {@link callerCanViewUser}. The search endpoint uses it
+ * to let already-known people surface by name even when their profile is private
+ * — you can only find, by name, someone you already have a relationship with, so
+ * it opens no new enumeration surface. Same `acceptedAt` gate applies: a pending,
+ * unaccepted invite is not an established relationship.
+ */
+export async function getRelatedUserIds(callerId: string): Promise<string[]> {
+  const related = new Set<string>();
+
+  const acceptedConnections = await db
+    .select({ user1Id: connections.user1Id, user2Id: connections.user2Id })
+    .from(connections)
+    .where(
+      and(
+        eq(connections.status, 'ACCEPTED'),
+        or(eq(connections.user1Id, callerId), eq(connections.user2Id, callerId)),
+      ),
+    );
+  for (const row of acceptedConnections) {
+    related.add(row.user1Id === callerId ? row.user2Id : row.user1Id);
+  }
+
+  const callerDriveIds = await getUserDriveIds(callerId);
+  if (callerDriveIds.length > 0) {
+    const [coMembers, owners] = await Promise.all([
+      db
+        .select({ userId: driveMembers.userId })
+        .from(driveMembers)
+        .where(
+          and(
+            inArray(driveMembers.driveId, callerDriveIds),
+            isNotNull(driveMembers.acceptedAt),
+          ),
+        ),
+      db
+        .select({ ownerId: drives.ownerId })
+        .from(drives)
+        .where(inArray(drives.id, callerDriveIds)),
+    ]);
+    for (const row of coMembers) related.add(row.userId);
+    for (const row of owners) related.add(row.ownerId);
+  }
+
+  related.delete(callerId);
+  return Array.from(related);
+}

--- a/apps/web/src/lib/users/visibility.ts
+++ b/apps/web/src/lib/users/visibility.ts
@@ -98,20 +98,25 @@ export async function callerCanViewUser(
 export async function getRelatedUserIds(callerId: string): Promise<string[]> {
   const related = new Set<string>();
 
-  const acceptedConnections = await db
-    .select({ user1Id: connections.user1Id, user2Id: connections.user2Id })
-    .from(connections)
-    .where(
-      and(
-        eq(connections.status, 'ACCEPTED'),
-        or(eq(connections.user1Id, callerId), eq(connections.user2Id, callerId)),
+  // Accepted connections and the caller's own drive ids are independent lookups;
+  // run them together to keep this off the critical path of a per-keystroke
+  // typeahead search.
+  const [acceptedConnections, callerDriveIds] = await Promise.all([
+    db
+      .select({ user1Id: connections.user1Id, user2Id: connections.user2Id })
+      .from(connections)
+      .where(
+        and(
+          eq(connections.status, 'ACCEPTED'),
+          or(eq(connections.user1Id, callerId), eq(connections.user2Id, callerId)),
+        ),
       ),
-    );
+    getUserDriveIds(callerId),
+  ]);
   for (const row of acceptedConnections) {
     related.add(row.user1Id === callerId ? row.user2Id : row.user1Id);
   }
 
-  const callerDriveIds = await getUserDriveIds(callerId);
   if (callerDriveIds.length > 0) {
     const [coMembers, owners] = await Promise.all([
       db


### PR DESCRIPTION
## Why

When you invite someone to a drive, the member search (`GET /api/users/search`, used by `UserSearch.tsx` on the invite page) was hardened against email-harvesting so that **name matches only return public profiles**; everything else is reachable only by typing an exact email address.

The consequence: a person you already have a relationship with on PageSpace — an **accepted connection**, or a **co-member of a drive you share** — whose profile is **private** can't be found by name. You have to already know their exact email. That contradicts the expectation: *if someone is my friend/collaborator, I should be able to find them by name.*

## What changed

The codebase already models this relationship in `apps/web/src/lib/users/visibility.ts` (`callerCanViewUser`, used by `/api/users/find`). This PR extends the search to honor the same relationship.

- **`lib/users/visibility.ts`** — adds `searchRelatedProfilesByName(callerId, pattern, limit)`: name-matches verified user profiles the caller already shares context with — accepted connections (either direction) and accepted co-members/owners of the caller's drives — **regardless of `isPublic`**, excluding the caller and temp/magic-link accounts. The relationship is expressed as correlated `EXISTS` subqueries so the **name predicate and `LIMIT` run in the database**; cost scales with matches, not with total drive membership, and no unbounded collaborator set is materialized or bound as parameters.
- **`app/api/users/search/route.ts`** — calls that helper for a related-profiles branch, and merges results **email-first → related → public** so an exact-email match always survives the final `slice(0, limit)`. LIKE metacharacters in the query are escaped via the shared `escapeLikePattern` helper (so `q=%%` matches literally instead of dumping private-profile metadata). The related branch keeps the `emailVerified` gate and carries **no email**.
- No API-contract change (`{ users: [...] }` shape unchanged), so `UserSearch.tsx` and the invite flow need no changes.

### Why this opens no new enumeration surface
You can only find, by name, someone you **already** have a relationship with, and the related branch never carries an email — so the M3/L1/L2 email-harvest hardening is preserved. `isPublic = false` is treated as "not discoverable by strangers," not "hidden from people I already collaborate with."

## Review feedback addressed
- **CodeRabbit (Major, CWE-200):** escape LIKE metacharacters so `%%` can't match every related private profile.
- **codex (P2):** don't materialize every member id into an `IN` list — bounded query via correlated `EXISTS`.
- **codex (P2):** preserve exact-email matches ahead of name matches so the slice can't drop them.

## Tests

- `lib/users/__tests__/visibility.test.ts` — `searchRelatedProfilesByName`: returns the bounded query's rows; composes the relationship/name/safety gates (ACCEPTED connections, `acceptedAt`, `emailVerified`, `ne(self)`, `ilike`); uses only the connection relationship when the caller has no drives.
- `app/api/users/search/__tests__/route.test.ts` — private friend findable by name; LIKE-escaped pattern passed through; dedupe when both public+related; exact-email match preserved email-first under `limit=1`.

## Verification note

I could not run the suite locally (this worktree isn't fully `bun install`ed and other agents were active), so I'm relying on CI to gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)