### PR TITLE
feat(env-bridge): bridge connection — ws route, per-env registry, shared correlator, signer/verifier, revoke (M1 · t07)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -404,5 +404,10 @@ FCM_SERVICE_ACCOUNT_JSON=
 # grant is signed with, and the key each enrolled machine pins. Generate one:
 #   node -e "const k=require('crypto').generateKeyPairSync('ed25519');console.log(k.privateKey.export({type:'pkcs8',format:'der'}).toString('base64'))"
 # A real value is a secret (cloud: `fly secrets set`); never commit one.
+# Rotation: set ENV_BRIDGE_SIGNING_KEYS instead — comma-separated, CURRENT key
+# first, previous keys after — so machines enrolled under a previous key keep
+# working while new enrollments pin the current one. Either variable satisfies
+# the boot check; ENV_BRIDGE_SIGNING_KEYS wins when both are set.
 # LOCAL_ENVS_ENABLED=true
 # ENV_BRIDGE_SIGNING_KEY=
+# ENV_BRIDGE_SIGNING_KEYS=

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ All notable user-facing changes to PageSpace are documented here. Format follows
 
 ### Added
 
+- **Local Environments: your enrolled computer can now hold a live connection, and you can
+  revoke it (opt-in, groundwork)** — an enrolled machine connects to PageSpace over a socket
+  addressed to its Environment, proves it is the machine you enrolled with a signed hello
+  before anything else is accepted, and stays "connected" in the Environments list while its
+  heartbeat is fresh. Two of your machines can be connected at once; reconnecting a machine
+  replaces its old connection cleanly. Every command PageSpace will later send that machine
+  is individually signed and bound to exactly what was requested, and every answer the
+  machine sends is verified against the key pinned at enrollment before an agent ever sees
+  it. Deleting a local Environment now revokes the machine completely: its connection tokens
+  are cancelled, the machine is told to forget its key, and it can no longer mint new tokens.
+  Server signing keys can be rotated without stranding already-enrolled machines. Nothing runs
+  on the machine yet (the daemon lands next). Still off by default (`LOCAL_ENVS_ENABLED`).
 - **Local Environments: the server now refuses what the machine cannot do (hardening,
   opt-in groundwork)** — before the bridge connection ships, every server path that could
   provision, bind a session to, or rebuild an Environment now recognises a local machine and

--- a/apps/web/.env.example
+++ b/apps/web/.env.example
@@ -132,8 +132,10 @@ SENTRY_SEND_DEFAULT_PII=
 NEXT_PUBLIC_SENTRY_SEND_DEFAULT_PII=
 
 # Local environments (user machines via the zero-trust bridge) — OFF by default;
-# only the exact value 'true' enables. When enabled, ENV_BRIDGE_SIGNING_KEY is
+# only the exact value 'true' enables. When enabled, ENV_BRIDGE_SIGNING_KEY (or,
+# for rotation, ENV_BRIDGE_SIGNING_KEYS = comma-separated, current key first) is
 # required at boot (base64 PKCS#8 Ed25519 private key; see the root .env.example
 # for how to generate one). Never commit a real value.
 # LOCAL_ENVS_ENABLED=true
 # ENV_BRIDGE_SIGNING_KEY=
+# ENV_BRIDGE_SIGNING_KEYS=

--- a/apps/web/src/app/api/drives/[driveId]/envs/[envId]/route.ts
+++ b/apps/web/src/app/api/drives/[driveId]/envs/[envId]/route.ts
@@ -11,6 +11,13 @@
  * 404 rather than 403: telling a stranger that an id exists elsewhere is itself
  * the leak.
  *
+ * **DELETE on a LOCAL env revokes the machine first** (Local Environments epic,
+ * Codex C4): `revokedAt` stamped, every `env:bridge` session for the env
+ * revoked, the daemon sent a signed `revoke` frame and closed 1008 — then the
+ * row is deleted as for any env. Owner/admin only, through the same
+ * centralized check as every other DELETE here; the revoke's three legs are
+ * audited on the drive with `operation: 'revoke'`.
+ *
  * **DELETE is the destructive verb.** It refuses while sessions are live inside
  * the env (409) unless `?force=true`, because deleting the row CASCADES those
  * sessions away — see `deleteDriveEnv`, which owns the ordering: guard → delete
@@ -38,6 +45,7 @@ import {
   deleteEnv,
   renameEnv,
   resolveEnvInDrive,
+  revokeEnv,
   toDriveEnvDTO,
 } from '@/lib/drive-envs/drive-envs-runtime';
 
@@ -145,8 +153,27 @@ export async function DELETE(request: Request, context: { params: Promise<{ driv
       return NextResponse.json({ error: 'Only drive owners and admins can delete environments' }, { status: 403 });
     }
 
-    if (!(await resolveEnvInDrive(envId, driveId))) {
+    const env = await resolveEnvInDrive(envId, driveId);
+    if (!env) {
       return NextResponse.json({ error: 'Environment not found' }, { status: 404 });
+    }
+
+    // A local env's machine is revoked BEFORE the row goes: the stamp, the
+    // sessions and the socket (C4). The row deletion below then cascades the
+    // sibling away; a later token mint finds nothing and fails either way.
+    let revoked: { sessionsRevoked: number; machine: string; alreadyRevoked: boolean } | null = null;
+    if (env.substrate === 'local') {
+      const revocation = await revokeEnv({ envId, reason: 'owner_revoked' });
+      if (revocation.ok) {
+        revoked = { sessionsRevoked: revocation.sessionsRevoked, machine: revocation.machine, alreadyRevoked: revocation.alreadyRevoked };
+        auditRequest(request, {
+          eventType: 'auth.token.revoked',
+          userId: auth.userId,
+          resourceType: 'drive_env',
+          resourceId: envId,
+          details: { route: 'drive-envs', operation: 'revoke', driveId, ...revoked },
+        });
+      }
     }
 
     // Opt-in by exact value: any other spelling reads as "not forced", so a
@@ -175,10 +202,10 @@ export async function DELETE(request: Request, context: { params: Promise<{ driv
       userId: auth.userId,
       resourceType: 'drive',
       resourceId: driveId,
-      details: { route: 'drive-envs', operation: 'delete', envId, force, spriteTornDown: result.spriteTornDown },
+      details: { route: 'drive-envs', operation: 'delete', envId, force, spriteTornDown: result.spriteTornDown, revoked },
     });
 
-    return NextResponse.json({ deleted: true, spriteTornDown: result.spriteTornDown });
+    return NextResponse.json({ deleted: true, spriteTornDown: result.spriteTornDown, ...(revoked && { revoked }) });
   } catch (error) {
     loggers.api.error('Failed to delete drive environment', error instanceof Error ? error : new Error(String(error)));
     return NextResponse.json({ error: 'Failed to delete environment' }, { status: 500 });

--- a/apps/web/src/app/api/drives/[driveId]/envs/__tests__/routes.test.ts
+++ b/apps/web/src/app/api/drives/[driveId]/envs/__tests__/routes.test.ts
@@ -26,6 +26,7 @@ vi.mock('@/lib/drive-envs/drive-envs-runtime', () => ({
   listEnvsInDrive: vi.fn(),
   renameEnv: vi.fn(),
   deleteEnv: vi.fn(),
+  revokeEnv: vi.fn(),
   rebuildEnv: vi.fn(),
   resolveEnvInDrive: vi.fn(),
   toDriveEnvDTO: vi.fn((row: { id: string; driveId: string; name: string }) => ({
@@ -49,7 +50,9 @@ import {
   rebuildEnv,
   renameEnv,
   resolveEnvInDrive,
+  revokeEnv,
 } from '@/lib/drive-envs/drive-envs-runtime';
+import { auditRequest } from '@pagespace/lib/audit/audit-log';
 
 const DRIVE_ID = 'drive-1';
 const ENV_ID = 'env-1';
@@ -320,5 +323,64 @@ describe('POST /envs/[envId]/rebuild — the only sprite-replacing verb', () => 
     const response = await rebuildEnvRoute(rebuildReq(), envParams);
     expect(response.status).toBe(503);
     expect(await response.json()).toMatchObject({ reason: 'teardown_failed' });
+  });
+});
+
+describe('DELETE /envs/[envId] on a LOCAL env — revoke first (Codex C4), then delete', () => {
+  const localRow = { id: ENV_ID, driveId: DRIVE_ID, name: 'mac', substrate: 'local' };
+  const del = () => deleteEnvRoute(req(`http://localhost/api/drives/${DRIVE_ID}/envs/${ENV_ID}`, { method: 'DELETE' }), envParams);
+
+  beforeEach(() => {
+    vi.mocked(resolveEnvInDrive).mockResolvedValue(localRow as never);
+    vi.mocked(deleteEnv).mockResolvedValue({ ok: true, spriteTornDown: false });
+    vi.mocked(revokeEnv).mockResolvedValue({ ok: true, alreadyRevoked: false, revokedAt: new Date(), sessionsRevoked: 2, machine: 'sent_and_closed' });
+  });
+
+  it('given a drive owner/admin, should revoke the machine BEFORE deleting the row, audit the revoke, and report it', async () => {
+    const order: string[] = [];
+    vi.mocked(revokeEnv).mockImplementation(async () => {
+      order.push('revoke');
+      return { ok: true, alreadyRevoked: false, revokedAt: new Date(), sessionsRevoked: 2, machine: 'sent_and_closed' };
+    });
+    vi.mocked(deleteEnv).mockImplementation(async () => {
+      order.push('delete');
+      return { ok: true, spriteTornDown: false };
+    });
+    const response = await del();
+    expect(response.status).toBe(200);
+    expect(order).toEqual(['revoke', 'delete']);
+    expect(revokeEnv).toHaveBeenCalledWith({ envId: ENV_ID, reason: 'owner_revoked' });
+    expect(await response.json()).toEqual({ deleted: true, spriteTornDown: false, revoked: { sessionsRevoked: 2, machine: 'sent_and_closed', alreadyRevoked: false } });
+    expect(auditRequest).toHaveBeenCalledWith(expect.anything(), expect.objectContaining({ eventType: 'auth.token.revoked', resourceType: 'drive_env', resourceId: ENV_ID, details: expect.objectContaining({ operation: 'revoke', sessionsRevoked: 2 }) }));
+  });
+
+  it('given a plain member, should refuse 403 through the centralized owner/admin check and revoke NOTHING', async () => {
+    vi.mocked(isPrincipalDriveOwnerOrAdmin).mockResolvedValue(false);
+    const response = await del();
+    expect(response.status).toBe(403);
+    expect(revokeEnv).not.toHaveBeenCalled();
+    expect(deleteEnv).not.toHaveBeenCalled();
+  });
+
+  it('given an env in another drive, should answer 404 and revoke NOTHING', async () => {
+    vi.mocked(resolveEnvInDrive).mockResolvedValue(null);
+    const response = await del();
+    expect(response.status).toBe(404);
+    expect(revokeEnv).not.toHaveBeenCalled();
+  });
+
+  it('given a Sprite env, should NOT call revoke — behaviour unchanged', async () => {
+    vi.mocked(resolveEnvInDrive).mockResolvedValue({ ...localRow, substrate: 'sprite' } as never);
+    const response = await del();
+    expect(response.status).toBe(200);
+    expect(revokeEnv).not.toHaveBeenCalled();
+    expect(await response.json()).toEqual({ deleted: true, spriteTornDown: false });
+  });
+
+  it('given live sessions in the env, should still have revoked the machine (revocation is not a deletion) and answer 409', async () => {
+    vi.mocked(deleteEnv).mockResolvedValue({ ok: false, reason: 'live_sessions', liveSessionCount: 1 });
+    const response = await del();
+    expect(response.status).toBe(409);
+    expect(revokeEnv).toHaveBeenCalledTimes(1);
   });
 });

--- a/apps/web/src/app/api/env-bridge/ws/__tests__/route.security.test.ts
+++ b/apps/web/src/app/api/env-bridge/ws/__tests__/route.security.test.ts
@@ -40,7 +40,8 @@ import { parseServerSigningKeyring, type SigningKeyPrimitives } from '@pagespace
 import { clearAllEnvConnectionsForTesting, getEnvConnection, readEnvLiveConnection, ENV_SUPERSEDED_CLOSE_CODE, ENV_SUPERSEDED_CLOSE_REASON } from '@/lib/websocket/ws-env-connections';
 import { getEnvBridgeClient } from '@/lib/env-bridge/bridge-client';
 import { envBridgeHash } from '@/lib/env-bridge/crypto';
-import { UPGRADE, GET, ENV_BRIDGE_HELLO_TIMEOUT_MS, ENV_BRIDGE_PING_INTERVAL_MS } from '../route';
+import { ENV_BRIDGE_HELLO_TIMEOUT_MS, ENV_BRIDGE_PING_INTERVAL_MS } from '@/lib/env-bridge/ws-route-config';
+import { UPGRADE, GET } from '../route';
 
 // ---- keys -------------------------------------------------------------------
 const primitives: SigningKeyPrimitives = {

--- a/apps/web/src/app/api/env-bridge/ws/__tests__/route.security.test.ts
+++ b/apps/web/src/app/api/env-bridge/ws/__tests__/route.security.test.ts
@@ -106,7 +106,10 @@ function signedHello(envId = ENV, key = machine, over: Partial<{ capabilities: t
   return encodeFrame({ type: 'hello', ...body, sig: Buffer.from(nodeSign(null, encodeHelloForSigning(body), key.privateKey)).toString('base64') });
 }
 
-function signedResult(body: Omit<MachineResultFrame, 'sig'>, key = machine): string {
+/** Distributive: `Omit` over the union would collapse it to the common keys. */
+type UnsignedResult<T = MachineResultFrame> = T extends unknown ? Omit<T, 'sig'> : never;
+
+function signedResult(body: UnsignedResult, key = machine): string {
   const resultHash = resultHashForFrame({ ...body, sig: '' } as MachineResultFrame, envBridgeHash);
   return encodeFrame({ ...body, sig: Buffer.from(nodeSign(null, encodeResultForSigning({ grantId: body.grantId, resultHash }), key.privateKey)).toString('base64') } as MachineResultFrame);
 }

--- a/apps/web/src/app/api/env-bridge/ws/__tests__/route.security.test.ts
+++ b/apps/web/src/app/api/env-bridge/ws/__tests__/route.security.test.ts
@@ -482,6 +482,24 @@ describe('env-bridge ws route', () => {
       expect(events()).toContain('env_bridge_result_unverified');
     });
 
+    it('given env B answers env A\'s pending grant on its own socket with its own key, should refuse it, audit at high risk, and leave A\'s request pending', async () => {
+      const wsA = await connectAuthorized();
+      vi.mocked(sessionService.validateSession).mockResolvedValue(claimsFor({ resourceId: ENV_B, sessionId: 'sess-2' }) as never);
+      const wsB = await connectAuthorized(ENV_B, machineB);
+      const pending = getEnvBridgeClient().sendGrant({ envId: ENV, frame: { type: 'grant_exec', cmd: 'ls' }, principal });
+      let state = 'pending';
+      pending.then(() => (state = 'resolved'), () => (state = 'rejected'));
+      const grantFrame = lastSent(wsA);
+      if (grantFrame.type !== 'grant_exec') throw new Error('grant not sent');
+      const grantId = (grantFrame.grant as { grantId: string }).grantId;
+      wsB.emit('message', Buffer.from(signedResult({ type: 'exec_result', grantId, exitCode: 0, stdoutB64: 'cHduZWQ=', stderrB64: '', truncated: false }, machineB)));
+      await flush();
+      expect(state).toBe('pending');
+      expect(events()).toContain('env_bridge_result_wrong_env');
+      wsA.emit('message', Buffer.from(signedResult({ type: 'exec_result', grantId, exitCode: 0, stdoutB64: 'b2s=', stderrB64: '', truncated: false })));
+      await expect(pending).resolves.toMatchObject({ exitCode: 0, stdoutB64: 'b2s=' });
+    });
+
     it('given a result for a grant nothing is waiting on, should drop it and audit', async () => {
       const ws = await connectAuthorized();
       ws.emit('message', Buffer.from(signedResult({ type: 'grant_denied', grantId: 'g-nobody', reason: 'x' })));

--- a/apps/web/src/app/api/env-bridge/ws/__tests__/route.security.test.ts
+++ b/apps/web/src/app/api/env-bridge/ws/__tests__/route.security.test.ts
@@ -1,0 +1,523 @@
+/**
+ * Security suite for the env-bridge WebSocket route — the checks mirrored
+ * one-for-one from `mcp-ws/route.security.test.ts`, then the bridge's own:
+ * exact scope, token↔env binding, token→enrollment binding (C8), the signed
+ * hello, the handshake window, direction, heartbeat throttling, and results
+ * delivered only after their machine signature verifies (invariant 7).
+ *
+ * The registry, correlator and bridge client are REAL (in-memory); the session
+ * service, audit log, store, key ring and ws-security helpers are mocked.
+ */
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import type { WebSocket, WebSocketServer } from 'ws';
+import type { NextRequest } from 'next/server';
+import { generateKeyPairSync, createPrivateKey, createPublicKey, createHash, sign as nodeSign } from 'node:crypto';
+
+vi.mock('@pagespace/lib/auth/session-service', () => ({ sessionService: { validateSession: vi.fn() } }));
+vi.mock('@pagespace/lib/audit/audit-log', () => ({ auditRequest: vi.fn() }));
+vi.mock('@pagespace/lib/services/drive-envs/local-envs-enabled', () => ({ isLocalEnvsEnabled: vi.fn(() => true) }));
+vi.mock('@/lib/websocket/ws-security', () => ({
+  getConnectionFingerprint: vi.fn(() => 'fp-1'),
+  validateMessageSize: vi.fn(() => ({ valid: true })),
+  isSecureConnection: vi.fn(() => true),
+}));
+vi.mock('@/lib/drive-envs/drive-envs-runtime', () => ({ getDriveEnvStore: vi.fn() }));
+vi.mock('@pagespace/lib/auth/env-bridge-signing-key', () => ({ loadServerSigningKeyring: vi.fn() }));
+vi.mock('@pagespace/lib/logging/logger-config', () => ({
+  logger: { child: () => ({ info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() }) },
+}));
+
+import { sessionService } from '@pagespace/lib/auth/session-service';
+import { auditRequest } from '@pagespace/lib/audit/audit-log';
+import { isLocalEnvsEnabled } from '@pagespace/lib/services/drive-envs/local-envs-enabled';
+import { getConnectionFingerprint, isSecureConnection, validateMessageSize } from '@/lib/websocket/ws-security';
+import { getDriveEnvStore } from '@/lib/drive-envs/drive-envs-runtime';
+import { loadServerSigningKeyring } from '@pagespace/lib/auth/env-bridge-signing-key';
+import { LOCAL_ENV_HEARTBEAT_WINDOW_MS } from '@pagespace/lib/services/drive-envs/drive-envs';
+import { decodeFrame, encodeFrame, type Frame } from '@pagespace/lib/env-bridge/frame-codec';
+import { encodeHelloForSigning, encodeResultForSigning, resultHashForFrame, type MachineResultFrame } from '@pagespace/lib/env-bridge/machine-signatures';
+import { parseServerSigningKeyring, type SigningKeyPrimitives } from '@pagespace/lib/env-bridge/server-signing-key';
+import { clearAllEnvConnectionsForTesting, getEnvConnection, readEnvLiveConnection, ENV_SUPERSEDED_CLOSE_CODE, ENV_SUPERSEDED_CLOSE_REASON } from '@/lib/websocket/ws-env-connections';
+import { getEnvBridgeClient } from '@/lib/env-bridge/bridge-client';
+import { envBridgeHash } from '@/lib/env-bridge/crypto';
+import { UPGRADE, GET, ENV_BRIDGE_HELLO_TIMEOUT_MS, ENV_BRIDGE_PING_INTERVAL_MS } from '../route';
+
+// ---- keys -------------------------------------------------------------------
+const primitives: SigningKeyPrimitives = {
+  importPrivateKey: (pkcs8) => {
+    const privateKey = createPrivateKey({ key: Buffer.from(pkcs8), type: 'pkcs8', format: 'der' });
+    return { publicKey: new Uint8Array(createPublicKey(privateKey).export({ type: 'spki', format: 'der' })), sign: (m) => new Uint8Array(nodeSign(null, m, privateKey)) };
+  },
+  hash: (bytes) => createHash('sha256').update(bytes).digest('hex'),
+};
+const ringVerdict = parseServerSigningKeyring({ single: generateKeyPairSync('ed25519').privateKey.export({ type: 'pkcs8', format: 'der' }).toString('base64'), multi: undefined }, primitives);
+if (!ringVerdict.ok) throw new Error('ring');
+const ring = ringVerdict.keyring;
+const machine = generateKeyPairSync('ed25519');
+const machineB = generateKeyPairSync('ed25519');
+const rogue = generateKeyPairSync('ed25519');
+const spkiB64 = (k: typeof machine) => k.publicKey.export({ type: 'spki', format: 'der' }).toString('base64');
+
+// ---- fixtures -----------------------------------------------------------------
+const NOW = new Date('2026-09-06T12:00:00.000Z');
+const ENV = 'env_a';
+const ENV_B = 'env_b';
+const USER = 'user-1';
+const CAPS = { shell: true, pty: false, fs: true, checkpoint: false };
+
+function claimsFor(over: Record<string, unknown> = {}) {
+  return { sessionId: 'sess-1', userId: USER, userRole: 'user', tokenVersion: 1, adminRoleVersion: 0, type: 'mcp', scopes: ['env:bridge'], expiresAt: new Date(NOW.getTime() + 3600_000), resourceType: 'drive_env', resourceId: ENV, ...over };
+}
+
+type LocalRow = { envId: string; ownerId: string; enrollmentId: string; machinePublicKey: string | null; serverKeyId: string | null; enrolledAt: Date | null; revokedAt: Date | null };
+function rowFor(over: Partial<LocalRow> = {}): LocalRow {
+  return { envId: ENV, ownerId: USER, enrollmentId: 'enr_a', machinePublicKey: spkiB64(machine), serverKeyId: ring.current.keyId, enrolledAt: NOW, revokedAt: null, ...over };
+}
+
+type FakeSocket = WebSocket & { readyState: number; sent: string[]; handlers: Record<string, (...args: unknown[]) => void>; emit: (event: string, ...args: unknown[]) => void };
+function socket(): FakeSocket {
+  const handlers: Record<string, (...args: unknown[]) => void> = {};
+  const sent: string[] = [];
+  const ws = {
+    readyState: 1,
+    sent,
+    handlers,
+    send: vi.fn((data: string) => sent.push(data)),
+    close: vi.fn(function (this: { readyState: number }) {
+      ws.readyState = 3;
+    }),
+    on: vi.fn((event: string, handler: (...args: unknown[]) => void) => {
+      handlers[event] = handler;
+    }),
+    emit: (event: string, ...args: unknown[]) => handlers[event]?.(...args),
+  } as unknown as FakeSocket;
+  return ws;
+}
+
+function request(over: { headers?: Record<string, string>; url?: string } = {}): NextRequest {
+  return {
+    headers: new Headers({ 'user-agent': 'pagespace-cli/1.0', 'x-forwarded-for': '203.0.113.7', authorization: 'Bearer mcp_opaque_token', ...over.headers }),
+    url: over.url ?? `wss://example.com/api/env-bridge/ws?envId=${ENV}`,
+  } as unknown as NextRequest;
+}
+
+function signedHello(envId = ENV, key = machine, over: Partial<{ capabilities: typeof CAPS; policyDigest: string }> = {}): string {
+  const body = { envId, capabilities: over.capabilities ?? CAPS, policyDigest: over.policyDigest ?? 'sha256:policy' };
+  return encodeFrame({ type: 'hello', ...body, sig: Buffer.from(nodeSign(null, encodeHelloForSigning(body), key.privateKey)).toString('base64') });
+}
+
+function signedResult(body: Omit<MachineResultFrame, 'sig'>, key = machine): string {
+  const resultHash = resultHashForFrame({ ...body, sig: '' } as MachineResultFrame, envBridgeHash);
+  return encodeFrame({ ...body, sig: Buffer.from(nodeSign(null, encodeResultForSigning({ grantId: body.grantId, resultHash }), key.privateKey)).toString('base64') } as MachineResultFrame);
+}
+
+const events = () => vi.mocked(auditRequest).mock.calls.map((call) => (call[1] as { details?: { originalEvent?: string } }).details?.originalEvent);
+const lastSent = (ws: FakeSocket): Frame => {
+  const decoded = decodeFrame(ws.sent[ws.sent.length - 1]!, { maxFrameBytes: 1024 * 1024 });
+  if (!decoded.ok) throw new Error(decoded.reason);
+  return decoded.frame;
+};
+const flush = async () => {
+  for (let i = 0; i < 5; i += 1) await Promise.resolve();
+};
+
+describe('env-bridge ws route', () => {
+  let rows: Map<string, LocalRow>;
+  let store: { findLocalByEnvId: ReturnType<typeof vi.fn>; recordHello: ReturnType<typeof vi.fn>; recordHeartbeat: ReturnType<typeof vi.fn> };
+  const server = {} as unknown as WebSocketServer;
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(NOW);
+    vi.clearAllMocks();
+    clearAllEnvConnectionsForTesting();
+    rows = new Map([[ENV, rowFor()], [ENV_B, rowFor({ envId: ENV_B, enrollmentId: 'enr_b', machinePublicKey: spkiB64(machineB) })]]);
+    store = {
+      findLocalByEnvId: vi.fn(async (envId: string) => rows.get(envId) ?? null),
+      recordHello: vi.fn(async ({ envId }: { envId: string }) => {
+        const row = rows.get(envId);
+        return !!row && row.enrolledAt !== null && row.revokedAt === null;
+      }),
+      recordHeartbeat: vi.fn(async ({ envId }: { envId: string }) => {
+        const row = rows.get(envId);
+        return !!row && row.enrolledAt !== null && row.revokedAt === null;
+      }),
+    };
+    vi.mocked(getDriveEnvStore).mockResolvedValue(store as never);
+    vi.mocked(sessionService.validateSession).mockResolvedValue(claimsFor() as never);
+    vi.mocked(isLocalEnvsEnabled).mockReturnValue(true);
+    vi.mocked(isSecureConnection).mockReturnValue(true);
+    vi.mocked(getConnectionFingerprint).mockReturnValue('fp-1');
+    vi.mocked(validateMessageSize).mockReturnValue({ valid: true } as never);
+    vi.mocked(loadServerSigningKeyring).mockReturnValue(ring);
+  });
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  /** Upgrade + signed hello ⇒ an authorized socket. */
+  async function connectAuthorized(envId = ENV, key = machine, req = request({ url: `wss://example.com/api/env-bridge/ws?envId=${envId}` })): Promise<FakeSocket> {
+    const ws = socket();
+    await UPGRADE(ws, server, req);
+    ws.emit('message', Buffer.from(signedHello(envId, key)));
+    await flush();
+    return ws;
+  }
+
+  // ---- mirrored from mcp-ws ------------------------------------------------------
+  describe('checks mirrored one-for-one from mcp-ws/route.ts', () => {
+    it('SECURITY CHECK 1: given an insecure connection, should close 1008 "Secure connection required" and audit', async () => {
+      vi.mocked(isSecureConnection).mockReturnValue(false);
+      const ws = socket();
+      await UPGRADE(ws, server, request());
+      expect(ws.close).toHaveBeenCalledWith(1008, 'Secure connection required');
+      expect(events()).toContain('ws_insecure_connection_rejected');
+      expect(sessionService.validateSession).not.toHaveBeenCalled();
+    });
+
+    it('SECURITY CHECK 2: given no Authorization header, should close 1008 "Authorization required" and audit', async () => {
+      const ws = socket();
+      await UPGRADE(ws, server, { headers: new Headers({ 'user-agent': 'x' }), url: `wss://example.com/api/env-bridge/ws?envId=${ENV}` } as unknown as NextRequest);
+      expect(ws.close).toHaveBeenCalledWith(1008, 'Authorization required');
+      expect(events()).toContain('ws_authentication_failed');
+    });
+
+    it('SECURITY CHECK 2: should validate the opaque token with expectedType mcp; an invalid token closes 1008, a thrown validation closes 1008 "Authentication error"', async () => {
+      vi.mocked(sessionService.validateSession).mockResolvedValueOnce(null);
+      const ws = socket();
+      await UPGRADE(ws, server, request());
+      expect(sessionService.validateSession).toHaveBeenCalledWith('mcp_opaque_token', { expectedType: 'mcp' });
+      expect(ws.close).toHaveBeenCalledWith(1008, 'Invalid or expired token');
+      vi.mocked(sessionService.validateSession).mockRejectedValueOnce(new Error('db down'));
+      const ws2 = socket();
+      await UPGRADE(ws2, server, request());
+      expect(ws2.close).toHaveBeenCalledWith(1008, 'Authentication error');
+      expect(events()).toContain('ws_session_validation_error');
+    });
+
+    it.each([['mcp:*'], ['*'], ['mcp:ws'], ['env:bridge:read']])('SECURITY CHECK 3: given scope %s (not exactly env:bridge), should close 1008 "Insufficient permissions"', async (scope) => {
+      vi.mocked(sessionService.validateSession).mockResolvedValue(claimsFor({ scopes: [scope] }) as never);
+      const ws = socket();
+      await UPGRADE(ws, server, request());
+      expect(ws.close).toHaveBeenCalledWith(1008, 'Insufficient permissions');
+      expect(events()).toContain('ws_insufficient_permissions');
+      expect(getEnvConnection(ENV)).toBeUndefined();
+    });
+
+    it('SECURITY CHECK 4: should register the socket with the request fingerprint, session expiry and token (for revalidation), in hello_pending', async () => {
+      const ws = socket();
+      await UPGRADE(ws, server, request());
+      expect(getConnectionFingerprint).toHaveBeenCalled();
+      expect(getEnvConnection(ENV)).toBe(ws);
+      expect(readEnvLiveConnection(ENV)).toBe('connecting');
+      expect(events()).toContain('env_bridge_connection_pending');
+      expect(ws.sent).toHaveLength(0);
+    });
+
+    it('SECURITY CHECK 5: given an oversized message once authorized, should audit and drop it without closing', async () => {
+      const ws = await connectAuthorized();
+      vi.mocked(validateMessageSize).mockReturnValueOnce({ valid: false, size: 2_000_000, maxSize: 1_048_576 } as never);
+      ws.emit('message', Buffer.from('x'));
+      expect(events()).toContain('ws_message_too_large');
+      expect(ws.readyState).toBe(1);
+    });
+
+    it('SECURITY CHECK 5: given invalid JSON / an unknown frame type once authorized, should audit and drop it without closing (invariant 6)', async () => {
+      const ws = await connectAuthorized();
+      ws.emit('message', Buffer.from('{not json'));
+      ws.emit('message', Buffer.from(JSON.stringify({ type: 'become_admin', isAdmin: true })));
+      expect(events().filter((e) => e === 'ws_message_validation_failed')).toHaveLength(2);
+      expect(ws.readyState).toBe(1);
+    });
+
+    it('SECURITY CHECK 6: given a pong whose fingerprint no longer matches, should close 1008 "Security violation" and audit', async () => {
+      const ws = await connectAuthorized();
+      vi.mocked(getConnectionFingerprint).mockReturnValue('fp-hijacked');
+      ws.emit('message', Buffer.from(encodeFrame({ type: 'pong', ts: 1 })));
+      await flush();
+      expect(ws.close).toHaveBeenCalledWith(1008, 'Security violation');
+      expect(events()).toContain('ws_fingerprint_mismatch');
+    });
+
+    it('SECURITY CHECK 7: given a result on a socket whose session has expired, should drop it and audit rather than accept it', async () => {
+      vi.mocked(sessionService.validateSession).mockResolvedValue(claimsFor({ expiresAt: new Date(NOW.getTime() + 1_000) }) as never);
+      const ws = await connectAuthorized();
+      vi.setSystemTime(new Date(NOW.getTime() + 2_000));
+      ws.emit('message', Buffer.from(signedResult({ type: 'grant_denied', grantId: 'g', reason: 'x' })));
+      expect(events()).toContain('ws_unhealthy_connection_result');
+    });
+
+    it('should audit abnormal closes (not 1000/1001) and errors', async () => {
+      const ws = await connectAuthorized();
+      ws.emit('close', 1006, Buffer.from(''));
+      expect(events()).toContain('ws_connection_closed');
+      vi.mocked(sessionService.validateSession).mockResolvedValue(claimsFor({ resourceId: ENV_B, sessionId: 'sess-2' }) as never);
+      const ws2 = await connectAuthorized(ENV_B, machineB);
+      ws2.emit('error', new Error('boom'));
+      expect(events()).toContain('ws_error');
+      ws2.emit('close', 1000, Buffer.from(''));
+      expect(events().filter((e) => e === 'ws_connection_closed')).toHaveLength(1);
+    });
+
+    it('GET should answer 426 Upgrade Required with hardening headers', () => {
+      const response = GET();
+      expect(response.status).toBe(426);
+      expect(response.headers.get('Upgrade')).toBe('websocket');
+      expect(response.headers.get('X-Frame-Options')).toBe('DENY');
+    });
+  });
+
+  // ---- bridge-specific -------------------------------------------------------------
+  describe('invariant 11 — the cloud opt-in', () => {
+    it('given LOCAL_ENVS_ENABLED off, should close 1008 before touching the session service and audit', async () => {
+      vi.mocked(isLocalEnvsEnabled).mockReturnValue(false);
+      const ws = socket();
+      await UPGRADE(ws, server, request());
+      expect(ws.close).toHaveBeenCalledWith(1008, 'Not available');
+      expect(sessionService.validateSession).not.toHaveBeenCalled();
+      expect(events()).toContain('env_bridge_disabled');
+    });
+  });
+
+  describe('token ↔ env binding', () => {
+    it('given a token whose resourceId is another env, should refuse the upgrade 1008 and audit', async () => {
+      vi.mocked(sessionService.validateSession).mockResolvedValue(claimsFor({ resourceId: ENV_B }) as never);
+      const ws = socket();
+      await UPGRADE(ws, server, request());
+      expect(ws.close).toHaveBeenCalledWith(1008, 'Token not bound to this environment');
+      expect(events()).toContain('env_bridge_token_env_mismatch');
+      expect(store.findLocalByEnvId).not.toHaveBeenCalled();
+    });
+
+    it('given a token whose resourceType is not drive_env, or no envId in the URL, should refuse the upgrade', async () => {
+      vi.mocked(sessionService.validateSession).mockResolvedValue(claimsFor({ resourceType: 'drive' }) as never);
+      const ws = socket();
+      await UPGRADE(ws, server, request());
+      expect(ws.close).toHaveBeenCalledWith(1008, 'Token not bound to this environment');
+      vi.mocked(sessionService.validateSession).mockResolvedValue(claimsFor() as never);
+      const ws2 = socket();
+      await UPGRADE(ws2, server, request({ url: 'wss://example.com/api/env-bridge/ws' }));
+      expect(ws2.close).toHaveBeenCalledWith(1008, 'Token not bound to this environment');
+    });
+  });
+
+  describe('Codex C8 — token → enrollment binding', () => {
+    it.each([
+      ['no row', () => rows.delete(ENV), 'not_found'],
+      ['not enrolled', () => rows.set(ENV, rowFor({ enrolledAt: null, machinePublicKey: null })), 'not_enrolled'],
+      ['revoked', () => rows.set(ENV, rowFor({ revokedAt: NOW })), 'revoked'],
+      ['owned by another user', () => rows.set(ENV, rowFor({ ownerId: 'user-2' })), 'owner_mismatch'],
+    ] as Array<[string, () => void, string]>)('given the enrollment row is %s, should refuse the upgrade 1008 and audit the reason', async (_label, arrange, reason) => {
+      arrange();
+      const ws = socket();
+      await UPGRADE(ws, server, request());
+      expect(ws.close).toHaveBeenCalledWith(1008, 'Environment not enrolled');
+      expect(vi.mocked(auditRequest).mock.calls.some((c) => (c[1] as { details?: { reason?: string } }).details?.reason === reason)).toBe(true);
+      expect(getEnvConnection(ENV)).toBeUndefined();
+    });
+
+    it('should verify the hello under THAT row\'s pinned key: a hello signed by another enrolled machine\'s key is refused', async () => {
+      const ws = socket();
+      await UPGRADE(ws, server, request());
+      ws.emit('message', Buffer.from(signedHello(ENV, machineB)));
+      await flush();
+      expect(ws.close).toHaveBeenCalledWith(1008, 'Invalid hello');
+      expect(events()).toContain('env_bridge_hello_invalid');
+    });
+  });
+
+  describe('the signed hello', () => {
+    it('given a hello signed by the pinned machine key for THIS env, should authorize: recordHello(capabilities), state connected, and the first server frame is a ping (the ack)', async () => {
+      const ws = await connectAuthorized();
+      expect(store.recordHello).toHaveBeenCalledWith({ envId: ENV, capabilities: CAPS, now: NOW });
+      expect(readEnvLiveConnection(ENV)).toBe('connected');
+      expect(events()).toContain('env_bridge_connection_established');
+      expect(ws.sent).toHaveLength(1);
+      expect(lastSent(ws).type).toBe('ping');
+    });
+
+    it('given a hello signed by a rogue key, should close 1008 "Invalid hello", audit at high risk, persist nothing', async () => {
+      const ws = socket();
+      await UPGRADE(ws, server, request());
+      ws.emit('message', Buffer.from(signedHello(ENV, rogue)));
+      await flush();
+      expect(ws.close).toHaveBeenCalledWith(1008, 'Invalid hello');
+      expect(store.recordHello).not.toHaveBeenCalled();
+      expect(readEnvLiveConnection(ENV)).toBeNull();
+    });
+
+    it('given a correctly signed hello for ANOTHER env id, should close 1008 (wrong_env) before crypto', async () => {
+      const ws = socket();
+      await UPGRADE(ws, server, request());
+      ws.emit('message', Buffer.from(signedHello(ENV_B, machine)));
+      await flush();
+      expect(ws.close).toHaveBeenCalledWith(1008, 'Invalid hello');
+      expect(vi.mocked(auditRequest).mock.calls.some((c) => (c[1] as { details?: { reason?: string } }).details?.reason === 'wrong_env')).toBe(true);
+    });
+
+    it('given a tampered hello (capabilities changed after signing), should close 1008', async () => {
+      const ws = socket();
+      await UPGRADE(ws, server, request());
+      const genuine = JSON.parse(signedHello()) as { capabilities: typeof CAPS };
+      ws.emit('message', Buffer.from(JSON.stringify({ ...genuine, capabilities: { ...genuine.capabilities, pty: true } })));
+      await flush();
+      expect(ws.close).toHaveBeenCalledWith(1008, 'Invalid hello');
+      expect(store.recordHello).not.toHaveBeenCalled();
+    });
+
+    it('given a first frame that is not a hello (a pong), should close 1008 "Hello required"', async () => {
+      const ws = socket();
+      await UPGRADE(ws, server, request());
+      ws.emit('message', Buffer.from(encodeFrame({ type: 'pong', ts: 1 })));
+      expect(ws.close).toHaveBeenCalledWith(1008, 'Hello required');
+      expect(events()).toContain('env_bridge_hello_required');
+    });
+
+    it('given a malformed first frame, should close 1008 within the handshake', async () => {
+      const ws = socket();
+      await UPGRADE(ws, server, request());
+      ws.emit('message', Buffer.from('garbage'));
+      expect(ws.close).toHaveBeenCalledWith(1008, 'Hello required');
+    });
+
+    it('given no hello within the handshake window, should close 1008 "Handshake timeout" (fake timers)', async () => {
+      const ws = socket();
+      await UPGRADE(ws, server, request());
+      await vi.advanceTimersByTimeAsync(ENV_BRIDGE_HELLO_TIMEOUT_MS - 1);
+      expect(ws.close).not.toHaveBeenCalled();
+      await vi.advanceTimersByTimeAsync(1);
+      expect(ws.close).toHaveBeenCalledWith(1008, 'Handshake timeout');
+      expect(events()).toContain('env_bridge_hello_timeout');
+    });
+
+    it('given the machine was revoked between the upgrade and the hello (recordHello CAS loses), should close 1008 "Environment revoked"', async () => {
+      const ws = socket();
+      await UPGRADE(ws, server, request());
+      rows.set(ENV, rowFor({ revokedAt: NOW }));
+      ws.emit('message', Buffer.from(signedHello()));
+      await flush();
+      expect(ws.close).toHaveBeenCalledWith(1008, 'Environment revoked');
+      expect(readEnvLiveConnection(ENV)).toBeNull();
+    });
+
+    it('given a second hello once authorized, should drop it (never re-run the handshake)', async () => {
+      const ws = await connectAuthorized();
+      ws.emit('message', Buffer.from(signedHello()));
+      await flush();
+      expect(store.recordHello).toHaveBeenCalledTimes(1);
+      expect(ws.readyState).toBe(1);
+      expect(vi.mocked(auditRequest).mock.calls.some((c) => (c[1] as { details?: { reason?: string } }).details?.reason === 'duplicate_hello')).toBe(true);
+    });
+  });
+
+  describe('heartbeat', () => {
+    it('should ping every ENV_BRIDGE_PING_INTERVAL_MS once authorized', async () => {
+      const ws = await connectAuthorized();
+      expect(ws.sent).toHaveLength(1);
+      await vi.advanceTimersByTimeAsync(ENV_BRIDGE_PING_INTERVAL_MS);
+      expect(ws.sent).toHaveLength(2);
+      expect(lastSent(ws).type).toBe('ping');
+    });
+
+    it('given pongs, should persist lastSeenAt at most once per heartbeat window — not on every ping', async () => {
+      const ws = await connectAuthorized();
+      const pong = () => ws.emit('message', Buffer.from(encodeFrame({ type: 'pong', ts: Date.now() })));
+      pong();
+      await flush();
+      await vi.advanceTimersByTimeAsync(30_000);
+      pong();
+      await flush();
+      expect(store.recordHeartbeat).not.toHaveBeenCalled();
+      await vi.advanceTimersByTimeAsync(LOCAL_ENV_HEARTBEAT_WINDOW_MS - 30_000);
+      pong();
+      await flush();
+      expect(store.recordHeartbeat).toHaveBeenCalledTimes(1);
+      pong();
+      await flush();
+      expect(store.recordHeartbeat).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('invariant 6 — direction and unknown frames', () => {
+    it('given a server→machine frame type arriving FROM the machine (grant_exec), should drop + audit and keep the socket', async () => {
+      const ws = await connectAuthorized();
+      ws.emit('message', Buffer.from(encodeFrame({ type: 'grant_exec', grant: {}, sig: '', cmd: 'rm' })));
+      expect(events()).toContain('env_bridge_wrong_direction_frame');
+      expect(ws.readyState).toBe(1);
+    });
+
+    it('given a PTY frame in M1, should drop it as unsupported without crashing', async () => {
+      const ws = await connectAuthorized();
+      ws.emit('message', Buffer.from(encodeFrame({ type: 'pty_data', sessionId: 's', seq: 0, dataB64: '' })));
+      expect(vi.mocked(auditRequest).mock.calls.some((c) => (c[1] as { details?: { reason?: string } }).details?.reason === 'unsupported_in_m1')).toBe(true);
+      expect(ws.readyState).toBe(1);
+    });
+  });
+
+  describe('invariant 7 — results reach the agent only after their machine signature verifies', () => {
+    const principal = { userId: USER, sessionId: 'sess-1', conversationId: 'conv-1' };
+
+    it('given a pending grant and an exec_result signed by the pinned machine key, should deliver it', async () => {
+      const ws = await connectAuthorized();
+      const pending = getEnvBridgeClient().sendGrant({ envId: ENV, frame: { type: 'grant_exec', cmd: 'ls' }, principal });
+      const grantFrame = lastSent(ws);
+      if (grantFrame.type !== 'grant_exec') throw new Error('grant not sent');
+      const grantId = (grantFrame.grant as { grantId: string }).grantId;
+      ws.emit('message', Buffer.from(signedResult({ type: 'exec_result', grantId, exitCode: 0, stdoutB64: 'b2s=', stderrB64: '', truncated: false })));
+      await expect(pending).resolves.toMatchObject({ type: 'exec_result', grantId, exitCode: 0 });
+    });
+
+    it('given an exec_result whose machine signature does not verify, should NOT deliver it: typed unverified_result to the caller and a high-risk audit', async () => {
+      const ws = await connectAuthorized();
+      const pending = getEnvBridgeClient().sendGrant({ envId: ENV, frame: { type: 'grant_exec', cmd: 'ls' }, principal });
+      const grantFrame = lastSent(ws);
+      if (grantFrame.type !== 'grant_exec') throw new Error('grant not sent');
+      const grantId = (grantFrame.grant as { grantId: string }).grantId;
+      ws.emit('message', Buffer.from(signedResult({ type: 'exec_result', grantId, exitCode: 0, stdoutB64: 'cHduZWQ=', stderrB64: '', truncated: false }, rogue)));
+      await expect(pending).rejects.toMatchObject({ kind: 'unverified_result' });
+      expect(events()).toContain('env_bridge_result_unverified');
+    });
+
+    it('given a result for a grant nothing is waiting on, should drop it and audit', async () => {
+      const ws = await connectAuthorized();
+      ws.emit('message', Buffer.from(signedResult({ type: 'grant_denied', grantId: 'g-nobody', reason: 'x' })));
+      expect(events()).toContain('env_bridge_result_dropped');
+    });
+  });
+
+  describe('the per-env registry through the route', () => {
+    const principal = { userId: USER, sessionId: 'sess-1', conversationId: 'conv-1' };
+
+    it('given two envs for one user, both should be authorized and connected at once', async () => {
+      const a = await connectAuthorized(ENV, machine);
+      vi.mocked(sessionService.validateSession).mockResolvedValue(claimsFor({ resourceId: ENV_B, sessionId: 'sess-2' }) as never);
+      const b = await connectAuthorized(ENV_B, machineB);
+      expect(readEnvLiveConnection(ENV)).toBe('connected');
+      expect(readEnvLiveConnection(ENV_B)).toBe('connected');
+      expect(a.close).not.toHaveBeenCalled();
+      expect(b.close).not.toHaveBeenCalled();
+    });
+
+    it('given a second socket for the same env, the newer wins, the older closes env_superseded, and its late close cancels nothing', async () => {
+      const older = await connectAuthorized();
+      const pending = getEnvBridgeClient().sendGrant({ envId: ENV, frame: { type: 'grant_exec', cmd: 'ls' }, principal });
+      let state = 'pending';
+      pending.then(() => (state = 'resolved'), () => (state = 'rejected'));
+      const newer = await connectAuthorized();
+      expect(older.close).toHaveBeenCalledWith(ENV_SUPERSEDED_CLOSE_CODE, ENV_SUPERSEDED_CLOSE_REASON);
+      older.emit('close', ENV_SUPERSEDED_CLOSE_CODE, Buffer.from(ENV_SUPERSEDED_CLOSE_REASON));
+      await flush();
+      expect(state).toBe('pending');
+      expect(getEnvConnection(ENV)).toBe(newer);
+      expect(readEnvLiveConnection(ENV)).toBe('connected');
+    });
+
+    it('given the LIVE socket closes, its in-flight requests fail with typed disconnected and the env reads disconnected', async () => {
+      const ws = await connectAuthorized();
+      const pending = getEnvBridgeClient().sendGrant({ envId: ENV, frame: { type: 'grant_exec', cmd: 'ls' }, principal });
+      ws.emit('close', 1006, Buffer.from(''));
+      await expect(pending).rejects.toMatchObject({ kind: 'disconnected' });
+      expect(readEnvLiveConnection(ENV)).toBeNull();
+    });
+  });
+});

--- a/apps/web/src/app/api/env-bridge/ws/route.ts
+++ b/apps/web/src/app/api/env-bridge/ws/route.ts
@@ -1,0 +1,513 @@
+import type { WebSocket, WebSocketServer } from 'ws';
+import type { NextRequest } from 'next/server';
+import {
+  registerEnvConnection,
+  unregisterEnvConnection,
+  updateEnvLastPing,
+  markEnvAuthorized,
+  isEnvAuthorized,
+  markEnvLastSeenPersisted,
+  getEnvConnectionMetadata,
+  startEnvCleanupInterval,
+  checkEnvConnectionHealth,
+  verifyEnvConnectionFingerprint,
+} from '@/lib/websocket/ws-env-connections';
+import { getConnectionFingerprint, validateMessageSize, isSecureConnection } from '@/lib/websocket/ws-security';
+import { decodeEnvBridgeFrame, encodeEnvBridgeFrame, isEnvBridgeMachineFrame, ENV_BRIDGE_FRAME_LIMITS, type EnvBridgeFrame } from '@/lib/websocket/ws-message-schemas';
+import { sessionService, type SessionClaims } from '@pagespace/lib/auth/session-service';
+import { ENV_BRIDGE_SCOPE } from '@pagespace/lib/auth/token-lifecycle-policy';
+import { auditRequest } from '@pagespace/lib/audit/audit-log';
+import { isLocalEnvsEnabled } from '@pagespace/lib/services/drive-envs/local-envs-enabled';
+import { LOCAL_ENV_HEARTBEAT_WINDOW_MS } from '@pagespace/lib/services/drive-envs/drive-envs';
+import type { DriveEnvLocalRecord } from '@pagespace/lib/services/drive-envs/drive-envs-store';
+import { initialBridgeSession, reduceBridgeSession, type BridgeSessionState } from '@pagespace/lib/env-bridge/bridge-session';
+import { verifyHello, isMachineResultFrame } from '@pagespace/lib/env-bridge/machine-signatures';
+import { getDriveEnvStore } from '@/lib/drive-envs/drive-envs-runtime';
+import { getEnvBridgeClient } from '@/lib/env-bridge/bridge-client';
+import { decodePinnedPublicKey, ed25519Verify } from '@/lib/env-bridge/crypto';
+
+// Initialize cleanup interval on module load
+// This prevents memory leaks from stale connections
+startEnvCleanupInterval();
+
+/** How long a socket may sit without a valid signed hello before it is closed. */
+export const ENV_BRIDGE_HELLO_TIMEOUT_MS = 10_000;
+/** Server → daemon heartbeat cadence; well inside LOCAL_ENV_HEARTBEAT_WINDOW_MS (90 s). */
+export const ENV_BRIDGE_PING_INTERVAL_MS = 30_000;
+
+const RESOURCE_TYPE = 'env_bridge_websocket';
+const DRIVE_ENV_RESOURCE = 'drive_env';
+
+/**
+ * Env-bridge WebSocket route — `/api/env-bridge/ws?envId=…` (Local Environments
+ * epic, M1 · t07). The server end of the zero-trust bridge to a user's own
+ * machine. A CLONE of `mcp-ws/route.ts`: every security check there is
+ * mirrored here one-for-one (numbered the same way), followed by the bridge's
+ * own checks. The differences are deliberate and listed:
+ *
+ * Mirrored from mcp-ws (same order, same close codes):
+ *  1. WSS-only in production                       → 1008 'Secure connection required'
+ *  2. Authorization: Bearer <opaque token>          → 1008 'Authorization required'
+ *     session validated by the session service      → 1008 'Authentication error' / 'Invalid or expired token'
+ *  3. scope                                          → 1008 'Insufficient permissions'
+ *  4. connection fingerprint (IP + UA hash), registered with the session's expiry and token for periodic revalidation
+ *  5. message size limit                              (audited; see "no error frames" below)
+ *     JSON parse + schema validation                 (the codec IS the schema — one closed set, imported)
+ *  6. fingerprint re-check on the heartbeat           → 1008 'Security violation'
+ *  7. connection health check before a result is accepted
+ *  Audit on every refusal via the `originalEvent` pattern; abnormal closes audited; errors audited.
+ *
+ * Bridge-specific, after the mirrored checks:
+ *  - Off switch: `LOCAL_ENVS_ENABLED` false ⇒ the route refuses everything (invariant 11).
+ *  - Scope must be EXACTLY `env:bridge`; `mcp:*` and `*` do NOT qualify (t06 keeps
+ *    `env:bridge` outside `mcp:*`). Session `expectedType: 'mcp'`.
+ *  - The token must be bound to THIS env: `resourceType = 'drive_env'`, `resourceId = envId` (URL).
+ *  - (Codex C8) Token → enrollment binding: `drive_env_local` is resolved by the token's
+ *    resourceId; it must be enrolled, not revoked, hold a pinned machine key, and belong to
+ *    the token's user. The hello is verified under THAT row's key. The mcp_tokens/session
+ *    split is never relied on for isolation.
+ *  - First frame MUST be a machine-signed `hello` (envId = this env) within
+ *    ENV_BRIDGE_HELLO_TIMEOUT_MS, or 1008. The pure reducer (`reduceBridgeSession`) decides
+ *    what a frame may do in each state; this route only executes its effects.
+ *  - On an authorized hello: capabilities + lastSeenAt persisted (`recordHello`), the socket
+ *    marked authorized, and a `ping` sent at once — that first server frame IS the hello
+ *    acknowledgement the daemon's reducer maps to `hello_ack` (the codec has no ack frame).
+ *  - Heartbeat: the server pings every ENV_BRIDGE_PING_INTERVAL_MS; the machine's `pong`
+ *    updates in-memory liveness on every beat and persists `lastSeenAt` at most once per
+ *    LOCAL_ENV_HEARTBEAT_WINDOW_MS.
+ *  - Direction: only machine→server frame types are accepted; a server→machine type arriving
+ *    from the machine is dropped + audited (invariant 6). Unknown/malformed frames are dropped
+ *    + audited once authorized, and close the socket 1008 while the hello is pending.
+ *  - Results (`exec_result` / `fs_read_result` / `fs_write_result` / `grant_denied`) go to the
+ *    bridge client, which delivers them ONLY after their machine signature verifies under the
+ *    socket's pinned key (invariant 7); an unverified result is audited at high risk.
+ *  - PTY frames are dropped in M1 (M2 adds them; see [D-2] for their signing).
+ *
+ * No error frames are echoed to the machine (mcp-ws sends `{type:'error'}` messages): the
+ * bridge's closed frame set has no error frame and the server never sends anything outside
+ * that set (invariant 6). Refusals are audited and, where the protocol requires, the socket is
+ * closed with a reason.
+ */
+export async function UPGRADE(client: WebSocket, server: WebSocketServer, request: NextRequest) {
+  const requestUrl = request.url;
+
+  // SECURITY CHECK 0 (bridge): the cloud opt-in. Off ⇒ nothing here exists.
+  if (!isLocalEnvsEnabled()) {
+    auditRequest(request, {
+      eventType: 'authz.access.denied',
+      resourceType: RESOURCE_TYPE,
+      riskScore: 0.2,
+      details: { originalEvent: 'env_bridge_disabled' },
+    });
+    client.close(1008, 'Not available');
+    return;
+  }
+
+  // SECURITY CHECK 1: Verify secure connection in production
+  if (!isSecureConnection(requestUrl, request)) {
+    auditRequest(request, {
+      eventType: 'security.anomaly.detected',
+      resourceType: RESOURCE_TYPE,
+      riskScore: 0.7,
+      details: { originalEvent: 'ws_insecure_connection_rejected', url: requestUrl },
+    });
+    client.close(1008, 'Secure connection required');
+    return;
+  }
+
+  // SECURITY CHECK 2: Extract and validate opaque token from Authorization header
+  const authHeader = request.headers.get('authorization');
+  if (!authHeader?.startsWith('Bearer ')) {
+    auditRequest(request, {
+      eventType: 'auth.login.failure',
+      resourceType: RESOURCE_TYPE,
+      riskScore: 0.3,
+      details: { originalEvent: 'ws_authentication_failed', reason: 'Missing Authorization header' },
+    });
+    client.close(1008, 'Authorization required');
+    return;
+  }
+
+  const token = authHeader.slice(7).trim();
+
+  let claims: SessionClaims | null = null;
+  try {
+    claims = await sessionService.validateSession(token, { expectedType: 'mcp' });
+  } catch (error) {
+    auditRequest(request, {
+      eventType: 'auth.login.failure',
+      resourceType: RESOURCE_TYPE,
+      riskScore: 0.3,
+      details: { originalEvent: 'ws_session_validation_error', error: error instanceof Error ? error.message : String(error) },
+    });
+    client.close(1008, 'Authentication error');
+    return;
+  }
+
+  if (!claims) {
+    auditRequest(request, {
+      eventType: 'auth.login.failure',
+      resourceType: RESOURCE_TYPE,
+      riskScore: 0.3,
+      details: { originalEvent: 'ws_authentication_failed', reason: 'Invalid or expired session token' },
+    });
+    client.close(1008, 'Invalid or expired token');
+    return;
+  }
+
+  const userId = claims.userId;
+
+  // SECURITY CHECK 3: scope — EXACTLY env:bridge. The mcp-ws wildcards do not qualify here.
+  if (!claims.scopes.includes(ENV_BRIDGE_SCOPE)) {
+    auditRequest(request, {
+      eventType: 'authz.access.denied',
+      userId,
+      resourceType: RESOURCE_TYPE,
+      riskScore: 0.5,
+      details: { originalEvent: 'ws_insufficient_permissions', scopes: claims.scopes },
+    });
+    client.close(1008, 'Insufficient permissions');
+    return;
+  }
+
+  // SECURITY CHECK 3b (bridge): the token is bound to THIS env.
+  const envId = new URL(requestUrl).searchParams.get('envId')?.trim() ?? '';
+  if (envId.length === 0 || claims.resourceType !== DRIVE_ENV_RESOURCE || claims.resourceId !== envId) {
+    auditRequest(request, {
+      eventType: 'authz.access.denied',
+      userId,
+      resourceType: RESOURCE_TYPE,
+      resourceId: envId || undefined,
+      riskScore: 0.6,
+      details: { originalEvent: 'env_bridge_token_env_mismatch', tokenResourceType: claims.resourceType ?? null, tokenResourceId: claims.resourceId ?? null },
+    });
+    client.close(1008, 'Token not bound to this environment');
+    return;
+  }
+
+  // SECURITY CHECK 3c (bridge, Codex C8): token → enrollment. The row the token's
+  // resourceId names must be an enrolled, unrevoked machine owned by the token's
+  // user; its pinned key is what the hello is verified under.
+  let row: DriveEnvLocalRecord | null = null;
+  try {
+    row = await (await getDriveEnvStore()).findLocalByEnvId(envId);
+  } catch (error) {
+    auditRequest(request, {
+      eventType: 'security.anomaly.detected',
+      userId,
+      resourceType: RESOURCE_TYPE,
+      resourceId: envId,
+      riskScore: 0.3,
+      details: { originalEvent: 'env_bridge_enrollment_lookup_error', error: error instanceof Error ? error.message : String(error) },
+    });
+    client.close(1008, 'Authentication error');
+    return;
+  }
+  const enrollmentRefusal = !row
+    ? 'not_found'
+    : row.revokedAt !== null
+      ? 'revoked'
+      : row.enrolledAt === null || row.machinePublicKey === null
+        ? 'not_enrolled'
+        : row.ownerId !== userId
+          ? 'owner_mismatch'
+          : null;
+  if (!row || enrollmentRefusal !== null) {
+    auditRequest(request, {
+      eventType: 'authz.access.denied',
+      userId,
+      resourceType: RESOURCE_TYPE,
+      resourceId: envId,
+      riskScore: enrollmentRefusal === 'owner_mismatch' ? 0.7 : 0.4,
+      details: { originalEvent: 'env_bridge_enrollment_refused', reason: enrollmentRefusal },
+    });
+    client.close(1008, 'Environment not enrolled');
+    return;
+  }
+  const machinePublicKey = decodePinnedPublicKey(row.machinePublicKey);
+  if (machinePublicKey === null) {
+    auditRequest(request, {
+      eventType: 'security.anomaly.detected',
+      userId,
+      resourceType: RESOURCE_TYPE,
+      resourceId: envId,
+      riskScore: 0.5,
+      details: { originalEvent: 'env_bridge_enrollment_refused', reason: 'bad_pinned_key' },
+    });
+    client.close(1008, 'Environment not enrolled');
+    return;
+  }
+  const enrollment = row;
+
+  // SECURITY CHECK 4: Generate connection fingerprint
+  const fingerprint = getConnectionFingerprint(request);
+
+  // Register in hello_pending (a second socket for this env supersedes the first).
+  // Pass sessionExpiresAt to enforce TTL on persistent connections
+  // Pass token to enable periodic session revalidation (detects revoked sessions)
+  registerEnvConnection(envId, client, {
+    userId,
+    sessionId: claims.sessionId,
+    enrollmentId: enrollment.enrollmentId,
+    machinePublicKey: enrollment.machinePublicKey!,
+    serverKeyId: enrollment.serverKeyId,
+    fingerprint,
+    sessionExpiresAt: claims.expiresAt,
+    wsToken: token,
+  });
+
+  // Fingerprint is intentionally NOT embedded in audit details — it is a
+  // stable, client-linkable pseudonym (hash of IP+UA) that would persist in
+  // the tamper-evident audit chain and resist GDPR erasure requests.
+  auditRequest(request, {
+    eventType: 'auth.session.created',
+    userId,
+    sessionId: claims.sessionId,
+    resourceType: RESOURCE_TYPE,
+    resourceId: envId,
+    riskScore: 0,
+    details: { originalEvent: 'env_bridge_connection_pending', enrollmentId: enrollment.enrollmentId },
+  });
+
+  // The daemon's lifecycle reducer, run on the server side of the same
+  // handshake: connecting (awaiting hello) → hello_sent (hello received,
+  // verifying) → authorized. Frames are dispatched ONLY in authorized.
+  let session: BridgeSessionState = reduceBridgeSession(initialBridgeSession(), { type: 'connect' }).state;
+  let pingTimer: ReturnType<typeof setInterval> | null = null;
+
+  const refuse = (event: string, reason: string, closeReason: string, riskScore = 0.5) => {
+    auditRequest(request, {
+      eventType: 'security.anomaly.detected',
+      userId,
+      resourceType: RESOURCE_TYPE,
+      resourceId: envId,
+      riskScore,
+      details: { originalEvent: event, reason },
+    });
+    client.close(1008, closeReason);
+  };
+
+  const dropFrame = (event: string, detail: Record<string, unknown>, riskScore = 0.3) => {
+    auditRequest(request, {
+      eventType: 'security.anomaly.detected',
+      userId,
+      resourceType: RESOURCE_TYPE,
+      resourceId: envId,
+      riskScore,
+      details: { originalEvent: event, ...detail },
+    });
+  };
+
+  // Not a valid signed hello within the window ⇒ 1008.
+  const helloTimer = setTimeout(() => {
+    if (!isEnvAuthorized(client)) refuse('env_bridge_hello_timeout', 'no valid hello within window', 'Handshake timeout', 0.4);
+  }, ENV_BRIDGE_HELLO_TIMEOUT_MS);
+
+  const sendPing = () => {
+    if (client.readyState !== 1 || !isEnvAuthorized(client)) return;
+    client.send(encodeEnvBridgeFrame({ type: 'ping', ts: Date.now() }));
+  };
+
+  const onHello = async (frame: Extract<EnvBridgeFrame, { type: 'hello' }>) => {
+    // The reducer opens the handshake with this hello (or refuses it).
+    const opened = reduceBridgeSession(session, { type: 'socket_open', hello: frame });
+    session = opened.state;
+    if (opened.effects.some((effect) => effect.type === 'reject')) {
+      refuse('env_bridge_hello_rejected', 'reducer rejected hello', 'Invalid hello', 0.6);
+      return;
+    }
+    const verdict = verifyHello({ hello: frame, expectedEnvId: envId, machinePublicKey, verify: ed25519Verify });
+    if (!verdict.ok) {
+      refuse('env_bridge_hello_invalid', verdict.reason, 'Invalid hello', 0.7);
+      return;
+    }
+    const now = new Date();
+    const recorded = await (await getDriveEnvStore()).recordHello({ envId, capabilities: frame.capabilities, now });
+    if (!recorded) {
+      // Revoked (or un-enrolled) between the upgrade and the hello: the CAS says no.
+      refuse('env_bridge_hello_refused', 'enrollment no longer live', 'Environment revoked', 0.5);
+      return;
+    }
+    if (client.readyState !== 1) return;
+    session = reduceBridgeSession(session, { type: 'hello_ack' }).state;
+    markEnvAuthorized(client);
+    markEnvLastSeenPersisted(client, now);
+    updateEnvLastPing(client);
+    clearTimeout(helloTimer);
+    auditRequest(request, {
+      eventType: 'auth.session.created',
+      userId,
+      sessionId: claims!.sessionId,
+      resourceType: RESOURCE_TYPE,
+      resourceId: envId,
+      riskScore: 0,
+      details: { originalEvent: 'env_bridge_connection_established', capabilities: frame.capabilities, policyDigest: frame.policyDigest },
+    });
+    // The first server frame acknowledges the hello (the daemon maps it to hello_ack).
+    sendPing();
+    pingTimer = setInterval(sendPing, ENV_BRIDGE_PING_INTERVAL_MS);
+  };
+
+  const onPong = async () => {
+    // SECURITY CHECK 6: Verify connection fingerprint on the heartbeat to detect session hijacking
+    const currentFingerprint = getConnectionFingerprint(request);
+    if (!verifyEnvConnectionFingerprint(client, currentFingerprint)) {
+      refuse('ws_fingerprint_mismatch', 'Connection fingerprint changed - possible session hijacking', 'Security violation', 0.7);
+      return;
+    }
+    updateEnvLastPing(client);
+    const metadata = getEnvConnectionMetadata(client);
+    const now = new Date();
+    const lastPersisted = metadata?.lastSeenPersistedAt?.getTime() ?? 0;
+    // Persist lastSeenAt at most once per heartbeat window — never on every ping.
+    if (now.getTime() - lastPersisted >= LOCAL_ENV_HEARTBEAT_WINDOW_MS) {
+      markEnvLastSeenPersisted(client, now);
+      const recorded = await (await getDriveEnvStore()).recordHeartbeat({ envId, now });
+      if (!recorded) refuse('env_bridge_heartbeat_refused', 'enrollment no longer live', 'Environment revoked', 0.5);
+    }
+  };
+
+  const onAuthorizedFrame = (frame: EnvBridgeFrame) => {
+    if (frame.type === 'pong') {
+      void onPong().catch((error) => dropFrame('env_bridge_heartbeat_error', { error: error instanceof Error ? error.message : String(error) }));
+      return;
+    }
+    if (isMachineResultFrame(frame)) {
+      // SECURITY CHECK 7: Connection health check before a result is accepted
+      const health = checkEnvConnectionHealth(client);
+      if (!health.isHealthy) {
+        dropFrame('ws_unhealthy_connection_result', { reason: health.reason, readyState: health.readyState, grantId: frame.grantId }, 0.5);
+        return;
+      }
+      const disposition = getEnvBridgeClient().handleMachineResult(client, frame);
+      if (disposition === 'unverified') {
+        dropFrame('env_bridge_result_unverified', { grantId: frame.grantId, frameType: frame.type }, 0.8);
+      } else if (disposition !== 'delivered') {
+        dropFrame('env_bridge_result_dropped', { grantId: frame.grantId, frameType: frame.type, disposition }, 0.3);
+      }
+      return;
+    }
+    // hello again, pty_opened / pty_data / pty_exit (M2): dropped, never crash.
+    dropFrame('env_bridge_frame_dropped', { frameType: frame.type, reason: frame.type === 'hello' ? 'duplicate_hello' : 'unsupported_in_m1' }, 0.2);
+  };
+
+  // Handle incoming messages
+  client.on('message', (data) => {
+    try {
+      // SECURITY CHECK 5: Validate message size
+      const sizeValidation = validateMessageSize(data);
+      if (!sizeValidation.valid) {
+        dropFrame('ws_message_too_large', { size: sizeValidation.size, maxSize: sizeValidation.maxSize });
+        if (session.status !== 'authorized') client.close(1008, 'Hello required');
+        return;
+      }
+
+      // Parse and validate with the closed frame set (the codec is the schema: size in bytes → JSON → shape)
+      const decoded = decodeEnvBridgeFrame(data.toString(), ENV_BRIDGE_FRAME_LIMITS);
+      if (!decoded.ok) {
+        dropFrame('ws_message_validation_failed', { reason: decoded.reason });
+        if (session.status !== 'authorized') client.close(1008, 'Hello required');
+        return;
+      }
+      const frame = decoded.frame;
+
+      // Direction: the machine may only send machine→server frames (invariant 6).
+      if (!isEnvBridgeMachineFrame(frame)) {
+        dropFrame('env_bridge_wrong_direction_frame', { frameType: frame.type }, 0.5);
+        if (session.status !== 'authorized') client.close(1008, 'Hello required');
+        return;
+      }
+
+      if (session.status === 'connecting') {
+        // The first frame must be the hello. Anything else is not a valid hello.
+        if (frame.type !== 'hello') {
+          refuse('env_bridge_hello_required', `first frame was ${frame.type}`, 'Hello required', 0.5);
+          return;
+        }
+        void onHello(frame).catch((error) => {
+          auditRequest(request, {
+            eventType: 'security.anomaly.detected',
+            userId,
+            resourceType: RESOURCE_TYPE,
+            resourceId: envId,
+            riskScore: 0.3,
+            details: { originalEvent: 'env_bridge_hello_error', error: error instanceof Error ? error.message : String(error) },
+          });
+          client.close(1008, 'Authentication error');
+        });
+        return;
+      }
+
+      if (session.status === 'hello_sent') {
+        // A hello is being verified; nothing else is accepted meanwhile.
+        dropFrame('env_bridge_frame_dropped', { frameType: frame.type, reason: 'hello_pending' }, 0.3);
+        return;
+      }
+
+      // Authorized (or revoked): the reducer decides; this route executes.
+      const reduction = reduceBridgeSession(session, { type: 'frame', frame });
+      session = reduction.state;
+      for (const effect of reduction.effects) {
+        if (effect.type === 'dispatch') onAuthorizedFrame(effect.frame);
+        else if (effect.type === 'reject') dropFrame('env_bridge_frame_rejected', { frameType: frame.type, reason: effect.reason }, 0.3);
+      }
+    } catch (error) {
+      auditRequest(request, {
+        eventType: 'security.anomaly.detected',
+        userId,
+        resourceType: RESOURCE_TYPE,
+        resourceId: envId,
+        riskScore: 0.3,
+        details: { originalEvent: 'ws_message_parse_error', error: error instanceof Error ? error.message : String(error) },
+      });
+    }
+  });
+
+  // Handle client disconnect
+  client.on('close', (code, reason) => {
+    clearTimeout(helloTimer);
+    if (pingTimer) clearInterval(pingTimer);
+    // Only audit abnormal closes. Normal closes (1000 = clean, 1001 = going away)
+    // are routine transport-level lifecycle events, not security events.
+    const isNormalClose = code === 1000 || code === 1001;
+    if (!isNormalClose) {
+      auditRequest(request, {
+        eventType: 'security.anomaly.detected',
+        userId,
+        resourceType: RESOURCE_TYPE,
+        resourceId: envId,
+        riskScore: 0.3,
+        details: { originalEvent: 'ws_connection_closed', code, reason: reason.toString() },
+      });
+    }
+    // CAS on identity inside: a superseded socket closing late evicts nothing
+    // and cancels nothing; the LIVE socket's loss cancels this env's in-flight
+    // requests through the bridge client's lost listener.
+    unregisterEnvConnection(envId, client);
+  });
+
+  // Handle errors
+  client.on('error', (error) => {
+    auditRequest(request, {
+      eventType: 'security.anomaly.detected',
+      userId,
+      resourceType: RESOURCE_TYPE,
+      resourceId: envId,
+      riskScore: 0.3,
+      details: { originalEvent: 'ws_error', error: error instanceof Error ? error.message : String(error) },
+    });
+  });
+}
+
+// Fallback for non-WebSocket requests
+export function GET(): Response {
+  return new Response('WebSocket endpoint - use WebSocket protocol to connect', {
+    status: 426,
+    headers: {
+      Upgrade: 'websocket',
+      'X-Content-Type-Options': 'nosniff',
+      'X-Frame-Options': 'DENY',
+      'Content-Security-Policy': "default-src 'none'",
+    },
+  });
+}

--- a/apps/web/src/app/api/env-bridge/ws/route.ts
+++ b/apps/web/src/app/api/env-bridge/ws/route.ts
@@ -378,6 +378,8 @@ export async function UPGRADE(client: WebSocket, server: WebSocketServer, reques
       const disposition = getEnvBridgeClient().handleMachineResult(client, frame);
       if (disposition === 'unverified') {
         dropFrame('env_bridge_result_unverified', { grantId: frame.grantId, frameType: frame.type }, 0.8);
+      } else if (disposition === 'dropped_wrong_env') {
+        dropFrame('env_bridge_result_wrong_env', { grantId: frame.grantId, frameType: frame.type }, 0.8);
       } else if (disposition !== 'delivered') {
         dropFrame('env_bridge_result_dropped', { grantId: frame.grantId, frameType: frame.type, disposition }, 0.3);
       }

--- a/apps/web/src/app/api/env-bridge/ws/route.ts
+++ b/apps/web/src/app/api/env-bridge/ws/route.ts
@@ -25,15 +25,11 @@ import { verifyHello, isMachineResultFrame } from '@pagespace/lib/env-bridge/mac
 import { getDriveEnvStore } from '@/lib/drive-envs/drive-envs-runtime';
 import { getEnvBridgeClient } from '@/lib/env-bridge/bridge-client';
 import { decodePinnedPublicKey, ed25519Verify } from '@/lib/env-bridge/crypto';
+import { ENV_BRIDGE_HELLO_TIMEOUT_MS, ENV_BRIDGE_PING_INTERVAL_MS } from '@/lib/env-bridge/ws-route-config';
 
 // Initialize cleanup interval on module load
 // This prevents memory leaks from stale connections
 startEnvCleanupInterval();
-
-/** How long a socket may sit without a valid signed hello before it is closed. */
-export const ENV_BRIDGE_HELLO_TIMEOUT_MS = 10_000;
-/** Server → daemon heartbeat cadence; well inside LOCAL_ENV_HEARTBEAT_WINDOW_MS (90 s). */
-export const ENV_BRIDGE_PING_INTERVAL_MS = 30_000;
 
 const RESOURCE_TYPE = 'env_bridge_websocket';
 const DRIVE_ENV_RESOURCE = 'drive_env';

--- a/apps/web/src/lib/drive-envs/drive-envs-runtime.ts
+++ b/apps/web/src/lib/drive-envs/drive-envs-runtime.ts
@@ -48,6 +48,7 @@ import {
 } from '@pagespace/lib/services/drive-envs/drive-envs';
 import type { DriveEnvDTO } from '@pagespace/lib/drive-envs/env-contract';
 import { getSandboxHost } from '@/lib/agent-workspaces/sandbox-host-runtime';
+import { readEnvLiveConnection } from '@/lib/websocket/ws-env-connections';
 import { createHash, createPublicKey, randomBytes, verify as nodeVerify } from 'crypto';
 import { createId } from '@paralleldrive/cuid2';
 import { loadServerSigningKey } from '@pagespace/lib/auth/env-bridge-signing-key';
@@ -226,10 +227,10 @@ export async function redeemEnvChallenge(input: { enrollmentId: string; response
 
 export async function listEnvsInDrive(driveId: string): Promise<DriveEnvDTO[]> {
   const store = await getDriveEnvStore();
-  // `liveConnection` is this replica's bridge-socket registry. Until the
-  // env-bridge socket route lands there is no registry, so a local env's status
-  // is derived from its heartbeat alone (`deriveLocalEnvStatus`).
-  return listDriveEnvs({ driveId, deps: { store, now: () => new Date(), liveConnection: () => null } });
+  // `liveConnection` is THIS replica's bridge-socket registry (t07): a socket
+  // held here wins; otherwise a local env's status derives from its heartbeat
+  // (`deriveLocalEnvStatus`), which whichever replica holds the socket writes.
+  return listDriveEnvs({ driveId, deps: { store, now: () => new Date(), liveConnection: readEnvLiveConnection } });
 }
 
 export async function renameEnv(input: { envId: string; name: string }): Promise<RenameDriveEnvResult> {
@@ -261,7 +262,7 @@ export async function ensureEnvSandboxForSession(input: {
     envId: input.envId,
     intent: input.intent,
     requesterId: input.requesterId,
-    deps: { store, host, resolvePayer: resolveDriveEnvPayer },
+    deps: { store, host, resolvePayer: resolveDriveEnvPayer, liveConnection: readEnvLiveConnection },
   });
 }
 
@@ -277,7 +278,7 @@ export async function gateLocalEnvBind(input: { envId: string; requesterId: stri
   const store = await getDriveEnvStore();
   const row = await store.findById(input.envId);
   if (!row) return { ok: false, refusal: 'revoked' };
-  return gateLocalEnvForRequester({ row, requesterId: input.requesterId, deps: { store, resolvePayer: resolveDriveEnvPayer } });
+  return gateLocalEnvForRequester({ row, requesterId: input.requesterId, deps: { store, resolvePayer: resolveDriveEnvPayer, liveConnection: readEnvLiveConnection } });
 }
 
 /**
@@ -305,7 +306,7 @@ export async function rebuildEnv(input: { envId: string; requesterId: string }):
           // `create` arm — through the same CAS every other provisioner runs.
           intent: 'ensure',
           requesterId: input.requesterId,
-          deps: { store, host, resolvePayer: resolveDriveEnvPayer },
+          deps: { store, host, resolvePayer: resolveDriveEnvPayer, liveConnection: readEnvLiveConnection },
         }),
     },
   });

--- a/apps/web/src/lib/drive-envs/drive-envs-runtime.ts
+++ b/apps/web/src/lib/drive-envs/drive-envs-runtime.ts
@@ -24,7 +24,7 @@ import {
   gateLocalEnvForRequester,
   type DriveEnvPayer,
 } from '@pagespace/lib/services/drive-envs/env-provision-deps';
-import type { LocalEnvGateVerdict } from '@pagespace/lib/services/drive-envs/local-env-gate';
+import type { LiveConnectionReader, LocalEnvGateVerdict } from '@pagespace/lib/services/drive-envs/local-env-gate';
 import type {
   EnsureSpriteHolderSandboxResult,
   SpriteHolderProvisionIntent,
@@ -49,7 +49,6 @@ import {
 import type { DriveEnvDTO } from '@pagespace/lib/drive-envs/env-contract';
 import type { RevokeLocalDriveEnvResult } from '@pagespace/lib/services/drive-envs/local-env-revoke';
 import { getSandboxHost } from '@/lib/agent-workspaces/sandbox-host-runtime';
-import { readEnvLiveConnection } from '@/lib/websocket/ws-env-connections';
 import { createHash, createPublicKey, randomBytes, verify as nodeVerify } from 'crypto';
 import { createId } from '@paralleldrive/cuid2';
 import { loadServerSigningKey } from '@pagespace/lib/auth/env-bridge-signing-key';
@@ -74,6 +73,17 @@ export type { DriveEnvDTO };
 // ---------------------------------------------------------------------------
 
 let envStorePromise: Promise<DriveEnvStore> | null = null;
+
+/**
+ * This replica's bridge-socket registry reading, loaded lazily: the registry
+ * builds its logger at import, and this runtime is imported by many suites
+ * that stub the logging module — the same reason the sandbox host is loaded
+ * with `await import()` rather than statically.
+ */
+async function liveConnectionReader(): Promise<LiveConnectionReader> {
+  const { readEnvLiveConnection } = await import('@/lib/websocket/ws-env-connections');
+  return readEnvLiveConnection;
+}
 
 export function getDriveEnvStore(): Promise<DriveEnvStore> {
   envStorePromise ??= createDbDriveEnvStore();
@@ -227,11 +237,11 @@ export async function redeemEnvChallenge(input: { enrollmentId: string; response
 }
 
 export async function listEnvsInDrive(driveId: string): Promise<DriveEnvDTO[]> {
-  const store = await getDriveEnvStore();
+  const [store, liveConnection] = await Promise.all([getDriveEnvStore(), liveConnectionReader()]);
   // `liveConnection` is THIS replica's bridge-socket registry (t07): a socket
   // held here wins; otherwise a local env's status derives from its heartbeat
   // (`deriveLocalEnvStatus`), which whichever replica holds the socket writes.
-  return listDriveEnvs({ driveId, deps: { store, now: () => new Date(), liveConnection: readEnvLiveConnection } });
+  return listDriveEnvs({ driveId, deps: { store, now: () => new Date(), liveConnection } });
 }
 
 export async function renameEnv(input: { envId: string; name: string }): Promise<RenameDriveEnvResult> {
@@ -268,12 +278,12 @@ export async function ensureEnvSandboxForSession(input: {
   intent: SpriteHolderProvisionIntent;
   requesterId: string;
 }): Promise<EnsureSpriteHolderSandboxResult> {
-  const [store, host] = await Promise.all([getDriveEnvStore(), getSandboxHost()]);
+  const [store, host, liveConnection] = await Promise.all([getDriveEnvStore(), getSandboxHost(), liveConnectionReader()]);
   return ensureDriveEnvSandbox({
     envId: input.envId,
     intent: input.intent,
     requesterId: input.requesterId,
-    deps: { store, host, resolvePayer: resolveDriveEnvPayer, liveConnection: readEnvLiveConnection },
+    deps: { store, host, resolvePayer: resolveDriveEnvPayer, liveConnection },
   });
 }
 
@@ -286,10 +296,10 @@ export async function ensureEnvSandboxForSession(input: {
  * the two reads.
  */
 export async function gateLocalEnvBind(input: { envId: string; requesterId: string }): Promise<LocalEnvGateVerdict> {
-  const store = await getDriveEnvStore();
+  const [store, liveConnection] = await Promise.all([getDriveEnvStore(), liveConnectionReader()]);
   const row = await store.findById(input.envId);
   if (!row) return { ok: false, refusal: 'revoked' };
-  return gateLocalEnvForRequester({ row, requesterId: input.requesterId, deps: { store, resolvePayer: resolveDriveEnvPayer, liveConnection: readEnvLiveConnection } });
+  return gateLocalEnvForRequester({ row, requesterId: input.requesterId, deps: { store, resolvePayer: resolveDriveEnvPayer, liveConnection } });
 }
 
 /**
@@ -302,7 +312,7 @@ export async function gateLocalEnvBind(input: { envId: string; requesterId: stri
  * exactly the same ones.
  */
 export async function rebuildEnv(input: { envId: string; requesterId: string }): Promise<RebuildDriveEnvResult> {
-  const [store, host] = await Promise.all([getDriveEnvStore(), getSandboxHost()]);
+  const [store, host, liveConnection] = await Promise.all([getDriveEnvStore(), getSandboxHost(), liveConnectionReader()]);
   return rebuildDriveEnv({
     envId: input.envId,
     deps: {
@@ -317,7 +327,7 @@ export async function rebuildEnv(input: { envId: string; requesterId: string }):
           // `create` arm — through the same CAS every other provisioner runs.
           intent: 'ensure',
           requesterId: input.requesterId,
-          deps: { store, host, resolvePayer: resolveDriveEnvPayer, liveConnection: readEnvLiveConnection },
+          deps: { store, host, resolvePayer: resolveDriveEnvPayer, liveConnection },
         }),
     },
   });

--- a/apps/web/src/lib/drive-envs/drive-envs-runtime.ts
+++ b/apps/web/src/lib/drive-envs/drive-envs-runtime.ts
@@ -47,6 +47,7 @@ import {
   type RebuildDriveEnvResult,
 } from '@pagespace/lib/services/drive-envs/drive-envs';
 import type { DriveEnvDTO } from '@pagespace/lib/drive-envs/env-contract';
+import type { RevokeLocalDriveEnvResult } from '@pagespace/lib/services/drive-envs/local-env-revoke';
 import { getSandboxHost } from '@/lib/agent-workspaces/sandbox-host-runtime';
 import { readEnvLiveConnection } from '@/lib/websocket/ws-env-connections';
 import { createHash, createPublicKey, randomBytes, verify as nodeVerify } from 'crypto';
@@ -236,6 +237,16 @@ export async function listEnvsInDrive(driveId: string): Promise<DriveEnvDTO[]> {
 export async function renameEnv(input: { envId: string; name: string }): Promise<RenameDriveEnvResult> {
   const store = await getDriveEnvStore();
   return renameDriveEnv({ envId: input.envId, name: input.name, deps: { store, now: () => new Date() } });
+}
+
+/**
+ * Revoke a LOCAL env's machine (Codex C4, all three legs) — the button the M1
+ * exit gate presses through DELETE. Re-exported from the env-bridge adapter so
+ * the route has one seam to mock.
+ */
+export async function revokeEnv(input: { envId: string; reason: string }): Promise<RevokeLocalDriveEnvResult> {
+  const { revokeLocalEnv } = await import('@/lib/env-bridge/revoke');
+  return revokeLocalEnv(input);
 }
 
 export async function deleteEnv(input: { envId: string; force: boolean }): Promise<DeleteDriveEnvResult> {

--- a/apps/web/src/lib/env-bridge/__tests__/bridge-client.test.ts
+++ b/apps/web/src/lib/env-bridge/__tests__/bridge-client.test.ts
@@ -1,0 +1,216 @@
+/**
+ * The bridge client: one granted request end to end against fake sockets and
+ * fake timers. The exit-criterion row lives here — a result whose machine
+ * signature does not verify is NOT delivered, the pending request fails with
+ * a typed `unverified_result`, and nothing the machine sent reaches the caller.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import type { WebSocket } from 'ws';
+import { generateKeyPairSync, createPrivateKey, createPublicKey, createHash, sign as nodeSign } from 'node:crypto';
+
+vi.mock('@pagespace/lib/logging/logger-config', () => ({ logger: { child: () => ({ info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() }) } }));
+vi.mock('@/lib/websocket/ws-env-connections', () => ({ getAuthorizedEnvConnection: vi.fn(), getEnvConnectionMetadata: vi.fn(), onEnvConnectionLost: vi.fn() }));
+vi.mock('@pagespace/lib/auth/env-bridge-signing-key', () => ({ loadServerSigningKeyring: vi.fn() }));
+
+import { decodeFrame, type Frame } from '@pagespace/lib/env-bridge/frame-codec';
+import { encodeResultForSigning, resultHashForFrame, type MachineResultFrame } from '@pagespace/lib/env-bridge/machine-signatures';
+import { parseServerSigningKeyring, type SigningKeyPrimitives } from '@pagespace/lib/env-bridge/server-signing-key';
+import { DEFAULT_TIMEOUT_DEFAULTS } from '@pagespace/lib/env-bridge/resolve-timeout';
+import { RequestCorrelator } from '../correlator';
+import { EnvBridgeClient, EnvBridgeError, type EnvBridgeClientDeps, type EnvSocketFacts } from '../bridge-client';
+import { envBridgeHash } from '../crypto';
+import { verifyResultFromMachine } from '../result-verifier';
+
+const primitives: SigningKeyPrimitives = {
+  importPrivateKey: (pkcs8) => {
+    const privateKey = createPrivateKey({ key: Buffer.from(pkcs8), type: 'pkcs8', format: 'der' });
+    return { publicKey: new Uint8Array(createPublicKey(privateKey).export({ type: 'spki', format: 'der' })), sign: (m) => new Uint8Array(nodeSign(null, m, privateKey)) };
+  },
+  hash: (bytes) => createHash('sha256').update(bytes).digest('hex'),
+};
+const serverRaw = generateKeyPairSync('ed25519').privateKey.export({ type: 'pkcs8', format: 'der' }).toString('base64');
+const ringVerdict = parseServerSigningKeyring({ single: serverRaw, multi: undefined }, primitives);
+if (!ringVerdict.ok) throw new Error('ring');
+const ring = ringVerdict.keyring;
+const machine = generateKeyPairSync('ed25519');
+const rogue = generateKeyPairSync('ed25519');
+const machinePublicKey = machine.publicKey.export({ type: 'spki', format: 'der' }).toString('base64');
+
+type FakeSocket = WebSocket & { readyState: number; sent: string[] };
+function socket(): FakeSocket {
+  const sent: string[] = [];
+  return { readyState: 1, sent, send: (data: string) => sent.push(data), close: vi.fn(), on: vi.fn() } as unknown as FakeSocket;
+}
+
+const principal = { userId: 'user-1', sessionId: 'sess-1', conversationId: 'conv-1' };
+
+function signedResult(body: Omit<MachineResultFrame, 'sig'>, key = machine): MachineResultFrame {
+  const resultHash = resultHashForFrame({ ...body, sig: '' } as MachineResultFrame, envBridgeHash);
+  return { ...body, sig: Buffer.from(nodeSign(null, encodeResultForSigning({ grantId: body.grantId, resultHash }), key.privateKey)).toString('base64') } as MachineResultFrame;
+}
+
+describe('EnvBridgeClient', () => {
+  let counter: number;
+  let sockets: Map<string, FakeSocket>;
+  let facts: Map<FakeSocket, EnvSocketFacts>;
+  let unverified: Array<{ envId: string; grantId: string; reason: string }>;
+  let client: EnvBridgeClient;
+  let correlator: RequestCorrelator<MachineResultFrame>;
+
+  function connect(envId: string, over: Partial<EnvSocketFacts> = {}): FakeSocket {
+    const ws = socket();
+    sockets.set(envId, ws);
+    facts.set(ws, { envId, machinePublicKey, serverKeyId: ring.current.keyId, ...over });
+    return ws;
+  }
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    counter = 0;
+    sockets = new Map();
+    facts = new Map();
+    unverified = [];
+    correlator = new RequestCorrelator<MachineResultFrame>();
+    const deps: EnvBridgeClientDeps = {
+      correlator,
+      getAuthorizedConnection: (envId) => sockets.get(envId),
+      getSocketFacts: (ws) => facts.get(ws as FakeSocket),
+      keyring: () => ring,
+      now: () => 1_760_000_000_000,
+      ids: { grantId: () => `g-${++counter}`, nonce: () => `n-${counter}` },
+      onUnverified: (info) => unverified.push({ envId: info.envId, grantId: info.grantId, reason: info.reason }),
+    };
+    client = new EnvBridgeClient(deps);
+  });
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  function sentFrame(ws: FakeSocket, index = 0): Frame {
+    const decoded = decodeFrame(ws.sent[index]!, { maxFrameBytes: 1024 * 1024 });
+    if (!decoded.ok) throw new Error(decoded.reason);
+    return decoded.frame;
+  }
+
+  it('given an authorized socket, should sign the grant with the pinned key and send the encoded frame over THAT socket', async () => {
+    const ws = connect('env-1');
+    const pending = client.sendGrant({ envId: 'env-1', frame: { type: 'grant_fs_read', paths: ['/a'] }, principal });
+    pending.catch(() => {});
+    expect(ws.sent).toHaveLength(1);
+    const frame = sentFrame(ws);
+    expect(frame.type).toBe('grant_fs_read');
+    if (frame.type !== 'grant_fs_read') throw new Error('type');
+    expect(frame.grant).toMatchObject({ grantId: 'g-1', envId: 'env-1', op: 'fs_read', principal });
+    expect(frame.sig.length).toBeGreaterThan(0);
+    expect(client.pendingCountForEnv('env-1')).toBe(1);
+  });
+
+  it('given a result signed by the pinned machine key, should deliver it to the caller', async () => {
+    const ws = connect('env-1');
+    const pending = client.sendGrant({ envId: 'env-1', frame: { type: 'grant_exec', cmd: 'ls' }, principal });
+    const result = signedResult({ type: 'exec_result', grantId: 'g-1', exitCode: 0, stdoutB64: 'b2s=', stderrB64: '', truncated: false });
+    expect(client.handleMachineResult(ws, result)).toBe('delivered');
+    await expect(pending).resolves.toEqual(result);
+    expect(unverified).toEqual([]);
+  });
+
+  it('EXIT CRITERION — given an exec_result whose machine signature does not verify, should NOT deliver it: the request fails with typed unverified_result and the event is surfaced', async () => {
+    const ws = connect('env-1');
+    const pending = client.sendGrant({ envId: 'env-1', frame: { type: 'grant_exec', cmd: 'ls' }, principal });
+    const forged = signedResult({ type: 'exec_result', grantId: 'g-1', exitCode: 0, stdoutB64: 'cHduZWQ=', stderrB64: '', truncated: false }, rogue);
+    expect(client.handleMachineResult(ws, forged)).toBe('unverified');
+    await expect(pending).rejects.toMatchObject({ kind: 'unverified_result' });
+    await expect(pending).rejects.toBeInstanceOf(EnvBridgeError);
+    expect(unverified).toEqual([{ envId: 'env-1', grantId: 'g-1', reason: 'bad_signature' }]);
+    expect(client.pendingCountForEnv('env-1')).toBe(0);
+  });
+
+  it('given a correctly signed result whose payload was edited in flight, should NOT deliver it either (every field is under the hash)', async () => {
+    const ws = connect('env-1');
+    const pending = client.sendGrant({ envId: 'env-1', frame: { type: 'grant_exec', cmd: 'ls' }, principal });
+    const genuine = signedResult({ type: 'exec_result', grantId: 'g-1', exitCode: 1, stdoutB64: '', stderrB64: 'ZGVuaWVk', truncated: false });
+    expect(client.handleMachineResult(ws, { ...genuine, exitCode: 0 })).toBe('unverified');
+    await expect(pending).rejects.toMatchObject({ kind: 'unverified_result' });
+  });
+
+  it('given a grant_denied signed by the machine, should deliver it as the (typed) answer', async () => {
+    const ws = connect('env-1');
+    const pending = client.sendGrant({ envId: 'env-1', frame: { type: 'grant_fs_write', files: [{ path: '/a', contentB64: 'aGk=' }] }, principal });
+    const denied = signedResult({ type: 'grant_denied', grantId: 'g-1', reason: 'policy_denied' });
+    expect(client.handleMachineResult(ws, denied)).toBe('delivered');
+    await expect(pending).resolves.toEqual(denied);
+  });
+
+  it('given a result for a grant that is not pending, should drop it WITHOUT doing crypto and resolve nothing', () => {
+    const ws = connect('env-1');
+    const result = signedResult({ type: 'exec_result', grantId: 'g-unknown', exitCode: 0, stdoutB64: '', stderrB64: '', truncated: false });
+    expect(client.handleMachineResult(ws, result)).toBe('dropped_unknown_grant');
+    // And from a socket the registry does not know: dropped before anything else.
+    expect(client.handleMachineResult(socket(), result)).toBe('dropped_unregistered_socket');
+  });
+
+  it('given a result arriving on ANOTHER env\'s socket, should verify under THAT socket\'s pinned key — a machine cannot answer for another machine', async () => {
+    const wsA = connect('env-a');
+    connect('env-b', { machinePublicKey: rogue.publicKey.export({ type: 'spki', format: 'der' }).toString('base64') });
+    const wsB = sockets.get('env-b')!;
+    const pending = client.sendGrant({ envId: 'env-a', frame: { type: 'grant_exec', cmd: 'ls' }, principal });
+    const result = signedResult({ type: 'exec_result', grantId: 'g-1', exitCode: 0, stdoutB64: '', stderrB64: '', truncated: false });
+    // Signed by env-a's machine but delivered over env-b's socket: env-b's key does not verify it.
+    expect(client.handleMachineResult(wsB, result)).toBe('unverified');
+    await expect(pending).rejects.toMatchObject({ kind: 'unverified_result' });
+    expect(wsA.sent).toHaveLength(1);
+  });
+
+  it('given no authorized socket for the env, should fail typed not_connected and send nothing', async () => {
+    await expect(client.sendGrant({ envId: 'env-x', frame: { type: 'grant_exec', cmd: 'ls' }, principal })).rejects.toMatchObject({ kind: 'not_connected' });
+  });
+
+  it('given an enrollment pinned to a key that is no longer loaded, should fail typed signing_key_unavailable and send nothing', async () => {
+    const ws = connect('env-1', { serverKeyId: 'rotated-out' });
+    await expect(client.sendGrant({ envId: 'env-1', frame: { type: 'grant_exec', cmd: 'ls' }, principal })).rejects.toMatchObject({ kind: 'signing_key_unavailable' });
+    expect(ws.sent).toHaveLength(0);
+  });
+
+  it('given a grant_exec with timeoutMs 120_000, should wait ≥120 s (resolveTimeout), never the MCP bridge\'s 30 s', async () => {
+    connect('env-1');
+    const pending = client.sendGrant({ envId: 'env-1', frame: { type: 'grant_exec', cmd: 'sleep', args: ['100'], timeoutMs: 120_000 }, principal });
+    let state = 'pending';
+    pending.then(() => (state = 'resolved'), () => (state = 'rejected'));
+    await vi.advanceTimersByTimeAsync(30_000);
+    expect(state).toBe('pending');
+    await vi.advanceTimersByTimeAsync(90_000 - 1);
+    expect(state).toBe('pending');
+    await vi.advanceTimersByTimeAsync(DEFAULT_TIMEOUT_DEFAULTS.correlatorMarginMs + 1);
+    expect(state).toBe('rejected');
+    await expect(pending).rejects.toMatchObject({ kind: 'timeout' });
+  });
+
+  it('given the env\'s live socket is lost, cancelEnv should fail its in-flight requests with typed disconnected and leave other envs alone', async () => {
+    connect('env-a');
+    connect('env-b');
+    const a = client.sendGrant({ envId: 'env-a', frame: { type: 'grant_exec', cmd: 'ls' }, principal });
+    const b = client.sendGrant({ envId: 'env-b', frame: { type: 'grant_exec', cmd: 'ls' }, principal });
+    b.catch(() => {});
+    expect(client.cancelEnv('env-a')).toBe(1);
+    await expect(a).rejects.toMatchObject({ kind: 'disconnected' });
+    expect(client.pendingCountForEnv('env-b')).toBe(1);
+  });
+
+  it('given a socket whose send throws, should fail typed send_failed and leave nothing pending', async () => {
+    const ws = connect('env-1');
+    (ws as unknown as { send: () => void }).send = () => {
+      throw new Error('EPIPE');
+    };
+    await expect(client.sendGrant({ envId: 'env-1', frame: { type: 'grant_exec', cmd: 'ls' }, principal })).rejects.toMatchObject({ kind: 'send_failed' });
+    expect(client.pendingCountForEnv('env-1')).toBe(0);
+  });
+});
+
+describe('verifyResultFromMachine — the adapter', () => {
+  it('given a pinned key that is not decodable, should answer bad_public_key rather than throw', () => {
+    const frame = signedResult({ type: 'grant_denied', grantId: 'g', reason: 'x' });
+    expect(verifyResultFromMachine({ frame, machinePublicKey: null })).toEqual({ ok: false, reason: 'bad_public_key' });
+    expect(verifyResultFromMachine({ frame, machinePublicKey: '!!' })).toEqual({ ok: false, reason: 'bad_public_key' });
+    expect(verifyResultFromMachine({ frame, machinePublicKey })).toMatchObject({ ok: true });
+  });
+});

--- a/apps/web/src/lib/env-bridge/__tests__/bridge-client.test.ts
+++ b/apps/web/src/lib/env-bridge/__tests__/bridge-client.test.ts
@@ -43,6 +43,9 @@ function socket(): FakeSocket {
 }
 
 const principal = { userId: 'user-1', sessionId: 'sess-1', conversationId: 'conv-1' };
+const flushPromises = async () => {
+  for (let i = 0; i < 5; i += 1) await Promise.resolve();
+};
 
 /** Distributive: `Omit` over the union would collapse it to the common keys. */
 type UnsignedResult<T = MachineResultFrame> = T extends unknown ? Omit<T, 'sig'> : never;
@@ -152,16 +155,33 @@ describe('EnvBridgeClient', () => {
     expect(client.handleMachineResult(socket(), result)).toBe('dropped_unregistered_socket');
   });
 
-  it('given a result arriving on ANOTHER env\'s socket, should verify under THAT socket\'s pinned key — a machine cannot answer for another machine', async () => {
+  it('given env B signs a result for env A\'s pending grant WITH ITS OWN pinned key and sends it on its own socket, should refuse it before crypto and leave A\'s request pending (Codex P1: the sending socket must be the env that owns the grant)', async () => {
     const wsA = connect('env-a');
-    connect('env-b', { machinePublicKey: rogue.publicKey.export({ type: 'spki', format: 'der' }).toString('base64') });
-    const wsB = sockets.get('env-b')!;
+    const wsB = connect('env-b', { machinePublicKey: rogue.publicKey.export({ type: 'spki', format: 'der' }).toString('base64') });
     const pending = client.sendGrant({ envId: 'env-a', frame: { type: 'grant_exec', cmd: 'ls' }, principal });
-    const result = signedResult({ type: 'exec_result', grantId: 'g-1', exitCode: 0, stdoutB64: '', stderrB64: '', truncated: false });
-    // Signed by env-a's machine but delivered over env-b's socket: env-b's key does not verify it.
-    expect(client.handleMachineResult(wsB, result)).toBe('unverified');
-    await expect(pending).rejects.toMatchObject({ kind: 'unverified_result' });
-    expect(wsA.sent).toHaveLength(1);
+    let state = 'pending';
+    pending.then(() => (state = 'resolved'), () => (state = 'rejected'));
+    // B's key is the one pinned for B's socket — this WOULD verify if the socket's key were the only check.
+    const forgedByB = signedResult({ type: 'exec_result', grantId: 'g-1', exitCode: 0, stdoutB64: 'cHduZWQ=', stderrB64: '', truncated: false }, rogue);
+    expect(client.handleMachineResult(wsB, forgedByB)).toBe('dropped_wrong_env');
+    await flushPromises();
+    expect(state).toBe('pending');
+    expect(client.pendingCountForEnv('env-a')).toBe(1);
+    expect(unverified).toEqual([{ envId: 'env-b', grantId: 'g-1', reason: 'wrong_env' }]);
+    // The real owner can still answer.
+    const genuine = signedResult({ type: 'exec_result', grantId: 'g-1', exitCode: 0, stdoutB64: 'b2s=', stderrB64: '', truncated: false });
+    expect(client.handleMachineResult(wsA, genuine)).toBe('delivered');
+    await expect(pending).resolves.toEqual(genuine);
+  });
+
+  it('given a result for env A\'s pending grant arriving on env B\'s socket but signed with A\'s key, should still be refused as wrong env (the socket, not the signature, names the sender)', async () => {
+    connect('env-a');
+    const wsB = connect('env-b', { machinePublicKey: rogue.publicKey.export({ type: 'spki', format: 'der' }).toString('base64') });
+    const pending = client.sendGrant({ envId: 'env-a', frame: { type: 'grant_exec', cmd: 'ls' }, principal });
+    pending.catch(() => {});
+    const signedByA = signedResult({ type: 'exec_result', grantId: 'g-1', exitCode: 0, stdoutB64: '', stderrB64: '', truncated: false });
+    expect(client.handleMachineResult(wsB, signedByA)).toBe('dropped_wrong_env');
+    expect(client.pendingCountForEnv('env-a')).toBe(1);
   });
 
   it('given no authorized socket for the env, should fail typed not_connected and send nothing', async () => {

--- a/apps/web/src/lib/env-bridge/__tests__/bridge-client.test.ts
+++ b/apps/web/src/lib/env-bridge/__tests__/bridge-client.test.ts
@@ -44,7 +44,10 @@ function socket(): FakeSocket {
 
 const principal = { userId: 'user-1', sessionId: 'sess-1', conversationId: 'conv-1' };
 
-function signedResult(body: Omit<MachineResultFrame, 'sig'>, key = machine): MachineResultFrame {
+/** Distributive: `Omit` over the union would collapse it to the common keys. */
+type UnsignedResult<T = MachineResultFrame> = T extends unknown ? Omit<T, 'sig'> : never;
+
+function signedResult(body: UnsignedResult, key = machine): MachineResultFrame {
   const resultHash = resultHashForFrame({ ...body, sig: '' } as MachineResultFrame, envBridgeHash);
   return { ...body, sig: Buffer.from(nodeSign(null, encodeResultForSigning({ grantId: body.grantId, resultHash }), key.privateKey)).toString('base64') } as MachineResultFrame;
 }
@@ -128,7 +131,7 @@ describe('EnvBridgeClient', () => {
   it('given a correctly signed result whose payload was edited in flight, should NOT deliver it either (every field is under the hash)', async () => {
     const ws = connect('env-1');
     const pending = client.sendGrant({ envId: 'env-1', frame: { type: 'grant_exec', cmd: 'ls' }, principal });
-    const genuine = signedResult({ type: 'exec_result', grantId: 'g-1', exitCode: 1, stdoutB64: '', stderrB64: 'ZGVuaWVk', truncated: false });
+    const genuine = signedResult({ type: 'exec_result', grantId: 'g-1', exitCode: 1, stdoutB64: '', stderrB64: 'ZGVuaWVk', truncated: false }) as Extract<MachineResultFrame, { type: 'exec_result' }>;
     expect(client.handleMachineResult(ws, { ...genuine, exitCode: 0 })).toBe('unverified');
     await expect(pending).rejects.toMatchObject({ kind: 'unverified_result' });
   });

--- a/apps/web/src/lib/env-bridge/__tests__/correlator.test.ts
+++ b/apps/web/src/lib/env-bridge/__tests__/correlator.test.ts
@@ -1,0 +1,186 @@
+/**
+ * The shared request/reply correlator — the id-correlated pending map both
+ * bridges (MCP desktop, env bridge) sit on. Fake timers throughout: every
+ * deadline here is asserted to the millisecond, never waited for.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import type { GrantFrame } from '@pagespace/lib/env-bridge/grant-args';
+import { DEFAULT_TIMEOUT_DEFAULTS } from '@pagespace/lib/env-bridge/resolve-timeout';
+import { RequestCorrelator, CorrelationError, grantCorrelatorTimeoutMs } from '../correlator';
+
+function settled<T>(promise: Promise<T>): { state: () => 'pending' | 'resolved' | 'rejected'; value: () => T | undefined; error: () => unknown } {
+  let state: 'pending' | 'resolved' | 'rejected' = 'pending';
+  let value: T | undefined;
+  let error: unknown;
+  promise.then(
+    (v) => {
+      state = 'resolved';
+      value = v;
+    },
+    (e) => {
+      state = 'rejected';
+      error = e;
+    },
+  );
+  return { state: () => state, value: () => value, error: () => error };
+}
+
+const flush = () => Promise.resolve().then(() => Promise.resolve());
+
+describe('RequestCorrelator', () => {
+  let dropped: string[];
+  let correlator: RequestCorrelator<string>;
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    dropped = [];
+    correlator = new RequestCorrelator<string>({ onDropped: (id) => dropped.push(id) });
+  });
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('given a response for a pending id, should resolve that promise once and forget the id', async () => {
+    const send = vi.fn();
+    const p = settled(correlator.open({ id: 'r1', group: 'env-1', timeoutMs: 1_000, send }));
+    expect(send).toHaveBeenCalledTimes(1);
+    expect(correlator.has('r1')).toBe(true);
+    expect(correlator.resolve('r1', 'ok')).toBe(true);
+    await flush();
+    expect(p.state()).toBe('resolved');
+    expect(p.value()).toBe('ok');
+    expect(correlator.has('r1')).toBe(false);
+    expect(correlator.pendingCount()).toBe(0);
+  });
+
+  it('given no response, should reject with a typed timeout exactly at timeoutMs and not one tick before', async () => {
+    const p = settled(correlator.open({ id: 'r1', group: 'g', timeoutMs: 1_000, send: () => {} }));
+    await vi.advanceTimersByTimeAsync(999);
+    expect(p.state()).toBe('pending');
+    await vi.advanceTimersByTimeAsync(1);
+    expect(p.state()).toBe('rejected');
+    const error = p.error();
+    expect(error).toBeInstanceOf(CorrelationError);
+    expect((error as CorrelationError).kind).toBe('timeout');
+    expect(correlator.pendingCount()).toBe(0);
+  });
+
+  it('given a grant_exec with timeoutMs 120_000, should wait at least 120 s — the MCP bridge 30 s default must not apply', async () => {
+    const frame: GrantFrame = { type: 'grant_exec', grant: {}, sig: '', cmd: 'sleep', args: ['100'], timeoutMs: 120_000 };
+    const timeoutMs = grantCorrelatorTimeoutMs(frame);
+    expect(timeoutMs).toBe(120_000 + DEFAULT_TIMEOUT_DEFAULTS.correlatorMarginMs);
+    const p = settled(correlator.open({ id: 'g1', group: 'env-1', timeoutMs, send: () => {} }));
+    await vi.advanceTimersByTimeAsync(30_000);
+    expect(p.state()).toBe('pending');
+    await vi.advanceTimersByTimeAsync(89_999);
+    expect(p.state()).toBe('pending');
+    await vi.advanceTimersByTimeAsync(DEFAULT_TIMEOUT_DEFAULTS.correlatorMarginMs + 1);
+    expect(p.state()).toBe('rejected');
+    expect((p.error() as CorrelationError).kind).toBe('timeout');
+  });
+
+  it('given a grant_exec without timeoutMs, should use the resolver default (120 s), never 30 s', () => {
+    const frame: GrantFrame = { type: 'grant_exec', grant: {}, sig: '', cmd: 'ls' };
+    expect(grantCorrelatorTimeoutMs(frame)).toBe(DEFAULT_TIMEOUT_DEFAULTS.execTimeoutMs + DEFAULT_TIMEOUT_DEFAULTS.correlatorMarginMs);
+  });
+
+  it('given a grant_pty_open, should report the channel as unbounded — no deadline is ever armed', async () => {
+    const frame: GrantFrame = { type: 'grant_pty_open', grant: {}, sig: '', cols: 80, rows: 24 };
+    expect(grantCorrelatorTimeoutMs(frame)).toBe('unbounded');
+    const p = settled(correlator.open({ id: 'p1', group: 'env-1', timeoutMs: 'unbounded', send: () => {} }));
+    await vi.advanceTimersByTimeAsync(365 * 24 * 60 * 60 * 1000);
+    expect(p.state()).toBe('pending');
+    expect(vi.getTimerCount()).toBe(0);
+  });
+
+  it('given a response for an id that is not pending (late, duplicate or forged), should drop it, report it and resolve nothing', async () => {
+    const p = settled(correlator.open({ id: 'r1', group: 'g', timeoutMs: 1_000, send: () => {} }));
+    expect(correlator.resolve('forged', 'x')).toBe(false);
+    expect(correlator.reject('forged', new Error('x'))).toBe(false);
+    expect(dropped).toEqual(['forged', 'forged']);
+    await flush();
+    expect(p.state()).toBe('pending');
+    // Duplicate: the second answer to an id already answered is dropped too.
+    correlator.resolve('r1', 'first');
+    expect(correlator.resolve('r1', 'second')).toBe(false);
+    await flush();
+    expect(p.value()).toBe('first');
+    // Late: an answer after the deadline finds nothing pending.
+    const late = settled(correlator.open({ id: 'r2', group: 'g', timeoutMs: 10, send: () => {} }));
+    await vi.advanceTimersByTimeAsync(10);
+    expect(late.state()).toBe('rejected');
+    expect(correlator.resolve('r2', 'too late')).toBe(false);
+  });
+
+  it('given a send that throws, should reject with send_failed, clear the deadline and leave nothing pending', async () => {
+    const p = settled(
+      correlator.open({
+        id: 'r1',
+        group: 'g',
+        timeoutMs: 1_000,
+        send: () => {
+          throw new Error('socket closed');
+        },
+      }),
+    );
+    await flush();
+    expect(p.state()).toBe('rejected');
+    expect((p.error() as CorrelationError).kind).toBe('send_failed');
+    expect((p.error() as CorrelationError).message).toContain('socket closed');
+    expect(correlator.pendingCount()).toBe(0);
+    expect(vi.getTimerCount()).toBe(0);
+  });
+
+  it('given cancelGroup, should reject only that group with the given error and leave other groups pending', async () => {
+    const a1 = settled(correlator.open({ id: 'a1', group: 'env-a', timeoutMs: 1_000, send: () => {} }));
+    const a2 = settled(correlator.open({ id: 'a2', group: 'env-a', timeoutMs: 1_000, send: () => {} }));
+    const b1 = settled(correlator.open({ id: 'b1', group: 'env-b', timeoutMs: 1_000, send: () => {} }));
+    const cancelled = correlator.cancelGroup('env-a', new CorrelationError('disconnected', 'env-a went away'));
+    await flush();
+    expect(cancelled).toBe(2);
+    expect(a1.state()).toBe('rejected');
+    expect((a1.error() as CorrelationError).kind).toBe('disconnected');
+    expect(a2.state()).toBe('rejected');
+    expect(b1.state()).toBe('pending');
+    expect(correlator.pendingCount()).toBe(1);
+    expect(correlator.pendingCountForGroup('env-a')).toBe(0);
+    // Their deadlines are gone too: nothing fires later for a cancelled request.
+    await vi.advanceTimersByTimeAsync(1_000);
+    expect(b1.state()).toBe('rejected');
+    expect(vi.getTimerCount()).toBe(0);
+  });
+
+  it('given an id already pending, should reject the second open as duplicate_id and leave the first untouched', async () => {
+    const first = settled(correlator.open({ id: 'r1', group: 'g', timeoutMs: 1_000, send: () => {} }));
+    const send = vi.fn();
+    const second = settled(correlator.open({ id: 'r1', group: 'g', timeoutMs: 1_000, send }));
+    await flush();
+    expect(second.state()).toBe('rejected');
+    expect((second.error() as CorrelationError).kind).toBe('duplicate_id');
+    expect(send).not.toHaveBeenCalled();
+    expect(first.state()).toBe('pending');
+    expect(correlator.pendingCount()).toBe(1);
+  });
+
+  it('given injected timers, should arm and clear deadlines through them (the clock is a dependency, not a global)', async () => {
+    const armed: Array<{ fn: () => void; ms: number }> = [];
+    const cleared: unknown[] = [];
+    const timers = {
+      setTimeout: (fn: () => void, ms: number) => {
+        armed.push({ fn, ms });
+        return armed.length;
+      },
+      clearTimeout: (handle: unknown) => {
+        cleared.push(handle);
+      },
+    };
+    const injected = new RequestCorrelator<string>({ timers });
+    const p = settled(injected.open({ id: 'r1', group: 'g', timeoutMs: 4_242, send: () => {} }));
+    expect(armed).toHaveLength(1);
+    expect(armed[0]!.ms).toBe(4_242);
+    injected.resolve('r1', 'done');
+    await flush();
+    expect(p.state()).toBe('resolved');
+    expect(cleared).toEqual([1]);
+  });
+});

--- a/apps/web/src/lib/env-bridge/__tests__/correlator.test.ts
+++ b/apps/web/src/lib/env-bridge/__tests__/correlator.test.ts
@@ -150,6 +150,14 @@ describe('RequestCorrelator', () => {
     expect(vi.getTimerCount()).toBe(0);
   });
 
+  it('should name the group a pending id belongs to, and nothing once it is answered', async () => {
+    correlator.open({ id: 'r1', group: 'env-a', timeoutMs: 1_000, send: () => {} }).catch(() => {});
+    expect(correlator.groupOf('r1')).toBe('env-a');
+    expect(correlator.groupOf('nope')).toBeUndefined();
+    correlator.resolve('r1', 'done');
+    expect(correlator.groupOf('r1')).toBeUndefined();
+  });
+
   it('given an id already pending, should reject the second open as duplicate_id and leave the first untouched', async () => {
     const first = settled(correlator.open({ id: 'r1', group: 'g', timeoutMs: 1_000, send: () => {} }));
     const send = vi.fn();

--- a/apps/web/src/lib/env-bridge/__tests__/grant-signer.test.ts
+++ b/apps/web/src/lib/env-bridge/__tests__/grant-signer.test.ts
@@ -1,0 +1,156 @@
+/**
+ * The signer and the daemon's gate must agree by construction (Codex C7):
+ * every grant signed here is verified with the PURE `verifyGrant` under the
+ * request `grantRequestForFrame(frame)` — the same projection both call.
+ * Tampering any projected field after signing ⇒ `args_mismatch`. The key is
+ * the one the enrollment pinned (Codex C10); an unloaded key id signs nothing.
+ */
+import { describe, it, expect } from 'vitest';
+import { generateKeyPairSync, createPrivateKey, createPublicKey, createHash, sign as nodeSign } from 'node:crypto';
+import { verifyGrant, createMemoryNonceStore, canonicalizeArgs, GRANT_MAX_TTL_MS } from '@pagespace/lib/env-bridge/grant';
+import { grantRequestForFrame, type GrantFrame } from '@pagespace/lib/env-bridge/grant-args';
+import { parseServerSigningKeyring, type SigningKeyPrimitives } from '@pagespace/lib/env-bridge/server-signing-key';
+import { signGrantFrame, type UnsignedGrantFrame } from '../grant-signer';
+import { ed25519Verify, envBridgeHash } from '../crypto';
+
+const primitives: SigningKeyPrimitives = {
+  importPrivateKey: (pkcs8) => {
+    const privateKey = createPrivateKey({ key: Buffer.from(pkcs8), type: 'pkcs8', format: 'der' });
+    return { publicKey: new Uint8Array(createPublicKey(privateKey).export({ type: 'spki', format: 'der' })), sign: (m) => new Uint8Array(nodeSign(null, m, privateKey)) };
+  },
+  hash: (bytes) => createHash('sha256').update(bytes).digest('hex'),
+};
+const pkcs8 = () => generateKeyPairSync('ed25519').privateKey.export({ type: 'pkcs8', format: 'der' }).toString('base64');
+const ringVerdict = parseServerSigningKeyring({ single: undefined, multi: `${pkcs8()},${pkcs8()}` }, primitives);
+if (!ringVerdict.ok) throw new Error('ring');
+const ring = ringVerdict.keyring;
+const [currentId, previousId] = ring.keyIds as [string, string];
+
+const NOW = 1_760_000_000_000;
+const principal = { userId: 'user-1', sessionId: 'sess-1', conversationId: 'conv-1' };
+let counter = 0;
+const ids = { grantId: () => `g-${++counter}`, nonce: () => `n-${counter}` };
+
+const frames: Record<GrantFrame['type'], UnsignedGrantFrame> = {
+  grant_exec: { type: 'grant_exec', cmd: 'bun', args: ['test'], cwd: '/repo', env: { CI: '1' }, timeoutMs: 120_000, maxBytes: 1_000_000 },
+  grant_fs_read: { type: 'grant_fs_read', paths: ['/repo/a.ts', '/repo/b.ts'] },
+  grant_fs_write: { type: 'grant_fs_write', files: [{ path: '/repo/a.ts', contentB64: 'aGVsbG8=', mode: 420 }] },
+  grant_pty_open: { type: 'grant_pty_open', cols: 80, rows: 24, cwd: '/repo', command: 'zsh', args: ['-l'] },
+};
+
+function sign(frame: UnsignedGrantFrame, serverKeyId: string | null = currentId, over: Partial<Parameters<typeof signGrantFrame>[0]> = {}) {
+  return signGrantFrame({ frame, envId: 'env-1', principal, serverKeyId, keyring: ring, now: NOW, ids, ...over });
+}
+
+/** The daemon's gate, exactly as t08 will call it: the request comes from the frame as received. */
+function gate(frame: GrantFrame, publicKey: Uint8Array = ring.get(currentId)!.publicKey, expectedEnvId = 'env-1') {
+  return verifyGrant({
+    grant: frame.grant,
+    signature: frame.sig,
+    serverPublicKey: publicKey,
+    now: NOW + 1_000,
+    nonces: createMemoryNonceStore(),
+    expectedEnvId,
+    request: grantRequestForFrame(frame),
+    verify: ed25519Verify,
+    hash: envBridgeHash,
+  });
+}
+
+describe('signGrantFrame ↔ verifyGrant — agreement by construction (C7)', () => {
+  it.each(Object.keys(frames) as GrantFrame['type'][])('given a %s, the signed frame should verify under the daemon gate with the projection of the frame itself', (type) => {
+    const signed = sign(frames[type]);
+    if (!signed.ok) throw new Error(signed.reason);
+    const verdict = gate(signed.frame);
+    expect(verdict.ok).toBe(true);
+    expect(signed.grant.op).toBe(grantRequestForFrame(signed.frame).op);
+    // C7: the hash is of the PROJECTION of the sent frame, nothing else.
+    expect(signed.grant.argsHash).toBe(envBridgeHash(canonicalizeArgs(grantRequestForFrame(signed.frame).args)));
+    expect(signed.keyId).toBe(currentId);
+    expect(signed.grant).toMatchObject({ envId: 'env-1', principal, iat: NOW, exp: NOW + GRANT_MAX_TTL_MS });
+  });
+
+  const tampers: Array<[string, (f: GrantFrame) => GrantFrame]> = [
+    ['exec.cmd', (f) => ({ ...(f as Extract<GrantFrame, { type: 'grant_exec' }>), cmd: 'rm' })],
+    ['exec.args', (f) => ({ ...(f as Extract<GrantFrame, { type: 'grant_exec' }>), args: ['test', '--evil'] })],
+    ['exec.cwd', (f) => ({ ...(f as Extract<GrantFrame, { type: 'grant_exec' }>), cwd: '/' })],
+    ['exec.env (LD_PRELOAD added)', (f) => ({ ...(f as Extract<GrantFrame, { type: 'grant_exec' }>), env: { CI: '1', LD_PRELOAD: '/x.so' } })],
+    ['exec.timeoutMs', (f) => ({ ...(f as Extract<GrantFrame, { type: 'grant_exec' }>), timeoutMs: 1 })],
+    ['exec.maxBytes', (f) => ({ ...(f as Extract<GrantFrame, { type: 'grant_exec' }>), maxBytes: 1 })],
+    ['exec.cwd removed', (f) => {
+      const { cwd: _cwd, ...rest } = f as Extract<GrantFrame, { type: 'grant_exec' }>;
+      return rest as GrantFrame;
+    }],
+  ];
+  it.each(tampers)('given %s changed after signing, the gate should deny args_mismatch', (_label, tamper) => {
+    const signed = sign(frames.grant_exec);
+    if (!signed.ok) throw new Error(signed.reason);
+    expect(gate(tamper(signed.frame))).toEqual({ ok: false, reason: 'args_mismatch' });
+  });
+
+  it('given fs_read paths, fs_write content/mode/path, or pty cols/command changed after signing, the gate should deny args_mismatch', () => {
+    const read = sign(frames.grant_fs_read);
+    const write = sign(frames.grant_fs_write);
+    const pty = sign(frames.grant_pty_open);
+    if (!read.ok || !write.ok || !pty.ok) throw new Error('sign');
+    const r = read.frame as Extract<GrantFrame, { type: 'grant_fs_read' }>;
+    const w = write.frame as Extract<GrantFrame, { type: 'grant_fs_write' }>;
+    const p = pty.frame as Extract<GrantFrame, { type: 'grant_pty_open' }>;
+    expect(gate({ ...r, paths: ['/etc/passwd'] })).toEqual({ ok: false, reason: 'args_mismatch' });
+    expect(gate({ ...w, files: [{ ...w.files[0]!, contentB64: 'ZXZpbA==' }] })).toEqual({ ok: false, reason: 'args_mismatch' });
+    expect(gate({ ...w, files: [{ ...w.files[0]!, mode: 493 }] })).toEqual({ ok: false, reason: 'args_mismatch' });
+    expect(gate({ ...w, files: [{ ...w.files[0]!, path: '/etc/cron.d/x' }] })).toEqual({ ok: false, reason: 'args_mismatch' });
+    expect(gate({ ...p, cols: 81 })).toEqual({ ok: false, reason: 'args_mismatch' });
+    expect(gate({ ...p, command: 'bash' })).toEqual({ ok: false, reason: 'args_mismatch' });
+  });
+
+  it('given an exec grant moved onto an fs_read frame, the gate should deny op_mismatch', () => {
+    const exec = sign(frames.grant_exec);
+    if (!exec.ok) throw new Error(exec.reason);
+    const moved: GrantFrame = { type: 'grant_fs_read', grant: exec.frame.grant, sig: exec.frame.sig, paths: ['/x'] };
+    expect(gate(moved)).toEqual({ ok: false, reason: 'op_mismatch' });
+  });
+
+  it('given a grant for env-1 presented to env-2\'s daemon, the gate should deny wrong_env', () => {
+    const signed = sign(frames.grant_exec);
+    if (!signed.ok) throw new Error(signed.reason);
+    expect(gate(signed.frame, ring.get(currentId)!.publicKey, 'env-2')).toEqual({ ok: false, reason: 'wrong_env' });
+  });
+});
+
+describe('signGrantFrame — which key signs (C10)', () => {
+  it('given an enrollment pinned to the PREVIOUS key, should sign with that key: verifies under its public key, not the current one', () => {
+    const signed = sign(frames.grant_exec, previousId);
+    if (!signed.ok) throw new Error(signed.reason);
+    expect(signed.keyId).toBe(previousId);
+    expect(gate(signed.frame, ring.get(previousId)!.publicKey).ok).toBe(true);
+    expect(gate(signed.frame, ring.get(currentId)!.publicKey)).toEqual({ ok: false, reason: 'bad_signature' });
+  });
+
+  it('given an enrollment pinned to a key that is no longer loaded, should answer signing_key_unavailable and produce NO frame', () => {
+    expect(sign(frames.grant_exec, 'gone-key')).toEqual({ ok: false, reason: 'signing_key_unavailable' });
+  });
+
+  it('given an enrollment with no pinned key (never enrolled), should answer signing_key_unavailable', () => {
+    expect(sign(frames.grant_exec, null)).toEqual({ ok: false, reason: 'signing_key_unavailable' });
+  });
+});
+
+describe('signGrantFrame — window and identity', () => {
+  it('should default the window to GRANT_MAX_TTL_MS and refuse a longer one before signing', () => {
+    const ok = sign(frames.grant_fs_read);
+    if (!ok.ok) throw new Error(ok.reason);
+    expect(ok.grant.exp - ok.grant.iat).toBe(GRANT_MAX_TTL_MS);
+    expect(sign(frames.grant_fs_read, currentId, { ttlMs: GRANT_MAX_TTL_MS + 1 })).toEqual({ ok: false, reason: 'ttl_too_long' });
+    expect(sign(frames.grant_fs_read, currentId, { ttlMs: 0 })).toEqual({ ok: false, reason: 'ttl_too_long' });
+  });
+
+  it('should mint a fresh grantId and nonce per call and carry the wire grant as a plain record with exactly the gate\'s fields', () => {
+    const a = sign(frames.grant_fs_read);
+    const b = sign(frames.grant_fs_read);
+    if (!a.ok || !b.ok) throw new Error('sign');
+    expect(a.grant.grantId).not.toBe(b.grant.grantId);
+    expect(a.grant.nonce).not.toBe(b.grant.nonce);
+    expect(Object.keys(a.frame.grant).sort()).toEqual(['argsHash', 'envId', 'exp', 'grantId', 'iat', 'nonce', 'op', 'principal']);
+  });
+});

--- a/apps/web/src/lib/env-bridge/__tests__/revoke.test.ts
+++ b/apps/web/src/lib/env-bridge/__tests__/revoke.test.ts
@@ -1,0 +1,161 @@
+/**
+ * Revoke through the production seams: the row stamp, EVERY env:bridge session
+ * for the env, and the machine's socket — signed by the key the enrollment
+ * pinned, verified with the pure `verifyRevoke` (so t08's daemon agrees by
+ * construction), closed 1008, and its in-flight requests failed at once.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import type { WebSocket } from 'ws';
+import { generateKeyPairSync, createPrivateKey, createPublicKey, createHash, sign as nodeSign } from 'node:crypto';
+
+vi.mock('@pagespace/lib/logging/logger-config', () => ({ logger: { child: () => ({ info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() }) } }));
+vi.mock('@pagespace/lib/auth/session-service', () => ({ sessionService: { revokeResourceSessions: vi.fn(async () => 2), validateSession: vi.fn() } }));
+vi.mock('@pagespace/lib/auth/env-bridge-signing-key', () => ({ loadServerSigningKeyring: vi.fn() }));
+vi.mock('@/lib/drive-envs/drive-envs-runtime', () => ({ getDriveEnvStore: vi.fn() }));
+
+import { sessionService } from '@pagespace/lib/auth/session-service';
+import { loadServerSigningKeyring } from '@pagespace/lib/auth/env-bridge-signing-key';
+import { getDriveEnvStore } from '@/lib/drive-envs/drive-envs-runtime';
+import { decodeFrame } from '@pagespace/lib/env-bridge/frame-codec';
+import { verifyRevoke } from '@pagespace/lib/env-bridge/machine-signatures';
+import { parseServerSigningKeyring, type SigningKeyPrimitives } from '@pagespace/lib/env-bridge/server-signing-key';
+import { clearAllEnvConnectionsForTesting, getEnvConnection, markEnvAuthorized, registerEnvConnection } from '@/lib/websocket/ws-env-connections';
+import { getEnvBridgeClient } from '@/lib/env-bridge/bridge-client';
+import { ed25519Verify } from '@/lib/env-bridge/crypto';
+import { revokeLocalEnv, buildRevokeFrame, ENV_REVOKED_CLOSE_CODE, ENV_REVOKED_CLOSE_REASON } from '../revoke';
+
+const primitives: SigningKeyPrimitives = {
+  importPrivateKey: (pkcs8) => {
+    const privateKey = createPrivateKey({ key: Buffer.from(pkcs8), type: 'pkcs8', format: 'der' });
+    return { publicKey: new Uint8Array(createPublicKey(privateKey).export({ type: 'spki', format: 'der' })), sign: (m) => new Uint8Array(nodeSign(null, m, privateKey)) };
+  },
+  hash: (bytes) => createHash('sha256').update(bytes).digest('hex'),
+};
+const pkcs8 = () => generateKeyPairSync('ed25519').privateKey.export({ type: 'pkcs8', format: 'der' }).toString('base64');
+const ringVerdict = parseServerSigningKeyring({ single: undefined, multi: `${pkcs8()},${pkcs8()}` }, primitives);
+if (!ringVerdict.ok) throw new Error('ring');
+const ring = ringVerdict.keyring;
+const [currentId, previousId] = ring.keyIds as [string, string];
+
+const NOW = new Date('2026-09-06T12:00:00.000Z');
+const ENV = 'env_a';
+
+type FakeSocket = WebSocket & { readyState: number; sent: string[] };
+function socket(): FakeSocket {
+  const sent: string[] = [];
+  const ws = { readyState: 1, sent, send: vi.fn((d: string) => sent.push(d)), close: vi.fn(() => { ws.readyState = 3; }), on: vi.fn() } as unknown as FakeSocket;
+  return ws;
+}
+
+describe('revokeLocalEnv — all three legs through the production seams', () => {
+  let row: { envId: string; enrollmentId: string; serverKeyId: string | null; revokedAt: Date | null } | null;
+  let store: { findLocalByEnvId: ReturnType<typeof vi.fn>; revokeLocal: ReturnType<typeof vi.fn> };
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(NOW);
+    vi.clearAllMocks();
+    clearAllEnvConnectionsForTesting();
+    row = { envId: ENV, enrollmentId: 'enr_a', serverKeyId: currentId, revokedAt: null };
+    store = {
+      findLocalByEnvId: vi.fn(async () => row),
+      revokeLocal: vi.fn(async ({ now }: { now: Date }) => {
+        if (!row || row.revokedAt !== null) return false;
+        row.revokedAt = now;
+        return true;
+      }),
+    };
+    vi.mocked(getDriveEnvStore).mockResolvedValue(store as never);
+    vi.mocked(loadServerSigningKeyring).mockReturnValue(ring);
+    vi.mocked(sessionService.revokeResourceSessions).mockResolvedValue(2);
+  });
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  function liveSocket(serverKeyId: string | null = currentId, authorized = true): FakeSocket {
+    const ws = socket();
+    registerEnvConnection(ENV, ws, { userId: 'u', sessionId: 's', enrollmentId: 'enr_a', machinePublicKey: 'pk', serverKeyId, sessionExpiresAt: new Date(NOW.getTime() + 3600_000) });
+    if (authorized) markEnvAuthorized(ws);
+    return ws;
+  }
+
+  it('given an authorized socket, should stamp the row, revoke every drive_env session for the env, push a revoke frame the daemon can verify under the pinned key, close 1008 and unregister', async () => {
+    const ws = liveSocket();
+    const result = await revokeLocalEnv({ envId: ENV, reason: 'owner_revoked' });
+    expect(result).toEqual({ ok: true, alreadyRevoked: false, revokedAt: NOW, sessionsRevoked: 2, machine: 'sent_and_closed' });
+    expect(store.revokeLocal).toHaveBeenCalledWith({ envId: ENV, now: NOW });
+    expect(sessionService.revokeResourceSessions).toHaveBeenCalledWith('drive_env', ENV, 'env_bridge_owner_revoked');
+    expect(ws.sent).toHaveLength(1);
+    const decoded = decodeFrame(ws.sent[0]!, { maxFrameBytes: 65536 });
+    if (!decoded.ok || decoded.frame.type !== 'revoke') throw new Error('no revoke frame');
+    expect(decoded.frame.issuedAt).toBe(NOW.getTime());
+    expect(decoded.frame.reason).toBe('owner_revoked');
+    // The daemon's check, by construction: the frame binds {envId, enrollmentId, keyId, issuedAt} under the pinned key.
+    expect(verifyRevoke({ frame: decoded.frame, envId: ENV, enrollmentId: 'enr_a', keyId: currentId, issuedAt: NOW.getTime(), serverPublicKey: ring.get(currentId)!.publicKey, verify: ed25519Verify })).toEqual({ ok: true });
+    expect(verifyRevoke({ frame: decoded.frame, envId: ENV, enrollmentId: 'enr_OTHER', keyId: currentId, issuedAt: NOW.getTime(), serverPublicKey: ring.get(currentId)!.publicKey, verify: ed25519Verify })).toEqual({ ok: false, reason: 'bad_signature' });
+    expect(ws.close).toHaveBeenCalledWith(ENV_REVOKED_CLOSE_CODE, ENV_REVOKED_CLOSE_REASON);
+    expect(getEnvConnection(ENV)).toBeUndefined();
+  });
+
+  it('should fail the env\'s in-flight requests immediately with typed disconnected (the unregister runs through the lost listener)', async () => {
+    liveSocket();
+    const pending = getEnvBridgeClient().sendGrant({ envId: ENV, frame: { type: 'grant_exec', cmd: 'ls' }, principal: { userId: 'u', sessionId: 's', conversationId: 'c' } });
+    await revokeLocalEnv({ envId: ENV, reason: 'owner_revoked' });
+    await expect(pending).rejects.toMatchObject({ kind: 'disconnected' });
+  });
+
+  it('given an enrollment pinned to the PREVIOUS key (the ROW is the source of truth), should sign the revoke with THAT key', async () => {
+    row!.serverKeyId = previousId;
+    const ws = liveSocket(previousId);
+    await revokeLocalEnv({ envId: ENV, reason: 'r' });
+    const decoded = decodeFrame(ws.sent[0]!, { maxFrameBytes: 65536 });
+    if (!decoded.ok || decoded.frame.type !== 'revoke') throw new Error('no revoke frame');
+    expect(verifyRevoke({ frame: decoded.frame, envId: ENV, enrollmentId: 'enr_a', keyId: previousId, issuedAt: NOW.getTime(), serverPublicKey: ring.get(previousId)!.publicKey, verify: ed25519Verify })).toEqual({ ok: true });
+    expect(verifyRevoke({ frame: decoded.frame, envId: ENV, enrollmentId: 'enr_a', keyId: currentId, issuedAt: NOW.getTime(), serverPublicKey: ring.get(currentId)!.publicKey, verify: ed25519Verify })).toEqual({ ok: false, reason: 'bad_signature' });
+  });
+
+  it('given the pinned key is no longer loaded, should still stamp + revoke sessions, close 1008 WITHOUT a frame, and say so', async () => {
+    row!.serverKeyId = 'rotated-out';
+    const ws = liveSocket('rotated-out');
+    const result = await revokeLocalEnv({ envId: ENV, reason: 'r' });
+    expect(result).toMatchObject({ ok: true, machine: 'closed_unsigned_key_unavailable', sessionsRevoked: 2 });
+    expect(ws.sent).toHaveLength(0);
+    expect(ws.close).toHaveBeenCalledWith(ENV_REVOKED_CLOSE_CODE, ENV_REVOKED_CLOSE_REASON);
+    expect(row?.revokedAt).toEqual(NOW);
+  });
+
+  it('given no key ring is configured at all, should still complete legs 1 and 2 and close the socket', async () => {
+    vi.mocked(loadServerSigningKeyring).mockImplementation(() => {
+      throw new Error('ENV_BRIDGE_SIGNING_KEY is required');
+    });
+    const ws = liveSocket();
+    const result = await revokeLocalEnv({ envId: ENV, reason: 'r' });
+    expect(result).toMatchObject({ ok: true, machine: 'closed_unsigned_key_unavailable' });
+    expect(ws.close).toHaveBeenCalled();
+    expect(sessionService.revokeResourceSessions).toHaveBeenCalled();
+  });
+
+  it('given a socket that has not completed its hello, should close it WITHOUT a frame (nothing is sent to an unauthorized socket)', async () => {
+    const ws = liveSocket(currentId, false);
+    const result = await revokeLocalEnv({ envId: ENV, reason: 'r' });
+    expect(result).toMatchObject({ ok: true, machine: 'closed_unauthorized_socket' });
+    expect(ws.sent).toHaveLength(0);
+    expect(ws.close).toHaveBeenCalledWith(ENV_REVOKED_CLOSE_CODE, ENV_REVOKED_CLOSE_REASON);
+  });
+
+  it('given no socket on this replica, should report no_live_socket and still complete legs 1 and 2', async () => {
+    const result = await revokeLocalEnv({ envId: ENV, reason: 'r' });
+    expect(result).toEqual({ ok: true, alreadyRevoked: false, revokedAt: NOW, sessionsRevoked: 2, machine: 'no_live_socket' });
+  });
+
+  it('given a Sprite env (no drive_env_local row), should answer not_found and touch nothing', async () => {
+    row = null;
+    expect(await revokeLocalEnv({ envId: ENV, reason: 'r' })).toEqual({ ok: false, reason: 'not_found' });
+    expect(sessionService.revokeResourceSessions).not.toHaveBeenCalled();
+  });
+
+  it('buildRevokeFrame: given a null serverKeyId (never enrolled), should answer signing_key_unavailable', () => {
+    expect(buildRevokeFrame({ envId: ENV, enrollmentId: 'e', serverKeyId: null, issuedAt: 1, reason: 'r' }, ring)).toEqual({ ok: false, reason: 'signing_key_unavailable' });
+  });
+});

--- a/apps/web/src/lib/env-bridge/bridge-client.ts
+++ b/apps/web/src/lib/env-bridge/bridge-client.ts
@@ -58,9 +58,14 @@ export interface EnvBridgeClientDeps {
 
 export type MachineResultDisposition = 'delivered' | 'unverified' | 'dropped_unknown_grant' | 'dropped_unregistered_socket' | 'dropped_wrong_env';
 
-export class EnvBridgeClient {
-  private readonly log = logger.child({ component: 'env-bridge-client' });
+/** Built on first use, never at import (see ws-env-connections.ts for why). */
+let clientLogger: ReturnType<typeof logger.child> | null = null;
+function log(): ReturnType<typeof logger.child> {
+  clientLogger ??= logger.child({ component: 'env-bridge-client' });
+  return clientLogger;
+}
 
+export class EnvBridgeClient {
   constructor(private readonly deps: EnvBridgeClientDeps) {}
 
   /**
@@ -84,7 +89,7 @@ export class EnvBridgeClient {
     if (!signed.ok) throw new EnvBridgeError(signed.reason, `Cannot sign grant for ${input.envId}: ${signed.reason}`, { envId: input.envId, serverKeyId: facts.serverKeyId });
 
     const timeoutMs = grantCorrelatorTimeoutMs(signed.frame);
-    this.log.info('Sending grant to local environment', { envId: input.envId, grantId: signed.grant.grantId, op: signed.grant.op, keyId: signed.keyId, timeoutMs, action: 'send_grant' });
+    log().info('Sending grant to local environment', { envId: input.envId, grantId: signed.grant.grantId, op: signed.grant.op, keyId: signed.keyId, timeoutMs, action: 'send_grant' });
     try {
       return await this.deps.correlator.open({
         id: signed.grant.grantId,
@@ -114,22 +119,22 @@ export class EnvBridgeClient {
   handleMachineResult(ws: WebSocket, frame: MachineResultFrame): MachineResultDisposition {
     const facts = this.deps.getSocketFacts(ws);
     if (!facts) {
-      this.log.warn('Result frame from an unregistered socket dropped', { grantId: frame.grantId, frameType: frame.type, action: 'result_dropped' });
+      log().warn('Result frame from an unregistered socket dropped', { grantId: frame.grantId, frameType: frame.type, action: 'result_dropped' });
       return 'dropped_unregistered_socket';
     }
     const owner = this.deps.correlator.groupOf(frame.grantId);
     if (owner === undefined) {
-      this.log.warn('Result frame for an unknown grant dropped', { envId: facts.envId, grantId: frame.grantId, frameType: frame.type, action: 'result_dropped' });
+      log().warn('Result frame for an unknown grant dropped', { envId: facts.envId, grantId: frame.grantId, frameType: frame.type, action: 'result_dropped' });
       return 'dropped_unknown_grant';
     }
     if (owner !== facts.envId) {
-      this.log.error('Result frame from an env that does not own the grant refused — request stays pending for its owner', { envId: facts.envId, ownerEnvId: owner, grantId: frame.grantId, frameType: frame.type, action: 'result_wrong_env' });
+      log().error('Result frame from an env that does not own the grant refused — request stays pending for its owner', { envId: facts.envId, ownerEnvId: owner, grantId: frame.grantId, frameType: frame.type, action: 'result_wrong_env' });
       this.deps.onUnverified?.({ envId: facts.envId, grantId: frame.grantId, frameType: frame.type, reason: 'wrong_env' });
       return 'dropped_wrong_env';
     }
     const verified = verifyResultFromMachine({ frame, machinePublicKey: facts.machinePublicKey });
     if (!verified.ok) {
-      this.log.error('Result frame failed machine-signature verification — NOT delivered', { envId: facts.envId, grantId: frame.grantId, frameType: frame.type, reason: verified.reason, action: 'result_unverified' });
+      log().error('Result frame failed machine-signature verification — NOT delivered', { envId: facts.envId, grantId: frame.grantId, frameType: frame.type, reason: verified.reason, action: 'result_unverified' });
       this.deps.onUnverified?.({ envId: facts.envId, grantId: frame.grantId, frameType: frame.type, reason: verified.reason });
       this.deps.correlator.reject(frame.grantId, new EnvBridgeError('unverified_result', `Result for grant ${frame.grantId} failed machine-signature verification (${verified.reason})`, { envId: facts.envId, grantId: frame.grantId, reason: verified.reason }));
       return 'unverified';
@@ -166,7 +171,7 @@ export function getEnvBridgeClient(): EnvBridgeClient {
   if (singleton) return singleton;
   const client = new EnvBridgeClient({
     correlator: new RequestCorrelator<MachineResultFrame>({
-      onDropped: (id) => logger.child({ component: 'env-bridge-client' }).warn('Reply for a grant that is not pending dropped', { grantId: id, action: 'reply_dropped' }),
+      onDropped: (id) => log().warn('Reply for a grant that is not pending dropped', { grantId: id, action: 'reply_dropped' }),
     }),
     getAuthorizedConnection: getAuthorizedEnvConnection,
     getSocketFacts: (ws) => {

--- a/apps/web/src/lib/env-bridge/bridge-client.ts
+++ b/apps/web/src/lib/env-bridge/bridge-client.ts
@@ -1,0 +1,172 @@
+/**
+ * Env-bridge client — the server side of one request to a LOCAL environment:
+ * sign the grant (invariant 3), send it over the env's AUTHORIZED socket
+ * only (invariant 6), correlate the reply by grantId with a deadline from
+ * `resolveTimeout`, and hand the reply to the caller ONLY after its machine
+ * signature verified (invariant 7).
+ *
+ * This is the seam the t09 host (`local-env-sandbox-host.ts`) will call; the
+ * socket route calls `handleMachineResult` for every result frame it decodes.
+ * Everything with a side effect is injected so the contract is testable with
+ * fake sockets and fake timers; `getEnvBridgeClient()` binds the real
+ * registry, key ring and clock.
+ */
+import type { WebSocket } from 'ws';
+import { encodeFrame } from '@pagespace/lib/env-bridge/frame-codec';
+import type { GrantPrincipal } from '@pagespace/lib/env-bridge/grant';
+import type { MachineResultFrame } from '@pagespace/lib/env-bridge/machine-signatures';
+import type { ServerSigningKeyring } from '@pagespace/lib/env-bridge/server-signing-key';
+import { logger } from '@pagespace/lib/logging/logger-config';
+import { loadServerSigningKeyring } from '@pagespace/lib/auth/env-bridge-signing-key';
+import { getAuthorizedEnvConnection, getEnvConnectionMetadata, onEnvConnectionLost } from '@/lib/websocket/ws-env-connections';
+import { RequestCorrelator, CorrelationError, grantCorrelatorTimeoutMs, type CorrelationFailureKind } from './correlator';
+import { signGrantFrame, type GrantIdSource, type UnsignedGrantFrame } from './grant-signer';
+import { verifyResultFromMachine } from './result-verifier';
+
+export type EnvBridgeFailureKind = CorrelationFailureKind | 'not_connected' | 'signing_key_unavailable' | 'ttl_too_long';
+
+export class EnvBridgeError extends Error {
+  constructor(
+    readonly kind: EnvBridgeFailureKind,
+    message: string,
+    readonly detail?: Record<string, unknown>,
+  ) {
+    super(message);
+    this.name = 'EnvBridgeError';
+  }
+}
+
+/** What the client needs to know about the socket a frame arrived on / goes out on. */
+export interface EnvSocketFacts {
+  readonly envId: string;
+  readonly machinePublicKey: string | null;
+  readonly serverKeyId: string | null;
+}
+
+export interface EnvBridgeClientDeps {
+  readonly correlator: RequestCorrelator<MachineResultFrame>;
+  /** The env's socket IFF authorized and open — `getAuthorizedEnvConnection`. */
+  readonly getAuthorizedConnection: (envId: string) => WebSocket | undefined;
+  readonly getSocketFacts: (ws: WebSocket) => EnvSocketFacts | undefined;
+  /** Lazy: loading the ring throws when no key is configured, and a Sprite-only deployment must never trip on it. */
+  readonly keyring: () => Pick<ServerSigningKeyring, 'get'>;
+  readonly now: () => number;
+  readonly ids: GrantIdSource;
+  /** Observability hook for a result that failed verification (audit/log). */
+  readonly onUnverified?: (info: { envId: string; grantId: string; frameType: MachineResultFrame['type']; reason: string }) => void;
+}
+
+export type MachineResultDisposition = 'delivered' | 'unverified' | 'dropped_unknown_grant' | 'dropped_unregistered_socket';
+
+export class EnvBridgeClient {
+  private readonly log = logger.child({ component: 'env-bridge-client' });
+
+  constructor(private readonly deps: EnvBridgeClientDeps) {}
+
+  /**
+   * Send one granted request to the env and await its VERIFIED result.
+   * Rejects with a typed `EnvBridgeError` on every failure path.
+   */
+  async sendGrant(input: { envId: string; frame: UnsignedGrantFrame; principal: GrantPrincipal }): Promise<MachineResultFrame> {
+    const ws = this.deps.getAuthorizedConnection(input.envId);
+    const facts = ws ? this.deps.getSocketFacts(ws) : undefined;
+    if (!ws || !facts) throw new EnvBridgeError('not_connected', `Environment ${input.envId} has no authorized bridge connection on this replica`, { envId: input.envId });
+
+    const signed = signGrantFrame({
+      frame: input.frame,
+      envId: input.envId,
+      principal: input.principal,
+      serverKeyId: facts.serverKeyId,
+      keyring: this.deps.keyring(),
+      now: this.deps.now(),
+      ids: this.deps.ids,
+    });
+    if (!signed.ok) throw new EnvBridgeError(signed.reason, `Cannot sign grant for ${input.envId}: ${signed.reason}`, { envId: input.envId, serverKeyId: facts.serverKeyId });
+
+    const timeoutMs = grantCorrelatorTimeoutMs(signed.frame);
+    this.log.info('Sending grant to local environment', { envId: input.envId, grantId: signed.grant.grantId, op: signed.grant.op, keyId: signed.keyId, timeoutMs, action: 'send_grant' });
+    try {
+      return await this.deps.correlator.open({
+        id: signed.grant.grantId,
+        group: input.envId,
+        timeoutMs,
+        send: () => ws.send(encodeFrame(signed.frame)),
+      });
+    } catch (error) {
+      if (error instanceof CorrelationError) throw new EnvBridgeError(error.kind, error.message, { ...error.detail, envId: input.envId });
+      throw error;
+    }
+  }
+
+  /**
+   * A result frame arrived on `ws`. Cheap checks first (is the socket ours, is
+   * the grant pending), THEN the signature, and only a verified result is
+   * delivered. An unverified result fails the pending request with
+   * `unverified_result` — the agent never sees its contents.
+   */
+  handleMachineResult(ws: WebSocket, frame: MachineResultFrame): MachineResultDisposition {
+    const facts = this.deps.getSocketFacts(ws);
+    if (!facts) {
+      this.log.warn('Result frame from an unregistered socket dropped', { grantId: frame.grantId, frameType: frame.type, action: 'result_dropped' });
+      return 'dropped_unregistered_socket';
+    }
+    if (!this.deps.correlator.has(frame.grantId)) {
+      this.log.warn('Result frame for an unknown grant dropped', { envId: facts.envId, grantId: frame.grantId, frameType: frame.type, action: 'result_dropped' });
+      return 'dropped_unknown_grant';
+    }
+    const verified = verifyResultFromMachine({ frame, machinePublicKey: facts.machinePublicKey });
+    if (!verified.ok) {
+      this.log.error('Result frame failed machine-signature verification — NOT delivered', { envId: facts.envId, grantId: frame.grantId, frameType: frame.type, reason: verified.reason, action: 'result_unverified' });
+      this.deps.onUnverified?.({ envId: facts.envId, grantId: frame.grantId, frameType: frame.type, reason: verified.reason });
+      this.deps.correlator.reject(frame.grantId, new EnvBridgeError('unverified_result', `Result for grant ${frame.grantId} failed machine-signature verification (${verified.reason})`, { envId: facts.envId, grantId: frame.grantId, reason: verified.reason }));
+      return 'unverified';
+    }
+    this.deps.correlator.resolve(frame.grantId, frame);
+    return 'delivered';
+  }
+
+  /** The env's live socket is gone: fail its in-flight requests with a typed `disconnected`. */
+  cancelEnv(envId: string, reason = 'bridge connection lost'): number {
+    return this.deps.correlator.cancelGroup(envId, new EnvBridgeError('disconnected', `Environment ${envId}: ${reason}`, { envId }));
+  }
+
+  pendingCountForEnv(envId: string): number {
+    return this.deps.correlator.pendingCountForGroup(envId);
+  }
+}
+
+let singleton: EnvBridgeClient | null = null;
+let keyring: ServerSigningKeyring | null = null;
+
+/**
+ * The key ring, loaded on FIRST USE rather than at import: loading throws when
+ * no signing key is configured (fail closed, invariant 3), and a Sprite-only
+ * deployment must never trip on it merely by importing the route.
+ */
+function loadKeyring(): ServerSigningKeyring {
+  keyring ??= loadServerSigningKeyring();
+  return keyring;
+}
+
+/** The production client: real registry, real key ring (lazily), real clock; cancels an env's requests when its live socket is lost. */
+export function getEnvBridgeClient(): EnvBridgeClient {
+  if (singleton) return singleton;
+  const client = new EnvBridgeClient({
+    correlator: new RequestCorrelator<MachineResultFrame>({
+      onDropped: (id) => logger.child({ component: 'env-bridge-client' }).warn('Reply for a grant that is not pending dropped', { grantId: id, action: 'reply_dropped' }),
+    }),
+    getAuthorizedConnection: getAuthorizedEnvConnection,
+    getSocketFacts: (ws) => {
+      const metadata = getEnvConnectionMetadata(ws);
+      return metadata ? { envId: metadata.envId, machinePublicKey: metadata.machinePublicKey, serverKeyId: metadata.serverKeyId } : undefined;
+    },
+    keyring: loadKeyring,
+    now: () => Date.now(),
+    ids: { grantId: () => `grant_${crypto.randomUUID()}`, nonce: () => crypto.randomUUID() },
+  });
+  onEnvConnectionLost((envId) => {
+    client.cancelEnv(envId);
+  });
+  singleton = client;
+  return client;
+}

--- a/apps/web/src/lib/env-bridge/bridge-client.ts
+++ b/apps/web/src/lib/env-bridge/bridge-client.ts
@@ -56,7 +56,7 @@ export interface EnvBridgeClientDeps {
   readonly onUnverified?: (info: { envId: string; grantId: string; frameType: MachineResultFrame['type']; reason: string }) => void;
 }
 
-export type MachineResultDisposition = 'delivered' | 'unverified' | 'dropped_unknown_grant' | 'dropped_unregistered_socket';
+export type MachineResultDisposition = 'delivered' | 'unverified' | 'dropped_unknown_grant' | 'dropped_unregistered_socket' | 'dropped_wrong_env';
 
 export class EnvBridgeClient {
   private readonly log = logger.child({ component: 'env-bridge-client' });
@@ -100,9 +100,16 @@ export class EnvBridgeClient {
 
   /**
    * A result frame arrived on `ws`. Cheap checks first (is the socket ours, is
-   * the grant pending), THEN the signature, and only a verified result is
-   * delivered. An unverified result fails the pending request with
-   * `unverified_result` — the agent never sees its contents.
+   * the grant pending, is THIS socket's env the env that owns the pending
+   * request), THEN the signature, and only a verified result is delivered.
+   *
+   * The env binding is load-bearing (Codex P1 on #2543): verification runs
+   * under the SENDING socket's pinned key, so without it an authorized env B
+   * that learned env A's pending grantId could sign a result with its own key,
+   * verify, and answer A's request. A result from any env other than the
+   * request's owner is refused before crypto and the request stays pending
+   * for its real owner. An unverified result from the owning env fails the
+   * request with `unverified_result` — the agent never sees its contents.
    */
   handleMachineResult(ws: WebSocket, frame: MachineResultFrame): MachineResultDisposition {
     const facts = this.deps.getSocketFacts(ws);
@@ -110,9 +117,15 @@ export class EnvBridgeClient {
       this.log.warn('Result frame from an unregistered socket dropped', { grantId: frame.grantId, frameType: frame.type, action: 'result_dropped' });
       return 'dropped_unregistered_socket';
     }
-    if (!this.deps.correlator.has(frame.grantId)) {
+    const owner = this.deps.correlator.groupOf(frame.grantId);
+    if (owner === undefined) {
       this.log.warn('Result frame for an unknown grant dropped', { envId: facts.envId, grantId: frame.grantId, frameType: frame.type, action: 'result_dropped' });
       return 'dropped_unknown_grant';
+    }
+    if (owner !== facts.envId) {
+      this.log.error('Result frame from an env that does not own the grant refused — request stays pending for its owner', { envId: facts.envId, ownerEnvId: owner, grantId: frame.grantId, frameType: frame.type, action: 'result_wrong_env' });
+      this.deps.onUnverified?.({ envId: facts.envId, grantId: frame.grantId, frameType: frame.type, reason: 'wrong_env' });
+      return 'dropped_wrong_env';
     }
     const verified = verifyResultFromMachine({ frame, machinePublicKey: facts.machinePublicKey });
     if (!verified.ok) {

--- a/apps/web/src/lib/env-bridge/correlator.ts
+++ b/apps/web/src/lib/env-bridge/correlator.ts
@@ -161,6 +161,11 @@ export class RequestCorrelator<T> {
     return this.pending.has(id);
   }
 
+  /** The group a pending id belongs to — the env that OWNS the request; undefined when nothing is pending under `id`. */
+  groupOf(id: string): string | undefined {
+    return this.pending.get(id)?.group;
+  }
+
   pendingCount(): number {
     return this.pending.size;
   }

--- a/apps/web/src/lib/env-bridge/correlator.ts
+++ b/apps/web/src/lib/env-bridge/correlator.ts
@@ -1,0 +1,193 @@
+/**
+ * Request/reply correlator — the id-correlated pending map, per-request
+ * deadline and cancel-all core that BOTH bridges sit on: the MCP desktop
+ * bridge (`lib/mcp/mcp-bridge.ts`, 30 s default preserved there) and the env
+ * bridge (deadlines from `resolveTimeout`, never a fixed default — an agent
+ * command routinely runs for minutes and a PTY is open for as long as the
+ * terminal is).
+ *
+ * What it guarantees:
+ * - A reply for an id that is not pending — late, duplicate, forged — resolves
+ *   NOTHING. It is dropped and reported through `onDropped`, so the socket
+ *   handler can log it and move on (invariant 6: unknown frames are dropped,
+ *   never guessed).
+ * - Every request belongs to a `group` (a userId, an envId) so a lost socket
+ *   can cancel exactly its own in-flight requests with a typed error, and no
+ *   one else's.
+ * - The clock is injected. Production gets `setTimeout`; tests use fake timers
+ *   (the default reads the global lazily, so `vi.useFakeTimers()` works) or a
+ *   recording stub.
+ *
+ * Pure-ish: no I/O of its own. The only side effect it performs is calling
+ * the `send` thunk the caller hands it, inside the same turn the request is
+ * registered, so a reply can never arrive before its id is pending.
+ */
+import { grantOpForFrame, type GrantFrame } from '@pagespace/lib/env-bridge/grant-args';
+import { resolveTimeout } from '@pagespace/lib/env-bridge/resolve-timeout';
+
+export type CorrelationFailureKind =
+  /** No reply within the request's deadline. */
+  | 'timeout'
+  /** The `send` thunk threw; nothing was registered. */
+  | 'send_failed'
+  /** The connection carrying this request went away. */
+  | 'disconnected'
+  /** A reply arrived but its machine signature did not verify (invariant 7). */
+  | 'unverified_result'
+  /** An id already pending was opened again; the original is untouched. */
+  | 'duplicate_id'
+  /** Cancelled by the owner for a stated reason. */
+  | 'cancelled';
+
+export class CorrelationError extends Error {
+  constructor(
+    readonly kind: CorrelationFailureKind,
+    message: string,
+    readonly detail?: Record<string, unknown>,
+  ) {
+    super(message);
+    this.name = 'CorrelationError';
+  }
+}
+
+export interface CorrelatorTimers {
+  setTimeout(fn: () => void, ms: number): unknown;
+  clearTimeout(handle: unknown): void;
+}
+
+/** Reads the globals at CALL time so fake timers installed after construction still apply. */
+const globalTimers: CorrelatorTimers = {
+  setTimeout: (fn, ms) => setTimeout(fn, ms),
+  clearTimeout: (handle) => clearTimeout(handle as ReturnType<typeof setTimeout>),
+};
+
+export interface OpenRequestInput {
+  /** The correlation id the reply will carry. */
+  readonly id: string;
+  /** Whose request this is (a userId, an envId) — the unit `cancelGroup` acts on. */
+  readonly group: string;
+  /** Deadline in ms, or `'unbounded'` for a channel whose liveness is the heartbeat's job (PTY). */
+  readonly timeoutMs: number | 'unbounded';
+  /** Puts the request on the wire. Invoked once, synchronously, after the id is pending. */
+  readonly send: () => void;
+}
+
+interface Pending<T> {
+  readonly group: string;
+  readonly resolve: (value: T) => void;
+  readonly reject: (error: Error) => void;
+  readonly timer: unknown | null;
+}
+
+export class RequestCorrelator<T> {
+  private readonly pending = new Map<string, Pending<T>>();
+  private readonly timers: CorrelatorTimers;
+  private readonly onDropped: (id: string) => void;
+
+  constructor(options: { timers?: CorrelatorTimers; onDropped?: (id: string) => void } = {}) {
+    this.timers = options.timers ?? globalTimers;
+    this.onDropped = options.onDropped ?? (() => {});
+  }
+
+  /** Register `id`, arm its deadline, put it on the wire. Rejects with a typed `CorrelationError` on every failure path. */
+  open(input: OpenRequestInput): Promise<T> {
+    if (this.pending.has(input.id)) {
+      return Promise.reject(new CorrelationError('duplicate_id', `Request id already pending: ${input.id}`, { id: input.id }));
+    }
+    return new Promise<T>((resolve, reject) => {
+      const timer =
+        input.timeoutMs === 'unbounded'
+          ? null
+          : this.timers.setTimeout(() => {
+              this.pending.delete(input.id);
+              reject(new CorrelationError('timeout', `Request timed out after ${input.timeoutMs}ms`, { id: input.id, timeoutMs: input.timeoutMs }));
+            }, input.timeoutMs);
+      this.pending.set(input.id, { group: input.group, resolve, reject, timer });
+      try {
+        input.send();
+      } catch (error) {
+        this.take(input.id);
+        reject(new CorrelationError('send_failed', `Failed to send request: ${error instanceof Error ? error.message : String(error)}`, { id: input.id }));
+      }
+    });
+  }
+
+  /** @returns false when nothing was pending under `id` — the reply is dropped and reported, nothing resolves. */
+  resolve(id: string, value: T): boolean {
+    const entry = this.take(id);
+    if (!entry) {
+      this.onDropped(id);
+      return false;
+    }
+    entry.resolve(value);
+    return true;
+  }
+
+  /** @returns false when nothing was pending under `id` — dropped and reported. */
+  reject(id: string, error: Error): boolean {
+    const entry = this.take(id);
+    if (!entry) {
+      this.onDropped(id);
+      return false;
+    }
+    entry.reject(error);
+    return true;
+  }
+
+  /** Reject every request in `group` with `error`. @returns how many were cancelled. */
+  cancelGroup(group: string, error: Error): number {
+    let count = 0;
+    for (const [id, entry] of [...this.pending.entries()]) {
+      if (entry.group !== group) continue;
+      this.take(id);
+      entry.reject(error);
+      count += 1;
+    }
+    return count;
+  }
+
+  /** Reject everything pending. @returns how many were cancelled. */
+  cancelAll(error: Error): number {
+    let count = 0;
+    for (const [id, entry] of [...this.pending.entries()]) {
+      this.take(id);
+      entry.reject(error);
+      count += 1;
+    }
+    return count;
+  }
+
+  has(id: string): boolean {
+    return this.pending.has(id);
+  }
+
+  pendingCount(): number {
+    return this.pending.size;
+  }
+
+  pendingCountForGroup(group: string): number {
+    let count = 0;
+    for (const entry of this.pending.values()) if (entry.group === group) count += 1;
+    return count;
+  }
+
+  /** Remove `id` and disarm its deadline. */
+  private take(id: string): Pending<T> | undefined {
+    const entry = this.pending.get(id);
+    if (!entry) return undefined;
+    this.pending.delete(id);
+    if (entry.timer !== null) this.timers.clearTimeout(entry.timer);
+    return entry;
+  }
+}
+
+/**
+ * The correlator deadline for a grant frame — ALWAYS from `resolveTimeout`,
+ * so an exec with `timeoutMs: 120_000` waits its full two minutes plus
+ * transport margin and a PTY open is `'unbounded'`. There is no other source
+ * of this number for the env bridge.
+ */
+export function grantCorrelatorTimeoutMs(frame: GrantFrame): number | 'unbounded' {
+  const timeoutMs = frame.type === 'grant_exec' ? frame.timeoutMs : undefined;
+  return resolveTimeout({ op: grantOpForFrame(frame), timeoutMs }).correlatorTimeoutMs;
+}

--- a/apps/web/src/lib/env-bridge/crypto.ts
+++ b/apps/web/src/lib/env-bridge/crypto.ts
@@ -1,0 +1,32 @@
+/**
+ * The node primitives the env bridge injects into the pure core. ONE place, so
+ * the server hashes and verifies with exactly what the daemon (t08) is
+ * documented to use:
+ *
+ * - `envBridgeHash`: SHA-256, lowercase hex. This is the `hash` behind
+ *   `argsHash` (grant binding, invariant 3) and `resultHash` (invariant 7).
+ *   The daemon MUST use the same algorithm and encoding or every grant is
+ *   `args_mismatch` and every result `unverified_result`.
+ * - `ed25519Verify`: Ed25519 over SPKI DER public keys, never throws.
+ */
+import { createHash, createPublicKey, verify as nodeVerify } from 'crypto';
+import type { Ed25519Verify, HashBytes } from '@pagespace/lib/env-bridge/grant';
+import { decodeBase64 } from '@pagespace/lib/env-bridge/grant';
+
+export const ENV_BRIDGE_HASH_ALGORITHM = 'sha256';
+
+export const envBridgeHash: HashBytes = (bytes) => createHash(ENV_BRIDGE_HASH_ALGORITHM).update(bytes).digest('hex');
+
+export const ed25519Verify: Ed25519Verify = (message, signature, publicKey) => {
+  try {
+    return nodeVerify(null, message, createPublicKey({ key: Buffer.from(publicKey), type: 'spki', format: 'der' }), signature);
+  } catch {
+    return false;
+  }
+};
+
+/** A pinned machine key as stored (base64 SPKI DER) → bytes, or null when the row is unusable. */
+export function decodePinnedPublicKey(base64Spki: string | null): Uint8Array | null {
+  if (base64Spki === null) return null;
+  return decodeBase64(base64Spki);
+}

--- a/apps/web/src/lib/env-bridge/grant-signer.ts
+++ b/apps/web/src/lib/env-bridge/grant-signer.ts
@@ -1,0 +1,102 @@
+/**
+ * Grant signer — the server end of invariant 3. Builds the `Grant` a
+ * `grant_*` frame carries and signs the canonical bytes `verifyGrant` (the
+ * daemon's gate, pure core) checks.
+ *
+ * Two things are settled here and nowhere else:
+ *
+ * - **What is hashed (Codex C7).** `argsHash = hash(canonicalizeArgs(
+ *   grantArgsForFrame(frame)))` — the per-op projection from `grant-args.ts`,
+ *   the SAME function the daemon's gate calls before verifying. The signer
+ *   never hashes "the frame" or its own idea of the args; it asks the
+ *   projection. A field the projection covers cannot be altered in flight; a
+ *   field it does not cover is, by definition, not part of the request.
+ * - **Which key signs (Codex C10).** The key the ENROLLMENT pinned
+ *   (`drive_env_local.serverKeyId`), looked up in the loaded ring. A pinned
+ *   key that is no longer loaded is a typed `signing_key_unavailable` — never a
+ *   signature under a different key, which the daemon could not verify anyway
+ *   and which would teach an operator that rotation "works" when it strands.
+ *
+ * Pure apart from the injected id source: the byte layout comes from
+ * `encodeGrant` (never re-implemented here), the clock is a parameter.
+ */
+import { canonicalizeArgs, encodeGrant, GRANT_MAX_TTL_MS, type Grant, type GrantPrincipal, type HashBytes } from '@pagespace/lib/env-bridge/grant';
+import { grantRequestForFrame, type GrantFrame } from '@pagespace/lib/env-bridge/grant-args';
+import type { ServerSigningKeyring } from '@pagespace/lib/env-bridge/server-signing-key';
+import { envBridgeHash } from './crypto';
+
+/** A grant frame before its grant + signature are attached — what a host asks the bridge to send. */
+export type UnsignedGrantFrame = {
+  [K in GrantFrame['type']]: Omit<Extract<GrantFrame, { type: K }>, 'grant' | 'sig'>;
+}[GrantFrame['type']];
+
+export interface GrantIdSource {
+  grantId(): string;
+  nonce(): string;
+}
+
+export interface SignGrantFrameInput {
+  readonly frame: UnsignedGrantFrame;
+  readonly envId: string;
+  readonly principal: GrantPrincipal;
+  /** `drive_env_local.serverKeyId` — the key this enrollment pinned. `null` = never enrolled. */
+  readonly serverKeyId: string | null;
+  readonly keyring: Pick<ServerSigningKeyring, 'get'>;
+  /** ms since epoch. */
+  readonly now: number;
+  /** Defaults to GRANT_MAX_TTL_MS; anything longer is refused (the gate would too). */
+  readonly ttlMs?: number;
+  readonly ids: GrantIdSource;
+  /** Defaults to the bridge's SHA-256; injectable for tests that pair the signer with a differently-hashing gate. */
+  readonly hash?: HashBytes;
+}
+
+export type SignGrantFrameResult =
+  | { readonly ok: true; readonly frame: GrantFrame; readonly grant: Grant; readonly keyId: string }
+  | { readonly ok: false; readonly reason: 'signing_key_unavailable' | 'ttl_too_long' };
+
+export function signGrantFrame(input: SignGrantFrameInput): SignGrantFrameResult {
+  const key = input.serverKeyId === null ? null : input.keyring.get(input.serverKeyId);
+  if (!key) return { ok: false, reason: 'signing_key_unavailable' };
+
+  const ttlMs = input.ttlMs ?? GRANT_MAX_TTL_MS;
+  if (ttlMs > GRANT_MAX_TTL_MS || ttlMs <= 0) return { ok: false, reason: 'ttl_too_long' };
+
+  // The projection is computed on the frame AS IT WILL BE SENT (grant/sig are
+  // envelope, not args, so placeholders change nothing) — the daemon's gate
+  // calls the same function on the frame as received.
+  const provisional = { ...input.frame, grant: {}, sig: '' } as GrantFrame;
+  const request = grantRequestForFrame(provisional);
+  const hash = input.hash ?? envBridgeHash;
+  const argsHash = hash(canonicalizeArgs(request.args));
+
+  const grant: Grant = {
+    grantId: input.ids.grantId(),
+    envId: input.envId,
+    principal: {
+      userId: input.principal.userId,
+      sessionId: input.principal.sessionId,
+      conversationId: input.principal.conversationId,
+    },
+    op: request.op,
+    argsHash,
+    iat: input.now,
+    exp: input.now + ttlMs,
+    nonce: input.ids.nonce(),
+  };
+  const sig = Buffer.from(key.sign(encodeGrant(grant))).toString('base64');
+
+  // The grant travels opaque on the wire (frame-codec keeps it a record); the
+  // strict parser on the daemon is the one that types it again.
+  const wireGrant: Record<string, unknown> = {
+    grantId: grant.grantId,
+    envId: grant.envId,
+    principal: { ...grant.principal },
+    op: grant.op,
+    argsHash: grant.argsHash,
+    iat: grant.iat,
+    exp: grant.exp,
+    nonce: grant.nonce,
+  };
+  return { ok: true, frame: { ...input.frame, grant: wireGrant, sig } as GrantFrame, grant, keyId: key.keyId };
+}

--- a/apps/web/src/lib/env-bridge/result-verifier.ts
+++ b/apps/web/src/lib/env-bridge/result-verifier.ts
@@ -1,0 +1,30 @@
+/**
+ * Result verifier — the server end of invariant 7. Before ANY `exec_result`,
+ * `fs_read_result`, `fs_write_result` or `grant_denied` reaches the agent, its
+ * machine signature over `{grantId, resultHash}` is verified under the public
+ * key the env's enrollment pinned. A result that does not verify is not
+ * delivered — the pending request is failed with a typed `unverified_result`
+ * (see `bridge-client.ts`), and the event is logged.
+ *
+ * The bytes and the payload projection live in the pure core
+ * (`env-bridge/machine-signatures.ts`), where the daemon (t08) produces them;
+ * this module only binds the node primitives and the stored key format.
+ *
+ * PTY frames (`pty_data`, `pty_exit`) and `pong` are OUTSIDE this verifier by
+ * design — see founder decision [D-2] on the epic page ("PTY is a
+ * session-bound channel, not per-frame grants"; recommended (b): a per-session
+ * HMAC derived at `pty_open`). Whatever is decided slots in beside this
+ * verifier for PTY frames; exec/fs verification here does not change.
+ */
+import { verifyMachineResult, type MachineResultFrame, type MachineSignatureDenyReason } from '@pagespace/lib/env-bridge/machine-signatures';
+import { decodePinnedPublicKey, ed25519Verify, envBridgeHash } from './crypto';
+
+export type ResultVerification =
+  | { readonly ok: true; readonly resultHash: string }
+  | { readonly ok: false; readonly reason: MachineSignatureDenyReason | 'bad_public_key' };
+
+export function verifyResultFromMachine(input: { frame: MachineResultFrame; machinePublicKey: string | null }): ResultVerification {
+  const publicKey = decodePinnedPublicKey(input.machinePublicKey);
+  if (publicKey === null) return { ok: false, reason: 'bad_public_key' };
+  return verifyMachineResult({ frame: input.frame, machinePublicKey: publicKey, verify: ed25519Verify, hash: envBridgeHash });
+}

--- a/apps/web/src/lib/env-bridge/revoke.ts
+++ b/apps/web/src/lib/env-bridge/revoke.ts
@@ -1,0 +1,127 @@
+/**
+ * Revoke a local environment's machine — the apps/web adapter for
+ * `revokeLocalDriveEnv` (Codex C4: all three legs, or it is not a revoke):
+ *
+ *   1. `drive_env_local.revokedAt` stamped (store CAS);
+ *   2. every session with `resourceType = 'drive_env' AND resourceId = envId`
+ *      revoked (`sessionService.revokeResourceSessions`) — the `env:bridge`
+ *      socket tokens die now, not at their TTL;
+ *   3. the machine told: a server-signed `revoke` frame — signed by the key
+ *      this ENROLLMENT pinned, binding `{envId, enrollmentId, keyId, issuedAt}`
+ *      (`encodeRevokeForSigning`, the bytes the daemon verifies) — pushed over
+ *      the live socket on this replica, then the socket closed 1008 and
+ *      unregistered so its in-flight requests fail `disconnected` at once.
+ *
+ * Leg 3 is best-effort and reported, never thrown: a socket on another
+ * replica is closed by the 5-minute revalidation once leg 2 killed its
+ * token; a socket that has not completed its hello is closed WITHOUT a
+ * frame (nothing is ever sent to an unauthorized socket); a pinned key that
+ * is no longer loaded closes WITHOUT a frame rather than signing under
+ * another key (Codex C10).
+ */
+import type { WebSocket } from 'ws';
+import { encodeFrame } from '@pagespace/lib/env-bridge/frame-codec';
+import { encodeRevokeForSigning, type RevokeFrame } from '@pagespace/lib/env-bridge/machine-signatures';
+import type { ServerSigningKeyring } from '@pagespace/lib/env-bridge/server-signing-key';
+import { loadServerSigningKeyring } from '@pagespace/lib/auth/env-bridge-signing-key';
+import { sessionService } from '@pagespace/lib/auth/session-service';
+import { revokeLocalDriveEnv, type RevokeLocalDriveEnvResult, type RevokeMachineNotifyOutcome } from '@pagespace/lib/services/drive-envs/local-env-revoke';
+import { logger } from '@pagespace/lib/logging/logger-config';
+import { getEnvConnection, isEnvAuthorized, unregisterEnvConnection } from '@/lib/websocket/ws-env-connections';
+import { getDriveEnvStore } from '@/lib/drive-envs/drive-envs-runtime';
+
+export const ENV_REVOKED_CLOSE_CODE = 1008;
+export const ENV_REVOKED_CLOSE_REASON = 'Environment revoked';
+
+const log = logger.child({ component: 'env-bridge-revoke' });
+
+export interface RevokeFrameInput {
+  envId: string;
+  enrollmentId: string;
+  /** `drive_env_local.serverKeyId` — the ONLY key that may sign this revoke. */
+  serverKeyId: string | null;
+  issuedAt: number;
+  reason: string;
+}
+
+/** The signed revoke frame for this enrollment, or `signing_key_unavailable` — never a signature under another key. */
+export function buildRevokeFrame(input: RevokeFrameInput, keyring: Pick<ServerSigningKeyring, 'get'>): { ok: true; frame: RevokeFrame; keyId: string } | { ok: false; reason: 'signing_key_unavailable' } {
+  const key = input.serverKeyId === null ? null : keyring.get(input.serverKeyId);
+  if (!key) return { ok: false, reason: 'signing_key_unavailable' };
+  const sig = Buffer.from(key.sign(encodeRevokeForSigning({ envId: input.envId, enrollmentId: input.enrollmentId, keyId: key.keyId, issuedAt: input.issuedAt }))).toString('base64');
+  return { ok: true, frame: { type: 'revoke', sig, issuedAt: input.issuedAt, reason: input.reason }, keyId: key.keyId };
+}
+
+export interface NotifyMachineDeps {
+  getConnection: (envId: string) => WebSocket | undefined;
+  isAuthorized: (ws: WebSocket) => boolean;
+  unregister: (envId: string, ws: WebSocket) => boolean;
+  keyring: () => Pick<ServerSigningKeyring, 'get'>;
+}
+
+/** Leg 3 against injected socket/registry/keyring seams. Never throws. */
+export async function notifyMachineOfRevoke(input: RevokeFrameInput, deps: NotifyMachineDeps): Promise<RevokeMachineNotifyOutcome> {
+  const ws = deps.getConnection(input.envId);
+  if (!ws || (ws.readyState !== 0 && ws.readyState !== 1)) return 'no_live_socket';
+
+  let outcome: RevokeMachineNotifyOutcome;
+  if (!deps.isAuthorized(ws)) {
+    outcome = 'closed_unauthorized_socket';
+  } else {
+    const built = buildRevokeFrame(input, deps.keyring());
+    if (built.ok) {
+      try {
+        ws.send(encodeFrame(built.frame));
+        outcome = 'sent_and_closed';
+      } catch (error) {
+        log.warn('Revoke frame send failed; closing anyway', { envId: input.envId, error: error instanceof Error ? error.message : String(error), action: 'revoke_send_failed' });
+        outcome = 'closed_unsigned_key_unavailable';
+      }
+    } else {
+      log.error('Enrollment pinned a signing key that is no longer loaded; closing without a revoke frame', { envId: input.envId, serverKeyId: input.serverKeyId, action: 'revoke_key_unavailable' });
+      outcome = 'closed_unsigned_key_unavailable';
+    }
+  }
+  try {
+    ws.close(ENV_REVOKED_CLOSE_CODE, ENV_REVOKED_CLOSE_REASON);
+  } catch (error) {
+    log.warn('Error closing revoked socket', { envId: input.envId, error: error instanceof Error ? error.message : String(error), action: 'revoke_close_error' });
+  }
+  // Through the CAS: fails this env's in-flight requests now rather than on the close event.
+  deps.unregister(input.envId, ws);
+  return outcome;
+}
+
+/** Revokes are rare: read the ring each time so a rotation is honoured without a restart. */
+function loadKeyring(): ServerSigningKeyring {
+  return loadServerSigningKeyring();
+}
+
+/** Revoke through the production seams. `reason` is recorded on the sessions (prefixed) and sent to the machine. */
+export async function revokeLocalEnv(input: { envId: string; reason: string }): Promise<RevokeLocalDriveEnvResult> {
+  const store = await getDriveEnvStore();
+  return revokeLocalDriveEnv({
+    envId: input.envId,
+    reason: input.reason,
+    deps: {
+      store,
+      now: () => new Date(),
+      revokeSessions: ({ envId, reason }) => sessionService.revokeResourceSessions('drive_env', envId, `env_bridge_${reason}`),
+      notifyMachine: (machine) =>
+        notifyMachineOfRevoke(machine, {
+          getConnection: getEnvConnection,
+          isAuthorized: isEnvAuthorized,
+          unregister: unregisterEnvConnection,
+          keyring: () => {
+            try {
+              return loadKeyring();
+            } catch (error) {
+              // No key configured at all: nothing can sign; the socket still closes.
+              log.error('Signing key ring unavailable during revoke', { envId: machine.envId, error: error instanceof Error ? error.message : String(error), action: 'revoke_keyring_error' });
+              return { get: () => null };
+            }
+          },
+        }),
+    },
+  });
+}

--- a/apps/web/src/lib/env-bridge/revoke.ts
+++ b/apps/web/src/lib/env-bridge/revoke.ts
@@ -33,7 +33,12 @@ import { getDriveEnvStore } from '@/lib/drive-envs/drive-envs-runtime';
 export const ENV_REVOKED_CLOSE_CODE = 1008;
 export const ENV_REVOKED_CLOSE_REASON = 'Environment revoked';
 
-const log = logger.child({ component: 'env-bridge-revoke' });
+/** Built on first use, never at import (see ws-env-connections.ts for why). */
+let revokeLogger: ReturnType<typeof logger.child> | null = null;
+function log(): ReturnType<typeof logger.child> {
+  revokeLogger ??= logger.child({ component: 'env-bridge-revoke' });
+  return revokeLogger;
+}
 
 export interface RevokeFrameInput {
   envId: string;
@@ -74,18 +79,18 @@ export async function notifyMachineOfRevoke(input: RevokeFrameInput, deps: Notif
         ws.send(encodeFrame(built.frame));
         outcome = 'sent_and_closed';
       } catch (error) {
-        log.warn('Revoke frame send failed; closing anyway', { envId: input.envId, error: error instanceof Error ? error.message : String(error), action: 'revoke_send_failed' });
+        log().warn('Revoke frame send failed; closing anyway', { envId: input.envId, error: error instanceof Error ? error.message : String(error), action: 'revoke_send_failed' });
         outcome = 'closed_unsigned_key_unavailable';
       }
     } else {
-      log.error('Enrollment pinned a signing key that is no longer loaded; closing without a revoke frame', { envId: input.envId, serverKeyId: input.serverKeyId, action: 'revoke_key_unavailable' });
+      log().error('Enrollment pinned a signing key that is no longer loaded; closing without a revoke frame', { envId: input.envId, serverKeyId: input.serverKeyId, action: 'revoke_key_unavailable' });
       outcome = 'closed_unsigned_key_unavailable';
     }
   }
   try {
     ws.close(ENV_REVOKED_CLOSE_CODE, ENV_REVOKED_CLOSE_REASON);
   } catch (error) {
-    log.warn('Error closing revoked socket', { envId: input.envId, error: error instanceof Error ? error.message : String(error), action: 'revoke_close_error' });
+    log().warn('Error closing revoked socket', { envId: input.envId, error: error instanceof Error ? error.message : String(error), action: 'revoke_close_error' });
   }
   // Through the CAS: fails this env's in-flight requests now rather than on the close event.
   deps.unregister(input.envId, ws);
@@ -117,7 +122,7 @@ export async function revokeLocalEnv(input: { envId: string; reason: string }): 
               return loadKeyring();
             } catch (error) {
               // No key configured at all: nothing can sign; the socket still closes.
-              log.error('Signing key ring unavailable during revoke', { envId: machine.envId, error: error instanceof Error ? error.message : String(error), action: 'revoke_keyring_error' });
+              log().error('Signing key ring unavailable during revoke', { envId: machine.envId, error: error instanceof Error ? error.message : String(error), action: 'revoke_keyring_error' });
               return { get: () => null };
             }
           },

--- a/apps/web/src/lib/env-bridge/ws-route-config.ts
+++ b/apps/web/src/lib/env-bridge/ws-route-config.ts
@@ -1,0 +1,11 @@
+/**
+ * Timing constants for the env-bridge socket route. They live here rather
+ * than in `app/api/env-bridge/ws/route.ts` because a Next.js route module may
+ * export only its HTTP handlers and the route-segment config — any other
+ * export fails `next build`'s route type check (tsc does not catch it).
+ */
+
+/** How long a socket may sit without a valid signed hello before it is closed. */
+export const ENV_BRIDGE_HELLO_TIMEOUT_MS = 10_000;
+/** Server → daemon heartbeat cadence; well inside LOCAL_ENV_HEARTBEAT_WINDOW_MS (90 s). */
+export const ENV_BRIDGE_PING_INTERVAL_MS = 30_000;

--- a/apps/web/src/lib/mcp/mcp-bridge.ts
+++ b/apps/web/src/lib/mcp/mcp-bridge.ts
@@ -1,5 +1,6 @@
 import { getConnection, checkConnectionHealth } from '@/lib/websocket';
 import { logger } from '@pagespace/lib/logging/logger';
+import { RequestCorrelator, CorrelationError } from '@/lib/env-bridge/correlator';
 
 /**
  * MCP Bridge - Server-side WebSocket manager for tool execution
@@ -8,7 +9,9 @@ import { logger } from '@pagespace/lib/logging/logger';
  * clients for executing MCP tools locally on the user's machine.
  *
  * Features:
- * - Tool execution request/response matching
+ * - Tool execution request/response matching (the shared `RequestCorrelator`;
+ *   this bridge keeps its 30s default, the env bridge takes its deadlines from
+ *   `resolveTimeout`)
  * - Timeout handling (30s default)
  * - Connection status checking
  * - Error handling and logging
@@ -30,16 +33,10 @@ interface ToolExecutionResponse {
   error?: string;
 }
 
-interface PendingRequest {
-  resolve: (value: unknown) => void;
-  reject: (error: Error) => void;
-  timeout: NodeJS.Timeout;
-}
-
 export class MCPBridge {
-  private pendingRequests: Map<string, PendingRequest> = new Map();
   private readonly defaultTimeout = 30000; // 30 seconds
   private readonly logger = logger.child({ component: 'mcp-bridge' });
+  private readonly correlator = new RequestCorrelator<unknown>();
 
   /**
    * Execute a tool on the user's desktop via WebSocket
@@ -95,39 +92,25 @@ export class MCPBridge {
       action: 'send_tool_request',
     });
 
-    // Return a promise that will be resolved when we receive the response
-    return new Promise((resolve, reject) => {
-      // Set up timeout
-      const timeout = setTimeout(() => {
-        this.pendingRequests.delete(requestId);
-        reject(
-          new Error(
-            `Tool execution timeout after ${this.defaultTimeout}ms: ${serverName}.${toolName}`
-          )
-        );
-      }, this.defaultTimeout);
-
-      // Store the pending request
-      this.pendingRequests.set(requestId, {
-        resolve,
-        reject,
-        timeout,
+    // The correlator registers the id, arms the 30s deadline and puts the
+    // request on the wire; its typed failures are mapped back to this bridge's
+    // historical error messages so callers see exactly what they always did.
+    return this.correlator
+      .open({
+        id: requestId,
+        group: userId,
+        timeoutMs: this.defaultTimeout,
+        send: () => connection.send(JSON.stringify(request)),
+      })
+      .catch((error: unknown) => {
+        if (error instanceof CorrelationError && error.kind === 'timeout') {
+          throw new Error(`Tool execution timeout after ${this.defaultTimeout}ms: ${serverName}.${toolName}`);
+        }
+        if (error instanceof CorrelationError && error.kind === 'send_failed') {
+          throw new Error(`Failed to send tool execution request: ${error.message.replace(/^Failed to send request: /, '')}`);
+        }
+        throw error;
       });
-
-      // Send the request to the desktop client
-      try {
-        connection.send(JSON.stringify(request));
-      } catch (error) {
-        // Clean up if send fails
-        clearTimeout(timeout);
-        this.pendingRequests.delete(requestId);
-        reject(
-          new Error(
-            `Failed to send tool execution request: ${error instanceof Error ? error.message : String(error)}`
-          )
-        );
-      }
-    });
   }
 
   /**
@@ -139,9 +122,7 @@ export class MCPBridge {
    * @param response - The tool execution response from the desktop
    */
   handleToolResponse(response: ToolExecutionResponse): void {
-    const pending = this.pendingRequests.get(response.id);
-
-    if (!pending) {
+    if (!this.correlator.has(response.id)) {
       this.logger.warn('Received response for unknown request ID', {
         requestId: response.id,
         action: 'handle_tool_response',
@@ -150,20 +131,14 @@ export class MCPBridge {
       return;
     }
 
-    // Clear the timeout
-    clearTimeout(pending.timeout);
-
-    // Remove from pending requests
-    this.pendingRequests.delete(response.id);
-
-    // Resolve or reject the promise
+    // Resolve or reject the promise (the correlator clears the deadline and forgets the id)
     if (response.success) {
       this.logger.info('Tool execution succeeded', {
         requestId: response.id,
         action: 'handle_tool_response',
         status: 'success',
       });
-      pending.resolve(response.result);
+      this.correlator.resolve(response.id, response.result);
     } else {
       this.logger.error('Tool execution failed', {
         requestId: response.id,
@@ -171,7 +146,8 @@ export class MCPBridge {
         action: 'handle_tool_response',
         status: 'failed',
       });
-      pending.reject(
+      this.correlator.reject(
+        response.id,
         new Error(response.error || 'Tool execution failed with unknown error')
       );
     }
@@ -187,7 +163,7 @@ export class MCPBridge {
     // belong to which user. For simplicity, we'll just note this in the logs.
     this.logger.info('User disconnected, pending requests will timeout', {
       userId,
-      pendingCount: this.pendingRequests.size,
+      pendingCount: this.correlator.pendingCount(),
       action: 'cancel_user_requests',
     });
   }
@@ -207,7 +183,7 @@ export class MCPBridge {
    * Get the number of pending requests
    */
   getPendingRequestCount(): number {
-    return this.pendingRequests.size;
+    return this.correlator.pendingCount();
   }
 }
 

--- a/apps/web/src/lib/websocket/__tests__/ws-env-connections.test.ts
+++ b/apps/web/src/lib/websocket/__tests__/ws-env-connections.test.ts
@@ -1,0 +1,284 @@
+/**
+ * The per-ENV bridge socket registry. Keyed by envId, not userId: one user's
+ * two machines hold two live sockets. Copied from `ws-connections.ts` and
+ * pinned here: the stale-cleanup sweep, the 5-minute session revalidation and
+ * the CAS-on-socket-identity guard in unregister (a dead socket must never
+ * cancel a live env's in-flight requests).
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import type { WebSocket } from 'ws';
+
+vi.mock('@pagespace/lib/auth/session-service', () => ({ sessionService: { validateSession: vi.fn() } }));
+vi.mock('@pagespace/lib/logging/logger-config', () => ({
+  logger: { child: () => ({ info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() }) },
+}));
+
+import { sessionService } from '@pagespace/lib/auth/session-service';
+import {
+  registerEnvConnection,
+  unregisterEnvConnection,
+  getEnvConnection,
+  getAuthorizedEnvConnection,
+  getEnvConnectionMetadata,
+  markEnvAuthorized,
+  updateEnvLastPing,
+  readEnvLiveConnection,
+  onEnvConnectionLost,
+  checkEnvConnectionHealth,
+  verifyEnvConnectionFingerprint,
+  triggerEnvCleanup,
+  clearAllEnvConnectionsForTesting,
+  ENV_SUPERSEDED_CLOSE_CODE,
+  ENV_SUPERSEDED_CLOSE_REASON,
+  ENV_SESSION_REVALIDATION_INTERVAL_MS,
+  ENV_STALE_CONNECTION_TIMEOUT_MS,
+} from '../ws-env-connections';
+import { RequestCorrelator, CorrelationError } from '@/lib/env-bridge/correlator';
+
+type FakeSocket = WebSocket & { readyState: number };
+function socket(readyState = 1): FakeSocket {
+  return { readyState, send: vi.fn(), close: vi.fn(), on: vi.fn() } as unknown as FakeSocket;
+}
+
+const NOW = new Date('2026-09-06T10:00:00.000Z');
+const meta = (envId: string, over: Partial<Parameters<typeof registerEnvConnection>[2]> = {}) => ({
+  userId: 'user-1',
+  sessionId: `sess-${envId}`,
+  enrollmentId: `enr-${envId}`,
+  machinePublicKey: 'MCowBQYDK2VwAyEA',
+  serverKeyId: 'k1',
+  fingerprint: 'fp-1',
+  sessionExpiresAt: new Date(NOW.getTime() + 60 * 60 * 1000),
+  wsToken: `tok-${envId}`,
+  ...over,
+});
+
+describe('ws-env-connections — the per-env registry', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(NOW);
+    clearAllEnvConnectionsForTesting();
+    vi.mocked(sessionService.validateSession).mockReset();
+  });
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('given two envs for one user, should hold two live sockets at once (regression vs the per-user map)', () => {
+    const a = socket();
+    const b = socket();
+    registerEnvConnection('env-a', a, meta('env-a'));
+    registerEnvConnection('env-b', b, meta('env-b'));
+    expect(getEnvConnection('env-a')).toBe(a);
+    expect(getEnvConnection('env-b')).toBe(b);
+    expect(a.close).not.toHaveBeenCalled();
+    expect(b.close).not.toHaveBeenCalled();
+  });
+
+  it('given a second socket for the SAME env, the newer should win and the older close with the documented code + reason', () => {
+    const older = socket();
+    const newer = socket();
+    registerEnvConnection('env-a', older, meta('env-a'));
+    registerEnvConnection('env-a', newer, meta('env-a'));
+    expect(getEnvConnection('env-a')).toBe(newer);
+    expect(older.close).toHaveBeenCalledWith(ENV_SUPERSEDED_CLOSE_CODE, ENV_SUPERSEDED_CLOSE_REASON);
+    expect(getEnvConnectionMetadata(older)).toBeUndefined();
+    expect(getEnvConnectionMetadata(newer)?.envId).toBe('env-a');
+  });
+
+  it('given the superseded socket then closes, its unregister should be a no-op (CAS on identity): no lost event, no cancellation of answered OR in-flight requests', async () => {
+    const correlator = new RequestCorrelator<string>();
+    const lost: string[] = [];
+    const off = onEnvConnectionLost((envId) => {
+      lost.push(envId);
+      correlator.cancelGroup(envId, new CorrelationError('disconnected', 'gone'));
+    });
+    const older = socket();
+    registerEnvConnection('env-a', older, meta('env-a'));
+    markEnvAuthorized(older);
+    const answered = correlator.open({ id: 'r1', group: 'env-a', timeoutMs: 10_000, send: () => {} });
+    correlator.resolve('r1', 'done');
+    const inFlight = correlator.open({ id: 'r2', group: 'env-a', timeoutMs: 10_000, send: () => {} });
+    let inFlightState = 'pending';
+    inFlight.then(() => (inFlightState = 'resolved'), () => (inFlightState = 'rejected'));
+
+    const newer = socket();
+    registerEnvConnection('env-a', newer, meta('env-a'));
+    // The old socket's close handler runs AFTER the new one registered — the historical race.
+    expect(unregisterEnvConnection('env-a', older)).toBe(false);
+    await Promise.resolve();
+    expect(lost).toEqual([]);
+    expect(await answered).toBe('done');
+    expect(inFlightState).toBe('pending');
+    expect(getEnvConnection('env-a')).toBe(newer);
+    off();
+  });
+
+  it('given the LIVE socket unregisters, should fire the lost listener exactly once so its pending requests cancel with a typed disconnected error', async () => {
+    const correlator = new RequestCorrelator<string>();
+    const lost: string[] = [];
+    const off = onEnvConnectionLost((envId) => {
+      lost.push(envId);
+      correlator.cancelGroup(envId, new CorrelationError('disconnected', 'gone'));
+    });
+    const ws = socket();
+    registerEnvConnection('env-a', ws, meta('env-a'));
+    const pending = correlator.open({ id: 'r1', group: 'env-a', timeoutMs: 10_000, send: () => {} });
+    expect(unregisterEnvConnection('env-a', ws)).toBe(true);
+    expect(lost).toEqual(['env-a']);
+    await expect(pending).rejects.toMatchObject({ kind: 'disconnected' });
+    expect(getEnvConnection('env-a')).toBeUndefined();
+    expect(getEnvConnectionMetadata(ws)).toBeUndefined();
+    // A second unregister of the same dead socket is a no-op.
+    expect(unregisterEnvConnection('env-a', ws)).toBe(false);
+    expect(lost).toEqual(['env-a']);
+    off();
+  });
+
+  it('should read the live-connection status the way the DTO expects: connecting while hello is pending, connected once authorized, null otherwise', () => {
+    expect(readEnvLiveConnection('env-a')).toBeNull();
+    const ws = socket();
+    registerEnvConnection('env-a', ws, meta('env-a'));
+    expect(readEnvLiveConnection('env-a')).toBe('connecting');
+    markEnvAuthorized(ws);
+    expect(readEnvLiveConnection('env-a')).toBe('connected');
+    ws.readyState = 3;
+    expect(readEnvLiveConnection('env-a')).toBeNull();
+  });
+
+  it('should hand out a socket for server→daemon frames ONLY when authorized and open (invariant 6 — nothing is sent to a socket that has not proven itself)', () => {
+    const ws = socket();
+    registerEnvConnection('env-a', ws, meta('env-a'));
+    expect(getAuthorizedEnvConnection('env-a')).toBeUndefined();
+    markEnvAuthorized(ws);
+    expect(getAuthorizedEnvConnection('env-a')).toBe(ws);
+    ws.readyState = 2;
+    expect(getAuthorizedEnvConnection('env-a')).toBeUndefined();
+  });
+
+  it('should verify the fingerprint against what was registered', () => {
+    const ws = socket();
+    registerEnvConnection('env-a', ws, meta('env-a', { fingerprint: 'fp-1' }));
+    expect(verifyEnvConnectionFingerprint(ws, 'fp-1')).toBe(true);
+    expect(verifyEnvConnectionFingerprint(ws, 'fp-2')).toBe(false);
+    expect(verifyEnvConnectionFingerprint(socket(), 'fp-1')).toBe(false);
+  });
+
+  describe('health check (mirrors checkConnectionHealth)', () => {
+    it('given an unregistered socket, should be unhealthy: not registered', () => {
+      expect(checkEnvConnectionHealth(socket())).toMatchObject({ isHealthy: false, reason: 'Connection not registered' });
+    });
+    it('given a registered but not-yet-authorized socket, should be unhealthy: authentication not completed', () => {
+      const ws = socket();
+      registerEnvConnection('env-a', ws, meta('env-a'));
+      expect(checkEnvConnectionHealth(ws)).toMatchObject({ isHealthy: false, reason: 'Authentication not completed' });
+    });
+    it('given a closed socket, should be unhealthy: not open', () => {
+      const ws = socket(3);
+      registerEnvConnection('env-a', ws, meta('env-a'));
+      markEnvAuthorized(ws);
+      expect(checkEnvConnectionHealth(ws).reason).toMatch(/not open/);
+    });
+    it('given an expired session, should be unhealthy: session expired', () => {
+      const ws = socket();
+      registerEnvConnection('env-a', ws, meta('env-a', { sessionExpiresAt: new Date(NOW.getTime() - 1) }));
+      markEnvAuthorized(ws);
+      expect(checkEnvConnectionHealth(ws)).toMatchObject({ isHealthy: false, reason: 'Session expired', sessionExpired: true });
+    });
+    it('given an authorized, open, unexpired socket, should be healthy', () => {
+      const ws = socket();
+      registerEnvConnection('env-a', ws, meta('env-a'));
+      markEnvAuthorized(ws);
+      updateEnvLastPing(ws);
+      expect(checkEnvConnectionHealth(ws)).toMatchObject({ isHealthy: true, readyState: 1 });
+    });
+  });
+
+  describe('stale-connection sweep (copied from ws-connections)', () => {
+    it('given a socket that is already closed, should drop it from the map and fire the lost listener', async () => {
+      const lost: string[] = [];
+      const off = onEnvConnectionLost((envId) => lost.push(envId));
+      const ws = socket();
+      registerEnvConnection('env-a', ws, meta('env-a'));
+      ws.readyState = 3;
+      // The session is still valid: only the closed-socket check may remove it.
+      vi.mocked(sessionService.validateSession).mockResolvedValue({ userId: 'user-1' } as never);
+      await triggerEnvCleanup();
+      expect(getEnvConnection('env-a')).toBeUndefined();
+      expect(ws.close).not.toHaveBeenCalled();
+      expect(lost).toEqual(['env-a']);
+      off();
+    });
+
+    it('given an expired session, should close 1000 "Session expired" and drop it', async () => {
+      const ws = socket();
+      registerEnvConnection('env-a', ws, meta('env-a', { sessionExpiresAt: new Date(NOW.getTime() + 1000) }));
+      vi.setSystemTime(new Date(NOW.getTime() + 2000));
+      await triggerEnvCleanup();
+      expect(ws.close).toHaveBeenCalledWith(1000, 'Session expired');
+      expect(getEnvConnection('env-a')).toBeUndefined();
+    });
+
+    it('given no ping for longer than the stale timeout, should close as inactive', async () => {
+      const ws = socket();
+      registerEnvConnection('env-a', ws, meta('env-a', { sessionExpiresAt: new Date(NOW.getTime() + 3 * 60 * 60 * 1000) }));
+      vi.setSystemTime(new Date(NOW.getTime() + ENV_STALE_CONNECTION_TIMEOUT_MS + 1));
+      vi.mocked(sessionService.validateSession).mockResolvedValue({ userId: 'user-1' } as never);
+      await triggerEnvCleanup();
+      expect(ws.close).toHaveBeenCalledWith(1000, 'Connection cleanup - inactive');
+      expect(getEnvConnection('env-a')).toBeUndefined();
+    });
+
+    it('given a recent ping, should keep the socket', async () => {
+      const ws = socket();
+      registerEnvConnection('env-a', ws, meta('env-a', { sessionExpiresAt: new Date(NOW.getTime() + 3 * 60 * 60 * 1000) }));
+      vi.setSystemTime(new Date(NOW.getTime() + ENV_STALE_CONNECTION_TIMEOUT_MS - 1000));
+      updateEnvLastPing(ws);
+      vi.setSystemTime(new Date(NOW.getTime() + ENV_STALE_CONNECTION_TIMEOUT_MS + 1000));
+      vi.mocked(sessionService.validateSession).mockResolvedValue({ userId: 'user-1' } as never);
+      await triggerEnvCleanup();
+      expect(ws.close).not.toHaveBeenCalled();
+      expect(getEnvConnection('env-a')).toBe(ws);
+    });
+  });
+
+  describe('5-minute session revalidation (copied from ws-connections)', () => {
+    it('given a token the session service no longer honours, should close 1008 "Session revoked", drop it and fire the lost listener', async () => {
+      const lost: string[] = [];
+      const off = onEnvConnectionLost((envId) => lost.push(envId));
+      const ws = socket();
+      registerEnvConnection('env-a', ws, meta('env-a', { wsToken: 'tok-a' }));
+      vi.mocked(sessionService.validateSession).mockResolvedValue(null);
+      await triggerEnvCleanup();
+      expect(sessionService.validateSession).toHaveBeenCalledWith('tok-a', { expectedType: 'mcp' });
+      expect(ws.close).toHaveBeenCalledWith(1008, 'Session revoked');
+      expect(getEnvConnection('env-a')).toBeUndefined();
+      expect(lost).toEqual(['env-a']);
+      off();
+    });
+
+    it('given a still-valid token, should keep the socket and not ask again within the interval', async () => {
+      const ws = socket();
+      registerEnvConnection('env-a', ws, meta('env-a', { wsToken: 'tok-a' }));
+      vi.mocked(sessionService.validateSession).mockResolvedValue({ userId: 'user-1' } as never);
+      await triggerEnvCleanup();
+      expect(sessionService.validateSession).toHaveBeenCalledTimes(1);
+      vi.setSystemTime(new Date(NOW.getTime() + ENV_SESSION_REVALIDATION_INTERVAL_MS - 1));
+      await triggerEnvCleanup();
+      expect(sessionService.validateSession).toHaveBeenCalledTimes(1);
+      vi.setSystemTime(new Date(NOW.getTime() + ENV_SESSION_REVALIDATION_INTERVAL_MS + 1));
+      await triggerEnvCleanup();
+      expect(sessionService.validateSession).toHaveBeenCalledTimes(2);
+      expect(getEnvConnection('env-a')).toBe(ws);
+    });
+
+    it('given a transient validation error, should keep the socket (retry next interval, never close on an outage)', async () => {
+      const ws = socket();
+      registerEnvConnection('env-a', ws, meta('env-a', { wsToken: 'tok-a' }));
+      vi.mocked(sessionService.validateSession).mockRejectedValue(new Error('db down'));
+      await triggerEnvCleanup();
+      expect(ws.close).not.toHaveBeenCalled();
+      expect(getEnvConnection('env-a')).toBe(ws);
+    });
+  });
+});

--- a/apps/web/src/lib/websocket/ws-env-connections.ts
+++ b/apps/web/src/lib/websocket/ws-env-connections.ts
@@ -1,0 +1,454 @@
+import type { WebSocket } from 'ws';
+import { logger } from '@pagespace/lib/logging/logger-config';
+import { sessionService } from '@pagespace/lib/auth/session-service';
+
+/**
+ * Env-bridge connection registry — the socket a LOCAL environment's daemon
+ * holds open to this replica, keyed by **envId** (Local Environments epic,
+ * M1 · t07).
+ *
+ * Deliberately a sibling of `ws-connections.ts` (the desktop MCP bridge's
+ * per-USER map) rather than a change to it: a user with two machines needs two
+ * live sockets, and the desktop bridge's one-socket-per-user rule is exactly
+ * right for the desktop app. The three properties that make the desktop map
+ * safe are copied here verbatim and pinned by tests:
+ *
+ * - the stale-connection sweep (closed / expired-session / inactive sockets
+ *   are dropped on an interval, so a socket that never said goodbye cannot
+ *   leak);
+ * - the 5-minute session revalidation (a revoked `env:bridge` token closes the
+ *   socket within the interval even when nothing else notices);
+ * - the **compare-and-swap on socket identity in `unregisterEnvConnection`**:
+ *   a socket is removed only if it is STILL the env's live socket. A
+ *   superseded socket closing late must never evict its replacement, and —
+ *   the reason the guard is load-bearing here — must never cancel the live
+ *   env's in-flight requests (`onEnvConnectionLost` fires only for the live
+ *   socket).
+ *
+ * A socket is registered in `hello_pending` and becomes `authorized` only when
+ * the route has verified the machine-signed hello. Server→daemon frames are
+ * only ever sent to a socket `getAuthorizedEnvConnection` hands out.
+ */
+
+export type EnvConnectionState = 'hello_pending' | 'authorized';
+
+export interface EnvConnectionMetadata {
+  envId: string;
+  /** The machine owner — whose `env:bridge` token this is. */
+  userId: string;
+  sessionId: string;
+  enrollmentId: string;
+  /** The machine public key pinned at enrollment (base64 SPKI) — results on this socket verify under it. */
+  machinePublicKey: string;
+  /** The server key id this enrollment pinned — grants on this socket are signed by it. */
+  serverKeyId: string | null;
+  sessionExpiresAt?: Date;
+  connectedAt: Date;
+  lastPing?: Date;
+  fingerprint?: string;
+  state: EnvConnectionState;
+  wsToken?: string;
+  lastRevalidated?: Date;
+  /** When `lastSeenAt` was last persisted for this socket — pings persist at most once per heartbeat window. */
+  lastSeenPersistedAt?: Date;
+}
+
+export interface RegisterEnvConnectionInput {
+  userId: string;
+  sessionId: string;
+  enrollmentId: string;
+  machinePublicKey: string;
+  serverKeyId: string | null;
+  fingerprint?: string;
+  sessionExpiresAt?: Date;
+  wsToken?: string;
+}
+
+/** The close a superseded socket receives. 1000 (normal): the daemon must NOT treat it as a failure and reconnect into a fight with its replacement. */
+export const ENV_SUPERSEDED_CLOSE_CODE = 1000;
+export const ENV_SUPERSEDED_CLOSE_REASON = 'env_superseded';
+
+export const ENV_STALE_CONNECTION_TIMEOUT_MS = 60 * 60 * 1000; // 1 hour
+const CLEANUP_INTERVAL_MS = 5 * 60 * 1000; // 5 minutes
+export const ENV_SESSION_REVALIDATION_INTERVAL_MS = 5 * 60 * 1000; // 5 minutes - revalidate sessions to detect revoked tokens
+
+const connections = new Map<string, WebSocket>();
+const connectionMetadata = new Map<WebSocket, EnvConnectionMetadata>();
+const lostListeners = new Set<(envId: string, ws: WebSocket) => void>();
+
+let cleanupInterval: NodeJS.Timeout | null = null;
+
+const wsLogger = logger.child({ component: 'ws-env-connections' });
+
+/** Subscribe to "the env's LIVE socket is gone" — the bridge client cancels that env's pending requests on it. */
+export function onEnvConnectionLost(listener: (envId: string, ws: WebSocket) => void): () => void {
+  lostListeners.add(listener);
+  return () => {
+    lostListeners.delete(listener);
+  };
+}
+
+function emitLost(envId: string, ws: WebSocket): void {
+  for (const listener of lostListeners) {
+    try {
+      listener(envId, ws);
+    } catch (error) {
+      wsLogger.error('Env connection lost listener threw', { envId, error: error instanceof Error ? error.message : String(error), action: 'lost_listener_error' });
+    }
+  }
+}
+
+/**
+ * Register the env's socket. A previous socket for the SAME env is closed with
+ * the documented supersede code — the newer wins. Its metadata is dropped now,
+ * so its late `close` handler finds nothing to unregister (the CAS below).
+ */
+export function registerEnvConnection(envId: string, ws: WebSocket, input: RegisterEnvConnectionInput): void {
+  const existing = connections.get(envId);
+  if (existing && existing !== ws) {
+    if (existing.readyState === 0 || existing.readyState === 1) {
+      wsLogger.info('Closing existing env connection for new connection', { envId, action: 'close_existing' });
+      try {
+        existing.close(ENV_SUPERSEDED_CLOSE_CODE, ENV_SUPERSEDED_CLOSE_REASON);
+      } catch (error) {
+        wsLogger.warn('Error closing superseded env connection', { envId, error: error instanceof Error ? error.message : String(error), action: 'close_existing_error' });
+      }
+    }
+    connectionMetadata.delete(existing);
+  }
+
+  connections.set(envId, ws);
+  connectionMetadata.set(ws, {
+    envId,
+    userId: input.userId,
+    sessionId: input.sessionId,
+    enrollmentId: input.enrollmentId,
+    machinePublicKey: input.machinePublicKey,
+    serverKeyId: input.serverKeyId,
+    sessionExpiresAt: input.sessionExpiresAt,
+    connectedAt: new Date(),
+    fingerprint: input.fingerprint,
+    state: 'hello_pending',
+    wsToken: input.wsToken,
+  });
+
+  wsLogger.info('Env connection registered', {
+    envId,
+    userId: input.userId,
+    sessionId: input.sessionId,
+    sessionExpiresAt: input.sessionExpiresAt?.toISOString(),
+    totalConnections: connections.size,
+    action: 'register',
+  });
+}
+
+/**
+ * Unregister a socket — ONLY if it is still the env's live socket (CAS on
+ * identity). @returns true when the live socket was removed (listeners fired);
+ * false for a superseded or already-removed socket (nothing else happens).
+ */
+export function unregisterEnvConnection(envId: string, ws: WebSocket): boolean {
+  const current = connections.get(envId);
+  const wasLive = current === ws;
+  if (wasLive) {
+    connections.delete(envId);
+    wsLogger.info('Env connection unregistered', { envId, totalConnections: connections.size, action: 'unregister' });
+  } else {
+    wsLogger.debug('Skipped unregistering stale env connection', { envId, action: 'unregister_skipped', reason: 'not_active_connection' });
+  }
+  // Always clean up metadata for this specific WebSocket
+  connectionMetadata.delete(ws);
+  if (wasLive) emitLost(envId, ws);
+  return wasLive;
+}
+
+/** The env's registered socket in ANY state — for close/cleanup paths, never for sending frames. */
+export function getEnvConnection(envId: string): WebSocket | undefined {
+  return connections.get(envId);
+}
+
+/** The env's socket IFF it has completed the signed hello and is open — the ONLY socket server→daemon frames may go to. */
+export function getAuthorizedEnvConnection(envId: string): WebSocket | undefined {
+  const ws = connections.get(envId);
+  if (!ws) return undefined;
+  const metadata = connectionMetadata.get(ws);
+  if (!metadata || metadata.state !== 'authorized' || ws.readyState !== 1) return undefined;
+  return ws;
+}
+
+export function getEnvConnectionMetadata(ws: WebSocket): EnvConnectionMetadata | undefined {
+  return connectionMetadata.get(ws);
+}
+
+/** The route calls this once the machine-signed hello has verified. */
+export function markEnvAuthorized(ws: WebSocket): void {
+  const metadata = connectionMetadata.get(ws);
+  if (metadata) metadata.state = 'authorized';
+}
+
+export function isEnvAuthorized(ws: WebSocket): boolean {
+  return connectionMetadata.get(ws)?.state === 'authorized';
+}
+
+export function updateEnvLastPing(ws: WebSocket): void {
+  const metadata = connectionMetadata.get(ws);
+  if (metadata) metadata.lastPing = new Date();
+}
+
+/** Record that `lastSeenAt` was persisted now (heartbeat-window throttle lives in the route). */
+export function markEnvLastSeenPersisted(ws: WebSocket, at: Date): void {
+  const metadata = connectionMetadata.get(ws);
+  if (metadata) metadata.lastSeenPersistedAt = at;
+}
+
+export function verifyEnvConnectionFingerprint(ws: WebSocket, currentFingerprint: string): boolean {
+  const metadata = connectionMetadata.get(ws);
+  if (!metadata || !metadata.fingerprint) return false;
+  return metadata.fingerprint === currentFingerprint;
+}
+
+/**
+ * This replica's live reading of an env, in the DTO's vocabulary
+ * (`deriveLocalEnvStatus`'s `liveConnection` input): `connecting` while the
+ * hello is pending, `connected` once authorized, `null` when there is no open
+ * socket here.
+ */
+export function readEnvLiveConnection(envId: string): 'connecting' | 'connected' | null {
+  const ws = connections.get(envId);
+  if (!ws || (ws.readyState !== 0 && ws.readyState !== 1)) return null;
+  const metadata = connectionMetadata.get(ws);
+  if (!metadata) return null;
+  return metadata.state === 'authorized' ? 'connected' : 'connecting';
+}
+
+/**
+ * Clean up stale connections that are closed, inactive, or have expired sessions
+ * Prevents memory leaks and enforces session expiry security
+ * Also revalidates sessions to detect revoked tokens
+ */
+async function cleanupStaleConnections(): Promise<void> {
+  const now = Date.now();
+  const nowDate = new Date();
+  const staleConnections: Array<{ envId: string; ws: WebSocket; reason: string }> = [];
+
+  for (const [envId, ws] of connections.entries()) {
+    const metadata = connectionMetadata.get(ws);
+
+    // Check if WebSocket is closed (readyState 2 = CLOSING, 3 = CLOSED)
+    if (ws.readyState === 2 || ws.readyState === 3) {
+      staleConnections.push({ envId, ws, reason: 'closed' });
+      continue;
+    }
+
+    if (metadata) {
+      // Check if session has expired (critical security check)
+      if (metadata.sessionExpiresAt && nowDate > metadata.sessionExpiresAt) {
+        wsLogger.warn('Closing env connection due to expired session', {
+          envId,
+          sessionId: metadata.sessionId,
+          expiredAt: metadata.sessionExpiresAt.toISOString(),
+          action: 'session_expired_cleanup',
+        });
+        staleConnections.push({ envId, ws, reason: 'session_expired' });
+        continue;
+      }
+
+      // Check if connection has been inactive for too long
+      const lastActivity = metadata.lastPing?.getTime() || metadata.connectedAt.getTime();
+      const inactiveDuration = now - lastActivity;
+
+      if (inactiveDuration > ENV_STALE_CONNECTION_TIMEOUT_MS) {
+        wsLogger.warn('Env connection is stale due to inactivity', {
+          envId,
+          inactiveDurationMinutes: Math.round(inactiveDuration / 60000),
+          action: 'stale_detected',
+        });
+        staleConnections.push({ envId, ws, reason: 'inactive' });
+      }
+    }
+  }
+
+  if (staleConnections.length > 0) {
+    wsLogger.info('Cleaning up stale env connections', { staleCount: staleConnections.length, action: 'cleanup_start' });
+
+    for (const { envId, ws, reason } of staleConnections) {
+      if (ws.readyState === 0 || ws.readyState === 1) {
+        try {
+          const closeMessage = reason === 'session_expired' ? 'Session expired' : 'Connection cleanup - inactive';
+          ws.close(1000, closeMessage);
+        } catch (error) {
+          wsLogger.warn('Error closing stale env connection', {
+            envId,
+            reason,
+            error: error instanceof Error ? error.message : String(error),
+            action: 'close_error',
+          });
+        }
+      }
+      // Through the CAS, so a socket that was already superseded fires no lost event.
+      unregisterEnvConnection(envId, ws);
+    }
+
+    wsLogger.info('Env cleanup complete', { activeConnections: connections.size, removedCount: staleConnections.length, action: 'cleanup_complete' });
+  }
+
+  // Revalidate sessions to detect revoked tokens (P1 security fix)
+  await revalidateSessions();
+}
+
+/**
+ * Revalidate active sessions to detect revoked tokens
+ * Closes connections where the `env:bridge` session has been revoked (revokedAt
+ * set — e.g. by `revokeLocalEnv`), the user's tokenVersion changed, or the user
+ * was suspended. Parallel validation, as in the desktop map.
+ */
+async function revalidateSessions(): Promise<void> {
+  const now = Date.now();
+
+  const connectionsToValidate: Array<{ envId: string; ws: WebSocket; metadata: EnvConnectionMetadata }> = [];
+
+  for (const [envId, ws] of connections.entries()) {
+    const metadata = connectionMetadata.get(ws);
+    if (!metadata?.wsToken) continue;
+
+    const lastRevalidated = metadata.lastRevalidated?.getTime() || 0;
+    if (now - lastRevalidated < ENV_SESSION_REVALIDATION_INTERVAL_MS) continue;
+
+    connectionsToValidate.push({ envId, ws, metadata });
+  }
+
+  if (connectionsToValidate.length === 0) return;
+
+  const validationResults = await Promise.allSettled(
+    connectionsToValidate.map(async ({ envId, ws, metadata }) => {
+      const claims = await sessionService.validateSession(metadata.wsToken!, { expectedType: 'mcp' });
+      return { envId, ws, metadata, claims };
+    }),
+  );
+
+  const connectionsToClose: Array<{ envId: string; ws: WebSocket; reason: string }> = [];
+
+  for (let i = 0; i < validationResults.length; i++) {
+    const result = validationResults[i];
+    const { envId, ws, metadata } = connectionsToValidate[i];
+
+    if (result.status === 'fulfilled') {
+      metadata.lastRevalidated = new Date();
+
+      if (!result.value.claims) {
+        wsLogger.warn('Env session revalidation failed', { envId, sessionId: metadata.sessionId, action: 'session_revoked' });
+        connectionsToClose.push({ envId, ws, reason: 'session_revoked' });
+      }
+    } else {
+      // Don't close on transient errors - will retry next interval
+      wsLogger.error('Env session revalidation error', {
+        envId,
+        error: result.reason instanceof Error ? result.reason.message : String(result.reason),
+        action: 'revalidation_error',
+      });
+    }
+  }
+
+  for (const { envId, ws, reason } of connectionsToClose) {
+    if (ws.readyState === 0 || ws.readyState === 1) {
+      ws.close(1008, 'Session revoked');
+    }
+    unregisterEnvConnection(envId, ws);
+    wsLogger.info('Closed env connection due to revoked session', { envId, reason, action: 'session_revoked_cleanup' });
+  }
+}
+
+export function startEnvCleanupInterval(): void {
+  if (cleanupInterval) {
+    wsLogger.debug('Env cleanup interval already running', { action: 'start_cleanup_interval', status: 'already_running' });
+    return;
+  }
+  cleanupInterval = setInterval(() => {
+    cleanupStaleConnections().catch((err) =>
+      wsLogger.error('Env cleanup error', { error: err instanceof Error ? err.message : String(err), action: 'cleanup_interval_error' }),
+    );
+  }, CLEANUP_INTERVAL_MS);
+  wsLogger.info('Started env cleanup interval', { intervalMinutes: CLEANUP_INTERVAL_MS / 60000, action: 'start_cleanup_interval', status: 'started' });
+}
+
+export function stopEnvCleanupInterval(): void {
+  if (cleanupInterval) {
+    clearInterval(cleanupInterval);
+    cleanupInterval = null;
+    wsLogger.info('Stopped env cleanup interval', { action: 'stop_cleanup_interval', status: 'stopped' });
+  }
+}
+
+/** Manually trigger cleanup (useful for testing) */
+export async function triggerEnvCleanup(): Promise<void> {
+  await cleanupStaleConnections();
+}
+
+export interface EnvConnectionHealthCheck {
+  isHealthy: boolean;
+  reason?: string;
+  readyState: number;
+  lastPing?: Date;
+  connectedDuration: number;
+  sessionExpired?: boolean;
+}
+
+/**
+ * Health check before anything is sent to the daemon: registered, open,
+ * authorized (signed hello verified), session not expired — the same four
+ * checks as the desktop map's `checkConnectionHealth`, in the same order.
+ */
+export function checkEnvConnectionHealth(ws: WebSocket): EnvConnectionHealthCheck {
+  const metadata = connectionMetadata.get(ws);
+
+  if (!metadata) {
+    return { isHealthy: false, reason: 'Connection not registered', readyState: ws.readyState, connectedDuration: 0 };
+  }
+
+  if (ws.readyState !== 1) {
+    const stateNames = ['CONNECTING', 'OPEN', 'CLOSING', 'CLOSED'];
+    return {
+      isHealthy: false,
+      reason: `Connection not open (state: ${stateNames[ws.readyState] || 'UNKNOWN'})`,
+      readyState: ws.readyState,
+      lastPing: metadata.lastPing,
+      connectedDuration: Date.now() - metadata.connectedAt.getTime(),
+    };
+  }
+
+  if (metadata.state !== 'authorized') {
+    return {
+      isHealthy: false,
+      reason: 'Authentication not completed',
+      readyState: ws.readyState,
+      lastPing: metadata.lastPing,
+      connectedDuration: Date.now() - metadata.connectedAt.getTime(),
+    };
+  }
+
+  if (metadata.sessionExpiresAt && new Date() > metadata.sessionExpiresAt) {
+    wsLogger.warn('Session expired for env connection', {
+      envId: metadata.envId,
+      sessionId: metadata.sessionId,
+      expiredAt: metadata.sessionExpiresAt.toISOString(),
+      action: 'session_expired',
+    });
+    return {
+      isHealthy: false,
+      reason: 'Session expired',
+      readyState: ws.readyState,
+      lastPing: metadata.lastPing,
+      connectedDuration: Date.now() - metadata.connectedAt.getTime(),
+      sessionExpired: true,
+    };
+  }
+
+  return { isHealthy: true, readyState: ws.readyState, lastPing: metadata.lastPing, connectedDuration: Date.now() - metadata.connectedAt.getTime() };
+}
+
+/** @internal testing only */
+export function clearAllEnvConnectionsForTesting(): void {
+  connections.clear();
+  connectionMetadata.clear();
+  lostListeners.clear();
+}

--- a/apps/web/src/lib/websocket/ws-env-connections.ts
+++ b/apps/web/src/lib/websocket/ws-env-connections.ts
@@ -446,9 +446,8 @@ export function checkEnvConnectionHealth(ws: WebSocket): EnvConnectionHealthChec
   return { isHealthy: true, readyState: ws.readyState, lastPing: metadata.lastPing, connectedDuration: Date.now() - metadata.connectedAt.getTime() };
 }
 
-/** @internal testing only */
+/** @internal testing only — clears connection STATE; lost listeners are module wiring (the bridge client subscribes once) and stay. */
 export function clearAllEnvConnectionsForTesting(): void {
   connections.clear();
   connectionMetadata.clear();
-  lostListeners.clear();
 }

--- a/apps/web/src/lib/websocket/ws-env-connections.ts
+++ b/apps/web/src/lib/websocket/ws-env-connections.ts
@@ -78,7 +78,16 @@ const lostListeners = new Set<(envId: string, ws: WebSocket) => void>();
 
 let cleanupInterval: NodeJS.Timeout | null = null;
 
-const wsLogger = logger.child({ component: 'ws-env-connections' });
+/**
+ * Built on FIRST USE, never at import: this module sits in the drive-envs
+ * runtime's import graph, and suites that stub the logging module must be able
+ * to import that runtime without a logger existing yet.
+ */
+let wsLoggerInstance: ReturnType<typeof logger.child> | null = null;
+function wsLogger(): ReturnType<typeof logger.child> {
+  wsLoggerInstance ??= logger.child({ component: 'ws-env-connections' });
+  return wsLoggerInstance;
+}
 
 /** Subscribe to "the env's LIVE socket is gone" — the bridge client cancels that env's pending requests on it. */
 export function onEnvConnectionLost(listener: (envId: string, ws: WebSocket) => void): () => void {
@@ -93,7 +102,7 @@ function emitLost(envId: string, ws: WebSocket): void {
     try {
       listener(envId, ws);
     } catch (error) {
-      wsLogger.error('Env connection lost listener threw', { envId, error: error instanceof Error ? error.message : String(error), action: 'lost_listener_error' });
+      wsLogger().error('Env connection lost listener threw', { envId, error: error instanceof Error ? error.message : String(error), action: 'lost_listener_error' });
     }
   }
 }
@@ -107,11 +116,11 @@ export function registerEnvConnection(envId: string, ws: WebSocket, input: Regis
   const existing = connections.get(envId);
   if (existing && existing !== ws) {
     if (existing.readyState === 0 || existing.readyState === 1) {
-      wsLogger.info('Closing existing env connection for new connection', { envId, action: 'close_existing' });
+      wsLogger().info('Closing existing env connection for new connection', { envId, action: 'close_existing' });
       try {
         existing.close(ENV_SUPERSEDED_CLOSE_CODE, ENV_SUPERSEDED_CLOSE_REASON);
       } catch (error) {
-        wsLogger.warn('Error closing superseded env connection', { envId, error: error instanceof Error ? error.message : String(error), action: 'close_existing_error' });
+        wsLogger().warn('Error closing superseded env connection', { envId, error: error instanceof Error ? error.message : String(error), action: 'close_existing_error' });
       }
     }
     connectionMetadata.delete(existing);
@@ -132,7 +141,7 @@ export function registerEnvConnection(envId: string, ws: WebSocket, input: Regis
     wsToken: input.wsToken,
   });
 
-  wsLogger.info('Env connection registered', {
+  wsLogger().info('Env connection registered', {
     envId,
     userId: input.userId,
     sessionId: input.sessionId,
@@ -152,9 +161,9 @@ export function unregisterEnvConnection(envId: string, ws: WebSocket): boolean {
   const wasLive = current === ws;
   if (wasLive) {
     connections.delete(envId);
-    wsLogger.info('Env connection unregistered', { envId, totalConnections: connections.size, action: 'unregister' });
+    wsLogger().info('Env connection unregistered', { envId, totalConnections: connections.size, action: 'unregister' });
   } else {
-    wsLogger.debug('Skipped unregistering stale env connection', { envId, action: 'unregister_skipped', reason: 'not_active_connection' });
+    wsLogger().debug('Skipped unregistering stale env connection', { envId, action: 'unregister_skipped', reason: 'not_active_connection' });
   }
   // Always clean up metadata for this specific WebSocket
   connectionMetadata.delete(ws);
@@ -243,7 +252,7 @@ async function cleanupStaleConnections(): Promise<void> {
     if (metadata) {
       // Check if session has expired (critical security check)
       if (metadata.sessionExpiresAt && nowDate > metadata.sessionExpiresAt) {
-        wsLogger.warn('Closing env connection due to expired session', {
+        wsLogger().warn('Closing env connection due to expired session', {
           envId,
           sessionId: metadata.sessionId,
           expiredAt: metadata.sessionExpiresAt.toISOString(),
@@ -258,7 +267,7 @@ async function cleanupStaleConnections(): Promise<void> {
       const inactiveDuration = now - lastActivity;
 
       if (inactiveDuration > ENV_STALE_CONNECTION_TIMEOUT_MS) {
-        wsLogger.warn('Env connection is stale due to inactivity', {
+        wsLogger().warn('Env connection is stale due to inactivity', {
           envId,
           inactiveDurationMinutes: Math.round(inactiveDuration / 60000),
           action: 'stale_detected',
@@ -269,7 +278,7 @@ async function cleanupStaleConnections(): Promise<void> {
   }
 
   if (staleConnections.length > 0) {
-    wsLogger.info('Cleaning up stale env connections', { staleCount: staleConnections.length, action: 'cleanup_start' });
+    wsLogger().info('Cleaning up stale env connections', { staleCount: staleConnections.length, action: 'cleanup_start' });
 
     for (const { envId, ws, reason } of staleConnections) {
       if (ws.readyState === 0 || ws.readyState === 1) {
@@ -277,7 +286,7 @@ async function cleanupStaleConnections(): Promise<void> {
           const closeMessage = reason === 'session_expired' ? 'Session expired' : 'Connection cleanup - inactive';
           ws.close(1000, closeMessage);
         } catch (error) {
-          wsLogger.warn('Error closing stale env connection', {
+          wsLogger().warn('Error closing stale env connection', {
             envId,
             reason,
             error: error instanceof Error ? error.message : String(error),
@@ -289,7 +298,7 @@ async function cleanupStaleConnections(): Promise<void> {
       unregisterEnvConnection(envId, ws);
     }
 
-    wsLogger.info('Env cleanup complete', { activeConnections: connections.size, removedCount: staleConnections.length, action: 'cleanup_complete' });
+    wsLogger().info('Env cleanup complete', { activeConnections: connections.size, removedCount: staleConnections.length, action: 'cleanup_complete' });
   }
 
   // Revalidate sessions to detect revoked tokens (P1 security fix)
@@ -336,12 +345,12 @@ async function revalidateSessions(): Promise<void> {
       metadata.lastRevalidated = new Date();
 
       if (!result.value.claims) {
-        wsLogger.warn('Env session revalidation failed', { envId, sessionId: metadata.sessionId, action: 'session_revoked' });
+        wsLogger().warn('Env session revalidation failed', { envId, sessionId: metadata.sessionId, action: 'session_revoked' });
         connectionsToClose.push({ envId, ws, reason: 'session_revoked' });
       }
     } else {
       // Don't close on transient errors - will retry next interval
-      wsLogger.error('Env session revalidation error', {
+      wsLogger().error('Env session revalidation error', {
         envId,
         error: result.reason instanceof Error ? result.reason.message : String(result.reason),
         action: 'revalidation_error',
@@ -354,28 +363,28 @@ async function revalidateSessions(): Promise<void> {
       ws.close(1008, 'Session revoked');
     }
     unregisterEnvConnection(envId, ws);
-    wsLogger.info('Closed env connection due to revoked session', { envId, reason, action: 'session_revoked_cleanup' });
+    wsLogger().info('Closed env connection due to revoked session', { envId, reason, action: 'session_revoked_cleanup' });
   }
 }
 
 export function startEnvCleanupInterval(): void {
   if (cleanupInterval) {
-    wsLogger.debug('Env cleanup interval already running', { action: 'start_cleanup_interval', status: 'already_running' });
+    wsLogger().debug('Env cleanup interval already running', { action: 'start_cleanup_interval', status: 'already_running' });
     return;
   }
   cleanupInterval = setInterval(() => {
     cleanupStaleConnections().catch((err) =>
-      wsLogger.error('Env cleanup error', { error: err instanceof Error ? err.message : String(err), action: 'cleanup_interval_error' }),
+      wsLogger().error('Env cleanup error', { error: err instanceof Error ? err.message : String(err), action: 'cleanup_interval_error' }),
     );
   }, CLEANUP_INTERVAL_MS);
-  wsLogger.info('Started env cleanup interval', { intervalMinutes: CLEANUP_INTERVAL_MS / 60000, action: 'start_cleanup_interval', status: 'started' });
+  wsLogger().info('Started env cleanup interval', { intervalMinutes: CLEANUP_INTERVAL_MS / 60000, action: 'start_cleanup_interval', status: 'started' });
 }
 
 function stopEnvCleanupInterval(): void {
   if (cleanupInterval) {
     clearInterval(cleanupInterval);
     cleanupInterval = null;
-    wsLogger.info('Stopped env cleanup interval', { action: 'stop_cleanup_interval', status: 'stopped' });
+    wsLogger().info('Stopped env cleanup interval', { action: 'stop_cleanup_interval', status: 'stopped' });
   }
 }
 
@@ -427,7 +436,7 @@ export function checkEnvConnectionHealth(ws: WebSocket): EnvConnectionHealthChec
   }
 
   if (metadata.sessionExpiresAt && new Date() > metadata.sessionExpiresAt) {
-    wsLogger.warn('Session expired for env connection', {
+    wsLogger().warn('Session expired for env connection', {
       envId: metadata.envId,
       sessionId: metadata.sessionId,
       expiredAt: metadata.sessionExpiresAt.toISOString(),

--- a/apps/web/src/lib/websocket/ws-env-connections.ts
+++ b/apps/web/src/lib/websocket/ws-env-connections.ts
@@ -371,7 +371,7 @@ export function startEnvCleanupInterval(): void {
   wsLogger.info('Started env cleanup interval', { intervalMinutes: CLEANUP_INTERVAL_MS / 60000, action: 'start_cleanup_interval', status: 'started' });
 }
 
-export function stopEnvCleanupInterval(): void {
+function stopEnvCleanupInterval(): void {
   if (cleanupInterval) {
     clearInterval(cleanupInterval);
     cleanupInterval = null;
@@ -446,8 +446,9 @@ export function checkEnvConnectionHealth(ws: WebSocket): EnvConnectionHealthChec
   return { isHealthy: true, readyState: ws.readyState, lastPing: metadata.lastPing, connectedDuration: Date.now() - metadata.connectedAt.getTime() };
 }
 
-/** @internal testing only — clears connection STATE; lost listeners are module wiring (the bridge client subscribes once) and stay. */
+/** @internal testing only — clears connection STATE and stops the sweep; lost listeners are module wiring (the bridge client subscribes once) and stay. */
 export function clearAllEnvConnectionsForTesting(): void {
+  stopEnvCleanupInterval();
   connections.clear();
   connectionMetadata.clear();
 }

--- a/apps/web/src/lib/websocket/ws-message-schemas.ts
+++ b/apps/web/src/lib/websocket/ws-message-schemas.ts
@@ -2,9 +2,25 @@
  * WebSocket Message Validation Schemas
  * Zod schemas for all WebSocket message types (MCP bridge + fetch bridge)
  * Provides runtime validation and type safety
+ *
+ * The ENV BRIDGE's closed frame set is registered here BY IMPORT from the pure
+ * core (`@pagespace/lib/env-bridge/frame-codec`) — never duplicated: the daemon
+ * and the server must decode the same schema, and there is exactly one.
  */
 
 import { z } from 'zod';
+
+export {
+  decodeFrame as decodeEnvBridgeFrame,
+  encodeFrame as encodeEnvBridgeFrame,
+  isMachineToServerFrame as isEnvBridgeMachineFrame,
+  FRAME_TYPES as ENV_BRIDGE_FRAME_TYPES,
+  type Frame as EnvBridgeFrame,
+  type FrameLimits as EnvBridgeFrameLimits,
+} from '@pagespace/lib/env-bridge/frame-codec';
+
+/** One frame may be at most the socket's message ceiling (`MAX_MESSAGE_SIZE` in ws-security, 1 MiB), checked in BYTES before parsing. */
+export const ENV_BRIDGE_FRAME_LIMITS = { maxFrameBytes: 1024 * 1024 } as const;
 
 /**
  * Base message schema with common fields

--- a/packages/lib/package.json
+++ b/packages/lib/package.json
@@ -223,6 +223,11 @@
       "import": "./dist/env-bridge/challenge.js",
       "require": "./dist/env-bridge/challenge.js"
     },
+    "./env-bridge/machine-signatures": {
+      "types": "./dist/env-bridge/machine-signatures.d.ts",
+      "import": "./dist/env-bridge/machine-signatures.js",
+      "require": "./dist/env-bridge/machine-signatures.js"
+    },
     "./env-bridge/server-signing-key": {
       "types": "./dist/env-bridge/server-signing-key.d.ts",
       "import": "./dist/env-bridge/server-signing-key.js",

--- a/packages/lib/package.json
+++ b/packages/lib/package.json
@@ -123,6 +123,11 @@
       "import": "./dist/drive-envs/plan-env-delete.js",
       "require": "./dist/drive-envs/plan-env-delete.js"
     },
+    "./services/drive-envs/local-env-revoke": {
+      "types": "./dist/services/drive-envs/local-env-revoke.d.ts",
+      "import": "./dist/services/drive-envs/local-env-revoke.js",
+      "require": "./dist/services/drive-envs/local-env-revoke.js"
+    },
     "./services/drive-envs/env-provision-deps": {
       "types": "./dist/services/drive-envs/env-provision-deps.d.ts",
       "import": "./dist/services/drive-envs/env-provision-deps.js",
@@ -222,6 +227,11 @@
       "types": "./dist/env-bridge/challenge.d.ts",
       "import": "./dist/env-bridge/challenge.js",
       "require": "./dist/env-bridge/challenge.js"
+    },
+    "./env-bridge/grant-args": {
+      "types": "./dist/env-bridge/grant-args.d.ts",
+      "import": "./dist/env-bridge/grant-args.js",
+      "require": "./dist/env-bridge/grant-args.js"
     },
     "./env-bridge/machine-signatures": {
       "types": "./dist/env-bridge/machine-signatures.d.ts",

--- a/packages/lib/src/auth/__tests__/env-bridge-signing-key.test.ts
+++ b/packages/lib/src/auth/__tests__/env-bridge-signing-key.test.ts
@@ -1,9 +1,11 @@
 import { describe, it, expect } from 'vitest';
 import { generateKeyPairSync, verify as nodeVerify } from 'node:crypto';
-import { loadServerSigningKey } from '../env-bridge-signing-key';
+import { loadServerSigningKey, loadServerSigningKeyring } from '../env-bridge-signing-key';
 
 const pair = generateKeyPairSync('ed25519');
 const raw = pair.privateKey.export({ type: 'pkcs8', format: 'der' }).toString('base64');
+const previousPair = generateKeyPairSync('ed25519');
+const previousRaw = previousPair.privateKey.export({ type: 'pkcs8', format: 'der' }).toString('base64');
 
 describe('loadServerSigningKey — the node adapter over parseServerSigningKey', () => {
   it('given ENV_BRIDGE_SIGNING_KEY set to a base64 PKCS#8 Ed25519 key, should load a key whose signatures verify', () => {
@@ -24,5 +26,32 @@ describe('loadServerSigningKey — the node adapter over parseServerSigningKey',
 
   it('should be deterministic: the same variable loads the same keyId twice (no per-call randomness)', () => {
     expect(loadServerSigningKey({ ENV_BRIDGE_SIGNING_KEY: raw }).keyId).toBe(loadServerSigningKey({ ENV_BRIDGE_SIGNING_KEY: raw }).keyId);
+  });
+});
+
+describe('loadServerSigningKeyring — rotation (Codex C10)', () => {
+  it('given ENV_BRIDGE_SIGNING_KEYS "current,previous", should make the first current and serve the previous BY ITS OWN key', () => {
+    const ring = loadServerSigningKeyring({ ENV_BRIDGE_SIGNING_KEYS: `${raw},${previousRaw}` });
+    expect(ring.current.keyId).toBe(loadServerSigningKey({ ENV_BRIDGE_SIGNING_KEY: raw }).keyId);
+    const previousId = loadServerSigningKey({ ENV_BRIDGE_SIGNING_KEY: previousRaw }).keyId;
+    const previous = ring.get(previousId);
+    expect(previous).not.toBeNull();
+    const message = new TextEncoder().encode('grant');
+    expect(nodeVerify(null, message, previousPair.publicKey, previous!.sign(message))).toBe(true);
+    expect(nodeVerify(null, message, pair.publicKey, previous!.sign(message))).toBe(false);
+  });
+
+  it('given ENV_BRIDGE_SIGNING_KEYS set, should let it win over ENV_BRIDGE_SIGNING_KEY and expose loadServerSigningKey as the ring\'s current', () => {
+    expect(loadServerSigningKey({ ENV_BRIDGE_SIGNING_KEY: previousRaw, ENV_BRIDGE_SIGNING_KEYS: raw }).keyId).toBe(loadServerSigningKey({ ENV_BRIDGE_SIGNING_KEY: raw }).keyId);
+  });
+
+  it('given a key id that is no longer loaded, should answer null — the signer turns that into signing_key_unavailable, never another key', () => {
+    const ring = loadServerSigningKeyring({ ENV_BRIDGE_SIGNING_KEYS: raw });
+    expect(ring.get(loadServerSigningKey({ ENV_BRIDGE_SIGNING_KEY: previousRaw }).keyId)).toBeNull();
+  });
+
+  it('given one malformed entry in the list, should THROW naming the entry — never load a partial ring', () => {
+    expect(() => loadServerSigningKeyring({ ENV_BRIDGE_SIGNING_KEYS: `${raw},nope` })).toThrow(/entry 1/);
+    expect(() => loadServerSigningKeyring({ ENV_BRIDGE_SIGNING_KEYS: `${raw},${raw}` })).toThrow(/twice/);
   });
 });

--- a/packages/lib/src/auth/__tests__/session-repository-resource.integration.test.ts
+++ b/packages/lib/src/auth/__tests__/session-repository-resource.integration.test.ts
@@ -1,0 +1,85 @@
+/**
+ * `sessionRepository.revokeAllForResource` — REAL Postgres. What it must get
+ * right is a predicate, and predicates are proved against the database, not a
+ * fake: exactly the LIVE sessions of ONE resource are revoked, other resources
+ * and already-revoked rows are untouched (their original reason survives).
+ *
+ * Runs in CI (the Unit Tests job provides Postgres). Locally:
+ *     DATABASE_URL=... bun run --filter '@pagespace/lib' test -- src/auth/__tests__/session-repository-resource.integration.test.ts
+ */
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { createId } from '@paralleldrive/cuid2';
+import { db } from '@pagespace/db/db';
+import { eq, inArray } from '@pagespace/db/operators';
+import { users } from '@pagespace/db/schema/auth';
+import { sessions } from '@pagespace/db/schema/sessions';
+import { sessionRepository } from '../session-repository';
+
+const userId = createId();
+const envA = `env_${createId()}`;
+const envB = `env_${createId()}`;
+const hashes = { a1: `h_${createId()}`, a2: `h_${createId()}`, aOld: `h_${createId()}`, b1: `h_${createId()}`, userOnly: `h_${createId()}` };
+const EARLIER = new Date('2026-09-01T00:00:00.000Z');
+
+async function insertSession(tokenHash: string, over: Partial<typeof sessions.$inferInsert> = {}) {
+  await db.insert(sessions).values({
+    tokenHash,
+    tokenPrefix: 'mcp_',
+    userId,
+    type: 'mcp',
+    scopes: ['env:bridge'],
+    tokenVersion: 1,
+    expiresAt: new Date(Date.now() + 60 * 60 * 1000),
+    ...over,
+  });
+}
+
+const rowOf = async (tokenHash: string) => (await db.select().from(sessions).where(eq(sessions.tokenHash, tokenHash)))[0];
+
+beforeAll(async () => {
+  await db.insert(users).values({ id: userId, email: `env-revoke-${userId}@test.local`, name: 'Env Revoke', updatedAt: new Date() }).onConflictDoNothing();
+  await insertSession(hashes.a1, { resourceType: 'drive_env', resourceId: envA });
+  await insertSession(hashes.a2, { resourceType: 'drive_env', resourceId: envA });
+  await insertSession(hashes.aOld, { resourceType: 'drive_env', resourceId: envA, revokedAt: EARLIER, revokedReason: 'earlier' });
+  await insertSession(hashes.b1, { resourceType: 'drive_env', resourceId: envB });
+  await insertSession(hashes.userOnly, {});
+});
+
+afterAll(async () => {
+  await db.delete(sessions).where(inArray(sessions.tokenHash, Object.values(hashes)));
+  await db.delete(users).where(eq(users.id, userId));
+});
+
+describe('sessionRepository.revokeAllForResource', () => {
+  it("given three sessions on env A (one already revoked) and others elsewhere, should revoke exactly A's two live ones with the reason, and report 2", async () => {
+    expect(await sessionRepository.revokeAllForResource('drive_env', envA, 'env_revoked')).toBe(2);
+    for (const hash of [hashes.a1, hashes.a2]) {
+      const row = await rowOf(hash);
+      expect(row?.revokedAt).not.toBeNull();
+      expect(row?.revokedReason).toBe('env_revoked');
+      expect(await sessionRepository.findActiveSession(hash)).toBeUndefined();
+    }
+  });
+
+  it('should leave the already-revoked row with its ORIGINAL stamp and reason (revokedAt IS NULL is in the predicate)', async () => {
+    const row = await rowOf(hashes.aOld);
+    expect(row?.revokedAt?.getTime()).toBe(EARLIER.getTime());
+    expect(row?.revokedReason).toBe('earlier');
+  });
+
+  it("should not touch another env's session nor the user's unbound session", async () => {
+    expect((await rowOf(hashes.b1))?.revokedAt).toBeNull();
+    expect((await rowOf(hashes.userOnly))?.revokedAt).toBeNull();
+    expect(await sessionRepository.findActiveSession(hashes.b1)).toBeDefined();
+  });
+
+  it('should be idempotent: a repeat finds nothing live and reports 0', async () => {
+    expect(await sessionRepository.revokeAllForResource('drive_env', envA, 'again')).toBe(0);
+    expect((await rowOf(hashes.a1))?.revokedReason).toBe('env_revoked');
+  });
+
+  it('should scope by resourceType too: the same id under another type is not this resource', async () => {
+    expect(await sessionRepository.revokeAllForResource('other_type', envB, 'x')).toBe(0);
+    expect((await rowOf(hashes.b1))?.revokedAt).toBeNull();
+  });
+});

--- a/packages/lib/src/auth/env-bridge-signing-key.ts
+++ b/packages/lib/src/auth/env-bridge-signing-key.ts
@@ -1,14 +1,17 @@
 /**
- * Node adapter over the pure `parseServerSigningKey`: reads
- * `ENV_BRIDGE_SIGNING_KEY` and supplies the Ed25519 primitives. Throws — never
- * falls back — when the key is unset or unusable (invariant 3; see the pure
- * module's docblock).
+ * Node adapter over the pure `parseServerSigningKeyring`: reads
+ * `ENV_BRIDGE_SIGNING_KEYS` (rotation form, current first — Codex C10) or
+ * `ENV_BRIDGE_SIGNING_KEY` (single-key form) and supplies the Ed25519
+ * primitives. Throws — never falls back — when no key is set or any entry is
+ * unusable (invariant 3; see the pure module's docblock).
  */
 import { createHash, createPrivateKey, createPublicKey, sign as nodeSign } from 'crypto';
 import {
-  parseServerSigningKey,
+  parseServerSigningKeyring,
   ENV_BRIDGE_SIGNING_KEY_VAR,
+  ENV_BRIDGE_SIGNING_KEYS_VAR,
   type ServerSigningKey,
+  type ServerSigningKeyring,
   type SigningKeyPrimitives,
 } from '../env-bridge/server-signing-key';
 
@@ -26,11 +29,20 @@ const primitives: SigningKeyPrimitives = {
   hash: (bytes) => createHash('sha256').update(bytes).digest('hex'),
 };
 
-export function loadServerSigningKey(env: Record<string, string | undefined> = process.env): ServerSigningKey {
-  const verdict = parseServerSigningKey(env[ENV_BRIDGE_SIGNING_KEY_VAR], primitives);
-  if (verdict.ok) return verdict.key;
+/** The whole ring: current key for new enrollments, previous keys for the enrollments that pinned them. */
+export function loadServerSigningKeyring(env: Record<string, string | undefined> = process.env): ServerSigningKeyring {
+  const verdict = parseServerSigningKeyring({ single: env[ENV_BRIDGE_SIGNING_KEY_VAR], multi: env[ENV_BRIDGE_SIGNING_KEYS_VAR] }, primitives);
+  if (verdict.ok) return verdict.keyring;
   if (verdict.reason === 'unset') {
-    throw new Error(`${ENV_BRIDGE_SIGNING_KEY_VAR} is required: the env bridge signs every grant with it and never falls back to an ephemeral key`);
+    throw new Error(`${ENV_BRIDGE_SIGNING_KEY_VAR} (or ${ENV_BRIDGE_SIGNING_KEYS_VAR}) is required: the env bridge signs every grant with it and never falls back to an ephemeral key`);
   }
-  throw new Error(`${ENV_BRIDGE_SIGNING_KEY_VAR} must be a base64-encoded PKCS#8 Ed25519 private key`);
+  if (verdict.reason === 'duplicate_key') {
+    throw new Error(`${ENV_BRIDGE_SIGNING_KEYS_VAR} lists the same key twice (entry ${verdict.index})`);
+  }
+  throw new Error(`${ENV_BRIDGE_SIGNING_KEY_VAR} / ${ENV_BRIDGE_SIGNING_KEYS_VAR} entries must be base64-encoded PKCS#8 Ed25519 private keys (entry ${verdict.index} is not)`);
+}
+
+/** The CURRENT key — what new enrollments pin. */
+export function loadServerSigningKey(env: Record<string, string | undefined> = process.env): ServerSigningKey {
+  return loadServerSigningKeyring(env).current;
 }

--- a/packages/lib/src/auth/session-repository.ts
+++ b/packages/lib/src/auth/session-repository.ts
@@ -137,6 +137,21 @@ export const sessionRepository = {
     return result.rowCount ?? 0;
   },
 
+  // Revoke every active session bound to ONE resource — e.g. every `env:bridge`
+  // socket token of a local environment (`resourceType = 'drive_env'`,
+  // `resourceId = envId`) when that environment is revoked (Codex C4). Same
+  // shape as `revokeAllForUser`: only live sessions, one UPDATE.
+  revokeAllForResource: async (resourceType: string, resourceId: string, reason: string): Promise<number> => {
+    const result = await db.update(sessions)
+      .set({ revokedAt: new Date(), revokedReason: reason })
+      .where(and(
+        eq(sessions.resourceType, resourceType),
+        eq(sessions.resourceId, resourceId),
+        isNull(sessions.revokedAt),
+      ));
+    return result.rowCount ?? 0;
+  },
+
   // Revoke every active session for the user EXCEPT admin-console sessions, so a
   // web login does not knock the user out of the admin app.
   revokeWebForUser: async (userId: string, reason: string): Promise<number> => {

--- a/packages/lib/src/auth/session-service.ts
+++ b/packages/lib/src/auth/session-service.ts
@@ -287,6 +287,15 @@ export class SessionService {
   }
 
   /**
+   * Revoke every live session bound to one resource (`resourceType` +
+   * `resourceId`) — the env bridge's socket tokens on a revoked local
+   * environment. Returns how many were live.
+   */
+  async revokeResourceSessions(resourceType: string, resourceId: string, reason: string): Promise<number> {
+    return sessionRepository.revokeAllForResource(resourceType, resourceId, reason);
+  }
+
+  /**
    * Revoke the user's sessions EXCEPT admin-console sessions. Used by web login
    * flows so signing into the web app does not log the user out of the admin app.
    */

--- a/packages/lib/src/config/__tests__/env-validation.test.ts
+++ b/packages/lib/src/config/__tests__/env-validation.test.ts
@@ -546,18 +546,39 @@ describe('env-validation', () => {
     // Turning local envs on without the key would let every local-env create
     // reach loadServerSigningKey() and answer a generic 500. Boot is where an
     // operator finds out, not the first user.
-    it('given LOCAL_ENVS_ENABLED=true and no ENV_BRIDGE_SIGNING_KEY, should refuse to boot naming the key', () => {
+    it('given LOCAL_ENVS_ENABLED=true and NEITHER ENV_BRIDGE_SIGNING_KEY nor ENV_BRIDGE_SIGNING_KEYS, should refuse to boot naming the key', () => {
       bootable();
       process.env.LOCAL_ENVS_ENABLED = 'true';
       delete process.env.ENV_BRIDGE_SIGNING_KEY;
-      expect(() => validateEnv()).toThrow(/ENV_BRIDGE_SIGNING_KEY must be set when LOCAL_ENVS_ENABLED=true/);
+      delete process.env.ENV_BRIDGE_SIGNING_KEYS;
+      expect(() => validateEnv()).toThrow(/ENV_BRIDGE_SIGNING_KEY \(or ENV_BRIDGE_SIGNING_KEYS for rotation\) must be set when LOCAL_ENVS_ENABLED=true/);
+    });
+
+    // The rotation contract (Codex C10, PR #2543): a deployment that follows it
+    // sets ONLY the plural variable, and boot must accept that exactly as the
+    // loader does — otherwise the documented rotation-only configuration cannot start.
+    it('given LOCAL_ENVS_ENABLED=true and ONLY ENV_BRIDGE_SIGNING_KEYS (rotation form), should boot', () => {
+      bootable();
+      process.env.LOCAL_ENVS_ENABLED = 'true';
+      delete process.env.ENV_BRIDGE_SIGNING_KEY;
+      process.env.ENV_BRIDGE_SIGNING_KEYS = 'MC4CAQAwBQYDK2VwBCIEIA,MC4CAQAwBQYDK2VwBCIEIB';
+      expect(() => validateEnv()).not.toThrow();
+    });
+
+    it('given LOCAL_ENVS_ENABLED=true, a blank singular and a blank plural, should refuse to boot', () => {
+      bootable();
+      process.env.LOCAL_ENVS_ENABLED = 'true';
+      process.env.ENV_BRIDGE_SIGNING_KEY = '';
+      process.env.ENV_BRIDGE_SIGNING_KEYS = '  ';
+      expect(() => validateEnv()).toThrow(/must be set when LOCAL_ENVS_ENABLED=true/);
     });
 
     it('given LOCAL_ENVS_ENABLED=true and a blank key, should refuse to boot', () => {
       bootable();
       process.env.LOCAL_ENVS_ENABLED = 'true';
       process.env.ENV_BRIDGE_SIGNING_KEY = '   ';
-      expect(() => validateEnv()).toThrow(/ENV_BRIDGE_SIGNING_KEY must be set when LOCAL_ENVS_ENABLED=true/);
+      delete process.env.ENV_BRIDGE_SIGNING_KEYS;
+      expect(() => validateEnv()).toThrow(/must be set when LOCAL_ENVS_ENABLED=true/);
     });
 
     it('given LOCAL_ENVS_ENABLED=true and a key, should boot', () => {

--- a/packages/lib/src/config/env-validation.ts
+++ b/packages/lib/src/config/env-validation.ts
@@ -158,6 +158,10 @@ export const serverEnvSchema = z
     // other optional secrets here; the superRefine below is what requires a
     // real value once the feature is on.
     ENV_BRIDGE_SIGNING_KEY: z.string().min(1).optional().or(z.literal('')),
+    // Rotation form (Codex C10): comma-separated keys, current first, previous
+    // after. EITHER variable satisfies the boot check below — the same rule the
+    // loader applies (`parseServerSigningKeyring`: KEYS wins when both are set).
+    ENV_BRIDGE_SIGNING_KEYS: z.string().min(1).optional().or(z.literal('')),
 
     // Server-held secret keying the sandbox session-key HMAC (see
     // services/sandbox/session-key.ts). A configured value must be >= 32 chars,
@@ -283,17 +287,18 @@ export const serverEnvSchema = z
       });
     }
 
-    // Local environments sign every bridge grant with ENV_BRIDGE_SIGNING_KEY,
-    // and loadServerSigningKey() fails closed without it — which, at request
-    // time, is a generic 500 on the first local-env create. Boot is where an
-    // operator should learn the key is missing, and only once the feature is
-    // actually on: a deployment that never enables local envs must not be
-    // asked for a signing key.
-    if (data.LOCAL_ENVS_ENABLED === 'true' && !data.ENV_BRIDGE_SIGNING_KEY?.trim()) {
+    // Local environments sign every bridge grant with the server signing key
+    // (ENV_BRIDGE_SIGNING_KEY, or the rotation list ENV_BRIDGE_SIGNING_KEYS),
+    // and loadServerSigningKeyring() fails closed without one — which, at
+    // request time, is a generic 500 on the first local-env create. Boot is
+    // where an operator should learn the key is missing, and only once the
+    // feature is actually on: a deployment that never enables local envs must
+    // not be asked for a signing key.
+    if (data.LOCAL_ENVS_ENABLED === 'true' && !data.ENV_BRIDGE_SIGNING_KEY?.trim() && !data.ENV_BRIDGE_SIGNING_KEYS?.trim()) {
       ctx.addIssue({
         code: z.ZodIssueCode.custom,
         message:
-          'ENV_BRIDGE_SIGNING_KEY must be set when LOCAL_ENVS_ENABLED=true — it is the base64 PKCS#8 Ed25519 key every bridge grant is signed with and every enrolled machine pins; see .env.example for how to generate one',
+          'ENV_BRIDGE_SIGNING_KEY (or ENV_BRIDGE_SIGNING_KEYS for rotation) must be set when LOCAL_ENVS_ENABLED=true — it is the base64 PKCS#8 Ed25519 key every bridge grant is signed with and every enrolled machine pins; see .env.example for how to generate one',
         path: ['ENV_BRIDGE_SIGNING_KEY'],
       });
     }

--- a/packages/lib/src/env-bridge/__tests__/machine-signatures.test.ts
+++ b/packages/lib/src/env-bridge/__tests__/machine-signatures.test.ts
@@ -84,7 +84,8 @@ describe('hello — the machine-signed first frame', () => {
   });
 });
 
-const results: Record<MachineResultFrame['type'], Omit<MachineResultFrame, 'sig'>> = {
+type UnsignedResult = { [K in MachineResultFrame['type']]: Omit<Extract<MachineResultFrame, { type: K }>, 'sig'> };
+const results: UnsignedResult = {
   exec_result: { type: 'exec_result', grantId: 'g1', exitCode: 0, stdoutB64: 'b3V0', stderrB64: '', truncated: false },
   fs_read_result: { type: 'fs_read_result', grantId: 'g2', found: true, contentB64: 'ZGF0YQ==' },
   fs_write_result: { type: 'fs_write_result', grantId: 'g3', ok: true },
@@ -118,7 +119,7 @@ describe('results — machine-signed over {grantId, resultHash} (invariant 7)', 
     ['fs_write_result.ok', { ...results.fs_write_result, ok: false }],
     ['fs_write_result.error', { ...results.fs_write_result, error: 'disk full' }],
     ['grant_denied.reason', { ...results.grant_denied, reason: 'other' }],
-  ] as Array<[string, Omit<MachineResultFrame, 'sig'>]>)('given %s changed after signing, should deny bad_signature — every payload field is covered', (_label, tampered) => {
+  ] as Array<[string, UnsignedResult[keyof UnsignedResult]]>)('given %s changed after signing, should deny bad_signature — every payload field is covered', (_label, tampered) => {
     const original = results[tampered.type];
     const signed = signResult(original);
     const frame = { ...tampered, sig: signed.sig } as MachineResultFrame;

--- a/packages/lib/src/env-bridge/__tests__/machine-signatures.test.ts
+++ b/packages/lib/src/env-bridge/__tests__/machine-signatures.test.ts
@@ -1,0 +1,205 @@
+/**
+ * The bytes a machine signs (hello, results) and the bytes the server signs
+ * for a revoke — defined ONCE here so the daemon (t08) and the socket route
+ * (t07) agree by construction. Adversarial matrix per message: the right key
+ * verifies; a rogue key, a tampered field, a wrong env, a cross-domain
+ * signature and a malformed signature each fail for the stated reason.
+ */
+import { describe, it, expect } from 'vitest';
+import { generateKeyPairSync, sign as nodeSign, verify as nodeVerify, createPublicKey, createHash } from 'node:crypto';
+import type { Ed25519Verify, HashBytes } from '../grant';
+import type { Frame } from '../frame-codec';
+import { FRAME_TYPES, MACHINE_TO_SERVER_FRAME_TYPES, SERVER_TO_MACHINE_FRAME_TYPES, isMachineToServerFrame } from '../frame-codec';
+import {
+  encodeHelloForSigning,
+  encodeResultForSigning,
+  encodeRevokeForSigning,
+  resultHashForFrame,
+  verifyHello,
+  verifyMachineResult,
+  verifyRevoke,
+  isMachineResultFrame,
+  MACHINE_RESULT_FRAME_TYPES,
+  type MachineResultFrame,
+} from '../machine-signatures';
+
+const machine = generateKeyPairSync('ed25519');
+const rogue = generateKeyPairSync('ed25519');
+const server = generateKeyPairSync('ed25519');
+const spki = (key: typeof machine) => new Uint8Array(key.publicKey.export({ type: 'spki', format: 'der' }));
+const verify: Ed25519Verify = (message, signature, publicKey) =>
+  nodeVerify(null, message, createPublicKey({ key: Buffer.from(publicKey), type: 'spki', format: 'der' }), signature);
+const hash: HashBytes = (bytes) => createHash('sha256').update(bytes).digest('hex');
+const signWith = (key: typeof machine, bytes: Uint8Array) => Buffer.from(nodeSign(null, bytes, key.privateKey)).toString('base64');
+
+const capabilities = { shell: true, pty: false, fs: true, checkpoint: false };
+const helloBody = { envId: 'env-1', capabilities, policyDigest: 'sha256:abc' };
+const signedHello = (over: Partial<typeof helloBody> = {}, key = machine): Extract<Frame, { type: 'hello' }> => {
+  const body = { ...helloBody, ...over };
+  return { type: 'hello', ...body, sig: signWith(key, encodeHelloForSigning(body)) };
+};
+
+describe('hello — the machine-signed first frame', () => {
+  it('given a hello signed by the pinned machine key over the defined bytes, should verify', () => {
+    expect(verifyHello({ hello: signedHello(), expectedEnvId: 'env-1', machinePublicKey: spki(machine), verify })).toEqual({ ok: true });
+  });
+
+  it('given a hello signed by another key, should deny bad_signature', () => {
+    expect(verifyHello({ hello: signedHello({}, rogue), expectedEnvId: 'env-1', machinePublicKey: spki(machine), verify })).toEqual({ ok: false, reason: 'bad_signature' });
+  });
+
+  it('given a hello for another env — even correctly signed — should deny wrong_env BEFORE touching crypto', () => {
+    let called = 0;
+    const counting: Ed25519Verify = (...args) => {
+      called += 1;
+      return verify(...args);
+    };
+    expect(verifyHello({ hello: signedHello({ envId: 'env-2' }), expectedEnvId: 'env-1', machinePublicKey: spki(machine), verify: counting })).toEqual({ ok: false, reason: 'wrong_env' });
+    expect(called).toBe(0);
+  });
+
+  it.each([
+    ['capabilities.fs flipped', (h: ReturnType<typeof signedHello>) => ({ ...h, capabilities: { ...h.capabilities, fs: false } })],
+    ['capabilities.shell flipped', (h: ReturnType<typeof signedHello>) => ({ ...h, capabilities: { ...h.capabilities, shell: false } })],
+    ['policyDigest changed', (h: ReturnType<typeof signedHello>) => ({ ...h, policyDigest: 'sha256:evil' })],
+  ])('given a signed hello with %s after signing, should deny bad_signature', (_label, tamper) => {
+    expect(verifyHello({ hello: tamper(signedHello()), expectedEnvId: 'env-1', machinePublicKey: spki(machine), verify })).toEqual({ ok: false, reason: 'bad_signature' });
+  });
+
+  it.each([['', 'empty'], ['not*base64', 'not base64'], ['YWJj', 'wrong length but valid base64']])('given sig %j (%s), should deny malformed / bad_signature without throwing', (sig) => {
+    const verdict = verifyHello({ hello: { ...signedHello(), sig }, expectedEnvId: 'env-1', machinePublicKey: spki(machine), verify });
+    expect(verdict.ok).toBe(false);
+    expect(['malformed', 'bad_signature']).toContain((verdict as { reason: string }).reason);
+  });
+
+  it('given a signature over the RESULT bytes carrying the same strings, should not verify as a hello (domain separation)', () => {
+    const crossed = { type: 'hello' as const, ...helloBody, sig: signWith(machine, encodeResultForSigning({ grantId: 'env-1', resultHash: 'sha256:abc' })) };
+    expect(verifyHello({ hello: crossed, expectedEnvId: 'env-1', machinePublicKey: spki(machine), verify })).toEqual({ ok: false, reason: 'bad_signature' });
+  });
+
+  it('given the same hello with fields in a different insertion order, should encode identical bytes', () => {
+    const a = encodeHelloForSigning({ envId: 'e', capabilities: { shell: true, pty: true, fs: false, checkpoint: false }, policyDigest: 'd' });
+    const b = encodeHelloForSigning({ policyDigest: 'd', capabilities: { checkpoint: false, fs: false, pty: true, shell: true }, envId: 'e' } as typeof helloBody);
+    expect(Buffer.from(a).equals(Buffer.from(b))).toBe(true);
+  });
+});
+
+const results: Record<MachineResultFrame['type'], Omit<MachineResultFrame, 'sig'>> = {
+  exec_result: { type: 'exec_result', grantId: 'g1', exitCode: 0, stdoutB64: 'b3V0', stderrB64: '', truncated: false },
+  fs_read_result: { type: 'fs_read_result', grantId: 'g2', found: true, contentB64: 'ZGF0YQ==' },
+  fs_write_result: { type: 'fs_write_result', grantId: 'g3', ok: true },
+  grant_denied: { type: 'grant_denied', grantId: 'g4', reason: 'policy_denied' },
+};
+
+function signResult(body: Omit<MachineResultFrame, 'sig'>, key = machine): MachineResultFrame {
+  const frame = { ...body, sig: '' } as MachineResultFrame;
+  const resultHash = resultHashForFrame(frame, hash);
+  return { ...body, sig: signWith(key, encodeResultForSigning({ grantId: body.grantId, resultHash })) } as MachineResultFrame;
+}
+
+describe('results — machine-signed over {grantId, resultHash} (invariant 7)', () => {
+  it.each(Object.keys(results) as MachineResultFrame['type'][])('given a %s signed by the pinned key, should verify and return the resultHash it covers', (type) => {
+    const frame = signResult(results[type]);
+    const verdict = verifyMachineResult({ frame, machinePublicKey: spki(machine), verify, hash });
+    expect(verdict).toEqual({ ok: true, resultHash: resultHashForFrame(frame, hash) });
+  });
+
+  it.each(Object.keys(results) as MachineResultFrame['type'][])('given a %s signed by a rogue key, should deny bad_signature', (type) => {
+    expect(verifyMachineResult({ frame: signResult(results[type], rogue), machinePublicKey: spki(machine), verify, hash })).toEqual({ ok: false, reason: 'bad_signature' });
+  });
+
+  it.each([
+    ['exec_result.exitCode', { ...results.exec_result, exitCode: 1 }],
+    ['exec_result.stdoutB64', { ...results.exec_result, stdoutB64: 'ZXZpbA==' }],
+    ['exec_result.stderrB64', { ...results.exec_result, stderrB64: 'ZXZpbA==' }],
+    ['exec_result.truncated', { ...results.exec_result, truncated: true }],
+    ['fs_read_result.found', { ...results.fs_read_result, found: false }],
+    ['fs_read_result.contentB64', { ...results.fs_read_result, contentB64: 'ZXZpbA==' }],
+    ['fs_write_result.ok', { ...results.fs_write_result, ok: false }],
+    ['fs_write_result.error', { ...results.fs_write_result, error: 'disk full' }],
+    ['grant_denied.reason', { ...results.grant_denied, reason: 'other' }],
+  ] as Array<[string, Omit<MachineResultFrame, 'sig'>]>)('given %s changed after signing, should deny bad_signature — every payload field is covered', (_label, tampered) => {
+    const original = results[tampered.type];
+    const signed = signResult(original);
+    const frame = { ...tampered, sig: signed.sig } as MachineResultFrame;
+    expect(verifyMachineResult({ frame, machinePublicKey: spki(machine), verify, hash })).toEqual({ ok: false, reason: 'bad_signature' });
+  });
+
+  it('given the grantId swapped onto another grant after signing, should deny bad_signature (a result cannot be replayed under another grant)', () => {
+    const signed = signResult(results.exec_result);
+    expect(verifyMachineResult({ frame: { ...signed, grantId: 'g-other' }, machinePublicKey: spki(machine), verify, hash })).toEqual({ ok: false, reason: 'bad_signature' });
+  });
+
+  it('given fs_read_result with contentB64 absent vs empty, should hash distinctly (absent is not empty)', () => {
+    const absent = resultHashForFrame({ type: 'fs_read_result', grantId: 'g', found: false, sig: '' }, hash);
+    const empty = resultHashForFrame({ type: 'fs_read_result', grantId: 'g', found: false, contentB64: '', sig: '' }, hash);
+    expect(absent).not.toBe(empty);
+  });
+
+  it('given a malformed sig, should deny malformed without throwing', () => {
+    const frame = { ...results.exec_result, sig: '!!' } as MachineResultFrame;
+    expect(verifyMachineResult({ frame, machinePublicKey: spki(machine), verify, hash })).toEqual({ ok: false, reason: 'malformed' });
+  });
+
+  it('given a verify primitive that throws, should deny bad_signature rather than crash the socket handler', () => {
+    const throwing: Ed25519Verify = () => {
+      throw new Error('boom');
+    };
+    expect(verifyMachineResult({ frame: signResult(results.exec_result), machinePublicKey: spki(machine), verify: throwing, hash })).toEqual({ ok: false, reason: 'bad_signature' });
+  });
+
+  it('should name exactly the exec/fs/denied result frames — PTY frames and pong are outside this verifier by design ([D-2])', () => {
+    expect([...MACHINE_RESULT_FRAME_TYPES].sort()).toEqual(['exec_result', 'fs_read_result', 'fs_write_result', 'grant_denied']);
+    expect(isMachineResultFrame({ type: 'pty_data', sessionId: 's', seq: 0, dataB64: '' })).toBe(false);
+    expect(isMachineResultFrame({ type: 'pty_exit', sessionId: 's', code: 0 })).toBe(false);
+    expect(isMachineResultFrame({ type: 'pong', ts: 1 })).toBe(false);
+    expect(isMachineResultFrame({ type: 'exec_result', grantId: 'g', exitCode: 0, stdoutB64: '', stderrB64: '', truncated: false, sig: '' })).toBe(true);
+  });
+});
+
+describe('revoke — server-signed over {envId, enrollmentId, keyId, issuedAt}', () => {
+  const binding = { envId: 'env-1', enrollmentId: 'enr-1', keyId: 'k1', issuedAt: 1_700_000_000_000 };
+  const revokeFrame = (key = server, over: Partial<typeof binding> = {}): Extract<Frame, { type: 'revoke' }> => ({
+    type: 'revoke',
+    issuedAt: binding.issuedAt,
+    reason: 'owner_revoked',
+    sig: signWith(key, encodeRevokeForSigning({ ...binding, ...over })),
+  });
+
+  it('given a revoke signed by the pinned server key for THIS enrollment, should verify', () => {
+    expect(verifyRevoke({ frame: revokeFrame(), ...binding, serverPublicKey: spki(server), verify })).toEqual({ ok: true });
+  });
+
+  it.each([
+    ['envId', { envId: 'env-2' }],
+    ['enrollmentId', { enrollmentId: 'enr-2' }],
+    ['keyId', { keyId: 'k2' }],
+    ['issuedAt', { issuedAt: 1 }],
+  ] as Array<[string, Partial<typeof binding>]>)('given a revoke signed for a different %s, should deny bad_signature — the frame binds all four', (_label, over) => {
+    expect(verifyRevoke({ frame: revokeFrame(server, over), ...binding, serverPublicKey: spki(server), verify })).toEqual({ ok: false, reason: 'bad_signature' });
+  });
+
+  it('given a revoke signed by a rogue key, should deny bad_signature', () => {
+    expect(verifyRevoke({ frame: revokeFrame(rogue), ...binding, serverPublicKey: spki(server), verify })).toEqual({ ok: false, reason: 'bad_signature' });
+  });
+
+  it('given the reason changed, should still verify — reason is advisory and unsigned', () => {
+    expect(verifyRevoke({ frame: { ...revokeFrame(), reason: 'other' }, ...binding, serverPublicKey: spki(server), verify })).toEqual({ ok: true });
+  });
+});
+
+describe('frame direction — the closed set split by who may send what', () => {
+  it('should partition FRAME_TYPES exactly: every type in one direction, none in both', () => {
+    const union = new Set([...MACHINE_TO_SERVER_FRAME_TYPES, ...SERVER_TO_MACHINE_FRAME_TYPES]);
+    expect([...union].sort()).toEqual([...FRAME_TYPES].sort());
+    for (const type of MACHINE_TO_SERVER_FRAME_TYPES) expect(SERVER_TO_MACHINE_FRAME_TYPES.has(type)).toBe(false);
+  });
+
+  it('should classify a grant/revoke/ping as server→machine and results/hello/pong as machine→server', () => {
+    expect(isMachineToServerFrame({ type: 'hello', envId: 'e', capabilities, policyDigest: '', sig: '' })).toBe(true);
+    expect(isMachineToServerFrame({ type: 'pong', ts: 1 })).toBe(true);
+    expect(isMachineToServerFrame({ type: 'revoke', sig: '', issuedAt: 1 })).toBe(false);
+    expect(isMachineToServerFrame({ type: 'grant_exec', grant: {}, sig: '', cmd: 'ls' })).toBe(false);
+    expect(isMachineToServerFrame({ type: 'ping', ts: 1 })).toBe(false);
+  });
+});

--- a/packages/lib/src/env-bridge/__tests__/server-signing-keyring.test.ts
+++ b/packages/lib/src/env-bridge/__tests__/server-signing-keyring.test.ts
@@ -1,0 +1,87 @@
+/**
+ * Key rotation for the server signing key (Codex C10): `ENV_BRIDGE_SIGNING_KEYS`
+ * lists current + previous keys so an enrollment pinned to a previous key is
+ * still served — by THAT key — while `ENV_BRIDGE_SIGNING_KEY` keeps working as
+ * the single-key form.
+ */
+import { describe, it, expect } from 'vitest';
+import { generateKeyPairSync, createPrivateKey, createPublicKey, createHash, sign as nodeSign } from 'node:crypto';
+import { parseServerSigningKeyring, parseServerSigningKey, type SigningKeyPrimitives } from '../server-signing-key';
+
+const primitives: SigningKeyPrimitives = {
+  importPrivateKey: (pkcs8) => {
+    try {
+      const privateKey = createPrivateKey({ key: Buffer.from(pkcs8), type: 'pkcs8', format: 'der' });
+      if (privateKey.asymmetricKeyType !== 'ed25519') return null;
+      return { publicKey: new Uint8Array(createPublicKey(privateKey).export({ type: 'spki', format: 'der' })), sign: (m) => new Uint8Array(nodeSign(null, m, privateKey)) };
+    } catch {
+      return null;
+    }
+  },
+  hash: (bytes) => createHash('sha256').update(bytes).digest('hex'),
+};
+
+const pkcs8 = () => generateKeyPairSync('ed25519').privateKey.export({ type: 'pkcs8', format: 'der' }).toString('base64');
+const k1 = pkcs8();
+const k2 = pkcs8();
+const k3 = pkcs8();
+const idOf = (raw: string) => {
+  const v = parseServerSigningKey(raw, primitives);
+  if (!v.ok) throw new Error(v.reason);
+  return v.key.keyId;
+};
+
+describe('parseServerSigningKeyring', () => {
+  it('given only ENV_BRIDGE_SIGNING_KEY, should build a ring of one whose current is that key', () => {
+    const v = parseServerSigningKeyring({ single: k1, multi: undefined }, primitives);
+    if (!v.ok) throw new Error(v.reason);
+    expect(v.keyring.current.keyId).toBe(idOf(k1));
+    expect(v.keyring.keyIds).toEqual([idOf(k1)]);
+    expect(v.keyring.get(idOf(k1))?.keyId).toBe(idOf(k1));
+  });
+
+  it('given ENV_BRIDGE_SIGNING_KEYS "current,previous", should make the FIRST current and still serve the previous by id', () => {
+    const v = parseServerSigningKeyring({ single: undefined, multi: `${k1},${k2}` }, primitives);
+    if (!v.ok) throw new Error(v.reason);
+    expect(v.keyring.current.keyId).toBe(idOf(k1));
+    expect(v.keyring.keyIds).toEqual([idOf(k1), idOf(k2)]);
+    const previous = v.keyring.get(idOf(k2));
+    expect(previous?.keyId).toBe(idOf(k2));
+    // The previous key signs with ITS key, not the current one.
+    const message = new TextEncoder().encode('m');
+    expect(Buffer.from(previous!.sign(message)).equals(Buffer.from(v.keyring.current.sign(message)))).toBe(false);
+  });
+
+  it('given both variables, should honour ENV_BRIDGE_SIGNING_KEYS (the rotation form wins, documented)', () => {
+    const v = parseServerSigningKeyring({ single: k3, multi: `${k1},${k2}` }, primitives);
+    if (!v.ok) throw new Error(v.reason);
+    expect(v.keyring.current.keyId).toBe(idOf(k1));
+    expect(v.keyring.get(idOf(k3))).toBeNull();
+  });
+
+  it('given a key id not in the ring, should answer null — never a different key', () => {
+    const v = parseServerSigningKeyring({ single: k1, multi: undefined }, primitives);
+    if (!v.ok) throw new Error(v.reason);
+    expect(v.keyring.get('nope')).toBeNull();
+    expect(v.keyring.get(idOf(k2))).toBeNull();
+  });
+
+  it('given neither variable, should be unset', () => {
+    expect(parseServerSigningKeyring({ single: undefined, multi: undefined }, primitives)).toEqual({ ok: false, reason: 'unset' });
+    expect(parseServerSigningKeyring({ single: '  ', multi: '' }, primitives)).toEqual({ ok: false, reason: 'unset' });
+  });
+
+  it('given one malformed entry in the list, should refuse the whole ring naming the index — never load a partial ring', () => {
+    expect(parseServerSigningKeyring({ single: undefined, multi: `${k1},not-a-key,${k2}` }, primitives)).toEqual({ ok: false, reason: 'malformed', index: 1 });
+  });
+
+  it('given the same key listed twice, should refuse as duplicate_key', () => {
+    expect(parseServerSigningKeyring({ single: undefined, multi: `${k1},${k1}` }, primitives)).toEqual({ ok: false, reason: 'duplicate_key', index: 1 });
+  });
+
+  it('given whitespace and newlines around entries, should tolerate them', () => {
+    const v = parseServerSigningKeyring({ single: undefined, multi: ` ${k1} ,\n${k2}\n` }, primitives);
+    if (!v.ok) throw new Error(v.reason);
+    expect(v.keyring.keyIds).toEqual([idOf(k1), idOf(k2)]);
+  });
+});

--- a/packages/lib/src/env-bridge/frame-codec.ts
+++ b/packages/lib/src/env-bridge/frame-codec.ts
@@ -100,6 +100,23 @@ export const FRAME_TYPES: ReadonlySet<FrameType> = new Set<FrameType>([
   'grant_exec', 'grant_fs_read', 'grant_fs_write', 'grant_pty_open', 'pty_input', 'pty_resize', 'pty_kill', 'revoke', 'ping',
 ]);
 
+/**
+ * The closed set split by DIRECTION. A socket end only ever accepts frames
+ * from the other direction: the server drops a `grant_exec` arriving from a
+ * machine (nobody grants the server anything) and the daemon drops an
+ * `exec_result` arriving from the server. Every frame type is in exactly one.
+ */
+export const MACHINE_TO_SERVER_FRAME_TYPES: ReadonlySet<FrameType> = new Set<FrameType>([
+  'hello', 'exec_result', 'fs_read_result', 'fs_write_result', 'grant_denied', 'pty_opened', 'pty_data', 'pty_exit', 'pong',
+]);
+export const SERVER_TO_MACHINE_FRAME_TYPES: ReadonlySet<FrameType> = new Set<FrameType>([
+  'grant_exec', 'grant_fs_read', 'grant_fs_write', 'grant_pty_open', 'pty_input', 'pty_resize', 'pty_kill', 'revoke', 'ping',
+]);
+
+export function isMachineToServerFrame(frame: Frame): boolean {
+  return MACHINE_TO_SERVER_FRAME_TYPES.has(frame.type);
+}
+
 export type DecodeFrameReason = 'oversized' | 'malformed' | 'unknown_type' | 'bad_base64';
 export type DecodeFrameVerdict = { readonly ok: true; readonly frame: Frame } | { readonly ok: false; readonly reason: DecodeFrameReason };
 

--- a/packages/lib/src/env-bridge/index.ts
+++ b/packages/lib/src/env-bridge/index.ts
@@ -23,3 +23,4 @@ export * from './plan-local-provision';
 export * from './enrollment';
 export * from './challenge';
 export * from './server-signing-key';
+export * from './machine-signatures';

--- a/packages/lib/src/env-bridge/machine-signatures.ts
+++ b/packages/lib/src/env-bridge/machine-signatures.ts
@@ -1,0 +1,195 @@
+/**
+ * The bytes each side signs on the bridge, defined ONCE so the daemon (which
+ * produces them) and the socket route (which verifies them) agree by
+ * construction rather than by convention:
+ *
+ * - **hello** (machine → server, invariant 2): the first frame on every
+ *   socket, signed by the machine key pinned at enrollment. Covers
+ *   `{envId, capabilities, policyDigest}` — so a captured hello cannot be
+ *   replayed for another env, and neither the advertised capabilities nor the
+ *   policy digest can be altered in flight.
+ * - **result** (machine → server, invariant 7): every `exec_result`,
+ *   `fs_read_result`, `fs_write_result` and `grant_denied` is signed over
+ *   `{grantId, resultHash}` where `resultHash` covers EVERY payload field of
+ *   the frame (`resultHashForFrame`). A result cannot be moved onto another
+ *   grant, and no field of it can be edited between the machine and the agent.
+ * - **revoke** (server → machine, invariant 8): signed over
+ *   `{envId, enrollmentId, keyId, issuedAt}` — a revoke for one enrollment
+ *   cannot revoke another, and it must be signed by the key that enrollment
+ *   pinned (`keyId`), so a rotated-out key cannot be used to revoke.
+ *
+ * Every encoding is domain-separated (a fixed leading `domain` string) and
+ * built from the TYPED value in a fixed key order, so insertion order can never
+ * change the signed message and a signature over one message type can never
+ * verify as another.
+ *
+ * **Out of scope by design ([D-2] on the epic page):** `pty_data`, `pty_exit`
+ * and `pong` are not covered here. Whether PTY frames get a per-session HMAC
+ * derived at `pty_open` (recommended), full per-frame signatures, or a stated
+ * exception is an open founder decision; the verifier for exec/fs results
+ * above does not change under any of those outcomes.
+ *
+ * Pure: the Ed25519 `verify` and the `hash` primitives are injected.
+ */
+import type { Frame } from './frame-codec';
+import { canonicalizeArgs, constantTimeEqual, decodeBase64, type Ed25519Verify, type HashBytes } from './grant';
+
+export const HELLO_SIGNING_DOMAIN = 'pagespace-env-bridge/hello/v1';
+export const RESULT_SIGNING_DOMAIN = 'pagespace-env-bridge/result/v1';
+export const REVOKE_SIGNING_DOMAIN = 'pagespace-env-bridge/revoke/v1';
+
+export type HelloFrame = Extract<Frame, { type: 'hello' }>;
+export type RevokeFrame = Extract<Frame, { type: 'revoke' }>;
+export type MachineResultFrame = Extract<Frame, { type: 'exec_result' | 'fs_read_result' | 'fs_write_result' | 'grant_denied' }>;
+export type MachineResultFrameType = MachineResultFrame['type'];
+
+/** The machine frames that answer a grant and therefore MUST be signed (invariant 7). */
+export const MACHINE_RESULT_FRAME_TYPES: ReadonlySet<MachineResultFrameType> = new Set<MachineResultFrameType>(['exec_result', 'fs_read_result', 'fs_write_result', 'grant_denied']);
+
+export function isMachineResultFrame(frame: Frame): frame is MachineResultFrame {
+  return (MACHINE_RESULT_FRAME_TYPES as ReadonlySet<string>).has(frame.type);
+}
+
+export type MachineSignatureDenyReason = 'wrong_env' | 'bad_signature' | 'malformed';
+export type MachineSignatureVerdict = { readonly ok: true } | { readonly ok: false; readonly reason: MachineSignatureDenyReason };
+
+const encode = (value: unknown): Uint8Array => new TextEncoder().encode(JSON.stringify(value));
+
+// ---- hello -----------------------------------------------------------------
+
+/** Canonical bytes the machine signs for its hello; rebuilt field by field from the typed value. */
+export function encodeHelloForSigning(hello: Pick<HelloFrame, 'envId' | 'capabilities' | 'policyDigest'>): Uint8Array {
+  return encode({
+    domain: HELLO_SIGNING_DOMAIN,
+    envId: hello.envId,
+    capabilities: {
+      shell: hello.capabilities.shell,
+      pty: hello.capabilities.pty,
+      fs: hello.capabilities.fs,
+      checkpoint: hello.capabilities.checkpoint,
+    },
+    policyDigest: hello.policyDigest,
+  });
+}
+
+export interface VerifyHelloInput {
+  readonly hello: HelloFrame;
+  /** The env the socket was authenticated for (URL + token); a hello for any other env is refused before crypto. */
+  readonly expectedEnvId: string;
+  /** The machine public key pinned at enrollment (SPKI DER). */
+  readonly machinePublicKey: Uint8Array;
+  readonly verify: Ed25519Verify;
+}
+
+/** Deny order: wrong_env → malformed (signature not base64) → bad_signature. */
+export function verifyHello(input: VerifyHelloInput): MachineSignatureVerdict {
+  if (input.hello.envId !== input.expectedEnvId) return { ok: false, reason: 'wrong_env' };
+  const signature = decodeBase64(input.hello.sig);
+  if (signature === null) return { ok: false, reason: 'malformed' };
+  return safeVerify(input.verify, encodeHelloForSigning(input.hello), signature, input.machinePublicKey);
+}
+
+// ---- results ---------------------------------------------------------------
+
+/**
+ * The fixed field set `resultHash` covers, per result type. Every field, every
+ * time: an optional the frame omitted is `null`, never a missing key, so
+ * "absent" hashes identically on both sides and distinctly from "empty".
+ */
+export function resultPayloadForFrame(frame: MachineResultFrame): Record<string, unknown> {
+  switch (frame.type) {
+    case 'exec_result':
+      return { type: frame.type, grantId: frame.grantId, exitCode: frame.exitCode, stdoutB64: frame.stdoutB64, stderrB64: frame.stderrB64, truncated: frame.truncated };
+    case 'fs_read_result':
+      return { type: frame.type, grantId: frame.grantId, found: frame.found, contentB64: frame.contentB64 ?? null };
+    case 'fs_write_result':
+      return { type: frame.type, grantId: frame.grantId, ok: frame.ok, error: frame.error ?? null };
+    case 'grant_denied':
+      return { type: frame.type, grantId: frame.grantId, reason: frame.reason };
+  }
+}
+
+/** `hash(canonicalizeArgs(resultPayloadForFrame(frame)))` — what the signature's `resultHash` must equal. */
+export function resultHashForFrame(frame: MachineResultFrame, hash: HashBytes): string {
+  return hash(canonicalizeArgs(resultPayloadForFrame(frame)));
+}
+
+/** Canonical bytes the machine signs for a result. */
+export function encodeResultForSigning(result: { grantId: string; resultHash: string }): Uint8Array {
+  return encode({ domain: RESULT_SIGNING_DOMAIN, grantId: result.grantId, resultHash: result.resultHash });
+}
+
+export interface VerifyMachineResultInput {
+  readonly frame: MachineResultFrame;
+  /** The machine public key pinned at enrollment (SPKI DER). */
+  readonly machinePublicKey: Uint8Array;
+  readonly verify: Ed25519Verify;
+  readonly hash: HashBytes;
+}
+
+export type MachineResultVerdict = { readonly ok: true; readonly resultHash: string } | { readonly ok: false; readonly reason: MachineSignatureDenyReason };
+
+/**
+ * Recompute the result hash from the frame's own fields and verify the
+ * machine's signature over `{grantId, resultHash}`. A result that fails here
+ * is never delivered (invariant 7). Deny order: malformed → bad_signature.
+ */
+export function verifyMachineResult(input: VerifyMachineResultInput): MachineResultVerdict {
+  const signature = decodeBase64(input.frame.sig);
+  if (signature === null) return { ok: false, reason: 'malformed' };
+  let resultHash: string;
+  try {
+    resultHash = resultHashForFrame(input.frame, input.hash);
+  } catch {
+    return { ok: false, reason: 'malformed' };
+  }
+  const verdict = safeVerify(input.verify, encodeResultForSigning({ grantId: input.frame.grantId, resultHash }), signature, input.machinePublicKey);
+  return verdict.ok ? { ok: true, resultHash } : verdict;
+}
+
+// ---- revoke ----------------------------------------------------------------
+
+export interface RevokeBinding {
+  readonly envId: string;
+  readonly enrollmentId: string;
+  /** The server key id this enrollment pinned; the revoke must be signed by THAT key. */
+  readonly keyId: string;
+  /** ms since epoch; carried in the frame as `issuedAt`. */
+  readonly issuedAt: number;
+}
+
+/** Canonical bytes the server signs for a revoke. */
+export function encodeRevokeForSigning(binding: RevokeBinding): Uint8Array {
+  return encode({ domain: REVOKE_SIGNING_DOMAIN, envId: binding.envId, enrollmentId: binding.enrollmentId, keyId: binding.keyId, issuedAt: binding.issuedAt });
+}
+
+export interface VerifyRevokeInput extends RevokeBinding {
+  readonly frame: RevokeFrame;
+  /** The server public key the daemon pinned at enrollment (SPKI DER). */
+  readonly serverPublicKey: Uint8Array;
+  readonly verify: Ed25519Verify;
+}
+
+/** The daemon's check before it honours a revoke (t08). `issuedAt` is taken from the binding the daemon supplies, and must equal the frame's. */
+export function verifyRevoke(input: VerifyRevokeInput): MachineSignatureVerdict {
+  if (input.frame.issuedAt !== input.issuedAt) return { ok: false, reason: 'bad_signature' };
+  const signature = decodeBase64(input.frame.sig);
+  if (signature === null) return { ok: false, reason: 'malformed' };
+  const bytes = encodeRevokeForSigning({ envId: input.envId, enrollmentId: input.enrollmentId, keyId: input.keyId, issuedAt: input.issuedAt });
+  return safeVerify(input.verify, bytes, signature, input.serverPublicKey);
+}
+
+// ---- shared ----------------------------------------------------------------
+
+function safeVerify(verify: Ed25519Verify, message: Uint8Array, signature: Uint8Array, publicKey: Uint8Array): MachineSignatureVerdict {
+  let valid = false;
+  try {
+    valid = verify(message, signature, publicKey);
+  } catch {
+    valid = false;
+  }
+  return valid ? { ok: true } : { ok: false, reason: 'bad_signature' };
+}
+
+/** Compare two digests without leaking how much matched. Re-exported for adapters that compare hashes they were handed. */
+export const digestsEqual = constantTimeEqual;

--- a/packages/lib/src/env-bridge/machine-signatures.ts
+++ b/packages/lib/src/env-bridge/machine-signatures.ts
@@ -32,13 +32,14 @@
  * Pure: the Ed25519 `verify` and the `hash` primitives are injected.
  */
 import type { Frame } from './frame-codec';
+import type { HelloFrame } from './bridge-session';
 import { canonicalizeArgs, constantTimeEqual, decodeBase64, type Ed25519Verify, type HashBytes } from './grant';
 
 export const HELLO_SIGNING_DOMAIN = 'pagespace-env-bridge/hello/v1';
 export const RESULT_SIGNING_DOMAIN = 'pagespace-env-bridge/result/v1';
 export const REVOKE_SIGNING_DOMAIN = 'pagespace-env-bridge/revoke/v1';
 
-export type HelloFrame = Extract<Frame, { type: 'hello' }>;
+export type { HelloFrame };
 export type RevokeFrame = Extract<Frame, { type: 'revoke' }>;
 export type MachineResultFrame = Extract<Frame, { type: 'exec_result' | 'fs_read_result' | 'fs_write_result' | 'grant_denied' }>;
 export type MachineResultFrameType = MachineResultFrame['type'];

--- a/packages/lib/src/env-bridge/server-signing-key.ts
+++ b/packages/lib/src/env-bridge/server-signing-key.ts
@@ -16,6 +16,14 @@
 import { decodeBase64, type HashBytes } from './grant';
 
 export const ENV_BRIDGE_SIGNING_KEY_VAR = 'ENV_BRIDGE_SIGNING_KEY';
+/**
+ * Rotation form (Codex C10): a comma-separated list of base64 PKCS#8 keys,
+ * CURRENT FIRST, then previous keys still pinned by live enrollments. Each
+ * key's id is derived from its public half, so ids are stable across
+ * restarts and the list needs no explicit labels. When set, it takes
+ * precedence over the single-key variable.
+ */
+export const ENV_BRIDGE_SIGNING_KEYS_VAR = 'ENV_BRIDGE_SIGNING_KEYS';
 
 export interface ServerSigningKey {
   /** Stable id derived from the public key; stored per enrollment so a rotated key can be told apart. */
@@ -45,5 +53,59 @@ export function parseServerSigningKey(raw: string | undefined, primitives: Signi
   return {
     ok: true,
     key: { keyId: primitives.hash(imported.publicKey).slice(0, KEY_ID_LENGTH), publicKey: imported.publicKey, sign: imported.sign },
+  };
+}
+
+/**
+ * The loaded ring: `current` signs new enrollments; `get(keyId)` serves an
+ * enrollment pinned to any loaded key — and answers `null`, never a different
+ * key, for one that is no longer loaded (the signer surfaces that as
+ * `signing_key_unavailable`).
+ */
+export interface ServerSigningKeyring {
+  readonly current: ServerSigningKey;
+  /** Current first, in configured order. */
+  readonly keyIds: readonly string[];
+  get(keyId: string): ServerSigningKey | null;
+}
+
+export type ServerSigningKeyringVerdict =
+  | { readonly ok: true; readonly keyring: ServerSigningKeyring }
+  | { readonly ok: false; readonly reason: 'unset' }
+  /** `index` is the offending entry's position in the list. */
+  | { readonly ok: false; readonly reason: 'malformed' | 'duplicate_key'; readonly index: number };
+
+/**
+ * Parse the ring from the two variables: `multi` (`ENV_BRIDGE_SIGNING_KEYS`)
+ * wins when set; otherwise `single` (`ENV_BRIDGE_SIGNING_KEY`) is a ring of
+ * one. One bad entry refuses the WHOLE ring — a partially loaded ring would
+ * silently strand the enrollments pinned to the missing key.
+ */
+export function parseServerSigningKeyring(
+  { single, multi }: { single: string | undefined; multi: string | undefined },
+  primitives: SigningKeyPrimitives,
+): ServerSigningKeyringVerdict {
+  const entries = (multi ?? '').split(',').map((entry) => entry.trim()).filter((entry) => entry.length > 0);
+  if (entries.length === 0) {
+    const one = parseServerSigningKey(single, primitives);
+    if (!one.ok) return one.reason === 'unset' ? { ok: false, reason: 'unset' } : { ok: false, reason: 'malformed', index: 0 };
+    return { ok: true, keyring: ringOf([one.key]) };
+  }
+  const keys: ServerSigningKey[] = [];
+  for (let index = 0; index < entries.length; index += 1) {
+    const parsed = parseServerSigningKey(entries[index], primitives);
+    if (!parsed.ok) return { ok: false, reason: 'malformed', index };
+    if (keys.some((key) => key.keyId === parsed.key.keyId)) return { ok: false, reason: 'duplicate_key', index };
+    keys.push(parsed.key);
+  }
+  return { ok: true, keyring: ringOf(keys) };
+}
+
+function ringOf(keys: readonly ServerSigningKey[]): ServerSigningKeyring {
+  const byId = new Map(keys.map((key) => [key.keyId, key] as const));
+  return {
+    current: keys[0]!,
+    keyIds: keys.map((key) => key.keyId),
+    get: (keyId) => byId.get(keyId) ?? null,
   };
 }

--- a/packages/lib/src/services/drive-envs/__tests__/drive-envs-store.integration.test.ts
+++ b/packages/lib/src/services/drive-envs/__tests__/drive-envs-store.integration.test.ts
@@ -776,3 +776,81 @@ describe('the local-env identity slice — compare-and-set predicates, in SQL', 
     expect(row?.lastSeenAt?.getTime()).toBe(later.getTime());
   });
 });
+
+describe('the local-env connection slice (t07) — recordHello / recordHeartbeat / revokeLocal, in SQL', () => {
+  const NOW = new Date('2026-09-06T10:00:00.000Z');
+  const CAPS = { shell: true, pty: false, fs: true, checkpoint: false };
+  async function createLocal(enroll: boolean) {
+    const enrollmentId = `enr_${createId()}`;
+    const created = await store.createIfUnderLimit({
+      driveId,
+      name: `mac-${enrollmentId.slice(-6)}`,
+      createdBy: payerId,
+      now: NOW,
+      payerId,
+      maxEnvs: 10,
+      local: { ownerId: payerId, label: 'jono-macstudio', enrollmentId, enrollmentCodeHash: 'hash', enrollmentCodeExpiresAt: new Date(NOW.getTime() + 600_000) },
+    });
+    if (!created.ok) throw new Error(created.reason);
+    if (enroll) await store.pinMachineKey({ envId: created.env.id, machinePublicKey: 'pk', machineKeyFingerprint: 'fp', serverKeyId: 'k1', now: NOW });
+    return created.env.id;
+  }
+  const rowOf = async (envId: string) => (await db.select().from(driveEnvLocal).where(eq(driveEnvLocal.envId, envId)))[0];
+
+  it('recordHello: given an enrolled, unrevoked machine, should persist capabilities + lastSeenAt (UTC wall-clock, non-UTC session) and answer true', async () => {
+    const envId = await createLocal(true);
+    const at = new Date(NOW.getTime() + 5_000);
+    expect(await store.recordHello({ envId, capabilities: CAPS, now: at })).toBe(true);
+    const row = await rowOf(envId);
+    expect(row?.capabilities).toEqual(CAPS);
+    expect(row?.lastSeenAt?.getTime()).toBe(at.getTime());
+  });
+
+  it('recordHello: given a machine that never enrolled, should change nothing and answer false', async () => {
+    const envId = await createLocal(false);
+    expect(await store.recordHello({ envId, capabilities: CAPS, now: NOW })).toBe(false);
+    const row = await rowOf(envId);
+    expect(row?.capabilities).toBeNull();
+    expect(row?.lastSeenAt).toBeNull();
+  });
+
+  it('recordHello / recordHeartbeat: given a REVOKED machine, should change nothing and answer false (a revoked hello is not a heartbeat)', async () => {
+    const envId = await createLocal(true);
+    expect(await store.revokeLocal({ envId, now: NOW })).toBe(true);
+    expect(await store.recordHello({ envId, capabilities: CAPS, now: NOW })).toBe(false);
+    expect(await store.recordHeartbeat({ envId, now: NOW })).toBe(false);
+    const row = await rowOf(envId);
+    expect(row?.capabilities).toBeNull();
+    expect(row?.lastSeenAt).toBeNull();
+  });
+
+  it('recordHeartbeat: should move lastSeenAt forward and nothing else', async () => {
+    const envId = await createLocal(true);
+    await store.recordHello({ envId, capabilities: CAPS, now: NOW });
+    const later = new Date(NOW.getTime() + 60_000);
+    expect(await store.recordHeartbeat({ envId, now: later })).toBe(true);
+    const row = await rowOf(envId);
+    expect(row?.lastSeenAt?.getTime()).toBe(later.getTime());
+    expect(row?.capabilities).toEqual(CAPS);
+  });
+
+  it('revokeLocal: should stamp revokedAt exactly once (CAS on revokedAt IS NULL) and keep the FIRST stamp on a repeat', async () => {
+    const envId = await createLocal(true);
+    expect(await store.revokeLocal({ envId, now: NOW })).toBe(true);
+    const later = new Date(NOW.getTime() + 60_000);
+    expect(await store.revokeLocal({ envId, now: later })).toBe(false);
+    expect((await rowOf(envId))?.revokedAt?.getTime()).toBe(NOW.getTime());
+  });
+
+  it('revokeLocal: after it, setChallenge and consumeChallenge should both lose their CAS — no future token mint', async () => {
+    const envId = await createLocal(true);
+    expect(await store.setChallenge({ envId, nonce: 'n1', expiresAt: new Date(NOW.getTime() + 60_000), now: NOW })).toBe(true);
+    expect(await store.revokeLocal({ envId, now: NOW })).toBe(true);
+    expect(await store.consumeChallenge({ envId, nonce: 'n1', now: NOW })).toBe(false);
+    expect(await store.setChallenge({ envId, nonce: 'n2', expiresAt: new Date(NOW.getTime() + 60_000), now: new Date(NOW.getTime() + 120_000) })).toBe(false);
+  });
+
+  it('revokeLocal: given an unknown env, should answer false without throwing', async () => {
+    expect(await store.revokeLocal({ envId: createId(), now: NOW })).toBe(false);
+  });
+});

--- a/packages/lib/src/services/drive-envs/__tests__/fakes.ts
+++ b/packages/lib/src/services/drive-envs/__tests__/fakes.ts
@@ -184,6 +184,28 @@ export function makeDriveEnvStore(seed: DriveEnvRecord[] = [], now: () => Date =
       return true;
     },
 
+    async recordHello({ envId, capabilities, now: at }) {
+      const sibling = local.get(envId);
+      if (!sibling || sibling.enrolledAt === null || sibling.revokedAt !== null) return false;
+      local.set(envId, { ...sibling, capabilities, lastSeenAt: at, updatedAt: at });
+      return true;
+    },
+
+    async recordHeartbeat({ envId, now: at }) {
+      const sibling = local.get(envId);
+      if (!sibling || sibling.enrolledAt === null || sibling.revokedAt !== null) return false;
+      local.set(envId, { ...sibling, lastSeenAt: at, updatedAt: at });
+      return true;
+    },
+
+    async revokeLocal({ envId, now: at }) {
+      const sibling = local.get(envId);
+      // CAS on `revokedAt IS NULL`: a second revoke is an answer (false), not a rewrite of the stamp.
+      if (!sibling || sibling.revokedAt !== null) return false;
+      local.set(envId, { ...sibling, revokedAt: at, updatedAt: at });
+      return true;
+    },
+
     async rename({ envId, name, now: at }) {
       const row = rows.get(envId);
       if (!row) return { ok: false, reason: 'not_found' };

--- a/packages/lib/src/services/drive-envs/__tests__/local-env-revoke.test.ts
+++ b/packages/lib/src/services/drive-envs/__tests__/local-env-revoke.test.ts
@@ -1,0 +1,136 @@
+/**
+ * Revoke = all three legs (Codex C4): the row stamp, every env:bridge session,
+ * the machine's socket. Against the fake store, wired to the REAL enrollment
+ * services so "future token mints fail" is pinned through the service, not a
+ * fake's flag.
+ */
+import { describe, it, expect } from 'vitest';
+import { createHash, generateKeyPairSync, randomBytes, sign as nodeSign, verify as nodeVerify, createPublicKey } from 'node:crypto';
+import { createDriveEnv, enrollLocalDriveEnv, issueLocalEnvChallenge, redeemLocalEnvChallenge, type LocalEnvIdentityDeps } from '../drive-envs';
+import { revokeLocalDriveEnv, type RevokeLocalDriveEnvDeps, type RevokeMachineNotifyOutcome } from '../local-env-revoke';
+import { encodeChallenge } from '../../../env-bridge/challenge';
+import { makeDriveEnvStore, DRIVE_ID, PAYER_ID, NOW } from './fakes';
+
+const machine = generateKeyPairSync('ed25519');
+const server = generateKeyPairSync('ed25519');
+const machinePublicKey = machine.publicKey.export({ type: 'spki', format: 'der' }).toString('base64');
+
+const identity: LocalEnvIdentityDeps = {
+  random: (length) => new Uint8Array(randomBytes(length)),
+  hash: (bytes) => createHash('sha3-256').update(bytes).digest('hex'),
+  fingerprint: (bytes) => `sha256:${createHash('sha256').update(bytes).digest('hex')}`,
+  isEd25519PublicKey: () => true,
+  verify: (message, signature, publicKey) => nodeVerify(null, message, createPublicKey({ key: Buffer.from(publicKey), type: 'spki', format: 'der' }), signature),
+  newEnrollmentId: () => 'enr-1',
+  signingKey: { keyId: 'srv-k1', publicKey: new Uint8Array(server.publicKey.export({ type: 'spki', format: 'der' })) },
+};
+
+function harness(machineOutcome: RevokeMachineNotifyOutcome = 'sent_and_closed') {
+  const fake = makeDriveEnvStore();
+  const order: string[] = [];
+  const sessionRevokes: Array<{ envId: string; reason: string }> = [];
+  const notifies: Array<Parameters<RevokeLocalDriveEnvDeps['notifyMachine']>[0]> = [];
+  const identityDeps = {
+    store: fake.store,
+    resolvePayer: async () => ({ payerId: PAYER_ID, tier: 'pro' as const }),
+    now: () => NOW,
+    identity,
+    mintToken: async () => {
+      order.push('mint');
+      return 'tok';
+    },
+    revokeToken: async () => {
+      order.push('revoke_token');
+    },
+  };
+  const revokeDeps: RevokeLocalDriveEnvDeps = {
+    store: {
+      findLocalByEnvId: fake.store.findLocalByEnvId,
+      revokeLocal: async (input) => {
+        order.push('stamp');
+        return fake.store.revokeLocal(input);
+      },
+    },
+    now: () => NOW,
+    revokeSessions: async (input) => {
+      order.push('sessions');
+      sessionRevokes.push(input);
+      return 2;
+    },
+    notifyMachine: async (input) => {
+      order.push('machine');
+      notifies.push(input);
+      return machineOutcome;
+    },
+  };
+  return { fake, order, sessionRevokes, notifies, identityDeps, revokeDeps };
+}
+
+async function enrolledEnv(h: ReturnType<typeof harness>) {
+  const created = await createDriveEnv({ driveId: DRIVE_ID, name: 'mac', createdBy: 'user-1', local: { label: 'mac', ownerId: 'user-1' }, deps: h.identityDeps });
+  if (!created.ok || !created.enrollment) throw new Error('create failed');
+  const enrolled = await enrollLocalDriveEnv({ enrollmentId: 'enr-1', code: created.enrollment.code, machinePublicKey, deps: h.identityDeps });
+  if (!enrolled.ok) throw new Error(`enroll failed: ${enrolled.reason}`);
+  return created.env.id;
+}
+
+describe('revokeLocalDriveEnv — all three legs, in order', () => {
+  it('given an enrolled machine, should stamp revokedAt, revoke its sessions, notify the machine — in that order — and report each', async () => {
+    const h = harness();
+    const envId = await enrolledEnv(h);
+    const result = await revokeLocalDriveEnv({ envId, reason: 'owner_revoked', deps: h.revokeDeps });
+    expect(result).toEqual({ ok: true, alreadyRevoked: false, revokedAt: NOW, sessionsRevoked: 2, machine: 'sent_and_closed' });
+    expect(h.order).toEqual(['stamp', 'sessions', 'machine']);
+    expect(h.sessionRevokes).toEqual([{ envId, reason: 'owner_revoked' }]);
+    expect(h.notifies).toEqual([{ envId, enrollmentId: 'enr-1', serverKeyId: 'srv-k1', issuedAt: NOW.getTime(), reason: 'owner_revoked' }]);
+    expect(h.fake.local.get(envId)?.revokedAt).toEqual(NOW);
+  });
+
+  it('after a revoke, the daemon\'s next token mint should fail: challenge and redeem both answer revoked through the REAL service', async () => {
+    const h = harness();
+    const envId = await enrolledEnv(h);
+    // A challenge issued BEFORE the revoke must not redeem after it either.
+    const issued = await issueLocalEnvChallenge({ enrollmentId: 'enr-1', deps: h.identityDeps });
+    if (!issued.ok) throw new Error(issued.reason);
+    await revokeLocalDriveEnv({ envId, reason: 'owner_revoked', deps: h.revokeDeps });
+
+    const sig = Buffer.from(nodeSign(null, encodeChallenge({ nonce: issued.nonce, enrollmentId: 'enr-1', exp: issued.expiresAt.getTime() }), machine.privateKey)).toString('base64');
+    expect(await redeemLocalEnvChallenge({ enrollmentId: 'enr-1', response: { enrollmentId: 'enr-1', nonce: issued.nonce, signature: sig }, deps: h.identityDeps })).toEqual({ ok: false, reason: 'revoked' });
+    expect(await issueLocalEnvChallenge({ enrollmentId: 'enr-1', deps: h.identityDeps })).toEqual({ ok: false, reason: 'revoked' });
+    expect(h.order).not.toContain('mint');
+  });
+
+  it('given a machine already revoked (an earlier attempt crashed between legs), should STILL run legs 2 and 3 and report alreadyRevoked with the ORIGINAL stamp', async () => {
+    const h = harness();
+    const envId = await enrolledEnv(h);
+    const first = new Date(NOW.getTime() - 60_000);
+    await h.fake.store.revokeLocal({ envId, now: first });
+    const result = await revokeLocalDriveEnv({ envId, reason: 'retry', deps: h.revokeDeps });
+    expect(result).toEqual({ ok: true, alreadyRevoked: true, revokedAt: first, sessionsRevoked: 2, machine: 'sent_and_closed' });
+    expect(h.order).toEqual(['stamp', 'sessions', 'machine']);
+    expect(h.fake.local.get(envId)?.revokedAt).toEqual(first);
+  });
+
+  it('given the pinned server key is no longer loaded, should still complete legs 1 and 2 and report the socket closed unsigned (never signed under another key)', async () => {
+    const h = harness('closed_unsigned_key_unavailable');
+    const envId = await enrolledEnv(h);
+    const result = await revokeLocalDriveEnv({ envId, reason: 'owner_revoked', deps: h.revokeDeps });
+    expect(result).toMatchObject({ ok: true, machine: 'closed_unsigned_key_unavailable', sessionsRevoked: 2 });
+    expect(h.fake.local.get(envId)?.revokedAt).toEqual(NOW);
+  });
+
+  it('given no drive_env_local row (a Sprite env, or a deleted one), should answer not_found and touch nothing', async () => {
+    const h = harness();
+    expect(await revokeLocalDriveEnv({ envId: 'env-nope', reason: 'x', deps: h.revokeDeps })).toEqual({ ok: false, reason: 'not_found' });
+    expect(h.order).toEqual([]);
+  });
+
+  it('given a machine that never enrolled (pending code), should still revoke: the code can no longer be redeemed', async () => {
+    const h = harness('no_live_socket');
+    const created = await createDriveEnv({ driveId: DRIVE_ID, name: 'mac', createdBy: 'user-1', local: { label: 'mac', ownerId: 'user-1' }, deps: h.identityDeps });
+    if (!created.ok || !created.enrollment) throw new Error('create failed');
+    const result = await revokeLocalDriveEnv({ envId: created.env.id, reason: 'owner_revoked', deps: h.revokeDeps });
+    expect(result).toMatchObject({ ok: true, alreadyRevoked: false, machine: 'no_live_socket' });
+    expect(await enrollLocalDriveEnv({ enrollmentId: 'enr-1', code: created.enrollment.code, machinePublicKey, deps: h.identityDeps })).toEqual({ ok: false, reason: 'revoked' });
+  });
+});

--- a/packages/lib/src/services/drive-envs/drive-envs-store.ts
+++ b/packages/lib/src/services/drive-envs/drive-envs-store.ts
@@ -227,6 +227,21 @@ export interface DriveEnvStore {
    */
   consumeChallenge(input: { envId: string; nonce: string; now: Date }): Promise<boolean>;
   /**
+   * On an AUTHORIZED hello (signature verified by the socket route): persist
+   * the machine's advertised capabilities and a heartbeat, IFF enrolled and
+   * not revoked — a revoked machine's hello changes nothing.
+   */
+  recordHello(input: { envId: string; capabilities: NonNullable<DriveEnvLocalRecord['capabilities']>; now: Date }): Promise<boolean>;
+  /** Heartbeat from the live socket (throttled by the route to once per heartbeat window). Same CAS as `recordHello`. */
+  recordHeartbeat(input: { envId: string; now: Date }): Promise<boolean>;
+  /**
+   * Revoke: stamp `revokedAt` IFF `revokedAt IS NULL` (Codex C4). False means
+   * it was already revoked — the caller still completes the other two legs
+   * (sessions, socket), because a half-finished earlier revoke is the case
+   * this guards.
+   */
+  revokeLocal(input: { envId: string; now: Date }): Promise<boolean>;
+  /**
    * Rename, subject to the same unique constraint — and reporting the same
    * `name_taken` answer for the same reason. `not_found` distinguishes a
    * vanished env from a refused one, which the caller needs to choose 404 vs 409.
@@ -657,6 +672,33 @@ export async function createDbDriveEnvStore(now: () => Date = () => new Date()):
         // a revocation landing between the service's read and this write must
         // win, or a revoked machine mints one last token.
         .where(and(eq(driveEnvLocal.envId, envId), eq(driveEnvLocal.challengeNonce, nonce), isNull(driveEnvLocal.challengeUsedAt), isNull(driveEnvLocal.revokedAt)))
+        .returning({ envId: driveEnvLocal.envId });
+      return updated.length === 1;
+    },
+
+    async recordHello({ envId, capabilities, now: at }) {
+      const updated = await db
+        .update(driveEnvLocal)
+        .set({ capabilities, lastSeenAt: at, updatedAt: at })
+        .where(and(eq(driveEnvLocal.envId, envId), sql`${driveEnvLocal.enrolledAt} IS NOT NULL`, isNull(driveEnvLocal.revokedAt)))
+        .returning({ envId: driveEnvLocal.envId });
+      return updated.length === 1;
+    },
+
+    async recordHeartbeat({ envId, now: at }) {
+      const updated = await db
+        .update(driveEnvLocal)
+        .set({ lastSeenAt: at, updatedAt: at })
+        .where(and(eq(driveEnvLocal.envId, envId), sql`${driveEnvLocal.enrolledAt} IS NOT NULL`, isNull(driveEnvLocal.revokedAt)))
+        .returning({ envId: driveEnvLocal.envId });
+      return updated.length === 1;
+    },
+
+    async revokeLocal({ envId, now: at }) {
+      const updated = await db
+        .update(driveEnvLocal)
+        .set({ revokedAt: at, updatedAt: at })
+        .where(and(eq(driveEnvLocal.envId, envId), isNull(driveEnvLocal.revokedAt)))
         .returning({ envId: driveEnvLocal.envId });
       return updated.length === 1;
     },

--- a/packages/lib/src/services/drive-envs/local-env-revoke.ts
+++ b/packages/lib/src/services/drive-envs/local-env-revoke.ts
@@ -1,0 +1,79 @@
+/**
+ * Revoke a LOCAL environment's machine — the service that makes "revoke"
+ * mean all three of its legs, or it is not a revoke (Codex C4; epic
+ * invariant 8):
+ *
+ *   1. stamp `revokedAt` on `drive_env_local` (compare-and-set), so every
+ *      future challenge / redeem / bind refuses `revoked`;
+ *   2. revoke EVERY session with `resourceType = 'drive_env' AND resourceId =
+ *      envId` — the `env:bridge` socket tokens — so a token already minted
+ *      dies now rather than at its TTL;
+ *   3. tell the machine: push the server-signed `revoke` frame over the live
+ *      socket (if one is held on this replica) and close it 1008, so the
+ *      daemon deletes its key.
+ *
+ * The legs run in that order and ALL run even when leg 1 finds the row
+ * already revoked: a crash between legs on an earlier attempt is exactly the
+ * case a repeat has to finish. The stamp goes first so that nothing minted
+ * during the call survives — `redeemLocalEnvChallenge` re-reads `revokedAt`
+ * after its mint (t06b) and revokes what it just minted.
+ *
+ * Leg 3 is best-effort by nature (the socket may be on another replica, or
+ * gone): a machine that misses the frame is closed within the 5-minute
+ * session revalidation anyway, because leg 2 killed its token. IO is
+ * injected; the apps/web adapter (`lib/env-bridge/revoke.ts`) binds the
+ * store, the session service, the signer and the socket registry.
+ */
+import type { DriveEnvStore } from './drive-envs-store';
+
+/** What leg 3 managed. Reported, never thrown: legs 1 and 2 are the revoke; this is the courtesy. */
+export type RevokeMachineNotifyOutcome =
+  /** Signed revoke frame sent, socket closed 1008. */
+  | 'sent_and_closed'
+  /** No socket for this env on this replica; nothing to send. */
+  | 'no_live_socket'
+  /** The key this enrollment pinned is no longer loaded: socket closed 1008 WITHOUT a frame (never signed under another key — Codex C10). */
+  | 'closed_unsigned_key_unavailable'
+  /** A socket was held but had not completed its signed hello: closed 1008, no frame (server→daemon frames go only to authorized sockets). */
+  | 'closed_unauthorized_socket';
+
+export interface RevokeLocalDriveEnvDeps {
+  store: Pick<DriveEnvStore, 'findLocalByEnvId' | 'revokeLocal'>;
+  now: () => Date;
+  /** Leg 2: revoke every session bound to this env. @returns how many were live. */
+  revokeSessions: (input: { envId: string; reason: string }) => Promise<number>;
+  /** Leg 3: sign + push the revoke frame to the live socket and close it. */
+  notifyMachine: (input: { envId: string; enrollmentId: string; serverKeyId: string | null; issuedAt: number; reason: string }) => Promise<RevokeMachineNotifyOutcome>;
+}
+
+export type RevokeLocalDriveEnvResult =
+  | { ok: true; alreadyRevoked: boolean; revokedAt: Date; sessionsRevoked: number; machine: RevokeMachineNotifyOutcome }
+  /** No `drive_env_local` row: not a local env, or already deleted. */
+  | { ok: false; reason: 'not_found' };
+
+export async function revokeLocalDriveEnv({
+  envId,
+  reason,
+  deps,
+}: {
+  envId: string;
+  /** Recorded on the sessions and sent to the machine (advisory). */
+  reason: string;
+  deps: RevokeLocalDriveEnvDeps;
+}): Promise<RevokeLocalDriveEnvResult> {
+  const row = await deps.store.findLocalByEnvId(envId);
+  if (!row) return { ok: false, reason: 'not_found' };
+
+  const now = deps.now();
+  // Leg 1 — the stamp. False = already revoked; carry on regardless.
+  const stamped = await deps.store.revokeLocal({ envId, now });
+  const revokedAt = stamped ? now : (row.revokedAt ?? now);
+
+  // Leg 2 — every env:bridge session for this env.
+  const sessionsRevoked = await deps.revokeSessions({ envId, reason });
+
+  // Leg 3 — the machine.
+  const machine = await deps.notifyMachine({ envId, enrollmentId: row.enrollmentId, serverKeyId: row.serverKeyId, issuedAt: now.getTime(), reason });
+
+  return { ok: true, alreadyRevoked: !stamped, revokedAt, sessionsRevoked, machine };
+}


### PR DESCRIPTION
Task page `ck6kq5kxgmmdcdzx4ks4o96d` · Epic `j945few5ssv75k5ad0bowbb4` (Local Environments — zero-trust bridge) · M1 · t07 · board task `n4mt5a440w1gio7lnd71wqtc`.

The server end of the socket. Everything stays behind `LOCAL_ENVS_ENABLED` (invariant 11). The MCP desktop bridge is behaviourally unchanged — its suites (`mcp-ws/__tests__/route.security.test.ts`, `mcp/__tests__/mcp-bridge.test.ts`) are untouched and green. **No migration**: every column used (`capabilities`, `lastSeenAt`, `revokedAt`, `serverKeyId`) already exists from t05. Carries Codex **C3, C4, C7, C8, C10**; C6/C9/C11 are t08 and untouched. [D-1]/[D-2] are not settled here; the result verifier is scoped so a per-session PTY HMAC slots in beside it.

Commit order note: deliverable **4 lands before 3** because the socket route consumes the signer/verifier/client and every commit must compile. Everything else is 1 → 2 → store → 4 → 3 → 5.

## Deliverables

### 1 · Shared correlator — `apps/web/src/lib/env-bridge/correlator.ts`
**What/why.** The id-correlated pending map / per-request deadline / cancel core extracted from `mcp-bridge.ts` into `RequestCorrelator`; `MCPBridge` is a thin consumer that keeps its 30 s default and its historical error strings. The env bridge's deadline comes ONLY from `resolveTimeout` (`grantCorrelatorTimeoutMs`): `grant_exec` with `timeoutMs: 120_000` waits 120 s + margin; `pty_open` is `'unbounded'`. A reply for an id that is not pending (late, duplicate, forged) resolves nothing and is reported. Timers injected (default reads the global lazily so fake timers work).
**Tests.** `__tests__/correlator.test.ts` (10, fake timers) + both MCP suites unchanged (39). **Mutation 5/5** (hard-code 30 s ⇒ red; timeout/send-failure leave id pending ⇒ red; unknown id unreported ⇒ red; cancelGroup ignores group ⇒ red).

### Pure core groundwork — `packages/lib/src/env-bridge/machine-signatures.ts`, `frame-codec.ts`, `server-signing-key.ts`, `auth/env-bridge-signing-key.ts`
**What/why.** The exact signed bytes, defined ONCE for both sides: `encodeHelloForSigning({envId, capabilities, policyDigest})`, `encodeResultForSigning({grantId, resultHash})` with `resultHashForFrame` covering every payload field per result type (absent ≠ empty), `encodeRevokeForSigning({envId, enrollmentId, keyId, issuedAt})`; each domain-separated; `verifyHello` / `verifyMachineResult` / `verifyRevoke` with injected primitives (t08 calls the same functions). `frame-codec` gains the machine→server / server→machine partition of the closed set. `parseServerSigningKeyring`: `ENV_BRIDGE_SIGNING_KEYS` = current first, previous after; `ENV_BRIDGE_SIGNING_KEY` still the single-key form; KEYS wins when both set; one bad entry refuses the whole ring; `get(unknown)` is `null`, never another key. Loader exposes `loadServerSigningKeyring`; `loadServerSigningKey` is the ring's current (what enrollment already pins — `enrollLocalDriveEnv` writes `identity.signingKey.keyId`, verified). New lib subpath exported in `package.json`.
**Tests.** `machine-signatures.test.ts` (34), `server-signing-keyring.test.ts` (8), loader rows (4 new). **Mutation 9/9.**

### 2 · Per-env registry — `apps/web/src/lib/websocket/ws-env-connections.ts`
**What/why.** `Map<envId, socket>`. Copied verbatim from `ws-connections.ts`: the stale sweep (closed / expired-session / inactive), the 5-minute revalidation (`expectedType: 'mcp'`; transient errors never close), and the CAS on socket identity in unregister. Second socket for the same env wins; older closes `1000` / `'env_superseded'` (documented: the daemon must not reconnect into a fight). Only the LIVE socket's loss fires `onEnvConnectionLost` → the bridge client cancels that env's pending requests with typed `disconnected`; a superseded socket closing late evicts nothing and cancels nothing. `getAuthorizedEnvConnection` hands out a socket only after the signed hello (invariant 6). `readEnvLiveConnection` feeds `deriveLocalEnvStatus` (wired into the env listing and the bind gate in `drive-envs-runtime.ts`).
**Tests.** `__tests__/ws-env-connections.test.ts` (19). **Mutation 7/7** (one test tightened after a survivor slipped through via the revalidation path).

### Store + session repository (real Postgres)
`recordHello` (capabilities + lastSeenAt, CAS enrolled ∧ not revoked), `recordHeartbeat`, `revokeLocal` (CAS `revokedAt IS NULL`, first stamp kept). `sessionRepository.revokeAllForResource(resourceType, resourceId, reason)` beside `revokeAllForUser`, exposed as `sessionService.revokeResourceSessions`. Rows in `drive-envs-store.integration.test.ts` (+7) and new `session-repository-resource.integration.test.ts` (5), run against homebrew pg16 with session TZ `America/Chicago`. **Mutation 2/2 + 2/2** against the real database.

### 4 · Grant signer + result verifier + bridge client — `grant-signer.ts`, `result-verifier.ts`, `bridge-client.ts`, `crypto.ts`
**What/why.** `signGrantFrame` builds the `Grant` and signs `encodeGrant()` (layout never re-implemented). **C7:** `argsHash = hash(canonicalizeArgs(grantArgsForFrame(frame)))` — the projection the daemon's `verifyGrant` hashes; pinned by signing each frame type and verifying with the PURE gate under `grantRequestForFrame(sentFrame)`, then tampering every projected field after signing ⇒ `args_mismatch` (op moved ⇒ `op_mismatch`; other env ⇒ `wrong_env`). **C10:** signs with the key the enrollment pinned (`serverKeyId`) from the ring; previous key still serves its enrollments; unloaded id ⇒ typed `signing_key_unavailable`, no frame. **C3/invariant 7:** `EnvBridgeClient.handleMachineResult` delivers a result to the pending request ONLY after `verifyResultFromMachine` under the pinned key of the socket it arrived on; failure ⇒ typed `unverified_result`, logged/audited, never delivered; unknown grants dropped before any crypto. `crypto.ts` pins SHA-256 hex + Ed25519/SPKI (what t08 must match). PTY frames outside the verifier by design ([D-2], commented in `result-verifier.ts`).
**Tests.** `grant-signer.test.ts` (19), `bridge-client.test.ts` (13). **Mutation 6/6 incl. the exit criterion** (skip the signature check ⇒ 3 red); one further mutant was semantically equivalent to the original and discarded.

### 3 · The socket route — `apps/web/src/app/api/env-bridge/ws/route.ts` (+ `ws-message-schemas.ts`, `drive-envs-runtime.ts`)
**Security checks mirrored one-for-one from `mcp-ws/route.ts`** (same order, same close codes):
| # | mcp-ws | env-bridge |
|---|---|---|
| 0 | — | `LOCAL_ENVS_ENABLED` off ⇒ 1008 before any auth work (invariant 11) |
| 1 | WSS-only in prod ⇒ 1008 `Secure connection required` | same |
| 2 | `Authorization: Bearer` ⇒ 1008 `Authorization required`; session service validates; throw ⇒ `Authentication error`; null ⇒ `Invalid or expired token` | same, with `expectedType: 'mcp'` |
| 3 | scope `mcp:ws` **or** `mcp:*` **or** `*` | scope EXACTLY `env:bridge` — `mcp:*` and `*` refused (t06 keeps `env:bridge` outside `mcp:*`) |
| 3b | — | token `resourceType='drive_env'` ∧ `resourceId = envId` (URL) ⇒ else 1008 |
| 3c | — | **C8**: `drive_env_local` by the token's `resourceId` must be enrolled, unrevoked, hold a pinned key, and belong to the token's user; the hello verifies under THAT row's key |
| 4 | `getConnectionFingerprint`; register with session expiry + token for revalidation | same (`registerEnvConnection`, state `hello_pending`) |
| 5 | `validateMessageSize`; JSON parse; Zod schema | same size check; `decodeFrame` (the closed set, imported — the codec IS the schema; bytes ⇒ JSON ⇒ shape) |
| 6 | fingerprint re-check on ping ⇒ 1008 `Security violation` | fingerprint re-check on the machine's `pong` (the server pings) |
| 7 | health check before tool execution | `checkEnvConnectionHealth` before a result is accepted |
| — | audit every refusal via `originalEvent`; abnormal closes; errors | same (`resourceType: 'env_bridge_websocket'`) |
| — | sends `{type:'error'}` messages | **deliberately not**: the frame set has no error frame and the server sends nothing outside it (invariant 6); refusals are audited and, where the protocol requires, the socket is closed with a reason |

Bridge-specific: first frame must be a machine-signed `hello` for THIS env within `ENV_BRIDGE_HELLO_TIMEOUT_MS` (10 s) or 1008; the pure `reduceBridgeSession` decides per state, the route executes effects; on an authorized hello `recordHello` (CAS — a revoke that landed meanwhile wins ⇒ 1008 `Environment revoked`), socket marked authorized, and the first `ping` is sent at once — **that first server frame is the hello acknowledgement** the daemon's reducer maps to `hello_ack` (the codec has no ack frame; t08 note). Server pings every 30 s; `pong` updates in-memory liveness every beat and persists `lastSeenAt` **at most once per `LOCAL_ENV_HEARTBEAT_WINDOW_MS`**. Direction enforced (a `grant_exec` arriving FROM the machine is dropped + audited); unknown/malformed/PTY frames dropped + audited once authorized, close 1008 while the hello is pending. Results go to the bridge client (verified before delivery; `env_bridge_result_unverified` audited at 0.8).
**Tests.** `ws/__tests__/route.security.test.ts` (41; real registry + real bridge client underneath). **Mutation 9/9** (scope accepts wildcards ⇒ red; token↔env binding dropped ⇒ red; C8 dropped ⇒ red; hello verdict ignored ⇒ red; recordHello CAS ignored ⇒ red; heartbeat persisted every pong ⇒ red; direction dropped ⇒ red; handshake timer disarmed ⇒ red; first frame need not be hello ⇒ red).

### 5 · Revocation — `apps/web/src/lib/env-bridge/revoke.ts`, `packages/lib/src/services/drive-envs/local-env-revoke.ts`, `DELETE /api/drives/[driveId]/envs/[envId]`
**What/why (C4).** `revokeLocalDriveEnv`: (1) stamp `revokedAt` (CAS), (2) revoke EVERY session `resourceType='drive_env' ∧ resourceId=envId`, (3) push the server-signed `revoke` frame — signed by the key THIS enrollment pinned, binding `{envId, enrollmentId, keyId, issuedAt}` — close 1008 `Environment revoked`, unregister (in-flight requests fail `disconnected` at once). All three legs run even when the row was already revoked (a crash between legs on an earlier attempt is the case a repeat must finish). Leg 3 is reported, never thrown: `no_live_socket` (another replica — the 5-min revalidation closes it since leg 2 killed its token), `closed_unauthorized_socket` (no frame to a socket that never proved itself), `closed_unsigned_key_unavailable` (never signed under another key). After a revoke the daemon's next token mint fails — pinned through the REAL `issueLocalEnvChallenge` / `redeemLocalEnvChallenge` (a challenge issued before the revoke does not redeem after it). `DELETE` on a `substrate:'local'` env revokes first (owner/admin via the existing centralized `isPrincipalDriveOwnerOrAdmin`, 404 for a foreign drive, 403 revokes nothing), audits `auth.token.revoked` with `operation:'revoke'`, then deletes the row as before; Sprite envs unchanged.
**Tests.** `local-env-revoke.test.ts` (6, real services over the fake store), `revoke.test.ts` (9, real registry + client; the frame verified with the pure `verifyRevoke`), `envs/__tests__/routes.test.ts` (+5). **Mutation 2/2 (service) + 4/4 (adapter + DELETE)** (frame sent to an unauthorized socket ⇒ red; enrollmentId dropped from the binding ⇒ red; socket not unregistered ⇒ red; DELETE skips revoke ⇒ red).

## The twelve task-page requirements → named tests
1. Two envs, one user, both live — `ws-env-connections.test.ts` "given two envs for one user…"; route: "given two envs for one user, both should be authorized…".
2. Second socket same env: newer wins, older closes (documented), answered requests not cancelled — registry "given a second socket for the SAME env…" + "given the superseded socket then closes…"; route "…the older closes env_superseded, and its late close cancels nothing".
3. First frame not a valid signed hello ⇒ 1008 within the window — route "given a first frame that is not a hello", "rogue key", "tampered hello", "malformed first frame", "no hello within the handshake window".
4. Token without `env:bridge` / envId claim ≠ URL ⇒ refuse — route SECURITY CHECK 3 `each` + "token ↔ env binding".
5. `exec_result` with bad machine signature NOT delivered, typed `unverified_result` — `bridge-client.test.ts` "EXIT CRITERION…"; route invariant-7 block.
6. `grant_exec` `timeoutMs: 120_000` waits ≥ 120 s — `correlator.test.ts` and `bridge-client.test.ts` (fake timers).
7. Revoke ⇒ next mint fails + socket closed 1008 — `local-env-revoke.test.ts` "after a revoke, the daemon's next token mint should fail…"; `revoke.test.ts` first row.
8. MCP bridge unchanged — both MCP suites untouched, green.
9. C4 all three legs — `local-env-revoke.test.ts` first row (order pinned) + `revoke.test.ts`.
10. C8 token → enrollment binding — route "Codex C8" block.
11. C10 pinned key / rotation — `grant-signer.test.ts` "which key signs", keyring suites, `revoke.test.ts` previous-key row.
12. C7 signer hashes the projection — `grant-signer.test.ts` "agreement by construction".

## Verification (exact commands)
Worktree with no dist builds (~10 agents live); lib/web resolved from source via throwaway `vitest.wt.config.ts` files (uncommitted, in `info/exclude`). Every mutant applied by LINE INDEX with a helper that restores the file; a no-op mutant was run first per batch to prove the harness.
```
# lib unit
cd packages/lib && bunx vitest run --config vitest.wt.config.ts src/env-bridge/ src/auth/__tests__/env-bridge-signing-key.test.ts \
  src/services/drive-envs/__tests__/{local-env-revoke,local-env-enrollment,drive-envs}.test.ts
# lib integration, REAL Postgres (homebrew pg16 5432, session TZ America/Chicago)
DATABASE_URL=postgresql://jono@localhost:5432/pagespace_t07 bunx vitest run --config vitest.wt.config.ts \
  src/services/drive-envs/__tests__/drive-envs-store.integration.test.ts src/auth/__tests__/session-repository-resource.integration.test.ts
# web
cd apps/web && bunx vitest run --config vitest.wt.config.ts src/lib/env-bridge/__tests__/ src/lib/websocket/__tests__/ws-env-connections.test.ts \
  src/app/api/env-bridge/ws/__tests__/route.security.test.ts src/lib/mcp/__tests__/mcp-bridge.test.ts src/app/api/mcp-ws/__tests__/route.security.test.ts \
  'src/app/api/drives/[driveId]/envs/__tests__/routes.test.ts' src/lib/drive-envs/__tests__/drive-envs-runtime.test.ts
# single-package tsc after every test edit
cd packages/lib && bunx tsc --noEmit -p tsconfig.json ; cd apps/web && bunx tsc --noEmit -p tsconfig.json
# lint on every changed .ts file (lib + web)
```
CI (`bun run typecheck` monorepo, lint, security suite, test:coverage) is the gate — not run locally per the no-local-builds rule.

## Notes for t08 / reviewers
- **Hello ack = first server `ping`.** The codec has no `hello_ack` frame; the daemon's reducer produces the `hello_ack` EVENT when the first server frame arrives after its hello. A socket whose hello is refused is closed 1008 within the window, so the daemon learns by close.
- **Hash + key formats the daemon must match:** `argsHash`/`resultHash` = SHA-256 lowercase hex over `canonicalizeArgs(...)`; keys are Ed25519 over SPKI DER (`apps/web/src/lib/env-bridge/crypto.ts`).
- **Multi-replica:** the registry is per replica. A revoke reaches a socket held elsewhere through leg 2 + the 5-minute revalidation. A cross-replica push is out of M1 scope.
- Revoke reads the key ring per call (revokes are rare; rotation honoured without restart); the grant path caches it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HvtDpubt9J7yJwNbYyyNfw
