### PR TITLE
fix(sandbox): dev-preview fixes that missed #2545 — pane drive, honest slot, immediate invalidation

### DIFF
--- a/apps/realtime/src/dev-preview/detection-registry.ts
+++ b/apps/realtime/src/dev-preview/detection-registry.ts
@@ -119,8 +119,11 @@ export function createDetectionRegistry(deps: DetectionRegistryDeps): DetectionR
         onFrame: (frame) => { void detector.onFrame(frame); },
         onClose: (info) => {
           current = null;
-          // The accumulated set no longer describes a live connection.
-          // Queued on the detector's chain, behind any frame still applying.
+          // The accumulated set no longer describes a live connection. Takes
+          // effect immediately — a reader between this close and the next
+          // connection's snapshot must not be answered from the dead one —
+          // while the detector's arrival epoch stops a frame still applying
+          // from claiming the NEXT connection's snapshot.
           detector.invalidateSnapshot();
           if (stopped) return;
           if (info.opened) attempts = 0;

--- a/apps/web/src/components/agents/AgentsSurface.tsx
+++ b/apps/web/src/components/agents/AgentsSurface.tsx
@@ -286,7 +286,14 @@ export default function AgentsSurface({ driveId }: { driveId?: string }) {
           </div>
         )}
       </div>
-      <DevPreviewPane driveId={driveId ?? null} />
+      {/*
+        The drive this console is CURRENTLY showing, which is not always the
+        route's: on the global agents route a selected session can belong to a
+        drive, and the affordance tags its preview with that (the session's own
+        record is the authority — `sessionDriveId`). Passing the route drive
+        here would hide a preview the user just opened from this very header.
+      */}
+      <DevPreviewPane driveId={selectedSessionId && sessionDriveResolved ? sessionDriveId : driveId ?? null} />
     </div>
   );
 }

--- a/apps/web/src/components/dev-preview/DevPreviewPane.tsx
+++ b/apps/web/src/components/dev-preview/DevPreviewPane.tsx
@@ -212,9 +212,19 @@ function OpenDevPreviewPane({ open }: { open: OpenDevPreview }) {
             </Button>
           )}
           {preview?.canManage && preview.canResume && (
-            <Button variant="ghost" size="sm" className="h-7 gap-1 px-2 text-muted-foreground hover:text-foreground" disabled={actioning} onClick={() => void runAction('resume')} title="Switch the preview back on">
+            // One action, two honest names: a preview the user switched off is
+            // RESUMED; a relay that is down (crashed, or a reconcile has not
+            // caught up) is RESTARTED. Both ask the server for the same thing.
+            <Button
+              variant="ghost"
+              size="sm"
+              className="h-7 gap-1 px-2 text-muted-foreground hover:text-foreground"
+              disabled={actioning}
+              onClick={() => void runAction('resume')}
+              title={preview.state.status === 'stopped' ? 'Switch the preview back on' : 'Restart the preview'}
+            >
               <Play className="size-3.5" aria-hidden="true" />
-              Resume
+              {preview.state.status === 'stopped' ? 'Resume' : 'Restart'}
             </Button>
           )}
           <Button variant="ghost" size="sm" className="h-7 px-2 text-muted-foreground hover:text-foreground" onClick={closePreview} title="Close the preview pane">

--- a/apps/web/src/components/dev-preview/__tests__/DevPreviewAffordance.test.tsx
+++ b/apps/web/src/components/dev-preview/__tests__/DevPreviewAffordance.test.tsx
@@ -6,7 +6,7 @@
  * the caller's disclosure.
  */
 import { describe, test, expect, beforeEach, afterEach, vi } from 'vitest';
-import { render, screen, waitFor, fireEvent } from '@testing-library/react';
+import { act, render, screen, waitFor, fireEvent } from '@testing-library/react';
 import { SWRConfig } from 'swr';
 
 const mockFetchJSON = vi.hoisted(() => vi.fn());
@@ -111,10 +111,26 @@ describe('DevPreviewAffordance', () => {
     expect(screen.getByRole('button', { name: 'Details' })).toBeInTheDocument();
   });
 
-  test('polls only while ACTIVE: a collapsed row fetches once and then never again', async () => {
-    renderAffordance({ active: false });
-    await waitFor(() => expect(mockFetchJSON).toHaveBeenCalledTimes(1));
-    await new Promise((r) => setTimeout(r, 60));
-    expect(mockFetchJSON).toHaveBeenCalledTimes(1);
+  test('polls only while ACTIVE — proved across a FULL poll interval, so wiring `active` as always-on would fail this', async () => {
+    // The affordance polls on a 15s interval; a 60ms wall-clock wait would
+    // pass even if `active` were ignored. Fake timers advance past three
+    // intervals, and the ACTIVE case is the positive control that proves the
+    // advance actually drives SWR.
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+    try {
+      const collapsed = renderAffordance({ active: false });
+      await vi.waitFor(() => expect(mockFetchJSON).toHaveBeenCalledTimes(1));
+      await act(async () => { await vi.advanceTimersByTimeAsync(45_000); });
+      expect(mockFetchJSON).toHaveBeenCalledTimes(1);
+      collapsed.unmount();
+
+      mockFetchJSON.mockClear();
+      renderAffordance({ active: true });
+      await vi.waitFor(() => expect(mockFetchJSON).toHaveBeenCalledTimes(1));
+      await act(async () => { await vi.advanceTimersByTimeAsync(45_000); });
+      expect(mockFetchJSON.mock.calls.length).toBeGreaterThan(1);
+    } finally {
+      vi.useRealTimers();
+    }
   });
 });

