### PR TITLE
fix(web): account menu showed "Billing (Business)" to free users

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -269,6 +269,13 @@ All notable user-facing changes to PageSpace are documented here. Format follows
 
 ### Fixed
 
+- **The account menu no longer labels free accounts "Billing (Business)"** — the plan name in the
+  avatar dropdown fell through to "Business" whenever the subscription lookup had not answered yet
+  (every first paint, and permanently if the request failed), so a brand-new free user saw a paid
+  plan the moment they signed in. It also mislabelled Founder accounts as Business. The label now
+  comes from the canonical tier table, starts from the tier your session already knows, and treats
+  anything unrecognised as Free. The subscription status endpoint returns the same normalised tier.
+
 - **Every pane in an AI page's split grid now offers Chat/History/Settings from its own bar** — the
   "host" pane (the one showing the same conversation the page's own header already tracks) used to
   collapse to a bare name label with no way to reach History or Settings from that pane, unlike

--- a/apps/web/src/app/api/subscriptions/status/__tests__/route.test.ts
+++ b/apps/web/src/app/api/subscriptions/status/__tests__/route.test.ts
@@ -253,6 +253,28 @@ describe('GET /api/subscriptions/status', () => {
     });
   });
 
+  describe('Tier coercion', () => {
+    it.each([null, '', 'enterprise-legacy'])(
+      'should coerce a stored tier of %j to free instead of passing it through',
+      async (stored) => {
+        mockSelectWhere.mockResolvedValueOnce([
+          { ...mockUser(), subscriptionTier: stored as unknown as string },
+        ]);
+
+        const request = new Request('https://example.com/api/subscriptions/status', {
+          method: 'GET',
+        }) as unknown as import('next/server').NextRequest;
+
+        const response = await GET(request);
+        const body = await response.json();
+
+        expect(response.status).toBe(200);
+        expect(body.subscriptionTier).toBe('free');
+        expect(body.storage.tier).toBe('free');
+      },
+    );
+  });
+
   describe('Error handling', () => {
     it('should return 404 when user not found', async () => {
       mockSelectWhere.mockResolvedValueOnce([]);

--- a/apps/web/src/app/api/subscriptions/status/route.ts
+++ b/apps/web/src/app/api/subscriptions/status/route.ts
@@ -4,7 +4,8 @@ import { db } from '@pagespace/db/db'
 import { eq, and, inArray, desc } from '@pagespace/db/operators'
 import { users } from '@pagespace/db/schema/auth'
 import { subscriptions } from '@pagespace/db/schema/subscriptions';
-import { getStorageConfigFromSubscription, type SubscriptionTier } from '@pagespace/lib/services/subscription-utils';
+import { getStorageConfigFromSubscription } from '@pagespace/lib/services/subscription-utils';
+import { toSubscriptionTier } from '@pagespace/lib/billing/subscription-tiers';
 import { auditRequest } from '@pagespace/lib/audit/audit-log';
 
 export async function GET(request: NextRequest) {
@@ -43,13 +44,14 @@ export async function GET(request: NextRequest) {
     }
 
     // Compute storage config from subscription tier
-    const subscriptionTier = (user.subscriptionTier || 'free') as SubscriptionTier;
+    // Coerce the untyped column through the canonical vocabulary (schema contract).
+    const subscriptionTier = toSubscriptionTier(user.subscriptionTier);
     const storageConfig = getStorageConfigFromSubscription(subscriptionTier);
 
     auditRequest(request, { eventType: 'data.read', userId, resourceType: 'subscription_status', resourceId: 'self', details: { tier: subscriptionTier } });
 
     return NextResponse.json({
-      subscriptionTier: user.subscriptionTier,
+      subscriptionTier,
       stripeCustomerId: user.stripeCustomerId,
       subscription: subscription ? {
         status: subscription.status,

--- a/apps/web/src/components/shared/UserDropdown.tsx
+++ b/apps/web/src/components/shared/UserDropdown.tsx
@@ -27,6 +27,7 @@ import { isOnPrem } from '@/lib/deployment-mode';
 import useSWR from 'swr';
 import { FeedbackDialog } from './FeedbackDialog';
 import { formatCreditCount } from '@/lib/subscription/credits';
+import { TIER_PLAN_LIMITS, toSubscriptionTier } from '@pagespace/lib/billing/subscription-tiers';
 
 const LOW_BALANCE_THRESHOLD_PCT = 15;
 
@@ -56,6 +57,13 @@ export default function UserDropdown() {
       revalidateOnFocus: false,
     }
   );
+
+  // Tier label: prefer the fresh /api/subscriptions/status value, fall back to
+  // the tier /api/auth/me already gave us so the label is right on first paint,
+  // and coerce through the canonical vocabulary (unknown/missing => 'free').
+  const tierName = TIER_PLAN_LIMITS[
+    toSubscriptionTier(subscriptionInfo?.subscriptionTier ?? user?.subscriptionTier)
+  ].name;
 
   // Derive credit balance display values
   const spendable = balance?.spendable ?? 0;
@@ -131,7 +139,7 @@ export default function UserDropdown() {
             <DropdownMenuItem onClick={() => router.push('/settings/billing')}>
               <CreditCard className="mr-2 h-4 w-4" />
               <span>
-                Billing ({subscriptionInfo?.subscriptionTier === 'free' ? 'Free' : subscriptionInfo?.subscriptionTier === 'pro' ? 'Pro' : 'Business'})
+                Billing ({tierName})
               </span>
             </DropdownMenuItem>
           )}

--- a/apps/web/src/components/shared/__tests__/UserDropdown.test.tsx
+++ b/apps/web/src/components/shared/__tests__/UserDropdown.test.tsx
@@ -1,0 +1,108 @@
+/**
+ * @vitest-environment jsdom
+ */
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+
+// Radix dropdown content is portalled; `forceMount` on the content keeps it in
+// the tree, but the trigger still needs a pointer-capable environment. Mock the
+// menu primitives down to plain elements so the label is always rendered.
+vi.mock('@/components/ui/dropdown-menu', () => {
+  const Passthrough = ({ children }: { children?: React.ReactNode }) => <div>{children}</div>;
+  return {
+    DropdownMenu: Passthrough,
+    DropdownMenuContent: Passthrough,
+    DropdownMenuItem: Passthrough,
+    DropdownMenuLabel: Passthrough,
+    DropdownMenuSeparator: () => <hr />,
+    DropdownMenuTrigger: Passthrough,
+    DropdownMenuSub: Passthrough,
+    DropdownMenuSubContent: Passthrough,
+    DropdownMenuSubTrigger: Passthrough,
+    DropdownMenuPortal: Passthrough,
+  };
+});
+
+const mockUseAuth = vi.fn();
+vi.mock('@/hooks/useAuth', () => ({ useAuth: () => mockUseAuth() }));
+
+const mockUseSWR = vi.fn();
+vi.mock('swr', () => ({ default: (...args: unknown[]) => mockUseSWR(...args) }));
+
+vi.mock('next/navigation', () => ({ useRouter: () => ({ push: vi.fn() }) }));
+vi.mock('next-themes', () => ({ useTheme: () => ({ setTheme: vi.fn() }) }));
+vi.mock('@/hooks/useBillingVisibility', () => ({
+  useBillingVisibility: () => ({ showBilling: true, hideBilling: false, isReady: true }),
+}));
+vi.mock('@/hooks/useCreditBalance', () => ({ useCreditBalance: () => ({ balance: null }) }));
+vi.mock('@/lib/deployment-mode', () => ({ isOnPrem: () => false }));
+vi.mock('@/lib/auth/auth-fetch', () => ({ fetchWithAuth: vi.fn() }));
+vi.mock('../FeedbackDialog', () => ({ FeedbackDialog: () => null }));
+
+import UserDropdown from '../UserDropdown';
+
+const authUser = (subscriptionTier?: string) => ({
+  isAuthenticated: true,
+  isLoading: false,
+  user: { id: 'u1', name: 'Test', email: 't@example.com', subscriptionTier },
+  actions: { logout: vi.fn(), refreshAuth: vi.fn(), checkAuth: vi.fn() },
+});
+
+const billingLabel = () => screen.getByText(/^Billing \(/).textContent;
+
+describe('UserDropdown billing tier label', () => {
+  beforeEach(() => {
+    mockUseAuth.mockReset();
+    mockUseSWR.mockReset();
+  });
+
+  it('shows Free while the subscription status fetch is still loading (auth says free)', () => {
+    mockUseAuth.mockReturnValue(authUser('free'));
+    mockUseSWR.mockReturnValue({ data: undefined });
+    render(<UserDropdown />);
+    expect(billingLabel()).toBe('Billing (Free)');
+  });
+
+  it('shows Free when neither the fetch nor the auth user carry a tier', () => {
+    mockUseAuth.mockReturnValue(authUser(undefined));
+    mockUseSWR.mockReturnValue({ data: undefined });
+    render(<UserDropdown />);
+    expect(billingLabel()).toBe('Billing (Free)');
+  });
+
+  it('shows Free when the fetch failed', () => {
+    mockUseAuth.mockReturnValue(authUser(undefined));
+    mockUseSWR.mockReturnValue({ data: undefined, error: new Error('Failed to fetch: 500') });
+    render(<UserDropdown />);
+    expect(billingLabel()).toBe('Billing (Free)');
+  });
+
+  it('shows Founder for the founder tier', () => {
+    mockUseAuth.mockReturnValue(authUser('free'));
+    mockUseSWR.mockReturnValue({ data: { subscriptionTier: 'founder' } });
+    render(<UserDropdown />);
+    expect(billingLabel()).toBe('Billing (Founder)');
+  });
+
+  it('shows Business only for the business tier', () => {
+    mockUseAuth.mockReturnValue(authUser('free'));
+    mockUseSWR.mockReturnValue({ data: { subscriptionTier: 'business' } });
+    render(<UserDropdown />);
+    expect(billingLabel()).toBe('Billing (Business)');
+  });
+
+  it('prefers the fresh fetch over the auth snapshot after an upgrade', () => {
+    mockUseAuth.mockReturnValue(authUser('free'));
+    mockUseSWR.mockReturnValue({ data: { subscriptionTier: 'pro' } });
+    render(<UserDropdown />);
+    expect(billingLabel()).toBe('Billing (Pro)');
+  });
+
+  it('coerces an unknown stored tier value to Free instead of Business', () => {
+    mockUseAuth.mockReturnValue(authUser('free'));
+    mockUseSWR.mockReturnValue({ data: { subscriptionTier: 'enterprise-legacy' } });
+    render(<UserDropdown />);
+    expect(billingLabel()).toBe('Billing (Free)');
+  });
+});


### PR DESCRIPTION
## Problem

A brand-new user on the free plan opens the avatar dropdown and sees **Billing (Business)**.

The DB default, signup paths, and API all say `free`. The defect is the label in `UserDropdown.tsx`:

```tsx
Billing ({tier === 'free' ? 'Free' : tier === 'pro' ? 'Pro' : 'Business'})
```

`'Business'` is the catch-all, so it renders whenever the tier is not literally `free`/`pro`:

- `undefined` while the SWR fetch of `/api/subscriptions/status` is loading — i.e. every first paint. With `revalidateOnFocus: false` and a 5-minute `refreshInterval`, a slow or failed first fetch (the fetcher throws on non-2xx) leaves it wrong indefinitely.
- the real `founder` tier was mislabelled "Business".

This ternary is a hand-rolled tier copy that survived the canonical-vocabulary refactor (9415c05b9).

## Fix

- **`UserDropdown.tsx`** — derive the label from `TIER_PLAN_LIMITS[toSubscriptionTier(...)].name`. Prefer the fresh status response; fall back to the `subscriptionTier` that `/api/auth/me` already put on the auth user, so the label is right before the status fetch resolves. Unknown/missing coerces to Free.
- **`api/subscriptions/status/route.ts`** — return the coerced tier instead of the raw column, matching `/api/auth/me` and the schema comment on `users.subscriptionTier`.
- Changelog entry under Unreleased / Fixed.

## Tests

- New `UserDropdown.test.tsx` (7 cases): loading window with auth tier free / no tier / fetch error → Free; founder → Founder; business → Business; fresh fetch wins over auth snapshot; unknown stored value → Free.
- `status/__tests__/route.test.ts`: +3 coercion cases (`null`, `''`, garbage → `free`).

Mutation check: reverting both fixes turns 8 of the 24 tests red.

Not run locally: monorepo typecheck/build (pu agents active). CI is the gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TxbdC6mM9y3m7kfGTF91dt


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed the account menu billing label to display the correct subscription tier, including Founder plans.
  - Prevented temporary or failed subscription lookups from incorrectly showing Business; unknown tiers now display as Free.
  - Standardized subscription status responses to return normalized tier values.

- **Tests**
  - Added coverage for tier labels during loading, failed lookups, missing data, and unrecognized subscription tiers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->