### PR TITLE
chore(release): @pagespace/sdk 2.3.0 and @pagespace/cli 1.9.0

### DIFF
--- a/apps/marketing/src/app/docs/features/cli/page.tsx
+++ b/apps/marketing/src/app/docs/features/cli/page.tsx
@@ -27,7 +27,7 @@ Or run it without installing:
 npx -y -p @pagespace/cli pagespace <command>
 \`\`\`
 
-The current version is **1.8.0**. Installing gives you two binaries: \`pagespace\` (the CLI) and \`pagespace-mcp\` (the MCP server).
+The current version is **1.9.0**. Installing gives you two binaries: \`pagespace\` (the CLI) and \`pagespace-mcp\` (the MCP server).
 
 ## Sign in
 

--- a/apps/marketing/src/app/docs/features/sdk/page.tsx
+++ b/apps/marketing/src/app/docs/features/sdk/page.tsx
@@ -21,7 +21,7 @@ It's the same client the [\`pagespace\` CLI](/docs/features/cli) and the \`pages
 npm install @pagespace/sdk
 \`\`\`
 
-ESM only, with a single runtime dependency (\`zod\`). The current version is **2.2.0**.
+ESM only, with a single runtime dependency (\`zod\`). The current version is **2.3.0**.
 
 ## Quickstart
 

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
-## [Unreleased]
+## [1.9.0] — 2026-09-06
 
 ### Added
 

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pagespace/cli",
-  "version": "1.8.0",
+  "version": "1.9.0",
   "description": "pagespace \u2014 the official CLI for PageSpace: browser-based login, drive/page/task management, and a `pagespace mcp` stdio server for coding agents.",
   "license": "MIT",
   "repository": {

--- a/packages/cli/src/commands/version.ts
+++ b/packages/cli/src/commands/version.ts
@@ -7,7 +7,7 @@ import type { CommandHandler } from '../router/router.js';
  * guarded by `commands/__tests__/version.test.ts`, which reads package.json
  * directly, so bumping one without the other fails the suite.
  */
-export const CLI_VERSION = '1.8.0';
+export const CLI_VERSION = '1.9.0';
 
 export const versionHandler: CommandHandler = async (ctx, intent) => {
   if (intent.flags.json) {

--- a/packages/sdk/CHANGELOG.md
+++ b/packages/sdk/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
-## [Unreleased]
+## [2.3.0] — 2026-09-06
 
 ### Added
 


### PR DESCRIPTION
## What

Cuts the release that has been sitting unpublished on master since 2026-09-01.

- `@pagespace/sdk` → **2.3.0** (manifest was already bumped; only the changelog heading was missing)
- `@pagespace/cli` → **1.9.0** (was still `1.8.0`, a version npm already serves — a publish would have been rejected)

## Why

`uploadFile` / `client.uploads` (`f22069dca`) and `pagespace files upload` (`12c9897a8`) are on master but not on npm. I unpacked both published tarballs to confirm: `@pagespace/cli@1.8.0` and `@pagespace/sdk@2.2.0` contain zero occurrences of `uploadFile` or `files upload`. Until this ships, nothing outside the web client can put bytes in a drive — the exact gap the change set closed.

The CLI release also carries the `env connect` / `env enroll` bridge daemon and the `pages replace-lines --expect-lines` staleness guard, all of which are in the same `[Unreleased]` block.

## Changes

- `packages/cli/package.json` and `packages/cli/src/commands/version.ts` → `1.9.0` (kept in step so `pagespace version` does not lie)
- Both CHANGELOGs: `[Unreleased]` becomes a dated release heading
- `apps/marketing/src/app/docs/features/{cli,sdk}/page.tsx` carry the version being published rather than the previous one — same pairing as the 2.2.0 / 1.8.0 release commit (`35cb823b7`)

## Publish order

`@pagespace/cli` depends on `"@pagespace/sdk": "^2.3.0"`, so SDK publishes first, then CLI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011x9S91mKqdtRBNwcwmH3T5


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated the CLI documentation to show version 1.9.0.
  - Updated the SDK documentation to show version 2.3.0.

- **Release Updates**
  - Published CLI version 1.9.0 with release details dated September 6, 2026.
  - Published SDK version 2.3.0 with release details dated September 6, 2026.
  - Updated displayed CLI version information to 1.9.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->