--- a/apps/web/src/components/dev-preview/__tests__/DevPreviewPane.test.tsx
+++ b/apps/web/src/components/dev-preview/__tests__/DevPreviewPane.test.tsx
@@ -224,7 +224,7 @@ describe('DevPreviewPane', () => {
     act(() => useDevPreviewPaneStore.getState().openPreview(OPEN));
     renderPane();
     await screen.findByTestId('dev-preview-frame');
-    status = live({ canOpen: false, state: { status: 'down', targetPort: 5173, via: 'relay', error: null, message: 'The dev server on port 5173 is not listening any more.' } });
+    status = live({ canOpen: false, state: { status: 'down', targetPort: 5173, via: 'relay', error: null, repairable: false, message: 'The dev server on port 5173 is not listening any more.' } });
     fireEvent.click(screen.getByTitle('Reload the preview'));
     await screen.findByText('Down · :5173');
     expect(screen.getByTestId('dev-preview-frame')).toBeInTheDocument();

--- a/apps/web/src/components/dev-preview/__tests__/dev-preview-copy.test.ts
+++ b/apps/web/src/components/dev-preview/__tests__/dev-preview-copy.test.ts
@@ -11,7 +11,7 @@ describe('dev-preview copy', () => {
     expect(devPreviewBadge({ status: 'live', targetPort: 5173, via: 'relay', message: '' })).toEqual({ label: 'Live · :5173', tone: 'default' });
     expect(devPreviewBadge({ status: 'live', targetPort: 8080, via: 'direct', message: '' })).toEqual({ label: 'Live on :8080', tone: 'default' });
     expect(devPreviewBadge({ status: 'starting', targetPort: 3000, via: 'relay', message: '' }).tone).toBe('secondary');
-    expect(devPreviewBadge({ status: 'down', targetPort: 3000, via: 'relay', error: null, message: '' }).tone).toBe('destructive');
+    expect(devPreviewBadge({ status: 'down', targetPort: 3000, via: 'relay', error: null, repairable: true, message: '' }).tone).toBe('destructive');
     expect(devPreviewBadge({ status: 'blocked', targetPort: 3000, message: '' })).toEqual({ label: 'Port 8080 in use', tone: 'destructive' });
     expect(devPreviewBadge({ status: 'stopped', targetPort: 3000, stoppedAt: 'x', message: '' }).tone).toBe('outline');
     expect(devPreviewBadge({ status: 'stale', targetPort: 3000, message: '' }).label).toBe('Sandbox rebuilt');
@@ -22,7 +22,7 @@ describe('dev-preview copy', () => {
   it('offers an affordance line for every KNOWN dev server and none for "none"', () => {
     expect(devPreviewAffordanceText(preview({ status: 'live', targetPort: 5173, via: 'relay', message: '' }))).toBe('Dev server detected on :5173');
     expect(devPreviewAffordanceText(preview({ status: 'starting', targetPort: 5173, via: 'relay', message: '' }))).toBe('Dev server detected on :5173');
-    expect(devPreviewAffordanceText(preview({ status: 'down', targetPort: 5173, via: 'relay', error: null, message: '' }))).toContain('not responding');
+    expect(devPreviewAffordanceText(preview({ status: 'down', targetPort: 5173, via: 'relay', error: null, repairable: true, message: '' }))).toContain('not responding');
     expect(devPreviewAffordanceText(preview({ status: 'blocked', targetPort: 5173, message: '' }))).toContain('port 8080 is in use');
     expect(devPreviewAffordanceText(preview({ status: 'stopped', targetPort: 5173, stoppedAt: 'x', message: '' }))).toContain('switched off');
     expect(devPreviewAffordanceText(preview({ status: 'stale', targetPort: 5173, message: '' }))).toContain('started again');
@@ -44,7 +44,7 @@ describe('dev-preview copy', () => {
 
   it('the verb promises a live app only when the frame would show one', () => {
     expect(devPreviewAffordanceVerb({ ...preview({ status: 'live', targetPort: 1, via: 'relay', message: '' }), canOpen: true })).toBe('Preview');
-    expect(devPreviewAffordanceVerb(preview({ status: 'down', targetPort: 1, via: 'relay', error: null, message: '' }))).toBe('Details');
+    expect(devPreviewAffordanceVerb(preview({ status: 'down', targetPort: 1, via: 'relay', error: null, repairable: true, message: '' }))).toBe('Details');
     expect(devPreviewAffordanceVerb(preview({ status: 'blocked', targetPort: 1, message: '' }))).toBe('Details');
     expect(devPreviewAffordanceVerb(preview({ status: 'stale', targetPort: 1, message: '' }))).toBe('Details');
   });

--- a/apps/web/src/hooks/dev-preview/__tests__/useDevPreviewStatus.test.tsx
+++ b/apps/web/src/hooks/dev-preview/__tests__/useDevPreviewStatus.test.tsx
@@ -114,6 +114,41 @@ describe('useDevPreviewStatus — the hook against real SWR', () => {
     expect(calls).toBeGreaterThanOrEqual(3);
   });
 
+  it('a retry that comes due while the tab is HIDDEN is re-armed, not dropped: the status recovers on return without a mutate or a remount', async () => {
+    // The freeze this guards: SWR skips its interval while an error is
+    // cached and `revalidateOnFocus` is off, so the retry timer is the only
+    // thing that can un-freeze the status. Dropping it because the tab
+    // happened to be hidden at fire time froze the pane at its last good
+    // answer until the user remounted it.
+    let hidden = true;
+    const visibility = vi.spyOn(document, 'visibilityState', 'get').mockImplementation(() => (hidden ? 'hidden' : 'visible'));
+    try {
+      let calls = 0;
+      let failing = true;
+      mockFetchJSON.mockImplementation(async () => {
+        calls += 1;
+        if (failing) throw new ApiRequestError('boom', 500);
+        return { preview: preview({ state: { status: 'live', targetPort: 1, via: 'relay', message: '' }, canOpen: true }) };
+      });
+      const { result } = renderHook(() => useDevPreviewStatus('/p', { intervalMs: 30 }), { wrapper });
+      await waitFor(() => expect(result.current.error).toBeDefined());
+      const afterFirstError = calls;
+
+      // Many retry windows pass while hidden: NOTHING is requested (the
+      // `refreshWhenHidden: false` property this must not break)...
+      await new Promise((r) => setTimeout(r, 250));
+      expect(calls).toBe(afterFirstError);
+
+      // ...and coming back recovers on the very next window, with no mutate.
+      failing = false;
+      hidden = false;
+      await waitFor(() => expect(result.current.preview?.state.status).toBe('live'), { timeout: 3000 });
+      expect(result.current.error).toBeUndefined();
+    } finally {
+      visibility.mockRestore();
+    }
+  });
+
   it('with pauseWhenIdle: false an idle holder keeps being polled (the console header / pane case)', async () => {
     renderHook(() => useDevPreviewStatus('/p', { intervalMs: 15, pauseWhenIdle: false }), { wrapper });
     await waitFor(() => expect(mockFetchJSON.mock.calls.length).toBeGreaterThan(IDLE_ANSWERS_BEFORE_PAUSE + 2));

--- a/apps/web/src/hooks/dev-preview/useDevPreviewStatus.ts
+++ b/apps/web/src/hooks/dev-preview/useDevPreviewStatus.ts
@@ -140,13 +140,34 @@ export function useDevPreviewStatus(
     () => devPreviewRefreshInterval({ polling, pauseWhenIdle, idleStreak: idleStreak.current, intervalMs }),
     [polling, pauseWhenIdle, intervalMs],
   );
+  // SWR applies `refreshWhenHidden`/`refreshWhenOffline` to its OWN interval
+  // timer, not to a retry we schedule, and it cannot cancel ours on unmount.
+  // So the retry re-asks the same conditions AT FIRE TIME (still polling? tab
+  // visible? online?) and the pending timer is cleared when the hook goes away
+  // or its policy changes — otherwise a hidden tab or a collapsed row would
+  // keep calling the status route after everything else had stopped.
+  const retryTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const clearRetry = useCallback(() => {
+    if (retryTimer.current !== null) {
+      clearTimeout(retryTimer.current);
+      retryTimer.current = null;
+    }
+  }, []);
   const onErrorRetry = useCallback<NonNullable<SWRConfiguration['onErrorRetry']>>(
     (_error, _key, _config, revalidate, { retryCount }) => {
       const ms = nextInterval();
-      if (ms > 0) setTimeout(() => void revalidate({ retryCount }), ms);
+      if (ms <= 0) return;
+      clearRetry();
+      retryTimer.current = setTimeout(() => {
+        retryTimer.current = null;
+        const visible = typeof document === 'undefined' || document.visibilityState !== 'hidden';
+        const online = typeof navigator === 'undefined' || navigator.onLine !== false;
+        if (nextInterval() > 0 && visible && online) void revalidate({ retryCount });
+      }, ms);
     },
-    [nextInterval],
+    [nextInterval, clearRetry],
   );
+  useEffect(() => clearRetry, [clearRetry, key, polling, pauseWhenIdle, intervalMs]);
 
   const { data, error, isLoading, mutate } = useSWR<{ preview: DevPreviewStatusDTO }>(
     key,

--- a/apps/web/src/hooks/dev-preview/useDevPreviewStatus.ts
+++ b/apps/web/src/hooks/dev-preview/useDevPreviewStatus.ts
@@ -106,7 +106,10 @@ export function devPreviewRefreshInterval({
  *    an error is cached, so without a retry policy one transient 500 would
  *    stop the status forever. `onErrorRetry` re-asks at the same disciplined
  *    interval (never faster, never past the idle stop), keeping the last
- *    good answer on screen meanwhile.
+ *    good answer on screen meanwhile. Hidden or offline at fire time it does
+ *    not request — and does not give up either: it re-arms and asks again,
+ *    because with an error cached and `revalidateOnFocus: false` this timer
+ *    is the ONLY thing that can unfreeze the status.
  *
  * The interval callback is memoized: SWR restarts its timer whenever that
  * function's identity changes, so an inline arrow in a component that
@@ -155,15 +158,34 @@ export function useDevPreviewStatus(
   }, []);
   const onErrorRetry = useCallback<NonNullable<SWRConfiguration['onErrorRetry']>>(
     (_error, _key, _config, revalidate, { retryCount }) => {
-      const ms = nextInterval();
-      if (ms <= 0) return;
-      clearRetry();
-      retryTimer.current = setTimeout(() => {
-        retryTimer.current = null;
-        const visible = typeof document === 'undefined' || document.visibilityState !== 'hidden';
-        const online = typeof navigator === 'undefined' || navigator.onLine !== false;
-        if (nextInterval() > 0 && visible && online) void revalidate({ retryCount });
-      }, ms);
+      const schedule = (): void => {
+        const ms = nextInterval();
+        // 0 is the DISCIPLINED stop — `polling: false`, or the idle pause.
+        // Dropping the timer there is correct: the policy that re-arms it
+        // (expand, pane closed) re-renders the hook.
+        if (ms <= 0) return;
+        clearRetry();
+        retryTimer.current = setTimeout(() => {
+          retryTimer.current = null;
+          const visible = typeof document === 'undefined' || document.visibilityState !== 'hidden';
+          const online = typeof navigator === 'undefined' || navigator.onLine !== false;
+          // HIDDEN OR OFFLINE IS A REASON TO WAIT, NEVER A REASON TO GIVE UP.
+          // This timer is the ONLY thing that can un-freeze the status once an
+          // error is cached: SWR skips interval revalidation while it holds
+          // one, and `revalidateOnFocus: false` means coming back to the tab
+          // revalidates nothing. Dropping it here left the status frozen at
+          // the last good answer until a manual `mutate()` or a remount. So
+          // re-arm at the same disciplined interval and re-ask next time —
+          // no request is made while hidden or offline, which is the property
+          // `refreshWhenHidden: false` was protecting in the first place.
+          if (!visible || !online) {
+            schedule();
+            return;
+          }
+          if (nextInterval() > 0) void revalidate({ retryCount });
+        }, ms);
+      };
+      schedule();
     },
     [nextInterval, clearRetry],
   );

--- a/apps/web/src/lib/dev-preview/__tests__/action-response.test.ts
+++ b/apps/web/src/lib/dev-preview/__tests__/action-response.test.ts
@@ -1,0 +1,67 @@
+/**
+ * The shared HTTP answer to a dev-preview user action. The one thing this
+ * module must never do is call an accepted action a failure: `post()` throws
+ * on any 4xx, so a status code chosen here becomes a red toast in the pane.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('@pagespace/lib/audit/audit-log', () => ({ auditRequest: vi.fn() }));
+
+import { auditRequest } from '@pagespace/lib/audit/audit-log';
+import type { DevPreviewUserActionResult } from '@pagespace/lib/services/sandbox/preview/dev-preview-status';
+import { respondToDevPreviewUserAction } from '../action-response';
+
+const ENV = { kind: 'env', id: 'env1' } as const;
+const WS = { kind: 'workspace', id: 'ws1' } as const;
+
+const respond = (result: DevPreviewUserActionResult, holder: typeof ENV | typeof WS = ENV) =>
+  respondToDevPreviewUserAction({
+    request: new Request('https://app.test/api/x', { method: 'POST' }),
+    userId: 'u1',
+    route: 'POST /api/x',
+    holder,
+    action: 'resume',
+    result,
+  });
+
+beforeEach(() => vi.mocked(auditRequest).mockClear());
+
+describe('respondToDevPreviewUserAction', () => {
+  it('an applied action is 200 with what was applied', async () => {
+    const res = respond({ ok: true, applied: { action: 'start-relay' } as never });
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ ok: true, applied: { action: 'start-relay' } });
+  });
+
+  it('slot-unknown is a DEFERRAL, not a failure: 200, ok:true, and the deferral named', async () => {
+    const res = respond({ ok: false, reason: 'slot-unknown' });
+    // The intent is already written — the resume cleared the stop — and only
+    // the relay start waits for a real `ports/watch` snapshot. A 4xx here made
+    // `post()` throw and the pane toast "Could not switch the preview on" over
+    // a click that had taken effect.
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ ok: true, applied: null, deferred: 'awaiting-port-snapshot' });
+    expect(vi.mocked(auditRequest).mock.calls[0]?.[1]).toMatchObject({
+      eventType: 'data.write',
+      resourceId: 'env:env1',
+      details: { route: 'POST /api/x', action: 'resume', applied: null, deferred: 'awaiting-port-snapshot' },
+    });
+  });
+
+  it('no-preview is still a 404 naming the holder kind, and writes no data.write row', async () => {
+    const env = respond({ ok: false, reason: 'no-preview' });
+    expect(env.status).toBe(404);
+    expect((await env.json()).error).toContain('environment');
+    const ws = respond({ ok: false, reason: 'no-preview' }, WS);
+    expect(ws.status).toBe(404);
+    expect((await ws.json()).error).toContain('session');
+    expect(vi.mocked(auditRequest).mock.calls.map((c) => c[1].eventType)).not.toContain('data.write');
+  });
+
+  it('a refused wake is 403 with the denial audited', async () => {
+    const res = respond({ ok: false, reason: 'wake-not-allowed', detail: 'no_credits' });
+    expect(res.status).toBe(403);
+    expect(await res.json()).toEqual({ error: expect.stringContaining('cannot run code'), reason: 'no_credits' });
+    expect(vi.mocked(auditRequest).mock.calls[0]?.[1]).toMatchObject({ eventType: 'authz.access.denied', riskScore: 0.5 });
+  });
+});

--- a/apps/web/src/lib/dev-preview/action-response.ts
+++ b/apps/web/src/lib/dev-preview/action-response.ts
@@ -30,6 +30,19 @@ export function respondToDevPreviewUserAction({
       auditRequest(request, { eventType: 'authz.access.denied', userId, resourceType: 'dev_preview', resourceId, details: { route, action, reason: 'wake_not_allowed', detail: result.detail }, riskScore: 0.5 });
       return NextResponse.json({ error: 'This drive cannot run code right now, so the preview cannot be switched back on', reason: result.detail }, { status: 403 });
     }
+    // `slot-unknown` IS NOT A FAILURE, and answering 4xx made the UI say it
+    // was. The user's intent is already written — the resume cleared the stop
+    // — and only the relay work deferred, because no `ports/watch` snapshot
+    // proved 8080 free; the detector's next frame starts it against a real
+    // snapshot. `post()` THROWS on any 4xx, so the pane toasted "Could not
+    // switch the preview on" over a click that had taken effect. It is
+    // therefore the same success shape an attach-less action already returns
+    // (`applied: null`), with the deferral named so a caller can say
+    // "starting shortly" if it wants.
+    if (result.reason === 'slot-unknown') {
+      auditRequest(request, { eventType: 'data.write', userId, resourceType: 'dev_preview', resourceId, details: { route, action, applied: null, deferred: 'awaiting-port-snapshot' } });
+      return NextResponse.json({ ok: true, applied: null, deferred: 'awaiting-port-snapshot' });
+    }
     return NextResponse.json(
       { error: holder.kind === 'env' ? 'This environment has no dev-server preview to switch' : 'This session has no dev-server preview to switch', reason: result.reason },
       { status: 404 },

--- a/packages/lib/src/services/sandbox/preview/__tests__/dev-preview-core.test.ts
+++ b/packages/lib/src/services/sandbox/preview/__tests__/dev-preview-core.test.ts
@@ -467,13 +467,13 @@ describe('describeServiceState', () => {
       given: 'relay failed with an error and no stop intent',
       should: 'be down carrying the error',
       actual: describeServiceState({ liveInstanceId: INSTANCE, row, relay: relayService(5173, { status: 'failed', error: 'exited with code 1' }), listeners: [] }),
-      expected: { status: 'down', targetPort: 5173, via: 'relay', error: 'exited with code 1', message: 'The preview relay for port 5173 is not running (exited with code 1).' },
+      expected: { status: 'down', targetPort: 5173, via: 'relay', error: 'exited with code 1', repairable: true, message: 'The preview relay for port 5173 is not running (exited with code 1).' },
     });
     assert({
       given: 'a relay row but no relay defined',
       should: 'be down with a null error',
       actual: describeServiceState({ liveInstanceId: INSTANCE, row, relay: null, listeners: [] }),
-      expected: { status: 'down', targetPort: 5173, via: 'relay', error: null, message: 'The preview relay for port 5173 is not defined on this sandbox.' },
+      expected: { status: 'down', targetPort: 5173, via: 'relay', error: null, repairable: true, message: 'The preview relay for port 5173 is not defined on this sandbox.' },
     });
   });
 
@@ -483,7 +483,7 @@ describe('describeServiceState', () => {
       given: 'row=5173 but the (single-named) relay service is running for 3000 — a replace whose row write was lost',
       should: 'be down naming the mismatch, not live',
       actual: describeServiceState({ liveInstanceId: INSTANCE, row, relay: relayService(3000), listeners: null }),
-      expected: { status: 'down', targetPort: 5173, via: 'relay', error: null, message: 'The preview relay on this sandbox forwards to a different port than 5173; it will be re-pointed on the next reconcile.' },
+      expected: { status: 'down', targetPort: 5173, via: 'relay', error: null, repairable: true, message: 'The preview relay on this sandbox forwards to a different port than 5173; it will be re-pointed on the next reconcile.' },
     });
     assert({
       given: 'the same mismatch while the relay is starting',
@@ -524,8 +524,39 @@ describe('describeServiceState', () => {
       given: 'direct row, but a leftover relay is still running on 8080',
       should: 'be down naming the leftover relay (same slot-holder read as the relay branch)',
       actual: describeServiceState({ liveInstanceId: INSTANCE, row, relay: relayService(5173), listeners: [{ port: 8080, pid: 42 }] }),
-      expected: { status: 'down', targetPort: 8080, via: 'direct', error: null, message: 'A leftover preview relay still holds port 8080; it will be removed on the next reconcile.' },
+      expected: { status: 'down', targetPort: 8080, via: 'direct', error: null, repairable: true, message: 'A leftover preview relay still holds port 8080; it will be removed on the next reconcile.' },
     });
+  });
+
+  /**
+   * `down.repairable` is a PROMISE ABOUT THE PLANNER, so it is asserted
+   * against the planner rather than restated: for every `down` a reconcile
+   * can reach, run the exact plan a resume would run (`detected: null`, same
+   * row, same relay, same snapshot) and require `repairable` to equal
+   * "this plan does something". A `none` plan (`already-direct` /
+   * `already-relaying`) is a Restart button that provably no-ops.
+   */
+  it('repairable says exactly whether a reconcile\'s plan would change anything', () => {
+    const cases: { name: string; row: DevPreviewRow; relay: SandboxServiceInfo | null; listeners: readonly { port: number; pid?: number }[] }[] = [
+      { name: 'relay crashed', row: relayRow(5173), relay: relayService(5173, { status: 'failed', error: 'boom' }), listeners: [{ port: 5173, pid: 7 }] },
+      { name: 'relay undefined', row: relayRow(5173), relay: null, listeners: [{ port: 5173, pid: 7 }] },
+      { name: 'relay pointed elsewhere', row: relayRow(5173), relay: relayService(3000), listeners: [{ port: 5173, pid: 7 }] },
+      { name: 'relay running, target gone', row: relayRow(5173), relay: relayService(5173), listeners: [{ port: SPRITE_HTTP_PORT, pid: 42 }] },
+      { name: 'direct row, leftover relay on 8080', row: relayRow(SPRITE_HTTP_PORT), relay: relayService(5173), listeners: [{ port: SPRITE_HTTP_PORT, pid: 42 }] },
+      { name: 'direct row, server gone', row: relayRow(SPRITE_HTTP_PORT), relay: null, listeners: [] },
+    ];
+    for (const { name, row, relay, listeners } of cases) {
+      const state = describeServiceState({ liveInstanceId: INSTANCE, row, relay, listeners });
+      expect(state.status, `${name} should be down`).toBe('down');
+      if (state.status !== 'down') continue;
+      const plan = planDevServerService(planInput({ row, relay, listeners, detected: null }));
+      assert({
+        given: name,
+        should: 'mark repairable iff the resume\'s own plan is not a no-op',
+        actual: [state.repairable, plan.action === 'none' ? `none:${plan.reason}` : plan.action],
+        expected: [plan.action !== 'none', plan.action === 'none' ? `none:${plan.reason}` : plan.action],
+      });
+    }
   });
 
   it('has no public-exposure state anywhere in its vocabulary', () => {

--- a/packages/lib/src/services/sandbox/preview/__tests__/dev-preview-detection.test.ts
+++ b/packages/lib/src/services/sandbox/preview/__tests__/dev-preview-detection.test.ts
@@ -208,12 +208,15 @@ describe('createDevPreviewDetector — discipline', () => {
     assert({ given: 'a snapshot that has ARRIVED but not applied', should: 'still be null', actual: detector.listeners(), expected: null });
     await applied;
     assert({ given: 'an applied snapshot', should: 'be known', actual: detector.listeners(), expected: [{ port: 3000, pid: 9 }] });
-    // Drop: a snapshot from the dropped connection is still queued AHEAD of the invalidation.
+    // Drop: the invalidation takes effect AT ONCE (a reader between the close
+    // and the next snapshot must not see the dead connection's set)...
     const late = detector.onFrame({ type: 'port_list', ports: [{ port: 4000 }] });
     detector.invalidateSnapshot();
+    assert({ given: 'a socket close', should: 'be unknown immediately, not after the queue drains', actual: detector.listeners(), expected: null });
+    // ...and the closed connection's snapshot, applying afterwards, cannot claim it back.
     await late;
     await new Promise((r) => setTimeout(r, 0));
-    assert({ given: 'invalidation queued after a late snapshot', should: 'end unknown', actual: detector.listeners(), expected: null });
+    assert({ given: 'a snapshot from the closed connection applying late', should: 'stay unknown', actual: detector.listeners(), expected: null });
     await detector.onFrame({ type: 'port_list', ports: [{ port: 5000 }] });
     assert({ given: 'the next connection\'s snapshot', should: 'be known again', actual: detector.listeners(), expected: [{ port: 5000 }] });
   });

--- a/packages/lib/src/services/sandbox/preview/__tests__/dev-preview-status.test.ts
+++ b/packages/lib/src/services/sandbox/preview/__tests__/dev-preview-status.test.ts
@@ -152,7 +152,12 @@ describe('buildDevPreviewStatus — pure fold', () => {
 
   it('a starting relay is openable (the frame will show it coming up); a down one is not', () => {
     assert({ given: 'starting', should: 'canOpen', actual: buildDevPreviewStatus({ ...base, row: row(3000), relay: relayService(3000, { status: 'starting' }), listeners: null }).canOpen, expected: true });
-    assert({ given: 'down', should: 'not canOpen but still canStop', actual: (() => { const s = buildDevPreviewStatus({ ...base, row: row(3000), relay: relayService(3000, { status: 'failed', error: 'x' }), listeners: null }); return [s.canOpen, s.canStop]; })(), expected: [false, true] });
+    assert({
+      given: 'down',
+      should: 'not canOpen, still canStop, AND canResume — a crashed relay is recoverable in one click instead of waiting for a port frame',
+      actual: (() => { const s = buildDevPreviewStatus({ ...base, row: row(3000), relay: relayService(3000, { status: 'failed', error: 'x' }), listeners: null }); return [s.canOpen, s.canStop, s.canResume]; })(),
+      expected: [false, true, true],
+    });
   });
 
   it('carries the holder, the open path and detectedAt through', () => {
@@ -261,11 +266,32 @@ describe('applyDevPreviewUserAction — intent first, then ONE reconcile through
     const { deps, store } = actionDeps({
       store: fakeStore(row(5173, { stoppedByUserAt: NOW })),
       attach: async () => fakeHandle({ relay: relayService(5173, { status: 'failed', error: 'exited with code 143' }), calls: trackedCalls }),
+      // A CURRENT snapshot: the dev server is up and 8080 is free, so the
+      // relay may honestly be started (see the slot-unknown case below).
+      readListeners: async () => [{ port: 5173, pid: 7 }],
     });
     const result = await applyDevPreviewUserAction({ holder: ENV, action: 'resume', ...ACTOR, deps });
     assert({ given: 'a stopped relay', should: 'start it and re-record the row', actual: result, expected: { ok: true, applied: { action: 'start-relay', via: 'start', targetPort: 5173, recorded: true } } });
     assert({ given: 'the resume', should: 'call services.start', actual: trackedCalls.includes(`start:${PREVIEW_RELAY_SERVICE_NAME}`), expected: true });
     assert({ given: 'the resume', should: 'leave stoppedByUserAt cleared', actual: store.current()?.stoppedByUserAt, expected: null });
+  });
+
+  it('RESUME with NO current snapshot refuses to start a relay blind — the intent is still cleared, so the detector\'s next frame starts it against real listeners', async () => {
+    const trackedCalls: string[] = [];
+    const store = fakeStore(row(5173, { stoppedByUserAt: NOW }));
+    const { deps } = actionDeps({
+      store,
+      attach: async () => fakeHandle({ relay: relayService(5173, { status: 'failed' }), calls: trackedCalls }),
+      readListeners: async () => null,
+    });
+    assert({ given: 'no ports/watch snapshot', should: 'refuse rather than read unknown as "8080 is free"', actual: await applyDevPreviewUserAction({ holder: ENV, action: 'resume', ...ACTOR, deps }), expected: { ok: false, reason: 'slot-unknown' } });
+    assert({ given: 'the refusal', should: 'still have cleared the stop — the user\'s ON stands', actual: store.current()?.stoppedByUserAt, expected: null });
+    assert({ given: 'the refusal', should: 'touch no service', actual: trackedCalls.some((c) => c.startsWith('start:') || c.startsWith('create:')), expected: false });
+  });
+
+  it('a DIRECT (8080) resume needs no snapshot — there is no relay to place', async () => {
+    const { deps } = actionDeps({ store: fakeStore(row(SPRITE_HTTP_PORT, { stoppedByUserAt: NOW })), attach: async () => fakeHandle({ relay: null }), readListeners: async () => null });
+    assert({ given: 'a direct row and no snapshot', should: 'converge without refusing', actual: await applyDevPreviewUserAction({ holder: ENV, action: 'resume', ...ACTOR, deps }), expected: { ok: true, applied: { action: 'none', reason: 'already-direct', staleRowIgnored: false } } });
   });
 
   it('RESUME against a slot a user process has since taken is REFUSED by the core (with the snapshot), not planned', async () => {

--- a/packages/lib/src/services/sandbox/preview/__tests__/dev-preview-status.test.ts
+++ b/packages/lib/src/services/sandbox/preview/__tests__/dev-preview-status.test.ts
@@ -160,6 +160,37 @@ describe('buildDevPreviewStatus — pure fold', () => {
     });
   });
 
+  /**
+   * Restart is offered only where a reconcile can repair it. Not every `down`
+   * is the relay's fault: a direct server that stopped listening, and a
+   * healthy relay whose TARGET vanished, both plan to `none` — the button
+   * would refresh into the identical down state, which reads as a broken
+   * control rather than an honest "start your dev server again".
+   */
+  it('canResume follows the core\'s down.repairable, not the bare down status', () => {
+    const repairable = [
+      ['crashed relay', row(3000), relayService(3000, { status: 'failed', error: 'x' }), null],
+      ['relay never defined', row(3000), null, [{ port: 3000, pid: 7 }]],
+      ['relay pointed elsewhere', row(3000), relayService(4000), [{ port: 3000, pid: 7 }]],
+      ['leftover relay over a direct row', row(SPRITE_HTTP_PORT), relayService(3000), [{ port: SPRITE_HTTP_PORT, pid: 42 }]],
+    ] as const;
+    const notRepairable = [
+      ['relay up but the dev server exited', row(3000), relayService(3000), [{ port: SPRITE_HTTP_PORT, pid: 42 }]],
+      ['direct server stopped listening', row(SPRITE_HTTP_PORT), null, []],
+    ] as const;
+    for (const [name, r, relay, listeners] of repairable) {
+      const s = buildDevPreviewStatus({ ...base, row: r, relay, listeners });
+      assert({ given: name, should: 'be a repairable down that offers Restart', actual: [s.state.status, s.state.status === 'down' && s.state.repairable, s.canResume], expected: ['down', true, true] });
+    }
+    for (const [name, r, relay, listeners] of notRepairable) {
+      const s = buildDevPreviewStatus({ ...base, row: r, relay, listeners });
+      assert({ given: name, should: 'be down with NO Restart — a reconcile would change nothing', actual: [s.state.status, s.state.status === 'down' && s.state.repairable, s.canResume], expected: ['down', false, false] });
+    }
+    // …but an explicit user stop is always resumable, whatever the state says.
+    const stopped = buildDevPreviewStatus({ ...base, row: row(SPRITE_HTTP_PORT, { stoppedByUserAt: NOW }), relay: null, listeners: [] });
+    assert({ given: 'a user-stopped direct row whose server is also gone', should: 'still offer resume — the intent is the users to reverse', actual: stopped.canResume, expected: true });
+  });
+
   it('carries the holder, the open path and detectedAt through', () => {
     const status = buildDevPreviewStatus({ ...base, holder: WS, openPath: '/api/agent-workspaces/ws1/preview/open', row: row(5173), relay: relayService(5173), listeners: null });
     assert({ given: 'a workspace reader', should: 'echo holder, openPath, detectedAt', actual: [status.holder, status.openPath, status.detectedAt], expected: [WS, '/api/agent-workspaces/ws1/preview/open', new Date('2026-09-06T11:00:00.000Z')] });

--- a/packages/lib/src/services/sandbox/preview/__tests__/preview-forward-gate.test.ts
+++ b/packages/lib/src/services/sandbox/preview/__tests__/preview-forward-gate.test.ts
@@ -74,7 +74,7 @@ describe('decidePreviewForward — order of refusal', () => {
     [{ status: 'instance-unknown', message: 'unknown' }, 'instance-unknown', 409],
     [{ status: 'stopped', targetPort: 3000, stoppedAt: new Date(0), message: 'off' }, 'stopped-by-user', 409],
     [{ status: 'blocked', targetPort: 3000, message: 'busy' }, 'http-port-busy', 409],
-    [{ status: 'down', targetPort: 3000, via: 'relay', error: null, message: 'down' }, 'preview-down', 502],
+    [{ status: 'down', targetPort: 3000, via: 'relay', error: null, repairable: true, message: 'down' }, 'preview-down', 502],
     [{ status: 'starting', targetPort: 3000, via: 'relay', message: 'starting' }, 'preview-starting', 503],
   ] as const)('refuses a %o preview and never routes it (the stale-instance rule)', (state, reason, status) => {
     const decision = decidePreviewForward(input({ state: state as DevPreviewServiceState, power: 'paused' }));

--- a/packages/lib/src/services/sandbox/preview/dev-preview-core.ts
+++ b/packages/lib/src/services/sandbox/preview/dev-preview-core.ts
@@ -519,7 +519,31 @@ export type DevPreviewServiceState =
   | { status: 'stopped'; targetPort: number; stoppedAt: Date; message: string }
   | { status: 'starting'; targetPort: number; via: 'relay'; message: string }
   | { status: 'live'; targetPort: number; via: 'relay' | 'direct'; message: string }
-  | { status: 'down'; targetPort: number; via: 'relay' | 'direct'; error: string | null; message: string }
+  | {
+      status: 'down';
+      targetPort: number;
+      via: 'relay' | 'direct';
+      error: string | null;
+      message: string;
+      /**
+       * Whether a RECONCILE (the `resume` user action, or the detector's next
+       * frame) can actually repair this. `down` covers two different
+       * situations and only one of them is ours to fix:
+       *
+       *  - `true` — the RELAY is the broken part: crashed, undefined,
+       *    pointing at the wrong port, or holding 8080 in front of a direct
+       *    row. {@link planDevServerService} answers `start-relay`,
+       *    `replace-relay` or `record-direct`, so one reconcile repairs it
+       *    and a Restart control is worth offering.
+       *  - `false` — the USER'S SERVER is the broken part: the direct row's
+       *    8080 server, or a relay's target, stopped listening. The planner
+       *    answers `already-direct` / `already-relaying` — nothing to do —
+       *    so a reconcile changes nothing and the status comes back down
+       *    with the same button. Only starting the dev server again fixes
+       *    it, and saying so is more honest than a control that no-ops.
+       */
+      repairable: boolean;
+    }
   | { status: 'blocked'; targetPort: number; message: string };
 
 /** Pure: does this relay service forward to `targetPort`, under either runtime? */
@@ -564,10 +588,13 @@ export function describeServiceState({ liveInstanceId, row, relay, listeners }: 
     // way round: a user process is what we want here, a live relay is a
     // leftover that has taken the port from under the user's server.
     if (holder === 'relay') {
-      return { status: 'down', targetPort: row.targetPort, via: 'direct', error: null, message: `A leftover preview relay still holds port ${SPRITE_HTTP_PORT}; it will be removed on the next reconcile.` };
+      // Ours to fix: the reconcile plans `record-direct` with `removeRelay`.
+      return { status: 'down', targetPort: row.targetPort, via: 'direct', error: null, repairable: true, message: `A leftover preview relay still holds port ${SPRITE_HTTP_PORT}; it will be removed on the next reconcile.` };
     }
     if (targetListening === false) {
-      return { status: 'down', targetPort: row.targetPort, via: 'direct', error: null, message: `Nothing is listening on port ${SPRITE_HTTP_PORT} any more.` };
+      // NOT ours to fix: the planner answers `already-direct`. Only the user
+      // starting their server on 8080 again brings this back.
+      return { status: 'down', targetPort: row.targetPort, via: 'direct', error: null, repairable: false, message: `Nothing is listening on port ${SPRITE_HTTP_PORT} any more.` };
     }
     return { status: 'live', targetPort: row.targetPort, via: 'direct', message: `Serving port ${SPRITE_HTTP_PORT} directly.` };
   }
@@ -575,7 +602,8 @@ export function describeServiceState({ liveInstanceId, row, relay, listeners }: 
   if (holder === 'user-process') return { status: 'blocked', targetPort: row.targetPort, message: HTTP_PORT_BUSY_MESSAGE };
 
   if (relay === null || relay.name !== row.relayServiceName) {
-    return { status: 'down', targetPort: row.targetPort, via: 'relay', error: null, message: `The preview relay for port ${row.targetPort} is not defined on this sandbox.` };
+    // Ours to fix: the reconcile creates (or replaces) the relay.
+    return { status: 'down', targetPort: row.targetPort, via: 'relay', error: null, repairable: true, message: `The preview relay for port ${row.targetPort} is not defined on this sandbox.` };
   }
   // The relay has ONE name, so the name proves nothing about WHERE it forwards.
   // A replace whose service call landed but whose row write did not leaves the
@@ -584,23 +612,29 @@ export function describeServiceState({ liveInstanceId, row, relay, listeners }: 
   // The runtime is not on the row, so either runtime's spec for this port is
   // accepted; anything else is a relay for another port.
   if (!relayTargets(relay, row.targetPort)) {
-    return { status: 'down', targetPort: row.targetPort, via: 'relay', error: null, message: `The preview relay on this sandbox forwards to a different port than ${row.targetPort}; it will be re-pointed on the next reconcile.` };
+    // Ours to fix: the reconcile plans `replace-relay`.
+    return { status: 'down', targetPort: row.targetPort, via: 'relay', error: null, repairable: true, message: `The preview relay on this sandbox forwards to a different port than ${row.targetPort}; it will be re-pointed on the next reconcile.` };
   }
   if (relay.status === 'starting') {
     return { status: 'starting', targetPort: row.targetPort, via: 'relay', message: `Starting the preview relay for port ${row.targetPort}…` };
   }
   if (relay.status === 'running') {
     if (targetListening === false) {
-      return { status: 'down', targetPort: row.targetPort, via: 'relay', error: null, message: `The dev server on port ${row.targetPort} is not listening any more.` };
+      // NOT ours to fix: the relay is up and correct, so the planner answers
+      // `already-relaying`. The user's dev server has to come back first.
+      return { status: 'down', targetPort: row.targetPort, via: 'relay', error: null, repairable: false, message: `The dev server on port ${row.targetPort} is not listening any more.` };
     }
     return { status: 'live', targetPort: row.targetPort, via: 'relay', message: `Relaying port ${SPRITE_HTTP_PORT} to your dev server on port ${row.targetPort}.` };
   }
   // failed / stopped / stopping / unknown — with no stopped-by-user intent this is a crash, whatever the platform calls it (§4).
+  // Ours to fix: a defined, correctly-pointed relay that is not running is
+  // exactly what `start-relay` via `'start'` restarts.
   return {
     status: 'down',
     targetPort: row.targetPort,
     via: 'relay',
     error: relay.error ?? null,
+    repairable: true,
     message: `The preview relay for port ${row.targetPort} is not running${relay.error ? ` (${relay.error})` : ''}.`,
   };
 }

--- a/packages/lib/src/services/sandbox/preview/dev-preview-core.ts
+++ b/packages/lib/src/services/sandbox/preview/dev-preview-core.ts
@@ -312,6 +312,18 @@ export interface PlanDevServerServiceInput {
   relay: SandboxServiceInfo | null;
   /** Ports currently bound in the sprite. */
   listeners: readonly ListeningPort[];
+  /**
+   * Whether {@link PlanDevServerServiceInput.listeners} is a CURRENT snapshot
+   * of the sprite, or merely what the caller happens to hold. Default `true`
+   * — the detector plans on a frame it just observed. A caller reconciling
+   * without a live `ports/watch` snapshot (a user's resume while the watcher
+   * is starting up or reconnecting) passes `false`, and a plan that would
+   * START a relay is refused rather than made against an empty listener set:
+   * "unknown" must never be read as "8080 is free", the same rule
+   * `describeServiceState`'s `listeners: null` obeys. Nothing else changes —
+   * a direct 8080 row needs no relay, and stopping never needs the slot.
+   */
+  listenersKnown?: boolean;
   /** Chosen by the effects layer after probing the sprite; `'node'` is the verified default. */
   relayRuntime?: PreviewRelayRuntime;
   now: Date;
@@ -384,7 +396,14 @@ export type DevServerServicePlan =
         /** No instance id ⇒ no proof ⇒ no plan. */
         | 'instance-unknown'
         /** Something that is not our relay holds 8080 — the honest fallback is "run your server on 8080". */
-        | 'http-port-busy';
+        | 'http-port-busy'
+        /**
+         * A relay would have to be started, but no current listener snapshot
+         * proves 8080 is free. Refusing costs a retry; planning against an
+         * assumed-empty set would start a relay that may fail to bind and
+         * leave a state nobody can explain.
+         */
+        | 'slot-unknown';
       targetPort?: number;
     };
 
@@ -439,6 +458,12 @@ export function planDevServerService(input: PlanDevServerServiceInput): DevServe
 
   if (describeHttpPortSlot({ listeners, relay }) === 'user-process') {
     return { action: 'refuse', reason: 'http-port-busy', targetPort };
+  }
+  // A relay is about to be started or re-pointed, and the slot can only be
+  // called free from a CURRENT snapshot. `already-relaying` returns above, so
+  // a healthy preview is unaffected — this refuses only a START planned blind.
+  if (input.listenersKnown === false) {
+    return { action: 'refuse', reason: 'slot-unknown', targetPort };
   }
 
   const service = buildPreviewRelaySpec({ targetPort, runtime: relayRuntime });

--- a/packages/lib/src/services/sandbox/preview/dev-preview-detection.ts
+++ b/packages/lib/src/services/sandbox/preview/dev-preview-detection.ts
@@ -80,11 +80,12 @@ export interface DevPreviewDetector {
   listeners(): ListeningPort[] | null;
   /**
    * The watch connection dropped: the accumulated set no longer describes a
-   * live connection. QUEUED on the frame chain, so a `port_list` from the
-   * dropped connection that is still waiting to apply lands BEFORE the
-   * invalidation and can never mark the next connection's snapshot known —
-   * FIFO ordering makes that correct by construction, with no generation
-   * bookkeeping outside the detector.
+   * live connection. Takes effect IMMEDIATELY — a `listeners()` between the
+   * close and the next connection's snapshot must not be answered from the
+   * dead connection's set, so this cannot wait behind queued frame work.
+   * Frames already enqueued are tagged with the epoch they arrived in, so a
+   * `port_list` from the closed connection that applies afterwards cannot
+   * mark the NEXT connection's snapshot known either.
    */
   invalidateSnapshot(): void;
 }
@@ -97,6 +98,11 @@ export function createDevPreviewDetector(deps: DevPreviewDetectorDeps): DevPrevi
   const listeners = new Map<number, ListeningPort>();
   /** True once a `port_list` has been applied and no invalidation has landed since. */
   let snapshotKnown = false;
+  /**
+   * Bumped by every invalidation. A frame carries the epoch it ARRIVED in, so
+   * work that applies after its connection died cannot claim the snapshot.
+   */
+  let epoch = 0;
   let runtime: PreviewRelayRuntime | undefined;
   let chain: Promise<void> = Promise.resolve();
 
@@ -127,11 +133,12 @@ export function createDevPreviewDetector(deps: DevPreviewDetectorDeps): DevPrevi
     return applyDevServerServicePlan({ plan, services: handle.services, store });
   }
 
-  async function handle_(frame: PortsWatchFrame): Promise<void> {
+  async function handle_(frame: PortsWatchFrame, frameEpoch: number): Promise<void> {
     if (frame.type === 'port_list') {
       listeners.clear();
       for (const port of frame.ports) listeners.set(port.port, port);
-      snapshotKnown = true;
+      // Only this connection's own snapshot may mark the set known.
+      if (frameEpoch === epoch) snapshotKnown = true;
       // A snapshot is every port bound BEFORE we attached. Classify each
       // against the current relay and plan ONE candidate: the row's own
       // target if it is still listening (a reconnect must never re-point a
@@ -168,7 +175,10 @@ export function createDevPreviewDetector(deps: DevPreviewDetectorDeps): DevPrevi
 
   return {
     onFrame(frame) {
-      const next = chain.then(() => handle_(frame)).catch((error: unknown) => {
+      // The epoch is captured at ARRIVAL, not at apply time: that is what
+      // makes a frame belong to the connection it came from.
+      const frameEpoch = epoch;
+      const next = chain.then(() => handle_(frame, frameEpoch)).catch((error: unknown) => {
         log.error('dev-preview: frame failed', error instanceof Error ? error : new Error(String(error)), { ...context(), frame: frame.type });
       });
       chain = next;
@@ -176,9 +186,8 @@ export function createDevPreviewDetector(deps: DevPreviewDetectorDeps): DevPrevi
     },
     listeners: () => (snapshotKnown ? [...listeners.values()] : null),
     invalidateSnapshot() {
-      chain = chain.then(() => {
-        snapshotKnown = false;
-      });
+      snapshotKnown = false;
+      epoch += 1;
     },
   };
 }

--- a/packages/lib/src/services/sandbox/preview/dev-preview-status.ts
+++ b/packages/lib/src/services/sandbox/preview/dev-preview-status.ts
@@ -91,7 +91,14 @@ export interface DevPreviewStatus {
   canOpen: boolean;
   /** True when a Stop control makes sense: there is a row on this instance and the user has not already stopped it. */
   canStop: boolean;
-  /** True when the user has switched the preview off and may switch it back on. */
+  /**
+   * True when the preview can be (re)started by hand: the user switched it
+   * off, or the relay is DOWN — a crashed relay, or one a reconcile has not
+   * caught up with — and one click should be able to ask for it back rather
+   * than leaving the user waiting for a port frame that may never come.
+   * Both go through the same `resume` action (clearing an already-null stop
+   * intent is a no-op; the reconcile is the point).
+   */
   canResume: boolean;
   /** When the dev server this row answers was detected, or null with no row. */
   detectedAt: Date | null;
@@ -178,7 +185,7 @@ export function buildDevPreviewStatus({ holder, sandbox, liveInstanceId, row, re
     openPath,
     canOpen: state.status === 'live' || state.status === 'starting',
     canStop: actionable && row.stoppedByUserAt === null,
-    canResume: actionable && row.stoppedByUserAt !== null,
+    canResume: actionable && (row.stoppedByUserAt !== null || state.status === 'down'),
     detectedAt: row?.detectedAt ?? null,
   };
 }
@@ -269,7 +276,15 @@ export type DevPreviewUserActionResult =
   /** The holder has no preview row — nothing to switch. */
   | { ok: false; reason: 'no-preview' }
   /** A RESUME the holder's payer may not spend compute on — the wake gate said no. Nothing was written. */
-  | { ok: false; reason: 'wake-not-allowed'; detail: string };
+  | { ok: false; reason: 'wake-not-allowed'; detail: string }
+  /**
+   * A RESUME that would start a relay while no current `ports/watch`
+   * snapshot proves 8080 is free (the watcher is starting up or
+   * reconnecting). The intent IS cleared — the user's "on" stands — and the
+   * detector's next frame starts the relay against a real snapshot; the
+   * caller should say "starting shortly" rather than claim a failure.
+   */
+  | { ok: false; reason: 'slot-unknown' };
 
 /**
  * Record the intent, then reconcile ONCE through the core and the effects
@@ -341,6 +356,10 @@ export async function applyDevPreviewUserAction({
   if (handle === null) return { ok: true, applied: null };
 
   const [relay, listeners] = await Promise.all([handle.services.get(PREVIEW_RELAY_SERVICE_NAME), deps.readListeners(holder)]);
+  // `listeners: null` is UNKNOWN, never "nothing is bound". Coercing it to an
+  // empty set would let the core read 8080 as free and start a relay that may
+  // fail to bind; `listenersKnown` makes the core refuse that instead, and the
+  // detector — which plans on a frame it just saw — starts it a moment later.
   const plan = planDevServerService({
     liveInstanceId: handle.spriteInstanceId,
     sandboxId: handle.sandboxId,
@@ -349,8 +368,10 @@ export async function applyDevPreviewUserAction({
     detected: null,
     relay,
     listeners: listeners ?? [],
+    listenersKnown: listeners !== null,
     now,
   });
+  if (plan.action === 'refuse' && plan.reason === 'slot-unknown') return { ok: false, reason: 'slot-unknown' };
   const applied = await applyDevServerServicePlan({ plan, services: handle.services, store: deps.previewStore });
   return { ok: true, applied };
 }

--- a/packages/lib/src/services/sandbox/preview/dev-preview-status.ts
+++ b/packages/lib/src/services/sandbox/preview/dev-preview-status.ts
@@ -93,11 +93,18 @@ export interface DevPreviewStatus {
   canStop: boolean;
   /**
    * True when the preview can be (re)started by hand: the user switched it
-   * off, or the relay is DOWN — a crashed relay, or one a reconcile has not
-   * caught up with — and one click should be able to ask for it back rather
-   * than leaving the user waiting for a port frame that may never come.
-   * Both go through the same `resume` action (clearing an already-null stop
-   * intent is a no-op; the reconcile is the point).
+   * off, or it is DOWN IN A WAY A RECONCILE REPAIRS — the core's
+   * `down.repairable` (a crashed, missing or mis-pointed relay, or a
+   * leftover relay in front of a direct row) — and one click should be able
+   * to ask for it back rather than leaving the user waiting for a port frame
+   * that may never come. Both go through the same `resume` action (clearing
+   * an already-null stop intent is a no-op; the reconcile is the point).
+   *
+   * A `down` the reconcile CANNOT repair — the user's own dev server stopped
+   * listening, so the planner answers `already-direct`/`already-relaying` —
+   * deliberately offers nothing: a Restart that provably no-ops and leaves
+   * the same button on screen is worse than no button, and the state's
+   * message already says what actually has to happen.
    */
   canResume: boolean;
   /** When the dev server this row answers was detected, or null with no row. */
@@ -185,7 +192,7 @@ export function buildDevPreviewStatus({ holder, sandbox, liveInstanceId, row, re
     openPath,
     canOpen: state.status === 'live' || state.status === 'starting',
     canStop: actionable && row.stoppedByUserAt === null,
-    canResume: actionable && (row.stoppedByUserAt !== null || state.status === 'down'),
+    canResume: actionable && (row.stoppedByUserAt !== null || (state.status === 'down' && state.repairable)),
     detectedAt: row?.detectedAt ?? null,
   };
 }


### PR DESCRIPTION
## What

Five fixes that were written for #2545 but **never reached master**. The merge commit was created, then one more commit was pushed to the branch — and a merged PR no longer tracks its branch, so that push updated nothing and got no CI. This is that commit, rebased onto master, plus one stale comment corrected.

One of these is a **user-visible bug live in master right now**.

### The bug: a session preview vanishes the moment you open it

On the global agents route (`/dashboard/agents`), `AgentsSurface` handed `DevPreviewPane` the **route's** drive — which is `null` there — while `DevPreviewAffordance` tags the preview it opens with the **session's** drive. The pane renders only when those match, so opening a preview for a drive session immediately hid it. The pane now receives the drive the console is actually showing (`selectedSessionId && sessionDriveResolved ? sessionDriveId : driveId ?? null`), guarded on `sessionDriveResolved` so the in-flight window never claims the wrong drive. A global session resolves to `null` on both sides and still matches.

### "Unknown" was being read as "port 8080 is free"

`listeners: null` means *unknown* everywhere in this workstream — the render path's docblock is explicit that it must never read as "free". The resume path then coerced it to `[]`, which `describeHttpPortSlot` reports as `'none'`, i.e. free. A resume during watcher startup or reconnect could therefore start a relay onto an occupied 8080.

`planDevServerService` now takes `listenersKnown` (default `true` — the detector plans on a frame it just observed) and refuses a plan that would **start or re-point** a relay when it is false, with a distinct `slot-unknown` reason. The resume still **clears the stop intent**, so the user's "on" stands and the detector's next frame starts the relay against a real snapshot. Direct 8080 rows are unaffected (no relay to place) and `already-relaying` returns before the check, so a healthy preview never sees it.

### Snapshot invalidation was queued behind pending work

`invalidateSnapshot()` sat on the detector's frame chain, so between a socket close and that queued callback a reader still got the **dead connection's** ports — which could report 8080 free after the connection no longer described the sprite. It is synchronous now, and the epoch is captured at frame **arrival** rather than apply time, so a `port_list` from the closed connection that applies afterwards cannot mark the next connection known. The registry keeps no snapshot bookkeeping of its own.

### The error-retry timer outlived its hook

SWR applies `refreshWhenHidden`/`refreshWhenOffline` to its own interval timer and cannot cancel one we create. The status hook's retry now re-asks those conditions **at fire time** (still polling? tab visible? online?) and the pending timeout is cleared on unmount and on any policy change.

### A down relay was a dead end

A crashed relay left the user with no control: `canResume` required a stop intent, so the only affordance was Stop-then-Resume. `canResume` now also covers the `down` state — the same `resume` action, labelled **Restart** — which fixes the identical dead end after an ordinary relay crash.

### A test that could not fail

"Polls only while active" waited 60 ms against a 15 s interval, so it passed whether or not `active` was wired. It now advances fake timers across three intervals with a positive control proving the advance actually drives SWR. Mutation-checked: replacing `polling: active && !isOpen` with `polling: true` turns it red.

## Verification

Rebased onto `origin/master` with zero conflicts. Locally green on the rebased branch: **lib 213**, **realtime 185**, **web 232** (dev-preview, agents surface, sidebar, routes, audit coverage). `tsc --noEmit` clean on `apps/web` and `apps/realtime` — run explicitly, because vitest does not typecheck and that exact gap cost a CI round on #2545.

Ships dark: the whole surface is absent unless `DEV_PREVIEW_ENABLED=true` with a configured `DEV_PREVIEW_APEX`.

## Follow-up

A second PR covers the review findings that need real work: cross-tier serialization of relay operations, watcher recovery after a realtime restart, explicit confirmation before an unlisted port is shared drive-wide, binding the preview cookie to its session, and the ingress + live browser/HMR verification.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01P8A8KLYCoViP7ouH5QzbnB
