### PR TITLE
feat(billing): free tier is a one-time $5 starter grant, not a monthly allowance

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -194,6 +194,8 @@ skills-lock.json
 # Broadcast idempotency ledger (credits announcement email)
 .credits-change-sent.jsonl
 .sdk-launch-sent.jsonl
+.agent-sandbox-launch-sent.jsonl
+.free-credits-change-sent.jsonl
 
 # Vercel CLI local project-link metadata
 .vercel/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -321,6 +321,16 @@ All notable user-facing changes to PageSpace are documented here. Format follows
 
 ### Changed
 
+- **Free plan credits are now a one-time starter grant instead of a monthly allowance** — new
+  free accounts still get 5 credits to try AI with, granted once on their first AI call, but
+  that grant no longer refills or accumulates month over month. Credits you already have never
+  expire, and nothing is taken away: free accounts that had built up a balance keep it. To keep
+  going after the starter credits are spent, buy a top-up pack (top-ups never expire) or upgrade
+  to a paid plan, which includes a monthly allowance that rolls over. The credits card, the plan
+  comparison, the out-of-credits message, and the pricing, FAQ, terms, and docs pages now say
+  "5 credits to start" for Free rather than "5/month", and free accounts no longer show a
+  "Renews" date.
+
 - **Dark mode is now a lighter charcoal instead of near-black** — every dark surface (page,
   sidebar, cards, popovers, menus, borders, and the glass panels) moved up one step so text no
   longer sits on a pure-black floor, which is easier to read and reduces halation. Hover

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -329,7 +329,8 @@ All notable user-facing changes to PageSpace are documented here. Format follows
   to a paid plan, which includes a monthly allowance that rolls over. The credits card, the plan
   comparison, the out-of-credits message, and the pricing, FAQ, terms, and docs pages now say
   "5 credits to start" for Free rather than "5/month", and free accounts no longer show a
-  "Renews" date.
+  "Renews" date. Every Free account receives a one-time email explaining the change, quoting
+  the exact balance they keep, and pointing to top-ups and the Pro plan.
 
 - **Dark mode is now a lighter charcoal instead of near-black** — every dark surface (page,
   sidebar, cards, popovers, menus, borders, and the glass panels) moved up one step so text no

