### PR TITLE
feat(lib): env-bridge pure core — signed grant verification (M0/t01)

### DIFF
--- a/packages/lib/package.json
+++ b/packages/lib/package.json
@@ -143,6 +143,16 @@
       "import": "./dist/drive-envs/env-sprite-key.js",
       "require": "./dist/drive-envs/env-sprite-key.js"
     },
+    "./env-bridge": {
+      "types": "./dist/env-bridge/index.d.ts",
+      "import": "./dist/env-bridge/index.js",
+      "require": "./dist/env-bridge/index.js"
+    },
+    "./env-bridge/grant": {
+      "types": "./dist/env-bridge/grant.d.ts",
+      "import": "./dist/env-bridge/grant.js",
+      "require": "./dist/env-bridge/grant.js"
+    },
     "./agent-workspaces/credential-scope": {
       "types": "./dist/agent-workspaces/credential-scope.d.ts",
       "import": "./dist/agent-workspaces/credential-scope.js",

--- a/packages/lib/src/env-bridge/__tests__/grant.test.ts
+++ b/packages/lib/src/env-bridge/__tests__/grant.test.ts
@@ -1,20 +1,24 @@
 import { describe, it, expect } from 'vitest';
-import { generateKeyPairSync, sign as nodeSign, verify as nodeVerify, createPublicKey } from 'node:crypto';
+import { generateKeyPairSync, sign as nodeSign, verify as nodeVerify, createPublicKey, createHash } from 'node:crypto';
 import {
   encodeGrant,
+  canonicalizeArgs,
   verifyGrant,
   createMemoryNonceStore,
   GRANT_MAX_TTL_MS,
   GRANT_MAX_CLOCK_SKEW_MS,
   type Grant,
+  type GrantOp,
   type Ed25519Verify,
+  type HashBytes,
   type NonceStore,
 } from '../grant';
 
 // ---------------------------------------------------------------------------
-// Fixtures. Real Ed25519 keys so the signature path is exercised for real, but
-// the verifier is still INJECTED into verifyGrant — the module under test never
-// touches node:crypto itself (it must stay pure).
+// Fixtures. Real Ed25519 keys and a real SHA-256 so the signature and hashing
+// paths are exercised for real, but both primitives are still INJECTED into
+// verifyGrant — the module under test never touches node:crypto (it must stay
+// pure).
 // ---------------------------------------------------------------------------
 
 const server = generateKeyPairSync('ed25519');
@@ -25,6 +29,8 @@ const serverPublicKey = new Uint8Array(server.publicKey.export({ type: 'spki', f
 const verify: Ed25519Verify = (message, signature, publicKey) =>
   nodeVerify(null, message, createPublicKey({ key: Buffer.from(publicKey), type: 'spki', format: 'der' }), signature);
 
+const hash: HashBytes = (bytes) => createHash('sha256').update(bytes).digest('hex');
+
 function signWith(privateKey: typeof server.privateKey, grant: Grant): string {
   return Buffer.from(nodeSign(null, encodeGrant(grant), privateKey)).toString('base64');
 }
@@ -32,13 +38,17 @@ function signWith(privateKey: typeof server.privateKey, grant: Grant): string {
 const NOW = 1_800_000_000_000; // fixed clock — verifyGrant must never read Date.now()
 const ENV = 'env_local_1';
 
+/** The request the grant in makeGrant() was issued for. */
+const ARGS = { cmd: 'ls', args: ['-la'], cwd: '/home/u/proj', env: { LANG: 'C' } };
+const ARGS_HASH = hash(canonicalizeArgs(ARGS));
+
 function makeGrant(overrides: Partial<Grant> = {}): Grant {
   return {
     grantId: 'grant_1',
     envId: ENV,
     principal: { userId: 'user_1', sessionId: 'session_1', conversationId: 'conv_1' },
     op: 'exec',
-    argsHash: 'a'.repeat(64),
+    argsHash: ARGS_HASH,
     iat: NOW - 1_000,
     exp: NOW + 30_000,
     nonce: 'nonce_1',
@@ -46,7 +56,16 @@ function makeGrant(overrides: Partial<Grant> = {}): Grant {
   };
 }
 
-function run(grant: unknown, opts: { signature?: string; nonces?: NonceStore; expectedEnvId?: string; now?: number; key?: Uint8Array } = {}) {
+interface RunOpts {
+  signature?: string;
+  nonces?: NonceStore;
+  expectedEnvId?: string;
+  now?: number;
+  key?: Uint8Array;
+  request?: { op: GrantOp; args: unknown };
+}
+
+function run(grant: unknown, opts: RunOpts = {}) {
   const signature = opts.signature ?? signWith(server.privateKey, grant as Grant);
   return verifyGrant({
     grant,
@@ -55,12 +74,14 @@ function run(grant: unknown, opts: { signature?: string; nonces?: NonceStore; ex
     now: opts.now ?? NOW,
     nonces: opts.nonces ?? createMemoryNonceStore(),
     expectedEnvId: opts.expectedEnvId ?? ENV,
+    request: opts.request ?? { op: 'exec', args: ARGS },
     verify,
+    hash,
   });
 }
 
 describe('verifyGrant — the daemon-side authorization gate (invariant 3)', () => {
-  it('given a well-formed grant signed by the pinned server key with an unseen nonce, should return ok with the parsed grant AND record the nonce', () => {
+  it('given a well-formed grant signed by the pinned server key, bound to this exact request, with an unseen nonce, should return ok with the parsed grant AND record the nonce', () => {
     const nonces = createMemoryNonceStore();
     const grant = makeGrant();
     const verdict = run(grant, { nonces });
@@ -75,14 +96,13 @@ describe('verifyGrant — the daemon-side authorization gate (invariant 3)', () 
   });
 
   it.each<[keyof Grant, Grant[keyof Grant]]>([
-    ['op', 'fs_write'],
-    ['argsHash', 'b'.repeat(64)],
     ['exp', NOW + 20_000],
     ['grantId', 'grant_2'],
     ['nonce', 'nonce_2'],
   ])('given field %s altered AFTER signing, should deny bad_signature (canonical encoding is field-stable)', (field, value) => {
-    // envId is deliberately absent from this table: tampering it fails EARLIER as
-    // wrong_env, which the deny-order test below pins.
+    // envId / op / argsHash are deliberately absent from this table: tampering
+    // them fails EARLIER as wrong_env / op_mismatch / args_mismatch, each pinned
+    // by its own test below.
     const original = makeGrant();
     const signature = signWith(server.privateKey, original);
     const tampered = { ...original, [field]: value };
@@ -94,6 +114,41 @@ describe('verifyGrant — the daemon-side authorization gate (invariant 3)', () 
     const signature = signWith(server.privateKey, original);
     const tampered = { ...original, principal: { ...original.principal, userId: 'user_evil' } };
     expect(run(tampered, { signature })).toEqual({ ok: false, reason: 'bad_signature' });
+  });
+
+  // -------------------------------------------------------------------------
+  // Request binding (Codex P1 on PR #2527). A captured, unused, correctly signed
+  // grant must be useless for any work other than the exact request it was
+  // issued for. The gate itself compares the signed op/argsHash against the
+  // frame that carries the grant — it is not left to a later layer.
+  // -------------------------------------------------------------------------
+
+  it('given a valid signed grant carried by a frame whose op differs from the signed op, should deny op_mismatch and not burn the nonce', () => {
+    const nonces = createMemoryNonceStore();
+    const grant = makeGrant({ op: 'fs_read' });
+    expect(run(grant, { nonces, request: { op: 'exec', args: ARGS } })).toEqual({ ok: false, reason: 'op_mismatch' });
+    expect(nonces.has(grant.nonce)).toBe(false);
+  });
+
+  it('given a valid signed grant carried by a frame whose args hash to something other than the signed argsHash, should deny args_mismatch and not burn the nonce (request substitution)', () => {
+    const nonces = createMemoryNonceStore();
+    const grant = makeGrant();
+    const substituted = { ...ARGS, cmd: 'rm', args: ['-rf', '/'] };
+    expect(run(grant, { nonces, request: { op: 'exec', args: substituted } })).toEqual({ ok: false, reason: 'args_mismatch' });
+    expect(nonces.has(grant.nonce)).toBe(false);
+  });
+
+  it('given an attacker who rewrites grant.argsHash to match their own args and sends those args, should deny bad_signature (the signature covers argsHash)', () => {
+    const original = makeGrant();
+    const signature = signWith(server.privateKey, original);
+    const evilArgs = { ...ARGS, cmd: 'curl', args: ['evil'] };
+    const retargeted = { ...original, argsHash: hash(canonicalizeArgs(evilArgs)) };
+    expect(run(retargeted, { signature, request: { op: 'exec', args: evilArgs } })).toEqual({ ok: false, reason: 'bad_signature' });
+  });
+
+  it('given the same args with object keys in a different order, should still bind (canonical hashing)', () => {
+    const reordered = { env: { LANG: 'C' }, cwd: '/home/u/proj', args: ['-la'], cmd: 'ls' };
+    expect(run(makeGrant(), { request: { op: 'exec', args: reordered } }).ok).toBe(true);
   });
 
   it('given exp < now, should deny expired', () => {
@@ -138,9 +193,10 @@ describe('verifyGrant — the daemon-side authorization gate (invariant 3)', () 
     run(grant, { nonces, signature: signWith(rogue.privateKey, grant) });
     run(makeGrant({ envId: 'env_other', nonce: 'n_env' }), { nonces });
     run(makeGrant({ iat: NOW - 50_000, exp: NOW - 1, nonce: 'n_exp' }), { nonces });
+    run(makeGrant({ nonce: 'n_op' }), { nonces, request: { op: 'fs_write', args: ARGS } });
+    run(makeGrant({ nonce: 'n_args' }), { nonces, request: { op: 'exec', args: { cmd: 'other' } } });
     expect(nonces.has(grant.nonce)).toBe(false);
-    expect(nonces.has('n_env')).toBe(false);
-    expect(nonces.has('n_exp')).toBe(false);
+    for (const n of ['n_env', 'n_exp', 'n_op', 'n_args']) expect(nonces.has(n)).toBe(false);
   });
 
   it.each<[string, unknown]>([
@@ -167,16 +223,24 @@ describe('verifyGrant — the daemon-side authorization gate (invariant 3)', () 
   it('should be deterministic: identical inputs yield identical verdicts (no hidden clock or randomness)', () => {
     const grant = makeGrant();
     const signature = signWith(server.privateKey, grant);
-    const a = verifyGrant({ grant, signature, serverPublicKey, now: NOW, nonces: createMemoryNonceStore(), expectedEnvId: ENV, verify });
-    const b = verifyGrant({ grant, signature, serverPublicKey, now: NOW, nonces: createMemoryNonceStore(), expectedEnvId: ENV, verify });
+    const input = { grant, signature, serverPublicKey, now: NOW, expectedEnvId: ENV, request: { op: 'exec' as const, args: ARGS }, verify, hash };
+    const a = verifyGrant({ ...input, nonces: createMemoryNonceStore() });
+    const b = verifyGrant({ ...input, nonces: createMemoryNonceStore() });
     expect(a).toEqual(b);
   });
 
   it('should enforce a fixed deny order: wrong_env is reported before signature is even checked', () => {
-    // A grant for another env signed by a ROGUE key: wrong_env must win (cheap structural
-    // checks run before crypto), proving the order is fixed rather than incidental.
+    // A grant for another env signed by a ROGUE key: wrong_env must win (cheap
+    // structural checks run before crypto), proving the order is fixed rather
+    // than incidental.
     const grant = makeGrant({ envId: 'env_other' });
     expect(run(grant, { signature: signWith(rogue.privateKey, grant) })).toEqual({ ok: false, reason: 'wrong_env' });
+  });
+
+  it('should enforce a fixed deny order: request binding is checked before the signature', () => {
+    const grant = makeGrant();
+    const verdict = run(grant, { signature: signWith(rogue.privateKey, grant), request: { op: 'pty_open', args: ARGS } });
+    expect(verdict).toEqual({ ok: false, reason: 'op_mismatch' });
   });
 });
 
@@ -189,6 +253,31 @@ describe('encodeGrant — canonical bytes for signing', () => {
 
   it('given two grants differing in exactly one field, should encode different bytes', () => {
     expect(Buffer.from(encodeGrant(makeGrant())).equals(Buffer.from(encodeGrant(makeGrant({ nonce: 'x' }))))).toBe(false);
+  });
+});
+
+describe('canonicalizeArgs — the bytes both ends hash to bind a grant to its request', () => {
+  const bytes = (v: unknown) => Buffer.from(canonicalizeArgs(v)).toString('utf8');
+
+  it('given objects with keys in different orders (including nested), should produce identical bytes', () => {
+    expect(bytes({ a: 1, b: { c: 2, d: [3, { e: 4, f: 5 }] } })).toBe(bytes({ b: { d: [3, { f: 5, e: 4 }], c: 2 }, a: 1 }));
+  });
+
+  it('should preserve array order (arguments are positional)', () => {
+    expect(bytes({ args: ['-la', '/'] })).not.toBe(bytes({ args: ['/', '-la'] }));
+  });
+
+  it('should distinguish values that JSON would otherwise conflate', () => {
+    expect(bytes({ a: 1 })).not.toBe(bytes({ a: '1' }));
+    expect(bytes({ a: null })).not.toBe(bytes({}));
+  });
+
+  it('should drop undefined-valued keys the same way at both ends (they are not on the wire)', () => {
+    expect(bytes({ a: 1, b: undefined })).toBe(bytes({ a: 1 }));
+  });
+
+  it('should be deterministic for primitives and nested arrays', () => {
+    expect(bytes([1, 'x', [true, null]])).toBe(bytes([1, 'x', [true, null]]));
   });
 });
 

--- a/packages/lib/src/env-bridge/__tests__/grant.test.ts
+++ b/packages/lib/src/env-bridge/__tests__/grant.test.ts
@@ -1,0 +1,202 @@
+import { describe, it, expect } from 'vitest';
+import { generateKeyPairSync, sign as nodeSign, verify as nodeVerify, createPublicKey } from 'node:crypto';
+import {
+  encodeGrant,
+  verifyGrant,
+  createMemoryNonceStore,
+  GRANT_MAX_TTL_MS,
+  GRANT_MAX_CLOCK_SKEW_MS,
+  type Grant,
+  type Ed25519Verify,
+  type NonceStore,
+} from '../grant';
+
+// ---------------------------------------------------------------------------
+// Fixtures. Real Ed25519 keys so the signature path is exercised for real, but
+// the verifier is still INJECTED into verifyGrant — the module under test never
+// touches node:crypto itself (it must stay pure).
+// ---------------------------------------------------------------------------
+
+const server = generateKeyPairSync('ed25519');
+const rogue = generateKeyPairSync('ed25519');
+
+const serverPublicKey = new Uint8Array(server.publicKey.export({ type: 'spki', format: 'der' }));
+
+const verify: Ed25519Verify = (message, signature, publicKey) =>
+  nodeVerify(null, message, createPublicKey({ key: Buffer.from(publicKey), type: 'spki', format: 'der' }), signature);
+
+function signWith(privateKey: typeof server.privateKey, grant: Grant): string {
+  return Buffer.from(nodeSign(null, encodeGrant(grant), privateKey)).toString('base64');
+}
+
+const NOW = 1_800_000_000_000; // fixed clock — verifyGrant must never read Date.now()
+const ENV = 'env_local_1';
+
+function makeGrant(overrides: Partial<Grant> = {}): Grant {
+  return {
+    grantId: 'grant_1',
+    envId: ENV,
+    principal: { userId: 'user_1', sessionId: 'session_1', conversationId: 'conv_1' },
+    op: 'exec',
+    argsHash: 'a'.repeat(64),
+    iat: NOW - 1_000,
+    exp: NOW + 30_000,
+    nonce: 'nonce_1',
+    ...overrides,
+  };
+}
+
+function run(grant: unknown, opts: { signature?: string; nonces?: NonceStore; expectedEnvId?: string; now?: number; key?: Uint8Array } = {}) {
+  const signature = opts.signature ?? signWith(server.privateKey, grant as Grant);
+  return verifyGrant({
+    grant,
+    signature,
+    serverPublicKey: opts.key ?? serverPublicKey,
+    now: opts.now ?? NOW,
+    nonces: opts.nonces ?? createMemoryNonceStore(),
+    expectedEnvId: opts.expectedEnvId ?? ENV,
+    verify,
+  });
+}
+
+describe('verifyGrant — the daemon-side authorization gate (invariant 3)', () => {
+  it('given a well-formed grant signed by the pinned server key with an unseen nonce, should return ok with the parsed grant AND record the nonce', () => {
+    const nonces = createMemoryNonceStore();
+    const grant = makeGrant();
+    const verdict = run(grant, { nonces });
+    expect(verdict).toEqual({ ok: true, grant });
+    expect(nonces.has(grant.nonce)).toBe(true);
+  });
+
+  it('given a grant signed by a different key, should deny bad_signature', () => {
+    const grant = makeGrant();
+    const verdict = run(grant, { signature: signWith(rogue.privateKey, grant) });
+    expect(verdict).toEqual({ ok: false, reason: 'bad_signature' });
+  });
+
+  it.each<[keyof Grant, Grant[keyof Grant]]>([
+    ['op', 'fs_write'],
+    ['argsHash', 'b'.repeat(64)],
+    ['exp', NOW + 20_000],
+    ['grantId', 'grant_2'],
+    ['nonce', 'nonce_2'],
+  ])('given field %s altered AFTER signing, should deny bad_signature (canonical encoding is field-stable)', (field, value) => {
+    // envId is deliberately absent from this table: tampering it fails EARLIER as
+    // wrong_env, which the deny-order test below pins.
+    const original = makeGrant();
+    const signature = signWith(server.privateKey, original);
+    const tampered = { ...original, [field]: value };
+    expect(run(tampered, { signature })).toEqual({ ok: false, reason: 'bad_signature' });
+  });
+
+  it('given the principal altered after signing, should deny bad_signature', () => {
+    const original = makeGrant();
+    const signature = signWith(server.privateKey, original);
+    const tampered = { ...original, principal: { ...original.principal, userId: 'user_evil' } };
+    expect(run(tampered, { signature })).toEqual({ ok: false, reason: 'bad_signature' });
+  });
+
+  it('given exp < now, should deny expired', () => {
+    expect(run(makeGrant({ iat: NOW - 50_000, exp: NOW - 1 }))).toEqual({ ok: false, reason: 'expired' });
+  });
+
+  it('given iat more than the allowed skew in the future, should deny clock_skew', () => {
+    const iat = NOW + GRANT_MAX_CLOCK_SKEW_MS + 1;
+    expect(run(makeGrant({ iat, exp: iat + 10_000 }))).toEqual({ ok: false, reason: 'clock_skew' });
+  });
+
+  it('given iat within the allowed skew in the future, should NOT deny for skew', () => {
+    const iat = NOW + GRANT_MAX_CLOCK_SKEW_MS;
+    expect(run(makeGrant({ iat, exp: iat + 10_000 })).ok).toBe(true);
+  });
+
+  it('given exp - iat > the max TTL, should deny ttl_too_long even when otherwise valid and unexpired', () => {
+    expect(run(makeGrant({ iat: NOW - 1_000, exp: NOW - 1_000 + GRANT_MAX_TTL_MS + 1 }))).toEqual({ ok: false, reason: 'ttl_too_long' });
+  });
+
+  it('given exp - iat exactly the max TTL, should allow', () => {
+    expect(run(makeGrant({ iat: NOW - 1_000, exp: NOW - 1_000 + GRANT_MAX_TTL_MS })).ok).toBe(true);
+  });
+
+  it('given grant.envId !== expectedEnvId, should deny wrong_env (a grant for another machine never runs here)', () => {
+    expect(run(makeGrant({ envId: 'env_other' }))).toEqual({ ok: false, reason: 'wrong_env' });
+  });
+
+  it('given a nonce already present in the store, should deny replayed and NOT re-add it', () => {
+    const nonces = createMemoryNonceStore();
+    const grant = makeGrant();
+    expect(run(grant, { nonces }).ok).toBe(true);
+    let adds = 0;
+    const spy: NonceStore = { has: (n) => nonces.has(n), add: (n, e) => { adds += 1; nonces.add(n, e); } };
+    expect(run(grant, { nonces: spy })).toEqual({ ok: false, reason: 'replayed' });
+    expect(adds).toBe(0);
+  });
+
+  it('given a grant that fails ANY check, should never record its nonce (a rejected grant cannot burn a nonce)', () => {
+    const nonces = createMemoryNonceStore();
+    const grant = makeGrant();
+    run(grant, { nonces, signature: signWith(rogue.privateKey, grant) });
+    run(makeGrant({ envId: 'env_other', nonce: 'n_env' }), { nonces });
+    run(makeGrant({ iat: NOW - 50_000, exp: NOW - 1, nonce: 'n_exp' }), { nonces });
+    expect(nonces.has(grant.nonce)).toBe(false);
+    expect(nonces.has('n_env')).toBe(false);
+    expect(nonces.has('n_exp')).toBe(false);
+  });
+
+  it.each<[string, unknown]>([
+    ['null', null],
+    ['a string', 'grant'],
+    ['an array', []],
+    ['a number', 42],
+    ['missing nonce', (() => { const { nonce: _n, ...rest } = makeGrant(); return rest; })()],
+    ['missing principal', (() => { const { principal: _p, ...rest } = makeGrant(); return rest; })()],
+    ['mistyped iat', { ...makeGrant(), iat: '123' }],
+    ['mistyped principal', { ...makeGrant(), principal: 'user_1' }],
+    ['extra field', { ...makeGrant(), isAdmin: true }],
+    ['op outside the closed union', { ...makeGrant(), op: 'rm_rf' }],
+  ])('given %s, should deny malformed and never throw', (_label, input) => {
+    expect(() => run(input, { signature: 'AAAA' })).not.toThrow();
+    expect(run(input, { signature: 'AAAA' })).toEqual({ ok: false, reason: 'malformed' });
+  });
+
+  it('given an undecodable signature string, should deny bad_signature and never throw', () => {
+    expect(() => run(makeGrant(), { signature: '!!!not-base64!!!' })).not.toThrow();
+    expect(run(makeGrant(), { signature: '' })).toEqual({ ok: false, reason: 'bad_signature' });
+  });
+
+  it('should be deterministic: identical inputs yield identical verdicts (no hidden clock or randomness)', () => {
+    const grant = makeGrant();
+    const signature = signWith(server.privateKey, grant);
+    const a = verifyGrant({ grant, signature, serverPublicKey, now: NOW, nonces: createMemoryNonceStore(), expectedEnvId: ENV, verify });
+    const b = verifyGrant({ grant, signature, serverPublicKey, now: NOW, nonces: createMemoryNonceStore(), expectedEnvId: ENV, verify });
+    expect(a).toEqual(b);
+  });
+
+  it('should enforce a fixed deny order: wrong_env is reported before signature is even checked', () => {
+    // A grant for another env signed by a ROGUE key: wrong_env must win (cheap structural
+    // checks run before crypto), proving the order is fixed rather than incidental.
+    const grant = makeGrant({ envId: 'env_other' });
+    expect(run(grant, { signature: signWith(rogue.privateKey, grant) })).toEqual({ ok: false, reason: 'wrong_env' });
+  });
+});
+
+describe('encodeGrant — canonical bytes for signing', () => {
+  it('given the same grant with keys in a different insertion order, should encode identical bytes', () => {
+    const a = makeGrant();
+    const b = { nonce: a.nonce, exp: a.exp, iat: a.iat, argsHash: a.argsHash, op: a.op, principal: { conversationId: a.principal.conversationId, sessionId: a.principal.sessionId, userId: a.principal.userId }, envId: a.envId, grantId: a.grantId } as Grant;
+    expect(Buffer.from(encodeGrant(a)).equals(Buffer.from(encodeGrant(b)))).toBe(true);
+  });
+
+  it('given two grants differing in exactly one field, should encode different bytes', () => {
+    expect(Buffer.from(encodeGrant(makeGrant())).equals(Buffer.from(encodeGrant(makeGrant({ nonce: 'x' }))))).toBe(false);
+  });
+});
+
+describe('createMemoryNonceStore', () => {
+  it('should report has() true only after add()', () => {
+    const s = createMemoryNonceStore();
+    expect(s.has('n')).toBe(false);
+    s.add('n', NOW + 1);
+    expect(s.has('n')).toBe(true);
+  });
+});

--- a/packages/lib/src/env-bridge/grant.ts
+++ b/packages/lib/src/env-bridge/grant.ts
@@ -11,17 +11,26 @@
  * the daemon verifies it here BEFORE anything runs. Server-side gating is
  * necessary but never sufficient; this function is the daemon's own gate.
  *
+ * A verified grant is also BOUND to the frame that carries it. Authenticity
+ * alone is not enough: an attacker holding a captured, unused, correctly signed
+ * grant could otherwise pair it with different work. `argsHash` exists to stop
+ * exactly that, so this gate recomputes `hash(canonicalizeArgs(request.args))`
+ * and compares it — and `op` — to the signed values. The binding is part of the
+ * mandatory gate, never left to a later layer (Codex P1 on PR #2527).
+ *
  * Pure by construction. Nothing in this module reads a clock, generates
  * randomness, touches `node:crypto`, or performs I/O: the caller injects `now`,
- * the Ed25519 `verify` primitive, and the `NonceStore`. That is what makes the
- * adversarial matrix in `__tests__/grant.test.ts` exhaustive rather than flaky,
- * and what lets the same verifier run unchanged in the CLI daemon and in tests.
+ * the Ed25519 `verify` primitive, the `hash` primitive, and the `NonceStore`.
+ * That is what makes the adversarial matrix in `__tests__/grant.test.ts`
+ * exhaustive rather than flaky, and what lets the same verifier run unchanged in
+ * the CLI daemon and in tests.
  *
- * Deny order is FIXED and tested: malformed → wrong_env → ttl_too_long →
- * clock_skew → expired → bad_signature → replayed. Cheap structural checks run
- * before the signature so junk never reaches crypto, and the replay check runs
- * LAST so a grant that fails any earlier check can never burn its nonce — the
- * nonce is recorded only when the whole verdict is `ok`.
+ * Deny order is FIXED and tested: malformed → wrong_env → op_mismatch →
+ * args_mismatch → ttl_too_long → clock_skew → expired → bad_signature →
+ * replayed. Cheap structural checks (including the request binding) run before
+ * the signature so junk never reaches crypto, and the replay check runs LAST so
+ * a grant that fails any earlier check can never burn its nonce — the nonce is
+ * recorded only when the whole verdict is `ok`.
  */
 import { z } from 'zod';
 
@@ -46,7 +55,7 @@ export interface Grant {
   readonly envId: string;
   readonly principal: GrantPrincipal;
   readonly op: GrantOp;
-  /** Hash of the request arguments, binding the grant to exactly this request. */
+  /** `hash(canonicalizeArgs(args))` of the request this grant was issued for. */
   readonly argsHash: string;
   /** Issued-at, ms since epoch. */
   readonly iat: number;
@@ -58,6 +67,8 @@ export interface Grant {
 export type GrantDenyReason =
   | 'malformed'
   | 'wrong_env'
+  | 'op_mismatch'
+  | 'args_mismatch'
   | 'ttl_too_long'
   | 'clock_skew'
   | 'expired'
@@ -80,6 +91,16 @@ export interface NonceStore {
 /** Ed25519 verification primitive, injected so this module stays free of `node:crypto`. */
 export type Ed25519Verify = (message: Uint8Array, signature: Uint8Array, publicKey: Uint8Array) => boolean;
 
+/** Cryptographic hash primitive (bytes → hex/base64 digest), injected for the same reason. */
+export type HashBytes = (bytes: Uint8Array) => string;
+
+/** The frame that carries the grant: what the caller is actually asking to run. */
+export interface GrantRequest {
+  readonly op: GrantOp;
+  /** The request's arguments exactly as received; hashed via `canonicalizeArgs`. */
+  readonly args: unknown;
+}
+
 export interface VerifyGrantInput {
   /** Untrusted: whatever arrived on the wire. */
   readonly grant: unknown;
@@ -92,7 +113,10 @@ export interface VerifyGrantInput {
   readonly nonces: NonceStore;
   /** The env this daemon serves. */
   readonly expectedEnvId: string;
+  /** The request the grant must be bound to. */
+  readonly request: GrantRequest;
   readonly verify: Ed25519Verify;
+  readonly hash: HashBytes;
 }
 
 const principalSchema = z
@@ -141,12 +165,52 @@ export function encodeGrant(grant: Grant): Uint8Array {
   return new TextEncoder().encode(JSON.stringify(canonical));
 }
 
+/**
+ * Deterministic serialization of request arguments, so the server (when it
+ * issues a grant) and the daemon (when it verifies one) hash identical bytes
+ * regardless of key insertion order or transport. Object keys are sorted
+ * recursively; arrays stay positional (arguments are ordered); `undefined`
+ * values are dropped exactly as JSON drops them on the wire; types stay
+ * distinct (`1` ≠ `'1'`, `null` ≠ absent).
+ */
+export function canonicalizeArgs(value: unknown): Uint8Array {
+  return new TextEncoder().encode(canonicalJson(value));
+}
+
+function canonicalJson(value: unknown): string {
+  if (value === null || value === undefined) return 'null';
+  if (Array.isArray(value)) return `[${value.map((item) => canonicalJson(item)).join(',')}]`;
+  if (typeof value === 'object') {
+    const record = value as Record<string, unknown>;
+    const keys = Object.keys(record)
+      .filter((key) => record[key] !== undefined)
+      .sort();
+    return `{${keys.map((key) => `${JSON.stringify(key)}:${canonicalJson(record[key])}`).join(',')}}`;
+  }
+  // string | number | boolean | bigint | symbol | function — JSON semantics for
+  // the first three; the rest cannot arrive on the wire and serialize to null.
+  const encoded = JSON.stringify(value);
+  return encoded === undefined ? 'null' : encoded;
+}
+
 const BASE64_RE = /^[A-Za-z0-9+/]+={0,2}$/;
 
 /** Strict base64 → bytes; `null` for anything that is not well-formed base64. */
 function decodeBase64(value: string): Uint8Array | null {
   if (value.length === 0 || value.length % 4 !== 0 || !BASE64_RE.test(value)) return null;
   return new Uint8Array(Buffer.from(value, 'base64'));
+}
+
+/**
+ * Length-then-XOR comparison that does not short-circuit on the first differing
+ * character. Digests are not secrets, but the gate should not leak how much of
+ * a hash matched either.
+ */
+function constantTimeEqual(a: string, b: string): boolean {
+  if (a.length !== b.length) return false;
+  let diff = 0;
+  for (let i = 0; i < a.length; i += 1) diff |= a.charCodeAt(i) ^ b.charCodeAt(i);
+  return diff === 0;
 }
 
 function deny(reason: GrantDenyReason): GrantVerdict {
@@ -159,6 +223,18 @@ export function verifyGrant(input: VerifyGrantInput): GrantVerdict {
   const grant: Grant = parsed.data;
 
   if (grant.envId !== input.expectedEnvId) return deny('wrong_env');
+
+  // Bind the grant to the frame carrying it BEFORE the signature: a signed grant
+  // for other work is still the wrong grant, and this check is cheap.
+  if (grant.op !== input.request.op) return deny('op_mismatch');
+  let requestHash: string;
+  try {
+    requestHash = input.hash(canonicalizeArgs(input.request.args));
+  } catch {
+    return deny('args_mismatch');
+  }
+  if (!constantTimeEqual(requestHash, grant.argsHash)) return deny('args_mismatch');
+
   if (grant.exp - grant.iat > GRANT_MAX_TTL_MS) return deny('ttl_too_long');
   if (grant.iat > input.now + GRANT_MAX_CLOCK_SKEW_MS) return deny('clock_skew');
   if (grant.exp < input.now) return deny('expired');

--- a/packages/lib/src/env-bridge/grant.ts
+++ b/packages/lib/src/env-bridge/grant.ts
@@ -1,0 +1,201 @@
+/**
+ * Grant — the unit of authorization for every exec / fs / pty-open request the
+ * server sends to a LOCAL environment (a user's own machine reached through the
+ * zero-trust bridge; epic "Local Environments — zero-trust bridge", invariant 3).
+ *
+ * The trust direction is the whole point. The cloud can REQUEST work on the
+ * user's hardware but must never be able to COMPEL it: a connection-level bearer
+ * would let anything that can inject a frame into the socket — a compromised
+ * server process, a replayed capture — execute. So every request carries its own
+ * short-lived grant, signed by a server key the daemon pinned at enrollment, and
+ * the daemon verifies it here BEFORE anything runs. Server-side gating is
+ * necessary but never sufficient; this function is the daemon's own gate.
+ *
+ * Pure by construction. Nothing in this module reads a clock, generates
+ * randomness, touches `node:crypto`, or performs I/O: the caller injects `now`,
+ * the Ed25519 `verify` primitive, and the `NonceStore`. That is what makes the
+ * adversarial matrix in `__tests__/grant.test.ts` exhaustive rather than flaky,
+ * and what lets the same verifier run unchanged in the CLI daemon and in tests.
+ *
+ * Deny order is FIXED and tested: malformed → wrong_env → ttl_too_long →
+ * clock_skew → expired → bad_signature → replayed. Cheap structural checks run
+ * before the signature so junk never reaches crypto, and the replay check runs
+ * LAST so a grant that fails any earlier check can never burn its nonce — the
+ * nonce is recorded only when the whole verdict is `ok`.
+ */
+import { z } from 'zod';
+
+/** The closed set of operations a grant may authorize. Anything else is malformed. */
+export const GRANT_OPS = ['exec', 'fs_read', 'fs_write', 'pty_open'] as const;
+export type GrantOp = (typeof GRANT_OPS)[number];
+
+/** Hard ceiling on `exp - iat`. A leaked grant is a bounded, not standing, capability. */
+export const GRANT_MAX_TTL_MS = 60_000;
+/** How far into the future `iat` may sit before the two clocks are judged out of step. */
+export const GRANT_MAX_CLOCK_SKEW_MS = 30_000;
+
+export interface GrantPrincipal {
+  readonly userId: string;
+  readonly sessionId: string;
+  readonly conversationId: string;
+}
+
+export interface Grant {
+  readonly grantId: string;
+  /** The env this grant is for. A grant for another machine never runs here. */
+  readonly envId: string;
+  readonly principal: GrantPrincipal;
+  readonly op: GrantOp;
+  /** Hash of the request arguments, binding the grant to exactly this request. */
+  readonly argsHash: string;
+  /** Issued-at, ms since epoch. */
+  readonly iat: number;
+  /** Expiry, ms since epoch. `exp - iat` must not exceed GRANT_MAX_TTL_MS. */
+  readonly exp: number;
+  readonly nonce: string;
+}
+
+export type GrantDenyReason =
+  | 'malformed'
+  | 'wrong_env'
+  | 'ttl_too_long'
+  | 'clock_skew'
+  | 'expired'
+  | 'bad_signature'
+  | 'replayed';
+
+export type GrantVerdict = { readonly ok: true; readonly grant: Grant } | { readonly ok: false; readonly reason: GrantDenyReason };
+
+/**
+ * Replay protection. Lives on the daemon — a single process — so the
+ * "in-memory nonces don't hold across replicas" caveat from the Zero Trust
+ * Assessment does not apply here. `add` receives the grant's `exp` so an
+ * implementation can evict entries once they could no longer verify anyway.
+ */
+export interface NonceStore {
+  has(nonce: string): boolean;
+  add(nonce: string, exp: number): void;
+}
+
+/** Ed25519 verification primitive, injected so this module stays free of `node:crypto`. */
+export type Ed25519Verify = (message: Uint8Array, signature: Uint8Array, publicKey: Uint8Array) => boolean;
+
+export interface VerifyGrantInput {
+  /** Untrusted: whatever arrived on the wire. */
+  readonly grant: unknown;
+  /** Base64 Ed25519 signature over `encodeGrant(grant)`. */
+  readonly signature: string;
+  /** The server public key pinned at enrollment (SPKI DER). */
+  readonly serverPublicKey: Uint8Array;
+  /** Injected clock, ms since epoch. */
+  readonly now: number;
+  readonly nonces: NonceStore;
+  /** The env this daemon serves. */
+  readonly expectedEnvId: string;
+  readonly verify: Ed25519Verify;
+}
+
+const principalSchema = z
+  .object({
+    userId: z.string().min(1),
+    sessionId: z.string().min(1),
+    conversationId: z.string().min(1),
+  })
+  .strict();
+
+// `.strict()` everywhere: an extra field is not "ignored", it is a malformed
+// grant. A privileged-looking `isAdmin: true` riding along must fail closed.
+const grantSchema = z
+  .object({
+    grantId: z.string().min(1),
+    envId: z.string().min(1),
+    principal: principalSchema,
+    op: z.enum(GRANT_OPS),
+    argsHash: z.string().min(1),
+    iat: z.number().int().nonnegative(),
+    exp: z.number().int().nonnegative(),
+    nonce: z.string().min(1),
+  })
+  .strict();
+
+/**
+ * Canonical bytes for signing: a fixed key order with no whitespace, rebuilt
+ * from the typed grant rather than serialized from whatever object the caller
+ * held, so insertion order can never change the signed message.
+ */
+export function encodeGrant(grant: Grant): Uint8Array {
+  const canonical = {
+    grantId: grant.grantId,
+    envId: grant.envId,
+    principal: {
+      userId: grant.principal.userId,
+      sessionId: grant.principal.sessionId,
+      conversationId: grant.principal.conversationId,
+    },
+    op: grant.op,
+    argsHash: grant.argsHash,
+    iat: grant.iat,
+    exp: grant.exp,
+    nonce: grant.nonce,
+  };
+  return new TextEncoder().encode(JSON.stringify(canonical));
+}
+
+const BASE64_RE = /^[A-Za-z0-9+/]+={0,2}$/;
+
+/** Strict base64 → bytes; `null` for anything that is not well-formed base64. */
+function decodeBase64(value: string): Uint8Array | null {
+  if (value.length === 0 || value.length % 4 !== 0 || !BASE64_RE.test(value)) return null;
+  return new Uint8Array(Buffer.from(value, 'base64'));
+}
+
+function deny(reason: GrantDenyReason): GrantVerdict {
+  return { ok: false, reason };
+}
+
+export function verifyGrant(input: VerifyGrantInput): GrantVerdict {
+  const parsed = grantSchema.safeParse(input.grant);
+  if (!parsed.success) return deny('malformed');
+  const grant: Grant = parsed.data;
+
+  if (grant.envId !== input.expectedEnvId) return deny('wrong_env');
+  if (grant.exp - grant.iat > GRANT_MAX_TTL_MS) return deny('ttl_too_long');
+  if (grant.iat > input.now + GRANT_MAX_CLOCK_SKEW_MS) return deny('clock_skew');
+  if (grant.exp < input.now) return deny('expired');
+
+  const signature = decodeBase64(input.signature);
+  if (signature === null) return deny('bad_signature');
+  let valid = false;
+  try {
+    valid = input.verify(encodeGrant(grant), signature, input.serverPublicKey);
+  } catch {
+    valid = false;
+  }
+  if (!valid) return deny('bad_signature');
+
+  // Replay is checked last and the nonce recorded only now: a grant that failed
+  // any check above has proven nothing and must not be able to burn a nonce.
+  if (input.nonces.has(grant.nonce)) return deny('replayed');
+  input.nonces.add(grant.nonce, grant.exp);
+  return { ok: true, grant };
+}
+
+/**
+ * The reference in-memory store. Suitable for the daemon (one process) and for
+ * tests. Entries are kept until `evictExpired(now)` is called; a daemon should
+ * call it periodically so the set cannot grow without bound.
+ */
+export function createMemoryNonceStore(): NonceStore & { evictExpired(now: number): void } {
+  const seen = new Map<string, number>();
+  return {
+    has: (nonce) => seen.has(nonce),
+    add: (nonce, exp) => {
+      seen.set(nonce, exp);
+    },
+    evictExpired: (now) => {
+      for (const [nonce, exp] of seen) {
+        if (exp < now) seen.delete(nonce);
+      }
+    },
+  };
+}

--- a/packages/lib/src/env-bridge/index.ts
+++ b/packages/lib/src/env-bridge/index.ts
@@ -1,0 +1,11 @@
+/**
+ * `@pagespace/lib/env-bridge` — the PURE decision core of the zero-trust bridge
+ * between PageSpace and a user's own machine (a "local environment").
+ *
+ * Everything under this folder is I/O-free: no sockets, no filesystem, no
+ * child processes, no clock, no `node:crypto`. Those are injected by the thin
+ * adapters in the CLI daemon and in apps/web. Keeping the boundary here is what
+ * makes every security decision exhaustively testable — see each module's
+ * `__tests__` for its adversarial matrix.
+ */
+export * from './grant';


### PR DESCRIPTION
## What

First slice of the **Local Environments — zero-trust bridge** epic (PageSpace dev drive epic `j945few5ssv75k5ad0bowbb4`, task **M0 · Pure core: signed grant verification**, page `jn3ytk9ev0dge6ogtgbw7kh8`). Establishes `packages/lib/src/env-bridge/` — the **I/O-free decision core** of the bridge between PageSpace and a user's own machine — and ships its first module: the **grant**.

A grant is the unit of authorization for every exec / fs / pty-open request the server sends to a local environment. The cloud can *request* work on the user's hardware but must never be able to *compel* it, so every request carries a short-lived grant signed by a server key the daemon pinned at enrollment, and the daemon verifies it here **before anything runs**. Server-side gating is necessary, never sufficient.

## Files
- `packages/lib/src/env-bridge/grant.ts` — `Grant`, `encodeGrant`, `canonicalizeArgs`, `verifyGrant`, `createMemoryNonceStore`, closed `GrantDenyReason` union, `GRANT_MAX_TTL_MS` (60s), `GRANT_MAX_CLOCK_SKEW_MS` (30s).
- `packages/lib/src/env-bridge/index.ts` — barrel + the purity contract for the folder.
- `packages/lib/src/env-bridge/__tests__/grant.test.ts` — the adversarial matrix (40 tests).
- `packages/lib/package.json` — `./env-bridge`, `./env-bridge/grant` exports.

## Design points
- **Pure by construction.** Clock (`now`), the Ed25519 `verify` primitive, the `hash` primitive, and the `NonceStore` are injected. No `node:crypto`, no I/O, no randomness — so the matrix is exhaustive, not flaky, and the same verifier runs unchanged in the CLI daemon.
- **A verified grant is bound to the frame that carries it** (Codex P1, addressed in the 2nd commit): the gate recomputes `hash(canonicalizeArgs(request.args))` and compares it (constant-time) and `op` to the signed values. A captured, unused, correctly signed grant is useless for any other work. `canonicalizeArgs` is exported so the server hashes identical bytes when issuing.
- **Fixed, tested deny order:** `malformed → wrong_env → op_mismatch → args_mismatch → ttl_too_long → clock_skew → expired → bad_signature → replayed`. Cheap structural checks (including the binding) run before crypto; the replay check runs **last** and the nonce is recorded **only** on a fully-ok verdict, so a grant that fails any check can never burn a nonce.
- **`.strict()` everywhere:** an extra field (e.g. `isAdmin: true`) is a *malformed* grant, not an ignored one — fail closed.
- Nonce store lives on the daemon (one process), so the Zero Trust Assessment's "in-memory nonces don't hold across replicas" caveat doesn't apply here.

## TDD evidence
1. Test written first → observed **red** (`Failed to load url ../grant`) → implementation → 32/32 green.
2. Codex P1 → 8 new tests first → observed **red** (`canonicalizeArgs is not a function`) → implementation → **40/40 green**.
3. **Mutation-checked by line index** (each mutation applied, single file run, restored; final restored run green):

| Mutation | Caught by |
|---|---|
| drop `wrong_env` | wrong_env · never-burn-nonce · deny-order (3 red) |
| drop `op_mismatch` | op_mismatch · never-burn-nonce · binding-before-signature order (3 red) |
| drop `args_mismatch` compare | args_mismatch (substitution) · never-burn-nonce (2 red) |
| drop key sort in `canonicalizeArgs` | reordered-keys-still-bind · canonicalizer key-order (2 red) |
| drop `ttl_too_long` | ttl_too_long (1 red) |
| drop `clock_skew` | clock_skew (1 red) |
| drop `expired` | expired · never-burn-nonce (2 red) |
| skip signature check | rogue key · field-tamper rows · principal tamper · re-target-then-resign · never-burn-nonce (7–8 red) |
| drop `replayed` | replayed (1 red) |
| drop nonce `add` | records-the-nonce · replayed (2 red) |
| drop `.strict()` on grant schema | extra-field-is-malformed (1 red) |
| burn nonce before verify | 5 red incl. never-burn-nonce |

No mutation survived.

## Checks
- Single-file vitest: 40/40. Strict single-file `tsc --noEmit`: clean. `eslint src/env-bridge`: clean. First-commit CI: Lint & TS ✅ Unit ✅ E2E ✅ (re-running on the fix).
- Per project rule, no local full builds/typecheck while other pu agents are running — **CI is the gate**.
- No user-visible change (pure library module) → no changelog entry.

## Next
t02 (execution decision + machine policy), t03 (frame codec / session reducer / timeouts), t04 (server bind + provision verdicts) complete M0 before any I/O is written.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015sE6Cm5fwux1wgLB7YXJ9t
