### PR TITLE
feat(lib): env-bridge pure core — frame codec, bridge-session reducer, timeouts (M0/t03)

### DIFF
--- a/packages/lib/package.json
+++ b/packages/lib/package.json
@@ -178,6 +178,21 @@
       "import": "./dist/env-bridge/decide-execution.js",
       "require": "./dist/env-bridge/decide-execution.js"
     },
+    "./env-bridge/frame-codec": {
+      "types": "./dist/env-bridge/frame-codec.d.ts",
+      "import": "./dist/env-bridge/frame-codec.js",
+      "require": "./dist/env-bridge/frame-codec.js"
+    },
+    "./env-bridge/bridge-session": {
+      "types": "./dist/env-bridge/bridge-session.d.ts",
+      "import": "./dist/env-bridge/bridge-session.js",
+      "require": "./dist/env-bridge/bridge-session.js"
+    },
+    "./env-bridge/resolve-timeout": {
+      "types": "./dist/env-bridge/resolve-timeout.d.ts",
+      "import": "./dist/env-bridge/resolve-timeout.js",
+      "require": "./dist/env-bridge/resolve-timeout.js"
+    },
     "./agent-workspaces/credential-scope": {
       "types": "./dist/agent-workspaces/credential-scope.d.ts",
       "import": "./dist/agent-workspaces/credential-scope.js",

--- a/packages/lib/src/env-bridge/__tests__/bridge-session.test.ts
+++ b/packages/lib/src/env-bridge/__tests__/bridge-session.test.ts
@@ -1,8 +1,8 @@
 import { describe, it, expect } from 'vitest';
-import { reduceBridgeSession, initialBridgeSession, type BridgeSessionState, type BridgeEvent } from '../bridge-session';
+import { reduceBridgeSession, initialBridgeSession, type BridgeSessionState, type BridgeEvent, type HelloFrame } from '../bridge-session';
 import type { Frame } from '../frame-codec';
 
-const HELLO: Frame = { type: 'hello', envId: 'e1', capabilities: { shell: true, pty: false, fs: true, checkpoint: false }, policyDigest: 'd', sig: 'AAAA' };
+const HELLO: HelloFrame = { type: 'hello', envId: 'e1', capabilities: { shell: true, pty: false, fs: true, checkpoint: false }, policyDigest: 'd', sig: 'AAAA' };
 const GRANT_EXEC: Frame = { type: 'grant_exec', grant: { grantId: 'g1' }, sig: 'AAAA', cmd: 'ls', args: [] };
 const PING: Frame = { type: 'ping', ts: 1 };
 
@@ -57,6 +57,24 @@ describe('reduceBridgeSession — the daemon connection lifecycle as a pure redu
     const out = reduceBridgeSession(at('authorized'), { type: 'frame', frame: revoke });
     expect(out.state).toEqual(at('authorized'));
     expect(out.effects).toEqual([{ type: 'dispatch', frame: revoke }]);
+  });
+
+  it.each(['disconnected', 'connecting', 'hello_sent'] as const)('%s + revoke FRAME → dispatched for verification even though not authorized (CWE-613: revocation must never wait for authorization)', (status) => {
+    const revoke: Frame = { type: 'revoke', sig: 'AAAA', issuedAt: 1 };
+    const out = reduceBridgeSession(at(status), { type: 'frame', frame: revoke });
+    expect(out.state).toEqual(at(status));
+    expect(out.effects).toEqual([{ type: 'dispatch', frame: revoke }]);
+  });
+
+  it('revoked + revoke FRAME → reject(revoked) (already terminal; nothing more to verify)', () => {
+    const revoke: Frame = { type: 'revoke', sig: 'AAAA', issuedAt: 1 };
+    expect(reduceBridgeSession(at('revoked'), { type: 'frame', frame: revoke })).toEqual({ state: at('revoked'), effects: [{ type: 'reject', reason: 'revoked' }] });
+  });
+
+  it('connecting + socket_open whose "hello" is NOT a hello frame → reject(invalid_hello), stays connecting, sends nothing (a ping must never open the handshake)', () => {
+    // A JS caller is not bound by the HelloFrame type, so the reducer must check at runtime.
+    const out = reduceBridgeSession(at('connecting'), { type: 'socket_open', hello: PING as unknown as HelloFrame });
+    expect(out).toEqual({ state: at('connecting'), effects: [{ type: 'reject', reason: 'invalid_hello' }] });
   });
 
   it.each(['connecting', 'hello_sent', 'authorized'] as const)('%s + disconnect → disconnected with schedule_reconnect and NO deleteKey', (status) => {

--- a/packages/lib/src/env-bridge/__tests__/bridge-session.test.ts
+++ b/packages/lib/src/env-bridge/__tests__/bridge-session.test.ts
@@ -1,0 +1,112 @@
+import { describe, it, expect } from 'vitest';
+import { reduceBridgeSession, initialBridgeSession, type BridgeSessionState, type BridgeEvent } from '../bridge-session';
+import type { Frame } from '../frame-codec';
+
+const HELLO: Frame = { type: 'hello', envId: 'e1', capabilities: { shell: true, pty: false, fs: true, checkpoint: false }, policyDigest: 'd', sig: 'AAAA' };
+const GRANT_EXEC: Frame = { type: 'grant_exec', grant: { grantId: 'g1' }, sig: 'AAAA', cmd: 'ls', args: [] };
+const PING: Frame = { type: 'ping', ts: 1 };
+
+const at = (status: BridgeSessionState['status']): BridgeSessionState => ({ status });
+const ALL: BridgeSessionState['status'][] = ['disconnected', 'connecting', 'hello_sent', 'authorized', 'revoked'];
+
+describe('reduceBridgeSession — the daemon connection lifecycle as a pure reducer (invariants 6, 8)', () => {
+  it('starts disconnected', () => {
+    expect(initialBridgeSession()).toEqual({ status: 'disconnected' });
+  });
+
+  it('disconnected + connect → connecting, no effects', () => {
+    expect(reduceBridgeSession(at('disconnected'), { type: 'connect' })).toEqual({ state: at('connecting'), effects: [] });
+  });
+
+  it('connecting + socket_open(hello) → hello_sent and emits send(hello)', () => {
+    expect(reduceBridgeSession(at('connecting'), { type: 'socket_open', hello: HELLO })).toEqual({ state: at('hello_sent'), effects: [{ type: 'send', frame: HELLO }] });
+  });
+
+  it('hello_sent + hello_ack → authorized', () => {
+    expect(reduceBridgeSession(at('hello_sent'), { type: 'hello_ack' })).toEqual({ state: at('authorized'), effects: [] });
+  });
+
+  it.each(ALL.filter((s) => s !== 'hello_sent'))('%s + hello_ack → reject(unexpected_hello_ack), state unchanged', (status) => {
+    const before = at(status);
+    const out = reduceBridgeSession(before, { type: 'hello_ack' });
+    expect(out.state).toEqual(before);
+    expect(out.effects).toEqual([{ type: 'reject', reason: status === 'revoked' ? 'revoked' : 'unexpected_hello_ack' }]);
+  });
+
+  it('authorized + inbound grant frame → dispatch(frame), state unchanged', () => {
+    expect(reduceBridgeSession(at('authorized'), { type: 'frame', frame: GRANT_EXEC })).toEqual({ state: at('authorized'), effects: [{ type: 'dispatch', frame: GRANT_EXEC }] });
+  });
+
+  it('authorized + ping → dispatch (the adapter answers with a clock the reducer does not have)', () => {
+    expect(reduceBridgeSession(at('authorized'), { type: 'frame', frame: PING })).toEqual({ state: at('authorized'), effects: [{ type: 'dispatch', frame: PING }] });
+  });
+
+  it.each(ALL.filter((s) => s !== 'authorized'))('%s + inbound grant frame → reject(not_authorized|revoked) and NOTHING is dispatched', (status) => {
+    const out = reduceBridgeSession(at(status), { type: 'frame', frame: GRANT_EXEC });
+    expect(out.state).toEqual(at(status));
+    expect(out.effects.some((e) => e.type === 'dispatch')).toBe(false);
+    expect(out.effects).toEqual([{ type: 'reject', reason: status === 'revoked' ? 'revoked' : 'not_authorized' }]);
+  });
+
+  it.each(ALL)('%s + revoke_verified → revoked and emits deleteKey (invariant 8: the daemon deletes its key)', (status) => {
+    expect(reduceBridgeSession(at(status), { type: 'revoke_verified' })).toEqual({ state: at('revoked'), effects: [{ type: 'deleteKey' }] });
+  });
+
+  it('a revoke frame arriving as an ordinary inbound frame is NOT honoured by the reducer — only the adapter-verified revoke_verified event is (signature checked first)', () => {
+    const revoke: Frame = { type: 'revoke', sig: 'AAAA', issuedAt: 1 };
+    const out = reduceBridgeSession(at('authorized'), { type: 'frame', frame: revoke });
+    expect(out.state).toEqual(at('authorized'));
+    expect(out.effects).toEqual([{ type: 'dispatch', frame: revoke }]);
+  });
+
+  it.each(['connecting', 'hello_sent', 'authorized'] as const)('%s + disconnect → disconnected with schedule_reconnect and NO deleteKey', (status) => {
+    const out = reduceBridgeSession(at(status), { type: 'disconnect' });
+    expect(out).toEqual({ state: at('disconnected'), effects: [{ type: 'schedule_reconnect' }] });
+    expect(out.effects.some((e) => e.type === 'deleteKey')).toBe(false);
+  });
+
+  it('disconnected + disconnect → no-op', () => {
+    expect(reduceBridgeSession(at('disconnected'), { type: 'disconnect' })).toEqual({ state: at('disconnected'), effects: [] });
+  });
+
+  it('revoked is terminal: connect / disconnect / socket_open / frames all reject(revoked) and never leave revoked', () => {
+    const events: BridgeEvent[] = [{ type: 'connect' }, { type: 'disconnect' }, { type: 'socket_open', hello: HELLO }, { type: 'frame', frame: GRANT_EXEC }, { type: 'hello_ack' }];
+    for (const event of events) {
+      const out = reduceBridgeSession(at('revoked'), event);
+      expect(out.state, event.type).toEqual(at('revoked'));
+      expect(out.effects, event.type).toEqual([{ type: 'reject', reason: 'revoked' }]);
+    }
+  });
+
+  it.each(['connecting', 'hello_sent', 'authorized'] as const)('%s + connect → reject(already_connected), state unchanged', (status) => {
+    expect(reduceBridgeSession(at(status), { type: 'connect' })).toEqual({ state: at(status), effects: [{ type: 'reject', reason: 'already_connected' }] });
+  });
+
+  it.each(['disconnected', 'hello_sent', 'authorized'] as const)('%s + socket_open → reject(unexpected_socket_open), no hello sent', (status) => {
+    const out = reduceBridgeSession(at(status), { type: 'socket_open', hello: HELLO });
+    expect(out.state).toEqual(at(status));
+    expect(out.effects).toEqual([{ type: 'reject', reason: 'unexpected_socket_open' }]);
+  });
+
+  it('is pure: same (state, event) → deep-equal output, input state not mutated, effects are plain data', () => {
+    const state = at('authorized');
+    const frozen = Object.freeze({ ...state });
+    const a = reduceBridgeSession(frozen, { type: 'frame', frame: GRANT_EXEC });
+    const b = reduceBridgeSession(frozen, { type: 'frame', frame: GRANT_EXEC });
+    expect(a).toEqual(b);
+    expect(frozen).toEqual(at('authorized'));
+    for (const e of a.effects) expect(typeof e.type).toBe('string');
+  });
+
+  it('walks the happy path end to end: disconnected → connecting → hello_sent → authorized → (dispatch) → disconnected → revoked', () => {
+    let s = initialBridgeSession();
+    const step = (e: BridgeEvent) => { const out = reduceBridgeSession(s, e); s = out.state; return out.effects; };
+    expect(step({ type: 'connect' })).toEqual([]);
+    expect(step({ type: 'socket_open', hello: HELLO })).toEqual([{ type: 'send', frame: HELLO }]);
+    expect(step({ type: 'hello_ack' })).toEqual([]);
+    expect(step({ type: 'frame', frame: GRANT_EXEC })).toEqual([{ type: 'dispatch', frame: GRANT_EXEC }]);
+    expect(step({ type: 'disconnect' })).toEqual([{ type: 'schedule_reconnect' }]);
+    expect(step({ type: 'revoke_verified' })).toEqual([{ type: 'deleteKey' }]);
+    expect(s).toEqual(at('revoked'));
+  });
+});

--- a/packages/lib/src/env-bridge/__tests__/frame-codec.test.ts
+++ b/packages/lib/src/env-bridge/__tests__/frame-codec.test.ts
@@ -178,6 +178,18 @@ describe('frame-codec — the wire protocol as pure data (invariant 6: unknown o
     for (const frame of Object.values(SAMPLES)) expect(encodeFrame(frame)).not.toMatch(/\n/);
   });
 
+  it('given an already-parsed object that would exceed maxFrameBytes on the wire, should reject oversized (the limit must not be bypassable by pre-parsing) — Codex P2', () => {
+    const big = { type: 'pty_data', sessionId: 'p1', seq: 0, dataB64: 'A'.repeat(200_000) };
+    expect(decodeFrame(big, LIMITS)).toEqual({ ok: false, reason: 'oversized' });
+  });
+
+  it('given an already-parsed object that cannot be serialized (circular), should reject malformed and never throw', () => {
+    const circular: Record<string, unknown> = { type: 'ping', ts: 1 };
+    circular.self = circular;
+    expect(() => decodeFrame(circular, LIMITS)).not.toThrow();
+    expect(decodeFrame(circular, LIMITS)).toEqual({ ok: false, reason: 'malformed' });
+  });
+
   it('given an already-parsed object (not a wire string), should decode it the same way', () => {
     expect(decodeFrame(SAMPLES.ping, LIMITS)).toEqual({ ok: true, frame: SAMPLES.ping });
     expect(decodeFrame({ type: 'nope' }, LIMITS)).toEqual({ ok: false, reason: 'unknown_type' });

--- a/packages/lib/src/env-bridge/__tests__/frame-codec.test.ts
+++ b/packages/lib/src/env-bridge/__tests__/frame-codec.test.ts
@@ -1,0 +1,185 @@
+import { describe, it, expect } from 'vitest';
+import { decodeFrame, encodeFrame, FRAME_TYPES, type Frame } from '../frame-codec';
+
+const LIMITS = { maxFrameBytes: 64 * 1024 };
+const B64 = Buffer.from('hello').toString('base64');
+const GRANT = { grantId: 'g1', envId: 'e1', principal: { userId: 'u', sessionId: 's', conversationId: 'c' }, op: 'exec', argsHash: 'h', iat: 1, exp: 2, nonce: 'n' };
+
+/** One valid instance of every frame variant — the closed set, exhaustively. */
+const SAMPLES: Record<Frame['type'], Frame> = {
+  // machine → server
+  hello: { type: 'hello', envId: 'e1', capabilities: { shell: true, pty: false, fs: true, checkpoint: false }, policyDigest: 'abc', sig: B64 },
+  exec_result: { type: 'exec_result', grantId: 'g1', exitCode: 0, stdoutB64: B64, stderrB64: '', truncated: false, sig: B64 },
+  fs_read_result: { type: 'fs_read_result', grantId: 'g1', found: true, contentB64: B64, sig: B64 },
+  fs_write_result: { type: 'fs_write_result', grantId: 'g1', ok: true, sig: B64 },
+  grant_denied: { type: 'grant_denied', grantId: 'g1', reason: 'principal_not_allowed', sig: B64 },
+  pty_opened: { type: 'pty_opened', grantId: 'g1', sessionId: 'p1' },
+  pty_data: { type: 'pty_data', sessionId: 'p1', seq: 0, dataB64: B64 },
+  pty_exit: { type: 'pty_exit', sessionId: 'p1', code: 0 },
+  pong: { type: 'pong', ts: 1 },
+  // server → machine
+  grant_exec: { type: 'grant_exec', grant: GRANT, sig: B64, cmd: 'ls', args: ['-la'], cwd: '/home/u/proj', env: { LANG: 'C' }, timeoutMs: 1000, maxBytes: 1024 },
+  grant_fs_read: { type: 'grant_fs_read', grant: GRANT, sig: B64, paths: ['/home/u/proj/a'] },
+  grant_fs_write: { type: 'grant_fs_write', grant: GRANT, sig: B64, files: [{ path: '/home/u/proj/a', contentB64: B64, mode: 420 }] },
+  grant_pty_open: { type: 'grant_pty_open', grant: GRANT, sig: B64, cols: 80, rows: 24, cwd: '/home/u/proj' },
+  pty_input: { type: 'pty_input', sessionId: 'p1', seq: 1, dataB64: B64 },
+  pty_resize: { type: 'pty_resize', sessionId: 'p1', cols: 100, rows: 30 },
+  pty_kill: { type: 'pty_kill', sessionId: 'p1' },
+  revoke: { type: 'revoke', sig: B64, issuedAt: 1, reason: 'owner_disconnect' },
+  ping: { type: 'ping', ts: 1 },
+};
+
+/** Tiny seeded PRNG so the property test is reproducible without a dependency. */
+function rng(seed: number) {
+  let s = seed >>> 0;
+  return () => {
+    s = (s * 1664525 + 1013904223) >>> 0;
+    return s / 0x100000000;
+  };
+}
+function randomB64(r: () => number): string {
+  const n = Math.floor(r() * 12);
+  return Buffer.from(Array.from({ length: n }, () => Math.floor(r() * 256))).toString('base64');
+}
+function randomStr(r: () => number): string {
+  const n = 1 + Math.floor(r() * 10);
+  return Array.from({ length: n }, () => String.fromCharCode(97 + Math.floor(r() * 26))).join('');
+}
+function randomInt(r: () => number, max = 100_000): number {
+  return Math.floor(r() * max);
+}
+/** Generate a random valid instance of a given variant. */
+function generate(type: Frame['type'], r: () => number): Frame {
+  const g = { ...GRANT, grantId: randomStr(r), nonce: randomStr(r), iat: randomInt(r), exp: randomInt(r) };
+  switch (type) {
+    case 'hello': return { type, envId: randomStr(r), capabilities: { shell: r() > 0.5, pty: r() > 0.5, fs: r() > 0.5, checkpoint: false }, policyDigest: randomStr(r), sig: randomB64(r) || B64 };
+    case 'exec_result': return { type, grantId: randomStr(r), exitCode: randomInt(r, 256), stdoutB64: randomB64(r), stderrB64: randomB64(r), truncated: r() > 0.5, sig: B64 };
+    case 'fs_read_result': return r() > 0.5 ? { type, grantId: randomStr(r), found: true, contentB64: randomB64(r), sig: B64 } : { type, grantId: randomStr(r), found: false, sig: B64 };
+    case 'fs_write_result': return r() > 0.5 ? { type, grantId: randomStr(r), ok: true, sig: B64 } : { type, grantId: randomStr(r), ok: false, error: randomStr(r), sig: B64 };
+    case 'grant_denied': return { type, grantId: randomStr(r), reason: randomStr(r), sig: B64 };
+    case 'pty_opened': return { type, grantId: randomStr(r), sessionId: randomStr(r) };
+    case 'pty_data': return { type, sessionId: randomStr(r), seq: randomInt(r), dataB64: randomB64(r) };
+    case 'pty_exit': return { type, sessionId: randomStr(r), code: randomInt(r, 256) };
+    case 'pong': return { type, ts: randomInt(r) };
+    case 'grant_exec': return { type, grant: g, sig: B64, cmd: randomStr(r), args: Array.from({ length: randomInt(r, 4) }, () => randomStr(r)), cwd: `/${randomStr(r)}`, env: { [randomStr(r).toUpperCase()]: randomStr(r) }, timeoutMs: randomInt(r), maxBytes: randomInt(r) };
+    case 'grant_fs_read': return { type, grant: g, sig: B64, paths: [`/${randomStr(r)}`] };
+    case 'grant_fs_write': return { type, grant: g, sig: B64, files: [{ path: `/${randomStr(r)}`, contentB64: randomB64(r), mode: 420 }] };
+    case 'grant_pty_open': return { type, grant: g, sig: B64, cols: 1 + randomInt(r, 300), rows: 1 + randomInt(r, 100), cwd: `/${randomStr(r)}` };
+    case 'pty_input': return { type, sessionId: randomStr(r), seq: randomInt(r), dataB64: randomB64(r) };
+    case 'pty_resize': return { type, sessionId: randomStr(r), cols: 1 + randomInt(r, 300), rows: 1 + randomInt(r, 100) };
+    case 'pty_kill': return { type, sessionId: randomStr(r) };
+    case 'revoke': return { type, sig: B64, issuedAt: randomInt(r), reason: randomStr(r) };
+    case 'ping': return { type, ts: randomInt(r) };
+  }
+}
+
+describe('frame-codec — the wire protocol as pure data (invariant 6: unknown or malformed frames are dropped, never guessed)', () => {
+  it('FRAME_TYPES is the closed set and SAMPLES covers every member', () => {
+    expect([...FRAME_TYPES].sort()).toEqual(Object.keys(SAMPLES).sort());
+  });
+
+  it.each(Object.keys(SAMPLES) as Frame['type'][])('given a valid %s frame, encodeFrame → decodeFrame should round-trip deep-equal', (type) => {
+    const frame = SAMPLES[type];
+    expect(decodeFrame(encodeFrame(frame), LIMITS)).toEqual({ ok: true, frame });
+  });
+
+  it('property: ≥200 random valid frames across every variant round-trip deep-equal, and random junk never throws', () => {
+    const r = rng(0xc0ffee);
+    const types = [...FRAME_TYPES];
+    let cases = 0;
+    for (let i = 0; i < 240; i += 1) {
+      const type = types[i % types.length] as Frame['type'];
+      const frame = generate(type, r);
+      expect(decodeFrame(encodeFrame(frame), LIMITS), `round-trip ${type} #${i}`).toEqual({ ok: true, frame });
+      cases += 1;
+    }
+    expect(cases).toBeGreaterThanOrEqual(200);
+    for (let i = 0; i < 200; i += 1) {
+      const junk = Array.from({ length: randomInt(r, 40) }, () => String.fromCharCode(randomInt(r, 127))).join('');
+      expect(() => decodeFrame(junk, LIMITS)).not.toThrow();
+    }
+  });
+
+  it('given a type outside the closed set, should reject unknown_type (never throw)', () => {
+    expect(decodeFrame(JSON.stringify({ type: 'exec_now', cmd: 'rm' }), LIMITS)).toEqual({ ok: false, reason: 'unknown_type' });
+    expect(decodeFrame(JSON.stringify({ type: 'tool_execute', id: '1' }), LIMITS)).toEqual({ ok: false, reason: 'unknown_type' });
+  });
+
+  it.each<[string, string]>([
+    ['non-JSON', '{not json'],
+    ['a JSON string', JSON.stringify('grant_exec')],
+    ['a JSON number', '42'],
+    ['null', 'null'],
+    ['an array', JSON.stringify([{ type: 'ping', ts: 1 }])],
+    ['an object without type', JSON.stringify({ ts: 1 })],
+    ['a non-string type', JSON.stringify({ type: 7 })],
+    ['a ping with a missing field', JSON.stringify({ type: 'ping' })],
+    ['a grant_exec whose grant is not an object', JSON.stringify({ ...SAMPLES.grant_exec, grant: 'g1' })],
+    ['a pty_data with a negative seq', JSON.stringify({ ...SAMPLES.pty_data, seq: -1 })],
+    ['a pty_data with a non-integer seq', JSON.stringify({ ...SAMPLES.pty_data, seq: 1.5 })],
+    ['a grant_fs_write with a non-array files', JSON.stringify({ ...SAMPLES.grant_fs_write, files: 'x' })],
+    ['a pty_resize with zero cols', JSON.stringify({ ...SAMPLES.pty_resize, cols: 0 })],
+  ])('given %s, should reject malformed (never throw)', (_label, raw) => {
+    expect(() => decodeFrame(raw, LIMITS)).not.toThrow();
+    expect(decodeFrame(raw, LIMITS)).toEqual({ ok: false, reason: 'malformed' });
+  });
+
+  it('given a frame larger than maxFrameBytes, should reject oversized BEFORE parsing (a 1-byte limit rejects even a valid ping)', () => {
+    const big = JSON.stringify({ type: 'pty_data', sessionId: 'p1', seq: 0, dataB64: 'A'.repeat(200_000) });
+    expect(decodeFrame(big, LIMITS)).toEqual({ ok: false, reason: 'oversized' });
+    let parsed = false;
+    const originalParse = JSON.parse;
+    JSON.parse = ((s: string) => { parsed = true; return originalParse(s); }) as typeof JSON.parse;
+    try {
+      decodeFrame(encodeFrame(SAMPLES.ping), { maxFrameBytes: 1 });
+    } finally {
+      JSON.parse = originalParse;
+    }
+    expect(parsed).toBe(false);
+  });
+
+  it('should measure size in BYTES, not UTF-16 code units', () => {
+    const emoji = JSON.stringify({ type: 'grant_denied', grantId: 'g1', reason: '😀😀😀😀', sig: B64 }); // 4 emoji = 16 bytes, 8 code units
+    expect(decodeFrame(emoji, { maxFrameBytes: emoji.length })).toEqual({ ok: false, reason: 'oversized' });
+  });
+
+  it.each<[string, unknown]>([
+    ['hello.sig', { ...SAMPLES.hello, sig: '!!!' }],
+    ['exec_result.stdoutB64', { ...SAMPLES.exec_result, stdoutB64: 'not base64' }],
+    ['pty_data.dataB64', { ...SAMPLES.pty_data, dataB64: 'A' }],
+    ['grant_fs_write.files[0].contentB64', { ...SAMPLES.grant_fs_write, files: [{ path: '/x', contentB64: '###', mode: 420 }] }],
+    ['grant_exec.sig', { ...SAMPLES.grant_exec, sig: 'abc' }],
+  ])('given invalid base64 in %s, should reject bad_base64', (_label, frame) => {
+    expect(decodeFrame(JSON.stringify(frame), LIMITS)).toEqual({ ok: false, reason: 'bad_base64' });
+  });
+
+  it('given a frame that is both structurally malformed AND has bad base64, should report malformed (structure first)', () => {
+    expect(decodeFrame(JSON.stringify({ type: 'pty_data', seq: 'x', dataB64: '###' }), LIMITS)).toEqual({ ok: false, reason: 'malformed' });
+  });
+
+  it('given a frame carrying extra privileged-looking fields, should decode with those fields STRIPPED (a grant is still required downstream)', () => {
+    const raw = JSON.stringify({ ...SAMPLES.grant_exec, isAdmin: true, skipPolicy: true, bypass: 'yes' });
+    const verdict = decodeFrame(raw, LIMITS);
+    expect(verdict).toEqual({ ok: true, frame: SAMPLES.grant_exec });
+    if (verdict.ok) {
+      expect('isAdmin' in verdict.frame).toBe(false);
+      expect('skipPolicy' in verdict.frame).toBe(false);
+    }
+  });
+
+  it('should keep the embedded grant OPAQUE (verifyGrant does the strict parse): extra keys inside grant survive decoding so the strict layer can refuse them', () => {
+    const raw = JSON.stringify({ ...SAMPLES.grant_exec, grant: { ...GRANT, isAdmin: true } });
+    const verdict = decodeFrame(raw, LIMITS);
+    expect(verdict.ok).toBe(true);
+    if (verdict.ok && verdict.frame.type === 'grant_exec') expect((verdict.frame.grant as Record<string, unknown>).isAdmin).toBe(true);
+  });
+
+  it('encodeFrame should produce a single-line JSON string with no embedded newlines', () => {
+    for (const frame of Object.values(SAMPLES)) expect(encodeFrame(frame)).not.toMatch(/\n/);
+  });
+
+  it('given an already-parsed object (not a wire string), should decode it the same way', () => {
+    expect(decodeFrame(SAMPLES.ping, LIMITS)).toEqual({ ok: true, frame: SAMPLES.ping });
+    expect(decodeFrame({ type: 'nope' }, LIMITS)).toEqual({ ok: false, reason: 'unknown_type' });
+  });
+});

--- a/packages/lib/src/env-bridge/__tests__/resolve-timeout.test.ts
+++ b/packages/lib/src/env-bridge/__tests__/resolve-timeout.test.ts
@@ -1,0 +1,45 @@
+import { describe, it, expect } from 'vitest';
+import { resolveTimeout, DEFAULT_TIMEOUT_DEFAULTS } from '../resolve-timeout';
+
+const D = DEFAULT_TIMEOUT_DEFAULTS;
+
+describe('resolveTimeout — the 30s bridge default must never apply to exec or PTY', () => {
+  it('given exec with timeoutMs 120_000, the correlator should wait 120_000 + margin, NOT a fixed 30s', () => {
+    const t = resolveTimeout({ op: 'exec', timeoutMs: 120_000 });
+    expect(t).toEqual({ execTimeoutMs: 120_000, correlatorTimeoutMs: 120_000 + D.correlatorMarginMs });
+    expect(t.correlatorTimeoutMs).toBeGreaterThan(30_000);
+  });
+
+  it('given exec with no timeoutMs, should use the documented default exec timeout (+ margin for the correlator)', () => {
+    expect(resolveTimeout({ op: 'exec' })).toEqual({ execTimeoutMs: D.execTimeoutMs, correlatorTimeoutMs: D.execTimeoutMs + D.correlatorMarginMs });
+  });
+
+  it.each([0, -1, Number.NaN, Number.POSITIVE_INFINITY, 1.5])('given exec with a bogus timeoutMs (%s), should fall back to the default — never 0 or NaN (child_process treats those as disabled)', (bogus) => {
+    const t = resolveTimeout({ op: 'exec', timeoutMs: bogus });
+    expect(t.execTimeoutMs).toBe(D.execTimeoutMs);
+    expect(Number.isInteger(t.correlatorTimeoutMs) && (t.correlatorTimeoutMs as number) > 0).toBe(true);
+  });
+
+  it.each(['fs_read', 'fs_write'] as const)('given %s, should behave like exec (bounded, timeoutMs honoured + margin)', (op) => {
+    expect(resolveTimeout({ op, timeoutMs: 5_000 })).toEqual({ execTimeoutMs: 5_000, correlatorTimeoutMs: 5_000 + D.correlatorMarginMs });
+  });
+
+  it('given pty_open, the correlator should be unbounded (heartbeat-monitored) while the OPEN handshake itself stays bounded', () => {
+    expect(resolveTimeout({ op: 'pty_open' })).toEqual({ execTimeoutMs: D.ptyOpenHandshakeMs, correlatorTimeoutMs: 'unbounded' });
+  });
+
+  it('given pty_open with a timeoutMs, should ignore it for the channel (still unbounded) — a PTY is not a command', () => {
+    expect(resolveTimeout({ op: 'pty_open', timeoutMs: 1_000 }).correlatorTimeoutMs).toBe('unbounded');
+  });
+
+  it('should honour injected defaults', () => {
+    const custom = { execTimeoutMs: 1_000, correlatorMarginMs: 10, ptyOpenHandshakeMs: 99 };
+    expect(resolveTimeout({ op: 'exec' }, custom)).toEqual({ execTimeoutMs: 1_000, correlatorTimeoutMs: 1_010 });
+    expect(resolveTimeout({ op: 'pty_open' }, custom)).toEqual({ execTimeoutMs: 99, correlatorTimeoutMs: 'unbounded' });
+  });
+
+  it('the defaults themselves must be positive integers, and the exec default must exceed the legacy 30s bridge default', () => {
+    for (const v of Object.values(D)) expect(Number.isInteger(v) && v > 0).toBe(true);
+    expect(D.execTimeoutMs).toBeGreaterThan(30_000);
+  });
+});

--- a/packages/lib/src/env-bridge/bridge-session.ts
+++ b/packages/lib/src/env-bridge/bridge-session.ts
@@ -1,0 +1,88 @@
+/**
+ * The daemon's connection lifecycle as a pure reducer (invariants 6 and 8).
+ *
+ *   disconnected → connecting → hello_sent → authorized
+ *                                        ↘ (disconnect) → disconnected
+ *   any state ── revoke_verified ──▶ revoked  (terminal; emits deleteKey)
+ *
+ * Effects are DATA (`send`, `dispatch`, `reject`, `deleteKey`,
+ * `schedule_reconnect`) and are never performed here; the adapter performs
+ * them. That is what makes every transition testable in isolation and keeps
+ * the security-relevant rules in one place:
+ *
+ * - An inbound frame is `dispatch`ed to the executor ONLY in `authorized`. In
+ *   every other state it is `reject`ed and nothing runs (invariant 6).
+ * - A `revoke` FRAME is not honoured here — it is dispatched like any frame so
+ *   the adapter can verify its signature; only the adapter's `revoke_verified`
+ *   EVENT moves the machine to `revoked`, which emits `deleteKey` (the daemon
+ *   destroys its own identity) and is terminal (invariant 8).
+ * - `disconnect` never deletes the key; it schedules a reconnect. Losing the
+ *   socket is not a revocation.
+ *
+ * No clock, no randomness: `ping` is dispatched so the adapter can answer
+ * with a timestamp the reducer does not have.
+ */
+import type { Frame } from './frame-codec';
+
+export type BridgeStatus = 'disconnected' | 'connecting' | 'hello_sent' | 'authorized' | 'revoked';
+
+export interface BridgeSessionState {
+  readonly status: BridgeStatus;
+}
+
+export type BridgeEvent =
+  | { readonly type: 'connect' }
+  | { readonly type: 'socket_open'; readonly hello: Frame }
+  | { readonly type: 'hello_ack' }
+  | { readonly type: 'frame'; readonly frame: Frame }
+  | { readonly type: 'revoke_verified' }
+  | { readonly type: 'disconnect' };
+
+export type BridgeRejectReason = 'not_authorized' | 'revoked' | 'unexpected_hello_ack' | 'unexpected_socket_open' | 'already_connected';
+
+export type BridgeEffect =
+  | { readonly type: 'send'; readonly frame: Frame }
+  | { readonly type: 'dispatch'; readonly frame: Frame }
+  | { readonly type: 'reject'; readonly reason: BridgeRejectReason }
+  | { readonly type: 'deleteKey' }
+  | { readonly type: 'schedule_reconnect' };
+
+export interface BridgeReduction {
+  readonly state: BridgeSessionState;
+  readonly effects: readonly BridgeEffect[];
+}
+
+export function initialBridgeSession(): BridgeSessionState {
+  return { status: 'disconnected' };
+}
+
+function stay(state: BridgeSessionState, ...effects: BridgeEffect[]): BridgeReduction {
+  return { state, effects };
+}
+
+function go(status: BridgeStatus, ...effects: BridgeEffect[]): BridgeReduction {
+  return { state: { status }, effects };
+}
+
+/**
+ * Reduce one event against the current state.
+ * @returns the next state and the effects the adapter must perform, as data.
+ */
+export function reduceBridgeSession(state: BridgeSessionState, event: BridgeEvent): BridgeReduction {
+  // Revocation wins from every state, and revoked is terminal.
+  if (event.type === 'revoke_verified') return go('revoked', { type: 'deleteKey' });
+  if (state.status === 'revoked') return stay(state, { type: 'reject', reason: 'revoked' });
+
+  switch (event.type) {
+    case 'connect':
+      return state.status === 'disconnected' ? go('connecting') : stay(state, { type: 'reject', reason: 'already_connected' });
+    case 'socket_open':
+      return state.status === 'connecting' ? go('hello_sent', { type: 'send', frame: event.hello }) : stay(state, { type: 'reject', reason: 'unexpected_socket_open' });
+    case 'hello_ack':
+      return state.status === 'hello_sent' ? go('authorized') : stay(state, { type: 'reject', reason: 'unexpected_hello_ack' });
+    case 'frame':
+      return state.status === 'authorized' ? stay(state, { type: 'dispatch', frame: event.frame }) : stay(state, { type: 'reject', reason: 'not_authorized' });
+    case 'disconnect':
+      return state.status === 'disconnected' ? stay(state) : go('disconnected', { type: 'schedule_reconnect' });
+  }
+}

--- a/packages/lib/src/env-bridge/bridge-session.ts
+++ b/packages/lib/src/env-bridge/bridge-session.ts
@@ -11,11 +11,17 @@
  * the security-relevant rules in one place:
  *
  * - An inbound frame is `dispatch`ed to the executor ONLY in `authorized`. In
- *   every other state it is `reject`ed and nothing runs (invariant 6).
- * - A `revoke` FRAME is not honoured here — it is dispatched like any frame so
- *   the adapter can verify its signature; only the adapter's `revoke_verified`
- *   EVENT moves the machine to `revoked`, which emits `deleteKey` (the daemon
- *   destroys its own identity) and is terminal (invariant 8).
+ *   every other state it is `reject`ed and nothing runs (invariant 6). The one
+ *   exception is `revoke`: it is dispatched from EVERY non-revoked state, so
+ *   revocation can never be delayed by simply not being authorized yet
+ *   (CWE-613).
+ * - A `revoke` FRAME is not honoured here — it is dispatched so the adapter
+ *   can verify its signature; only the adapter's `revoke_verified` EVENT moves
+ *   the machine to `revoked`, which emits `deleteKey` (the daemon destroys its
+ *   own identity) and is terminal (invariant 8).
+ * - Only a `hello` frame may open the handshake: `socket_open` is typed
+ *   `HelloFrame` AND checked at runtime, because a JS caller is not bound by
+ *   the type.
  * - `disconnect` never deletes the key; it schedules a reconnect. Losing the
  *   socket is not a revocation.
  *
@@ -26,19 +32,22 @@ import type { Frame } from './frame-codec';
 
 export type BridgeStatus = 'disconnected' | 'connecting' | 'hello_sent' | 'authorized' | 'revoked';
 
+/** The only frame that may open the handshake. */
+export type HelloFrame = Extract<Frame, { type: 'hello' }>;
+
 export interface BridgeSessionState {
   readonly status: BridgeStatus;
 }
 
 export type BridgeEvent =
   | { readonly type: 'connect' }
-  | { readonly type: 'socket_open'; readonly hello: Frame }
+  | { readonly type: 'socket_open'; readonly hello: HelloFrame }
   | { readonly type: 'hello_ack' }
   | { readonly type: 'frame'; readonly frame: Frame }
   | { readonly type: 'revoke_verified' }
   | { readonly type: 'disconnect' };
 
-export type BridgeRejectReason = 'not_authorized' | 'revoked' | 'unexpected_hello_ack' | 'unexpected_socket_open' | 'already_connected';
+export type BridgeRejectReason = 'not_authorized' | 'revoked' | 'unexpected_hello_ack' | 'unexpected_socket_open' | 'invalid_hello' | 'already_connected';
 
 export type BridgeEffect =
   | { readonly type: 'send'; readonly frame: Frame }
@@ -77,10 +86,16 @@ export function reduceBridgeSession(state: BridgeSessionState, event: BridgeEven
     case 'connect':
       return state.status === 'disconnected' ? go('connecting') : stay(state, { type: 'reject', reason: 'already_connected' });
     case 'socket_open':
-      return state.status === 'connecting' ? go('hello_sent', { type: 'send', frame: event.hello }) : stay(state, { type: 'reject', reason: 'unexpected_socket_open' });
+      if (state.status !== 'connecting') return stay(state, { type: 'reject', reason: 'unexpected_socket_open' });
+      // The type says HelloFrame; a JS caller is not bound by it. Only a hello opens the handshake.
+      if (event.hello.type !== 'hello') return stay(state, { type: 'reject', reason: 'invalid_hello' });
+      return go('hello_sent', { type: 'send', frame: event.hello });
     case 'hello_ack':
       return state.status === 'hello_sent' ? go('authorized') : stay(state, { type: 'reject', reason: 'unexpected_hello_ack' });
     case 'frame':
+      // A revoke must reach the adapter for signature verification from EVERY
+      // non-revoked state — revocation never waits for authorization (CWE-613).
+      if (event.frame.type === 'revoke') return stay(state, { type: 'dispatch', frame: event.frame });
       return state.status === 'authorized' ? stay(state, { type: 'dispatch', frame: event.frame }) : stay(state, { type: 'reject', reason: 'not_authorized' });
     case 'disconnect':
       return state.status === 'disconnected' ? stay(state) : go('disconnected', { type: 'schedule_reconnect' });

--- a/packages/lib/src/env-bridge/frame-codec.ts
+++ b/packages/lib/src/env-bridge/frame-codec.ts
@@ -132,6 +132,18 @@ export function decodeFrame(raw: unknown, limits: FrameLimits): DecodeFrameVerdi
       return reject('malformed');
     }
   } else {
+    // An already-parsed object must face the SAME size limit it would have
+    // faced on the wire, or the limit is bypassable by any transport that
+    // hands us objects (Codex P2 on PR #2529). Serializing to measure is the
+    // equivalent bounded check; anything unserializable is malformed.
+    let serialized: string | undefined;
+    try {
+      serialized = JSON.stringify(raw);
+    } catch {
+      return reject('malformed');
+    }
+    if (serialized === undefined) return reject('malformed');
+    if (Buffer.byteLength(serialized, 'utf8') > limits.maxFrameBytes) return reject('oversized');
     value = raw;
   }
 

--- a/packages/lib/src/env-bridge/frame-codec.ts
+++ b/packages/lib/src/env-bridge/frame-codec.ts
@@ -1,0 +1,149 @@
+/**
+ * The bridge wire protocol as pure data (invariant 6: the server never
+ * compels — there is no privileged frame, and anything unknown or malformed is
+ * dropped, never guessed).
+ *
+ * This module is the ENVELOPE layer only. It decides whether bytes off the
+ * socket are one of the closed set of frames below, with every field the type
+ * the rest of the daemon assumes. It deliberately does NOT interpret the grant
+ * a `grant_*` frame carries: the grant is kept opaque (`Record<string,
+ * unknown>`) so `verifyGrant` — the strict, signature-checking layer — is the
+ * one place a grant is parsed and refused. Extra fields on the ENVELOPE are
+ * stripped (a `isAdmin: true` riding on a frame changes nothing, because
+ * authorization comes only from the grant); extra fields INSIDE the grant
+ * survive to the strict layer so it can refuse them.
+ *
+ * `decodeFrame` is total: it never throws, and it checks size in BYTES before
+ * parsing so an oversized frame costs nothing. Deny reasons are a closed
+ * union: `oversized` → `malformed` (structure) → `unknown_type` → `bad_base64`
+ * (a structurally valid frame whose only defect is a `*B64`/`sig` field).
+ */
+import { z } from 'zod';
+
+/** Strict base64 (standard alphabet, correct padding); the empty string is allowed. */
+const BASE64_RE = /^(?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]{3}=)?$/;
+const BAD_BASE64 = 'bad_base64';
+
+const b64 = z.string().refine((value) => BASE64_RE.test(value), { message: BAD_BASE64 });
+const nonEmpty = z.string().min(1);
+const nonNegInt = z.number().int().nonnegative();
+const posInt = z.number().int().positive();
+/** The grant travels opaque; `verifyGrant` is the strict parser. */
+const opaqueGrant = z.record(z.string(), z.unknown());
+
+const capabilitiesSchema = z.object({
+  shell: z.boolean(),
+  pty: z.boolean(),
+  fs: z.boolean(),
+  checkpoint: z.boolean(),
+});
+
+// ---- machine → server -----------------------------------------------------
+
+const hello = z.object({ type: z.literal('hello'), envId: nonEmpty, capabilities: capabilitiesSchema, policyDigest: z.string(), sig: b64 });
+const execResult = z.object({ type: z.literal('exec_result'), grantId: nonEmpty, exitCode: z.number().int(), stdoutB64: b64, stderrB64: b64, truncated: z.boolean(), sig: b64 });
+const fsReadResult = z.object({ type: z.literal('fs_read_result'), grantId: nonEmpty, found: z.boolean(), contentB64: b64.optional(), sig: b64 });
+const fsWriteResult = z.object({ type: z.literal('fs_write_result'), grantId: nonEmpty, ok: z.boolean(), error: z.string().optional(), sig: b64 });
+const grantDenied = z.object({ type: z.literal('grant_denied'), grantId: nonEmpty, reason: nonEmpty, sig: b64 });
+const ptyOpened = z.object({ type: z.literal('pty_opened'), grantId: nonEmpty, sessionId: nonEmpty });
+const ptyData = z.object({ type: z.literal('pty_data'), sessionId: nonEmpty, seq: nonNegInt, dataB64: b64 });
+const ptyExit = z.object({ type: z.literal('pty_exit'), sessionId: nonEmpty, code: z.number().int() });
+const pong = z.object({ type: z.literal('pong'), ts: nonNegInt });
+
+// ---- server → machine -----------------------------------------------------
+
+const grantExec = z.object({
+  type: z.literal('grant_exec'),
+  grant: opaqueGrant,
+  sig: b64,
+  cmd: z.string(),
+  args: z.array(z.string()).optional(),
+  cwd: z.string().optional(),
+  env: z.record(z.string(), z.string()).optional(),
+  timeoutMs: z.number().optional(),
+  maxBytes: z.number().optional(),
+});
+const grantFsRead = z.object({ type: z.literal('grant_fs_read'), grant: opaqueGrant, sig: b64, paths: z.array(z.string()) });
+const grantFsWrite = z.object({
+  type: z.literal('grant_fs_write'),
+  grant: opaqueGrant,
+  sig: b64,
+  files: z.array(z.object({ path: z.string(), contentB64: b64, mode: nonNegInt.optional() })),
+});
+const grantPtyOpen = z.object({
+  type: z.literal('grant_pty_open'),
+  grant: opaqueGrant,
+  sig: b64,
+  cols: posInt,
+  rows: posInt,
+  cwd: z.string().optional(),
+  command: z.string().optional(),
+  args: z.array(z.string()).optional(),
+});
+const ptyInput = z.object({ type: z.literal('pty_input'), sessionId: nonEmpty, seq: nonNegInt, dataB64: b64 });
+const ptyResize = z.object({ type: z.literal('pty_resize'), sessionId: nonEmpty, cols: posInt, rows: posInt });
+const ptyKill = z.object({ type: z.literal('pty_kill'), sessionId: nonEmpty, signal: z.string().optional() });
+const revoke = z.object({ type: z.literal('revoke'), sig: b64, issuedAt: nonNegInt, reason: z.string().optional() });
+const ping = z.object({ type: z.literal('ping'), ts: nonNegInt });
+
+const frameSchema = z.discriminatedUnion('type', [
+  hello, execResult, fsReadResult, fsWriteResult, grantDenied, ptyOpened, ptyData, ptyExit, pong,
+  grantExec, grantFsRead, grantFsWrite, grantPtyOpen, ptyInput, ptyResize, ptyKill, revoke, ping,
+]);
+
+export type Frame = z.infer<typeof frameSchema>;
+export type FrameType = Frame['type'];
+
+/** The closed set. A `type` outside it is `unknown_type`, full stop. */
+export const FRAME_TYPES: ReadonlySet<FrameType> = new Set<FrameType>([
+  'hello', 'exec_result', 'fs_read_result', 'fs_write_result', 'grant_denied', 'pty_opened', 'pty_data', 'pty_exit', 'pong',
+  'grant_exec', 'grant_fs_read', 'grant_fs_write', 'grant_pty_open', 'pty_input', 'pty_resize', 'pty_kill', 'revoke', 'ping',
+]);
+
+export type DecodeFrameReason = 'oversized' | 'malformed' | 'unknown_type' | 'bad_base64';
+export type DecodeFrameVerdict = { readonly ok: true; readonly frame: Frame } | { readonly ok: false; readonly reason: DecodeFrameReason };
+
+export interface FrameLimits {
+  /** Maximum wire size in BYTES; checked before parsing. */
+  readonly maxFrameBytes: number;
+}
+
+function reject(reason: DecodeFrameReason): DecodeFrameVerdict {
+  return { ok: false, reason };
+}
+
+/** Serialize a frame for the wire: one line of JSON, no embedded newlines. */
+export function encodeFrame(frame: Frame): string {
+  return JSON.stringify(frame);
+}
+
+/**
+ * Decode bytes off the wire (a string) or an already-parsed value into a
+ * frame. Total: never throws.
+ * @returns the typed frame with envelope extras stripped, or a closed-union reason.
+ */
+export function decodeFrame(raw: unknown, limits: FrameLimits): DecodeFrameVerdict {
+  let value: unknown;
+  if (typeof raw === 'string') {
+    if (Buffer.byteLength(raw, 'utf8') > limits.maxFrameBytes) return reject('oversized');
+    try {
+      value = JSON.parse(raw);
+    } catch {
+      return reject('malformed');
+    }
+  } else {
+    value = raw;
+  }
+
+  if (value === null || typeof value !== 'object' || Array.isArray(value)) return reject('malformed');
+  const type = (value as { type?: unknown }).type;
+  if (typeof type !== 'string') return reject('malformed');
+  if (!FRAME_TYPES.has(type as FrameType)) return reject('unknown_type');
+
+  const parsed = frameSchema.safeParse(value);
+  if (parsed.success) return { ok: true, frame: parsed.data };
+  // A frame whose ONLY defects are base64 fields is reported as bad_base64;
+  // any structural defect wins as malformed.
+  const onlyBase64 = parsed.error.issues.length > 0 && parsed.error.issues.every((issue) => issue.message === BAD_BASE64);
+  return reject(onlyBase64 ? 'bad_base64' : 'malformed');
+}

--- a/packages/lib/src/env-bridge/index.ts
+++ b/packages/lib/src/env-bridge/index.ts
@@ -14,3 +14,6 @@ export * from './intersect-capabilities';
 export * from './scrub-env';
 export * from './confine-path';
 export * from './decide-execution';
+export * from './frame-codec';
+export * from './bridge-session';
+export * from './resolve-timeout';

--- a/packages/lib/src/env-bridge/resolve-timeout.ts
+++ b/packages/lib/src/env-bridge/resolve-timeout.ts
@@ -1,0 +1,50 @@
+/**
+ * Timeouts for a granted request, resolved purely.
+ *
+ * The desktop MCP bridge's request correlator defaults to 30 s, which is fine
+ * for a tool lookup and fatal for the bridge: agent commands routinely run for
+ * minutes, and a PTY is open for as long as the terminal is. This resolver is
+ * the single place those numbers come from, so the correlator can never fall
+ * back to a fixed default for an exec or a PTY:
+ *
+ * - `exec` / `fs_*`: the command's own timeout (or the documented default when
+ *   absent or bogus — never 0/NaN, which `child_process` treats as disabled),
+ *   and a correlator deadline of that plus a margin for transport.
+ * - `pty_open`: the OPEN handshake is bounded, but the channel it opens is
+ *   `unbounded` — its liveness is the heartbeat's job, not a deadline's.
+ */
+import type { GrantOp } from './grant';
+
+export interface TimeoutDefaults {
+  /** Exec/fs timeout when the request carries none (or a bogus one). */
+  readonly execTimeoutMs: number;
+  /** Transport slack added on top of the exec timeout for the correlator. */
+  readonly correlatorMarginMs: number;
+  /** Bound on the pty_open handshake itself; the channel is unbounded. */
+  readonly ptyOpenHandshakeMs: number;
+}
+
+export const DEFAULT_TIMEOUT_DEFAULTS: TimeoutDefaults = {
+  execTimeoutMs: 120_000,
+  correlatorMarginMs: 5_000,
+  ptyOpenHandshakeMs: 30_000,
+};
+
+export interface TimeoutRequest {
+  readonly op: GrantOp;
+  readonly timeoutMs?: number;
+}
+
+export interface ResolvedTimeouts {
+  readonly execTimeoutMs: number;
+  readonly correlatorTimeoutMs: number | 'unbounded';
+}
+
+const isPositiveInt = (value: unknown): value is number => typeof value === 'number' && Number.isInteger(value) && value > 0;
+
+/** @returns the exec deadline and the correlator deadline (`'unbounded'` for a PTY channel). */
+export function resolveTimeout(request: TimeoutRequest, defaults: TimeoutDefaults = DEFAULT_TIMEOUT_DEFAULTS): ResolvedTimeouts {
+  if (request.op === 'pty_open') return { execTimeoutMs: defaults.ptyOpenHandshakeMs, correlatorTimeoutMs: 'unbounded' };
+  const execTimeoutMs = isPositiveInt(request.timeoutMs) ? request.timeoutMs : defaults.execTimeoutMs;
+  return { execTimeoutMs, correlatorTimeoutMs: execTimeoutMs + defaults.correlatorMarginMs };
+}


### PR DESCRIPTION
## What

Third slice of the **Local Environments — zero-trust bridge** epic (dev-drive epic `j945few5ssv75k5ad0bowbb4`, task **M0 · Pure core: frame codec, bridge-session reducer, timeouts**, page `gricmf39ux2e9qdvx9gi5a64`). Follows #2527 (grant) and #2528 (execution decision). This is the wire layer as pure data — still zero I/O.

## Files (pure; no sockets, no clock)
- `frame-codec.ts` — the **closed set of 18 frames** as a zod discriminated union. `decodeFrame` is total (never throws), measures size in **bytes** before parsing, and returns a closed reason union `oversized → malformed → unknown_type → bad_base64`. Envelope extras (`isAdmin`, `skipPolicy`, `bypass`) are **stripped** (invariant 6: no privileged frame); the embedded grant stays **opaque** so `verifyGrant` remains the single strict parser — extras *inside* a grant survive to be refused there.
- `bridge-session.ts` — the daemon lifecycle `disconnected → connecting → hello_sent → authorized (→ disconnected)`, `any → revoked` as a pure reducer whose effects are **data** (`send`, `dispatch`, `reject`, `deleteKey`, `schedule_reconnect`). Inbound frames are dispatched **only** in `authorized`; a `revoke` *frame* is dispatched for signature verification and only the adapter's `revoke_verified` *event* reaches the terminal `revoked` state, which emits `deleteKey` (invariant 8); `disconnect` never deletes the key.
- `resolve-timeout.ts` — exec/fs get their own timeout plus a transport margin, or the documented default (never 0/NaN, never the bridge's fixed 30 s); `pty_open`'s handshake is bounded but its channel is `'unbounded'` (heartbeat-monitored).
- Barrel + `package.json` subpath exports.

## TDD evidence
1. 3 test files (92 tests) written first → **red** on every module (`Failed to load url`) → implemented → **296/296** across the folder.
2. Property test: a seeded PRNG (no new dependency) generates **≥200 valid frames across all 18 variants** that must round-trip deep-equal, plus 200 random junk inputs that must never throw.
3. **Mutation-checked by line index — 10 mutations, all caught:**

| Module | Mutation | Caught by |
|---|---|---|
| frame-codec | drop oversized guard | 2 red (incl. bytes-not-code-units) |
| | drop object check | null-input row (1) |
| | drop unknown_type | 2 red |
| | never report bad_base64 | 5 red |
| bridge-session | drop revoke_verified transition | 6 red |
| | hello_ack from any state | 3 red |
| | dispatch regardless of state | 3 red (not_authorized rows) |
| | disconnect deletes key | 5 red |
| resolve-timeout | drop pty unbounded | 3 red |
| | use raw timeoutMs | 5 red (0/-1/NaN/∞/1.5) |

## Review fixes (9f25078be)

- **Codex P2 — parsed objects skipped the size limit.** Object inputs are now serialized and measured against `maxFrameBytes` before structural parsing; unserializable input is `malformed`. Thread resolved.
- **CodeRabbit (correctness) — any frame could open the handshake.** `socket_open.hello` is `HelloFrame` in the type *and* checked at runtime (`invalid_hello`). Thread resolved.
- **CodeRabbit (security, CWE-613) — revocation waited for authorization.** `revoke` is dispatched for verification from every non-revoked state; every other frame keeps the gate. Thread resolved.

6 rows red-first → **303/303**; mutations: object size check → 1 red, hello check → 1 red, revoke gating → 3 red.

## Checks
- Folder vitest 303/303; `eslint src/env-bridge` clean; strict `tsc --noEmit --noUncheckedIndexedAccess` **including the test files** clean (the gate gap from #2528 is closed).
- No local full builds while other pu agents run — **CI is the gate**.
- Pure library module, no user-visible change → no changelog entry.

## Next
t04 (server-side `decideBind` + `planLocalProvision` verdicts) completes M0; then M1 begins with the schema.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015sE6Cm5fwux1wgLB7YXJ9t