--- a/apps/admin/src/app/(admin)/billing/page.tsx
+++ b/apps/admin/src/app/(admin)/billing/page.tsx
@@ -148,6 +148,8 @@ interface Enforcement {
   enabled: boolean;
   markupBps: number;
   tierAllowanceCents: Record<string, number>;
+  /** Whether the tier's allowance is re-granted each renewal; false = one-time starter grant. */
+  tierAllowanceRefills?: Record<string, boolean>;
 }
 
 interface BillingResponse {
@@ -739,18 +741,19 @@ function EnforcementTab({ data }: { data: BillingResponse }) {
 
       <Card>
         <CardHeader>
-          <CardTitle>Monthly credit allowance by tier</CardTitle>
-          <CardDescription>Credits granted on each subscription renewal.</CardDescription>
+          <CardTitle>Credit allowance by tier</CardTitle>
+          <CardDescription>Paid tiers are re-granted on each renewal; the free tier is a one-time starter grant.</CardDescription>
         </CardHeader>
         <CardContent>
           <Table>
             <TableHeader>
-              <TableRow><TableHead>Tier</TableHead><TableHead className="text-right">Monthly allowance</TableHead></TableRow>
+              <TableRow><TableHead>Tier</TableHead><TableHead>Cadence</TableHead><TableHead className="text-right">Allowance</TableHead></TableRow>
             </TableHeader>
             <TableBody>
               {Object.entries(enforcement.tierAllowanceCents).map(([tier, cents]) => (
                 <TableRow key={tier}>
                   <TableCell className="capitalize">{tier}</TableCell>
+                  <TableCell>{enforcement.tierAllowanceRefills?.[tier] === false ? 'One-time' : 'Monthly'}</TableCell>
                   <TableCell className="text-right">{usd(cents)}</TableCell>
                 </TableRow>
               ))}

--- a/apps/admin/src/app/api/admin/billing/route.ts
+++ b/apps/admin/src/app/api/admin/billing/route.ts
@@ -24,6 +24,7 @@ import {
 import {
   MARKUP_BPS,
   TIER_MONTHLY_ALLOWANCE_CENTS,
+  TIER_ALLOWANCE_REFILLS,
 } from '@pagespace/lib/billing/credit-pricing';
 import { loggers } from '@pagespace/lib/logging/logger-config';
 import { toCsv } from '@/lib/csv';
@@ -97,6 +98,8 @@ export const GET = withAdminAuth(async (_adminUser, request) => {
       enabled: true,
       markupBps: MARKUP_BPS,
       tierAllowanceCents: TIER_MONTHLY_ALLOWANCE_CENTS,
+      // false = one-time starter grant (free); true = re-granted each renewal.
+      tierAllowanceRefills: TIER_ALLOWANCE_REFILLS,
     };
 
     // Top-up revenue is real cash; monthly grants are allowance, never summed

--- a/apps/marketing/src/app/blog/[slug]/data.ts
+++ b/apps/marketing/src/app/blog/[slug]/data.ts
@@ -291,7 +291,7 @@ Look at everything you did not have to build: no AI model to choose and pay a se
     title:
       "Credits Replace Daily Limits: Pay for What You Use, Run the Models You Want",
     description:
-      "PageSpace AI is now usage-based. Every plan gets a monthly pool of credits you spend however you like, paid plans unlock frontier models, and you can top up any amount from $5 to $500. Here's how it works, plus the infrastructure move that makes it scale.",
+      "PageSpace AI is now usage-based. Every plan gets a pool of credits you spend however you like (a starter grant on Free, a monthly allowance on paid plans), paid plans unlock frontier models, and you can top up any amount from $5 to $500. Here's how it works, plus the infrastructure move that makes it scale.",
     image: "/blog/usage-based-pricing-and-built-for-scale.png",
     content: `
 ## Daily limits were a stopgap. We outgrew them.
@@ -300,7 +300,7 @@ When PageSpace was small, the simplest way to meter AI was a daily call count. F
 
 A quick yes/no question and a ten-step research agent counted the same: one call. The number on the wall had nothing to do with the cost behind it. And we kept leaning into longer, more agentic work: agents that plan, call tools, and run for many steps on your behalf, where a single task can do the work of a hundred old "calls." Stack that on top of better, more expensive models and the call-count math fell apart. We could cap you harder or quietly eat costs we couldn't sustain, and neither is how you build something meant to last.
 
-So we put our big-boy pants on. AI in PageSpace is now usage-based: a monthly pool of credits you spend on exactly what you use, priced on what each model actually costs. It's the model we should have started with. It's what lets us scale, and it's what lets us hand you genuinely better models instead of holding them back.
+So we put our big-boy pants on. AI in PageSpace is now usage-based: a pool of credits you spend on exactly what you use, priced on what each model actually costs. It's the model we should have started with. It's what lets us scale, and it's what lets us hand you genuinely better models instead of holding them back.
 
 ## Credits, not call counts
 
@@ -311,7 +311,7 @@ Every plan comes with a pool of credits — a one-time starter grant on Free, a 
 - **Founder:** 50/month in credits
 - **Business:** 100/month in credits
 
-Each period adds to your balance — unused credits carry over, so nothing is lost. You spend it however you like: long agent runs, quick questions, voice, whatever the work needs. There's no per-day ceiling and no separate bucket for "standard" versus "heavy" usage. It's one balance, and you decide where it goes.
+On paid plans each renewal adds to your balance — unused credits carry over, so nothing is lost. You spend it however you like: long agent runs, quick questions, voice, whatever the work needs. There's no per-day ceiling and no separate bucket for "standard" versus "heavy" usage. It's one balance, and you decide where it goes.
 
 Each call draws from your balance based on what that model actually costs. No per-model multipliers, no rounding a fraction-of-a-cent call up to something absurd. A cheap model costs you a little and an expensive one costs you more — keeping the math simple is what lets us open up the best models from every major provider instead of charging extra for the good ones.
 
@@ -327,7 +327,7 @@ Here's the part daily limits could never give you: when billing is usage-based, 
 
 ## When you run low
 
-If your balance runs out before your next renewal, you're not locked out until tomorrow. Top up.
+If your balance runs out, you're not locked out until tomorrow. Top up.
 
 You can add **any amount from $5 to $500** in one click, or grab a quick-pick pack of $10, $25, or $50. Top-up credits never expire, so anything you add during a busy week carries over.
 

--- a/apps/marketing/src/app/blog/[slug]/data.ts
+++ b/apps/marketing/src/app/blog/[slug]/data.ts
@@ -304,9 +304,9 @@ So we put our big-boy pants on. AI in PageSpace is now usage-based: a monthly po
 
 ## Credits, not call counts
 
-Every plan comes with a monthly pool of credits:
+Every plan comes with a pool of credits — a one-time starter grant on Free, a monthly allowance on paid plans:
 
-- **Free:** 5/month in credits
+- **Free:** 5 credits to start
 - **Pro:** 15/month in credits
 - **Founder:** 50/month in credits
 - **Business:** 100/month in credits

--- a/apps/marketing/src/app/blog/[slug]/page.tsx
+++ b/apps/marketing/src/app/blog/[slug]/page.tsx
@@ -10,7 +10,7 @@ import ReactMarkdown from "react-markdown";
 import remarkGfm from "remark-gfm";
 import { blogPosts, formatDate } from "./data";
 import { ShareButtons } from "./ShareButtons";
-import { MONTHLY_CREDITS } from "@/lib/credits";
+import { FREE_STARTER_CREDITS } from "@/lib/credits";
 import { APP_URL, SITE_URL } from "@/lib/metadata";
 import { JsonLd, createArticleSchema } from "@/lib/schema";
 
@@ -152,8 +152,8 @@ export default async function BlogPostPage(
           <div className="mx-auto max-w-2xl text-center">
             <h2 className="text-2xl font-bold mb-4">Ready to try PageSpace?</h2>
             <p className="text-muted-foreground mb-6">
-              Start free with {MONTHLY_CREDITS.free}/month in credits. No
-              credit card required.
+              Start free with {FREE_STARTER_CREDITS} credits. No credit card
+              required.
             </p>
             <Button size="lg" asChild>
               <a href={`${APP_URL}/auth/signup`} rel="noopener">

--- a/apps/marketing/src/app/docs/features/ai/page.tsx
+++ b/apps/marketing/src/app/docs/features/ai/page.tsx
@@ -26,7 +26,7 @@ AI in PageSpace isn't bolted on — it's a behaviour the whole product shares. A
 
 ## How it works
 
-**Models.** PageSpace gives you one catalogue of models from many vendors — OpenAI, Anthropic, Google, xAI, and more — all in a single picker. PageSpace holds the credentials, so you never paste an API key or manage a provider account. Each call draws from your plan's monthly credit allowance based on the model's real cost; free accounts pick from a curated set of efficient models, while paid plans unlock the full catalogue across every vendor, plus top-up credits whenever you need more.
+**Models.** PageSpace gives you one catalogue of models from many vendors — OpenAI, Anthropic, Google, xAI, and more — all in a single picker. PageSpace holds the credentials, so you never paste an API key or manage a provider account. Each call draws from your credits based on the model's real cost — a one-time starter grant on Free, a monthly allowance on paid plans; free accounts pick from a curated set of efficient models, while paid plans unlock the full catalogue across every vendor, plus top-up credits whenever you need more.
 
 **Permissions.** When an agent acts, it acts as **you**. It can only see pages you can see and only change pages you can change. Share a page with a teammate and *their* agents can now see it too, under their account. Revoke access and the agents lose access immediately — there is no AI back-door.
 

--- a/apps/marketing/src/app/docs/getting-started/page.tsx
+++ b/apps/marketing/src/app/docs/getting-started/page.tsx
@@ -1,6 +1,6 @@
 import { DocsMarkdown } from "@/components/DocsContent";
 import { createMetadata } from "@/lib/metadata";
-import { MONTHLY_CREDITS } from "@/lib/credits";
+import { FREE_STARTER_CREDITS } from "@/lib/credits";
 
 export const metadata = createMetadata({
   title: "Getting Started",
@@ -22,7 +22,7 @@ Sign up at **pagespace.ai** — there are no passwords. Pick one:
 - **Magic link**: enter your email and click the link we send.
 - **Google** or **Apple** OAuth.
 
-No credit card required. The free tier includes 500 MB storage, ${MONTHLY_CREDITS.free}/month of credits, and a 20 MB max file size.
+No credit card required. The free tier includes 500 MB storage, ${FREE_STARTER_CREDITS} credits to get started (a one-time grant), and a 20 MB max file size.
 
 After signup, PageSpace sets you up with a starter **drive** (workspace) so you can jump straight in.
 
@@ -70,7 +70,7 @@ PageSpace gives you one catalogue of models from many vendors, organised by vend
 | xAI | Grok 4 family |
 | DeepSeek, Qwen, Mistral, Moonshot, MiniMax, Meta, and more | Additional open and frontier models in the catalogue |
 
-Open **Settings > AI** to pick a model. The model you pick becomes your account-level default; any individual AI Chat page can override it. Each call draws from your plan's monthly credit allowance based on the model's real cost. Free accounts use a curated allowlist — \`z-ai/glm-5.3-flash\` (default), the GPT-5.4 nano and mini models, Claude Haiku 4.5, and the Gemini Flash family — while paid plans unlock the full catalogue.
+Open **Settings > AI** to pick a model. The model you pick becomes your account-level default; any individual AI Chat page can override it. Each call draws from your credits based on the model's real cost (free accounts start with a one-time grant; paid plans get a monthly allowance). Free accounts use a curated allowlist — \`z-ai/glm-5.3-flash\` (default), the GPT-5.4 nano and mini models, Claude Haiku 4.5, and the Gemini Flash family — while paid plans unlock the full catalogue.
 
 ## 5. Create an AI Agent
 

--- a/apps/marketing/src/app/faq/page.tsx
+++ b/apps/marketing/src/app/faq/page.tsx
@@ -5,7 +5,7 @@ import { Button } from "@/components/ui/button";
 import { SiteNavbar } from "@/components/SiteNavbar";
 import { SiteFooter } from "@/components/SiteFooter";
 import { pageMetadata } from "@/lib/metadata";
-import { MONTHLY_CREDITS, creditPacksPhrase } from "@/lib/credits";
+import { MONTHLY_CREDITS, FREE_STARTER_CREDITS, creditPacksPhrase } from "@/lib/credits";
 import { JsonLd, createFaqSchema } from "@/lib/schema";
 import { FAQHashOpener } from "./hash-opener";
 
@@ -75,7 +75,7 @@ const faqs: FAQItem[] = [
   {
     id: "is-there-a-free-plan",
     question: "Is there a free plan?",
-    answer: `Yes. The Free plan includes 500 MB of storage and ${MONTHLY_CREDITS.free}/month of credits that meter your usage. No credit card required.`,
+    answer: `Yes. The Free plan includes 500 MB of storage and ${FREE_STARTER_CREDITS} credits to get started — a one-time grant that meters your AI usage. No credit card required.`,
     category: "Pricing and plans",
   },
   {
@@ -97,13 +97,13 @@ const faqs: FAQItem[] = [
   {
     id: "how-ai-credits-work",
     question: "How do credits work?",
-    answer: `Every plan includes a monthly allowance of credits — ${MONTHLY_CREDITS.free}/month on Free, more on paid plans. Each AI action draws down credits based on what the underlying model actually costs, so a quick reply with a lightweight model costs far less than a long answer from a frontier model. Unused credits roll over and accumulate — they never expire.`,
+    answer: `Free accounts start with ${FREE_STARTER_CREDITS} credits, once; paid plans include a monthly credit allowance. Each AI action draws down credits based on what the underlying model actually costs, so a quick reply with a lightweight model costs far less than a long answer from a frontier model. Credits never expire — on paid plans, unused monthly credits roll over and accumulate.`,
     category: "Pricing and plans",
   },
   {
     id: "hit-daily-ai-limit",
     question: "What happens when I run out of credits?",
-    answer: `Everything else keeps working — your documents, tasks, channels, and collaboration are unaffected. AI features pause until you buy more credits (top-up packs come in ${creditPacksPhrase()}) or your next monthly allowance is added at your billing renewal.`,
+    answer: `Everything else keeps working — your documents, tasks, channels, and collaboration are unaffected. AI features pause until you buy more credits (top-up packs come in ${creditPacksPhrase()}), upgrade to a paid plan, or — on paid plans — your next monthly allowance is added at your billing renewal.`,
     category: "Pricing and plans",
   },
   // Getting started

--- a/apps/marketing/src/app/pricing/page.tsx
+++ b/apps/marketing/src/app/pricing/page.tsx
@@ -4,7 +4,7 @@ import { Button } from "@/components/ui/button";
 import { SiteNavbar } from "@/components/SiteNavbar";
 import { SiteFooter } from "@/components/SiteFooter";
 import { pageMetadata, APP_URL } from "@/lib/metadata";
-import { MONTHLY_CREDITS } from "@/lib/credits";
+import { creditsPhrase } from "@/lib/credits";
 import {
   TIERS as PLAN_ORDER,
   TIER_PLAN_LIMITS,
@@ -86,7 +86,7 @@ const plans: Plan[] = PLAN_ORDER.map((tier) => {
     highlight: copy.highlight,
     features: {
       storage: formatTierBytes(limits.quotaBytes, " "),
-      monthlyCredits: `${MONTHLY_CREDITS[tier]}/mo`,
+      monthlyCredits: creditsPhrase(tier),
       models: copy.models,
       buyMore: true,
       realtime: true,

--- a/apps/marketing/src/app/pricing/page.tsx
+++ b/apps/marketing/src/app/pricing/page.tsx
@@ -120,8 +120,9 @@ export default function PricingPage() {
               Simple, transparent pricing
             </h1>
             <p className="text-lg text-muted-foreground mb-4">
-              Every plan includes a monthly allowance of credits that meter
-              your usage. Run low? Buy more anytime. No hidden fees.
+              Every plan includes credits that meter your AI usage: a
+              one-time starter grant on Free, a monthly allowance on paid
+              plans. Run low? Buy more anytime. No hidden fees.
             </p>
             <p className="text-sm text-muted-foreground">
               No credit card required for the Free plan.
@@ -235,7 +236,7 @@ export default function PricingPage() {
               <tbody>
                 {[
                   { key: "storage", label: "Storage" },
-                  { key: "monthlyCredits", label: "Monthly credits" },
+                  { key: "monthlyCredits", label: "Credits" },
                   { key: "models", label: "Model access" },
                   { key: "sandbox", label: "Cloud sandbox — run code, use a terminal" },
                   { key: "buyMore", label: "Buy more credits anytime" },

--- a/apps/marketing/src/app/privacy/page.tsx
+++ b/apps/marketing/src/app/privacy/page.tsx
@@ -103,7 +103,7 @@ export default function PrivacyPolicy() {
               When you use AI features, we work with external AI providers, each subject to that provider&#39;s own privacy policy. Provider routing is managed by PageSpace at the deployment level — you no longer supply or store provider API keys yourself. Supported providers include:
             </p>
             <ul className="list-disc pl-6 mb-4">
-              <li><strong>Model providers:</strong> your prompts and the relevant context are sent to AI model providers — including Anthropic (Claude), OpenAI (GPT), Google (Gemini), xAI (Grok), and, via the OpenRouter routing provider, additional third-party models — to generate responses. AI usage is metered against your plan&#39;s monthly credit allowance; Free plans use a curated set of models, and paid plans unlock the full catalogue.</li>
+              <li><strong>Model providers:</strong> your prompts and the relevant context are sent to AI model providers — including Anthropic (Claude), OpenAI (GPT), Google (Gemini), xAI (Grok), and, via the OpenRouter routing provider, additional third-party models — to generate responses. AI usage is metered against your credits (a one-time starter grant on Free, a monthly allowance on paid plans); Free plans use a curated set of models, and paid plans unlock the full catalogue.</li>
               <li><strong>Ollama (on-premises/local option):</strong> for self-hosted deployments, PageSpace supports Ollama, which runs models locally — your prompts and content never leave your own infrastructure when using this option.</li>
             </ul>
             <p className="mb-4">

--- a/apps/marketing/src/app/terms/page.tsx
+++ b/apps/marketing/src/app/terms/page.tsx
@@ -2,7 +2,7 @@ import Link from "next/link";
 import { SiteNavbar } from "@/components/SiteNavbar";
 import { SiteFooter } from "@/components/SiteFooter";
 import { pageMetadata, LEGAL_LAST_UPDATED } from "@/lib/metadata";
-import { MONTHLY_CREDITS } from "@/lib/credits";
+import { MONTHLY_CREDITS, FREE_STARTER_CREDITS } from "@/lib/credits";
 
 export const metadata = pageMetadata.terms;
 
@@ -125,13 +125,13 @@ export default function TermsOfService() {
               PageSpace offers the following subscription plans:
             </p>
             <ul className="list-disc pl-6 mb-4">
-              <li><strong>Free Plan:</strong> {MONTHLY_CREDITS.free}/month in credits, standard models, 500MB storage</li>
+              <li><strong>Free Plan:</strong> {FREE_STARTER_CREDITS} credits as a one-time starter grant, standard models, 500MB storage</li>
               <li><strong>Pro Plan ($15/month):</strong> {MONTHLY_CREDITS.pro}/month in credits, standard and Pro models, 2GB storage</li>
               <li><strong>Founder Plan ($50/month):</strong> {MONTHLY_CREDITS.founder}/month in credits, standard and Pro models, 10GB storage, priority support</li>
               <li><strong>Business Plan ($100/month):</strong> {MONTHLY_CREDITS.business}/month in credits, standard and Pro models, 50GB storage, priority support</li>
             </ul>
             <p className="mb-4">
-              Each plan&#39;s monthly credit allowance meters AI usage; unused credits roll over and accumulate — they never expire. Additional credits may be purchased at any time as one-time top-ups, which also never expire. Model availability differs by plan: free accounts use standard models, while paid plans add access to Pro (advanced) models.
+              Credits meter AI usage. The Free plan&#39;s starter credits are granted once and are not renewed; paid plans receive a monthly credit allowance, and unused credits roll over and accumulate — they never expire. Additional credits may be purchased at any time as one-time top-ups, which also never expire. Model availability differs by plan: free accounts use standard models, while paid plans add access to Pro (advanced) models.
             </p>
 
             <h3 className="text-xl font-semibold mb-3">11.2 Billing and Payment</h3>
@@ -146,7 +146,7 @@ export default function TermsOfService() {
 
             <h3 className="text-xl font-semibold mb-3">11.3 Credits and Usage Limits</h3>
             <p className="mb-4">
-              AI usage is metered against your plan&#39;s monthly credit allowance. When your available credits are exhausted, AI features pause until you purchase additional credits or your monthly allowance is added at the next billing renewal; all non-AI features (documents, tasks, channels, and collaboration) remain available. Credit prices and allowances may be adjusted with reasonable notice. Storage and file-size limits also apply per plan, and exceeding them may result in service throttling or temporary suspension until your next billing cycle.
+              AI usage is metered against your available credits (the Free plan&#39;s one-time starter grant, or a paid plan&#39;s monthly allowance). When your available credits are exhausted, AI features pause until you purchase additional credits, upgrade your plan, or — on paid plans — your monthly allowance is added at the next billing renewal; all non-AI features (documents, tasks, channels, and collaboration) remain available. Credit prices and allowances may be adjusted with reasonable notice. Storage and file-size limits also apply per plan, and exceeding them may result in service throttling or temporary suspension until your next billing cycle.
             </p>
           </section>
 

--- a/apps/marketing/src/lib/credits.ts
+++ b/apps/marketing/src/lib/credits.ts
@@ -13,6 +13,7 @@
  */
 import {
   TIER_MONTHLY_ALLOWANCE_CENTS,
+  TIER_ALLOWANCE_REFILLS,
   CREDIT_PACKS,
 } from "@pagespace/lib/billing/credit-pricing";
 import type { SubscriptionTier } from "@pagespace/lib/services/subscription-utils";
@@ -29,13 +30,32 @@ function formatPrice(cents: number): string {
   return Number.isInteger(dollars) ? `$${dollars}` : `$${dollars.toFixed(2)}`;
 }
 
-/** Monthly included credit allowance per tier, as display strings (e.g. "5", "15"). */
+/**
+ * Included credit allowance per tier, as display strings (e.g. "5", "15").
+ * NOTE: the free tier's number is a ONE-TIME starter grant, not a monthly
+ * amount (TIER_ALLOWANCE_REFILLS.free === false). Use {@link creditsPhrase} /
+ * {@link FREE_STARTER_CREDITS} so copy never says "/month" for free.
+ */
 export const MONTHLY_CREDITS: Record<SubscriptionTier, string> = {
   free: formatCredits(TIER_MONTHLY_ALLOWANCE_CENTS.free),
   pro: formatCredits(TIER_MONTHLY_ALLOWANCE_CENTS.pro),
   founder: formatCredits(TIER_MONTHLY_ALLOWANCE_CENTS.founder),
   business: formatCredits(TIER_MONTHLY_ALLOWANCE_CENTS.business),
 };
+
+/** Whether a tier's allowance is re-granted every billing period. */
+const CREDITS_REFILL: Record<SubscriptionTier, boolean> = TIER_ALLOWANCE_REFILLS;
+
+/** The free tier's one-time starter credit quantity (e.g. "5"). */
+export const FREE_STARTER_CREDITS = MONTHLY_CREDITS.free;
+
+/**
+ * Per-tier allowance phrase for prose / feature rows: "5 to start" for the
+ * one-time free grant, "15/mo" for refilling paid tiers.
+ */
+export function creditsPhrase(tier: SubscriptionTier): string {
+  return CREDITS_REFILL[tier] ? `${MONTHLY_CREDITS[tier]}/mo` : `${MONTHLY_CREDITS[tier]} to start`;
+}
 
 /** Buyable top-up packs as dollar price strings (e.g. "$10"), sorted by value. */
 export const CREDIT_PACKS_DISPLAY: string[] = Object.values(CREDIT_PACKS)

--- a/apps/marketing/src/lib/metadata.ts
+++ b/apps/marketing/src/lib/metadata.ts
@@ -1,5 +1,5 @@
 import type { Metadata } from "next";
-import { MONTHLY_CREDITS } from "./credits";
+import { FREE_STARTER_CREDITS } from "./credits";
 
 const SITE_NAME = "PageSpace";
 export const SITE_URL = process.env.NEXT_PUBLIC_MARKETING_URL || "https://pagespace.ai";
@@ -185,7 +185,7 @@ export const pageMetadata = {
   pricing: createMetadata({
     title: "Pricing",
     description:
-      `Simple, transparent pricing for individuals, teams, and enterprises. Start free with 500MB storage and ${MONTHLY_CREDITS.free}/month of credits.`,
+      `Simple, transparent pricing for individuals, teams, and enterprises. Start free with 500MB storage and ${FREE_STARTER_CREDITS} credits to get started.`,
     path: "/pricing",
     keywords: ["pricing", "plans", "free tier", "subscription"],
   }),

--- a/apps/marketing/src/lib/search-data.ts
+++ b/apps/marketing/src/lib/search-data.ts
@@ -1,5 +1,5 @@
 import { blogPosts } from "@/app/blog/[slug]/data";
-import { MONTHLY_CREDITS } from "@/lib/credits";
+import { FREE_STARTER_CREDITS } from "@/lib/credits";
 
 export interface SearchEntry {
   title: string;
@@ -117,7 +117,7 @@ const faqEntries: SearchEntry[] = [
   },
   {
     title: "Is there a free plan?",
-    description: `Yes. Free plan includes 500 MB storage and ${MONTHLY_CREDITS.free}/month of credits. No credit card required.`,
+    description: `Yes. Free plan includes 500 MB storage and ${FREE_STARTER_CREDITS} credits to get started. No credit card required.`,
     href: "/faq#is-there-a-free-plan",
     category: "FAQ",
     keywords: "free plan pricing cost no credit card credits",

--- a/apps/marketing/src/lib/search-data.ts
+++ b/apps/marketing/src/lib/search-data.ts
@@ -125,15 +125,15 @@ const faqEntries: SearchEntry[] = [
   {
     title: "How do credits work?",
     description:
-      "Every plan includes a monthly credit allowance. Each AI action draws down credits based on the model's real cost; unused credits roll over and accumulate — they never expire.",
+      "Free accounts start with a one-time grant of credits; paid plans include a monthly allowance. Each AI action draws down credits based on the model's real cost. Credits never expire — on paid plans, unused monthly credits roll over and accumulate.",
     href: "/faq#how-ai-credits-work",
     category: "FAQ",
-    keywords: "credits metered usage allowance rollover monthly billing",
+    keywords: "credits metered usage allowance starter grant rollover monthly billing",
   },
   {
     title: "What happens when I run out of credits?",
     description:
-      "Documents, tasks, channels, and collaboration keep working. AI pauses until you buy more credits or your next monthly allowance is added at your billing renewal.",
+      "Documents, tasks, channels, and collaboration keep working. AI pauses until you buy more credits, upgrade, or — on paid plans — your next monthly allowance is added at your billing renewal.",
     href: "/faq#hit-daily-ai-limit",
     category: "FAQ",
     keywords: "out of credits ai limit reset buy more top up quota",

--- a/apps/web/src/app/api/credits/breakdown/route.ts
+++ b/apps/web/src/app/api/credits/breakdown/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { requireAuth, isAuthError } from '@/lib/auth/auth-helpers';
 import { getUserUsageBreakdown } from '@/lib/subscription/usage-breakdown-query';
+import { resolveTier } from '@pagespace/lib/billing/credit-balance';
 import { auditRequest } from '@pagespace/lib/audit/audit-log';
 import { loggers } from '@pagespace/lib/logging/logger-config';
 
@@ -16,7 +17,7 @@ export async function GET(request: NextRequest) {
 
     const { userId } = auth;
 
-    const breakdown = await getUserUsageBreakdown(userId);
+    const breakdown = await getUserUsageBreakdown(userId, await resolveTier(userId));
 
     auditRequest(request, {
       eventType: 'data.read',

--- a/apps/web/src/app/api/credits/route.ts
+++ b/apps/web/src/app/api/credits/route.ts
@@ -12,8 +12,8 @@ import { auditRequest } from '@pagespace/lib/audit/audit-log';
  *
  * Returns the allowance bucket (paid tiers: re-granted and rolled over each period;
  * free: a one-time starter grant, `periodEnd` null), the never-expiring
- * top-up bucket, the spendable total (net of in-flight reservations), and the
- * reserved amount. Drives the credit-balance widget and the buy-credits surfaces.
+ * top-up bucket, the spendable total (GROSS of in-flight holds — `reserved` is
+ * reported separately, never netted out), and that reserved amount. Drives the credit-balance widget and the buy-credits surfaces.
  */
 export async function GET(request: NextRequest) {
   try {

--- a/apps/web/src/app/api/credits/route.ts
+++ b/apps/web/src/app/api/credits/route.ts
@@ -10,7 +10,8 @@ import { auditRequest } from '@pagespace/lib/audit/audit-log';
 /**
  * GET /api/credits — the authenticated user's prepaid credit balance.
  *
- * Returns the monthly allowance bucket (rolls over each period), the never-expiring
+ * Returns the allowance bucket (paid tiers: re-granted and rolled over each period;
+ * free: a one-time starter grant, `periodEnd` null), the never-expiring
  * top-up bucket, the spendable total (net of in-flight reservations), and the
  * reserved amount. Drives the credit-balance widget and the buy-credits surfaces.
  */

--- a/apps/web/src/app/settings/plan/page.tsx
+++ b/apps/web/src/app/settings/plan/page.tsx
@@ -15,7 +15,7 @@ import { PlanChangeConfirmation } from '@/components/billing/PlanChangeConfirmat
 import { PlanCard } from '@/components/billing/PlanCard';
 import { BillingGuard } from '@/components/billing/BillingGuard';
 import { getAllPlans, getPlan, getTierFromPriceId, type SubscriptionTier, type PlanDefinition } from '@/lib/subscription/plans';
-import { formatCreditCount } from '@/lib/subscription/credits';
+import { creditsCellPhrase } from '@/lib/subscription/credits';
 import type { AppliedPromo } from '@/components/billing/PromoCodeInput';
 
 interface SubscriptionData {
@@ -439,10 +439,10 @@ export default function PlanPage() {
                 </thead>
                 <tbody>
                   <tr className="border-b">
-                    <td className="py-4 pr-6">Monthly credits</td>
+                    <td className="py-4 pr-6">Credits</td>
                     {plans.map((plan) => (
                       <td key={plan.id} className="text-center py-4 px-4 font-semibold">
-                        {formatCreditCount(plan.limits.monthlyCreditsCents)} credits/mo
+                        {creditsCellPhrase(plan.id, plan.limits.monthlyCreditsCents)}
                       </td>
                     ))}
                   </tr>

--- a/apps/web/src/components/billing/CreditBalance.tsx
+++ b/apps/web/src/components/billing/CreditBalance.tsx
@@ -16,7 +16,7 @@ import { BuyCreditsButton } from '@/components/billing/BuyCreditsButton';
 import { UpgradeTierButton } from '@/components/billing/UpgradeTierButton';
 import { centsToCredits, formatCreditCount } from '@/lib/subscription/credits';
 
-/** Percentage of monthly allowance remaining below which we warn the user. */
+/** Percentage of the allowance remaining below which we warn the user. */
 const LOW_BALANCE_THRESHOLD_PCT = 15;
 
 export function CreditBalance() {
@@ -107,7 +107,7 @@ export function CreditBalance() {
             </p>
             {debt > 0 && (
               <p className="text-xs text-primary-foreground/80">
-                Overage clears at your next renewal or with a top-up
+                {isFree ? 'Overage clears with a top-up' : 'Overage clears at your next renewal or with a top-up'}
               </p>
             )}
             {topupCredits > 0 && (

--- a/apps/web/src/components/billing/CreditBalanceCard.tsx
+++ b/apps/web/src/components/billing/CreditBalanceCard.tsx
@@ -35,7 +35,9 @@ export function CreditBalanceCard() {
           Credits
         </CardTitle>
         <CardDescription>
-          Credits power AI features. Your monthly allowance renews each billing period; purchased top-up credits never expire.
+          {isFree
+            ? 'Credits power AI features. Your starter credits are a one-time grant; buy top-up credits (they never expire) or upgrade for a monthly allowance.'
+            : 'Credits power AI features. Your monthly allowance renews each billing period; purchased top-up credits never expire.'}
         </CardDescription>
       </CardHeader>
       <CardContent>
@@ -79,7 +81,9 @@ export function CreditBalanceCard() {
               <div className="text-sm text-muted-foreground space-y-0.5">
                 {balance.debt > 0 && (
                   <div className="text-red-600 dark:text-red-400">
-                    In the red — add credits to keep using AI (or it clears at your next renewal).
+                    {isFree
+                      ? 'In the red — add credits to keep using AI.'
+                      : 'In the red — add credits to keep using AI (or it clears at your next renewal).'}
                   </div>
                 )}
                 {balance.topup.remaining > 0 && (

--- a/apps/web/src/lib/subscription/__tests__/credits.test.ts
+++ b/apps/web/src/lib/subscription/__tests__/credits.test.ts
@@ -184,14 +184,16 @@ describe('MONTHLY_CREDITS (credit unit strings — regression guard)', () => {
 });
 
 describe('monthlyCreditsPhrase', () => {
-  it('free tier phrase contains the credit count and the word "credits"', () => {
+  it('free tier phrase is a one-time starter grant — count + "credits", never "/month"', () => {
     expect(monthlyCreditsPhrase('free')).toContain(MONTHLY_CREDITS.free);
     expect(monthlyCreditsPhrase('free')).toContain('credits');
+    expect(monthlyCreditsPhrase('free')).not.toContain('/month');
+    expect(monthlyCreditsPhrase('free')).toBe('5 credits to start');
   });
 
-  it('pro tier phrase contains the credit count and the word "credits"', () => {
+  it('pro tier phrase contains the credit count and "/month" (refilling tier)', () => {
     expect(monthlyCreditsPhrase('pro')).toContain(MONTHLY_CREDITS.pro);
-    expect(monthlyCreditsPhrase('pro')).toContain('credits');
+    expect(monthlyCreditsPhrase('pro')).toContain('credits/month');
   });
 
   it('founder tier phrase contains the credit count and the word "credits"', () => {

--- a/apps/web/src/lib/subscription/credit-gate-response.ts
+++ b/apps/web/src/lib/subscription/credit-gate-response.ts
@@ -10,7 +10,8 @@ import type { GateResult } from '@pagespace/lib/billing/credit-core';
  *   - daily_cap_exceeded -> 429: the per-user/day exposure backstop; the user has hit
  *     their daily spend ceiling and should retry tomorrow, not buy credits.
  *   - everything else (out_of_credits / needs_init) -> 402: the prepaid balance is
- *     exhausted; the user must add credits or wait for the next monthly renewal.
+ *     exhausted; the user must add credits, upgrade, or (paid tiers) wait for the
+ *     next monthly renewal. The free starter grant never renews.
  */
 export function creditGatePayload(reason: GateResult['reason']): {
   status: number;
@@ -34,7 +35,7 @@ export function creditGatePayload(reason: GateResult['reason']): {
   return {
     status: 402,
     error: 'out_of_credits',
-    message: 'Your credit balance is too low. Add credits to get back to positive, or wait for your monthly allowance to be added at your next renewal.',
+    message: 'Your credit balance is too low. Add credits to get back to positive, or upgrade your plan for a monthly allowance.',
   };
 }
 

--- a/apps/web/src/lib/subscription/credit-gate-response.ts
+++ b/apps/web/src/lib/subscription/credit-gate-response.ts
@@ -35,7 +35,7 @@ export function creditGatePayload(reason: GateResult['reason']): {
   return {
     status: 402,
     error: 'out_of_credits',
-    message: 'Your credit balance is too low. Add credits to get back to positive, or upgrade your plan for a monthly allowance.',
+    message: 'Your credit balance is too low. Add credits to get back to positive, or upgrade your plan. On a paid plan, your monthly allowance is also added at your next renewal.',
   };
 }
 

--- a/apps/web/src/lib/subscription/credits.ts
+++ b/apps/web/src/lib/subscription/credits.ts
@@ -16,6 +16,7 @@
  */
 import {
   TIER_MONTHLY_ALLOWANCE_CENTS,
+  TIER_ALLOWANCE_REFILLS,
   CREDIT_PACKS,
   CREDIT_TOPUP_MIN_CENTS,
   CREDIT_TOPUP_MAX_CENTS,
@@ -98,9 +99,24 @@ export const MONTHLY_CREDITS: Record<SubscriptionTier, string> = {
   business: formatCreditCount(TIER_MONTHLY_ALLOWANCE_CENTS.business),
 };
 
-/** "5 credits/month" style phrase for a tier. */
+/** Whether a tier's allowance is re-granted every billing period (free is a one-time grant). */
+const CREDITS_REFILL: Record<SubscriptionTier, boolean> = TIER_ALLOWANCE_REFILLS;
+
+/**
+ * Allowance phrase for a tier: "15 credits/month" for refilling paid tiers,
+ * "5 credits to start" for the free tier's one-time starter grant.
+ */
 export function monthlyCreditsPhrase(tier: SubscriptionTier): string {
-  return `${MONTHLY_CREDITS[tier]} credits/month`;
+  return CREDITS_REFILL[tier]
+    ? `${MONTHLY_CREDITS[tier]} credits/month`
+    : `${MONTHLY_CREDITS[tier]} credits to start`;
+}
+
+/** Short table-cell form: "15 credits/mo" or "5 credits to start". */
+export function creditsCellPhrase(tier: SubscriptionTier, cents: number): string {
+  return CREDITS_REFILL[tier]
+    ? `${formatCreditCount(cents)} credits/mo`
+    : `${formatCreditCount(cents)} credits to start`;
 }
 
 /** Buyable top-up packs, sorted by ascending credit value. */

--- a/apps/web/src/lib/subscription/usage-breakdown-query.ts
+++ b/apps/web/src/lib/subscription/usage-breakdown-query.ts
@@ -12,6 +12,8 @@ import { aiUsageLogs } from '@pagespace/db/schema/monitoring';
 import { pages } from '@pagespace/db/schema/core';
 import { driveEnvs } from '@pagespace/db/schema/drive-envs';
 import { aggregateUsageBreakdown, resolveUsageWindow, type UsageBreakdown } from './usage-breakdown';
+import { allowanceRefills } from '@pagespace/lib/billing/credit-pricing';
+import type { SubscriptionTier } from '@pagespace/lib/services/subscription-utils';
 
 /**
  * Spend-by-feature, spend-by-model, spend-by-agent-session and spend-by-environment
@@ -27,7 +29,10 @@ import { aggregateUsageBreakdown, resolveUsageWindow, type UsageBreakdown } from
  * unresolvable), so every row this query returns for `userId` is already scoped to
  * a session they own or a run they footed the bill for directly.
  */
-export async function getUserUsageBreakdown(userId: string): Promise<UsageBreakdown> {
+export async function getUserUsageBreakdown(
+  userId: string,
+  tier: SubscriptionTier = 'free',
+): Promise<UsageBreakdown> {
   const [balance] = await db
     .select({
       periodStart: creditBalances.monthlyPeriodStart,
@@ -39,9 +44,13 @@ export async function getUserUsageBreakdown(userId: string): Promise<UsageBreakd
 
   // A stale window (periodEnd in the past — renewal never landed) falls back to
   // the trailing lookback so current spend is never hidden; see resolveUsageWindow.
+  // A NON-refilling tier (free: one-time starter grant) has no renewal at all, so
+  // its stamped period end is informational only: report null so the card never
+  // says "renews <date>", mirroring getCreditBalance. Spend is still counted from
+  // the grant onward (periodStart).
   const { periodStart, periodEnd } = resolveUsageWindow({
     periodStart: balance?.periodStart ?? null,
-    periodEnd: balance?.periodEnd ?? null,
+    periodEnd: allowanceRefills(tier) ? (balance?.periodEnd ?? null) : null,
     now: new Date(),
   });
 

--- a/packages/db/src/schema/credits.ts
+++ b/packages/db/src/schema/credits.ts
@@ -6,7 +6,9 @@ import { users } from './auth';
 /**
  * creditBalances — denormalized, one row per user. The fast pre-request gate and
  * the dashboard read this. Two buckets plus a debt counter:
- *   - monthly: subscription allowance, ACCUMULATES across periods (rollover)
+ *   - monthly: tier allowance. Paid tiers: re-granted each renewal and ACCUMULATES
+ *              across periods (rollover). Free: a ONE-TIME starter grant, never refilled
+ *              (TIER_ALLOWANCE_REFILLS in credit-pricing)
  *   - topup:   purchased packs, NEVER expire
  *   - debt:    overage owed (a NON-NEGATIVE magnitude). Accrues when a call's real
  *              cost can't be covered; paid down by a purchase; FORGIVEN (zeroed) at

--- a/packages/lib/package.json
+++ b/packages/lib/package.json
@@ -1368,6 +1368,11 @@
       "import": "./dist/email-templates/AgentSandboxLaunchEmail.js",
       "require": "./dist/email-templates/AgentSandboxLaunchEmail.js"
     },
+    "./email-templates/FreeCreditsChangeEmail": {
+      "types": "./dist/email-templates/FreeCreditsChangeEmail.d.ts",
+      "import": "./dist/email-templates/FreeCreditsChangeEmail.js",
+      "require": "./dist/email-templates/FreeCreditsChangeEmail.js"
+    },
     "./email-templates/render-email": {
       "types": "./dist/email-templates/render-email.d.ts",
       "import": "./dist/email-templates/render-email.js",
@@ -2669,6 +2674,9 @@
       ],
       "email-templates/AgentSandboxLaunchEmail": [
         "./dist/email-templates/AgentSandboxLaunchEmail.d.ts"
+      ],
+      "email-templates/FreeCreditsChangeEmail": [
+        "./dist/email-templates/FreeCreditsChangeEmail.d.ts"
       ],
       "email-templates/PaymentReceiptEmail": [
         "./dist/email-templates/PaymentReceiptEmail.d.ts"

--- a/packages/lib/src/billing/__tests__/credit-balance.test.ts
+++ b/packages/lib/src/billing/__tests__/credit-balance.test.ts
@@ -269,6 +269,35 @@ describe('getCreditBalance', () => {
       expect(b.monthly.periodEnd).toBeNull();
     });
 
+    it('pre-credits the pending starter grant for a free bare top-up row (no period stamped) — the gate grants it on next call', async () => {
+      balanceRows = [
+        {
+          monthlyRemainingCents: 0,
+          monthlyAllowanceCents: 0,
+          topupRemainingCents: 2500,
+          monthlyPeriodEnd: null,
+        },
+      ];
+      const b = await getCreditBalance('u1', 'free');
+      expect(b.monthly.remaining).toBe(500);
+      expect(b.spendable).toBe(3000);
+      expect(await readSpendableCents('u1', 'free')).toBe(3000); // lean read agrees
+    });
+
+    it('does NOT pre-credit a free row whose period IS stamped (the grant already landed)', async () => {
+      balanceRows = [
+        {
+          monthlyRemainingCents: 120,
+          monthlyAllowanceCents: 500,
+          topupRemainingCents: 0,
+          monthlyPeriodEnd: past,
+        },
+      ];
+      const b = await getCreditBalance('u1', 'free');
+      expect(b.monthly.remaining).toBe(120);
+      expect(b.spendable).toBe(120);
+    });
+
     it('projects addOneMonth(now) for a paid user when no periodEnd has been stamped yet (null in DB)', async () => {
       balanceRows = [
         {

--- a/packages/lib/src/billing/__tests__/credit-balance.test.ts
+++ b/packages/lib/src/billing/__tests__/credit-balance.test.ts
@@ -97,7 +97,7 @@ describe('getCreditBalance', () => {
     expect(b.spendable).toBe(320 + 1000);
   });
 
-  it('shows the full allowance for a free tier whose period has lapsed with zero carry (gate will add allowance)', async () => {
+  it('shows ZERO for a free tier whose period has lapsed with zero carry — the starter grant is one-time, nothing upcoming', async () => {
     balanceRows = [
       {
         monthlyRemainingCents: 0,
@@ -107,12 +107,13 @@ describe('getCreditBalance', () => {
       },
     ];
     const b = await getCreditBalance('u1', 'free');
-    // 0 carried + 500 allowance = 500
-    expect(b.monthly.remaining).toBe(500);
-    expect(b.spendable).toBe(500);
+    // No refill is ever coming: do NOT pre-credit the allowance.
+    expect(b.monthly.remaining).toBe(0);
+    expect(b.spendable).toBe(0);
+    expect(b.monthly.allowance).toBe(500);
   });
 
-  it('shows stored remaining + allowance for a free tier with a non-zero carried balance (rollover)', async () => {
+  it('shows only the stored remaining for a free tier with a carried balance past its window (no rollover)', async () => {
     balanceRows = [
       {
         monthlyRemainingCents: 200,
@@ -122,15 +123,14 @@ describe('getCreditBalance', () => {
       },
     ];
     const b = await getCreditBalance('u1', 'free');
-    // 200 carried + 500 allowance = 700
-    expect(b.monthly.remaining).toBe(700);
-    expect(b.spendable).toBe(700);
+    // 200 stored, no +500: the free grant never refills. The 200 stays spendable (no expiry).
+    expect(b.monthly.remaining).toBe(200);
+    expect(b.spendable).toBe(200);
   });
 
-  it('shows actual debt for expired free-period; spendable reflects debt that will be netted at reset', async () => {
-    // 0¢ remaining, 300¢ debt, expired period. Gate will apply: max(0, 0−300+500)=200 on next call.
-    // Balance display anticipates the allowance (monthly.remaining = 0+500=500) and shows
-    // actual stored debt (300), so spendable = 500−300 = 200 — the real post-reset outcome.
+  it('shows actual debt for an expired free window; spendable goes negative because no reset will net it', async () => {
+    // 0¢ remaining, 300¢ debt, expired period. Free never resets, so nothing will absorb
+    // the debt — only a top-up purchase clears it. Display: remaining 0, debt 300, spendable −300.
     balanceRows = [
       {
         monthlyRemainingCents: 0,
@@ -141,9 +141,9 @@ describe('getCreditBalance', () => {
       },
     ];
     const b = await getCreditBalance('u1', 'free');
-    expect(b.monthly.remaining).toBe(500);
+    expect(b.monthly.remaining).toBe(0);
     expect(b.debt).toBe(300);
-    expect(b.spendable).toBe(200);
+    expect(b.spendable).toBe(-300);
   });
 
   it('shows the stored monthly remaining for a paid tier whose period has lapsed (rollover: credits carry forward)', async () => {
@@ -203,7 +203,20 @@ describe('getCreditBalance', () => {
   });
 
   describe('monthly.periodEnd display projection', () => {
-    it('returns an active periodEnd as-is (ISO string)', async () => {
+    it('returns an active periodEnd as-is (ISO string) for a refilling tier', async () => {
+      balanceRows = [
+        {
+          monthlyRemainingCents: 400,
+          monthlyAllowanceCents: 1500,
+          topupRemainingCents: 0,
+          monthlyPeriodEnd: future,
+        },
+      ];
+      const b = await getCreditBalance('u1', 'pro');
+      expect(b.monthly.periodEnd).toBe(future.toISOString());
+    });
+
+    it('returns null periodEnd for a free user even inside an active window — the grant never renews', async () => {
       balanceRows = [
         {
           monthlyRemainingCents: 400,
@@ -213,10 +226,10 @@ describe('getCreditBalance', () => {
         },
       ];
       const b = await getCreditBalance('u1', 'free');
-      expect(b.monthly.periodEnd).toBe(future.toISOString());
+      expect(b.monthly.periodEnd).toBeNull();
     });
 
-    it('projects addOneMonth(now) for a free user with an expired period — never shows a past date', async () => {
+    it('returns null periodEnd for a free user with an expired period — no phantom "renews on" date', async () => {
       balanceRows = [
         {
           monthlyRemainingCents: 0,
@@ -226,9 +239,7 @@ describe('getCreditBalance', () => {
         },
       ];
       const b = await getCreditBalance('u1', 'free');
-      // periodEnd must be in the future (not the stale past date from the DB)
-      expect(b.monthly.periodEnd).not.toBeNull();
-      expect(new Date(b.monthly.periodEnd!).getTime()).toBeGreaterThan(Date.now());
+      expect(b.monthly.periodEnd).toBeNull();
     });
 
     it('projects addOneMonth(pastPeriodEnd) for a paid user with an expired period — shows next expected Stripe cycle date', async () => {
@@ -245,7 +256,7 @@ describe('getCreditBalance', () => {
       expect(new Date(b.monthly.periodEnd!).getTime()).toBeGreaterThan(Date.now());
     });
 
-    it('projects addOneMonth(now) for a free user when no periodEnd has been stamped yet (null in DB)', async () => {
+    it('returns null periodEnd for a free user when no periodEnd has been stamped yet (null in DB)', async () => {
       balanceRows = [
         {
           monthlyRemainingCents: 500,
@@ -254,10 +265,8 @@ describe('getCreditBalance', () => {
           monthlyPeriodEnd: null,
         },
       ];
-      // null DB periodEnd counts as expired; free tier projects addOneMonth
       const b = await getCreditBalance('u1', 'free');
-      expect(b.monthly.periodEnd).not.toBeNull();
-      expect(new Date(b.monthly.periodEnd!).getTime()).toBeGreaterThan(Date.now());
+      expect(b.monthly.periodEnd).toBeNull();
     });
 
     it('projects addOneMonth(now) for a paid user when no periodEnd has been stamped yet (null in DB)', async () => {
@@ -308,13 +317,13 @@ describe('readSpendableCents — the routing edge lean read', () => {
     expect(lean).toBeGreaterThan(0);
   });
 
-  it('agrees with the display read for a free user whose window has lapsed', async () => {
-    // The rollover the gate applies lazily: the user must not read as broke for the
-    // gap between the reset being due and something performing it.
+  it('agrees with the display read for a free user whose window has lapsed (no pre-credit: only top-up remains)', async () => {
+    // Free never refills, so a lapsed window adds nothing; whatever top-up is funded is
+    // all that's spendable, and both reads must agree on that.
     balanceRows = funded({ monthlyRemainingCents: 0, monthlyPeriodEnd: past });
     const [lean, display] = [await readSpendableCents('u1', 'free'), await getCreditBalance('u1', 'free')];
     expect(lean).toBe(display.spendable);
-    expect(lean).toBeGreaterThan(0);
+    expect(lean).toBe(display.topup.remaining);
   });
 
   it('agrees with the display read for a user in debt, and goes negative', async () => {

--- a/packages/lib/src/billing/__tests__/credit-gate.test.ts
+++ b/packages/lib/src/billing/__tests__/credit-gate.test.ts
@@ -335,19 +335,20 @@ describe('canConsumeAI', () => {
     expect(r.reason).toBe('ok');
   });
 
-  it('nets outstanding debt against carry at gate-driven free reset (debt absorbed into monthly balance)', async () => {
-    // 0¢ remaining, 300¢ debt, 500¢ free allowance → net = (0 − 300) + 500 = 200¢.
+  it('nets outstanding debt against carry at a gate-driven reset (comped pro, debt absorbed into monthly balance)', async () => {
+    // 0¢ remaining, 300¢ debt, 1500¢ pro allowance → net = (0 − 300) + 1500 = 1200¢.
     mockDb.select
       .mockReturnValueOnce(selectReturning([{ monthlyRemainingCents: 0, topupRemainingCents: 0, debtCents: 300, monthlyPeriodEnd: PAST }]))
-      .mockReturnValueOnce(selectReturning([{ monthlyRemainingCents: 200, topupRemainingCents: 0, debtCents: 0, monthlyPeriodEnd: FUTURE }]));
+      .mockReturnValueOnce(selectReturning([])) // subscription lookup: none (comped)
+      .mockReturnValueOnce(selectReturning([{ monthlyRemainingCents: 1200, topupRemainingCents: 0, debtCents: 0, monthlyPeriodEnd: FUTURE }]));
     const sink: { set?: Record<string, unknown> } = {};
     mockResetTransaction(sink, { monthlyRemainingCents: 0, debtCents: 300, monthlyPeriodEnd: PAST });
-    mockTransaction({ monthlyRemainingCents: 200, topupRemainingCents: 0, debtCents: 0, monthlyPeriodEnd: FUTURE }, { reserved: 0, inFlight: 0 });
+    mockTransaction({ monthlyRemainingCents: 1200, topupRemainingCents: 0, debtCents: 0, monthlyPeriodEnd: FUTURE }, { reserved: 0, inFlight: 0 });
 
-    const r = await canConsumeAI('u1', 'free');
+    const r = await canConsumeAI('u1', 'pro');
 
-    // Debt absorbed: net = 0 − 300 + 500 = 200; debtCents zeroed in the UPDATE.
-    expect(sink.set).toMatchObject({ monthlyRemainingCents: 200, monthlyAllowanceCents: 500, debtCents: 0 });
+    // Debt absorbed: net = 0 − 300 + 1500 = 1200; debtCents zeroed in the UPDATE.
+    expect(sink.set).toMatchObject({ monthlyRemainingCents: 1200, monthlyAllowanceCents: 1500, debtCents: 0 });
     expect(r.allowed).toBe(true);
     expect(r.reason).toBe('ok');
   });
@@ -409,47 +410,58 @@ describe('canConsumeAI', () => {
     expect(r.reason).toBe('out_of_credits');
   });
 
-  it('resets the monthly bucket to the tier allowance when the period has expired (free, gate-driven)', async () => {
-    mockDb.select
-      .mockReturnValueOnce(selectReturning([{ monthlyRemainingCents: 0, topupRemainingCents: 0, monthlyPeriodEnd: PAST }]))
-      .mockReturnValueOnce(selectReturning([{ monthlyRemainingCents: 500, topupRemainingCents: 0, monthlyPeriodEnd: FUTURE }]));
-    const sink: { set?: Record<string, unknown> } = {};
-    mockResetTransaction(sink, { monthlyRemainingCents: 0, debtCents: 0, monthlyPeriodEnd: PAST });
-    mockTransaction({ monthlyRemainingCents: 500, topupRemainingCents: 0, monthlyPeriodEnd: FUTURE }, { reserved: 0, inFlight: 0 });
+  // ── Free tier: ONE-TIME grant, never refilled ─────────────────────────────
+  // TIER_ALLOWANCE_REFILLS.free === false. An expired (or never-stamped) free window
+  // must be left alone: no reset transaction, no UPDATE, no monthly_grant row.
+
+  it('does NOT reset a free user whose window has expired — the starter grant is one-time (out_of_credits at 0)', async () => {
+    // Only ONE unlocked select (the pre-read): no subscription lookup, no post-reset re-read.
+    mockDb.select.mockReturnValueOnce(selectReturning([{ monthlyRemainingCents: 0, topupRemainingCents: 0, monthlyPeriodEnd: PAST }]));
+    mockTransaction({ monthlyRemainingCents: 0, topupRemainingCents: 0, monthlyPeriodEnd: PAST }, { reserved: 0, inFlight: 0 });
 
     const r = await canConsumeAI('u1', 'free');
 
-    expect(sink.set).toMatchObject({ monthlyRemainingCents: 500, monthlyAllowanceCents: 500 });
+    expect(mockDb.select).toHaveBeenCalledTimes(1);
+    expect(mockDb.update).not.toHaveBeenCalled();
+    expect(mockDb.transaction).toHaveBeenCalledTimes(1); // the hold transaction only
+    expect(r).toMatchObject({ allowed: false, reason: 'out_of_credits' });
+  });
+
+  it('keeps spending a free user\'s carried balance after the window expires — no refill, but no expiry either', async () => {
+    mockDb.select.mockReturnValueOnce(selectReturning([{ monthlyRemainingCents: 200, topupRemainingCents: 0, monthlyPeriodEnd: PAST }]));
+    mockTransaction({ monthlyRemainingCents: 200, topupRemainingCents: 0, monthlyPeriodEnd: PAST }, { reserved: 0, inFlight: 0 });
+
+    const r = await canConsumeAI('u1', 'free');
+
+    expect(mockDb.update).not.toHaveBeenCalled();
+    expect(mockDb.transaction).toHaveBeenCalledTimes(1);
     expect(r.allowed).toBe(true);
     expect(r.reason).toBe('ok');
   });
 
-  it('accumulates: carries the remaining balance into the new period when resetting (free, gate-driven rollover)', async () => {
-    // 200 remaining when the period expired → 200 carried + 500 allowance = 700.
-    mockDb.select
-      .mockReturnValueOnce(selectReturning([{ monthlyRemainingCents: 200, topupRemainingCents: 0, monthlyPeriodEnd: PAST }]))
-      .mockReturnValueOnce(selectReturning([{ monthlyRemainingCents: 700, topupRemainingCents: 0, monthlyPeriodEnd: FUTURE }]));
-    const sink: { set?: Record<string, unknown> } = {};
-    mockResetTransaction(sink, { monthlyRemainingCents: 200, debtCents: 0, monthlyPeriodEnd: PAST });
-    mockTransaction({ monthlyRemainingCents: 700, topupRemainingCents: 0, monthlyPeriodEnd: FUTURE }, { reserved: 0, inFlight: 0 });
+  it('does NOT grant a free allowance when a top-up created the row without a period — top-up bucket alone is spendable', async () => {
+    mockDb.select.mockReturnValueOnce(selectReturning([{ monthlyRemainingCents: 0, topupRemainingCents: 2500, monthlyPeriodEnd: null }]));
+    mockTransaction({ monthlyRemainingCents: 0, topupRemainingCents: 2500, monthlyPeriodEnd: null }, { reserved: 0, inFlight: 0 });
 
     const r = await canConsumeAI('u1', 'free');
 
-    expect(sink.set).toMatchObject({ monthlyRemainingCents: 700, monthlyAllowanceCents: 500 });
+    expect(mockDb.update).not.toHaveBeenCalled();
+    expect(mockDb.transaction).toHaveBeenCalledTimes(1);
     expect(r.allowed).toBe(true);
   });
 
-  it('grants the monthly allowance and stamps a window when a top-up created the row without a period', async () => {
+  it('still gate-resets a comped paid user whose row was created bare by a top-up (null period)', async () => {
     mockDb.select
       .mockReturnValueOnce(selectReturning([{ monthlyRemainingCents: 0, topupRemainingCents: 2500, monthlyPeriodEnd: null }]))
-      .mockReturnValueOnce(selectReturning([{ monthlyRemainingCents: 500, topupRemainingCents: 2500, monthlyPeriodEnd: FUTURE }]));
+      .mockReturnValueOnce(selectReturning([])) // no renewal-capable subscription
+      .mockReturnValueOnce(selectReturning([{ monthlyRemainingCents: 1500, topupRemainingCents: 2500, monthlyPeriodEnd: FUTURE }]));
     const sink: { set?: Record<string, unknown> } = {};
     mockResetTransaction(sink, { monthlyRemainingCents: 0, debtCents: 0, monthlyPeriodEnd: null });
-    mockTransaction({ monthlyRemainingCents: 500, topupRemainingCents: 2500, monthlyPeriodEnd: FUTURE }, { reserved: 0, inFlight: 0 });
+    mockTransaction({ monthlyRemainingCents: 1500, topupRemainingCents: 2500, monthlyPeriodEnd: FUTURE }, { reserved: 0, inFlight: 0 });
 
-    const r = await canConsumeAI('u1', 'free');
+    const r = await canConsumeAI('u1', 'pro');
 
-    expect(sink.set).toMatchObject({ monthlyRemainingCents: 500, monthlyAllowanceCents: 500 });
+    expect(sink.set).toMatchObject({ monthlyRemainingCents: 1500, monthlyAllowanceCents: 1500 });
     expect(r.allowed).toBe(true);
   });
 
@@ -528,18 +540,15 @@ describe('canConsumeAI', () => {
     expect(r).toMatchObject({ allowed: false, reason: 'out_of_credits' }); // invoice.paid owns the refill now
   });
 
-  it('does NOT look up subscriptions for a free user with an expired window (free reset path unchanged)', async () => {
-    mockDb.select
-      .mockReturnValueOnce(selectReturning([{ monthlyRemainingCents: 0, topupRemainingCents: 0, monthlyPeriodEnd: PAST }]))
-      .mockReturnValueOnce(selectReturning([{ monthlyRemainingCents: 500, topupRemainingCents: 0, monthlyPeriodEnd: FUTURE }]));
-    mockResetTransaction({}, { monthlyRemainingCents: 0, debtCents: 0, monthlyPeriodEnd: PAST });
-    mockTransaction({ monthlyRemainingCents: 500, topupRemainingCents: 0, monthlyPeriodEnd: FUTURE }, { reserved: 0, inFlight: 0 });
+  it('does NOT look up subscriptions for a free user with an expired window — free is excluded before the lookup', async () => {
+    mockDb.select.mockReturnValueOnce(selectReturning([{ monthlyRemainingCents: 300, topupRemainingCents: 0, monthlyPeriodEnd: PAST }]));
+    mockTransaction({ monthlyRemainingCents: 300, topupRemainingCents: 0, monthlyPeriodEnd: PAST }, { reserved: 0, inFlight: 0 });
 
     const r = await canConsumeAI('u1', 'free');
 
-    // Exactly two unlocked selects: the pre-read and the post-reset re-read — no
-    // subscription lookup in between.
-    expect(mockDb.select).toHaveBeenCalledTimes(2);
+    // Exactly one unlocked select — the pre-read. The refills flag short-circuits
+    // ahead of hasRenewalCapableSubscription, so the hot path stays a single read.
+    expect(mockDb.select).toHaveBeenCalledTimes(1);
     expect(r.allowed).toBe(true);
   });
 
@@ -620,27 +629,38 @@ describe('canConsumeAI', () => {
     expect(sink.ledgerValues).toBeUndefined();
   });
 
-  it('free-tier monthly reset writes a monthly_grant ledger row with the period-keyed stripeRef', async () => {
+  it('gate-driven reset (comped pro) writes a monthly_grant ledger row with the period-keyed stripeRef', async () => {
     mockDb.select
       .mockReturnValueOnce(selectReturning([{ monthlyRemainingCents: 0, topupRemainingCents: 0, monthlyPeriodEnd: PAST }]))
-      .mockReturnValueOnce(selectReturning([{ monthlyRemainingCents: 500, topupRemainingCents: 0, monthlyPeriodEnd: FUTURE }]));
+      .mockReturnValueOnce(selectReturning([])) // no renewal-capable subscription
+      .mockReturnValueOnce(selectReturning([{ monthlyRemainingCents: 1500, topupRemainingCents: 0, monthlyPeriodEnd: FUTURE }]));
     const sink: { set?: Record<string, unknown>; ledgerValues?: Record<string, unknown> } = {};
     mockResetTransaction(sink, { monthlyRemainingCents: 0, debtCents: 0, monthlyPeriodEnd: PAST });
-    mockTransaction({ monthlyRemainingCents: 500, topupRemainingCents: 0, monthlyPeriodEnd: FUTURE }, { reserved: 0, inFlight: 0 });
+    mockTransaction({ monthlyRemainingCents: 1500, topupRemainingCents: 0, monthlyPeriodEnd: FUTURE }, { reserved: 0, inFlight: 0 });
 
-    await canConsumeAI('u1', 'free');
+    await canConsumeAI('u1', 'pro');
 
     expect(sink.ledgerValues).toMatchObject({
       userId: 'u1',
       entryType: 'monthly_grant',
       bucket: 'monthly',
-      amountCents: 500,
+      amountCents: 1500,
       consumeStatus: 'applied',
     });
     // The stripeRef includes the period timestamp so each rollover gets a unique
     // key; concurrent resets within the same millisecond de-duplicate via the index.
     expect(typeof sink.ledgerValues?.stripeRef).toBe('string');
-    expect((sink.ledgerValues?.stripeRef as string).startsWith('free-reset-u1-')).toBe(true);
+    expect((sink.ledgerValues?.stripeRef as string).startsWith('gate-reset-u1-')).toBe(true);
+  });
+
+  it('never writes a free-reset ledger row: a free user with an expired window gets no grant', async () => {
+    mockDb.select.mockReturnValueOnce(selectReturning([{ monthlyRemainingCents: 0, topupRemainingCents: 0, monthlyPeriodEnd: PAST }]));
+    mockTransaction({ monthlyRemainingCents: 0, topupRemainingCents: 0, monthlyPeriodEnd: PAST }, { reserved: 0, inFlight: 0 });
+
+    await canConsumeAI('u1', 'free');
+
+    expect(mockDb.insert).not.toHaveBeenCalled();
+    expect(mockDb.update).not.toHaveBeenCalled();
   });
 
   // ── Locked-read ordering (M7 race fix) ──────────────────────────────────────
@@ -651,38 +671,40 @@ describe('canConsumeAI', () => {
   it('computes the refill from the post-lock read, NOT the unlocked pre-read snapshot', async () => {
     // Pre-transaction snapshot is stale: it shows 200¢ remaining. A concurrent settle
     // commits before we take the row lock, leaving only 50¢. The locked read inside the
-    // txn must drive the refill: 50 + 500 = 550 (NOT the stale 200 + 500 = 700, which
+    // txn must drive the refill: 50 + 1500 = 1550 (NOT the stale 200 + 1500 = 1700, which
     // would silently un-bill the concurrent spend).
     mockDb.select
       .mockReturnValueOnce(selectReturning([{ monthlyRemainingCents: 200, topupRemainingCents: 0, debtCents: 0, monthlyPeriodEnd: PAST }]))
-      .mockReturnValueOnce(selectReturning([{ monthlyRemainingCents: 550, topupRemainingCents: 0, debtCents: 0, monthlyPeriodEnd: FUTURE }]));
+      .mockReturnValueOnce(selectReturning([])) // no renewal-capable subscription (comped pro)
+      .mockReturnValueOnce(selectReturning([{ monthlyRemainingCents: 1550, topupRemainingCents: 0, debtCents: 0, monthlyPeriodEnd: FUTURE }]));
     const sink: { set?: Record<string, unknown>; updateCalled?: boolean } = {};
     // Locked row diverges from the pre-read: only 50¢ left.
     mockResetTransaction(sink, { monthlyRemainingCents: 50, debtCents: 0, monthlyPeriodEnd: PAST });
-    mockTransaction({ monthlyRemainingCents: 550, topupRemainingCents: 0, debtCents: 0, monthlyPeriodEnd: FUTURE }, { reserved: 0, inFlight: 0 });
+    mockTransaction({ monthlyRemainingCents: 1550, topupRemainingCents: 0, debtCents: 0, monthlyPeriodEnd: FUTURE }, { reserved: 0, inFlight: 0 });
 
-    const r = await canConsumeAI('u1', 'free');
+    const r = await canConsumeAI('u1', 'pro');
 
-    // 550, not 700 — proves the refill used the locked read.
-    expect(sink.set).toMatchObject({ monthlyRemainingCents: 550, monthlyAllowanceCents: 500, debtCents: 0 });
+    // 1550, not 1700 — proves the refill used the locked read.
+    expect(sink.set).toMatchObject({ monthlyRemainingCents: 1550, monthlyAllowanceCents: 1500, debtCents: 0 });
     expect(r.allowed).toBe(true);
   });
 
   it('nets debt from the LOCKED row so a concurrent debt-clearing top-up is not collected twice', async () => {
     // Pre-read snapshot shows 300¢ debt. A concurrent top-up pays it off before we lock,
     // so the locked read shows 0 debt. The refill must net against the locked debt (0):
-    // 0 + 500 = 500. Using the stale 300¢ debt would re-collect already-paid debt
-    // (0 − 300 + 500 = 200), shorting the user 300¢.
+    // 0 + 1500 = 1500. Using the stale 300¢ debt would re-collect already-paid debt
+    // (0 − 300 + 1500 = 1200), shorting the user 300¢.
     mockDb.select
       .mockReturnValueOnce(selectReturning([{ monthlyRemainingCents: 0, topupRemainingCents: 0, debtCents: 300, monthlyPeriodEnd: PAST }]))
-      .mockReturnValueOnce(selectReturning([{ monthlyRemainingCents: 500, topupRemainingCents: 0, debtCents: 0, monthlyPeriodEnd: FUTURE }]));
+      .mockReturnValueOnce(selectReturning([])) // no renewal-capable subscription (comped pro)
+      .mockReturnValueOnce(selectReturning([{ monthlyRemainingCents: 1500, topupRemainingCents: 0, debtCents: 0, monthlyPeriodEnd: FUTURE }]));
     const sink: { set?: Record<string, unknown> } = {};
     mockResetTransaction(sink, { monthlyRemainingCents: 0, debtCents: 0, monthlyPeriodEnd: PAST });
-    mockTransaction({ monthlyRemainingCents: 500, topupRemainingCents: 0, debtCents: 0, monthlyPeriodEnd: FUTURE }, { reserved: 0, inFlight: 0 });
+    mockTransaction({ monthlyRemainingCents: 1500, topupRemainingCents: 0, debtCents: 0, monthlyPeriodEnd: FUTURE }, { reserved: 0, inFlight: 0 });
 
-    const r = await canConsumeAI('u1', 'free');
+    const r = await canConsumeAI('u1', 'pro');
 
-    expect(sink.set).toMatchObject({ monthlyRemainingCents: 500, debtCents: 0 });
+    expect(sink.set).toMatchObject({ monthlyRemainingCents: 1500, debtCents: 0 });
     expect(r.allowed).toBe(true);
   });
 
@@ -692,13 +714,14 @@ describe('canConsumeAI', () => {
     // FUTURE. We must NOT update or write a grant; just re-read and proceed.
     mockDb.select
       .mockReturnValueOnce(selectReturning([{ monthlyRemainingCents: 0, topupRemainingCents: 0, monthlyPeriodEnd: PAST }]))
-      .mockReturnValueOnce(selectReturning([{ monthlyRemainingCents: 500, topupRemainingCents: 0, monthlyPeriodEnd: FUTURE }]));
+      .mockReturnValueOnce(selectReturning([])) // no renewal-capable subscription (comped pro)
+      .mockReturnValueOnce(selectReturning([{ monthlyRemainingCents: 1500, topupRemainingCents: 0, monthlyPeriodEnd: FUTURE }]));
     const sink: { set?: Record<string, unknown>; ledgerValues?: Record<string, unknown>; updateCalled?: boolean } = {};
     // Locked window is FUTURE → predicate recheck fails → skip.
-    mockResetTransaction(sink, { monthlyRemainingCents: 500, debtCents: 0, monthlyPeriodEnd: FUTURE });
-    mockTransaction({ monthlyRemainingCents: 500, topupRemainingCents: 0, monthlyPeriodEnd: FUTURE }, { reserved: 0, inFlight: 0 });
+    mockResetTransaction(sink, { monthlyRemainingCents: 1500, debtCents: 0, monthlyPeriodEnd: FUTURE });
+    mockTransaction({ monthlyRemainingCents: 1500, topupRemainingCents: 0, monthlyPeriodEnd: FUTURE }, { reserved: 0, inFlight: 0 });
 
-    const r = await canConsumeAI('u1', 'free');
+    const r = await canConsumeAI('u1', 'pro');
 
     expect(sink.updateCalled).toBeFalsy();
     expect(sink.set).toBeUndefined();
@@ -710,12 +733,13 @@ describe('canConsumeAI', () => {
   it('skips the UPDATE + grant when the locked read finds no row (row removed before the lock)', async () => {
     mockDb.select
       .mockReturnValueOnce(selectReturning([{ monthlyRemainingCents: 0, topupRemainingCents: 0, monthlyPeriodEnd: PAST }]))
-      .mockReturnValueOnce(selectReturning([{ monthlyRemainingCents: 500, topupRemainingCents: 0, monthlyPeriodEnd: FUTURE }]));
+      .mockReturnValueOnce(selectReturning([])) // no renewal-capable subscription (comped pro)
+      .mockReturnValueOnce(selectReturning([{ monthlyRemainingCents: 1500, topupRemainingCents: 0, monthlyPeriodEnd: FUTURE }]));
     const sink: { set?: Record<string, unknown>; ledgerValues?: Record<string, unknown>; updateCalled?: boolean } = {};
     mockResetTransaction(sink, null); // locked read returns []
-    mockTransaction({ monthlyRemainingCents: 500, topupRemainingCents: 0, monthlyPeriodEnd: FUTURE }, { reserved: 0, inFlight: 0 });
+    mockTransaction({ monthlyRemainingCents: 1500, topupRemainingCents: 0, monthlyPeriodEnd: FUTURE }, { reserved: 0, inFlight: 0 });
 
-    const r = await canConsumeAI('u1', 'free');
+    const r = await canConsumeAI('u1', 'pro');
 
     expect(sink.updateCalled).toBeFalsy();
     expect(sink.ledgerValues).toBeUndefined();

--- a/packages/lib/src/billing/__tests__/credit-gate.test.ts
+++ b/packages/lib/src/billing/__tests__/credit-gate.test.ts
@@ -173,6 +173,42 @@ function mockResetTransaction(
 }
 
 /**
+ * Mock the starter-grant transaction (free tier, existing row with no period). The
+ * ledger insert goes FIRST; `granted` controls whether `.returning()` reports a new
+ * row (false = the user-scoped key already existed, so the balance must not be
+ * touched). Captures the ledger values and the UPDATE's set payload.
+ */
+function mockStarterGrantTransaction(
+  sink: { set?: Record<string, unknown>; ledgerValues?: Record<string, unknown>; updateCalled?: boolean } = {},
+  granted = true,
+) {
+  mockDb.transaction.mockImplementationOnce(async (cb: (tx: unknown) => Promise<unknown>) => {
+    const tx = {
+      insert: vi.fn(() => ({
+        values: (v: Record<string, unknown>) => {
+          sink.ledgerValues = v;
+          return {
+            onConflictDoNothing: () => ({
+              returning: () => Promise.resolve(granted ? [{ id: 'cl_1' }] : []),
+            }),
+          };
+        },
+      })),
+      update: vi.fn(() => {
+        sink.updateCalled = true;
+        return {
+          set: (v: Record<string, unknown>) => {
+            sink.set = v;
+            return { where: () => Promise.resolve(undefined) };
+          },
+        };
+      }),
+    };
+    return cb(tx);
+  });
+}
+
+/**
  * Wire mockDb.transaction to run its callback against a fake tx. `balRow` is the
  * locked balance read; `holds` controls the reserved/inFlight aggregate. Captures
  * any inserted hold values and returns a stubbed id.
@@ -439,15 +475,43 @@ describe('canConsumeAI', () => {
     expect(r.reason).toBe('ok');
   });
 
-  it('does NOT grant a free allowance when a top-up created the row without a period — top-up bucket alone is spendable', async () => {
-    mockDb.select.mockReturnValueOnce(selectReturning([{ monthlyRemainingCents: 0, topupRemainingCents: 2500, monthlyPeriodEnd: null }]));
+  it('grants the one-time starter credits to a free user whose row was created bare by a top-up (no period) — ledger-first, once', async () => {
+    // A top-up before the first AI call creates the row with no period. Free is
+    // excluded from the reset path, so the starter grant must land HERE, keyed on the
+    // user-scoped ledger row so it can never double-fund.
+    mockDb.select
+      .mockReturnValueOnce(selectReturning([{ monthlyRemainingCents: 0, topupRemainingCents: 2500, monthlyPeriodEnd: null }]))
+      .mockReturnValueOnce(selectReturning([{ monthlyRemainingCents: 500, topupRemainingCents: 2500, monthlyPeriodEnd: FUTURE }]));
+    const sink: { set?: Record<string, unknown>; ledgerValues?: Record<string, unknown>; updateCalled?: boolean } = {};
+    mockStarterGrantTransaction(sink, true);
+    mockTransaction({ monthlyRemainingCents: 500, topupRemainingCents: 2500, monthlyPeriodEnd: FUTURE }, { reserved: 0, inFlight: 0 });
+
+    const r = await canConsumeAI('u1', 'free');
+
+    expect(sink.ledgerValues).toMatchObject({ userId: 'u1', entryType: 'monthly_grant', bucket: 'monthly', amountCents: 500, stripeRef: 'free-init-u1', consumeStatus: 'applied' });
+    expect(sink.updateCalled).toBe(true);
+    expect(sink.set).toMatchObject({ monthlyAllowanceCents: 500 });
+    expect(sink.set?.monthlyPeriodEnd).toBeInstanceOf(Date);
+    // The remaining is a RELATIVE increment (sql fragment), not an absolute 500 — it
+    // must add on top of whatever a concurrent top-up already put in the row.
+    expect(sink.set?.monthlyRemainingCents).toMatchObject({ sql: true });
+    expect(mockDb.select).toHaveBeenCalledTimes(2); // pre-read + post-grant re-read; no subscription lookup
+    expect(r.allowed).toBe(true);
+  });
+
+  it('does NOT fund the starter grant twice: when the free-init ledger row already exists, the balance is left alone', async () => {
+    mockDb.select
+      .mockReturnValueOnce(selectReturning([{ monthlyRemainingCents: 0, topupRemainingCents: 2500, monthlyPeriodEnd: null }]))
+      .mockReturnValueOnce(selectReturning([{ monthlyRemainingCents: 0, topupRemainingCents: 2500, monthlyPeriodEnd: null }]));
+    const sink: { set?: Record<string, unknown>; ledgerValues?: Record<string, unknown>; updateCalled?: boolean } = {};
+    mockStarterGrantTransaction(sink, false /* ledger insert conflicted: already granted */);
     mockTransaction({ monthlyRemainingCents: 0, topupRemainingCents: 2500, monthlyPeriodEnd: null }, { reserved: 0, inFlight: 0 });
 
     const r = await canConsumeAI('u1', 'free');
 
-    expect(mockDb.update).not.toHaveBeenCalled();
-    expect(mockDb.transaction).toHaveBeenCalledTimes(1);
-    expect(r.allowed).toBe(true);
+    expect(sink.updateCalled).toBeFalsy();
+    expect(sink.set).toBeUndefined();
+    expect(r.allowed).toBe(true); // the top-up bucket alone is spendable
   });
 
   it('still gate-resets a comped paid user whose row was created bare by a top-up (null period)', async () => {

--- a/packages/lib/src/billing/__tests__/credit-pricing.test.ts
+++ b/packages/lib/src/billing/__tests__/credit-pricing.test.ts
@@ -131,3 +131,23 @@ describe('TIER_ALLOWANCE_REFILLS', () => {
     expect(TIER_MONTHLY_ALLOWANCE_CENTS.free).toBe(500);
   });
 });
+
+describe('allowanceRefills / isOneTimeAllowanceTier', () => {
+  it('free is a one-time tier and does not refill; paid tiers refill and are not one-time', async () => {
+    const { allowanceRefills, isOneTimeAllowanceTier } = await import('../credit-pricing');
+    expect(allowanceRefills('free')).toBe(false);
+    expect(isOneTimeAllowanceTier('free')).toBe(true);
+    for (const tier of ['pro', 'founder', 'business']) {
+      expect(allowanceRefills(tier)).toBe(true);
+      expect(isOneTimeAllowanceTier(tier)).toBe(false);
+    }
+  });
+
+  it('an unknown/legacy tier string is NEITHER refilling NOR one-time — nothing is granted or pre-credited for it', async () => {
+    // users.subscriptionTier reaches callers as an unchecked string; a legacy value
+    // like 'normal' must not be mistaken for the free tier's starter grant.
+    const { allowanceRefills, isOneTimeAllowanceTier } = await import('../credit-pricing');
+    expect(allowanceRefills('normal')).toBe(false);
+    expect(isOneTimeAllowanceTier('normal')).toBe(false);
+  });
+});

--- a/packages/lib/src/billing/__tests__/credit-pricing.test.ts
+++ b/packages/lib/src/billing/__tests__/credit-pricing.test.ts
@@ -115,3 +115,19 @@ describe('realtime session constants', () => {
     expect(REALTIME_MAX_GLOBAL_SESSIONS).toBe(8);
   });
 });
+
+describe('TIER_ALLOWANCE_REFILLS', () => {
+  it('names every tier, and only the free tier is a one-time (non-refilling) grant', async () => {
+    const { TIER_ALLOWANCE_REFILLS, TIER_MONTHLY_ALLOWANCE_CENTS } = await import('../credit-pricing');
+    expect(Object.keys(TIER_ALLOWANCE_REFILLS).sort()).toEqual(Object.keys(TIER_MONTHLY_ALLOWANCE_CENTS).sort());
+    expect(TIER_ALLOWANCE_REFILLS.free).toBe(false);
+    expect(TIER_ALLOWANCE_REFILLS.pro).toBe(true);
+    expect(TIER_ALLOWANCE_REFILLS.founder).toBe(true);
+    expect(TIER_ALLOWANCE_REFILLS.business).toBe(true);
+  });
+
+  it('free starter grant is $5 of credit value by default', async () => {
+    const { TIER_MONTHLY_ALLOWANCE_CENTS } = await import('../credit-pricing');
+    expect(TIER_MONTHLY_ALLOWANCE_CENTS.free).toBe(500);
+  });
+});

--- a/packages/lib/src/billing/__tests__/credits-flow.integration.test.ts
+++ b/packages/lib/src/billing/__tests__/credits-flow.integration.test.ts
@@ -804,6 +804,27 @@ describe('credits flow — monthly reset', () => {
     expect(balanceOf('u1')!.monthlyRemainingCents).toBe(200); // untouched by any reset
   });
 
+  it('a FREE user who bought a top-up BEFORE their first AI call still gets the starter grant, once, on top of the top-up', async () => {
+    seedUser('u1', 'cus_1', 'free');
+    // A credit-pack checkout creates the balance row bare: no period stamped.
+    await applyStripeFunding(creditPackCheckout('cs_1', 'cus_1', 2500));
+    expect(balanceOf('u1')).toMatchObject({ monthlyRemainingCents: 0, topupRemainingCents: 2500, monthlyPeriodEnd: null });
+
+    const first = await canConsumeAI('u1', 'free');
+    expect(first).toMatchObject({ allowed: true, reason: 'ok' });
+    expect(balanceOf('u1')!.monthlyRemainingCents).toBe(TIER_MONTHLY_ALLOWANCE_CENTS.free);
+    expect(balanceOf('u1')!.topupRemainingCents).toBe(2500); // top-up untouched
+    expect(balanceOf('u1')!.monthlyPeriodEnd).not.toBeNull();
+    const grants = ledgerOf('u1').filter((r) => r.entryType === 'monthly_grant');
+    expect(grants).toHaveLength(1);
+    expect(String(grants[0].stripeRef)).toBe('free-init-u1');
+
+    // Second call: nothing further.
+    await canConsumeAI('u1', 'free');
+    expect(balanceOf('u1')!.monthlyRemainingCents).toBe(TIER_MONTHLY_ALLOWANCE_CENTS.free);
+    expect(ledgerOf('u1').filter((r) => r.entryType === 'monthly_grant')).toHaveLength(1);
+  });
+
   it('a brand-new FREE user gets the one-time starter grant on first call, and only once', async () => {
     seedUser('u1', 'cus_1', 'free');
 

--- a/packages/lib/src/billing/__tests__/credits-flow.integration.test.ts
+++ b/packages/lib/src/billing/__tests__/credits-flow.integration.test.ts
@@ -770,11 +770,29 @@ describe('credits flow — crash recovery (backfill reconcile)', () => {
 });
 
 describe('credits flow — monthly reset', () => {
-  it('gate resets an expired period to the tier allowance for a FREE user and rolls the window forward', async () => {
-    seedUser('u1', 'cus_1', 'free'); // free users always refill via the gate; subscription-backed paid users via invoice.paid
+  it('does NOT refill a FREE user whose period has expired — the starter grant is one-time (blocked at 0)', async () => {
+    seedUser('u1', 'cus_1', 'free'); // free = one-time grant (TIER_ALLOWANCE_REFILLS.free === false)
     // Drained balance whose period already ended yesterday.
+    const periodEnd = new Date(Date.now() - 24 * 60 * 60 * 1000);
     store.creditBalances.push({
       userId: 'u1', monthlyRemainingCents: 0, monthlyAllowanceCents: 500,
+      topupRemainingCents: 0, pendingMillicents: 0,
+      monthlyPeriodStart: new Date(Date.now() - 40 * 24 * 60 * 60 * 1000),
+      monthlyPeriodEnd: periodEnd,
+      updatedAt: new Date(),
+    });
+
+    const gate = await canConsumeAI('u1', 'free');
+    expect(gate).toEqual({ allowed: false, reason: 'out_of_credits' });
+    expect(balanceOf('u1')!.monthlyRemainingCents).toBe(0); // NOT refilled
+    expect(balanceOf('u1')!.monthlyPeriodEnd!.getTime()).toBe(periodEnd.getTime()); // window NOT advanced
+    expect(ledgerOf('u1').filter((r) => r.entryType === 'monthly_grant')).toHaveLength(0); // no grant row
+  });
+
+  it('a FREE user keeps spending carried starter credit after the window expires (no refill, no expiry)', async () => {
+    seedUser('u1', 'cus_1', 'free');
+    store.creditBalances.push({
+      userId: 'u1', monthlyRemainingCents: 200, monthlyAllowanceCents: 500,
       topupRemainingCents: 0, pendingMillicents: 0,
       monthlyPeriodStart: new Date(Date.now() - 40 * 24 * 60 * 60 * 1000),
       monthlyPeriodEnd: new Date(Date.now() - 24 * 60 * 60 * 1000),
@@ -783,8 +801,24 @@ describe('credits flow — monthly reset', () => {
 
     const gate = await canConsumeAI('u1', 'free');
     expect(gate).toMatchObject({ allowed: true, reason: 'ok' });
-    expect(balanceOf('u1')!.monthlyRemainingCents).toBe(TIER_MONTHLY_ALLOWANCE_CENTS.free); // refilled
-    expect(balanceOf('u1')!.monthlyPeriodEnd!.getTime()).toBeGreaterThan(Date.now()); // window advanced
+    expect(balanceOf('u1')!.monthlyRemainingCents).toBe(200); // untouched by any reset
+  });
+
+  it('a brand-new FREE user gets the one-time starter grant on first call, and only once', async () => {
+    seedUser('u1', 'cus_1', 'free');
+
+    const first = await canConsumeAI('u1', 'free');
+    expect(first).toMatchObject({ allowed: true, reason: 'ok' });
+    expect(balanceOf('u1')!.monthlyRemainingCents).toBe(TIER_MONTHLY_ALLOWANCE_CENTS.free);
+    const grants = ledgerOf('u1').filter((r) => r.entryType === 'monthly_grant');
+    expect(grants).toHaveLength(1);
+    expect(String(grants[0].stripeRef)).toBe('free-init-u1');
+
+    // Age the window past its end: still no second grant.
+    balanceOf('u1')!.monthlyPeriodEnd = new Date(Date.now() - 24 * 60 * 60 * 1000);
+    const second = await canConsumeAI('u1', 'free');
+    expect(second).toMatchObject({ allowed: true, reason: 'ok' });
+    expect(ledgerOf('u1').filter((r) => r.entryType === 'monthly_grant')).toHaveLength(1);
   });
 
   it('paid user with expired window, a live subscription, and ZERO carry is blocked (no credits — invoice.paid owns the refill)', async () => {

--- a/packages/lib/src/billing/credit-balance.ts
+++ b/packages/lib/src/billing/credit-balance.ts
@@ -3,12 +3,14 @@
  * dashboard widget and the `GET /api/credits` endpoint.
  *
  * This is the DISPLAY layer; it never mutates. The authoritative spend decision and
- * the free-tier periodic rollover live in `./credit-gate` (the imperative shell that
+ * the gate-driven periodic rollover live in `./credit-gate` (the imperative shell that
  * owns the clock and the row lock). Here we only mirror the gate's semantics for presentation:
- *   - free tier whose monthly window has lapsed is shown its stored remaining PLUS the
- *     tier allowance (the gate will add it on the next call — rollover semantics);
+ *   - free tier (a ONE-TIME starter grant, TIER_ALLOWANCE_REFILLS.free === false) is
+ *     shown its stored remaining only, and no renewal date — nothing will ever be
+ *     added to the monthly bucket again;
  *   - paid tier whose window has lapsed is shown its stored remaining (credits carry
- *     forward — the renewal invoice will add the new allowance via invoice.paid);
+ *     forward — the renewal invoice will add the new allowance via invoice.paid, or
+ *     the gate will roll it for a no-subscription account);
  *   - spendable is the FUNDED balance (monthly + top-up remaining) MINUS outstanding
  *     debt, and is deliberately GROSS of in-flight holds. We surface the sum of
  *     still-active holds separately as `reserved` (for an optional "call running"
@@ -31,7 +33,7 @@ import { creditBalances, creditHolds } from '@pagespace/db/schema/credits';
 import { users } from '@pagespace/db/schema/auth';
 import { and, eq, gt, sql } from '@pagespace/db/operators';
 import { isBillingEnabled } from '../deployment-mode';
-import { TIER_MONTHLY_ALLOWANCE_CENTS } from './credit-pricing';
+import { TIER_MONTHLY_ALLOWANCE_CENTS, TIER_ALLOWANCE_REFILLS } from './credit-pricing';
 import type { SubscriptionTier } from '../services/subscription-utils';
 
 // Mirror of addOneMonth in credit-gate (same logic, kept local to avoid pulling
@@ -115,21 +117,15 @@ interface FundedBalanceRow {
  * never netted out (see the file header). Clamped at 0 only when there is no
  * debt — outstanding overage pulls the figure negative.
  */
-function spendableCentsFor(
-  row: FundedBalanceRow | null,
-  tier: SubscriptionTier,
-  now: Date,
-): number {
+function spendableCentsFor(row: FundedBalanceRow | null, tier: SubscriptionTier): number {
   // No row yet: the gate lazy-inits from the tier allowance on the first call.
   if (!row) return Math.max(0, allowanceFor(tier));
 
-  const allowance = row.monthlyAllowanceCents || allowanceFor(tier);
-  const expired = row.monthlyPeriodEnd === null || row.monthlyPeriodEnd < now;
-  // A free user whose window has lapsed gets the allowance the gate will apply on
-  // its next call, so they are not treated as broke for the gap between the
-  // rollover being due and something performing it.
-  const monthlyRemaining =
-    tier === 'free' && expired ? row.monthlyRemainingCents + allowance : row.monthlyRemainingCents;
+  // Free is a one-time grant: no upcoming allowance is ever pre-credited, so the
+  // stored remaining is the whole story. (Historically the display pre-credited a
+  // lapsed free window with the next allowance the gate was about to add; the gate
+  // no longer rolls non-refilling tiers, so that projection would over-state.)
+  const monthlyRemaining = row.monthlyRemainingCents;
   const topupRemaining = row.topupRemainingCents;
   const debt = row.debtCents ?? 0;
   return debt > 0
@@ -165,7 +161,7 @@ export async function readSpendableCents(
     .where(eq(creditBalances.userId, userId))
     .limit(1);
 
-  return spendableCentsFor(row ?? null, tier, new Date());
+  return spendableCentsFor(row ?? null, tier);
 }
 
 /**
@@ -206,7 +202,7 @@ export async function getCreditBalance(
   // so present that as the spendable monthly balance.
   if (!row) {
     const allowance = allowanceFor(tier);
-    const spendable = spendableCentsFor(null, tier, now);
+    const spendable = spendableCentsFor(null, tier);
     return {
       billingEnabled: true,
       monthly: { remaining: allowance, allowance, periodEnd: null },
@@ -221,9 +217,12 @@ export async function getCreditBalance(
   const periodEnd = row.monthlyPeriodEnd;
   const expired = periodEnd === null || periodEnd < now;
   // For display: never show a past renewal date. Project addOneMonth from the last known
-  // period end (or now if none recorded) — free users get the same date the gate will stamp
-  // on their next call; paid users get the Stripe cycle date (same day next month).
+  // period end (or now if none recorded); paid users get the Stripe cycle date (same day
+  // next month). A NON-refilling tier (free) has no renewal at all — its allowance was a
+  // one-time grant — so surface null and let the UI omit "Renews …" entirely, rather
+  // than advancing a phantom date forever.
   const displayPeriodEnd: Date | null = (() => {
+    if (!TIER_ALLOWANCE_REFILLS[tier]) return null;
     if (!expired) return periodEnd;
     let projected = addOneMonth(periodEnd ?? now);
     while (projected <= now) {
@@ -233,18 +232,11 @@ export async function getCreditBalance(
   })();
 
   // Rollover: credits never expire. The carry balance is always spendable (both
-  // in the gate and here) — the renewal adds the allowance and nets outstanding debt.
-  // Free tiers without a Stripe subscription get their reset via the gate's addOneMonth
-  // path, so for a free user with a lapsed period we surface stored + upcoming allowance
-  // (what the gate will apply on next call). Debt is shown as-is — the gate will net it
-  // against the carry at reset. For paid tiers the period window doesn't affect display.
-  let monthlyRemaining: number;
-  if (tier === 'free' && expired) {
-    // Gate will net debt against carry and add the allowance on next call; surface the total.
-    monthlyRemaining = row.monthlyRemainingCents + allowance;
-  } else {
-    monthlyRemaining = row.monthlyRemainingCents;
-  }
+  // in the gate and here) — a renewal adds the allowance and nets outstanding debt.
+  // The period window never affects the displayed remaining: paid tiers carry forward
+  // until invoice.paid / the gate roll lands, and free is a one-time grant with nothing
+  // upcoming to pre-credit. Debt is shown as-is.
+  const monthlyRemaining = row.monthlyRemainingCents;
 
   const topupRemaining = row.topupRemainingCents;
   const debt = row.debtCents ?? 0;
@@ -254,7 +246,7 @@ export async function getCreditBalance(
   // shows the red. Debt accrues only after both buckets are exhausted, so the negative
   // branch is effectively −debt.
   // Shared with the routing gate's lean read, so the two can never disagree.
-  const spendable = spendableCentsFor(row, tier, now);
+  const spendable = spendableCentsFor(row, tier);
 
   return {
     billingEnabled: true,

--- a/packages/lib/src/billing/credit-balance.ts
+++ b/packages/lib/src/billing/credit-balance.ts
@@ -33,7 +33,7 @@ import { creditBalances, creditHolds } from '@pagespace/db/schema/credits';
 import { users } from '@pagespace/db/schema/auth';
 import { and, eq, gt, sql } from '@pagespace/db/operators';
 import { isBillingEnabled } from '../deployment-mode';
-import { TIER_MONTHLY_ALLOWANCE_CENTS, TIER_ALLOWANCE_REFILLS } from './credit-pricing';
+import { TIER_MONTHLY_ALLOWANCE_CENTS, allowanceRefills, isOneTimeAllowanceTier } from './credit-pricing';
 import type { SubscriptionTier } from '../services/subscription-utils';
 
 // Mirror of addOneMonth in credit-gate (same logic, kept local to avoid pulling
@@ -124,7 +124,7 @@ interface FundedBalanceRow {
  * lean routing read so both pre-credit the same rows.
  */
 function pendingStarterGrant(row: FundedBalanceRow, tier: SubscriptionTier): boolean {
-  return TIER_ALLOWANCE_REFILLS[tier] === false && row.monthlyPeriodEnd === null;
+  return isOneTimeAllowanceTier(tier) && row.monthlyPeriodEnd === null;
 }
 
 function spendableCentsFor(row: FundedBalanceRow | null, tier: SubscriptionTier): number {
@@ -237,7 +237,7 @@ export async function getCreditBalance(
   // one-time grant — so surface null and let the UI omit "Renews …" entirely, rather
   // than advancing a phantom date forever.
   const displayPeriodEnd: Date | null = (() => {
-    if (!TIER_ALLOWANCE_REFILLS[tier]) return null;
+    if (!allowanceRefills(tier)) return null;
     if (!expired) return periodEnd;
     let projected = addOneMonth(periodEnd ?? now);
     while (projected <= now) {

--- a/packages/lib/src/billing/credit-balance.ts
+++ b/packages/lib/src/billing/credit-balance.ts
@@ -117,15 +117,30 @@ interface FundedBalanceRow {
  * never netted out (see the file header). Clamped at 0 only when there is no
  * debt — outstanding overage pulls the figure negative.
  */
+/**
+ * A non-refilling tier's row with no period stamped is a bare top-up row the gate has
+ * not yet funded with the one-time starter grant (see credit-gate's starter-grant
+ * branch, which stamps the period when it grants). Shared by the display read and the
+ * lean routing read so both pre-credit the same rows.
+ */
+function pendingStarterGrant(row: FundedBalanceRow, tier: SubscriptionTier): boolean {
+  return TIER_ALLOWANCE_REFILLS[tier] === false && row.monthlyPeriodEnd === null;
+}
+
 function spendableCentsFor(row: FundedBalanceRow | null, tier: SubscriptionTier): number {
   // No row yet: the gate lazy-inits from the tier allowance on the first call.
   if (!row) return Math.max(0, allowanceFor(tier));
 
-  // Free is a one-time grant: no upcoming allowance is ever pre-credited, so the
-  // stored remaining is the whole story. (Historically the display pre-credited a
-  // lapsed free window with the next allowance the gate was about to add; the gate
-  // no longer rolls non-refilling tiers, so that projection would over-state.)
-  const monthlyRemaining = row.monthlyRemainingCents;
+  const allowance = row.monthlyAllowanceCents || allowanceFor(tier);
+
+  // A non-refilling tier (free) never gets an upcoming allowance pre-credited — the
+  // stored remaining is the whole story — with ONE exception that mirrors the gate:
+  // a row that exists with NO period stamped is a bare top-up row whose one-time
+  // starter grant has not landed yet (the gate grants it on the next call, keyed on
+  // the ledger), so the pending grant is shown rather than reading the user as 0/5.
+  const monthlyRemaining = pendingStarterGrant(row, tier)
+    ? row.monthlyRemainingCents + allowance
+    : row.monthlyRemainingCents;
   const topupRemaining = row.topupRemainingCents;
   const debt = row.debtCents ?? 0;
   return debt > 0
@@ -235,8 +250,11 @@ export async function getCreditBalance(
   // in the gate and here) — a renewal adds the allowance and nets outstanding debt.
   // The period window never affects the displayed remaining: paid tiers carry forward
   // until invoice.paid / the gate roll lands, and free is a one-time grant with nothing
-  // upcoming to pre-credit. Debt is shown as-is.
-  const monthlyRemaining = row.monthlyRemainingCents;
+  // upcoming to pre-credit — except a bare top-up row whose starter grant is still
+  // pending (see pendingStarterGrant). Debt is shown as-is.
+  const monthlyRemaining = pendingStarterGrant(row, tier)
+    ? row.monthlyRemainingCents + allowance
+    : row.monthlyRemainingCents;
 
   const topupRemaining = row.topupRemainingCents;
   const debt = row.debtCents ?? 0;

--- a/packages/lib/src/billing/credit-gate.ts
+++ b/packages/lib/src/billing/credit-gate.ts
@@ -35,7 +35,8 @@ import {
 import {
   RESERVE_FLOOR_CENTS,
   TIER_MONTHLY_ALLOWANCE_CENTS,
-  TIER_ALLOWANCE_REFILLS,
+  allowanceRefills,
+  isOneTimeAllowanceTier,
   CREDIT_HOLD_ESTIMATE_CENTS,
   CREDIT_HOLD_TTL_SECONDS,
   MAX_FREE_INFLIGHT,
@@ -282,11 +283,10 @@ export async function canConsumeAI(
   const tierHasAllowance = tier in TIER_MONTHLY_ALLOWANCE_CENTS;
   // Free never refills, so the (rare) subscription lookup is only ever reached by a
   // refilling tier with an expired window.
-  const tierRefills = TIER_ALLOWANCE_REFILLS[tier] === true;
   if (
     windowExpired &&
     tierHasAllowance &&
-    tierRefills &&
+    allowanceRefills(tier) &&
     !(await hasRenewalCapableSubscription(db, userId))
   ) {
     const newEnd = addOneMonth(now);
@@ -415,7 +415,7 @@ export async function canConsumeAI(
   // concurrent init, or a grant already recorded under the old monthly scheme, can
   // never double-fund. The increment is one relative UPDATE, atomic against a
   // concurrent top-up's own locked write to the same row.
-  if (row && row.monthlyPeriodEnd === null && tierHasAllowance && !tierRefills) {
+  if (row && row.monthlyPeriodEnd === null && isOneTimeAllowanceTier(tier)) {
     const monthly = TIER_MONTHLY_ALLOWANCE_CENTS[tier];
     await db.transaction(async (tx) => {
       const granted = await tx
@@ -494,8 +494,9 @@ export async function canConsumeAI(
     // Rollover: the monthly bucket is always spendable — credits never expire. A paid user
     // whose window has lapsed continues to spend from their carried balance; the renewal
     // invoice.paid will then add the new allowance on top of whatever remains (not reset).
-    // Free users were handled by the addOneMonth reset above and never reach here with an
-    // expired window. The gate still does NOT refill paid tiers — invoice.paid is
+    // A free user's allowance is a one-time grant (never refilled), so an expired free
+    // window is simply a user spending down what they have — no reset applies to it.
+    // The gate still does NOT refill paid tiers — invoice.paid is
     // authoritative for that — so there is no double-grant risk: the refill reads the
     // current DB balance inside its own transaction and adds the allowance to whatever is
     // there, exactly accounting for any spend that happened during the gap.
@@ -600,9 +601,9 @@ export async function canConsumeAI(
  * The decision RULE is the one `evaluateGate` applies — spendable above the
  * reserve floor, debt netted, billing-disabled deployments unlimited — reached
  * through `readSpendableCents`, which shares its arithmetic with the display read
- * (including the free-tier lapsed-window rollover the gate applies lazily, so a
- * free user whose month has ticked over is not parked for the gap between the
- * rollover being due and the next AI call performing it).
+ * (including the pending one-time starter grant on a bare free row, which the gate
+ * applies lazily on the next call — so a free user who topped up before their first
+ * AI request is not read as broke for the gap before that call).
  *
  * It reads the funded-balance columns and NOTHING else: ONE indexed row, no
  * aggregate. Going through `getCreditBalance` here would also run its `SUM` over

--- a/packages/lib/src/billing/credit-gate.ts
+++ b/packages/lib/src/billing/credit-gate.ts
@@ -3,15 +3,19 @@
  * credit_balances row and asks the pure evaluateGate whether the user may spend.
  * Never calls Stripe; the hot path stays a single indexed read.
  *
- * A missing balance row is lazy-initialized from the tier's monthly allowance
- * (this is how a brand-new free user gets their trial allowance without a Stripe
- * subscription) and then re-evaluated.
+ * A missing balance row is lazy-initialized from the tier's allowance (this is how a
+ * brand-new free user gets their ONE-TIME starter grant without a Stripe
+ * subscription — the `free-init-<userId>` ledger key makes it happen exactly once)
+ * and then re-evaluated.
  *
- * Free / no-subscription users get their periodic top-up HERE: there's no
- * invoice.paid to drive a refill, so when the period has expired the gate ADDS the
- * tier allowance to the carry balance (rollover) and rolls the window forward. This is
- * the imperative shell, so it owns the real clock; the period math stays trivial
- * and the rollover itself comes from the pure computeMonthlyRefill.
+ * Paid tiers WITHOUT a renewal-capable subscription (comped/founder accounts) get
+ * their periodic top-up HERE: there's no invoice.paid to drive a refill, so when the
+ * period has expired the gate ADDS the tier allowance to the carry balance (rollover)
+ * and rolls the window forward. Which tiers refill at all is data
+ * (TIER_ALLOWANCE_REFILLS): the free tier does NOT — its allowance is a single grant,
+ * so an expired free window is simply left alone. This is the imperative shell, so
+ * it owns the real clock; the period math stays trivial and the rollover itself
+ * comes from the pure computeMonthlyRefill.
  */
 
 import { db } from '@pagespace/db/db';
@@ -31,6 +35,7 @@ import {
 import {
   RESERVE_FLOOR_CENTS,
   TIER_MONTHLY_ALLOWANCE_CENTS,
+  TIER_ALLOWANCE_REFILLS,
   CREDIT_HOLD_ESTIMATE_CENTS,
   CREDIT_HOLD_TTL_SECONDS,
   MAX_FREE_INFLIGHT,
@@ -228,10 +233,12 @@ export async function canConsumeAI(
   let row = await readBalance();
 
   // Gate-driven monthly reset for users whose refill can never come from Stripe.
-  // Free users have no invoice.paid to drive a refill, so the gate rolls their
-  // window when it has expired (monthlyPeriodEnd < now) or was never stamped
-  // (monthlyPeriodEnd IS NULL — e.g. a top-up funding row created bare before the
-  // user's first AI request). Paid tiers get the same roll ONLY when no
+  // Only tiers that REFILL (TIER_ALLOWANCE_REFILLS) are eligible: the free tier's
+  // allowance is a one-time starter grant, so an expired or never-stamped free
+  // window is left alone and the user spends down what they have (plus top-ups).
+  // A refilling tier rolls here when its window has expired (monthlyPeriodEnd < now)
+  // or was never stamped (monthlyPeriodEnd IS NULL — e.g. a top-up funding row
+  // created bare before the user's first AI request), and ONLY when no
   // renewal-capable subscription exists (comped/founder accounts — see
   // hasRenewalCapableSubscription): with a live subscription, invoice.paid stays
   // authoritative (keyed to the invoice stripeRef), because resetting here would
@@ -256,10 +263,14 @@ export async function canConsumeAI(
   // through unchecked casts, and a legacy/unknown value (e.g. 'normal') reaching
   // computeMonthlyRefill would silently rewrite the account to the free allowance.
   const tierHasAllowance = tier in TIER_MONTHLY_ALLOWANCE_CENTS;
+  // Free never refills, so the (rare) subscription lookup is only ever reached by a
+  // refilling tier with an expired window.
+  const tierRefills = TIER_ALLOWANCE_REFILLS[tier] === true;
   if (
     windowExpired &&
     tierHasAllowance &&
-    (tier === 'free' || !(await hasRenewalCapableSubscription(db, userId)))
+    tierRefills &&
+    !(await hasRenewalCapableSubscription(db, userId))
   ) {
     const newEnd = addOneMonth(now);
     await db.transaction(async (tx) => {
@@ -285,13 +296,13 @@ export async function canConsumeAI(
         return;
       }
 
-      // Paid tiers: RE-CHECK the subscription state on the transaction right before
+      // RE-CHECK the subscription state on the transaction right before
       // granting. The unlocked pre-check races a concurrent checkout — if the
       // customer.subscription.* webhook committed a renewal-capable row since,
       // invoice.paid now owns this user's refill and granting here would double it.
       // (Not fully serialized against the webhook's own transaction, but it shrinks
       // the race from "any time since the pre-check" to the instant before commit.)
-      if (tier !== 'free' && (await hasRenewalCapableSubscription(tx, userId))) {
+      if (await hasRenewalCapableSubscription(tx, userId)) {
         return;
       }
 
@@ -328,10 +339,10 @@ export async function canConsumeAI(
           entryType: 'monthly_grant',
           bucket: 'monthly',
           amountCents: refill.monthlyAllowanceCents,
-          // 'free-reset' kept verbatim for the free tier (pre-existing ledger rows use
-          // it); paid no-subscription rolls get their own prefix so they're
-          // distinguishable in the ledger.
-          stripeRef: `${tier === 'free' ? 'free' : 'gate'}-reset-${userId}-${now.toISOString()}`,
+          // Historical free-tier rolls (before free became a one-time grant) were
+          // keyed 'free-reset-…'; only refilling tiers reach here now, so every new
+          // row gets the 'gate-reset-' prefix.
+          stripeRef: `gate-reset-${userId}-${now.toISOString()}`,
           consumeStatus: 'applied',
         })
         .onConflictDoNothing(STRIPE_REF_ARBITER);

--- a/packages/lib/src/billing/credit-gate.ts
+++ b/packages/lib/src/billing/credit-gate.ts
@@ -99,6 +99,23 @@ interface BalanceRow {
 export const RENEWAL_CAPABLE_STATUSES = ['active', 'trialing', 'past_due', 'unpaid'];
 
 /**
+ * The ledger row for a tier's first-ever allowance grant. The stripeRef is
+ * USER-scoped (no timestamp) on purpose: the partial unique index on stripeRef makes
+ * it the exactly-once key shared by the lazy-init path and the bare-row starter-grant
+ * path, so whichever lands first wins and the other is a no-op.
+ */
+function starterGrantLedgerRow(userId: string, monthly: number) {
+  return {
+    userId,
+    entryType: 'monthly_grant',
+    bucket: 'monthly',
+    amountCents: monthly,
+    stripeRef: `free-init-${userId}`,
+    consumeStatus: 'applied',
+  } as const;
+}
+
+/**
  * Whether ANY of the user's subscriptions could still deliver an invoice-driven
  * refill. Takes the executor so the reset transaction can RE-CHECK on `tx`
  * right before granting — a subscription created between the unlocked pre-check
@@ -380,14 +397,7 @@ export async function canConsumeAI(
       if (balanceInserted.length > 0) {
         await tx
           .insert(creditLedger)
-          .values({
-            userId,
-            entryType: 'monthly_grant',
-            bucket: 'monthly',
-            amountCents: monthly,
-            stripeRef: `free-init-${userId}`,
-            consumeStatus: 'applied',
-          })
+          .values(starterGrantLedgerRow(userId, monthly))
           .onConflictDoNothing(STRIPE_REF_ARBITER);
       }
     });
@@ -395,7 +405,8 @@ export async function canConsumeAI(
 
   // Starter grant for a NON-refilling tier whose row already exists but was never
   // granted. A top-up purchase before the user's first AI call (or a top-up racing
-  // the lazy-init above) creates a bare credit_balances row with no period stamped.
+  // the lazy-init above, caught on the next call) creates a bare credit_balances
+  // row with no period stamped.
   // A refilling tier gets such a row rolled by the reset path; free is excluded from
   // that path, so without this branch a user who bought credits first would
   // permanently miss the advertised starter grant. Eligibility is decided by the
@@ -409,14 +420,7 @@ export async function canConsumeAI(
     await db.transaction(async (tx) => {
       const granted = await tx
         .insert(creditLedger)
-        .values({
-          userId,
-          entryType: 'monthly_grant',
-          bucket: 'monthly',
-          amountCents: monthly,
-          stripeRef: `free-init-${userId}`,
-          consumeStatus: 'applied',
-        })
+        .values(starterGrantLedgerRow(userId, monthly))
         .onConflictDoNothing(STRIPE_REF_ARBITER)
         .returning({ id: creditLedger.id });
       if (granted.length === 0) return;

--- a/packages/lib/src/billing/credit-gate.ts
+++ b/packages/lib/src/billing/credit-gate.ts
@@ -393,6 +393,46 @@ export async function canConsumeAI(
     });
   }
 
+  // Starter grant for a NON-refilling tier whose row already exists but was never
+  // granted. A top-up purchase before the user's first AI call (or a top-up racing
+  // the lazy-init above) creates a bare credit_balances row with no period stamped.
+  // A refilling tier gets such a row rolled by the reset path; free is excluded from
+  // that path, so without this branch a user who bought credits first would
+  // permanently miss the advertised starter grant. Eligibility is decided by the
+  // LEDGER, not by the row: the user-scoped `free-init-<userId>` key is inserted
+  // FIRST, and the balance is funded only when that insert actually lands — so a
+  // concurrent init, or a grant already recorded under the old monthly scheme, can
+  // never double-fund. The increment is one relative UPDATE, atomic against a
+  // concurrent top-up's own locked write to the same row.
+  if (row && row.monthlyPeriodEnd === null && tierHasAllowance && !tierRefills) {
+    const monthly = TIER_MONTHLY_ALLOWANCE_CENTS[tier];
+    await db.transaction(async (tx) => {
+      const granted = await tx
+        .insert(creditLedger)
+        .values({
+          userId,
+          entryType: 'monthly_grant',
+          bucket: 'monthly',
+          amountCents: monthly,
+          stripeRef: `free-init-${userId}`,
+          consumeStatus: 'applied',
+        })
+        .onConflictDoNothing(STRIPE_REF_ARBITER)
+        .returning({ id: creditLedger.id });
+      if (granted.length === 0) return;
+      await tx
+        .update(creditBalances)
+        .set({
+          monthlyRemainingCents: sql`${creditBalances.monthlyRemainingCents} + ${monthly}`,
+          monthlyAllowanceCents: monthly,
+          monthlyPeriodStart: now,
+          monthlyPeriodEnd: addOneMonth(now),
+        })
+        .where(eq(creditBalances.userId, userId));
+    });
+    row = await readBalance();
+  }
+
   const estCost = reservationCents(opts.estCostCents ?? CREDIT_HOLD_ESTIMATE_CENTS);
   // Free users are capped on concurrent in-flight calls; paid tiers are bounded by
   // credits alone UNLESS the caller supplies its own cap (voice passes one to bound

--- a/packages/lib/src/billing/credit-pricing.ts
+++ b/packages/lib/src/billing/credit-pricing.ts
@@ -88,6 +88,27 @@ export const TIER_ALLOWANCE_REFILLS: Record<SubscriptionTier, boolean> = {
 };
 
 /**
+ * Whether `tier` is re-granted its allowance every billing period. Accepts the raw
+ * `users.subscriptionTier` string: an unknown/legacy value is NOT a refilling tier
+ * (no renewal is ever coming for it), so callers show no renewal date for it. The
+ * gate never rolls such a tier either (it has no allowance).
+ */
+export function allowanceRefills(tier: string): boolean {
+  return TIER_ALLOWANCE_REFILLS[tier as SubscriptionTier] === true;
+}
+
+/**
+ * Whether `tier` gets a ONE-TIME starter grant: it has an allowance AND that
+ * allowance does not refill. An unknown/legacy tier is neither — it must not be
+ * pre-credited or granted anything. The single predicate the gate's starter-grant
+ * branch and the balance display's pending-grant pre-credit share, so they can never
+ * disagree about which rows are "waiting for the grant".
+ */
+export function isOneTimeAllowanceTier(tier: string): boolean {
+  return tier in TIER_MONTHLY_ALLOWANCE_CENTS && TIER_ALLOWANCE_REFILLS[tier as SubscriptionTier] === false;
+}
+
+/**
  * Block AI when spendable credits are at or below this floor. Bounds the single
  * in-flight call that can overshoot zero: the gate runs BEFORE a call but the real
  * cost is only known AFTER the stream, so the gate can wave through one call that

--- a/packages/lib/src/billing/credit-pricing.ts
+++ b/packages/lib/src/billing/credit-pricing.ts
@@ -51,18 +51,40 @@ export const MARKUP_BPS = envInt('CREDIT_MARKUP_BPS', 15000);
 export const CACHE_READ_DISCOUNT_FACTOR_BPS = envInt('CACHE_READ_DISCOUNT_FACTOR_BPS', 1000);
 
 /**
- * Monthly credit allowance granted on each subscription renewal, per tier.
- * Accumulates across periods (rollover): each renewal ADDS this allowance to
- * the current balance rather than replacing it.
+ * Credit allowance per tier, in whole cents of customer-facing credit value.
+ *
+ * For tiers that REFILL (see {@link TIER_ALLOWANCE_REFILLS}) this is granted on each
+ * subscription renewal and accumulates across periods (rollover): each renewal ADDS
+ * the allowance to the current balance rather than replacing it.
+ *
+ * For the free tier it is a ONE-TIME starter grant: lazily granted on the user's
+ * first metered call (credit-gate's `free-init-` path) and never refilled. Bounded
+ * lifetime exposure per free user = allowance / markup (~$3.33 at $5 and 1.5×).
  */
 export const TIER_MONTHLY_ALLOWANCE_CENTS: Record<SubscriptionTier, number> = {
-  // Free: generous $5/mo of credit value, but the free-tier-only premium gate
+  // Free: $5 of starter credit, once. The free-tier-only premium gate
   // (requiresProSubscription) confines it to cheaper "standard" models, so the
   // real provider cost behind that $5 stays low.
   free: envInt('CREDIT_ALLOWANCE_FREE_CENTS', 500),
   pro: envInt('CREDIT_ALLOWANCE_PRO_CENTS', 1500),
   founder: envInt('CREDIT_ALLOWANCE_FOUNDER_CENTS', 5000),
   business: envInt('CREDIT_ALLOWANCE_BUSINESS_CENTS', 10000),
+};
+
+/**
+ * Whether a tier's allowance is re-granted each billing period. `true` = the
+ * allowance is added again at every renewal (Stripe invoice.paid, or the gate's own
+ * period roll for comped/no-subscription paid accounts) and unspent credit carries
+ * forward. `false` = the allowance is a single starter grant that never refills —
+ * the free tier. The gate's reset path, and the balance display's "upcoming
+ * allowance" / "renews on" projections, all key off this rather than on `tier ===
+ * 'free'`, so a future non-refilling tier needs only a row here.
+ */
+export const TIER_ALLOWANCE_REFILLS: Record<SubscriptionTier, boolean> = {
+  free: false,
+  pro: true,
+  founder: true,
+  business: true,
 };
 
 /**

--- a/packages/lib/src/email-templates/FreeCreditsChangeEmail.tsx
+++ b/packages/lib/src/email-templates/FreeCreditsChangeEmail.tsx
@@ -22,6 +22,12 @@ interface FreeCreditsChangeEmailProps {
    * in which case the email tells them their starter credits are still waiting.
    */
   currentCredits?: string;
+  /**
+   * How far in the red the recipient is, as a positive display string (e.g. "0.3"),
+   * when their balance is negative (an in-flight call overshot). Mutually exclusive
+   * with `currentCredits`; when set the email says a top-up clears the overage.
+   */
+  overageCredits?: string;
   /** The free starter grant, as a display string (e.g. "5"). */
   starterCredits: string;
   /** The Pro plan's monthly allowance, as a display string (e.g. "15"). */
@@ -113,6 +119,7 @@ const keepCard = {
 export function FreeCreditsChangeEmail({
   userName,
   currentCredits,
+  overageCredits,
   starterCredits,
   proMonthlyCredits,
   minTopup,
@@ -151,7 +158,13 @@ export function FreeCreditsChangeEmail({
                 Your current balance is not affected
               </Text>
               <Text style={{ ...calloutText, marginTop: spacing.xs }}>
-                {currentCredits !== undefined ? (
+                {overageCredits !== undefined ? (
+                  <>
+                    Your balance is {overageCredits} credits in the red. A
+                    top-up clears the overage first and the rest is added to
+                    your balance; purchased credits do not expire.
+                  </>
+                ) : currentCredits !== undefined ? (
                   <>
                     You have {currentCredits} credits. They remain available
                     until you use them and do not expire.

--- a/packages/lib/src/email-templates/FreeCreditsChangeEmail.tsx
+++ b/packages/lib/src/email-templates/FreeCreditsChangeEmail.tsx
@@ -1,0 +1,233 @@
+import * as React from 'react';
+import {
+  Body,
+  Button,
+  Container,
+  Head,
+  Heading,
+  Html,
+  Link,
+  Preview,
+  Section,
+  Text,
+} from '@react-email/components';
+import { emailStyles, colors, spacing, typography, radius } from './shared-styles';
+
+interface FreeCreditsChangeEmailProps {
+  /** Recipient's display name (falls back to a friendly default upstream). */
+  userName: string;
+  /**
+   * The recipient's current spendable credit balance as a display string (e.g. "3.2"),
+   * or undefined when they have never used AI and therefore have no balance row yet —
+   * in which case the email tells them their starter credits are still waiting.
+   */
+  currentCredits?: string;
+  /** The free starter grant, as a display string (e.g. "5"). */
+  starterCredits: string;
+  /** The Pro plan's monthly allowance, as a display string (e.g. "15"). */
+  proMonthlyCredits: string;
+  /** Cheapest top-up, as a dollar string (e.g. "$5"). */
+  minTopup: string;
+  /** In-app plan page — primary CTA. */
+  planUrl: string;
+  /** In-app usage/credits page — where top-ups are bought. */
+  usageUrl: string;
+  /**
+   * The sender's physical postal address. This is a RELATIONSHIP message (a notice of a
+   * change to the recipient's existing plan), which CAN-SPAM exempts from the commercial
+   * requirements — so there is deliberately no unsubscribe link, and the address is
+   * optional. Rendered in the footer when provided.
+   */
+  postalAddress?: string;
+}
+
+// Same black accent as the launch emails, as a LOCAL override — shared-styles.ts
+// (every other transactional email) stays on the brand blue.
+const INK = '#17181C';
+const INK_LIFT = '#2C2E36';
+
+const eyebrow = {
+  fontSize: typography.tiny,
+  fontWeight: typography.semibold,
+  color: INK,
+  letterSpacing: '0.6px',
+  textTransform: 'uppercase' as const,
+  margin: `0 0 ${spacing.xs} 0`,
+};
+
+const calloutCard = {
+  backgroundColor: colors.pageBackground,
+  border: `1px solid ${colors.border}`,
+  borderRadius: radius.md,
+  padding: `${spacing.md} ${spacing.lg}`,
+  margin: `${spacing.md} 0`,
+};
+
+const calloutHeading = {
+  fontSize: typography.h3,
+  fontWeight: typography.semibold,
+  color: colors.heading,
+  margin: `0 0 ${spacing.xs} 0`,
+  letterSpacing: '-0.2px',
+};
+
+const calloutText = {
+  fontSize: typography.small,
+  lineHeight: typography.bodyLineHeight,
+  color: colors.text,
+  margin: '0',
+};
+
+const secondaryLink = {
+  fontSize: typography.small,
+  color: INK,
+  textDecoration: 'underline',
+};
+
+const darkHeader = {
+  ...emailStyles.header,
+  background: `linear-gradient(135deg, ${INK} 0%, ${INK_LIFT} 100%)`,
+};
+
+const darkButton = {
+  ...emailStyles.button,
+  background: `linear-gradient(135deg, ${INK} 0%, ${INK_LIFT} 100%)`,
+  boxShadow: '0 2px 8px rgba(0, 0, 0, 0.28), 0 1px 2px rgba(0, 0, 0, 0.18)',
+};
+
+// The "what you keep" card is the one fact people will look for, so it gets
+// the tinted, left-ruled treatment rather than the plain callout.
+const keepCard = {
+  backgroundColor: colors.accent,
+  borderLeft: `4px solid ${INK}`,
+  borderRadius: radius.sm,
+  padding: `${spacing.md} ${spacing.lg}`,
+  margin: `${spacing.lg} 0`,
+};
+
+/**
+ * Notice to every Free-plan account that free credits are now a one-time
+ * starter grant rather than a monthly, accumulating allowance. Sent once by
+ * scripts/send-free-credits-change-notifications.ts.
+ */
+export function FreeCreditsChangeEmail({
+  userName,
+  currentCredits,
+  starterCredits,
+  proMonthlyCredits,
+  minTopup,
+  planUrl,
+  usageUrl,
+  postalAddress,
+}: FreeCreditsChangeEmailProps) {
+  return (
+    <Html>
+      <Head />
+      <Preview>Free credits are now a one-time starter grant. Everything you have stays yours.</Preview>
+      <Body style={emailStyles.main}>
+        <Container style={emailStyles.container}>
+          <Section style={darkHeader}>
+            <Heading style={emailStyles.headerTitle}>PageSpace</Heading>
+          </Section>
+          <Section style={emailStyles.content}>
+            <Text style={eyebrow}>Plan update</Text>
+            <Text style={emailStyles.contentHeading}>
+              A change to credits on the Free plan
+            </Text>
+            <Text style={emailStyles.paragraph}>Hi {userName},</Text>
+            <Text style={emailStyles.paragraph}>
+              A quick, honest heads-up about how AI credits work on your Free
+              plan. The short version: nothing you have is going away, but
+              the monthly top-up is.
+            </Text>
+
+            <Section style={calloutCard}>
+              <Text style={calloutHeading}>What&apos;s changing</Text>
+              <Text style={calloutText}>
+                Until now, Free accounts received {starterCredits} credits
+                every month, and unused credits piled up. Starting today,
+                Free comes with {starterCredits} credits once, granted the
+                first time you use AI. That grant doesn&apos;t refill.
+              </Text>
+            </Section>
+
+            <Section style={keepCard}>
+              <Text style={{ ...calloutText, fontWeight: typography.semibold, color: colors.heading }}>
+                What you keep
+              </Text>
+              <Text style={{ ...calloutText, marginTop: spacing.xs }}>
+                {currentCredits !== undefined ? (
+                  <>
+                    Every credit already in your account. You have{' '}
+                    {currentCredits} credits right now, and they stay there
+                    until you spend them. Credits never expire and nothing is
+                    being taken back.
+                  </>
+                ) : (
+                  <>
+                    Your {starterCredits} starter credits are still waiting
+                    for your first AI call, and once granted they never
+                    expire.
+                  </>
+                )}
+              </Text>
+              <Text style={{ ...calloutText, marginTop: spacing.xs }}>
+                Everything else on Free is unchanged: your documents, drives,
+                tasks, channels, collaboration, storage, and the same set of
+                AI models.
+              </Text>
+            </Section>
+
+            <Section style={calloutCard}>
+              <Text style={calloutHeading}>When you run low</Text>
+              <Text style={calloutText}>
+                Two options, and both keep whatever balance you already
+                have. Buy a top-up pack from {minTopup} (top-ups never
+                expire), or upgrade to Pro for {proMonthlyCredits} credits
+                every month that roll over when unused, plus the full model
+                catalogue.
+              </Text>
+              <Text style={{ ...calloutText, marginTop: spacing.sm }}>
+                <Link href={usageUrl} style={secondaryLink}>
+                  Buy credits
+                </Link>
+                {'   ·   '}
+                <Link href={planUrl} style={secondaryLink}>
+                  Compare plans
+                </Link>
+              </Text>
+            </Section>
+
+            <Text style={emailStyles.paragraph}>
+              Why: free credits that refilled every month and never expired
+              were an open-ended cost for a small team, and most Free
+              accounts never used them. A one-time grant keeps Free
+              genuinely free to try, and keeps us able to keep offering it.
+            </Text>
+
+            <Section style={emailStyles.buttonContainer}>
+              <Button style={darkButton} href={planUrl}>
+                See your plan
+              </Button>
+            </Section>
+
+            <Text style={emailStyles.hint}>
+              Questions, or think we got something wrong? Just reply to this
+              email. We read every one.
+            </Text>
+          </Section>
+          <Section style={emailStyles.footer}>
+            <Text style={emailStyles.footerText}>
+              You&apos;re receiving this because you have a PageSpace account
+              on the Free plan. It&apos;s a notice about a change to your
+              plan, so it goes to every Free account.
+            </Text>
+            {postalAddress ? (
+              <Text style={emailStyles.footerText}>{postalAddress}</Text>
+            ) : null}
+          </Section>
+        </Container>
+      </Body>
+    </Html>
+  );
+}

--- a/packages/lib/src/email-templates/FreeCreditsChangeEmail.tsx
+++ b/packages/lib/src/email-templates/FreeCreditsChangeEmail.tsx
@@ -123,7 +123,7 @@ export function FreeCreditsChangeEmail({
   return (
     <Html>
       <Head />
-      <Preview>Free credits are now a one-time starter grant. Everything you have stays yours.</Preview>
+      <Preview>Free plan credits are now a one-time grant of {starterCredits}. Your current balance is unchanged.</Preview>
       <Body style={emailStyles.main}>
         <Container style={emailStyles.container}>
           <Section style={darkHeader}>
@@ -132,60 +132,46 @@ export function FreeCreditsChangeEmail({
           <Section style={emailStyles.content}>
             <Text style={eyebrow}>Plan update</Text>
             <Text style={emailStyles.contentHeading}>
-              A change to credits on the Free plan
+              Free plan credits are changing
             </Text>
             <Text style={emailStyles.paragraph}>Hi {userName},</Text>
             <Text style={emailStyles.paragraph}>
-              A quick, honest heads-up about how AI credits work on your Free
-              plan. The short version: nothing you have is going away, but
-              the monthly top-up is.
+              Starting today, the Free plan includes a one-time grant of{' '}
+              {starterCredits} credits instead of {starterCredits} credits per
+              month. The grant is added the first time you use AI and is not
+              renewed.
             </Text>
-
-            <Section style={calloutCard}>
-              <Text style={calloutHeading}>What&apos;s changing</Text>
-              <Text style={calloutText}>
-                Until now, Free accounts received {starterCredits} credits
-                every month, and unused credits piled up. Starting today,
-                Free comes with {starterCredits} credits once, granted the
-                first time you use AI. That grant doesn&apos;t refill.
-              </Text>
-            </Section>
 
             <Section style={keepCard}>
               <Text style={{ ...calloutText, fontWeight: typography.semibold, color: colors.heading }}>
-                What you keep
+                Your current balance is not affected
               </Text>
               <Text style={{ ...calloutText, marginTop: spacing.xs }}>
                 {currentCredits !== undefined ? (
                   <>
-                    Every credit already in your account. You have{' '}
-                    {currentCredits} credits right now, and they stay there
-                    until you spend them. Credits never expire and nothing is
-                    being taken back.
+                    You have {currentCredits} credits. They remain available
+                    until you use them and do not expire.
                   </>
                 ) : (
                   <>
-                    Your {starterCredits} starter credits are still waiting
-                    for your first AI call, and once granted they never
+                    You have not used AI yet. Your {starterCredits} starter
+                    credits will be added on your first AI request and do not
                     expire.
                   </>
                 )}
               </Text>
               <Text style={{ ...calloutText, marginTop: spacing.xs }}>
-                Everything else on Free is unchanged: your documents, drives,
-                tasks, channels, collaboration, storage, and the same set of
-                AI models.
+                Storage, documents, drives, tasks, channels, and the Free plan
+                model list are unchanged.
               </Text>
             </Section>
 
             <Section style={calloutCard}>
-              <Text style={calloutHeading}>When you run low</Text>
+              <Text style={calloutHeading}>Adding credits</Text>
               <Text style={calloutText}>
-                Two options, and both keep whatever balance you already
-                have. Buy a top-up pack from {minTopup} (top-ups never
-                expire), or upgrade to Pro for {proMonthlyCredits} credits
-                every month that roll over when unused, plus the full model
-                catalogue.
+                Top-up packs start at {minTopup} and do not expire. The Pro plan
+                includes {proMonthlyCredits} credits per month, unused credits
+                carry over, and all models are available.
               </Text>
               <Text style={{ ...calloutText, marginTop: spacing.sm }}>
                 <Link href={usageUrl} style={secondaryLink}>
@@ -198,29 +184,20 @@ export function FreeCreditsChangeEmail({
               </Text>
             </Section>
 
-            <Text style={emailStyles.paragraph}>
-              Why: free credits that refilled every month and never expired
-              were an open-ended cost for a small team, and most Free
-              accounts never used them. A one-time grant keeps Free
-              genuinely free to try, and keeps us able to keep offering it.
-            </Text>
-
             <Section style={emailStyles.buttonContainer}>
               <Button style={darkButton} href={planUrl}>
-                See your plan
+                View your plan
               </Button>
             </Section>
 
             <Text style={emailStyles.hint}>
-              Questions, or think we got something wrong? Just reply to this
-              email. We read every one.
+              Reply to this email if you have questions.
             </Text>
           </Section>
           <Section style={emailStyles.footer}>
             <Text style={emailStyles.footerText}>
-              You&apos;re receiving this because you have a PageSpace account
-              on the Free plan. It&apos;s a notice about a change to your
-              plan, so it goes to every Free account.
+              You are receiving this notice because your PageSpace account is
+              on the Free plan.
             </Text>
             {postalAddress ? (
               <Text style={emailStyles.footerText}>{postalAddress}</Text>

--- a/packages/lib/src/email-templates/FreeCreditsChangeEmail.tsx
+++ b/packages/lib/src/email-templates/FreeCreditsChangeEmail.tsx
@@ -141,6 +141,10 @@ export function FreeCreditsChangeEmail({
               month. The grant is added the first time you use AI and is not
               renewed.
             </Text>
+            <Text style={emailStyles.paragraph}>
+              This lets us keep the Free plan available and put more into the
+              product for the people using it.
+            </Text>
 
             <Section style={keepCard}>
               <Text style={{ ...calloutText, fontWeight: typography.semibold, color: colors.heading }}>

--- a/packages/lib/src/email-templates/__tests__/FreeCreditsChangeEmail.test.tsx
+++ b/packages/lib/src/email-templates/__tests__/FreeCreditsChangeEmail.test.tsx
@@ -23,6 +23,7 @@ describe('FreeCreditsChangeEmail', () => {
     expect(html).toContain('one-time grant');
     expect(html).toContain('is not renewed');
     expect(html).not.toContain('/month');
+    expect(html).toContain('keep the Free plan available');
   });
 
   it('given a current balance, should tell the recipient exactly what they keep', async () => {

--- a/packages/lib/src/email-templates/__tests__/FreeCreditsChangeEmail.test.tsx
+++ b/packages/lib/src/email-templates/__tests__/FreeCreditsChangeEmail.test.tsx
@@ -13,7 +13,9 @@ const PROPS = {
   postalAddress: 'PageSpace, 1 Example St, Springfield, IL 62704',
 };
 
-const render = (props: Partial<typeof PROPS> = {}) =>
+type Props = Parameters<typeof FreeCreditsChangeEmail>[0];
+
+const render = (props: Partial<Props> = {}) =>
   renderEmailToHtml(FreeCreditsChangeEmail({ ...PROPS, ...props }));
 
 describe('FreeCreditsChangeEmail', () => {

--- a/packages/lib/src/email-templates/__tests__/FreeCreditsChangeEmail.test.tsx
+++ b/packages/lib/src/email-templates/__tests__/FreeCreditsChangeEmail.test.tsx
@@ -20,23 +20,23 @@ describe('FreeCreditsChangeEmail', () => {
   it('given the change props, should say the grant is one-time and no longer refills', async () => {
     const html = await render();
 
-    expect(html).toContain('once');
-    expect(html).toContain("doesn&#x27;t refill");
+    expect(html).toContain('one-time grant');
+    expect(html).toContain('is not renewed');
     expect(html).not.toContain('/month');
   });
 
   it('given a current balance, should tell the recipient exactly what they keep', async () => {
     const html = await render({ currentCredits: '3.2' });
 
-    expect(html).toMatch(/You have[\s\S]{0,40}3\.2[\s\S]{0,40}credits right now/);
-    expect(html).toContain('never expire');
+    expect(html).toMatch(/You have[\s\S]{0,40}3\.2[\s\S]{0,40}credits\./);
+    expect(html).toContain('do not expire');
   });
 
   it('given no balance (never used AI), should say the starter credits are still waiting', async () => {
     const html = await render({ currentCredits: undefined });
 
-    expect(html).toContain('still waiting');
-    expect(html).not.toContain('right now');
+    expect(html).toContain('have not used AI yet');
+    expect(html).not.toContain('You have 3.2');
   });
 
   it('given plan and usage URLs, should link both the plan CTA and buy-credits path', async () => {
@@ -49,8 +49,8 @@ describe('FreeCreditsChangeEmail', () => {
   it('given the pricing props, should quote the top-up floor and the Pro allowance', async () => {
     const html = await render({ minTopup: '$5', proMonthlyCredits: '15' });
 
-    expect(html).toMatch(/from[\s\S]{0,40}\$5/);
-    expect(html).toMatch(/Pro for[\s\S]{0,40}15[\s\S]{0,40}credits/);
+    expect(html).toMatch(/start at[\s\S]{0,40}\$5/);
+    expect(html).toMatch(/includes[\s\S]{0,40}15[\s\S]{0,40}credits per month/);
   });
 
   it('is a relationship notice, so it renders NO unsubscribe link', async () => {

--- a/packages/lib/src/email-templates/__tests__/FreeCreditsChangeEmail.test.tsx
+++ b/packages/lib/src/email-templates/__tests__/FreeCreditsChangeEmail.test.tsx
@@ -1,0 +1,75 @@
+import { describe, it, expect } from 'vitest';
+import { FreeCreditsChangeEmail } from '../FreeCreditsChangeEmail';
+import { renderEmailToHtml } from '../render-email';
+
+const PROPS = {
+  userName: 'Ada',
+  currentCredits: '3.2',
+  starterCredits: '5',
+  proMonthlyCredits: '15',
+  minTopup: '$5',
+  planUrl: 'https://app.pagespace.ai/settings/plan',
+  usageUrl: 'https://app.pagespace.ai/settings/usage',
+  postalAddress: 'PageSpace, 1 Example St, Springfield, IL 62704',
+};
+
+const render = (props: Partial<typeof PROPS> = {}) =>
+  renderEmailToHtml(FreeCreditsChangeEmail({ ...PROPS, ...props }));
+
+describe('FreeCreditsChangeEmail', () => {
+  it('given the change props, should say the grant is one-time and no longer refills', async () => {
+    const html = await render();
+
+    expect(html).toContain('once');
+    expect(html).toContain("doesn&#x27;t refill");
+    expect(html).not.toContain('/month');
+  });
+
+  it('given a current balance, should tell the recipient exactly what they keep', async () => {
+    const html = await render({ currentCredits: '3.2' });
+
+    expect(html).toMatch(/You have[\s\S]{0,40}3\.2[\s\S]{0,40}credits right now/);
+    expect(html).toContain('never expire');
+  });
+
+  it('given no balance (never used AI), should say the starter credits are still waiting', async () => {
+    const html = await render({ currentCredits: undefined });
+
+    expect(html).toContain('still waiting');
+    expect(html).not.toContain('right now');
+  });
+
+  it('given plan and usage URLs, should link both the plan CTA and buy-credits path', async () => {
+    const html = await render();
+
+    expect(html).toContain('https://app.pagespace.ai/settings/plan');
+    expect(html).toContain('https://app.pagespace.ai/settings/usage');
+  });
+
+  it('given the pricing props, should quote the top-up floor and the Pro allowance', async () => {
+    const html = await render({ minTopup: '$5', proMonthlyCredits: '15' });
+
+    expect(html).toMatch(/from[\s\S]{0,40}\$5/);
+    expect(html).toMatch(/Pro for[\s\S]{0,40}15[\s\S]{0,40}credits/);
+  });
+
+  it('is a relationship notice, so it renders NO unsubscribe link', async () => {
+    // A change to an existing plan is a relationship message under CAN-SPAM, and it
+    // must reach every affected account — there is no opt-out to offer.
+    const html = await render();
+
+    expect(html).not.toContain('Unsubscribe');
+    expect(html).not.toContain('/api/notifications/unsubscribe/');
+  });
+
+  it('given a postal address, should print it in the footer; given none, should omit it', async () => {
+    expect(await render()).toContain('1 Example St, Springfield, IL 62704');
+    expect(await render({ postalAddress: undefined })).not.toContain('Springfield');
+  });
+
+  it('given a recipient name, should greet them by it', async () => {
+    const html = await render({ userName: 'Grace' });
+
+    expect(html).toMatch(/Hi[\s\S]{0,40}Grace/);
+  });
+});

--- a/packages/lib/src/email-templates/__tests__/FreeCreditsChangeEmail.test.tsx
+++ b/packages/lib/src/email-templates/__tests__/FreeCreditsChangeEmail.test.tsx
@@ -33,6 +33,14 @@ describe('FreeCreditsChangeEmail', () => {
     expect(html).toContain('do not expire');
   });
 
+  it('given a negative balance, should say how far in the red and that a top-up clears it — never "You have -0.3 credits"', async () => {
+    const html = await render({ currentCredits: undefined, overageCredits: '0.3' });
+
+    expect(html).toMatch(/balance is[\s\S]{0,40}0\.3[\s\S]{0,40}credits in the red/);
+    expect(html).toContain('top-up clears the overage');
+    expect(html).not.toContain('You have');
+  });
+
   it('given no balance (never used AI), should say the starter credits are still waiting', async () => {
     const html = await render({ currentCredits: undefined });
 

--- a/scripts/send-free-credits-change-notifications.ts
+++ b/scripts/send-free-credits-change-notifications.ts
@@ -76,7 +76,7 @@ interface Recipient {
   email: string;
 }
 
-const EMAIL_SUBJECT = 'A change to credits on your Free plan';
+const EMAIL_SUBJECT = 'Free plan credits are changing';
 
 /**
  * Namespace for the per-recipient Resend idempotency key. Stable across

--- a/scripts/send-free-credits-change-notifications.ts
+++ b/scripts/send-free-credits-change-notifications.ts
@@ -1,0 +1,334 @@
+#!/usr/bin/env bun
+/**
+ * Notify every FREE-plan account that free credits are now a one-time starter
+ * grant rather than a monthly, accumulating allowance (PR #2547).
+ *
+ * Structurally the same as scripts/send-agent-sandbox-launch-notifications.ts —
+ * same shared broadcast core (`@pagespace/lib/services/broadcast/core`, via
+ * scripts/lib/sdk-launch-broadcast.ts), same GDPR/suppression exclusions, same
+ * fail-closed safety posture, same JSONL idempotency ledger. What differs:
+ *
+ *   - AUDIENCE is `users.subscriptionTier = 'free'` only. Paid tiers are not
+ *     affected and are not mailed.
+ *   - This is a RELATIONSHIP message (a notice of a change to the recipient's
+ *     existing plan), not a marketing broadcast. CAN-SPAM exempts it from the
+ *     commercial requirements, and it has to reach every affected account, so
+ *     it does NOT honour the PRODUCT_UPDATE opt-out and carries no unsubscribe
+ *     link. The GDPR rights-request and erasure-suppression exclusions still
+ *     apply — those are legal must-skips, not preferences.
+ *   - Each email quotes the recipient's CURRENT spendable balance (one LEFT JOIN
+ *     on credit_balances), so "what you keep" is a number, not a promise.
+ *
+ * Usage:
+ *   bun scripts/send-free-credits-change-notifications.ts                    # dry run (default)
+ *   bun scripts/send-free-credits-change-notifications.ts --live --limit=25  # canary
+ *   bun scripts/send-free-credits-change-notifications.ts --live
+ *
+ * Flags: --live, --dry-run, --include-unverified, --limit=N, --delay-ms=N, --log=PATH.
+ *
+ * Run this AFTER the PR is deployed: the email says "starting today" and links
+ * to the plan page whose copy the same PR changes.
+ *
+ * DO NOT run this in a throwaway container without mounting the ledger onto
+ * durable storage — see the SDK launch script's header for why.
+ */
+
+import type { FileHandle } from 'node:fs/promises';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { getMigrationDb } from '@pagespace/db/db';
+import { users } from '@pagespace/db/schema/auth';
+import { creditBalances } from '@pagespace/db/schema/credits';
+import { dataSubjectRequests } from '@pagespace/db/schema/data-subject-requests';
+import { and, eq, inArray, isNotNull, isNull, ne, or } from '@pagespace/db/operators';
+import { sendEmail } from '@pagespace/lib/services/email-service';
+import { listSuppressedEmails } from '@pagespace/lib/compliance/erasure/resend-suppression-client';
+import { decryptUserRow } from '@pagespace/lib/auth/user-repository';
+import { isValidEmail } from '@pagespace/lib/validators/email';
+import { isOnPrem } from '@pagespace/lib/deployment-mode';
+import {
+  TIER_MONTHLY_ALLOWANCE_CENTS,
+  CREDIT_TOPUP_MIN_CENTS,
+} from '@pagespace/lib/billing/credit-pricing';
+import { FreeCreditsChangeEmail } from '@pagespace/lib/email-templates/FreeCreditsChangeEmail';
+import { renderEmailToHtml } from '@pagespace/lib/email-templates/render-email';
+import {
+  findUnreachableUrls,
+  isLocalhostUrl,
+  LedgerWriteFailed,
+  loadSentEmails,
+  openLedger,
+  parseArgs,
+  preflight,
+  recordSent,
+  resolveBaseUrl,
+  runBroadcast,
+} from './lib/sdk-launch-broadcast';
+
+// One-shot ops script — runs on the unthrottled migration pool, not the
+// app-throttled `db` (see getMigrationDb()'s doc comment in packages/db).
+const db = getMigrationDb();
+
+/** One person the notice is about to mail. */
+interface Recipient {
+  userId: string;
+  userName: string;
+  email: string;
+}
+
+const EMAIL_SUBJECT = 'A change to credits on your Free plan';
+
+/**
+ * Namespace for the per-recipient Resend idempotency key. Stable across
+ * re-runs ON PURPOSE so a resumed run can never double-send. Bump it only if
+ * you ever genuinely intend to mail this audience again.
+ */
+const IDEMPOTENCY_PREFIX = 'free-credits-change-2026-09';
+
+/** Whole cents → credit units for display ("5", "3.2"). Mirrors apps/web's formatCreditCount. */
+function formatCredits(cents: number): string {
+  const units = cents / 100;
+  return Number.isInteger(units) ? `${units}` : units.toFixed(1);
+}
+
+function formatDollars(cents: number): string {
+  const dollars = cents / 100;
+  return Number.isInteger(dollars) ? `$${dollars}` : `$${dollars.toFixed(2)}`;
+}
+
+function defaultLogPath(): string {
+  const fromEnv = process.env.FREE_CREDITS_CHANGE_EMAIL_LOG_PATH?.trim();
+  if (fromEnv) return path.resolve(fromEnv);
+  const here = path.dirname(fileURLToPath(import.meta.url));
+  return path.join(here, '..', '.free-credits-change-sent.jsonl');
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+/** userIds we are forbidden to contact because of a GDPR rights request — see the SDK launch script's identical function for the full rationale. */
+async function loadRightsRestrictedUserIds(): Promise<Set<string>> {
+  const rows = await db
+    .select({ userId: dataSubjectRequests.userId })
+    .from(dataSubjectRequests)
+    .where(
+      or(
+        and(
+          eq(dataSubjectRequests.requestType, 'erasure'),
+          inArray(dataSubjectRequests.status, ['pending', 'queued', 'in_progress', 'blocked', 'failed']),
+        ),
+        and(
+          inArray(dataSubjectRequests.requestType, ['objection', 'restriction']),
+          ne(dataSubjectRequests.status, 'cancelled'),
+        ),
+      ),
+    );
+
+  return new Set(rows.map((r) => r.userId).filter((id): id is string => id !== null));
+}
+
+/** @returns the process exit code (non-zero if any send failed). */
+async function main(): Promise<number> {
+  const opts = parseArgs(process.argv.slice(2), defaultLogPath());
+  const baseUrl = resolveBaseUrl();
+  const planUrl = `${baseUrl}/settings/plan`;
+  const usageUrl = `${baseUrl}/settings/usage`;
+  const starterCredits = formatCredits(TIER_MONTHLY_ALLOWANCE_CENTS.free);
+  const proMonthlyCredits = formatCredits(TIER_MONTHLY_ALLOWANCE_CENTS.pro);
+  const minTopup = formatDollars(CREDIT_TOPUP_MIN_CENTS);
+
+  console.log('📢 Free-plan credits change notice');
+  console.log(`  Mode:          ${opts.live ? 'LIVE SEND' : 'DRY RUN (no sends) — pass --live to send'}`);
+  console.log(
+    `  Audience:      FREE tier, ${opts.includeUnverified ? 'including unverified addresses' : 'verified addresses only'}` +
+      ' (suspended accounts always excluded; PRODUCT_UPDATE opt-out NOT applied — plan-change notice)',
+  );
+  console.log(`  Ledger:        ${opts.logPath}`);
+  console.log(`  Plan page:     ${planUrl}`);
+  console.log(`  Usage page:    ${usageUrl}`);
+  console.log(`  Starter grant: ${starterCredits} credits · Pro: ${proMonthlyCredits}/mo · min top-up: ${minTopup}`);
+  if (opts.limit) console.log(`  Limit:         ${opts.limit}`);
+  console.log('');
+
+  const suppressed = await listSuppressedEmails();
+  const postalAddress = process.env.COMPANY_POSTAL_ADDRESS?.trim();
+
+  const check = preflight({
+    live: opts.live,
+    baseUrl,
+    suppressed,
+    isOnPrem: isOnPrem(),
+    fromEmail: process.env.FROM_EMAIL,
+  });
+  if (!check.ok) {
+    console.error(`❌ Refusing live send: ${check.reason}`);
+    process.exit(1);
+  }
+
+  // A relationship notice is exempt from CAN-SPAM's postal-address rule, so an
+  // empty COMPANY_POSTAL_ADDRESS is a warning here, not a refusal.
+  if (opts.live && !postalAddress) {
+    console.warn('  ⚠️  COMPANY_POSTAL_ADDRESS is empty — the footer will carry no postal address.\n');
+  }
+
+  // The pages this email links to must be DEPLOYED (with the new "5 credits to
+  // start" copy) before we mail a link to them. An anonymous probe follows the
+  // auth redirect; a 2xx sign-in page proves the deploy carries the route.
+  if (opts.live) {
+    const unreachable = await findUnreachableUrls([planUrl, usageUrl]);
+    if (unreachable.length > 0) {
+      console.error(
+        '❌ Refusing live send: the pages this email links to are not reachable.\n' +
+          '   Deploy the app first.\n' +
+          unreachable.map((u) => `     - ${u}`).join('\n'),
+      );
+      process.exit(1);
+    }
+    console.log('🔗 Plan + usage links verified reachable.\n');
+  }
+
+  if (suppressed === null) {
+    console.warn('  ⚠️  Suppression audience unavailable (unconfigured) — a live send would refuse to start.\n');
+  } else {
+    console.log(`🚫 ${suppressed.size} address(es) in the erasure-suppression audience will be skipped.\n`);
+  }
+  if (!opts.live && isLocalhostUrl(baseUrl)) {
+    console.warn('  ⚠️  Base URL resolves to localhost — set NEXT_PUBLIC_APP_URL or WEB_APP_URL before a real send.\n');
+  }
+
+  const alreadySent = await loadSentEmails(opts.logPath);
+  if (alreadySent.size > 0) {
+    console.log(`↩️  Resuming: ${alreadySent.size} recipient(s) already recorded in the ledger.\n`);
+  }
+
+  const rightsRestricted = await loadRightsRestrictedUserIds();
+  if (rightsRestricted.size > 0) {
+    console.log(`⚖️  ${rightsRestricted.size} user(s) excluded by a GDPR rights request.\n`);
+  }
+
+  const ledger: FileHandle | null = opts.live ? await openLedger(opts.logPath) : null;
+
+  const audience = [
+    eq(users.subscriptionTier, 'free'),
+    isNull(users.suspendedAt),
+    ...(opts.includeUnverified ? [] : [isNotNull(users.emailVerified)]),
+  ];
+  const rows = await db
+    .select({
+      id: users.id,
+      name: users.name,
+      email: users.email,
+      monthlyRemainingCents: creditBalances.monthlyRemainingCents,
+      topupRemainingCents: creditBalances.topupRemainingCents,
+      debtCents: creditBalances.debtCents,
+    })
+    .from(users)
+    .leftJoin(creditBalances, eq(creditBalances.userId, users.id))
+    .where(and(...audience));
+
+  console.log(`👥 ${rows.length} free-tier user(s) returned from the database.\n`);
+
+  // Spendable, the same arithmetic as credit-balance's display read: funded buckets
+  // minus debt, clamped at 0 when there is no debt. No row (never used AI) → undefined,
+  // and the template says the starter credits are still waiting.
+  const creditsByUserId = new Map<string, string | undefined>();
+  for (const r of rows) {
+    if (r.monthlyRemainingCents === null || r.topupRemainingCents === null) {
+      creditsByUserId.set(r.id, undefined);
+      continue;
+    }
+    const debt = r.debtCents ?? 0;
+    const funded = r.monthlyRemainingCents + r.topupRemainingCents;
+    const spendable = debt > 0 ? funded - debt : Math.max(0, funded);
+    creditsByUserId.set(r.id, formatCredits(spendable));
+  }
+
+  const propsFor = ({ userId, userName }: Recipient) => ({
+    userName,
+    currentCredits: creditsByUserId.get(userId),
+    starterCredits,
+    proMonthlyCredits,
+    minTopup,
+    planUrl,
+    usageUrl,
+    postalAddress,
+  });
+
+  const sendOne = async (recipient: Recipient): Promise<void> => {
+    await sendEmail({
+      to: recipient.email,
+      subject: EMAIL_SUBJECT,
+      react: FreeCreditsChangeEmail(propsFor(recipient)),
+      idempotencyKey: `${IDEMPOTENCY_PREFIX}:${recipient.userId}`,
+    });
+  };
+
+  /** Dry-run: render the real template so a template error still surfaces, and send nothing. */
+  const renderOne = (recipient: Recipient): Promise<string> =>
+    renderEmailToHtml(FreeCreditsChangeEmail(propsFor(recipient)));
+
+  let result;
+  try {
+    result = await runBroadcast({
+      live: opts.live,
+      limit: opts.limit,
+      delayMs: opts.delayMs,
+      rows,
+      decrypt: decryptUserRow,
+      isValidEmail,
+      alreadySent,
+      suppressed,
+      // Plan-change notice: reaches every Free account regardless of the
+      // PRODUCT_UPDATE preference (see the file header).
+      optedOut: new Set<string>(),
+      rightsRestricted,
+      sendOne,
+      renderOne,
+      record: (entry) => recordSent(ledger!, entry),
+      now: () => new Date().toISOString(),
+      sleep,
+      log: (msg) => console.log(msg),
+      logError: (msg) => console.error(msg),
+    });
+  } catch (error) {
+    if (error instanceof LedgerWriteFailed) {
+      console.error(`\n❌ FATAL: ${error.message}\n   Ledger: ${opts.logPath}`);
+      if (ledger) await ledger.close();
+      return 1;
+    }
+    throw error;
+  }
+
+  if (ledger) await ledger.close();
+
+  const { sent, skipped, errors } = result;
+  console.log('\n📊 Summary:');
+  console.log(`  ${opts.live ? 'Sent' : 'Would send'}:            ${sent}`);
+  console.log(`  Skipped (already sent):  ${skipped['already-sent']}`);
+  console.log(`  Skipped (suppressed):    ${skipped.suppressed}`);
+  console.log(`  Skipped (GDPR request):  ${skipped['rights-restricted']}`);
+  console.log(`  Skipped (invalid email): ${skipped['invalid-email']}`);
+  console.log(`  Errors:                  ${errors.length}`);
+  errors.forEach((err) => console.error(`    - ${err}`));
+  const errorCount = errors.length;
+
+  if (!opts.live) {
+    console.log('\n✅ Dry run complete — no emails sent, ledger untouched. Re-run with --live to send.');
+  } else if (errorCount === 0) {
+    console.log('\n✅ Notice sent.');
+  } else {
+    console.log('\n⚠️  Finished with errors; re-run to retry the failures.');
+  }
+
+  return errorCount === 0 ? 0 : 1;
+}
+
+if (import.meta.main) {
+  main()
+    .then((code) => process.exit(code))
+    .catch((error) => {
+      console.error('\n❌ Script failed:', error);
+      process.exit(1);
+    });
+}

--- a/scripts/send-free-credits-change-notifications.ts
+++ b/scripts/send-free-credits-change-notifications.ts
@@ -222,6 +222,7 @@ async function main(): Promise<number> {
       monthlyRemainingCents: creditBalances.monthlyRemainingCents,
       topupRemainingCents: creditBalances.topupRemainingCents,
       debtCents: creditBalances.debtCents,
+      monthlyPeriodEnd: creditBalances.monthlyPeriodEnd,
     })
     .from(users)
     .leftJoin(creditBalances, eq(creditBalances.userId, users.id))
@@ -230,23 +231,31 @@ async function main(): Promise<number> {
   console.log(`👥 ${rows.length} free-tier user(s) returned from the database.\n`);
 
   // Spendable, the same arithmetic as credit-balance's display read: funded buckets
-  // minus debt, clamped at 0 when there is no debt. No row (never used AI) → undefined,
-  // and the template says the starter credits are still waiting.
-  const creditsByUserId = new Map<string, string | undefined>();
+  // (plus the pending starter grant on a bare top-up row with no period stamped —
+  // the gate funds it on the next call) minus debt. Three outcomes, mirroring what
+  // the app shows: no row (never used AI) → the starter credits are still waiting;
+  // negative → in the red (a top-up clears it); otherwise the balance they keep.
+  const balanceByUserId = new Map<string, { currentCredits?: string; overageCredits?: string }>();
   for (const r of rows) {
     if (r.monthlyRemainingCents === null || r.topupRemainingCents === null) {
-      creditsByUserId.set(r.id, undefined);
+      balanceByUserId.set(r.id, {});
       continue;
     }
     const debt = r.debtCents ?? 0;
-    const funded = r.monthlyRemainingCents + r.topupRemainingCents;
+    const pendingStarter = r.monthlyPeriodEnd === null ? TIER_MONTHLY_ALLOWANCE_CENTS.free : 0;
+    const funded = r.monthlyRemainingCents + r.topupRemainingCents + pendingStarter;
     const spendable = debt > 0 ? funded - debt : Math.max(0, funded);
-    creditsByUserId.set(r.id, formatCredits(spendable));
+    balanceByUserId.set(
+      r.id,
+      spendable < 0
+        ? { overageCredits: formatCredits(-spendable) }
+        : { currentCredits: formatCredits(spendable) },
+    );
   }
 
   const propsFor = ({ userId, userName }: Recipient) => ({
     userName,
-    currentCredits: creditsByUserId.get(userId),
+    ...(balanceByUserId.get(userId) ?? {}),
     starterCredits,
     proMonthlyCredits,
     minTopup,


### PR DESCRIPTION
## Summary

Free tier credits become a **one-time $5 starter grant** instead of a monthly, accumulating allowance.

Today the gate re-grants free's 500¢ every month and rolls the old balance forward with no cap, so an idle free user accrues $60/yr of latent credit (~$40/yr of provider cost at the 1.5× markup). Most free users don't spend, so the real cost was the unbounded accrual liability, not the per-user number.

**Decision:** $5 once; existing free balances are left alone (no clawback, no migration). Rollover simply stops.

## Unit economics ($5 grant, 1.5× markup, 4k in / 1k out per call)

Max provider exposure per free user, **lifetime**: $3.33 (was $3.33 **per month**, forever).

| Free model | Charged/call | Calls on $5 |
|---|---|---|
| glm-5.3-flash (default) | 0.08¢ | ~6,000 |
| gpt-5.6-luna / gpt-5.4-nano | 0.31¢ | ~1,600 |
| gemini-3.7-flash | 0.51¢ | ~990 |
| gpt-5.4-mini | 1.1¢ | ~440 |
| claude-haiku-4.5 | 1.35¢ | ~370 |
| gemini-3.5-flash | 2.25¢ | ~220 |
| `:free` OpenRouter models | 0 | unbounded (only `MAX_FREE_INFLIGHT` + rate limiter apply, unchanged) |

## Changes

- `credit-pricing.ts`: new `TIER_ALLOWANCE_REFILLS` (`free: false`, paid: `true`). Everything keys off this flag rather than `tier === 'free'`, so a future non-refilling tier is one row.
- `credit-gate.ts`: only refilling tiers reach the gate-driven roll. Free's one-time grant is the existing `free-init-<userId>` lazy init (user-scoped ledger key ⇒ exactly once). The comped/no-subscription paid roll is unchanged and now always keys `gate-reset-`.
- `credit-gate.ts` **starter grant for a bare row** (review fix): a free user who buys a top-up before their first AI call has a row with no period, and free is excluded from the reset path — so a new branch inserts the user-scoped `free-init-<userId>` ledger key first and, only when it lands, funds the row with a relative increment and stamps the period. Ledger decides eligibility; a concurrent top-up write is never clobbered.
- `credit-balance.ts`: free shows stored remaining only (no "upcoming allowance" pre-credit) and `monthly.periodEnd` is `null`, so the UI never advances a phantom "Renews" date.
- Copy: credits card, navbar tooltip, plan comparison row, 402 message, `/api/credits` docs; marketing pricing / FAQ / terms / docs / blog CTA / metadata / search index now say "5 credits to start" for Free.
- `CHANGELOG.md` entry.
- **Review pass (self + Codex):** `/settings/usage` no longer says "renews <date>" for free (breakdown query takes the tier); marketing pricing hero/table label and the pricing blog post no longer promise a monthly allowance on every plan; admin billing table shows allowance cadence; shared `allowanceRefills` / `isOneTimeAllowanceTier` predicates replace three hand-spelled checks (unknown/legacy tier strings are neither); stale gate comments removed.
- **Notice email to Free accounts.** `FreeCreditsChangeEmail` + `scripts/send-free-credits-change-notifications.ts`, modeled on the agent-sandbox launch broadcast (shared core, JSONL ledger, suppression + GDPR exclusions, dry-run default). Audience is `subscriptionTier = 'free'` only; each email quotes the recipient's current spendable balance. It is a relationship notice about a change to an existing plan, so it does not honour the PRODUCT_UPDATE opt-out and has no unsubscribe link. A user in overage gets an "in the red; a top-up clears it" variant instead of a negative number, and a bare top-up row is pre-credited with the pending starter grant so the email matches the app. **Run it after deploy** — it says "starting today" and links to the plan page this PR re-words.

## Tests

- Free-reset gate tests flipped to assert **no** reset, no UPDATE, no `monthly_grant` row, no subscription lookup; the locked-read race tests moved to a comped pro tier so they still exercise the roll path.
- Balance tests: free + lapsed window ⇒ stored only, `periodEnd` null (active, expired, and never-stamped).
- Integration flow: expired free ⇒ blocked at 0 / carried credit still spendable / brand-new free gets exactly one grant even after the window ages.
- Starter grant on a bare top-up row: gate unit (ledger-first, relative increment, once; skip when key exists), integration (top-up → first call → +500 once, second call no-op), display pre-credit.
- Pricing: flag shape test.
- **Mutation checks:** flipping `TIER_ALLOWANCE_REFILLS.free` to `true` fails 9 tests; disabling the starter-grant branch fails its 3; restored ⇒ 127/127 green across `credit-gate`, `credit-balance`, `credit-pricing`, `credits-flow.integration`.

## Not verified locally

- `apps/web` `credits.test.ts` reads `@pagespace/lib` from a stale `dist` that predates the new export; rebuilding lib is off-limits here while pu agents are running, so CI is the gate for that file and for typecheck/knip.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Cu8Qu2V83H67gbxQueYEdv
