### PR TITLE
feat(sandbox): dev-preview hardening — serialized reconcile, watcher recovery, port consent, session-bound cookie

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,9 +29,10 @@ All notable user-facing changes to PageSpace are documented here. Format follows
   server has moved since the screen was drawn, PageSpace says so rather than sharing the new one.
   Approval is per port and per sandbox, so a rebuilt sandbox asks again. **Signing out ends the
   preview:** the preview page is tied to the session that opened it, so signing out or revoking a
-  device cuts it off on its very next request instead of letting it linger. Off by default: the whole surface is absent until
-  `DEV_PREVIEW_ENABLED` is set with a dedicated `DEV_PREVIEW_APEX`, which needs the preview-origin
-  ops work (wildcard DNS, certificate, and the Caddy block) to land first.
+  device cuts it off on its very next request instead of letting it linger. Off by default: the
+  whole surface is absent until `DEV_PREVIEW_ENABLED` is set with a dedicated `DEV_PREVIEW_APEX`,
+  which needs the preview-origin ops work (wildcard DNS, certificate, and the Caddy block) to land
+  first.
 - **Local Environments: an agent can now reach your own computer (opt-in groundwork)** — the two
   ends built so far are joined. An agent session bound to a local Environment whose machine is
   connected now runs its commands and reads and writes its files on that machine, through the same

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,15 @@ All notable user-facing changes to PageSpace are documented here. Format follows
   server again a moment later. Reading the status never wakes a sleeping sandbox. One thing to know
   about your own dev server: the preview reaches it through PageSpace's hostname, so a server that
   checks the `Host` header (Vite 6 and newer do) needs that hostname allowed — for Vite, add the
-  preview domain to `server.allowedHosts`. Off by default: the whole surface is absent until
+  preview domain to `server.allowedHosts`. **Sharing an unusual port is your call:** a server on a
+  usual dev-server port (Vite, Next, Astro, Django and friends) is previewed as soon as it is
+  detected, but anything else — an admin panel on :9000, a debug listener — is only *named*
+  ("Dev server detected on :9000 — not shared yet") until you open the pane, read who would be able
+  to reach it, and press Share. The port you press Share on is the port that gets shared: if the
+  server has moved since the screen was drawn, PageSpace says so rather than sharing the new one.
+  Approval is per port and per sandbox, so a rebuilt sandbox asks again. **Signing out ends the
+  preview:** the preview page is tied to the session that opened it, so signing out or revoking a
+  device cuts it off on its very next request instead of letting it linger. Off by default: the whole surface is absent until
   `DEV_PREVIEW_ENABLED` is set with a dedicated `DEV_PREVIEW_APEX`, which needs the preview-origin
   ops work (wildcard DNS, certificate, and the Caddy block) to land first.
 - **Local Environments: an agent can now reach your own computer (opt-in groundwork)** — the two

--- a/apps/e2e/tests/21-dev-preview.spec.ts
+++ b/apps/e2e/tests/21-dev-preview.spec.ts
@@ -1,0 +1,329 @@
+import { test, expect, type APIRequestContext, type Browser, type BrowserContext } from '@playwright/test';
+import {
+  CONSENT_COOKIE_NAME,
+  defaultConsentState,
+  rejectNonEssential,
+  serializeConsentState,
+} from '@pagespace/lib/consent';
+import { seedUser, type SeededUser } from '../support/db';
+import { sessionGet, sessionPost } from '../support/http';
+
+/**
+ * # Dev-server preview, end to end through a REAL browser and a REAL sandbox
+ *
+ * This is the one check no unit test can stand in for, and the reason it
+ * exists: every layer of the preview — detection, the relay, the grant
+ * handshake, the partitioned cookie, the iframe, the HMR socket — is
+ * individually tested and none of that proves a browser can load the app.
+ * The journey is: sign in → open a session → start a dev server inside its
+ * sandbox → see the affordance appear on its own → click Preview → watch the
+ * app render through `https://ws-<id>.preview.<apex>/` → edit a file → watch
+ * HMR update the frame without a reload.
+ *
+ * ## It does not run by default, and that is not laziness
+ *
+ * It needs three things a normal CI run does not have, and it names them
+ * rather than failing obscurely:
+ *
+ *  - a real Sprite sandbox (`E2E_SANDBOX=1`, a tier that may run code, and
+ *    the platform credentials);
+ *  - the preview feature configured (`DEV_PREVIEW_ENABLED` + a
+ *    `DEV_PREVIEW_APEX` with wildcard DNS and a wildcard certificate) — the
+ *    spec probes `/api/dev-preview/capability` and skips when it is dark;
+ *  - `apps/realtime` reachable, because detection IS the realtime tier's
+ *    `ports/watch` channel and the HMR half of the proxy is its upgrade
+ *    handler. Without it nothing is ever detected and every assertion here
+ *    fails for a reason that is not about the preview.
+ *
+ * ## The `allowedHosts` case is deliberately covered
+ *
+ * The preview reaches the dev server through PageSpace's hostname, and Vite 6+
+ * rejects a `Host` it does not know. That is the single most likely thing a
+ * real user hits, so this spec starts a server WITHOUT the allow-list first
+ * and records what the user actually sees, then starts one with it and
+ * asserts the app renders. The first half is documentation as much as
+ * assertion: if it ever starts passing, the platform changed and the
+ * changelog's warning should go.
+ *
+ * ## Typing into a terminal
+ *
+ * There is no HTTP route that runs a command in a sandbox — deliberately, the
+ * PTY lives on the realtime socket. So the spec drives the real terminal, and
+ * addresses it by xterm's own `.xterm-helper-textarea` (a library class, not
+ * a PageSpace detail) rather than a test id the product does not owe it.
+ */
+
+const SESSION_TTL_MS = 60 * 60 * 1000;
+/** A dev server, an npm install and a sandbox cold start — minutes, not seconds. */
+const SANDBOX_TIMEOUT_MS = 5 * 60 * 1000;
+/** How long to wait for detection to surface a port after the server binds. */
+const DETECTION_TIMEOUT_MS = 60 * 1000;
+
+const sandboxEnabled = () => process.env.E2E_SANDBOX === '1' && Boolean(process.env.DATABASE_URL);
+
+async function previewConfigured(request: APIRequestContext): Promise<boolean> {
+  // The one unauthenticated probe that answers "is this deployment dark?".
+  const response = await request.get('/api/dev-preview/capability');
+  if (!response.ok()) return false;
+  return ((await response.json()) as { enabled?: boolean }).enabled === true;
+}
+
+async function previewContext(browser: Browser, sessionToken: string, baseURL: string): Promise<BrowserContext> {
+  const url = new URL(baseURL);
+  // `bypassCSP` for the same harness reason spec 17 documents: locally the
+  // realtime server is on another port, which the app's own `connect-src`
+  // correctly refuses. A real deployment reaches realtime same-origin.
+  const context = await browser.newContext({ baseURL, bypassCSP: true });
+  const decided = rejectNonEssential(defaultConsentState(), new Date(0).toISOString());
+  await context.addCookies([
+    {
+      name: 'session',
+      value: sessionToken,
+      domain: url.hostname,
+      path: '/',
+      httpOnly: true,
+      secure: url.protocol === 'https:',
+      sameSite: 'Strict',
+      expires: Math.floor((Date.now() + SESSION_TTL_MS) / 1000),
+    },
+    {
+      name: CONSENT_COOKIE_NAME,
+      value: encodeURIComponent(serializeConsentState(decided)),
+      domain: url.hostname,
+      path: '/',
+      httpOnly: false,
+      secure: url.protocol === 'https:',
+      sameSite: 'Lax',
+    },
+  ]);
+  return context;
+}
+
+interface SessionWithSandbox {
+  workspaceId: string;
+  shellId: string;
+}
+
+/**
+ * `firstThing: 'shell'` is the one route that provisions a sandbox AND opens a
+ * PTY in a single call — exactly what this spec needs and nothing more.
+ */
+async function createSessionWithSandbox(request: APIRequestContext, user: SeededUser): Promise<SessionWithSandbox> {
+  const response = await sessionPost(request, '/api/agent-workspaces', user, {
+    driveId: user.driveId,
+    firstThing: 'shell',
+    name: 'dev-preview smoke',
+  });
+  expect(response.status(), await response.text()).toBe(201);
+  const body = (await response.json()) as { session: { workspaceId: string }; shellId: string };
+  return { workspaceId: body.session.workspaceId, shellId: body.shellId };
+}
+
+async function writeSandboxFile(request: APIRequestContext, user: SeededUser, workspaceId: string, path: string, content: string) {
+  const response = await sessionPost(request, `/api/agent-workspaces/${workspaceId}/files`, user, {
+    path,
+    kind: 'file',
+    content,
+    encoding: 'utf8',
+    overwrite: true,
+  });
+  expect(response.ok(), `writing ${path}: ${await response.text()}`).toBe(true);
+}
+
+interface PreviewStatus {
+  state: { status: string; targetPort?: number; message: string };
+  canOpen: boolean;
+  canApprove: boolean;
+  pendingApprovalPort: number | null;
+  openPath: string | null;
+}
+
+async function readPreview(request: APIRequestContext, user: SeededUser, workspaceId: string): Promise<PreviewStatus> {
+  const response = await sessionGet(request, `/api/agent-workspaces/${workspaceId}/preview`, user);
+  expect(response.ok(), await response.text()).toBe(true);
+  return ((await response.json()) as { preview: PreviewStatus }).preview;
+}
+
+/** Poll the status route until `predicate` holds, or fail naming the last state seen. */
+async function waitForPreview(
+  request: APIRequestContext,
+  user: SeededUser,
+  workspaceId: string,
+  predicate: (preview: PreviewStatus) => boolean,
+  timeoutMs = DETECTION_TIMEOUT_MS,
+): Promise<PreviewStatus> {
+  const deadline = Date.now() + timeoutMs;
+  let last: PreviewStatus | null = null;
+  while (Date.now() < deadline) {
+    last = await readPreview(request, user, workspaceId);
+    if (predicate(last)) return last;
+    await new Promise((resolve) => setTimeout(resolve, 2_000));
+  }
+  throw new Error(`preview never reached the expected state; last seen: ${JSON.stringify(last)}`);
+}
+
+/** Type a command into the session's real terminal and press Enter. */
+async function runInShell(context: BrowserContext, user: SeededUser, workspaceId: string, command: string) {
+  const page = await context.newPage();
+  await page.goto(`/dashboard/${user.driveId}/agents?workspace=${workspaceId}`);
+  const terminal = page.locator('.xterm-helper-textarea').first();
+  await terminal.waitFor({ state: 'attached', timeout: SANDBOX_TIMEOUT_MS });
+  await terminal.focus();
+  await page.keyboard.type(`${command}\n`);
+  return page;
+}
+
+const VITE_CONFIG_WITHOUT_HOSTS = `import { defineConfig } from 'vite';\nexport default defineConfig({ server: { host: '0.0.0.0', port: 5173 } });\n`;
+const VITE_CONFIG_WITH_HOSTS = `import { defineConfig } from 'vite';\nexport default defineConfig({ server: { host: '0.0.0.0', port: 5173, allowedHosts: true } });\n`;
+const INDEX_HTML = `<!doctype html><html><body><div id="app"></div><script type="module" src="/src/main.js"></script></body></html>\n`;
+const MAIN_JS = (marker: string) => `document.getElementById('app').textContent = ${JSON.stringify(marker)};\n`;
+const PACKAGE_JSON = `{ "name": "preview-smoke", "private": true, "type": "module", "scripts": { "dev": "vite" }, "devDependencies": { "vite": "^6.0.0" } }\n`;
+
+test.describe('dev-server preview: the browser journey', () => {
+  test.skip(
+    !sandboxEnabled(),
+    'Set E2E_SANDBOX=1 (with DATABASE_URL, sandbox credentials and a code-execution-eligible tier) to run the dev-preview smoke.',
+  );
+
+  const contexts: BrowserContext[] = [];
+  test.afterEach(async () => {
+    await Promise.all(contexts.map((context) => context.close()));
+    contexts.length = 0;
+  });
+
+  test('a Vite dev server on a usual port is detected, previewed, and hot-reloads inside the frame', async ({ request, browser, baseURL }) => {
+    test.skip(!(await previewConfigured(request)), 'The preview feature is dark on this deployment (DEV_PREVIEW_ENABLED / DEV_PREVIEW_APEX).');
+    test.setTimeout(SANDBOX_TIMEOUT_MS * 3);
+
+    const user = await seedUser({ tier: 'pro' });
+    const { workspaceId } = await createSessionWithSandbox(request, user);
+    const context = await previewContext(browser, user.sessionToken, baseURL ?? 'http://localhost:3000');
+    contexts.push(context);
+
+    await writeSandboxFile(request, user, workspaceId, 'preview-smoke/package.json', PACKAGE_JSON);
+    await writeSandboxFile(request, user, workspaceId, 'preview-smoke/index.html', INDEX_HTML);
+    await writeSandboxFile(request, user, workspaceId, 'preview-smoke/src/main.js', MAIN_JS('first render'));
+
+    // ---- the Host-header failure, recorded rather than assumed ---------------
+    // Vite 6+ refuses a Host it does not know, and the preview arrives on
+    // PageSpace's hostname. This half exists so we know exactly what the user
+    // sees when they have not set `allowedHosts`.
+    await writeSandboxFile(request, user, workspaceId, 'preview-smoke/vite.config.js', VITE_CONFIG_WITHOUT_HOSTS);
+    await runInShell(context, user, workspaceId, 'cd preview-smoke && npm install && npm run dev');
+
+    const detected = await waitForPreview(request, user, workspaceId, (preview) => preview.state.targetPort === 5173, SANDBOX_TIMEOUT_MS);
+    expect(detected.state.targetPort).toBe(5173);
+    // 5173 is a known dev-server port, so it is relayed with no approval.
+    expect(detected.canApprove).toBe(false);
+
+    const page = await context.newPage();
+    await page.goto(`/dashboard/${user.driveId}/agents?workspace=${workspaceId}`);
+    await page.getByTestId('dev-preview-affordance').waitFor({ timeout: DETECTION_TIMEOUT_MS });
+    await page.getByRole('button', { name: 'Preview' }).click();
+    const frame = page.frameLocator('[data-testid="dev-preview-frame"]');
+
+    // Without `allowedHosts` the dev server answers the proxy with its own
+    // refusal, so the app does NOT render. Asserted by absence of the marker,
+    // with the frame plainly mounted — if this ever renders, Vite or the
+    // platform changed and the changelog warning can go.
+    await expect(frame.locator('#app')).not.toHaveText('first render', { timeout: 15_000 });
+
+    // ---- with the allow-list: the app renders, and HMR works ----------------
+    await writeSandboxFile(request, user, workspaceId, 'preview-smoke/vite.config.js', VITE_CONFIG_WITH_HOSTS);
+    await runInShell(context, user, workspaceId, 'cd preview-smoke && npm run dev');
+    await page.getByTitle('Reload the preview').click();
+    await expect(frame.locator('#app')).toHaveText('first render', { timeout: SANDBOX_TIMEOUT_MS });
+
+    // HMR: edit the module and assert the FRAME updates without a reload. The
+    // navigation counter is what makes "without a reload" an assertion rather
+    // than a hope.
+    const framePage = page.frameLocator('[data-testid="dev-preview-frame"]');
+    await writeSandboxFile(request, user, workspaceId, 'preview-smoke/src/main.js', MAIN_JS('hot updated'));
+    await expect(framePage.locator('#app')).toHaveText('hot updated', { timeout: 60_000 });
+
+    // Open in a new tab mints its OWN grant (the partitioned cookie does not
+    // travel to a top-level navigation), so the app must render there too.
+    const status = await readPreview(request, user, workspaceId);
+    expect(status.openPath).not.toBeNull();
+    const tab = await context.newPage();
+    await tab.goto(status.openPath as string);
+    await expect(tab.locator('#app')).toHaveText('hot updated', { timeout: 60_000 });
+  });
+
+  test('an UNLISTED port is detected but serves nothing until it is explicitly shared', async ({ request, browser, baseURL }) => {
+    test.skip(!(await previewConfigured(request)), 'The preview feature is dark on this deployment (DEV_PREVIEW_ENABLED / DEV_PREVIEW_APEX).');
+    test.setTimeout(SANDBOX_TIMEOUT_MS * 2);
+
+    const user = await seedUser({ tier: 'pro' });
+    const { workspaceId } = await createSessionWithSandbox(request, user);
+    const context = await previewContext(browser, user.sessionToken, baseURL ?? 'http://localhost:3000');
+    contexts.push(context);
+
+    // A plain node server on 9000 — no framework, no install, nothing to go
+    // wrong except the thing under test.
+    await writeSandboxFile(
+      request,
+      user,
+      workspaceId,
+      'unlisted/server.js',
+      `import { createServer } from 'node:http';\ncreateServer((_req, res) => { res.end('unlisted app'); }).listen(9000, '0.0.0.0');\n`,
+    );
+    await runInShell(context, user, workspaceId, 'cd unlisted && node server.js');
+
+    const pending = await waitForPreview(request, user, workspaceId, (preview) => preview.state.status === 'needs-approval', SANDBOX_TIMEOUT_MS);
+    expect(pending.pendingApprovalPort).toBe(9000);
+    expect(pending.canOpen).toBe(false);
+
+    // The proxy refuses it — detection is not exposure.
+    const refused = await request.get(pending.openPath as string, { headers: { cookie: `session=${user.sessionToken}` } });
+    expect(refused.ok()).toBe(false);
+
+    // A port the row does not target cannot be approved by a click meant for it.
+    const wrongPort = await sessionPost(request, `/api/agent-workspaces/${workspaceId}/preview/actions`, user, { action: 'approve', port: 9001 });
+    expect(wrongPort.status()).toBe(409);
+
+    const approved = await sessionPost(request, `/api/agent-workspaces/${workspaceId}/preview/actions`, user, { action: 'approve', port: 9000 });
+    expect(approved.ok(), await approved.text()).toBe(true);
+
+    await waitForPreview(request, user, workspaceId, (preview) => preview.canOpen, DETECTION_TIMEOUT_MS);
+    const page = await context.newPage();
+    await page.goto(`/dashboard/${user.driveId}/agents?workspace=${workspaceId}`);
+    await page.getByRole('button', { name: 'Preview' }).click();
+    await expect(page.frameLocator('[data-testid="dev-preview-frame"]').locator('body')).toContainText('unlisted app', { timeout: 60_000 });
+  });
+
+  test('signing out cuts the preview on its very next request, not when the cookie expires', async ({ request, browser, baseURL }) => {
+    test.skip(!(await previewConfigured(request)), 'The preview feature is dark on this deployment (DEV_PREVIEW_ENABLED / DEV_PREVIEW_APEX).');
+    test.setTimeout(SANDBOX_TIMEOUT_MS * 2);
+
+    const user = await seedUser({ tier: 'pro' });
+    const { workspaceId } = await createSessionWithSandbox(request, user);
+    const context = await previewContext(browser, user.sessionToken, baseURL ?? 'http://localhost:3000');
+    contexts.push(context);
+
+    await writeSandboxFile(
+      request,
+      user,
+      workspaceId,
+      'known/server.js',
+      `import { createServer } from 'node:http';\ncreateServer((_req, res) => { res.end('still here'); }).listen(5173, '0.0.0.0');\n`,
+    );
+    await runInShell(context, user, workspaceId, 'cd known && node server.js');
+    const live = await waitForPreview(request, user, workspaceId, (preview) => preview.canOpen, SANDBOX_TIMEOUT_MS);
+
+    const page = await context.newPage();
+    await page.goto(`/dashboard/${user.driveId}/agents?workspace=${workspaceId}`);
+    await page.getByRole('button', { name: 'Preview' }).click();
+    const frame = page.frameLocator('[data-testid="dev-preview-frame"]');
+    await expect(frame.locator('body')).toContainText('still here', { timeout: 60_000 });
+
+    // Sign out through the app's own logout route: the preview cookie names this
+    // session, and the per-request gather re-checks it on every request.
+    const signOut = await sessionPost(request, '/api/auth/logout', user, {});
+    expect(signOut.ok(), await signOut.text()).toBe(true);
+
+    await page.getByTitle('Reload the preview').click();
+    await expect(frame.locator('body')).not.toContainText('still here', { timeout: 30_000 });
+    expect(live.openPath).not.toBeNull();
+  });
+});

--- a/apps/e2e/tests/21-dev-preview.spec.ts
+++ b/apps/e2e/tests/21-dev-preview.spec.ts
@@ -54,7 +54,7 @@ import { sessionGet, sessionPost } from '../support/http';
  */
 
 const SESSION_TTL_MS = 60 * 60 * 1000;
-/** A dev server, an npm install and a sandbox cold start — minutes, not seconds. */
+/** A dev server, a dependency install and a sandbox cold start — minutes, not seconds. */
 const SANDBOX_TIMEOUT_MS = 5 * 60 * 1000;
 /** How long to wait for detection to surface a port after the server binds. */
 const DETECTION_TIMEOUT_MS = 60 * 1000;
@@ -167,7 +167,7 @@ async function waitForPreview(
  * Type a command into the session's real terminal and press Enter.
  *
  * `interruptFirst` sends Ctrl-C before the command. It is not optional
- * politeness: this reaches the SAME PTY every time, so a second `npm run dev`
+ * politeness: this reaches the SAME PTY every time, so a second `bun run dev`
  * typed while the first one is still in the foreground goes into Vite's stdin
  * as shortcut keystrokes, not into a shell — the command silently never runs,
  * and the assertion that follows fails minutes later for a reason that has
@@ -231,7 +231,7 @@ test.describe('dev-server preview: the browser journey', () => {
     // PageSpace's hostname. This half exists so we know exactly what the user
     // sees when they have not set `allowedHosts`.
     await writeSandboxFile(request, user, workspaceId, 'preview-smoke/vite.config.js', VITE_CONFIG_WITHOUT_HOSTS);
-    await runInShell(context, user, workspaceId, 'cd preview-smoke && npm install && npm run dev');
+    await runInShell(context, user, workspaceId, 'cd preview-smoke && bun install && bun run dev');
 
     const detected = await waitForPreview(request, user, workspaceId, (preview) => preview.state.targetPort === 5173, SANDBOX_TIMEOUT_MS);
     expect(detected.state.targetPort).toBe(5173);
@@ -264,7 +264,7 @@ test.describe('dev-server preview: the browser journey', () => {
     // `preview-smoke` from the first command — a second `cd` fails, `&&`
     // short-circuits, and the server never starts. The two facts are the same
     // fact: if the PTY were not shared, the Ctrl-C would interrupt nothing.
-    await runInShell(context, user, workspaceId, 'npm run dev', { interruptFirst: true });
+    await runInShell(context, user, workspaceId, 'bun run dev', { interruptFirst: true });
     await page.getByTitle('Reload the preview').click();
     await expect(frame.locator('#app')).toHaveText('first render', { timeout: SANDBOX_TIMEOUT_MS });
 

--- a/apps/e2e/tests/21-dev-preview.spec.ts
+++ b/apps/e2e/tests/21-dev-preview.spec.ts
@@ -131,10 +131,11 @@ async function writeSandboxFile(request: APIRequestContext, user: SeededUser, wo
 }
 
 interface PreviewStatus {
+  // The state NAMES the port — there is no separate pending-port field, so a
+  // needs-approval status and the port awaiting a decision cannot disagree.
   state: { status: string; targetPort?: number; message: string };
   canOpen: boolean;
   canApprove: boolean;
-  pendingApprovalPort: number | null;
   openPath: string | null;
 }
 
@@ -277,7 +278,8 @@ test.describe('dev-server preview: the browser journey', () => {
     await runInShell(context, user, workspaceId, 'cd unlisted && node server.js');
 
     const pending = await waitForPreview(request, user, workspaceId, (preview) => preview.state.status === 'needs-approval', SANDBOX_TIMEOUT_MS);
-    expect(pending.pendingApprovalPort).toBe(9000);
+    expect(pending.state.targetPort).toBe(9000);
+    expect(pending.canApprove).toBe(true);
     expect(pending.canOpen).toBe(false);
 
     // The proxy refuses it — detection is not exposure.

--- a/apps/e2e/tests/21-dev-preview.spec.ts
+++ b/apps/e2e/tests/21-dev-preview.spec.ts
@@ -260,8 +260,11 @@ test.describe('dev-server preview: the browser journey', () => {
     await writeSandboxFile(request, user, workspaceId, 'preview-smoke/vite.config.js', VITE_CONFIG_WITH_HOSTS);
     // Ctrl-C first: the first server still owns this PTY and port 5173, and a
     // Vite that cannot bind its port moves to 5174 while the relay keeps
-    // pointing at 5173.
-    await runInShell(context, user, workspaceId, 'cd preview-smoke && npm run dev', { interruptFirst: true });
+    // pointing at 5173. And NO `cd`: it is the same shell, so it is already in
+    // `preview-smoke` from the first command — a second `cd` fails, `&&`
+    // short-circuits, and the server never starts. The two facts are the same
+    // fact: if the PTY were not shared, the Ctrl-C would interrupt nothing.
+    await runInShell(context, user, workspaceId, 'npm run dev', { interruptFirst: true });
     await page.getByTitle('Reload the preview').click();
     await expect(frame.locator('#app')).toHaveText('first render', { timeout: SANDBOX_TIMEOUT_MS });
 

--- a/apps/e2e/tests/21-dev-preview.spec.ts
+++ b/apps/e2e/tests/21-dev-preview.spec.ts
@@ -136,6 +136,8 @@ interface PreviewStatus {
   state: { status: string; targetPort?: number; message: string };
   canOpen: boolean;
   canApprove: boolean;
+  /** Echoed back on an approve, so consent cannot follow a rebuilt sandbox. */
+  spriteInstanceId: string | null;
   openPath: string | null;
 }
 
@@ -323,11 +325,23 @@ test.describe('dev-server preview: the browser journey', () => {
     await expect(beforePage.getByRole('button', { name: 'Preview' })).toHaveCount(0);
     await beforePage.close();
 
+    // Both halves of the echo come from the status the UI would have rendered.
+    const shown = pending.spriteInstanceId;
+    expect(shown).not.toBeNull();
+
     // A port the row does not target cannot be approved by a click meant for it.
-    const wrongPort = await sessionPost(request, `/api/agent-workspaces/${workspaceId}/preview/actions`, user, { action: 'approve', port: 9001 });
+    const wrongPort = await sessionPost(request, `/api/agent-workspaces/${workspaceId}/preview/actions`, user, { action: 'approve', port: 9001, spriteInstanceId: shown });
     expect(wrongPort.status()).toBe(409);
 
-    const approved = await sessionPost(request, `/api/agent-workspaces/${workspaceId}/preview/actions`, user, { action: 'approve', port: 9000 });
+    // Nor can a click made against a different sandbox, even on the right port.
+    const wrongInstance = await sessionPost(request, `/api/agent-workspaces/${workspaceId}/preview/actions`, user, { action: 'approve', port: 9000, spriteInstanceId: 'sprite-that-is-not-this-one' });
+    expect(wrongInstance.status()).toBe(409);
+
+    // And an approve with no instance at all is not a well-formed action.
+    const noInstance = await sessionPost(request, `/api/agent-workspaces/${workspaceId}/preview/actions`, user, { action: 'approve', port: 9000 });
+    expect(noInstance.status()).toBe(400);
+
+    const approved = await sessionPost(request, `/api/agent-workspaces/${workspaceId}/preview/actions`, user, { action: 'approve', port: 9000, spriteInstanceId: shown });
     expect(approved.ok(), await approved.text()).toBe(true);
 
     await waitForPreview(request, user, workspaceId, (preview) => preview.canOpen, DETECTION_TIMEOUT_MS);

--- a/apps/e2e/tests/21-dev-preview.spec.ts
+++ b/apps/e2e/tests/21-dev-preview.spec.ts
@@ -163,13 +163,34 @@ async function waitForPreview(
   throw new Error(`preview never reached the expected state; last seen: ${JSON.stringify(last)}`);
 }
 
-/** Type a command into the session's real terminal and press Enter. */
-async function runInShell(context: BrowserContext, user: SeededUser, workspaceId: string, command: string) {
+/**
+ * Type a command into the session's real terminal and press Enter.
+ *
+ * `interruptFirst` sends Ctrl-C before the command. It is not optional
+ * politeness: this reaches the SAME PTY every time, so a second `npm run dev`
+ * typed while the first one is still in the foreground goes into Vite's stdin
+ * as shortcut keystrokes, not into a shell — the command silently never runs,
+ * and the assertion that follows fails minutes later for a reason that has
+ * nothing to do with the preview.
+ */
+async function runInShell(
+  context: BrowserContext,
+  user: SeededUser,
+  workspaceId: string,
+  command: string,
+  { interruptFirst = false }: { interruptFirst?: boolean } = {},
+) {
   const page = await context.newPage();
   await page.goto(`/dashboard/${user.driveId}/agents?workspace=${workspaceId}`);
   const terminal = page.locator('.xterm-helper-textarea').first();
   await terminal.waitFor({ state: 'attached', timeout: SANDBOX_TIMEOUT_MS });
   await terminal.focus();
+  if (interruptFirst) {
+    await page.keyboard.press('Control+C');
+    // Give the foreground process time to die and the shell to draw a prompt;
+    // typing into a dying Vite is the same failure by a shorter route.
+    await page.waitForTimeout(3_000);
+  }
   await page.keyboard.type(`${command}\n`);
   return page;
 }
@@ -237,7 +258,10 @@ test.describe('dev-server preview: the browser journey', () => {
 
     // ---- with the allow-list: the app renders, and HMR works ----------------
     await writeSandboxFile(request, user, workspaceId, 'preview-smoke/vite.config.js', VITE_CONFIG_WITH_HOSTS);
-    await runInShell(context, user, workspaceId, 'cd preview-smoke && npm run dev');
+    // Ctrl-C first: the first server still owns this PTY and port 5173, and a
+    // Vite that cannot bind its port moves to 5174 while the relay keeps
+    // pointing at 5173.
+    await runInShell(context, user, workspaceId, 'cd preview-smoke && npm run dev', { interruptFirst: true });
     await page.getByTitle('Reload the preview').click();
     await expect(frame.locator('#app')).toHaveText('first render', { timeout: SANDBOX_TIMEOUT_MS });
 
@@ -282,9 +306,19 @@ test.describe('dev-server preview: the browser journey', () => {
     expect(pending.canApprove).toBe(true);
     expect(pending.canOpen).toBe(false);
 
-    // The proxy refuses it — detection is not exposure.
-    const refused = await request.get(pending.openPath as string, { headers: { cookie: `session=${user.sessionToken}` } });
-    expect(refused.ok()).toBe(false);
+    // Detection is not exposure, asserted where it is actually decided. A bare
+    // request to the open route would 403 at the cross-site-embed gate (an
+    // `APIRequestContext` sends no `Sec-Fetch-*` headers, and that gate fails
+    // closed) — which is the same answer an APPROVED preview would give, so it
+    // would prove nothing. What the pane offers is the honest signal at this
+    // layer: no way to open it, and the server-side refusal itself is covered
+    // exhaustively by the forward gate's own tests.
+    const beforePage = await context.newPage();
+    await beforePage.goto(`/dashboard/${user.driveId}/agents?workspace=${workspaceId}`);
+    await beforePage.getByTestId('dev-preview-affordance').waitFor({ timeout: DETECTION_TIMEOUT_MS });
+    await expect(beforePage.getByRole('button', { name: 'Details' })).toBeVisible();
+    await expect(beforePage.getByRole('button', { name: 'Preview' })).toHaveCount(0);
+    await beforePage.close();
 
     // A port the row does not target cannot be approved by a click meant for it.
     const wrongPort = await sessionPost(request, `/api/agent-workspaces/${workspaceId}/preview/actions`, user, { action: 'approve', port: 9001 });

--- a/apps/e2e/tests/21-dev-preview.spec.ts
+++ b/apps/e2e/tests/21-dev-preview.spec.ts
@@ -223,10 +223,16 @@ test.describe('dev-server preview: the browser journey', () => {
     const frame = page.frameLocator('[data-testid="dev-preview-frame"]');
 
     // Without `allowedHosts` the dev server answers the proxy with its own
-    // refusal, so the app does NOT render. Asserted by absence of the marker,
-    // with the frame plainly mounted — if this ever renders, Vite or the
-    // platform changed and the changelog warning can go.
-    await expect(frame.locator('#app')).not.toHaveText('first render', { timeout: 15_000 });
+    // refusal, so the app does NOT render.
+    //
+    // A bare `not.toHaveText` would be VACUOUS here: it passes the instant the
+    // element is absent, which is also what an empty frame looks like. So wait
+    // for the frame to actually have rendered SOMETHING first, then assert
+    // that something is not the app. If this ever fails because the marker
+    // appeared, Vite or the platform changed and the changelog warning can go.
+    const blocked = frame.locator('body');
+    await expect(blocked).not.toBeEmpty({ timeout: 30_000 });
+    await expect(blocked).not.toContainText('first render');
 
     // ---- with the allow-list: the app renders, and HMR works ----------------
     await writeSandboxFile(request, user, workspaceId, 'preview-smoke/vite.config.js', VITE_CONFIG_WITH_HOSTS);
@@ -323,7 +329,14 @@ test.describe('dev-server preview: the browser journey', () => {
     expect(signOut.ok(), await signOut.text()).toBe(true);
 
     await page.getByTitle('Reload the preview').click();
-    await expect(frame.locator('body')).not.toContainText('still here', { timeout: 30_000 });
+    // Same anti-vacuity rule as the allowedHosts case: wait for the frame to
+    // have rendered SOMETHING (the refusal, or the sign-in the re-mint lands
+    // on) before asserting it is no longer the app. The exact copy is not
+    // asserted — a revoked session and a signed-out app origin produce
+    // different pages, and both are correct answers to "this is over".
+    const after = frame.locator('body');
+    await expect(after).not.toBeEmpty({ timeout: 30_000 });
+    await expect(after).not.toContainText('still here');
     expect(live.openPath).not.toBeNull();
   });
 });

--- a/apps/realtime/src/__tests__/index.test.ts
+++ b/apps/realtime/src/__tests__/index.test.ts
@@ -275,9 +275,9 @@ vi.mock('../dev-preview/preview-upgrade', () => ({
   previewHolderForUpgrade: (req: unknown, apex: unknown) => mockPreviewHolderForUpgrade(req, apex),
 }));
 const mockRegistryEnsure = vi.fn<(input: unknown) => Promise<void>>().mockResolvedValue(undefined);
-const mockRegistryListeners = vi.fn<(input: unknown) => Promise<unknown>>().mockResolvedValue(null);
+const mockRegistryRead = vi.fn<(input: unknown) => Promise<unknown>>().mockResolvedValue({ detection: 'unavailable', listeners: null });
 vi.mock('../dev-preview/detection-registry', () => ({
-  createDetectionRegistry: () => ({ ensure: mockRegistryEnsure, listeners: mockRegistryListeners, watching: () => [], stopAll: vi.fn() }),
+  createDetectionRegistry: () => ({ ensure: mockRegistryEnsure, read: mockRegistryRead, watching: () => [], stopAll: vi.fn() }),
   nodeWebSocketFactory: vi.fn(),
 }));
 vi.mock('../dev-preview/preview-runtime', () => ({
@@ -2553,7 +2553,7 @@ describe('requestListener - /api/dev-preview/listeners', () => {
 
   it('given a valid signature and a holder, should answer the registry snapshot for that holder (sprite re-derived, never the caller\'s claim)', async () => {
     vi.mocked(verifyBroadcastSignature).mockReturnValue(true);
-    mockRegistryListeners.mockResolvedValueOnce([{ port: 5173, pid: 3 }]);
+    mockRegistryRead.mockResolvedValueOnce({ detection: 'watching', listeners: [{ port: 5173, pid: 3 }] });
     const body = JSON.stringify({ holder: { kind: 'workspace', id: 'ws1' }, sandboxId: 'ignored-caller-claim' });
     const req = createMockReq({ method: 'POST', url: '/api/dev-preview/listeners', headers: { 'x-broadcast-signature': 'valid-sig' } });
     const res = createMockRes();
@@ -2563,14 +2563,14 @@ describe('requestListener - /api/dev-preview/listeners', () => {
     req._emit('end');
     await new Promise(resolve => setTimeout(resolve, 0));
 
-    expect(mockRegistryListeners).toHaveBeenCalledWith({ holder: { kind: 'workspace', id: 'ws1' } });
+    expect(mockRegistryRead).toHaveBeenCalledWith({ holder: { kind: 'workspace', id: 'ws1' } });
     expect(res.writeHead).toHaveBeenCalledWith(200, { 'Content-Type': 'application/json' });
-    expect(res.end).toHaveBeenCalledWith(JSON.stringify({ listeners: [{ port: 5173, pid: 3 }] }));
+    expect(res.end).toHaveBeenCalledWith(JSON.stringify({ detection: 'watching', listeners: [{ port: 5173, pid: 3 }] }));
   });
 
-  it('given no snapshot in hand, should answer listeners: null (honest unknown, not an empty list)', async () => {
+  it('given no snapshot in hand, should answer listeners: null with the detection state (honest unknown, not an empty list)', async () => {
     vi.mocked(verifyBroadcastSignature).mockReturnValue(true);
-    mockRegistryListeners.mockResolvedValueOnce(null);
+    mockRegistryRead.mockResolvedValueOnce({ detection: 'unavailable', listeners: null });
     const req = createMockReq({ method: 'POST', url: '/api/dev-preview/listeners', headers: { 'x-broadcast-signature': 'valid-sig' } });
     const res = createMockRes();
 
@@ -2579,7 +2579,7 @@ describe('requestListener - /api/dev-preview/listeners', () => {
     req._emit('end');
     await new Promise(resolve => setTimeout(resolve, 0));
 
-    expect(res.end).toHaveBeenCalledWith(JSON.stringify({ listeners: null }));
+    expect(res.end).toHaveBeenCalledWith(JSON.stringify({ detection: 'unavailable', listeners: null }));
   });
 
   it('given a bad signature, should 401 without touching the registry', async () => {
@@ -2593,7 +2593,7 @@ describe('requestListener - /api/dev-preview/listeners', () => {
     await new Promise(resolve => setTimeout(resolve, 0));
 
     expect(res.writeHead).toHaveBeenCalledWith(401, { 'Content-Type': 'application/json' });
-    expect(mockRegistryListeners).not.toHaveBeenCalled();
+    expect(mockRegistryRead).not.toHaveBeenCalled();
   });
 
   it('given a signed but malformed body, should 400 without touching the registry', async () => {
@@ -2607,12 +2607,12 @@ describe('requestListener - /api/dev-preview/listeners', () => {
     await new Promise(resolve => setTimeout(resolve, 0));
 
     expect(res.writeHead).toHaveBeenCalledWith(400, { 'Content-Type': 'application/json' });
-    expect(mockRegistryListeners).not.toHaveBeenCalled();
+    expect(mockRegistryRead).not.toHaveBeenCalled();
   });
 
   it('given a registry failure, should 500 and log', async () => {
     vi.mocked(verifyBroadcastSignature).mockReturnValue(true);
-    mockRegistryListeners.mockRejectedValueOnce(new Error('boom'));
+    mockRegistryRead.mockRejectedValueOnce(new Error('boom'));
     const req = createMockReq({ method: 'POST', url: '/api/dev-preview/listeners', headers: { 'x-broadcast-signature': 'valid-sig' } });
     const res = createMockRes();
 

--- a/apps/realtime/src/dev-preview/__tests__/detection-registry.test.ts
+++ b/apps/realtime/src/dev-preview/__tests__/detection-registry.test.ts
@@ -24,10 +24,10 @@ function fakeSocketFactory() {
   return { sockets, createSocket };
 }
 
-function fakeHandle(): SandboxHandle {
+function fakeHandle(spriteInstanceId = 'inst'): SandboxHandle {
   return {
     sandboxId: 'sbx',
-    spriteInstanceId: 'inst',
+    spriteInstanceId,
     exec: async () => ({ exitCode: 1, stdout: '', stderr: '' }),
     writeFiles: async () => {},
     readFile: async () => null,
@@ -358,5 +358,50 @@ describe('createDetectionRegistry', () => {
     assert({ given: 'a dark deployment', should: 'be unavailable without even resolving the row', actual: await createDetectionRegistry(dark.deps).read({ holder: HOLDER }), expected: { detection: 'unavailable', listeners: null } });
     expect(h.sockets).toHaveLength(0);
     expect(dark.sockets).toHaveLength(0);
+  });
+
+  it('a sprite REBUILT under the same name is re-watched, and only an explicit trigger pays to notice', async () => {
+    // A name is reused across re-creates. A watcher armed against the old VM
+    // still answers `watchers.has`, and its detector holds a dead instance id —
+    // so it would write rows naming a VM that no longer exists while its
+    // service calls land on the new one: every render `stale`, the proxy 409,
+    // and no recovery short of a process restart.
+    let instance = 'inst-old';
+    const h = deps({ attach: async () => fakeHandle(instance) });
+    const registry = createDetectionRegistry(h.deps);
+    await registry.ensure({ holder: HOLDER });
+    expect(h.sockets).toHaveLength(1);
+
+    // Same VM: an explicit trigger checks and leaves the watcher alone.
+    await registry.ensure({ holder: HOLDER });
+    expect(h.sockets).toHaveLength(1);
+
+    // Rebuilt: the explicit trigger notices and re-watches.
+    instance = 'inst-new';
+    await registry.ensure({ holder: HOLDER });
+    expect(h.sockets).toHaveLength(2);
+    expect(h.logs.some((l) => l.includes('sprite replaced under the same name'))).toBe(true);
+
+    // The READ path does not pay for the check — it runs on every render, and
+    // an attach per render is exactly what the throttle exists to prevent.
+    instance = 'inst-newer';
+    await registry.read({ holder: HOLDER });
+    expect(h.sockets).toHaveLength(2);
+  });
+
+  it('drops a channel that flaps forever, because a status read re-arms it within a poll', async () => {
+    // `attempts` resets on any connection that OPENS, so a socket that opens
+    // and dies immediately would reconnect for ever — which is not what the
+    // budget claims to do.
+    const h = deps({ maxTotalReconnects: 3 });
+    const registry = createDetectionRegistry(h.deps);
+    await registry.ensure({ holder: HOLDER });
+    for (let i = 0; i < 6 && h.sockets.length > 0; i += 1) {
+      const socket = h.sockets[h.sockets.length - 1];
+      socket.emit('open');
+      socket.emit('close', { code: 1006 });
+      await new Promise((r) => setTimeout(r, 0));
+    }
+    expect(h.logs.some((l) => l.includes('watch channel gone'))).toBe(true);
   });
 });

--- a/apps/realtime/src/dev-preview/__tests__/detection-registry.test.ts
+++ b/apps/realtime/src/dev-preview/__tests__/detection-registry.test.ts
@@ -92,6 +92,10 @@ describe('createDetectionRegistry', () => {
     const registry = createDetectionRegistry(h.deps);
     await registry.ensure({ holder: HOLDER });
     h.sockets[0].emit('open');
+    // The platform sends a `port_list` on connect, always. The core will not
+    // plan a relay start from an accumulated set until it has, because before
+    // that the set says nothing about who holds port 8080.
+    h.sockets[0].emit('message', { data: JSON.stringify({ type: 'port_list', ports: [] }) });
     h.sockets[0].emit('message', { data: JSON.stringify({ type: 'port_opened', port: 5173, pid: 3 }) });
     await new Promise((r) => setTimeout(r, 10));
     expect(h.upserts).toHaveLength(1);

--- a/apps/realtime/src/dev-preview/__tests__/detection-registry.test.ts
+++ b/apps/realtime/src/dev-preview/__tests__/detection-registry.test.ts
@@ -389,6 +389,71 @@ describe('createDetectionRegistry', () => {
     expect(h.sockets).toHaveLength(2);
   });
 
+  it('two explicit triggers racing a rebuild leave exactly ONE watcher, never an orphan', async () => {
+    // The interleaving is SCRIPTED, because the orphan only appears in one
+    // order: the second trigger's comparison must resolve AFTER the first has
+    // already installed its replacement. Then closing the stale entry by KEY
+    // deletes the live replacement — socket open, detector still writing rows,
+    // nothing able to reach it — and a second watcher starts beside it.
+    let instance = 'inst-old';
+    const pending: Array<() => void> = [];
+    const flush = () => new Promise((r) => setTimeout(r, 0));
+    const h = deps({
+      attach: async () => {
+        await new Promise<void>((resolve) => pending.push(resolve));
+        return fakeHandle(instance);
+      },
+    });
+    const registry = createDetectionRegistry(h.deps);
+
+    const initial = registry.ensure({ holder: HOLDER });
+    await flush();
+    pending.shift()?.();                     // the first arm's own attach
+    await initial;
+    expect(h.sockets).toHaveLength(1);
+
+    instance = 'inst-new';
+    const t1 = registry.ensure({ holder: HOLDER });
+    await flush();                            // t1's comparison attach is queued
+    const t2 = registry.ensure({ holder: HOLDER });
+    await flush();                            // t2's comparison attach is queued behind it
+
+    pending.shift()?.();                      // t1 compares: mismatch, closes, reserves, attaches again
+    await flush();
+    const t1Start = pending.pop();            // t1's re-arm attach, queued last
+    t1Start?.();
+    await t1;
+    expect(h.sockets).toHaveLength(2);         // t1's replacement is LIVE
+
+    pending.shift()?.();                      // only now does t2 compare, against a map that moved on
+    await t2;
+    await flush();
+    while (pending.length > 0) pending.shift()?.();
+    await flush();
+
+    // Still exactly one replacement. Without the identity guard t2 tears down
+    // t1's live watcher and opens a third socket.
+    expect(h.sockets).toHaveLength(2);
+  });
+
+  it('a channel that stays up is NOT retired, however many times it is recycled', async () => {
+    // The lifetime ceiling exists for a flap. Counting clean recycles too
+    // would retire a healthy long-lived watcher, and an unattended session —
+    // nobody rendering status, so nothing to re-arm it — would lose detection
+    // for the life of the sprite, which is the case detection exists for.
+    const h = deps({ maxTotalReconnects: 2 });
+    const registry = createDetectionRegistry(h.deps);
+    await registry.ensure({ holder: HOLDER });
+    for (let i = 0; i < 5 && h.sockets.length > 0; i += 1) {
+      const socket = h.sockets[h.sockets.length - 1];
+      socket.emit('open');
+      clock.now = new Date(clock.now.getTime() + 5 * 60 * 1000);
+      socket.emit('close', { code: 1006 });
+      await new Promise((r) => setTimeout(r, 0));
+    }
+    expect(h.logs.some((l) => l.includes('watch channel gone'))).toBe(false);
+  });
+
   it('drops a channel that flaps forever, because a status read re-arms it within a poll', async () => {
     // `attempts` resets on any connection that OPENS, so a socket that opens
     // and dies immediately would reconnect for ever — which is not what the

--- a/apps/realtime/src/dev-preview/__tests__/detection-registry.test.ts
+++ b/apps/realtime/src/dev-preview/__tests__/detection-registry.test.ts
@@ -495,6 +495,25 @@ describe('createDetectionRegistry', () => {
     expect(h.logs.some((l) => l.includes('watch channel gone'))).toBe(false);
   });
 
+  it('a SLOW HANDSHAKE is not uptime — the ceiling still retires a channel that never stays up', async () => {
+    // `attemptStartedAt` is taken from the socket's own `open` event, not from
+    // when the attempt began. Measuring from the attempt would let a handshake
+    // that takes longer than the health window count as a healthy connection,
+    // clearing the very budget that exists to retire a channel like this.
+    const h = deps({ maxTotalReconnects: 2 });
+    const registry = createDetectionRegistry(h.deps);
+    await registry.ensure({ holder: HOLDER });
+    for (let i = 0; i < 5 && h.sockets.length > 0; i += 1) {
+      const socket = h.sockets[h.sockets.length - 1];
+      // Two minutes of HANDSHAKE, then it opens and dies at once.
+      clock.now = new Date(clock.now.getTime() + 2 * 60 * 1000);
+      socket.emit('open');
+      socket.emit('close', { code: 1006 });
+      await new Promise((r) => setTimeout(r, 0));
+    }
+    expect(h.logs.some((l) => l.includes('watch channel gone'))).toBe(true);
+  });
+
   it('drops a channel that flaps forever, because a status read re-arms it within a poll', async () => {
     // `attempts` resets on any connection that OPENS, so a socket that opens
     // and dies immediately would reconnect for ever — which is not what the

--- a/apps/realtime/src/dev-preview/__tests__/detection-registry.test.ts
+++ b/apps/realtime/src/dev-preview/__tests__/detection-registry.test.ts
@@ -1,4 +1,10 @@
 import { describe, it, expect, vi } from 'vitest';
+// WITHOUT THIS IMPORT the `assert({ given, should, actual, expected })` calls
+// below silently resolve to vitest's global chai `assert`, which asserts
+// TRUTHINESS of its first argument — and an object literal is always truthy.
+// Eight of them passed unconditionally, one whole test asserted nothing at
+// all, and it typechecked and went green the entire time.
+import { assert } from '../../terminal/__tests__/riteway';
 import type { SandboxHandle } from '@pagespace/lib/services/sandbox/sandbox-host';
 import type { PortsWatchSocketLike } from '@pagespace/lib/services/sandbox/preview/ports-watch';
 import { createDetectionRegistry, nodeWebSocketFactory, type DetectionRegistryDeps } from '../detection-registry';
@@ -433,6 +439,41 @@ describe('createDetectionRegistry', () => {
 
     // Still exactly one replacement. Without the identity guard t2 tears down
     // t1's live watcher and opens a third socket.
+    expect(h.sockets).toHaveLength(2);
+  });
+
+  it('a failed re-arm leaves the sprite armable by the next explicit trigger', async () => {
+    // The property, not the race. When a re-arm's own attach fails the slot is
+    // left EMPTY, and the next explicit trigger must arm rather than stand
+    // down — for an unattended session nothing else would.
+    //
+    // NOT COVERED: the concurrent interleaving where a second trigger captured
+    // the stale entry BEFORE the slot emptied, and so re-reads `undefined`
+    // rather than a stale entry. That is the case the empty-vs-occupied
+    // distinction in `armIfMissing` exists for; every attempt to script it
+    // deterministically here produced a test that either passed with the fix
+    // removed or hung, and a test that cannot fail is worth nothing. The
+    // distinction is argued in the code instead.
+    let instance = 'inst-old';
+    let attaches = 0;
+    // 1 = the first arm's own start; 2 = the rebuild comparison; 3 = the
+    // re-arm's start, which is the one that fails.
+    const h = deps({
+      attach: async () => {
+        attaches += 1;
+        return attaches === 3 ? null : fakeHandle(instance);
+      },
+    });
+    const registry = createDetectionRegistry(h.deps);
+    await registry.ensure({ holder: HOLDER });
+    expect(h.sockets).toHaveLength(1);
+
+    instance = 'inst-new';
+    await registry.ensure({ holder: HOLDER });
+    expect(h.sockets).toHaveLength(1);
+    expect(h.logs.some((l) => l.includes('not attachable'))).toBe(true);
+
+    await registry.ensure({ holder: HOLDER });
     expect(h.sockets).toHaveLength(2);
   });
 

--- a/apps/realtime/src/dev-preview/__tests__/detection-registry.test.ts
+++ b/apps/realtime/src/dev-preview/__tests__/detection-registry.test.ts
@@ -42,6 +42,8 @@ function fakeHandle(): SandboxHandle {
   };
 }
 
+const clock = { now: new Date('2026-09-06T12:00:00Z') };
+
 function deps(over: Partial<DetectionRegistryDeps> = {}) {
   const factory = fakeSocketFactory();
   const logs: string[] = [];
@@ -56,7 +58,7 @@ function deps(over: Partial<DetectionRegistryDeps> = {}) {
     spritesToken: () => 'tok',
     spritesApiBaseUrl: () => 'https://api.sprites.dev',
     log: { info: (m) => logs.push(`info:${m}`), warn: (m, c) => logs.push(`warn:${m}:${JSON.stringify(c)}`), error: (m) => logs.push(`error:${m}`) },
-    now: () => new Date('2026-09-06T12:00:00Z'),
+    now: () => clock.now,
     wait: async (ms) => { waits.push(ms); },
     ...over,
   };
@@ -99,26 +101,26 @@ describe('createDetectionRegistry', () => {
   it('listeners(): null before any watch AND until the connection\'s port_list has APPLIED (the detector owns that); the accumulated snapshot after it; null again once the watcher is gone or the feature is dark', async () => {
     const h = deps();
     const registry = createDetectionRegistry(h.deps);
-    expect(await registry.listeners({ holder: HOLDER })).toBeNull();
+    expect((await registry.read({ holder: HOLDER })).listeners).toBeNull();
     await registry.ensure({ holder: HOLDER });
     // Watching, socket open, but no `port_list` yet: the detector's empty
     // array is NOT a known-empty snapshot — it is nothing yet. Unknown.
     h.sockets[0].emit('open');
-    expect(await registry.listeners({ holder: HOLDER })).toBeNull();
+    expect((await registry.read({ holder: HOLDER })).listeners).toBeNull();
     h.sockets[0].emit('message', { data: JSON.stringify({ type: 'port_opened', port: 3000, pid: 1 }) });
     await new Promise((r) => setTimeout(r, 10));
-    expect(await registry.listeners({ holder: HOLDER })).toBeNull();
+    expect((await registry.read({ holder: HOLDER })).listeners).toBeNull();
     h.sockets[0].emit('message', { data: JSON.stringify({ type: 'port_list', ports: [{ port: 5173, pid: 3 }, { port: 8080, pid: 9 }] }) });
     // (Arrived-but-not-applied is the detector's own contract, tested there.)
     h.sockets[0].emit('message', { data: JSON.stringify({ type: 'port_closed', port: 8080 }) });
     await new Promise((r) => setTimeout(r, 10));
-    expect(await registry.listeners({ holder: HOLDER })).toEqual([{ port: 5173, pid: 3 }]);
+    expect((await registry.read({ holder: HOLDER })).listeners).toEqual([{ port: 5173, pid: 3 }]);
     // A holder whose row has no live sprite is never answered from someone else's watcher.
-    expect(await registry.listeners({ holder: { kind: 'env', id: 'gone-holder' } })).toBeNull();
+    expect((await registry.read({ holder: { kind: 'env', id: 'gone-holder' } })).listeners).toBeNull();
     registry.stopAll();
-    expect(await registry.listeners({ holder: HOLDER })).toBeNull();
+    expect((await registry.read({ holder: HOLDER })).listeners).toBeNull();
     const dark = createDetectionRegistry(deps({ featureEnabled: () => false }).deps);
-    expect(await dark.listeners({ holder: HOLDER })).toBeNull();
+    expect((await dark.read({ holder: HOLDER })).listeners).toBeNull();
   });
 
   it('listeners(): a DROPPED connection answers null through the reconnect backoff (the old array is stale), and is known again only after the new connection delivers its port_list', async () => {
@@ -128,17 +130,17 @@ describe('createDetectionRegistry', () => {
     h.sockets[0].emit('open');
     h.sockets[0].emit('message', { data: JSON.stringify({ type: 'port_list', ports: [{ port: 5173, pid: 3 }] }) });
     await new Promise((r) => setTimeout(r, 10));
-    expect(await registry.listeners({ holder: HOLDER })).toEqual([{ port: 5173, pid: 3 }]);
+    expect((await registry.read({ holder: HOLDER })).listeners).toEqual([{ port: 5173, pid: 3 }]);
     // Drop: reconnect is pending (the waits fake resolves at once, so a second socket exists) — still unknown until IT snapshots.
     h.sockets[0].emit('close', { code: 1006 });
     await new Promise((r) => setImmediate(r));
     expect(registry.watching()).toEqual(['sbx-env1']);
-    expect(await registry.listeners({ holder: HOLDER })).toBeNull();
+    expect((await registry.read({ holder: HOLDER })).listeners).toBeNull();
     h.sockets[1].emit('open');
-    expect(await registry.listeners({ holder: HOLDER })).toBeNull();
+    expect((await registry.read({ holder: HOLDER })).listeners).toBeNull();
     h.sockets[1].emit('message', { data: JSON.stringify({ type: 'port_list', ports: [{ port: 8080, pid: 42 }] }) });
     await new Promise((r) => setTimeout(r, 10));
-    expect(await registry.listeners({ holder: HOLDER })).toEqual([{ port: 8080, pid: 42 }]);
+    expect((await registry.read({ holder: HOLDER })).listeners).toEqual([{ port: 8080, pid: 42 }]);
   });
 
   it('listeners(): a port_list whose socket dropped before the detector applied it never marks the NEXT connection fresh', async () => {
@@ -152,7 +154,7 @@ describe('createDetectionRegistry', () => {
     await new Promise((r) => setTimeout(r, 10));
     expect(h.sockets).toHaveLength(2);
     h.sockets[1].emit('open');
-    expect(await registry.listeners({ holder: HOLDER })).toBeNull();
+    expect((await registry.read({ holder: HOLDER })).listeners).toBeNull();
   });
 
   it('a failing start leaves no entry behind (a malformed API base URL throws before the channel opens)', async () => {
@@ -160,7 +162,7 @@ describe('createDetectionRegistry', () => {
     const registry = createDetectionRegistry(h.deps);
     await registry.ensure({ holder: HOLDER });
     expect(registry.watching()).toEqual([]);
-    expect(await registry.listeners({ holder: HOLDER })).toBeNull();
+    expect((await registry.read({ holder: HOLDER })).listeners).toBeNull();
     expect(h.logs.some((l) => l.startsWith('error:dev-preview: watcher failed to start'))).toBe(true);
   });
 
@@ -171,11 +173,11 @@ describe('createDetectionRegistry', () => {
     h.sockets[0].emit('open');
     h.sockets[0].emit('message', { data: JSON.stringify({ type: 'port_list', ports: [{ port: 5173, pid: 3 }] }) });
     await new Promise((r) => setTimeout(r, 10));
-    expect(await registry.listeners({ holder: HOLDER })).toEqual([{ port: 5173, pid: 3 }]);
+    expect((await registry.read({ holder: HOLDER })).listeners).toEqual([{ port: 5173, pid: 3 }]);
     h.sockets[0].emit('close', { code: 1006 });
     await new Promise((r) => setImmediate(r));
     expect(registry.watching()).toEqual([]);
-    expect(await registry.listeners({ holder: HOLDER })).toBeNull();
+    expect((await registry.read({ holder: HOLDER })).listeners).toBeNull();
   });
 
   it('watches nothing for a holder whose row has no live sprite — the caller never names the sprite', async () => {
@@ -291,5 +293,66 @@ describe('createDetectionRegistry', () => {
     await pending;
     expect(h.sockets).toHaveLength(0);
     expect(registry.watching()).toEqual([]);
+  });
+
+  it('RECOVERY AFTER A RESTART: a fresh registry that was never told to `ensure` still starts watching when a status read arrives', async () => {
+    // This is the process-restart case. Watchers live only in memory, so a
+    // restart loses every one of them, and nothing else would ever start them
+    // again — a dev server begun afterwards was previously never detected.
+    const h = deps();
+    const registry = createDetectionRegistry(h.deps);
+    const first = await registry.read({ holder: HOLDER });
+    assert({ given: 'a read against a registry with no watchers', should: 'report arming and say nothing about ports', actual: first, expected: { detection: 'arming', listeners: null } });
+    await new Promise((r) => setTimeout(r, 5));
+    expect(h.sockets).toHaveLength(1);
+
+    h.sockets[0].emit('open');
+    h.sockets[0].emit('message', { data: JSON.stringify({ type: 'port_list', ports: [{ port: 5173, pid: 3 }] }) });
+    await new Promise((r) => setTimeout(r, 10));
+    assert({ given: 'the re-armed watcher once it has snapshotted', should: 'report watching, with the ports', actual: await registry.read({ holder: HOLDER }), expected: { detection: 'watching', listeners: [{ port: 5173, pid: 3 }] } });
+  });
+
+  it('an exhausted reconnect budget is no longer the end of detection — the next read re-arms it', async () => {
+    const h = deps({ maxReconnects: 0 });
+    const registry = createDetectionRegistry(h.deps);
+    await registry.ensure({ holder: HOLDER });
+    h.sockets[0].emit('open');
+    h.sockets[0].emit('close', { code: 1006 });
+    await new Promise((r) => setImmediate(r));
+    expect(registry.watching()).toEqual([]);
+
+    // Past the cool-down (the drop counts as an arm), a read starts over.
+    clock.now = new Date(clock.now.getTime() + 60_000);
+    assert({ given: 'a read after the budget was spent', should: 'arm again', actual: await registry.read({ holder: HOLDER }), expected: { detection: 'arming', listeners: null } });
+    await new Promise((r) => setTimeout(r, 5));
+    expect(h.sockets).toHaveLength(2);
+  });
+
+  it('the re-arm is THROTTLED, so a sick sprite is not re-attacked on every render — but an explicit ensure is never throttled', async () => {
+    const h = deps({ attach: async () => null });
+    const registry = createDetectionRegistry(h.deps);
+    for (let i = 0; i < 5; i += 1) await registry.read({ holder: HOLDER });
+    await new Promise((r) => setTimeout(r, 5));
+    assert({ given: 'five reads inside the cool-down for an unattachable sprite', should: 'have tried exactly once', actual: h.logs.filter((l) => l.startsWith('warn:dev-preview: sprite not attachable')).length, expected: 1 });
+
+    clock.now = new Date(clock.now.getTime() + 60_000);
+    await registry.read({ holder: HOLDER });
+    await new Promise((r) => setTimeout(r, 5));
+    assert({ given: 'a read past the cool-down', should: 'try again', actual: h.logs.filter((l) => l.startsWith('warn:dev-preview: sprite not attachable')).length, expected: 2 });
+
+    // An explicit trigger means something just happened — it never waits.
+    await registry.ensure({ holder: HOLDER });
+    await new Promise((r) => setTimeout(r, 5));
+    assert({ given: 'an ensure inside the cool-down', should: 'try immediately', actual: h.logs.filter((l) => l.startsWith('warn:dev-preview: sprite not attachable')).length, expected: 3 });
+  });
+
+  it('a holder with no live sprite, and a dark feature, report unavailable and arm nothing', async () => {
+    const h = deps();
+    const registry = createDetectionRegistry(h.deps);
+    assert({ given: 'a holder whose row has no sprite', should: 'be unavailable', actual: await registry.read({ holder: { kind: 'env', id: 'gone-holder' } }), expected: { detection: 'unavailable', listeners: null } });
+    const dark = deps({ featureEnabled: () => false });
+    assert({ given: 'a dark deployment', should: 'be unavailable without even resolving the row', actual: await createDetectionRegistry(dark.deps).read({ holder: HOLDER }), expected: { detection: 'unavailable', listeners: null } });
+    expect(h.sockets).toHaveLength(0);
+    expect(dark.sockets).toHaveLength(0);
   });
 });

--- a/apps/realtime/src/dev-preview/__tests__/preview-upgrade.test.ts
+++ b/apps/realtime/src/dev-preview/__tests__/preview-upgrade.test.ts
@@ -104,6 +104,18 @@ describe('buildPreviewUpgradeHandler', () => {
     expect(revoked.tunnelled).toHaveLength(0);
   });
 
+  it('bounds the tunnel by the COOKIE\'s expiry, so a socket cannot outlive the credential that opened it', async () => {
+    // The gather runs once, at upgrade, and HMR traffic resets the idle cut
+    // forever — so without this a revoked session, a removed drive member or a
+    // switched-off preview would keep streaming while the HTTP half refuses.
+    const d = deps();
+    const s = fakeSocket();
+    await buildPreviewUpgradeHandler(d.deps)(req({ cookie: cookieFor() }), s.socket, Buffer.alloc(0));
+    expect(d.tunnelled).toHaveLength(1);
+    // The cookie in this fixture expires 60s after the fixed clock.
+    expect(d.tunnelled[0].maxLifetimeMs).toBe(60_000);
+  });
+
   it('refuses with the gate status when the gather refuses, and logs the refusal with attribution', async () => {
     const d = deps({
       resolveTarget: async () => ({ decision: { kind: 'refuse', reason: 'stale-instance', status: 409, message: 'rebuilt' }, authorization: { allowed: false, reason: 'x' } }),

--- a/apps/realtime/src/dev-preview/__tests__/preview-upgrade.test.ts
+++ b/apps/realtime/src/dev-preview/__tests__/preview-upgrade.test.ts
@@ -12,7 +12,7 @@ const NOW = new Date('2026-09-06T12:00:00Z');
 const HOLDER = { kind: 'env', id: 'env1' } as const;
 
 function cookieFor(holder = HOLDER, key = KEY): string {
-  return `${PREVIEW_COOKIE_NAME}=${signPreviewCookie({ holder, userId: 'u1', expiresAt: NOW.getTime() + 60_000 }, key)}`;
+  return `${PREVIEW_COOKIE_NAME}=${signPreviewCookie({ holder, userId: 'u1', sessionId: 'sess1', expiresAt: NOW.getTime() + 60_000 }, key)}`;
 }
 
 function req(over: Partial<{ host: string; cookie: string; url: string; extra: Record<string, string> }> = {}): IncomingMessage {
@@ -87,6 +87,21 @@ describe('buildPreviewUpgradeHandler', () => {
       expect(s.destroyed()).toBe(true);
     }
     expect(resolveTarget).not.toHaveBeenCalled();
+  });
+
+  it('carries the cookie SESSION into the gather, so a revoked session cannot hold a socket open either', async () => {
+    const seen: Array<[unknown, string, string]> = [];
+    const d = deps({ resolveTarget: async (holder, userId, sessionId) => { seen.push([holder, userId, sessionId]); return forward; } });
+    const s = fakeSocket();
+    await buildPreviewUpgradeHandler(d.deps)(req({ cookie: cookieFor() }), s.socket, Buffer.alloc(0));
+    expect(seen).toEqual([[HOLDER, 'u1', 'sess1']]);
+
+    // And the refusal the gather gives a revoked session closes the upgrade.
+    const revoked = deps({ resolveTarget: async () => ({ decision: { kind: 'refuse', reason: 'not-authorized', status: 404, message: 'Not found', detail: 'session_revoked' }, authorization: { allowed: false, reason: 'session_revoked' } }) });
+    const s2 = fakeSocket();
+    expect(await buildPreviewUpgradeHandler(revoked.deps)(req({ cookie: cookieFor() }), s2.socket, Buffer.alloc(0))).toBe(true);
+    expect(s2.written.join('')).toMatch(/^HTTP\/1\.1 404 /);
+    expect(revoked.tunnelled).toHaveLength(0);
   });
 
   it('refuses with the gate status when the gather refuses, and logs the refusal with attribution', async () => {

--- a/apps/realtime/src/dev-preview/detection-registry.ts
+++ b/apps/realtime/src/dev-preview/detection-registry.ts
@@ -263,15 +263,24 @@ export function createDetectionRegistry(deps: DetectionRegistryDeps): DetectionR
       if (live === null || live.spriteInstanceId === existing.spriteInstanceId) return;
       // That attach was a full control-plane round trip, and two explicit
       // triggers for one holder are routine (a shell ensure and the signed
-      // watch call both fire, both `void`-ed). The map may have been re-armed
-      // meanwhile — by the other trigger, which has already done this exact
-      // work — so re-read before closing anything.
-      if (watchers.get(sandboxId) !== existing) return;
+      // watch call both fire, both `void`-ed). The map may have moved on
+      // meanwhile, and the two ways it can have moved need OPPOSITE answers:
+      //
+      //  - SOMETHING ELSE IS THERE ⇒ the other trigger already did this work.
+      //    Return, and above all do not close what it installed.
+      //  - THE SLOT IS EMPTY ⇒ the other trigger's re-arm FAILED and removed
+      //    its own entry (an attach that came back null right after a rebuild
+      //    is exactly when that happens). Returning here would leave the
+      //    sprite with no watcher at all while this trigger — explicit, and
+      //    deliberately un-throttled — had a perfectly good attach in hand.
+      //    Fall through and arm.
+      const current = watchers.get(sandboxId);
+      if (current !== undefined && current !== existing) return;
+      if (current === existing) existing.close();
       deps.log.info('dev-preview: sprite replaced under the same name, re-watching', {
         holderKind: holder.kind,
         holderId: holder.id,
       });
-      existing.close();
     }
     const now = deps.now().getTime();
     // Sweep as we go: the map only ever holds sprites armed within the
@@ -283,7 +292,16 @@ export function createDetectionRegistry(deps: DetectionRegistryDeps): DetectionR
     }
     lastArmAt.set(sandboxId, now);
     // Reserve the slot synchronously so two concurrent arms start one watcher.
-    const reservation: Watcher = { detector: null, spriteInstanceId: null, close() { watchers.delete(sandboxId); } };
+    // Guarded by identity for the same reason the live entry's `close()` is:
+    // nothing calls this today, and that is exactly when a blind
+    // delete-by-key survives long enough to become someone's bug.
+    const reservation: Watcher = {
+      detector: null,
+      spriteInstanceId: null,
+      close() {
+        if (watchers.get(sandboxId) === reservation) watchers.delete(sandboxId);
+      },
+    };
     watchers.set(sandboxId, reservation);
     try {
       await start(holder, sandboxId);

--- a/apps/realtime/src/dev-preview/detection-registry.ts
+++ b/apps/realtime/src/dev-preview/detection-registry.ts
@@ -103,7 +103,13 @@ export interface DetectionRegistry {
 
 const DEFAULT_MAX_RECONNECTS = 5;
 const BACKOFF_MS = [1_000, 2_000, 5_000, 10_000, 30_000];
-/** Roughly an hour of the longest backoff — long past "a blip", short of "forever". */
+/**
+ * How long a connection must stay up to count as HEALTHY, clearing both
+ * reconnect budgets. Comfortably longer than a flap (which dies in
+ * milliseconds) and far shorter than any real session.
+ */
+const HEALTHY_CONNECTION_MS = 60_000;
+/** Consecutive connections that did not survive, before the watcher is retired. A flap burns these in a couple of minutes. */
 const DEFAULT_MAX_TOTAL_RECONNECTS = 120;
 /**
  * How long a read-driven re-arm waits before trying a sprite again. The status
@@ -166,6 +172,8 @@ export function createDetectionRegistry(deps: DetectionRegistryDeps): DetectionR
     // ceiling costs at most that, and a flap that has survived it is a sprite
     // problem rather than a connection problem.
     let totalAttempts = 0;
+    /** When the CURRENT connection attempt was opened, for judging whether it survived. */
+    let attemptStartedAt = deps.now().getTime();
 
     const entry: Watcher = {
       detector,
@@ -173,11 +181,19 @@ export function createDetectionRegistry(deps: DetectionRegistryDeps): DetectionR
       close() {
         stopped = true;
         current?.close();
-        watchers.delete(sandboxId);
+        // BY IDENTITY, never by key. A sandbox NAME can be re-armed while an
+        // old entry is still held by a caller that read the map before the
+        // swap; deleting blindly would drop the LIVE watcher and orphan it —
+        // socket open, detector still writing rows, nothing able to reach it.
+        // The re-arm path guards its own call site as well, so this is the
+        // second line rather than the first: it is what keeps any FUTURE
+        // caller of `close()` from reintroducing the same bug.
+        if (watchers.get(sandboxId) === entry) watchers.delete(sandboxId);
       },
     };
 
     const open = () => {
+      attemptStartedAt = deps.now().getTime();
       current = openPortsWatch({
         url,
         token: deps.spritesToken(),
@@ -192,7 +208,16 @@ export function createDetectionRegistry(deps: DetectionRegistryDeps): DetectionR
           // from claiming the NEXT connection's snapshot.
           detector.invalidateSnapshot();
           if (stopped) return;
+          // A connection that OPENED and then SURVIVED is a healthy channel
+          // being recycled — an idle cut, a load balancer, a deploy — and it
+          // clears both budgets. One that opened and died at once is the flap
+          // the second budget exists for, and `info.opened` alone cannot tell
+          // them apart: it is true for both, which is why counting every
+          // reconnect would retire a perfectly healthy long-lived watcher and
+          // leave an unattended session with no detection at all.
+          const survived = info.opened && deps.now().getTime() - attemptStartedAt >= HEALTHY_CONNECTION_MS;
           if (info.opened) attempts = 0;
+          if (survived) totalAttempts = 0;
           if (info.reason === 'no-token' || attempts >= maxReconnects || totalAttempts >= maxTotalReconnects) {
             deps.log.warn('dev-preview: watch channel gone, detection stopped for this sprite', { holderKind: holder.kind, holderId: holder.id, reason: info.reason, attempts, totalAttempts });
             stopped = true;
@@ -236,6 +261,12 @@ export function createDetectionRegistry(deps: DetectionRegistryDeps): DetectionR
       if (throttled || existing.spriteInstanceId === null) return;
       const live = await deps.attach(sandboxId).catch(() => null);
       if (live === null || live.spriteInstanceId === existing.spriteInstanceId) return;
+      // That attach was a full control-plane round trip, and two explicit
+      // triggers for one holder are routine (a shell ensure and the signed
+      // watch call both fire, both `void`-ed). The map may have been re-armed
+      // meanwhile — by the other trigger, which has already done this exact
+      // work — so re-read before closing anything.
+      if (watchers.get(sandboxId) !== existing) return;
       deps.log.info('dev-preview: sprite replaced under the same name, re-watching', {
         holderKind: holder.kind,
         holderId: holder.id,

--- a/apps/realtime/src/dev-preview/detection-registry.ts
+++ b/apps/realtime/src/dev-preview/detection-registry.ts
@@ -10,12 +10,24 @@
  * (`dev-preview-detection.ts`), which plans and applies relay effects
  * through the core.
  *
- * FAIL CLOSED, BOUNDED. When the channel closes it is reopened with backoff
- * up to a small budget; past the budget the watcher is dropped and the fact
- * is logged. Nothing falls back to the TTY channel or to an exec probe (both
- * would miss or wake — see `ports-watch.ts`). A sprite that hibernates drops
- * the channel; a later ensure/shell re-asserts the watcher. A watcher whose
- * sprite the platform no longer has (attach → null) is dropped at once.
+ * FAIL CLOSED, BOUNDED — AND RECOVERABLE. When the channel closes it is
+ * reopened with backoff up to a small budget; past the budget the watcher is
+ * dropped and the fact is logged. Nothing falls back to the TTY channel or to
+ * an exec probe (both would miss or wake — see `ports-watch.ts`).
+ *
+ * Every drop is terminal FOR THAT CHANNEL, deliberately: recovery never
+ * resurrects a timer that might outlive the sprite, it re-derives the holder's
+ * live sandbox from its ROW. What makes a drop survivable is that the status
+ * READ re-arms a missing watcher (`read`, below) — which also covers the case
+ * no reconnect can: this process restarting and losing every watcher it had.
+ * Without that, a dropped watcher meant detection was over for that sprite
+ * until somebody happened to open a shell or provision a session again.
+ *
+ * The re-arm is throttled, because the read happens on every status render:
+ * an unattachable or hibernated sprite must not be re-attacked several times a
+ * minute. One holder nobody is looking at and nobody shells into still gets no
+ * watcher — that costs one poll interval of relay-start latency the moment
+ * someone does look, and nothing else.
  */
 
 import type { SandboxHandle } from '@pagespace/lib/services/sandbox/sandbox-host';
@@ -47,24 +59,41 @@ export interface DetectionRegistryDeps {
   maxReconnects?: number;
 }
 
+/**
+ * Whether detection is actually running for a holder right now — a fact the
+ * old `listeners()` could not express, because `null` meant both "no snapshot
+ * yet" and "nobody is watching at all".
+ */
+export type DevPreviewDetection = 'watching' | 'arming' | 'unavailable';
+
+export interface DevPreviewDetectionRead {
+  detection: DevPreviewDetection;
+  listeners: ListeningPort[] | null;
+}
+
 export interface DetectionRegistry {
   /** Watch the holder's live sprite (re-derived from the holder's row). Idempotent per sprite. */
   ensure(input: { holder: DevPreviewHolderRef }): Promise<void>;
   /**
-   * The listener snapshot the holder's watcher holds for its CURRENT
-   * connection, or `null` when there is no such snapshot: no watcher for the
-   * holder's live sprite (never watched, dropped past the reconnect budget,
-   * or the sprite is on another instance's channel), a connection that has
-   * not yet delivered its initial `port_list`, or a dropped connection
-   * waiting out the reconnect backoff. In those last two windows the
-   * detector's array is stale or merely empty, and handing it out as a KNOWN
-   * snapshot would let a render call 8080 free (and a resume start a relay
-   * onto an occupied port); "unknown" is the honest answer there. This is
-   * the ONLY listener source a status render may use — it is already in
-   * hand, so answering costs the sprite nothing (the never-probe-to-render
-   * rule). `null` renders as "slot unknown", never as "free".
+   * What this process knows about the holder's ports, and whether it is
+   * watching at all — plus the re-arm that makes a lost watcher recoverable.
+   *
+   * `listeners` is the snapshot for the CURRENT connection, or `null` when
+   * there is no such snapshot: no watcher, a connection that has not yet
+   * delivered its `port_list`, or a dropped connection waiting out the
+   * backoff. In those windows the detector's array is stale or merely empty,
+   * and handing it out as KNOWN would let a render call 8080 free (and a
+   * resume start a relay onto an occupied port). This is the ONLY listener
+   * source a status render may use — it is already in hand, so answering
+   * costs the sprite nothing (the never-probe-to-render rule).
+   *
+   * `detection` separates the two meanings `null` used to conflate, so the UI
+   * can say "the ports are not known right now" instead of implying the
+   * sandbox is idle. When nothing is watching a holder that HAS a live
+   * sprite, this fires a throttled re-arm and answers `'arming'`; the caller
+   * is never made to wait for it.
    */
-  listeners(input: { holder: DevPreviewHolderRef }): Promise<ListeningPort[] | null>;
+  read(input: { holder: DevPreviewHolderRef }): Promise<DevPreviewDetectionRead>;
   /** Sprites currently watched — for tests and for a status line. */
   watching(): string[];
   stopAll(): void;
@@ -72,6 +101,12 @@ export interface DetectionRegistry {
 
 const DEFAULT_MAX_RECONNECTS = 5;
 const BACKOFF_MS = [1_000, 2_000, 5_000, 10_000, 30_000];
+/**
+ * How long a read-driven re-arm waits before trying a sprite again. The status
+ * read fires every few seconds per viewer; without this, a sprite that cannot
+ * be attached (hibernated, gone) would be retried on every render.
+ */
+export const REARM_COOLDOWN_MS = 30_000;
 
 export function createDetectionRegistry(deps: DetectionRegistryDeps): DetectionRegistry {
   const wait = deps.wait ?? ((ms: number) => new Promise<void>((resolve) => setTimeout(resolve, ms)));
@@ -91,6 +126,8 @@ export function createDetectionRegistry(deps: DetectionRegistryDeps): DetectionR
     detector: DevPreviewDetector | null;
   }
   const watchers = new Map<string, Watcher>();
+  /** sandboxId → when a re-arm was last attempted, so the read path cannot storm a sick sprite. */
+  const lastArmAt = new Map<string, number>();
 
   async function start(holder: DevPreviewHolderRef, sandboxId: string): Promise<void> {
     const reservation = watchers.get(sandboxId);
@@ -152,6 +189,35 @@ export function createDetectionRegistry(deps: DetectionRegistryDeps): DetectionR
     deps.log.info('dev-preview: watching sprite', { holderKind: holder.kind, holderId: holder.id });
   }
 
+  /**
+   * Start a watcher for a sprite that has none. `throttled` is for the read
+   * path, which runs on every status render; explicit triggers (a shell open,
+   * a provision, the signed watch call) are never throttled — they mean
+   * something just happened.
+   */
+  async function armIfMissing(holder: DevPreviewHolderRef, sandboxId: string, { throttled }: { throttled: boolean }): Promise<void> {
+    if (watchers.has(sandboxId)) return;
+    const now = deps.now().getTime();
+    // Sweep as we go: the map only ever holds sprites armed within the
+    // cool-down, so it cannot grow with the number of sprites ever seen.
+    for (const [key, at] of lastArmAt) if (now - at >= REARM_COOLDOWN_MS) lastArmAt.delete(key);
+    if (throttled) {
+      const last = lastArmAt.get(sandboxId);
+      if (last !== undefined && now - last < REARM_COOLDOWN_MS) return;
+    }
+    lastArmAt.set(sandboxId, now);
+    // Reserve the slot synchronously so two concurrent arms start one watcher.
+    watchers.set(sandboxId, { detector: null, close() { watchers.delete(sandboxId); } });
+    try {
+      await start(holder, sandboxId);
+    } catch (error) {
+      // Whatever `start` had registered goes with the failure — the
+      // reservation, or the live entry if the throw came after it was set.
+      watchers.delete(sandboxId);
+      deps.log.error('dev-preview: watcher failed to start', error instanceof Error ? error : new Error(String(error)), { holderKind: holder.kind, holderId: holder.id });
+    }
+  }
+
   return {
     async ensure({ holder }) {
       if (!deps.featureEnabled()) return;
@@ -160,24 +226,23 @@ export function createDetectionRegistry(deps: DetectionRegistryDeps): DetectionR
       // any) that holder is on right now.
       const sandboxId = await deps.resolveHolderSandboxId(holder);
       if (sandboxId === null) return;
-      if (watchers.has(sandboxId)) return;
-      // Reserve the slot synchronously so two concurrent ensures start one watcher.
-      watchers.set(sandboxId, { detector: null, close() { watchers.delete(sandboxId); } });
-      try {
-        await start(holder, sandboxId);
-      } catch (error) {
-        // Whatever `start` had registered goes with the failure — the
-        // reservation, or the live entry if the throw came after it was set.
-        watchers.delete(sandboxId);
-        deps.log.error('dev-preview: watcher failed to start', error instanceof Error ? error : new Error(String(error)), { holderKind: holder.kind, holderId: holder.id });
-      }
+      await armIfMissing(holder, sandboxId, { throttled: false });
     },
-    async listeners({ holder }) {
-      if (!deps.featureEnabled()) return null;
+    async read({ holder }) {
+      if (!deps.featureEnabled()) return { detection: 'unavailable', listeners: null };
       // Same rule as `ensure`: the sprite is the holder's ROW's, never a claim.
       const sandboxId = await deps.resolveHolderSandboxId(holder);
-      if (sandboxId === null) return null;
-      return watchers.get(sandboxId)?.detector?.listeners() ?? null;
+      if (sandboxId === null) return { detection: 'unavailable', listeners: null };
+      const entry = watchers.get(sandboxId);
+      if (entry === undefined) {
+        // Nothing is watching a holder that HAS a live sprite — a restart, an
+        // exhausted budget, an unattachable moment that has passed. Re-arm and
+        // tell the caller so; never await it inside a render.
+        void armIfMissing(holder, sandboxId, { throttled: true });
+        return { detection: 'arming', listeners: null };
+      }
+      if (entry.detector === null) return { detection: 'arming', listeners: null };
+      return { detection: 'watching', listeners: entry.detector.listeners() };
     },
     watching: () => [...watchers.keys()],
     stopAll() {

--- a/apps/realtime/src/dev-preview/detection-registry.ts
+++ b/apps/realtime/src/dev-preview/detection-registry.ts
@@ -193,12 +193,18 @@ export function createDetectionRegistry(deps: DetectionRegistryDeps): DetectionR
     };
 
     const open = () => {
+      // Set on the OPEN event below, not here: the handshake can take seconds,
+      // and counting it as uptime would let a channel that keeps failing to
+      // stay up look like one being healthily recycled — which clears the
+      // ceiling that exists to retire it. Until it opens this stays at the
+      // attempt's start, which can only make `survived` stricter.
       attemptStartedAt = deps.now().getTime();
       current = openPortsWatch({
         url,
         token: deps.spritesToken(),
         createSocket: deps.createSocket,
         onFrame: (frame) => { void detector.onFrame(frame); },
+        onOpen: () => { attemptStartedAt = deps.now().getTime(); },
         onClose: (info) => {
           current = null;
           // The accumulated set no longer describes a live connection. Takes

--- a/apps/realtime/src/dev-preview/detection-registry.ts
+++ b/apps/realtime/src/dev-preview/detection-registry.ts
@@ -21,6 +21,7 @@
 import type { SandboxHandle } from '@pagespace/lib/services/sandbox/sandbox-host';
 import type { DevPreviewHolderRef, ListeningPort } from '@pagespace/lib/services/sandbox/preview/dev-preview-core';
 import { createDevPreviewDetector, type DevPreviewDetector, type DevPreviewDetectorLog } from '@pagespace/lib/services/sandbox/preview/dev-preview-detection';
+import type { DevPreviewLock } from '@pagespace/lib/services/sandbox/preview/dev-preview-lock';
 import type { DevPreviewStore } from '@pagespace/lib/services/sandbox/preview/dev-preview-store';
 import { buildPortsWatchUrl, openPortsWatch, type PortsWatchHandle, type PortsWatchSocketFactory } from '@pagespace/lib/services/sandbox/preview/ports-watch';
 
@@ -34,6 +35,12 @@ export interface DetectionRegistryDeps {
   spritesToken(): string;
   spritesApiBaseUrl(): string;
   log: DevPreviewDetectorLog;
+  /**
+   * Serializes a frame's read → plan → apply against the web tier's stop and
+   * resume. Optional so the unit surface needs no Postgres; `index.ts` binds
+   * the real advisory lock.
+   */
+  lock?: DevPreviewLock;
   now(): Date;
   /** Test seam for the reconnect delay. */
   wait?: (ms: number) => Promise<void>;
@@ -96,7 +103,7 @@ export function createDetectionRegistry(deps: DetectionRegistryDeps): DetectionR
       watchers.delete(sandboxId);
       return;
     }
-    const detector = createDevPreviewDetector({ holder, handle, store: deps.store, now: deps.now, log: deps.log });
+    const detector = createDevPreviewDetector({ holder, handle, store: deps.store, now: deps.now, log: deps.log, lock: deps.lock });
     const url = buildPortsWatchUrl(deps.spritesApiBaseUrl(), sandboxId);
     let stopped = false;
     let current: PortsWatchHandle | null = null;

--- a/apps/realtime/src/dev-preview/detection-registry.ts
+++ b/apps/realtime/src/dev-preview/detection-registry.ts
@@ -57,6 +57,8 @@ export interface DetectionRegistryDeps {
   /** Test seam for the reconnect delay. */
   wait?: (ms: number) => Promise<void>;
   maxReconnects?: number;
+  /** The non-resetting ceiling for one watcher; a flapping channel is dropped and the read path re-arms it. */
+  maxTotalReconnects?: number;
 }
 
 /**
@@ -101,6 +103,8 @@ export interface DetectionRegistry {
 
 const DEFAULT_MAX_RECONNECTS = 5;
 const BACKOFF_MS = [1_000, 2_000, 5_000, 10_000, 30_000];
+/** Roughly an hour of the longest backoff — long past "a blip", short of "forever". */
+const DEFAULT_MAX_TOTAL_RECONNECTS = 120;
 /**
  * How long a read-driven re-arm waits before trying a sprite again. The status
  * read fires every few seconds per viewer; without this, a sprite that cannot
@@ -111,6 +115,7 @@ export const REARM_COOLDOWN_MS = 30_000;
 export function createDetectionRegistry(deps: DetectionRegistryDeps): DetectionRegistry {
   const wait = deps.wait ?? ((ms: number) => new Promise<void>((resolve) => setTimeout(resolve, ms)));
   const maxReconnects = deps.maxReconnects ?? DEFAULT_MAX_RECONNECTS;
+  const maxTotalReconnects = deps.maxTotalReconnects ?? DEFAULT_MAX_TOTAL_RECONNECTS;
   /**
    * One entry per watched sprite: how to close it, and its detector — the
    * snapshot source for `listeners()`, null while the slot is only reserved.
@@ -124,6 +129,13 @@ export function createDetectionRegistry(deps: DetectionRegistryDeps): DetectionR
   interface Watcher {
     close(): void;
     detector: DevPreviewDetector | null;
+    /**
+     * The Sprite INSTANCE this watcher's detector holds a handle to, or null
+     * while the reservation is still resolving. A sprite NAME is reused across
+     * re-creates, so this is the only way to notice that the VM behind the
+     * name has been replaced — see {@link armIfMissing}.
+     */
+    spriteInstanceId: string | null;
   }
   const watchers = new Map<string, Watcher>();
   /** sandboxId → when a re-arm was last attempted, so the read path cannot storm a sick sprite. */
@@ -145,9 +157,19 @@ export function createDetectionRegistry(deps: DetectionRegistryDeps): DetectionR
     let stopped = false;
     let current: PortsWatchHandle | null = null;
     let attempts = 0;
+    // A SECOND, NON-RESETTING budget. `attempts` is reset by any connection
+    // that opens, which is right for a channel that drops once and recovers —
+    // but a channel that opens and dies immediately, over and over, resets it
+    // every time and reconnects forever, which the docblock's "past the budget
+    // the watcher is dropped" does not describe. Dropping such a watcher is
+    // cheap now: a status read re-arms it within a poll interval, so the
+    // ceiling costs at most that, and a flap that has survived it is a sprite
+    // problem rather than a connection problem.
+    let totalAttempts = 0;
 
     const entry: Watcher = {
       detector,
+      spriteInstanceId: handle.spriteInstanceId,
       close() {
         stopped = true;
         current?.close();
@@ -171,14 +193,15 @@ export function createDetectionRegistry(deps: DetectionRegistryDeps): DetectionR
           detector.invalidateSnapshot();
           if (stopped) return;
           if (info.opened) attempts = 0;
-          if (info.reason === 'no-token' || attempts >= maxReconnects) {
-            deps.log.warn('dev-preview: watch channel gone, detection stopped for this sprite', { holderKind: holder.kind, holderId: holder.id, reason: info.reason, attempts });
+          if (info.reason === 'no-token' || attempts >= maxReconnects || totalAttempts >= maxTotalReconnects) {
+            deps.log.warn('dev-preview: watch channel gone, detection stopped for this sprite', { holderKind: holder.kind, holderId: holder.id, reason: info.reason, attempts, totalAttempts });
             stopped = true;
             watchers.delete(sandboxId);
             return;
           }
           const delay = BACKOFF_MS[Math.min(attempts, BACKOFF_MS.length - 1)];
           attempts += 1;
+          totalAttempts += 1;
           void wait(delay).then(() => { if (!stopped) open(); });
         },
       });
@@ -196,7 +219,29 @@ export function createDetectionRegistry(deps: DetectionRegistryDeps): DetectionR
    * something just happened.
    */
   async function armIfMissing(holder: DevPreviewHolderRef, sandboxId: string, { throttled }: { throttled: boolean }): Promise<void> {
-    if (watchers.has(sandboxId)) return;
+    const existing = watchers.get(sandboxId);
+    if (existing !== undefined) {
+      // A NAME IS NOT AN IDENTITY. A rebuild re-creates the sprite under the
+      // same name, so a watcher armed against the old VM still answers
+      // `watchers.has` — and its detector holds a handle whose instance id is
+      // dead. It would then write rows naming a VM that no longer exists while
+      // its service calls land on the new one: every render says `stale`, the
+      // proxy 409s, and nothing recovers it short of a process restart. That
+      // is the ABA case `spriteInstanceId` exists for.
+      //
+      // Only an EXPLICIT trigger checks: those are the moments a VM can have
+      // just been replaced (a provision, a shell open, the signed watch call),
+      // and the check costs one control-plane attach, which never wakes a
+      // sprite. The throttled read path keeps its cheap short-circuit.
+      if (throttled || existing.spriteInstanceId === null) return;
+      const live = await deps.attach(sandboxId).catch(() => null);
+      if (live === null || live.spriteInstanceId === existing.spriteInstanceId) return;
+      deps.log.info('dev-preview: sprite replaced under the same name, re-watching', {
+        holderKind: holder.kind,
+        holderId: holder.id,
+      });
+      existing.close();
+    }
     const now = deps.now().getTime();
     // Sweep as we go: the map only ever holds sprites armed within the
     // cool-down, so it cannot grow with the number of sprites ever seen.
@@ -207,13 +252,16 @@ export function createDetectionRegistry(deps: DetectionRegistryDeps): DetectionR
     }
     lastArmAt.set(sandboxId, now);
     // Reserve the slot synchronously so two concurrent arms start one watcher.
-    watchers.set(sandboxId, { detector: null, close() { watchers.delete(sandboxId); } });
+    const reservation: Watcher = { detector: null, spriteInstanceId: null, close() { watchers.delete(sandboxId); } };
+    watchers.set(sandboxId, reservation);
     try {
       await start(holder, sandboxId);
     } catch (error) {
-      // Whatever `start` had registered goes with the failure — the
-      // reservation, or the live entry if the throw came after it was set.
-      watchers.delete(sandboxId);
+      // Whatever `start` had registered goes with the failure — but only if it
+      // is still OURS. A `stopAll` and a fresh arm can both have happened while
+      // this one was failing, and deleting blindly would drop a live entry
+      // without closing it, leaking its reconnecting socket.
+      if (watchers.get(sandboxId) === reservation) watchers.delete(sandboxId);
       deps.log.error('dev-preview: watcher failed to start', error instanceof Error ? error : new Error(String(error)), { holderKind: holder.kind, holderId: holder.id });
     }
   }

--- a/apps/realtime/src/dev-preview/preview-runtime.ts
+++ b/apps/realtime/src/dev-preview/preview-runtime.ts
@@ -9,6 +9,7 @@ import { db } from '@pagespace/db/db';
 import { eq } from '@pagespace/db/operators';
 import { drives } from '@pagespace/db/schema/core';
 import { canRunCode } from '@pagespace/lib/services/sandbox/can-run-code';
+import { sessionService } from '@pagespace/lib/auth/session-service';
 import { getSandboxSessionSecret } from '@pagespace/lib/services/sandbox/machine-session-manager';
 import { resolveDriveMembership } from '@pagespace/lib/services/agent-workspaces/agent-workspace-tenant';
 import { createDbAgentSessionStore } from '@pagespace/lib/services/agent-workspaces/agent-workspaces-store';
@@ -63,6 +64,7 @@ export function buildRealtimePreviewAccessDeps(): PreviewAccessDeps {
       return drive ? { payerId: drive.ownerId } : null;
     },
     canRunCode: ({ userId, driveId, ownerId }) => canRunCode({ userId, driveId: driveId ?? undefined, ownerId, requestOrigin: 'user' }),
+    isSessionUsable: ({ sessionId, userId }) => sessionService.isSessionUsableById(sessionId, userId),
     attach: async (sandboxId) => {
       try {
         return await (await createConnectScopedSandboxHost()).attach({ sandboxId });

--- a/apps/realtime/src/dev-preview/preview-upgrade.ts
+++ b/apps/realtime/src/dev-preview/preview-upgrade.ts
@@ -27,7 +27,7 @@ export interface PreviewUpgradeDeps {
   /** The configured apex, or null when the feature is dark (then no host is a preview host). */
   resolveApex(): string | null;
   cookieKey(): Buffer;
-  resolveTarget(holder: DevPreviewHolderRef, userId: string): Promise<PreviewTarget>;
+  resolveTarget(holder: DevPreviewHolderRef, userId: string, sessionId: string): Promise<PreviewTarget>;
   tunnel(input: TunnelWebSocketUpgradeInput): void;
   spritesToken(): string;
   log: {
@@ -90,11 +90,13 @@ export function buildPreviewUpgradeHandler(deps: PreviewUpgradeDeps) {
       refuse(socket, 401, 'Unauthorized');
       return true;
     }
-    const userId = verified.claims.userId;
+    const { userId, sessionId } = verified.claims;
 
     let target: PreviewTarget;
     try {
-      target = await deps.resolveTarget(holder, userId);
+      // The session is re-checked inside the gather: a socket must not outlive
+      // the session that opened it any more than an HTTP request may.
+      target = await deps.resolveTarget(holder, userId, sessionId);
     } catch (error) {
       deps.log.error('dev-preview: upgrade gather failed', asError(error), { holderKind: holder.kind, holderId: holder.id });
       refuse(socket, 502, 'Bad Gateway');

--- a/apps/realtime/src/dev-preview/preview-upgrade.ts
+++ b/apps/realtime/src/dev-preview/preview-upgrade.ts
@@ -124,6 +124,16 @@ export function buildPreviewUpgradeHandler(deps: PreviewUpgradeDeps) {
       requestHeaders: flatten(req.headers),
       upstreamUrl,
       token: deps.spritesToken(),
+      // THE SOCKET MAY NOT OUTLIVE THE COOKIE THAT OPENED IT. The gather runs
+      // once, at upgrade; the idle cut alone never fires while HMR keeps
+      // talking, so without a ceiling a tunnel authorized minutes ago would
+      // keep piping into the sandbox after the session was revoked, the member
+      // was removed from the drive, or the preview was switched off — all of
+      // which the HTTP half refuses on its very next request. Tying it to the
+      // cookie's own expiry makes the two halves agree: the client reconnects
+      // and goes back through the gather, which is where every one of those
+      // checks lives.
+      maxLifetimeMs: Math.max(1, verified.claims.expiresAt - deps.now().getTime()),
       onClose: (summary: TunnelSummary) => {
         deps.log.info('dev-preview.access', buildPreviewAccessLog({
           userId,

--- a/apps/realtime/src/index.ts
+++ b/apps/realtime/src/index.ts
@@ -1126,7 +1126,7 @@ const httpServer = createServer(requestListener);
 const previewUpgrade = buildPreviewUpgradeHandler({
   resolveApex: () => (isDevPreviewEnabled() ? resolveDevPreviewApex() : null),
   cookieKey: getRealtimePreviewCookieKey,
-  resolveTarget: (holder, userId) => resolvePreviewTarget({ holder, userId, deps: buildRealtimePreviewAccessDeps() }),
+  resolveTarget: (holder, userId, sessionId) => resolvePreviewTarget({ holder, userId, sessionId, deps: buildRealtimePreviewAccessDeps() }),
   tunnel: tunnelWebSocketUpgrade,
   spritesToken: resolveSpritesToken,
   log: loggers.realtime,

--- a/apps/realtime/src/index.ts
+++ b/apps/realtime/src/index.ts
@@ -1039,7 +1039,10 @@ const requestListener = (req: IncomingMessage, res: ServerResponse) => {
         //   listeners — a status render asks for the snapshot this process's
         //               watcher already holds; `null` is the honest "no
         //               snapshot in hand" (never-probe-to-render: the sprite
-        //               is not touched to answer).
+        //               is not touched to answer). It ALSO re-arms a missing
+        //               watcher, throttled — this is what makes detection
+        //               survive a restart or an exhausted reconnect budget,
+        //               since nothing else would ever start one again.
         const isWatch = req.url === '/api/dev-preview/watch';
         readCappedBody(body => {
             const signatureHeader = req.headers['x-broadcast-signature'] as string;
@@ -1060,9 +1063,9 @@ const requestListener = (req: IncomingMessage, res: ServerResponse) => {
                 res.end(JSON.stringify({ accepted: true }));
                 return;
             }
-            devPreviewRegistry.listeners({ holder }).then((listeners) => {
+            devPreviewRegistry.read({ holder }).then((read) => {
                 res.writeHead(200, { 'Content-Type': 'application/json' });
-                res.end(JSON.stringify({ listeners }));
+                res.end(JSON.stringify(read));
             }).catch((error: unknown) => {
                 loggers.realtime.error('dev-preview: listeners read failed', error instanceof Error ? error : new Error(String(error)));
                 res.writeHead(500, { 'Content-Type': 'application/json' });

--- a/apps/realtime/src/index.ts
+++ b/apps/realtime/src/index.ts
@@ -57,6 +57,7 @@ import { buildAppLogHandlers, type AppLogSocketLike } from './app-logs/app-log-h
 import { handleShellActivityRequest } from './terminal/shell-activity';
 import { buildPreviewUpgradeHandler, previewHolderForUpgrade } from './dev-preview/preview-upgrade';
 import { createDetectionRegistry, nodeWebSocketFactory } from './dev-preview/detection-registry';
+import { createDevPreviewLock, DEV_PREVIEW_DETECTOR_RETRIES } from '@pagespace/lib/services/sandbox/preview/dev-preview-lock';
 import { readDevPreviewHolderBody } from './dev-preview/holder-body';
 import {
   buildRealtimePreviewAccessDeps,
@@ -160,6 +161,10 @@ const devPreviewRegistry = createDetectionRegistry({
   spritesToken: resolveSpritesToken,
   spritesApiBaseUrl: resolveSpritesApiBaseUrl,
   log: loggers.realtime,
+  // Serialized against the web tier's stop/resume on the same holder. A short
+  // budget: frames arrive seconds apart, so waiting a few hundred ms costs the
+  // chain nothing, and past it the frame defers rather than fighting.
+  lock: createDevPreviewLock({ retries: DEV_PREVIEW_DETECTOR_RETRIES, log: loggers.realtime }),
   now: () => new Date(),
 });
 

--- a/apps/web/src/app/api/agent-workspaces/[workspaceId]/preview/actions/route.ts
+++ b/apps/web/src/app/api/agent-workspaces/[workspaceId]/preview/actions/route.ts
@@ -46,7 +46,7 @@ export async function POST(request: Request, context: { params: Promise<{ worksp
     if (isAuthError(auth)) return auth.error;
 
     const action = readDevPreviewUserAction(await request.json().catch(() => null));
-    if (action === null) return NextResponse.json({ error: 'action must be "stop" or "resume"' }, { status: 400 });
+    if (action === null) return NextResponse.json({ error: 'action must be "stop", "resume", or "approve" with the port shown' }, { status: 400 });
 
     const session = await findSessionRecord(workspaceId);
     if (!session) return workspaceNotFoundOrDenied(request, auth.userId, workspaceId, 'session_not_found', ROUTE);
@@ -58,7 +58,7 @@ export async function POST(request: Request, context: { params: Promise<{ worksp
     if (!manage.allowed) {
       // A denial AFTER the family gate: the caller already knows the session
       // exists, so a genuine 403 leaks nothing new (the `provisioningDenied` precedent).
-      auditRequest(request, { eventType: 'authz.access.denied', userId: auth.userId, resourceType: 'dev_preview', resourceId: `${holder.kind}:${holder.id}`, details: { route: ROUTE, action, reason: manage.reason }, riskScore: 0.5 });
+      auditRequest(request, { eventType: 'authz.access.denied', userId: auth.userId, resourceType: 'dev_preview', resourceId: `${holder.kind}:${holder.id}`, details: { route: ROUTE, action: action.kind, reason: manage.reason }, riskScore: 0.5 });
       return NextResponse.json({ error: manage.message }, { status: 403 });
     }
 

--- a/apps/web/src/app/api/agent-workspaces/[workspaceId]/preview/open/route.ts
+++ b/apps/web/src/app/api/agent-workspaces/[workspaceId]/preview/open/route.ts
@@ -17,7 +17,7 @@
  */
 
 import { NextResponse } from 'next/server';
-import { authenticateRequestWithOptions, isAuthError } from '@/lib/auth';
+import { authenticateRequestWithOptions, isAuthError, isSessionAuthResult } from '@/lib/auth';
 import { auditRequest } from '@pagespace/lib/audit/audit-log';
 import { loggers } from '@pagespace/lib/logging/logger-config';
 import { isDevPreviewConfigured } from '@pagespace/lib/services/sandbox/preview/dev-preview-env';
@@ -35,6 +35,9 @@ export async function GET(request: Request, context: { params: Promise<{ workspa
     const { workspaceId } = await context.params;
     const auth = await authenticateRequestWithOptions(request, AUTH_OPTIONS);
     if (isAuthError(auth)) return signInOrDeny(request, auth.error);
+    // `allow: ['session']` already excludes every other principal; narrowing
+    // makes that a type fact so `sessionId` is read, never asserted.
+    if (!isSessionAuthResult(auth)) return NextResponse.json({ error: 'Not found' }, { status: 404 });
 
     if (!isAllowedPreviewOpen(request)) {
       auditRequest(request, { eventType: 'authz.access.denied', userId: auth.userId, resourceType: 'dev_preview', resourceId: `workspace:${workspaceId}`, details: { route: ROUTE, reason: 'cross-site-embed' }, riskScore: 0.6 });
@@ -50,7 +53,7 @@ export async function GET(request: Request, context: { params: Promise<{ workspa
     // Authorization is the SESSION's (the user reached the preview through
     // the session); the grant is minted for the HOLDER — the env's origin for
     // an env-bound session, the session's own otherwise.
-    const opened = await openPreviewForUser({ authorizeAs: { kind: 'workspace', id: session.id }, mintFor: holder, userId: auth.userId });
+    const opened = await openPreviewForUser({ authorizeAs: { kind: 'workspace', id: session.id }, mintFor: holder, userId: auth.userId, sessionId: auth.sessionId });
     if (!opened.ok) {
       return workspaceNotFoundOrDenied(request, auth.userId, workspaceId, opened.reason === 'not-authorized' ? opened.detail ?? 'not-authorized' : opened.reason, ROUTE);
     }

--- a/apps/web/src/app/api/cron/reconcile-dev-previews/__tests__/route.test.ts
+++ b/apps/web/src/app/api/cron/reconcile-dev-previews/__tests__/route.test.ts
@@ -1,0 +1,61 @@
+/**
+ * Contract tests for /api/cron/reconcile-dev-previews — the dev-preview
+ * backstop sweep's endpoint: HMAC gating first, the run's counts in both the
+ * response and the audit row, and a thrown sweep answered as a 500 rather
+ * than a silent success.
+ */
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+
+const { mockReconcile, mockAudit } = vi.hoisted(() => ({ mockReconcile: vi.fn(), mockAudit: vi.fn() }));
+
+vi.mock('@/lib/auth/cron-auth', () => ({ validateSignedCronRequest: vi.fn() }));
+vi.mock('@/lib/dev-preview/preview-runtime', () => ({ reconcileStoppedDevPreviewsForCron: mockReconcile }));
+vi.mock('@pagespace/lib/audit/audit-log', () => ({ audit: mockAudit }));
+vi.mock('@pagespace/lib/logging/logger-config', () => ({ loggers: { system: { error: vi.fn() } } }));
+vi.mock('next/server', () => ({
+  NextResponse: {
+    json: (body: unknown, init?: ResponseInit) => new Response(JSON.stringify(body), { status: init?.status ?? 200, headers: { 'content-type': 'application/json' } }),
+  },
+}));
+
+import { GET, POST } from '../route';
+import { validateSignedCronRequest } from '@/lib/auth/cron-auth';
+
+const request = () => new Request('http://localhost:3000/api/cron/reconcile-dev-previews');
+
+describe('/api/cron/reconcile-dev-previews', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(validateSignedCronRequest).mockReturnValue(null);
+    mockReconcile.mockResolvedValue({ processed: 3, stopped: 1, skipped: 2, failed: 0 });
+  });
+
+  it('refuses an unsigned request BEFORE doing any work', async () => {
+    vi.mocked(validateSignedCronRequest).mockReturnValue(new Response('no', { status: 401 }) as never);
+    expect((await GET(request())).status).toBe(401);
+    expect(mockReconcile).not.toHaveBeenCalled();
+  });
+
+  it('runs the sweep and reports its counts, in the body and in the audit row', async () => {
+    const res = await GET(request());
+    expect(res.status).toBe(200);
+    expect(await res.json()).toMatchObject({ success: true, processed: 3, stopped: 1, skipped: 2, failed: 0 });
+    expect(mockAudit).toHaveBeenCalledWith(expect.objectContaining({
+      resourceType: 'cron_job',
+      resourceId: 'reconcile_dev_previews',
+      details: { processed: 3, stopped: 1, skipped: 2, failed: 0 },
+    }));
+  });
+
+  it('answers 500 when the sweep throws, rather than reporting a run that did not happen', async () => {
+    mockReconcile.mockRejectedValueOnce(new Error('control plane down'));
+    const res = await GET(request());
+    expect(res.status).toBe(500);
+    expect(await res.json()).toMatchObject({ success: false, error: 'control plane down' });
+    expect(mockAudit).not.toHaveBeenCalled();
+  });
+
+  it('POST is the same endpoint (the cron runner uses either)', async () => {
+    expect((await POST(request())).status).toBe(200);
+  });
+});

--- a/apps/web/src/app/api/cron/reconcile-dev-previews/route.ts
+++ b/apps/web/src/app/api/cron/reconcile-dev-previews/route.ts
@@ -1,0 +1,57 @@
+import { audit } from '@pagespace/lib/audit/audit-log';
+import { loggers } from '@pagespace/lib/logging/logger-config';
+import { NextResponse } from 'next/server';
+import { reconcileStoppedDevPreviewsForCron } from '@/lib/dev-preview/preview-runtime';
+import { validateSignedCronRequest } from '@/lib/auth/cron-auth';
+
+/**
+ * Cron endpoint that converges dev-server previews a user switched OFF whose
+ * relay is somehow still up.
+ *
+ * A Stop is durable the moment it is written — the action records the intent
+ * even when the holder's lock is contended or the lock pool is degraded, and
+ * defers the relay work to whoever next re-plans. Normally that is the
+ * realtime detector's next `ports/watch` frame. But a holder nobody is
+ * watching produces no frames, and a stop is exactly when a dev server tends
+ * to go quiet, so without this the row would say "switched off" while the
+ * relay kept serving until the sprite died.
+ *
+ * The sweep can only ever STOP a relay, structurally: it plans with no
+ * listener snapshot, which the core turns into `stop-relay` or nothing and
+ * which makes any plan that would START a relay a refusal. It never wakes a
+ * sprite (an attach is a control-plane read). Dark deployments do no work.
+ *
+ * No cron-level lock, and a per-holder try-lock with no retries: busy means a
+ * live path already owns that holder. Every write underneath is a
+ * compare-and-set, so overlapping runs converge — the
+ * `reconcile-orphaned-sprites` posture.
+ *
+ * Authentication: HMAC-signed request with X-Cron-Timestamp, X-Cron-Nonce,
+ * X-Cron-Signature headers.
+ */
+export async function GET(request: Request) {
+  const authError = validateSignedCronRequest(request);
+  if (authError) {
+    return authError;
+  }
+
+  try {
+    const run = await reconcileStoppedDevPreviewsForCron();
+
+    audit({
+      eventType: 'data.write',
+      resourceType: 'cron_job',
+      resourceId: 'reconcile_dev_previews',
+      details: { processed: run.processed, stopped: run.stopped, skipped: run.skipped, failed: run.failed },
+    });
+
+    return NextResponse.json({ success: true, ...run, timestamp: new Date().toISOString() });
+  } catch (error) {
+    loggers.system.error('[Cron] Error reconciling stopped dev previews', error as Error);
+    return NextResponse.json({ success: false, error: error instanceof Error ? error.message : 'Unknown error' }, { status: 500 });
+  }
+}
+
+export async function POST(request: Request) {
+  return GET(request);
+}

--- a/apps/web/src/app/api/dev-preview/__tests__/host-route.test.ts
+++ b/apps/web/src/app/api/dev-preview/__tests__/host-route.test.ts
@@ -45,7 +45,7 @@ const HOLDER: Holder = { kind: 'env', id: 'env1' };
 const consume = vi.fn();
 
 function cookie(holder: Holder = HOLDER, expiresAt = Date.now() + 60_000): string {
-  return `${PREVIEW_COOKIE_NAME}=${signPreviewCookie({ holder, userId: 'u1', expiresAt }, KEY)}`;
+  return `${PREVIEW_COOKIE_NAME}=${signPreviewCookie({ holder, userId: 'u1', sessionId: 'sess1', expiresAt }, KEY)}`;
 }
 
 function req(path: string, init: { host?: string; method?: string; body?: string; headers?: Record<string, string> } = {}): NextRequest {
@@ -84,12 +84,12 @@ describe('the host must be a preview host naming the holder in the path', () => 
 describe('the handshake: /__pagespace/auth', () => {
   it('consumes the grant, installs the host-only cookie, and redirects to /', async () => {
     const cookieExpiresAt = new Date(Date.now() + 3600_000);
-    consume.mockResolvedValue({ holder: HOLDER, userId: 'u1', cookieExpiresAt });
+    consume.mockResolvedValue({ holder: HOLDER, userId: 'u1', sessionId: 'sess1', cookieExpiresAt });
     const res = await GET(req('/__pagespace/auth?grant=g1'), ctx());
     expect(res.status).toBe(302);
     expect(res.headers.get('location')).toBe('/');
     const set = res.headers.get('set-cookie') ?? '';
-    expect(set).toMatch(new RegExp(`^${PREVIEW_COOKIE_NAME}=v1\\.`));
+    expect(set).toMatch(new RegExp(`^${PREVIEW_COOKIE_NAME}=v2\\.`));
     expect(set).toContain('Secure; HttpOnly; SameSite=None; Partitioned');
     expect(set).not.toMatch(/domain=/i);
     expect(consume).toHaveBeenCalledWith({ id: 'g1', now: expect.any(Date) });
@@ -98,7 +98,7 @@ describe('the handshake: /__pagespace/auth', () => {
   it('refuses an unknown/used grant and a grant minted for another host, and audits both', async () => {
     consume.mockResolvedValueOnce(null);
     expect((await GET(req('/__pagespace/auth?grant=g1'), ctx())).status).toBe(403);
-    consume.mockResolvedValueOnce({ holder: { kind: 'env', id: 'env2' }, userId: 'u1', cookieExpiresAt: new Date() });
+    consume.mockResolvedValueOnce({ holder: { kind: 'env', id: 'env2' }, userId: 'u1', sessionId: 'sess1', cookieExpiresAt: new Date() });
     expect((await GET(req('/__pagespace/auth?grant=g2'), ctx())).status).toBe(403);
     expect(vi.mocked(auditRequest).mock.calls.map((c) => (c[1].details as { reason: string }).reason)).toEqual(['grant-invalid', 'grant-holder-mismatch']);
   });
@@ -111,7 +111,7 @@ describe('the handshake: /__pagespace/auth', () => {
 
   it('answers 503 when the cookie key is not configured — BEFORE consuming the single-use grant', async () => {
     vi.mocked(getPreviewCookieKey).mockReturnValue(Buffer.alloc(0));
-    consume.mockResolvedValue({ holder: HOLDER, userId: 'u1', cookieExpiresAt: new Date(Date.now() + 1000) });
+    consume.mockResolvedValue({ holder: HOLDER, userId: 'u1', sessionId: 'sess1', cookieExpiresAt: new Date(Date.now() + 1000) });
     expect((await GET(req('/__pagespace/auth?grant=g1'), ctx())).status).toBe(503);
     expect(consume).not.toHaveBeenCalled();
   });
@@ -189,7 +189,9 @@ describe('authorize + decide, per request', () => {
     const res = await POST(req('/api/items?x=%2F', { method: 'POST', body: 'b', headers: { cookie: cookie(), 'content-type': 'text/plain' } }), ctx());
     expect(res).toBe(upstream);
     expect(forwardPreviewRequest).toHaveBeenCalledWith(expect.objectContaining({ pathAndQuery: '/api/items?x=%2F', spriteUrl: 'https://ps-x-org.sprites.app', token: 'org-token', appOrigin: 'https://app.pagespace.ai' }));
-    expect(resolvePreviewTargetForRequest).toHaveBeenCalledWith(HOLDER, 'u1');
+    // The SESSION travels grant → cookie → gather; without it revocation could
+    // not reach a live preview at all.
+    expect(resolvePreviewTargetForRequest).toHaveBeenCalledWith(HOLDER, 'u1', 'sess1');
     expect(loggers.security.info).toHaveBeenCalledWith('dev-preview.access', expect.objectContaining({ outcome: 'forwarded', status: 201, wake: true, method: 'POST', path: '/api/items' }));
   });
 

--- a/apps/web/src/app/api/dev-preview/__tests__/host-route.test.ts
+++ b/apps/web/src/app/api/dev-preview/__tests__/host-route.test.ts
@@ -195,6 +195,39 @@ describe('authorize + decide, per request', () => {
     expect(loggers.security.info).toHaveBeenCalledWith('dev-preview.access', expect.objectContaining({ outcome: 'forwarded', status: 201, wake: true, method: 'POST', path: '/api/items' }));
   });
 
+  it('a session that is GONE re-auths instead of dead-ending — a rotation is the usual cause, and the user is still signed in', async () => {
+    // Device refresh mints a replacement session and grace-expires the old
+    // one, on a desktop unlock or an app foregrounding. Without this the frame
+    // sits on a bare 404 for the rest of the cookie's life while the dashboard
+    // around it reports the preview healthy.
+    vi.mocked(resolvePreviewTargetForRequest).mockResolvedValue({
+      decision: { kind: 'refuse', reason: 'not-authorized', status: 404, message: 'Not found', detail: 'session_revoked' },
+      authorization: { allowed: false, reason: 'session_revoked' },
+    });
+    const framed = await GET(req('/', { headers: { cookie: cookie(), 'sec-fetch-dest': 'iframe' } }), ctx());
+    expect(framed.status).toBe(401);
+    expect(framed.headers.get('content-type')).toContain('text/html');
+    // The stale cookie must go, or the re-auth page's re-mint races it.
+    expect(framed.headers.get('set-cookie') ?? '').toMatch(new RegExp(`^${PREVIEW_COOKIE_NAME}=;`));
+
+    // A subresource cannot render a page, but it still clears the cookie so
+    // the frame's next navigation re-auths rather than piling up 404s.
+    const subresource = await GET(req('/main.js', { headers: { cookie: cookie(), 'sec-fetch-dest': 'script' } }), ctx());
+    expect(subresource.status).toBe(404);
+    expect(subresource.headers.get('set-cookie') ?? '').toMatch(new RegExp(`^${PREVIEW_COOKIE_NAME}=;`));
+
+    // Every OTHER refusal is unchanged — a stopped preview is not a re-auth,
+    // and clearing the cookie there would make the user redo the handshake for
+    // something they switched off themselves.
+    vi.mocked(resolvePreviewTargetForRequest).mockResolvedValue({
+      decision: { kind: 'refuse', reason: 'stopped-by-user', status: 409, message: 'switched off' },
+      authorization: { allowed: true, driveId: 'd', wakeSubject: { driveId: 'd', ownerId: 'o' }, sandboxId: 's' },
+    });
+    const stopped = await GET(req('/', { headers: { cookie: cookie(), 'sec-fetch-dest': 'iframe' } }), ctx());
+    expect(stopped.status).toBe(409);
+    expect(stopped.headers.get('set-cookie')).toBeNull();
+  });
+
   it('turns forwarder failures into 413/502/504 and logs them as limit/upstream outcomes', async () => {
     vi.mocked(resolvePreviewTargetForRequest).mockResolvedValue({ decision: { kind: 'forward', wake: false }, authorization: { allowed: true, driveId: 'd', wakeSubject: { driveId: 'd', ownerId: 'o' }, sandboxId: 's' }, spriteUrl: 'https://ps-x-org.sprites.app', handle: {} as never });
     vi.mocked(forwardPreviewRequest).mockResolvedValueOnce({ kind: 'refused', status: 413, reason: 'request-too-large' });

--- a/apps/web/src/app/api/dev-preview/__tests__/open-routes.test.ts
+++ b/apps/web/src/app/api/dev-preview/__tests__/open-routes.test.ts
@@ -13,6 +13,7 @@ vi.mock('@/lib/auth', () => ({
   authenticateRequestWithOptions: vi.fn(),
   isAuthError: vi.fn(() => false),
   isPrincipalDriveMember: vi.fn(),
+  isSessionAuthResult: vi.fn((r: unknown) => typeof (r as { sessionId?: unknown }).sessionId === 'string'),
 }));
 vi.mock('@pagespace/lib/services/sandbox/preview/dev-preview-env', () => ({
   isDevPreviewConfigured: vi.fn(() => true),
@@ -51,7 +52,7 @@ function req(headers: Record<string, string> = { 'sec-fetch-site': 'same-origin'
 beforeEach(() => {
   vi.clearAllMocks();
   vi.mocked(isDevPreviewConfigured).mockReturnValue(true);
-  vi.mocked(authenticateRequestWithOptions).mockResolvedValue({ userId: 'u1' } as never);
+  vi.mocked(authenticateRequestWithOptions).mockResolvedValue({ userId: 'u1', sessionId: 'sess1' } as never);
   vi.mocked(isPrincipalDriveMember).mockResolvedValue(true);
   vi.mocked(resolveEnvInDrive).mockResolvedValue({ id: 'env1', driveId: 'd1' } as never);
   vi.mocked(findSessionRecord).mockResolvedValue({ id: 'ws1', envId: null } as never);
@@ -63,7 +64,7 @@ describe('GET /api/drives/[driveId]/envs/[envId]/preview/open', () => {
     const res = await openEnv(req(), envCtx);
     expect(res.status).toBe(302);
     expect(res.headers.get('location')).toBe(REDIRECT);
-    expect(openPreviewForUser).toHaveBeenCalledWith({ authorizeAs: { kind: 'env', id: 'env1' }, userId: 'u1' });
+    expect(openPreviewForUser).toHaveBeenCalledWith({ authorizeAs: { kind: 'env', id: 'env1' }, userId: 'u1', sessionId: 'sess1' });
   });
 
   it('is dark (404) when the feature is not configured, before authentication', async () => {
@@ -129,13 +130,23 @@ describe('GET /api/agent-workspaces/[workspaceId]/preview/open', () => {
   it('authorizes as the session and mints for the session holder', async () => {
     const res = await openSession(req(), wsCtx);
     expect(res.status).toBe(302);
-    expect(openPreviewForUser).toHaveBeenCalledWith({ authorizeAs: { kind: 'workspace', id: 'ws1' }, mintFor: { kind: 'workspace', id: 'ws1' }, userId: 'u1' });
+    expect(openPreviewForUser).toHaveBeenCalledWith({ authorizeAs: { kind: 'workspace', id: 'ws1' }, mintFor: { kind: 'workspace', id: 'ws1' }, userId: 'u1', sessionId: 'sess1' });
   });
 
   it('for an env-bound session, authorizes as the session and mints for the ENV (the holder rule)', async () => {
     vi.mocked(findSessionRecord).mockResolvedValueOnce({ id: 'ws1', envId: 'env1' } as never);
     await openSession(req(), wsCtx);
-    expect(openPreviewForUser).toHaveBeenCalledWith({ authorizeAs: { kind: 'workspace', id: 'ws1' }, mintFor: { kind: 'env', id: 'env1' }, userId: 'u1' });
+    expect(openPreviewForUser).toHaveBeenCalledWith({ authorizeAs: { kind: 'workspace', id: 'ws1' }, mintFor: { kind: 'env', id: 'env1' }, userId: 'u1', sessionId: 'sess1' });
+  });
+
+  it('refuses a principal that is not a browser session, on BOTH routes — a grant with no session could never be revoked', async () => {
+    // `allow: ['session']` already excludes API keys and device tokens; the
+    // narrowing is what makes `sessionId` readable without an assertion, and
+    // this is the branch that proves it is not decoration.
+    vi.mocked(authenticateRequestWithOptions).mockResolvedValue({ userId: 'u1' } as never);
+    expect((await openSession(req(), wsCtx)).status).toBe(404);
+    expect((await openEnv(req(), envCtx)).status).toBe(404);
+    expect(openPreviewForUser).not.toHaveBeenCalled();
   });
 
   it('answers the family not-found/denied policy for an unknown session and for a refusal (audited)', async () => {

--- a/apps/web/src/app/api/dev-preview/__tests__/status-routes.test.ts
+++ b/apps/web/src/app/api/dev-preview/__tests__/status-routes.test.ts
@@ -137,7 +137,7 @@ describe('POST /api/agent-workspaces/[workspaceId]/preview/actions', () => {
     expect(res.status).toBe(200);
     expect(await res.json()).toEqual({ ok: true, applied: { action: 'stop-relay', relayServiceName: 'pagespace-preview-relay' } });
     expect(authorizePreviewHolderForUser).toHaveBeenCalledWith({ holder: { kind: 'workspace', id: 'ws1' }, userId: 'u1' });
-    expect(applyDevPreviewUserActionForHolder).toHaveBeenCalledWith({ holder: { kind: 'workspace', id: 'ws1' }, action: 'stop', userId: 'u1', wakeSubject: { driveId: 'd1', ownerId: 'o' } });
+    expect(applyDevPreviewUserActionForHolder).toHaveBeenCalledWith({ holder: { kind: 'workspace', id: 'ws1' }, action: { kind: 'stop' }, userId: 'u1', wakeSubject: { driveId: 'd1', ownerId: 'o' } });
     expect(auditRequest).toHaveBeenCalledWith(expect.anything(), expect.objectContaining({ eventType: 'data.write', resourceType: 'dev_preview', details: expect.objectContaining({ action: 'stop', applied: 'stop-relay' }) }));
   });
 
@@ -160,7 +160,24 @@ describe('POST /api/agent-workspaces/[workspaceId]/preview/actions', () => {
 
     vi.mocked(isPrincipalDriveOwnerOrAdmin).mockResolvedValueOnce(true);
     expect((await sessionAction(post({ action: 'resume' }), wsCtx)).status).toBe(200);
-    expect(applyDevPreviewUserActionForHolder).toHaveBeenCalledWith({ holder: { kind: 'env', id: 'env1' }, action: 'resume', userId: 'u1', wakeSubject: { driveId: 'd1', ownerId: 'o' } });
+    expect(applyDevPreviewUserActionForHolder).toHaveBeenCalledWith({ holder: { kind: 'env', id: 'env1' }, action: { kind: 'resume' }, userId: 'u1', wakeSubject: { driveId: 'd1', ownerId: 'o' } });
+  });
+
+  it('APPROVE carries the port through, and a port that moved answers 409 rather than sharing the wrong thing', async () => {
+    const res = await sessionAction(post({ action: 'approve', port: 9000 }), wsCtx);
+    expect(res.status).toBe(200);
+    expect(applyDevPreviewUserActionForHolder).toHaveBeenCalledWith({ holder: { kind: 'workspace', id: 'ws1' }, action: { kind: 'approve', port: 9000 }, userId: 'u1', wakeSubject: { driveId: 'd1', ownerId: 'o' } });
+    expect(auditRequest).toHaveBeenCalledWith(expect.anything(), expect.objectContaining({ eventType: 'data.write', details: expect.objectContaining({ action: 'approve', port: 9000 }) }));
+
+    // A body with no port is not an approve at all — 400 before anything runs.
+    vi.mocked(applyDevPreviewUserActionForHolder).mockClear();
+    expect((await sessionAction(post({ action: 'approve' }), wsCtx)).status).toBe(400);
+    expect(applyDevPreviewUserActionForHolder).not.toHaveBeenCalled();
+
+    vi.mocked(applyDevPreviewUserActionForHolder).mockResolvedValueOnce({ ok: false, reason: 'port-changed' });
+    const moved = await sessionAction(post({ action: 'approve', port: 9000 }), wsCtx);
+    expect(moved.status).toBe(409);
+    expect(await moved.json()).toMatchObject({ reason: 'port-changed' });
   });
 
   it('BILLING: a resume the wake gate refuses is a 403 with the gate reason, audited', async () => {
@@ -239,7 +256,7 @@ describe('POST /api/drives/[driveId]/envs/[envId]/preview/actions', () => {
     const res = await envAction(post({ action: 'resume' }), envCtx);
     expect(res.status).toBe(200);
     expect(authorizePreviewHolderForUser).toHaveBeenCalledWith({ holder: { kind: 'env', id: 'env1' }, userId: 'u1' });
-    expect(applyDevPreviewUserActionForHolder).toHaveBeenCalledWith({ holder: { kind: 'env', id: 'env1' }, action: 'resume', userId: 'u1', wakeSubject: { driveId: 'd1', ownerId: 'o' } });
+    expect(applyDevPreviewUserActionForHolder).toHaveBeenCalledWith({ holder: { kind: 'env', id: 'env1' }, action: { kind: 'resume' }, userId: 'u1', wakeSubject: { driveId: 'd1', ownerId: 'o' } });
     expect(auditRequest).toHaveBeenCalledWith(expect.anything(), expect.objectContaining({ eventType: 'data.write', resourceId: 'env:env1', details: expect.objectContaining({ action: 'resume' }) }));
   });
 

--- a/apps/web/src/app/api/dev-preview/__tests__/status-routes.test.ts
+++ b/apps/web/src/app/api/dev-preview/__tests__/status-routes.test.ts
@@ -163,10 +163,25 @@ describe('POST /api/agent-workspaces/[workspaceId]/preview/actions', () => {
     expect(applyDevPreviewUserActionForHolder).toHaveBeenCalledWith({ holder: { kind: 'env', id: 'env1' }, action: { kind: 'resume' }, userId: 'u1', wakeSubject: { driveId: 'd1', ownerId: 'o' } });
   });
 
-  it('APPROVE carries the port through, and a port that moved answers 409 rather than sharing the wrong thing', async () => {
-    const res = await sessionAction(post({ action: 'approve', port: 9000 }), wsCtx);
+  it('a DEFERRED relay is a success, not a toast: the intent landed and only the start waits', async () => {
+    // `post()` throws on any 4xx, so answering `slot-unknown` with a 409 made
+    // the pane say "Could not switch the preview on" over a click that had
+    // already cleared the stop. It is the same shape as a contended lock,
+    // which is reported as a success.
+    vi.mocked(applyDevPreviewUserActionForHolder).mockResolvedValueOnce({ ok: false, reason: 'slot-unknown' });
+    const res = await sessionAction(post({ action: 'resume' }), wsCtx);
     expect(res.status).toBe(200);
-    expect(applyDevPreviewUserActionForHolder).toHaveBeenCalledWith({ holder: { kind: 'workspace', id: 'ws1' }, action: { kind: 'approve', port: 9000 }, userId: 'u1', wakeSubject: { driveId: 'd1', ownerId: 'o' } });
+    expect(await res.json()).toMatchObject({ ok: true, applied: null, deferred: 'awaiting-port-snapshot' });
+    expect(auditRequest).toHaveBeenCalledWith(expect.anything(), expect.objectContaining({
+      eventType: 'data.write',
+      details: expect.objectContaining({ deferred: 'awaiting-port-snapshot' }),
+    }));
+  });
+
+  it('APPROVE carries the port through, and a port that moved answers 409 rather than sharing the wrong thing', async () => {
+    const res = await sessionAction(post({ action: 'approve', port: 9000, spriteInstanceId: 'inst-1' }), wsCtx);
+    expect(res.status).toBe(200);
+    expect(applyDevPreviewUserActionForHolder).toHaveBeenCalledWith({ holder: { kind: 'workspace', id: 'ws1' }, action: { kind: 'approve', port: 9000, spriteInstanceId: 'inst-1' }, userId: 'u1', wakeSubject: { driveId: 'd1', ownerId: 'o' } });
     expect(auditRequest).toHaveBeenCalledWith(expect.anything(), expect.objectContaining({ eventType: 'data.write', details: expect.objectContaining({ action: 'approve', port: 9000 }) }));
 
     // A body with no port is not an approve at all — 400 before anything runs.
@@ -175,7 +190,7 @@ describe('POST /api/agent-workspaces/[workspaceId]/preview/actions', () => {
     expect(applyDevPreviewUserActionForHolder).not.toHaveBeenCalled();
 
     vi.mocked(applyDevPreviewUserActionForHolder).mockResolvedValueOnce({ ok: false, reason: 'port-changed' });
-    const moved = await sessionAction(post({ action: 'approve', port: 9000 }), wsCtx);
+    const moved = await sessionAction(post({ action: 'approve', port: 9000, spriteInstanceId: 'inst-1' }), wsCtx);
     expect(moved.status).toBe(409);
     expect(await moved.json()).toMatchObject({ reason: 'port-changed' });
   });

--- a/apps/web/src/app/api/dev-preview/host/[kind]/[holderId]/[[...path]]/route.ts
+++ b/apps/web/src/app/api/dev-preview/host/[kind]/[holderId]/[[...path]]/route.ts
@@ -201,8 +201,39 @@ async function handle(request: NextRequest, context: RouteContext): Promise<Resp
       });
     }
     loggers.security.info('dev-preview.access', buildPreviewAccessLog({ userId, holder, method: request.method, path, outcome: 'refused', reason, status, durationMs: Date.now() - startedAt, transport: 'http' }));
+
+    // A DEAD SESSION IS A RE-AUTH, NOT A DEAD END. The cookie is well-formed
+    // and correctly signed; the session it names is simply gone — and the
+    // commonest way for that to happen is not a sign-out but a ROTATION: a
+    // device refresh mints a replacement session row and grace-expires the
+    // old one, which fires on a desktop unlock, an app foregrounding, any
+    // 401. The user is still signed in, on a page that still works, and
+    // without this the frame would sit on `404 {"error":"Not found"}` for the
+    // rest of the cookie's life while the dashboard around it reports the
+    // preview healthy. So the stale cookie is cleared and the same re-auth
+    // path a missing cookie takes is served: framed, it asks the dashboard to
+    // re-point at `/preview/open`, which mints a grant from the session the
+    // user actually has now. Refused subresources clear the cookie too, so
+    // the frame's next navigation re-auths rather than accumulating 404s.
+    const staleSession = detail === 'session_revoked';
+    if (staleSession && isNavigation(request)) {
+      const [appOrigin, openPath] = [resolveAppOrigin(), await resolvePreviewOpenPath(holder)];
+      if (appOrigin !== null && openPath !== null) {
+        return new NextResponse(buildReauthPage({ appOrigin, openPath, holder }), {
+          status: 401,
+          headers: {
+            'content-type': 'text/html; charset=utf-8',
+            'content-security-policy': `default-src 'none'; script-src '${REAUTH_SCRIPT_HASH}'; frame-ancestors ${appOrigin}`,
+            'set-cookie': buildClearPreviewCookieHeader(),
+            'cache-control': 'no-store',
+          },
+        });
+      }
+    }
+
     const headers: Record<string, string> = { 'cache-control': 'no-store' };
     if (status === 503) headers['retry-after'] = '2';
+    if (staleSession) headers['set-cookie'] = buildClearPreviewCookieHeader();
     return NextResponse.json({ error: message, reason }, { status, headers });
   }
 

--- a/apps/web/src/app/api/dev-preview/host/[kind]/[holderId]/[[...path]]/route.ts
+++ b/apps/web/src/app/api/dev-preview/host/[kind]/[holderId]/[[...path]]/route.ts
@@ -142,7 +142,9 @@ async function handle(request: NextRequest, context: RouteContext): Promise<Resp
       });
       return NextResponse.json({ error: 'This preview link has expired. Reopen the preview from PageSpace.' }, { status: 403, headers: { 'cache-control': 'no-store' } });
     }
-    const cookie = signPreviewCookie({ holder, userId: consumed.userId, expiresAt: consumed.cookieExpiresAt.getTime() }, cookieKey);
+    // The grant carries the session that opened it; the cookie carries it on,
+    // so revoking that session cuts this preview on its very next request.
+    const cookie = signPreviewCookie({ holder, userId: consumed.userId, sessionId: consumed.sessionId, expiresAt: consumed.cookieExpiresAt.getTime() }, cookieKey);
     loggers.security.info('dev-preview.access', buildPreviewAccessLog({ userId: consumed.userId, holder, method: 'GET', path, outcome: 'forwarded', reason: 'grant-redeemed', status: 302, transport: 'http' }));
     return new NextResponse(null, {
       status: 302,
@@ -182,10 +184,10 @@ async function handle(request: NextRequest, context: RouteContext): Promise<Resp
     }
     return NextResponse.json({ error: 'Preview session expired. Reopen the preview from PageSpace.', reason }, { status: 401, headers: { 'set-cookie': buildClearPreviewCookieHeader(), 'cache-control': 'no-store' } });
   }
-  const userId = verified.claims.userId;
+  const { userId, sessionId } = verified.claims;
 
   // ---- authorize + decide, per request ---------------------------------------
-  const target = await resolvePreviewTargetForRequest(holder, userId);
+  const target = await resolvePreviewTargetForRequest(holder, userId, sessionId);
   if (!('spriteUrl' in target)) {
     const { reason, status, message, detail } = target.decision;
     if (reason === 'not-authorized' || reason === 'wake-denied') {

--- a/apps/web/src/app/api/drives/[driveId]/envs/[envId]/preview/actions/route.ts
+++ b/apps/web/src/app/api/drives/[driveId]/envs/[envId]/preview/actions/route.ts
@@ -35,7 +35,7 @@ export async function POST(request: Request, context: { params: Promise<{ driveI
     if (isAuthError(auth)) return auth.error;
 
     const action = readDevPreviewUserAction(await request.json().catch(() => null));
-    if (action === null) return NextResponse.json({ error: 'action must be "stop" or "resume"' }, { status: 400 });
+    if (action === null) return NextResponse.json({ error: 'action must be "stop", "resume", or "approve" with the port shown' }, { status: 400 });
 
     const holder = { kind: 'env', id: envId } as const;
     // The ONE manage rule (`canManageDevPreview`), asked before any row is

--- a/apps/web/src/app/api/drives/[driveId]/envs/[envId]/preview/open/route.ts
+++ b/apps/web/src/app/api/drives/[driveId]/envs/[envId]/preview/open/route.ts
@@ -25,7 +25,7 @@
  */
 
 import { NextResponse } from 'next/server';
-import { authenticateRequestWithOptions, isAuthError, isPrincipalDriveMember } from '@/lib/auth';
+import { authenticateRequestWithOptions, isAuthError, isPrincipalDriveMember, isSessionAuthResult } from '@/lib/auth';
 import { auditRequest } from '@pagespace/lib/audit/audit-log';
 import { loggers } from '@pagespace/lib/logging/logger-config';
 import { isDevPreviewConfigured } from '@pagespace/lib/services/sandbox/preview/dev-preview-env';
@@ -41,6 +41,9 @@ export async function GET(request: Request, context: { params: Promise<{ driveId
     const { driveId, envId } = await context.params;
     const auth = await authenticateRequestWithOptions(request, AUTH_OPTIONS);
     if (isAuthError(auth)) return signInOrDeny(request, auth.error);
+    // `allow: ['session']` already excludes every other principal; narrowing
+    // makes that a type fact so `sessionId` is read, never asserted.
+    if (!isSessionAuthResult(auth)) return NextResponse.json({ error: 'Not found' }, { status: 404 });
 
     if (!isAllowedPreviewOpen(request)) {
       auditRequest(request, { eventType: 'authz.access.denied', userId: auth.userId, resourceType: 'dev_preview', resourceId: `env:${envId}`, details: { route: ROUTE, reason: 'cross-site-embed' }, riskScore: 0.6 });
@@ -52,7 +55,7 @@ export async function GET(request: Request, context: { params: Promise<{ driveId
     }
     if (!(await resolveEnvInDrive(envId, driveId))) return NextResponse.json({ error: 'Environment not found' }, { status: 404 });
 
-    const opened = await openPreviewForUser({ authorizeAs: { kind: 'env', id: envId }, userId: auth.userId });
+    const opened = await openPreviewForUser({ authorizeAs: { kind: 'env', id: envId }, userId: auth.userId, sessionId: auth.sessionId });
     if (!opened.ok) {
       if (opened.reason === 'not-authorized') {
         auditRequest(request, { eventType: 'authz.access.denied', userId: auth.userId, resourceType: 'dev_preview', resourceId: `env:${envId}`, details: { route: ROUTE, reason: opened.detail ?? 'not-authorized' } });

--- a/apps/web/src/components/dev-preview/DevPreviewPane.tsx
+++ b/apps/web/src/components/dev-preview/DevPreviewPane.tsx
@@ -160,7 +160,9 @@ function OpenDevPreviewPane({ open }: { open: OpenDevPreview }) {
       // The approve body ECHOES the port the user was just shown; the server
       // refuses it with a 409 if the dev server has moved since, rather than
       // sharing whatever is running now.
-      const body = action.kind === 'approve' ? { action: 'approve', port: action.port } : { action: action.kind };
+      const body = action.kind === 'approve'
+        ? { action: 'approve', port: action.port, spriteInstanceId: action.spriteInstanceId }
+        : { action: action.kind };
       try {
         await post(devPreviewActionsPath(open.statusPath), body);
       } catch (actionError) {
@@ -278,7 +280,7 @@ function OpenDevPreviewPane({ open }: { open: OpenDevPreview }) {
             // line in a list. The port comes off the NARROWED state, so the
             // button's label and the request it sends cannot name different
             // ports.
-            <ApprovalControl port={preview.state.targetPort} holder={preview.holder} disabled={actioning} onShare={runAction} />
+            <ApprovalControl port={preview.state.targetPort} spriteInstanceId={preview.spriteInstanceId} holder={preview.holder} disabled={actioning} onShare={runAction} />
           )}
         </div>
       )}
@@ -293,19 +295,23 @@ function OpenDevPreviewPane({ open }: { open: OpenDevPreview }) {
  */
 function ApprovalControl({
   port,
+  spriteInstanceId,
   holder,
   disabled,
   onShare,
 }: {
   port: number;
+  /** Null only when nothing is attached, in which case there is nothing to share. */
+  spriteInstanceId: string | null;
   holder: DevPreviewStatusDTO['holder'];
   disabled: boolean;
   onShare: (action: DevPreviewUserAction) => void;
 }) {
+  if (spriteInstanceId === null) return null;
   return (
     <>
       <p className="max-w-sm">{devPreviewApprovalAudience(holder)}</p>
-      <Button size="sm" className="h-7 gap-1 px-3" disabled={disabled} onClick={() => onShare({ kind: 'approve', port })} title={`Share port ${port}`}>
+      <Button size="sm" className="h-7 gap-1 px-3" disabled={disabled} onClick={() => onShare({ kind: 'approve', port, spriteInstanceId })} title={`Share port ${port}`}>
         <Share2 className="size-3.5" aria-hidden="true" />
         Share :{port}
       </Button>

--- a/apps/web/src/components/dev-preview/DevPreviewPane.tsx
+++ b/apps/web/src/components/dev-preview/DevPreviewPane.tsx
@@ -64,9 +64,11 @@ import { ApiRequestError, post } from '@/lib/auth/auth-fetch';
 import { isDevPreviewReauthMessageFor } from '@pagespace/lib/services/sandbox/preview/dev-preview-contract';
 import { useDevPreviewCapability } from '@/hooks/dev-preview/useDevPreviewCapability';
 import { devPreviewActionsPath, useDevPreviewStatus, type DevPreviewStatusDTO } from '@/hooks/dev-preview/useDevPreviewStatus';
+// Type-only, so nothing from that module reaches the browser bundle.
+import type { DevPreviewUserAction } from '@pagespace/lib/services/sandbox/preview/dev-preview-status';
 import { useDevPreviewPaneStore, type OpenDevPreview } from '@/stores/useDevPreviewPaneStore';
 import { useEditingSession } from '@/stores/useEditingSession';
-import { DETECTION_UNAVAILABLE_MESSAGE } from '@pagespace/lib/services/sandbox/preview/dev-preview-status';
+import { DETECTION_UNAVAILABLE_MESSAGE } from '@pagespace/lib/services/sandbox/preview/dev-preview-core';
 import { devPreviewApprovalAudience, devPreviewBadge } from './dev-preview-copy';
 
 /** The open pane polls faster than the affordance: its chrome should notice a relay crash within a few seconds. */
@@ -151,18 +153,20 @@ function OpenDevPreviewPane({ open }: { open: OpenDevPreview }) {
   }, [open.holder, reload]);
 
   const runAction = useCallback(
-    async (action: 'stop' | 'resume' | { approvePort: number }) => {
+    // The SERVER's own action type, not a client-side lookalike: the route's
+    // body parser produces exactly this shape, so one union spans the wire.
+    async (action: DevPreviewUserAction) => {
       setActioning(true);
       // The approve body ECHOES the port the user was just shown; the server
       // refuses it with a 409 if the dev server has moved since, rather than
       // sharing whatever is running now.
-      const body = typeof action === 'string' ? { action } : { action: 'approve', port: action.approvePort };
+      const body = action.kind === 'approve' ? { action: 'approve', port: action.port } : { action: action.kind };
       try {
         await post(devPreviewActionsPath(open.statusPath), body);
       } catch (actionError) {
         const failure =
-          action === 'stop' ? 'Could not switch the preview off'
-          : action === 'resume' ? 'Could not switch the preview on'
+          action.kind === 'stop' ? 'Could not switch the preview off'
+          : action.kind === 'resume' ? 'Could not switch the preview on'
           : 'Could not share the preview';
         toast.error(failure, { description: actionError instanceof Error ? actionError.message : 'Please try again.' });
       } finally {
@@ -218,7 +222,7 @@ function OpenDevPreviewPane({ open }: { open: OpenDevPreview }) {
               size="sm"
               className="h-7 gap-1 px-2 text-muted-foreground hover:text-foreground"
               disabled={actioning}
-              onClick={() => void runAction('stop')}
+              onClick={() => void runAction({ kind: 'stop' })}
               // Nothing is being served while a decision is pending, so "Stop"
               // would name an act that has not happened. The same write does
               // the honest thing: put the offer away.
@@ -237,7 +241,7 @@ function OpenDevPreviewPane({ open }: { open: OpenDevPreview }) {
               size="sm"
               className="h-7 gap-1 px-2 text-muted-foreground hover:text-foreground"
               disabled={actioning}
-              onClick={() => void runAction('resume')}
+              onClick={() => void runAction({ kind: 'resume' })}
               title={preview.state.status === 'stopped' ? 'Switch the preview back on' : 'Restart the preview'}
             >
               <Play className="size-3.5" aria-hidden="true" />
@@ -267,28 +271,45 @@ function OpenDevPreviewPane({ open }: { open: OpenDevPreview }) {
       ) : (
         <div className="flex min-h-0 flex-1 flex-col items-center justify-center gap-3 p-6 text-center text-xs text-muted-foreground" data-testid="dev-preview-placeholder">
           <p className="max-w-sm">{preview ? preview.state.message : 'Loading preview status…'}</p>
-          {preview?.canManage && preview.canApprove && preview.pendingApprovalPort !== null && (
+          {preview?.canManage && preview.canApprove && preview.state.status === 'needs-approval' && (
             // The decision lives HERE and not on the affordance row: this is
             // the surface that can state who would be able to see it, and
             // sharing something should not be a one-click side effect of a
-            // line in a list.
-            <>
-              <p className="max-w-sm">{devPreviewApprovalAudience(preview.holder)}</p>
-              <Button
-                size="sm"
-                className="h-7 gap-1 px-3"
-                disabled={actioning}
-                onClick={() => void runAction({ approvePort: preview.pendingApprovalPort as number })}
-                title={`Share port ${preview.pendingApprovalPort}`}
-              >
-                <Share2 className="size-3.5" aria-hidden="true" />
-                Share :{preview.pendingApprovalPort}
-              </Button>
-            </>
+            // line in a list. The port comes off the NARROWED state, so the
+            // button's label and the request it sends cannot name different
+            // ports.
+            <ApprovalControl port={preview.state.targetPort} holder={preview.holder} disabled={actioning} onShare={runAction} />
           )}
         </div>
       )}
     </aside>
+  );
+}
+
+/**
+ * The one explicit act that turns a detected port into a shared one, under the
+ * sentence that says who would then be able to reach it. Split out so the port
+ * is bound ONCE, where the state was narrowed.
+ */
+function ApprovalControl({
+  port,
+  holder,
+  disabled,
+  onShare,
+}: {
+  port: number;
+  holder: DevPreviewStatusDTO['holder'];
+  disabled: boolean;
+  onShare: (action: DevPreviewUserAction) => void;
+}) {
+  return (
+    <>
+      <p className="max-w-sm">{devPreviewApprovalAudience(holder)}</p>
+      <Button size="sm" className="h-7 gap-1 px-3" disabled={disabled} onClick={() => onShare({ kind: 'approve', port })} title={`Share port ${port}`}>
+        <Share2 className="size-3.5" aria-hidden="true" />
+        Share :{port}
+      </Button>
+    </>
   );
 }
 

--- a/apps/web/src/components/dev-preview/DevPreviewPane.tsx
+++ b/apps/web/src/components/dev-preview/DevPreviewPane.tsx
@@ -55,7 +55,7 @@
  */
 
 import { useCallback, useEffect, useRef, useState } from 'react';
-import { ExternalLink, Play, RefreshCw, Square, X } from 'lucide-react';
+import { ExternalLink, Play, RefreshCw, Share2, Square, X } from 'lucide-react';
 import { toast } from 'sonner';
 
 import { Badge } from '@/components/ui/badge';
@@ -67,7 +67,7 @@ import { devPreviewActionsPath, useDevPreviewStatus, type DevPreviewStatusDTO } 
 import { useDevPreviewPaneStore, type OpenDevPreview } from '@/stores/useDevPreviewPaneStore';
 import { useEditingSession } from '@/stores/useEditingSession';
 import { DETECTION_UNAVAILABLE_MESSAGE } from '@pagespace/lib/services/sandbox/preview/dev-preview-status';
-import { devPreviewBadge } from './dev-preview-copy';
+import { devPreviewApprovalAudience, devPreviewBadge } from './dev-preview-copy';
 
 /** The open pane polls faster than the affordance: its chrome should notice a relay crash within a few seconds. */
 const PANE_POLL_MS = 5_000;
@@ -151,14 +151,20 @@ function OpenDevPreviewPane({ open }: { open: OpenDevPreview }) {
   }, [open.holder, reload]);
 
   const runAction = useCallback(
-    async (action: 'stop' | 'resume') => {
+    async (action: 'stop' | 'resume' | { approvePort: number }) => {
       setActioning(true);
+      // The approve body ECHOES the port the user was just shown; the server
+      // refuses it with a 409 if the dev server has moved since, rather than
+      // sharing whatever is running now.
+      const body = typeof action === 'string' ? { action } : { action: 'approve', port: action.approvePort };
       try {
-        await post(devPreviewActionsPath(open.statusPath), { action });
+        await post(devPreviewActionsPath(open.statusPath), body);
       } catch (actionError) {
-        toast.error(action === 'stop' ? 'Could not switch the preview off' : 'Could not switch the preview on', {
-          description: actionError instanceof Error ? actionError.message : 'Please try again.',
-        });
+        const failure =
+          action === 'stop' ? 'Could not switch the preview off'
+          : action === 'resume' ? 'Could not switch the preview on'
+          : 'Could not share the preview';
+        toast.error(failure, { description: actionError instanceof Error ? actionError.message : 'Please try again.' });
       } finally {
         setActioning(false);
         mutate();
@@ -207,9 +213,19 @@ function OpenDevPreviewPane({ open }: { open: OpenDevPreview }) {
             </a>
           </Button>
           {preview?.canManage && preview.canStop && (
-            <Button variant="ghost" size="sm" className="h-7 gap-1 px-2 text-muted-foreground hover:text-foreground" disabled={actioning} onClick={() => void runAction('stop')} title="Switch the preview off">
+            <Button
+              variant="ghost"
+              size="sm"
+              className="h-7 gap-1 px-2 text-muted-foreground hover:text-foreground"
+              disabled={actioning}
+              onClick={() => void runAction('stop')}
+              // Nothing is being served while a decision is pending, so "Stop"
+              // would name an act that has not happened. The same write does
+              // the honest thing: put the offer away.
+              title={preview.state.status === 'needs-approval' ? 'Dismiss this preview' : 'Switch the preview off'}
+            >
               <Square className="size-3.5" aria-hidden="true" />
-              Stop
+              {preview.state.status === 'needs-approval' ? 'Dismiss' : 'Stop'}
             </Button>
           )}
           {preview?.canManage && preview.canResume && (
@@ -249,8 +265,27 @@ function OpenDevPreviewPane({ open }: { open: OpenDevPreview }) {
           data-testid="dev-preview-frame"
         />
       ) : (
-        <div className="flex min-h-0 flex-1 items-center justify-center p-6 text-center text-xs text-muted-foreground" data-testid="dev-preview-placeholder">
-          {preview ? preview.state.message : 'Loading preview status…'}
+        <div className="flex min-h-0 flex-1 flex-col items-center justify-center gap-3 p-6 text-center text-xs text-muted-foreground" data-testid="dev-preview-placeholder">
+          <p className="max-w-sm">{preview ? preview.state.message : 'Loading preview status…'}</p>
+          {preview?.canManage && preview.canApprove && preview.pendingApprovalPort !== null && (
+            // The decision lives HERE and not on the affordance row: this is
+            // the surface that can state who would be able to see it, and
+            // sharing something should not be a one-click side effect of a
+            // line in a list.
+            <>
+              <p className="max-w-sm">{devPreviewApprovalAudience(preview.holder)}</p>
+              <Button
+                size="sm"
+                className="h-7 gap-1 px-3"
+                disabled={actioning}
+                onClick={() => void runAction({ approvePort: preview.pendingApprovalPort as number })}
+                title={`Share port ${preview.pendingApprovalPort}`}
+              >
+                <Share2 className="size-3.5" aria-hidden="true" />
+                Share :{preview.pendingApprovalPort}
+              </Button>
+            </>
+          )}
         </div>
       )}
     </aside>

--- a/apps/web/src/components/dev-preview/DevPreviewPane.tsx
+++ b/apps/web/src/components/dev-preview/DevPreviewPane.tsx
@@ -165,14 +165,18 @@ function OpenDevPreviewPane({ open }: { open: OpenDevPreview }) {
         : { action: action.kind };
       try {
         // A DEFERRED action succeeded — the stop was cleared, the consent
-        // recorded — but the relay start is waiting on a ports snapshot, which
+        // recorded — but the relay start is still waiting on something, which
         // can take a poll or two. Saying so beats silence: without this the
         // click looks like it did nothing while the pane still reads "not
-        // running".
+        // running". ANY marker is worth a word; the two we send differ only
+        // in what is being waited on, so the sentence names it rather than
+        // asserting the wrong cause.
         const answer = await post<{ deferred?: string }>(devPreviewActionsPath(open.statusPath), body);
-        if (answer?.deferred === 'awaiting-port-snapshot') {
+        if (answer?.deferred !== undefined) {
           toast.info('The preview will start shortly', {
-            description: 'Waiting for the sandbox to report which ports are in use.',
+            description: answer.deferred === 'awaiting-reconcile'
+              ? 'Another change to this preview is being applied first.'
+              : 'Waiting for the sandbox to report which ports are in use.',
           });
         }
       } catch (actionError) {
@@ -268,6 +272,24 @@ function OpenDevPreviewPane({ open }: { open: OpenDevPreview }) {
       </div>
 
       <DevPreviewStatusLine preview={preview} frameMounted={frameArmed} />
+
+      {/*
+        The decision has to stay reachable AFTER the frame has been armed.
+        `frameArmed` latches on the first openable answer and never clears, so
+        putting the only Share control in its `else` branch meant a preview
+        that went live and then moved to a NEW unlisted port — approval is
+        recorded per port, so the new one is unapproved — re-entered
+        `needs-approval` with no way to say yes: the frame was still mounted,
+        and the user's only options were Dismiss or closing the pane. The
+        control renders above the frame in that state instead, so it does not
+        depend on how the pane happened to open.
+      */}
+      {frameArmed && preview?.canManage && preview.canApprove && preview.state.status === 'needs-approval' && (
+        <div className="flex shrink-0 flex-col items-center gap-2 border-b border-border px-3 py-3 text-center text-xs text-muted-foreground">
+          <p className="max-w-sm">{preview.state.message}</p>
+          <ApprovalControl port={preview.state.targetPort} spriteInstanceId={preview.spriteInstanceId} holder={preview.holder} disabled={actioning} onShare={runAction} />
+        </div>
+      )}
 
       {frameArmed ? (
         <iframe

--- a/apps/web/src/components/dev-preview/DevPreviewPane.tsx
+++ b/apps/web/src/components/dev-preview/DevPreviewPane.tsx
@@ -164,7 +164,17 @@ function OpenDevPreviewPane({ open }: { open: OpenDevPreview }) {
         ? { action: 'approve', port: action.port, spriteInstanceId: action.spriteInstanceId }
         : { action: action.kind };
       try {
-        await post(devPreviewActionsPath(open.statusPath), body);
+        // A DEFERRED action succeeded — the stop was cleared, the consent
+        // recorded — but the relay start is waiting on a ports snapshot, which
+        // can take a poll or two. Saying so beats silence: without this the
+        // click looks like it did nothing while the pane still reads "not
+        // running".
+        const answer = await post<{ deferred?: string }>(devPreviewActionsPath(open.statusPath), body);
+        if (answer?.deferred === 'awaiting-port-snapshot') {
+          toast.info('The preview will start shortly', {
+            description: 'Waiting for the sandbox to report which ports are in use.',
+          });
+        }
       } catch (actionError) {
         const failure =
           action.kind === 'stop' ? 'Could not switch the preview off'

--- a/apps/web/src/components/dev-preview/DevPreviewPane.tsx
+++ b/apps/web/src/components/dev-preview/DevPreviewPane.tsx
@@ -66,6 +66,7 @@ import { useDevPreviewCapability } from '@/hooks/dev-preview/useDevPreviewCapabi
 import { devPreviewActionsPath, useDevPreviewStatus, type DevPreviewStatusDTO } from '@/hooks/dev-preview/useDevPreviewStatus';
 import { useDevPreviewPaneStore, type OpenDevPreview } from '@/stores/useDevPreviewPaneStore';
 import { useEditingSession } from '@/stores/useEditingSession';
+import { DETECTION_UNAVAILABLE_MESSAGE } from '@pagespace/lib/services/sandbox/preview/dev-preview-status';
 import { devPreviewBadge } from './dev-preview-copy';
 
 /** The open pane polls faster than the affordance: its chrome should notice a relay crash within a few seconds. */
@@ -273,12 +274,18 @@ function DevPreviewStatusLine({ preview, frameMounted }: { preview: DevPreviewSt
   // for a held slot is the core's, carried by the `blocked` state's message.
   // A direct row's own server on 8080 is not worth a line.
   const showSlot = preview.slot.known && preview.slot.holder === 'user-process' && !(preview.state.status === 'live' && preview.state.via === 'direct');
-  if (!showState && !showSlot) return null;
+  // Nothing is watching this sandbox's ports, so what is shown may lag. Said
+  // only for a LIVE sandbox: with none attached there is nothing to detect,
+  // and the state message already says that. `'arming'` says nothing — it
+  // resolves within a poll, and a flicker on every first render is noise.
+  const showDetection = preview.detection === 'unavailable' && preview.sandbox === 'attached';
+  if (!showState && !showSlot && !showDetection) return null;
   const tone = preview.state.status === 'blocked' ? 'text-destructive' : 'text-muted-foreground';
   return (
     <div className={`shrink-0 space-y-0.5 border-b border-border px-2 py-1 text-xs ${tone}`} data-testid="dev-preview-status-line">
       {showState && <div>{preview.state.message}</div>}
       {showSlot && preview.slot.known && <div>{preview.slot.message}</div>}
+      {showDetection && <div>{DETECTION_UNAVAILABLE_MESSAGE}</div>}
     </div>
   );
 }

--- a/apps/web/src/components/dev-preview/__tests__/DevPreviewAffordance.test.tsx
+++ b/apps/web/src/components/dev-preview/__tests__/DevPreviewAffordance.test.tsx
@@ -33,6 +33,8 @@ function status(over: Partial<DevPreviewStatusDTO> = {}): DevPreviewStatusDTO {
     canOpen: true,
     canStop: true,
     canResume: false,
+    canApprove: false,
+    pendingApprovalPort: null,
     detectedAt: '2026-09-06T11:00:00.000Z',
     ...over,
   };
@@ -103,6 +105,23 @@ describe('DevPreviewAffordance', () => {
     expect(screen.getByText('Preview of :3000 is switched off')).toHaveAttribute('title', 'Preview of port 3000 is switched off.');
     expect(screen.getByRole('button', { name: 'Details' })).toBeInTheDocument();
     expect(screen.queryByRole('button', { name: 'Preview' })).toBeNull();
+  });
+
+  test('an UNSHARED port still gets its line — detection is not exposure — but the verb is "Details", never "Preview"', async () => {
+    preview = status({
+      canOpen: false,
+      canStop: true,
+      canResume: false,
+      canApprove: true,
+      pendingApprovalPort: 9000,
+      state: { status: 'needs-approval', targetPort: 9000, message: 'A dev server is running on port 9000. It is not a usual dev-server port, so it is not being shared until you say so.' },
+    });
+    renderAffordance();
+    await screen.findByText('Dev server detected on :9000 — not shared yet');
+    expect(screen.getByRole('button', { name: 'Details' })).toBeInTheDocument();
+    // Sharing is never a click on a row in a list: the decision lives in the
+    // pane, which is the surface that states who would be able to see it.
+    expect(screen.queryByRole('button', { name: /Share/ })).toBeNull();
   });
 
   test('an unknown status renders neutral copy and "Details" rather than crashing the row', async () => {

--- a/apps/web/src/components/dev-preview/__tests__/DevPreviewAffordance.test.tsx
+++ b/apps/web/src/components/dev-preview/__tests__/DevPreviewAffordance.test.tsx
@@ -34,7 +34,6 @@ function status(over: Partial<DevPreviewStatusDTO> = {}): DevPreviewStatusDTO {
     canStop: true,
     canResume: false,
     canApprove: false,
-    pendingApprovalPort: null,
     detectedAt: '2026-09-06T11:00:00.000Z',
     ...over,
   };
@@ -113,7 +112,6 @@ describe('DevPreviewAffordance', () => {
       canStop: true,
       canResume: false,
       canApprove: true,
-      pendingApprovalPort: 9000,
       state: { status: 'needs-approval', targetPort: 9000, message: 'A dev server is running on port 9000. It is not a usual dev-server port, so it is not being shared until you say so.' },
     });
     renderAffordance();

--- a/apps/web/src/components/dev-preview/__tests__/DevPreviewAffordance.test.tsx
+++ b/apps/web/src/components/dev-preview/__tests__/DevPreviewAffordance.test.tsx
@@ -26,6 +26,7 @@ function status(over: Partial<DevPreviewStatusDTO> = {}): DevPreviewStatusDTO {
     holder: { kind: 'workspace', id: 'ws1' },
     canManage: true,
     sandbox: 'attached',
+    detection: 'watching',
     state: { status: 'live', targetPort: 5173, via: 'relay', message: 'Relaying port 8080 to your dev server on port 5173.' },
     slot: { known: false },
     openPath: '/api/agent-workspaces/ws1/preview/open',

--- a/apps/web/src/components/dev-preview/__tests__/DevPreviewAffordance.test.tsx
+++ b/apps/web/src/components/dev-preview/__tests__/DevPreviewAffordance.test.tsx
@@ -34,6 +34,7 @@ function status(over: Partial<DevPreviewStatusDTO> = {}): DevPreviewStatusDTO {
     canStop: true,
     canResume: false,
     canApprove: false,
+    spriteInstanceId: null,
     detectedAt: '2026-09-06T11:00:00.000Z',
     ...over,
   };

--- a/apps/web/src/components/dev-preview/__tests__/DevPreviewPane.test.tsx
+++ b/apps/web/src/components/dev-preview/__tests__/DevPreviewPane.test.tsx
@@ -22,7 +22,8 @@ vi.mock('@/lib/auth/auth-fetch', async (importOriginal) => {
   };
 });
 const mockToastError = vi.hoisted(() => vi.fn());
-vi.mock('sonner', () => ({ toast: { error: (...args: unknown[]) => mockToastError(...args), success: vi.fn() } }));
+const mockToastInfo = vi.hoisted(() => vi.fn());
+vi.mock('sonner', () => ({ toast: { error: (...args: unknown[]) => mockToastError(...args), info: (...args: unknown[]) => mockToastInfo(...args), success: vi.fn() } }));
 
 import { DEV_PREVIEW_FRAME_SANDBOX, DevPreviewPane, buildFrameSrc } from '../DevPreviewPane';
 import { ApiRequestError } from '@/lib/auth/auth-fetch';
@@ -214,6 +215,20 @@ describe('DevPreviewPane', () => {
     await screen.findByTestId('dev-preview-frame');
     expect(screen.getByTestId('dev-preview-status-line')).toHaveTextContent('Starting the preview relay for port 5173…');
     expect(screen.getByText('Starting · :5173')).toBeInTheDocument();
+  });
+
+  test('a DEFERRED action says so, rather than looking like it did nothing', async () => {
+    // The server answers 200 because the intent landed; only the relay start
+    // waits on a ports snapshot. Without a word the click looks inert while
+    // the pane still reads "not running".
+    mockPost.mockResolvedValueOnce({ ok: true, applied: null, deferred: 'awaiting-port-snapshot' });
+    status = live({ canOpen: false, canStop: false, canResume: true, state: { status: 'down', targetPort: 5173, via: 'relay', error: null, message: 'The preview relay for port 5173 is not defined on this sandbox.' } });
+    act(() => useDevPreviewPaneStore.getState().openPreview(OPEN));
+    renderPane();
+    await screen.findByTitle('Restart the preview');
+    fireEvent.click(screen.getByTitle('Restart the preview'));
+    await waitFor(() => expect(mockToastInfo).toHaveBeenCalledWith('The preview will start shortly', expect.objectContaining({ description: expect.stringContaining('which ports are in use') })));
+    expect(mockToastError).not.toHaveBeenCalled();
   });
 
   test('a failed action toasts and still re-reads the status', async () => {

--- a/apps/web/src/components/dev-preview/__tests__/DevPreviewPane.test.tsx
+++ b/apps/web/src/components/dev-preview/__tests__/DevPreviewPane.test.tsx
@@ -175,6 +175,38 @@ describe('DevPreviewPane', () => {
     expect(screen.queryByTitle('Switch the preview off')).toBeNull();
   });
 
+  test('the Share control survives the frame having been armed — a live preview that MOVES to a new unlisted port can still be approved', async () => {
+    // `frameArmed` latches on the first openable answer and never clears, so
+    // the only Share control living in its `else` branch was unreachable for
+    // the whole life of the open. Approval is per PORT, so a preview that
+    // went live on 5173 and then moved to 9000 re-enters `needs-approval`
+    // with the frame still mounted — and the user could only Dismiss.
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+    try {
+      status = live({ spriteInstanceId: 'inst-live' });
+      act(() => useDevPreviewPaneStore.getState().openPreview(OPEN));
+      renderPane();
+      // The frame arms here, and `frameArmed` never clears again.
+      await vi.waitFor(() => expect(screen.getByTestId('dev-preview-frame')).toBeInTheDocument());
+
+      // The SAME mount then sees the server move to an unapproved port.
+      status = live({
+        canOpen: false,
+        canApprove: true,
+        spriteInstanceId: 'inst-live',
+        state: { status: 'needs-approval', targetPort: 9000, message: 'A dev server is running on port 9000. It is not a usual dev-server port, so it is not being shared until you say so.' },
+      });
+      await act(async () => { await vi.advanceTimersByTimeAsync(30_000); });
+      await vi.waitFor(() => expect(screen.getByTitle('Share port 9000')).toBeInTheDocument());
+
+      fireEvent.click(screen.getByTitle('Share port 9000'));
+      await vi.waitFor(() => expect(mockPost).toHaveBeenCalledWith(ACTIONS_PATH, { action: 'approve', port: 9000, spriteInstanceId: 'inst-live' }));
+    } finally {
+      vi.useRealTimers();
+    }
+
+  });
+
   test('NEEDS APPROVAL: no frame, the audience is stated, and Share posts the PORT that was shown', async () => {
     status = live({
       canOpen: false,

--- a/apps/web/src/components/dev-preview/__tests__/DevPreviewPane.test.tsx
+++ b/apps/web/src/components/dev-preview/__tests__/DevPreviewPane.test.tsx
@@ -44,6 +44,7 @@ function live(over: Partial<DevPreviewStatusDTO> = {}): DevPreviewStatusDTO {
     holder: OPEN.holder,
     canManage: true,
     sandbox: 'attached',
+    detection: 'watching',
     state: { status: 'live', targetPort: 5173, via: 'relay', message: 'Relaying port 8080 to your dev server on port 5173.' },
     slot: { known: true, holder: 'relay', pid: null, message: 'Port 8080 is held by the preview relay, forwarding to your dev server on port 5173.' },
     openPath: OPEN.openPath,

--- a/apps/web/src/components/dev-preview/__tests__/DevPreviewPane.test.tsx
+++ b/apps/web/src/components/dev-preview/__tests__/DevPreviewPane.test.tsx
@@ -222,7 +222,7 @@ describe('DevPreviewPane', () => {
     // waits on a ports snapshot. Without a word the click looks inert while
     // the pane still reads "not running".
     mockPost.mockResolvedValueOnce({ ok: true, applied: null, deferred: 'awaiting-port-snapshot' });
-    status = live({ canOpen: false, canStop: false, canResume: true, state: { status: 'down', targetPort: 5173, via: 'relay', error: null, message: 'The preview relay for port 5173 is not defined on this sandbox.' } });
+    status = live({ canOpen: false, canStop: false, canResume: true, state: { status: 'down', targetPort: 5173, via: 'relay', error: null, repairable: true, message: 'The preview relay for port 5173 is not defined on this sandbox.' } });
     act(() => useDevPreviewPaneStore.getState().openPreview(OPEN));
     renderPane();
     await screen.findByTitle('Restart the preview');

--- a/apps/web/src/components/dev-preview/__tests__/DevPreviewPane.test.tsx
+++ b/apps/web/src/components/dev-preview/__tests__/DevPreviewPane.test.tsx
@@ -52,6 +52,7 @@ function live(over: Partial<DevPreviewStatusDTO> = {}): DevPreviewStatusDTO {
     canStop: true,
     canResume: false,
     canApprove: false,
+    spriteInstanceId: null,
     detectedAt: '2026-09-06T11:00:00.000Z',
     ...over,
   };
@@ -179,6 +180,7 @@ describe('DevPreviewPane', () => {
       canStop: true,
       canResume: false,
       canApprove: true,
+      spriteInstanceId: 'inst-live',
       state: { status: 'needs-approval', targetPort: 9000, message: 'A dev server is running on port 9000. It is not a usual dev-server port, so it is not being shared until you say so.' },
     });
     act(() => useDevPreviewPaneStore.getState().openPreview(OPEN));
@@ -193,7 +195,8 @@ describe('DevPreviewPane', () => {
     expect(screen.getByTitle('Dismiss this preview')).toBeInTheDocument();
 
     fireEvent.click(screen.getByTitle('Share port 9000'));
-    await waitFor(() => expect(mockPost).toHaveBeenCalledWith(ACTIONS_PATH, { action: 'approve', port: 9000 }));
+    // The instance travels with the port: both are echoed from what was rendered.
+    await waitFor(() => expect(mockPost).toHaveBeenCalledWith(ACTIONS_PATH, { action: 'approve', port: 9000, spriteInstanceId: 'inst-live' }));
   });
 
   test('a viewer who may not manage is offered NO way to share, however unshared the preview is', async () => {

--- a/apps/web/src/components/dev-preview/__tests__/DevPreviewPane.test.tsx
+++ b/apps/web/src/components/dev-preview/__tests__/DevPreviewPane.test.tsx
@@ -51,6 +51,8 @@ function live(over: Partial<DevPreviewStatusDTO> = {}): DevPreviewStatusDTO {
     canOpen: true,
     canStop: true,
     canResume: false,
+    canApprove: false,
+    pendingApprovalPort: null,
     detectedAt: '2026-09-06T11:00:00.000Z',
     ...over,
   };
@@ -170,6 +172,38 @@ describe('DevPreviewPane', () => {
     fireEvent.click(screen.getByTitle('Reload the preview'));
     await waitFor(() => expect(screen.queryByTitle('Switch the preview back on')).toBeNull());
     expect(screen.queryByTitle('Switch the preview off')).toBeNull();
+  });
+
+  test('NEEDS APPROVAL: no frame, the audience is stated, and Share posts the PORT that was shown', async () => {
+    status = live({
+      canOpen: false,
+      canStop: true,
+      canResume: false,
+      canApprove: true,
+      pendingApprovalPort: 9000,
+      state: { status: 'needs-approval', targetPort: 9000, message: 'A dev server is running on port 9000. It is not a usual dev-server port, so it is not being shared until you say so.' },
+    });
+    act(() => useDevPreviewPaneStore.getState().openPreview(OPEN));
+    renderPane();
+    // Nothing is served, so nothing is framed — the pane must not imply it is.
+    await screen.findByTestId('dev-preview-placeholder');
+    expect(screen.queryByTestId('dev-preview-frame')).toBeNull();
+    expect(screen.getByText('Needs your OK · :9000')).toBeInTheDocument();
+    // "Share" is meaningless without saying with whom.
+    expect(screen.getByText('Everyone with access to this drive will be able to open it.')).toBeInTheDocument();
+    // Stop is honest here: nothing is running to switch off.
+    expect(screen.getByTitle('Dismiss this preview')).toBeInTheDocument();
+
+    fireEvent.click(screen.getByTitle('Share port 9000'));
+    await waitFor(() => expect(mockPost).toHaveBeenCalledWith(ACTIONS_PATH, { action: 'approve', port: 9000 }));
+  });
+
+  test('a viewer who may not manage is offered NO way to share, however unshared the preview is', async () => {
+    status = live({ canManage: false, canOpen: false, canApprove: true, pendingApprovalPort: 9000, state: { status: 'needs-approval', targetPort: 9000, message: 'not shared' } });
+    act(() => useDevPreviewPaneStore.getState().openPreview(OPEN));
+    renderPane();
+    await screen.findByTestId('dev-preview-placeholder');
+    expect(screen.queryByTitle('Share port 9000')).toBeNull();
   });
 
   test('STARTING: the frame is up AND the status line explains the relay is coming up (the one time both show)', async () => {

--- a/apps/web/src/components/dev-preview/__tests__/DevPreviewPane.test.tsx
+++ b/apps/web/src/components/dev-preview/__tests__/DevPreviewPane.test.tsx
@@ -52,7 +52,6 @@ function live(over: Partial<DevPreviewStatusDTO> = {}): DevPreviewStatusDTO {
     canStop: true,
     canResume: false,
     canApprove: false,
-    pendingApprovalPort: null,
     detectedAt: '2026-09-06T11:00:00.000Z',
     ...over,
   };
@@ -180,7 +179,6 @@ describe('DevPreviewPane', () => {
       canStop: true,
       canResume: false,
       canApprove: true,
-      pendingApprovalPort: 9000,
       state: { status: 'needs-approval', targetPort: 9000, message: 'A dev server is running on port 9000. It is not a usual dev-server port, so it is not being shared until you say so.' },
     });
     act(() => useDevPreviewPaneStore.getState().openPreview(OPEN));
@@ -199,7 +197,7 @@ describe('DevPreviewPane', () => {
   });
 
   test('a viewer who may not manage is offered NO way to share, however unshared the preview is', async () => {
-    status = live({ canManage: false, canOpen: false, canApprove: true, pendingApprovalPort: 9000, state: { status: 'needs-approval', targetPort: 9000, message: 'not shared' } });
+    status = live({ canManage: false, canOpen: false, canApprove: true, state: { status: 'needs-approval', targetPort: 9000, message: 'not shared' } });
     act(() => useDevPreviewPaneStore.getState().openPreview(OPEN));
     renderPane();
     await screen.findByTestId('dev-preview-placeholder');

--- a/apps/web/src/components/dev-preview/__tests__/dev-preview-copy.test.ts
+++ b/apps/web/src/components/dev-preview/__tests__/dev-preview-copy.test.ts
@@ -22,7 +22,9 @@ describe('dev-preview copy', () => {
   it('offers an affordance line for every KNOWN dev server and none for "none"', () => {
     expect(devPreviewAffordanceText(preview({ status: 'live', targetPort: 5173, via: 'relay', message: '' }))).toBe('Dev server detected on :5173');
     expect(devPreviewAffordanceText(preview({ status: 'starting', targetPort: 5173, via: 'relay', message: '' }))).toBe('Dev server detected on :5173');
-    expect(devPreviewAffordanceText(preview({ status: 'down', targetPort: 5173, via: 'relay', error: null, repairable: true, message: '' }))).toContain('not responding');
+    // Not "the dev server is not responding": a `down` preview is as often a
+    // relay that was never created, and the server itself may be fine.
+    expect(devPreviewAffordanceText(preview({ status: 'down', targetPort: 5173, via: 'relay', error: null, repairable: true, message: '' }))).toBe('Preview of :5173 is not running');
     expect(devPreviewAffordanceText(preview({ status: 'blocked', targetPort: 5173, message: '' }))).toContain('port 8080 is in use');
     expect(devPreviewAffordanceText(preview({ status: 'stopped', targetPort: 5173, stoppedAt: 'x', message: '' }))).toContain('switched off');
     expect(devPreviewAffordanceText(preview({ status: 'stale', targetPort: 5173, message: '' }))).toContain('started again');

--- a/apps/web/src/components/dev-preview/__tests__/dev-preview-copy.test.ts
+++ b/apps/web/src/components/dev-preview/__tests__/dev-preview-copy.test.ts
@@ -1,9 +1,9 @@
 import { describe, it, expect } from 'vitest';
-import { devPreviewAffordanceText, devPreviewAffordanceVerb, devPreviewBadge, shouldShowDevPreviewAffordance } from '../dev-preview-copy';
+import { devPreviewAffordanceText, devPreviewAffordanceVerb, devPreviewApprovalAudience, devPreviewBadge, shouldShowDevPreviewAffordance } from '../dev-preview-copy';
 import type { DevPreviewStatusDTO } from '@/hooks/dev-preview/useDevPreviewStatus';
 
 function preview(state: DevPreviewStatusDTO['state']): DevPreviewStatusDTO {
-  return { holder: { kind: 'env', id: 'e' }, canManage: false, sandbox: 'attached', detection: 'watching', state, slot: { known: false }, openPath: '/o', canOpen: false, canStop: false, canResume: false, detectedAt: null };
+  return { holder: { kind: 'env', id: 'e' }, canManage: false, sandbox: 'attached', detection: 'watching', state, slot: { known: false }, openPath: '/o', canOpen: false, canStop: false, canResume: false, canApprove: false, pendingApprovalPort: null, detectedAt: null };
 }
 
 describe('dev-preview copy', () => {
@@ -47,5 +47,18 @@ describe('dev-preview copy', () => {
     expect(devPreviewAffordanceVerb(preview({ status: 'down', targetPort: 1, via: 'relay', error: null, repairable: true, message: '' }))).toBe('Details');
     expect(devPreviewAffordanceVerb(preview({ status: 'blocked', targetPort: 1, message: '' }))).toBe('Details');
     expect(devPreviewAffordanceVerb(preview({ status: 'stale', targetPort: 1, message: '' }))).toBe('Details');
+  });
+});
+
+describe('needs-approval copy', () => {
+  it('names the port in the badge and the line, and never claims the preview is live', () => {
+    const state = { status: 'needs-approval' as const, targetPort: 9000, message: 'not shared yet' };
+    expect(devPreviewBadge(state)).toEqual({ label: 'Needs your OK · :9000', tone: 'secondary' });
+    expect(devPreviewAffordanceText(preview(state))).toBe('Dev server detected on :9000 — not shared yet');
+  });
+
+  it('states the audience per holder kind — the sentence that makes "share" mean something', () => {
+    expect(devPreviewApprovalAudience({ kind: 'env', id: 'e' })).toContain('drive');
+    expect(devPreviewApprovalAudience({ kind: 'workspace', id: 'w' })).toContain('session');
   });
 });

--- a/apps/web/src/components/dev-preview/__tests__/dev-preview-copy.test.ts
+++ b/apps/web/src/components/dev-preview/__tests__/dev-preview-copy.test.ts
@@ -3,7 +3,7 @@ import { devPreviewAffordanceText, devPreviewAffordanceVerb, devPreviewApprovalA
 import type { DevPreviewStatusDTO } from '@/hooks/dev-preview/useDevPreviewStatus';
 
 function preview(state: DevPreviewStatusDTO['state']): DevPreviewStatusDTO {
-  return { holder: { kind: 'env', id: 'e' }, canManage: false, sandbox: 'attached', detection: 'watching', state, slot: { known: false }, openPath: '/o', canOpen: false, canStop: false, canResume: false, canApprove: false, detectedAt: null };
+  return { holder: { kind: 'env', id: 'e' }, canManage: false, sandbox: 'attached', detection: 'watching', state, slot: { known: false }, openPath: '/o', canOpen: false, canStop: false, canResume: false, canApprove: false, spriteInstanceId: null, detectedAt: null };
 }
 
 describe('dev-preview copy', () => {

--- a/apps/web/src/components/dev-preview/__tests__/dev-preview-copy.test.ts
+++ b/apps/web/src/components/dev-preview/__tests__/dev-preview-copy.test.ts
@@ -3,7 +3,7 @@ import { devPreviewAffordanceText, devPreviewAffordanceVerb, devPreviewBadge, sh
 import type { DevPreviewStatusDTO } from '@/hooks/dev-preview/useDevPreviewStatus';
 
 function preview(state: DevPreviewStatusDTO['state']): DevPreviewStatusDTO {
-  return { holder: { kind: 'env', id: 'e' }, canManage: false, sandbox: 'attached', state, slot: { known: false }, openPath: '/o', canOpen: false, canStop: false, canResume: false, detectedAt: null };
+  return { holder: { kind: 'env', id: 'e' }, canManage: false, sandbox: 'attached', detection: 'watching', state, slot: { known: false }, openPath: '/o', canOpen: false, canStop: false, canResume: false, detectedAt: null };
 }
 
 describe('dev-preview copy', () => {

--- a/apps/web/src/components/dev-preview/__tests__/dev-preview-copy.test.ts
+++ b/apps/web/src/components/dev-preview/__tests__/dev-preview-copy.test.ts
@@ -3,7 +3,7 @@ import { devPreviewAffordanceText, devPreviewAffordanceVerb, devPreviewApprovalA
 import type { DevPreviewStatusDTO } from '@/hooks/dev-preview/useDevPreviewStatus';
 
 function preview(state: DevPreviewStatusDTO['state']): DevPreviewStatusDTO {
-  return { holder: { kind: 'env', id: 'e' }, canManage: false, sandbox: 'attached', detection: 'watching', state, slot: { known: false }, openPath: '/o', canOpen: false, canStop: false, canResume: false, canApprove: false, pendingApprovalPort: null, detectedAt: null };
+  return { holder: { kind: 'env', id: 'e' }, canManage: false, sandbox: 'attached', detection: 'watching', state, slot: { known: false }, openPath: '/o', canOpen: false, canStop: false, canResume: false, canApprove: false, detectedAt: null };
 }
 
 describe('dev-preview copy', () => {

--- a/apps/web/src/components/dev-preview/dev-preview-copy.ts
+++ b/apps/web/src/components/dev-preview/dev-preview-copy.ts
@@ -25,6 +25,8 @@ export function devPreviewBadge(state: DevPreviewStateDTO): { label: string; ton
       return { label: 'Port 8080 in use', tone: 'destructive' };
     case 'stopped':
       return { label: `Off · :${state.targetPort}`, tone: 'outline' };
+    case 'needs-approval':
+      return { label: `Needs your OK · :${state.targetPort}`, tone: 'secondary' };
     case 'stale':
       return { label: 'Sandbox rebuilt', tone: 'outline' };
     case 'instance-unknown':
@@ -57,6 +59,8 @@ export function devPreviewAffordanceText(preview: DevPreviewStatusDTO): string |
       return `Dev server on :${state.targetPort} — port 8080 is in use`;
     case 'stopped':
       return `Preview of :${state.targetPort} is switched off`;
+    case 'needs-approval':
+      return `Dev server detected on :${state.targetPort} — not shared yet`;
     case 'stale':
       return `Preview of :${state.targetPort} needs the dev server started again`;
     case 'instance-unknown':
@@ -81,4 +85,18 @@ export function devPreviewAffordanceVerb(preview: DevPreviewStatusDTO): 'Preview
 /** Whether the affordance should render at all for this status. */
 export function shouldShowDevPreviewAffordance(preview: DevPreviewStatusDTO | undefined): preview is DevPreviewStatusDTO {
   return preview !== undefined && devPreviewAffordanceText(preview) !== null;
+}
+
+/**
+ * WHO would be able to reach the preview once it is shared — the sentence the
+ * approval control is placed under, because "share" means nothing without it.
+ * An env's preview is viewable by every accepted member of the drive (the
+ * env routes' own GET bar); a session's is viewable by whoever may open that
+ * session. Neither is a guess: both restate the access decision the proxy
+ * enforces on every request.
+ */
+export function devPreviewApprovalAudience(holder: DevPreviewStatusDTO['holder']): string {
+  return holder.kind === 'env'
+    ? 'Everyone with access to this drive will be able to open it.'
+    : 'Anyone who can open this session will be able to open it.';
 }

--- a/apps/web/src/components/dev-preview/dev-preview-copy.ts
+++ b/apps/web/src/components/dev-preview/dev-preview-copy.ts
@@ -54,7 +54,11 @@ export function devPreviewAffordanceText(preview: DevPreviewStatusDTO): string |
     case 'starting':
       return `Dev server detected on :${state.targetPort}`;
     case 'down':
-      return `Dev server on :${state.targetPort} is not responding`;
+      // "not running", not "not responding": a `down` preview is as often a
+      // relay that was never created — the dev server itself may be perfectly
+      // healthy, and telling the user it is not responding sends them looking
+      // in the wrong place. The pane's status line carries the precise reason.
+      return `Preview of :${state.targetPort} is not running`;
     case 'blocked':
       return `Dev server on :${state.targetPort} — port 8080 is in use`;
     case 'stopped':

--- a/apps/web/src/hooks/dev-preview/__tests__/useDevPreviewStatus.test.tsx
+++ b/apps/web/src/hooks/dev-preview/__tests__/useDevPreviewStatus.test.tsx
@@ -39,7 +39,6 @@ function preview(over: Partial<DevPreviewStatusDTO> = {}): DevPreviewStatusDTO {
     canStop: false,
     canResume: false,
     canApprove: false,
-    pendingApprovalPort: null,
     detectedAt: null,
     ...over,
   };

--- a/apps/web/src/hooks/dev-preview/__tests__/useDevPreviewStatus.test.tsx
+++ b/apps/web/src/hooks/dev-preview/__tests__/useDevPreviewStatus.test.tsx
@@ -31,6 +31,7 @@ function preview(over: Partial<DevPreviewStatusDTO> = {}): DevPreviewStatusDTO {
     holder: { kind: 'env', id: 'e' },
     canManage: false,
     sandbox: 'attached',
+    detection: 'watching',
     state: { status: 'none', message: 'nothing' },
     slot: { known: false },
     openPath: '/o',

--- a/apps/web/src/hooks/dev-preview/__tests__/useDevPreviewStatus.test.tsx
+++ b/apps/web/src/hooks/dev-preview/__tests__/useDevPreviewStatus.test.tsx
@@ -39,6 +39,7 @@ function preview(over: Partial<DevPreviewStatusDTO> = {}): DevPreviewStatusDTO {
     canStop: false,
     canResume: false,
     canApprove: false,
+    spriteInstanceId: null,
     detectedAt: null,
     ...over,
   };

--- a/apps/web/src/hooks/dev-preview/__tests__/useDevPreviewStatus.test.tsx
+++ b/apps/web/src/hooks/dev-preview/__tests__/useDevPreviewStatus.test.tsx
@@ -38,6 +38,8 @@ function preview(over: Partial<DevPreviewStatusDTO> = {}): DevPreviewStatusDTO {
     canOpen: false,
     canStop: false,
     canResume: false,
+    canApprove: false,
+    pendingApprovalPort: null,
     detectedAt: null,
     ...over,
   };

--- a/apps/web/src/lib/dev-preview/__tests__/action-response.test.ts
+++ b/apps/web/src/lib/dev-preview/__tests__/action-response.test.ts
@@ -20,7 +20,7 @@ const respond = (result: DevPreviewUserActionResult, holder: typeof ENV | typeof
     userId: 'u1',
     route: 'POST /api/x',
     holder,
-    action: 'resume',
+    action: { kind: 'resume' },
     result,
   });
 

--- a/apps/web/src/lib/dev-preview/__tests__/action-response.test.ts
+++ b/apps/web/src/lib/dev-preview/__tests__/action-response.test.ts
@@ -33,6 +33,26 @@ describe('respondToDevPreviewUserAction', () => {
     expect(await res.json()).toEqual({ ok: true, applied: { action: 'start-relay' } });
   });
 
+  it('a CONTENDED action names its deferral too — the same silence, one branch over', () => {
+    // `lockContended` is documented as the same shape as `slot-unknown`: the
+    // intent landed, only the relay work waits. It was dropping the marker,
+    // so the pane — which speaks only when the body names one — said nothing
+    // over a click that had taken effect.
+    const res = respond({ ok: true, applied: null, lockContended: true });
+    expect(res.status).toBe(200);
+    return res.json().then((body: unknown) => {
+      expect(body).toEqual({ ok: true, applied: null, deferred: 'awaiting-reconcile' });
+      expect(vi.mocked(auditRequest).mock.calls[0]?.[1]).toMatchObject({
+        details: { route: 'POST /api/x', action: 'resume', applied: null, deferred: 'awaiting-reconcile' },
+      });
+    });
+  });
+
+  it('an UNCONTENDED success carries no deferral marker, so the pane stays quiet', async () => {
+    const res = respond({ ok: true, applied: null });
+    expect(await res.json()).toEqual({ ok: true, applied: null });
+  });
+
   it('slot-unknown is a DEFERRAL, not a failure: 200, ok:true, and the deferral named', async () => {
     const res = respond({ ok: false, reason: 'slot-unknown' });
     // The intent is already written — the resume cleared the stop — and only

--- a/apps/web/src/lib/dev-preview/__tests__/listeners-source.test.ts
+++ b/apps/web/src/lib/dev-preview/__tests__/listeners-source.test.ts
@@ -65,9 +65,20 @@ describe('readDevPreviewListeners', () => {
 });
 
 describe('readDevPreviewUserAction', () => {
-  it('accepts exactly stop / resume', () => {
-    expect(readDevPreviewUserAction({ action: 'stop' })).toBe('stop');
-    expect(readDevPreviewUserAction({ action: 'resume' })).toBe('resume');
+  it('accepts exactly stop / resume / approve-with-a-port', () => {
+    expect(readDevPreviewUserAction({ action: 'stop' })).toEqual({ kind: 'stop' });
+    expect(readDevPreviewUserAction({ action: 'resume' })).toEqual({ kind: 'resume' });
+    expect(readDevPreviewUserAction({ action: 'approve', port: 9000 })).toEqual({ kind: 'approve', port: 9000 });
     for (const bad of [{ action: 'start' }, {}, null, 'stop', 7, { action: 1 }]) expect(readDevPreviewUserAction(bad)).toBeNull();
+    // The ECHOED PORT is what binds the click to the port on screen, so a
+    // missing or nonsensical one is not an approve at all — never a default.
+    for (const bad of [
+      { action: 'approve' },
+      { action: 'approve', port: '9000' },
+      { action: 'approve', port: 0 },
+      { action: 'approve', port: 65536 },
+      { action: 'approve', port: 90.5 },
+      { action: 'approve', port: null },
+    ]) expect(readDevPreviewUserAction(bad)).toBeNull();
   });
 });

--- a/apps/web/src/lib/dev-preview/__tests__/listeners-source.test.ts
+++ b/apps/web/src/lib/dev-preview/__tests__/listeners-source.test.ts
@@ -68,17 +68,23 @@ describe('readDevPreviewUserAction', () => {
   it('accepts exactly stop / resume / approve-with-a-port', () => {
     expect(readDevPreviewUserAction({ action: 'stop' })).toEqual({ kind: 'stop' });
     expect(readDevPreviewUserAction({ action: 'resume' })).toEqual({ kind: 'resume' });
-    expect(readDevPreviewUserAction({ action: 'approve', port: 9000 })).toEqual({ kind: 'approve', port: 9000 });
+    expect(readDevPreviewUserAction({ action: 'approve', port: 9000, spriteInstanceId: 'inst-1' })).toEqual({ kind: 'approve', port: 9000, spriteInstanceId: 'inst-1' });
     for (const bad of [{ action: 'start' }, {}, null, 'stop', 7, { action: 1 }]) expect(readDevPreviewUserAction(bad)).toBeNull();
     // The ECHOED PORT is what binds the click to the port on screen, so a
     // missing or nonsensical one is not an approve at all — never a default.
     for (const bad of [
       { action: 'approve' },
-      { action: 'approve', port: '9000' },
-      { action: 'approve', port: 0 },
-      { action: 'approve', port: 65536 },
-      { action: 'approve', port: 90.5 },
-      { action: 'approve', port: null },
+      { action: 'approve', port: '9000', spriteInstanceId: 'i' },
+      { action: 'approve', port: 0, spriteInstanceId: 'i' },
+      { action: 'approve', port: 65536, spriteInstanceId: 'i' },
+      { action: 'approve', port: 90.5, spriteInstanceId: 'i' },
+      { action: 'approve', port: null, spriteInstanceId: 'i' },
+      // The INSTANCE is as required as the port — an approve without it is not
+      // bound to the sandbox the user was looking at.
+      { action: 'approve', port: 9000 },
+      { action: 'approve', port: 9000, spriteInstanceId: '' },
+      { action: 'approve', port: 9000, spriteInstanceId: 42 },
+      { action: 'approve', port: 9000, spriteInstanceId: 'x'.repeat(201) },
     ]) expect(readDevPreviewUserAction(bad)).toBeNull();
   });
 });

--- a/apps/web/src/lib/dev-preview/__tests__/listeners-source.test.ts
+++ b/apps/web/src/lib/dev-preview/__tests__/listeners-source.test.ts
@@ -31,10 +31,10 @@ afterEach(() => {
 
 describe('readDevPreviewListeners', () => {
   it('POSTs the holder, signed, to the listeners route with redirect: error and a timeout, and returns the cleaned snapshot', async () => {
-    const fetchImpl = vi.fn(async () => new Response(JSON.stringify({ listeners: [{ port: 5173, pid: 3 }, { port: 8080 }, { port: 'x' }, { port: 1, pid: 'y' }] })));
+    const fetchImpl = vi.fn(async () => new Response(JSON.stringify({ detection: 'watching', listeners: [{ port: 5173, pid: 3 }, { port: 8080 }, { port: 'x' }, { port: 1, pid: 'y' }] })));
     const result = await readDevPreviewListeners(HOLDER, fetchImpl as unknown as typeof fetch);
     // Parsed with the watch channel's own reader: a non-integer pid is dropped, the port is kept; a non-integer port is dropped.
-    expect(result).toEqual([{ port: 5173, pid: 3 }, { port: 8080 }, { port: 1 }]);
+    expect(result).toEqual({ detection: 'watching', listeners: [{ port: 5173, pid: 3 }, { port: 8080 }, { port: 1 }] });
     const [url, init] = fetchImpl.mock.calls[0] as unknown as [string, RequestInit];
     expect(url).toBe('http://realtime.internal:3001/api/dev-preview/listeners');
     expect(init.method).toBe('POST');
@@ -44,18 +44,22 @@ describe('readDevPreviewListeners', () => {
     expect((init.headers as Record<string, string>)['X-Broadcast-Signature']).toMatch(/^sig:/);
   });
 
-  it('answers null (honest unknown) for: realtime says null, a non-array, a non-2xx, a network failure (logged), a dark feature, no realtime URL', async () => {
-    expect(await readDevPreviewListeners(HOLDER, (async () => new Response(JSON.stringify({ listeners: null }))) as unknown as typeof fetch)).toBeNull();
-    expect(await readDevPreviewListeners(HOLDER, (async () => new Response(JSON.stringify({ listeners: 'nope' }))) as unknown as typeof fetch)).toBeNull();
-    expect(await readDevPreviewListeners(HOLDER, (async () => new Response('{}', { status: 500 })) as unknown as typeof fetch)).toBeNull();
-    expect(await readDevPreviewListeners(HOLDER, (async () => { throw new Error('ECONNREFUSED'); }) as unknown as typeof fetch)).toBeNull();
+  it('answers "unknown, and nothing is watching" for every failure: a non-array, a bogus detection, a non-2xx, a network failure (logged), a dark feature, no realtime URL', async () => {
+    const UNKNOWN = { detection: 'unavailable', listeners: null };
+    // A null snapshot from a WATCHING realtime keeps that fact: the ports are
+    // unknown, but detection IS running — a different sentence for the UI.
+    expect(await readDevPreviewListeners(HOLDER, (async () => new Response(JSON.stringify({ detection: 'watching', listeners: null }))) as unknown as typeof fetch)).toEqual({ detection: 'watching', listeners: null });
+    expect(await readDevPreviewListeners(HOLDER, (async () => new Response(JSON.stringify({ listeners: 'nope' }))) as unknown as typeof fetch)).toEqual(UNKNOWN);
+    expect(await readDevPreviewListeners(HOLDER, (async () => new Response(JSON.stringify({ detection: 'bogus', listeners: [] }))) as unknown as typeof fetch)).toEqual({ detection: 'unavailable', listeners: [] });
+    expect(await readDevPreviewListeners(HOLDER, (async () => new Response('{}', { status: 500 })) as unknown as typeof fetch)).toEqual(UNKNOWN);
+    expect(await readDevPreviewListeners(HOLDER, (async () => { throw new Error('ECONNREFUSED'); }) as unknown as typeof fetch)).toEqual(UNKNOWN);
     expect(loggers.realtime.warn).toHaveBeenCalledWith('dev-preview: listeners read failed', expect.objectContaining({ error: 'ECONNREFUSED' }));
 
     const fetchImpl = vi.fn();
     vi.mocked(isDevPreviewConfigured).mockReturnValueOnce(false);
-    expect(await readDevPreviewListeners(HOLDER, fetchImpl as unknown as typeof fetch)).toBeNull();
+    expect(await readDevPreviewListeners(HOLDER, fetchImpl as unknown as typeof fetch)).toEqual(UNKNOWN);
     delete process.env.INTERNAL_REALTIME_URL;
-    expect(await readDevPreviewListeners(HOLDER, fetchImpl as unknown as typeof fetch)).toBeNull();
+    expect(await readDevPreviewListeners(HOLDER, fetchImpl as unknown as typeof fetch)).toEqual(UNKNOWN);
     expect(fetchImpl).not.toHaveBeenCalled();
   });
 });

--- a/apps/web/src/lib/dev-preview/action-response.ts
+++ b/apps/web/src/lib/dev-preview/action-response.ts
@@ -25,22 +25,30 @@ export function respondToDevPreviewUserAction({
   result: DevPreviewUserActionResult;
 }): NextResponse {
   const resourceId = `${holder.kind}:${holder.id}`;
+  // The audit trail names the port for an approve — who agreed to share what
+  // is the whole point of recording the act.
+  const audited = action.kind === 'approve' ? { action: action.kind, port: action.port } : { action: action.kind };
   if (!result.ok) {
     if (result.reason === 'wake-not-allowed') {
-      auditRequest(request, { eventType: 'authz.access.denied', userId, resourceType: 'dev_preview', resourceId, details: { route, action, reason: 'wake_not_allowed', detail: result.detail }, riskScore: 0.5 });
+      auditRequest(request, { eventType: 'authz.access.denied', userId, resourceType: 'dev_preview', resourceId, details: { route, ...audited, reason: 'wake_not_allowed', detail: result.detail }, riskScore: 0.5 });
       return NextResponse.json({ error: 'This drive cannot run code right now, so the preview cannot be switched back on', reason: result.detail }, { status: 403 });
     }
+    // Neither of these is "there is nothing to switch", and answering 404
+    // would tell the user their preview does not exist when it plainly does.
+    if (result.reason === 'port-changed') {
+      return NextResponse.json({ error: 'The dev server has moved to a different port since this was shown. Check the port and share it again.', reason: result.reason }, { status: 409 });
+    }
     // `slot-unknown` IS NOT A FAILURE, and answering 4xx made the UI say it
-    // was. The user's intent is already written — the resume cleared the stop
-    // — and only the relay work deferred, because no `ports/watch` snapshot
-    // proved 8080 free; the detector's next frame starts it against a real
-    // snapshot. `post()` THROWS on any 4xx, so the pane toasted "Could not
-    // switch the preview on" over a click that had taken effect. It is
-    // therefore the same success shape an attach-less action already returns
-    // (`applied: null`), with the deferral named so a caller can say
-    // "starting shortly" if it wants.
+    // was. The user's intent is already written — the resume cleared the stop,
+    // the approval recorded the consent — and only the relay work deferred,
+    // because no `ports/watch` snapshot proved 8080 free; the detector's next
+    // frame starts it against a real snapshot. `post()` THROWS on any 4xx, so
+    // the pane toasted "Could not switch the preview on" over a click that had
+    // taken effect. It is therefore the same success shape an attach-less
+    // action already returns (`applied: null`), with the deferral named so a
+    // caller can say "starting shortly" if it wants.
     if (result.reason === 'slot-unknown') {
-      auditRequest(request, { eventType: 'data.write', userId, resourceType: 'dev_preview', resourceId, details: { route, action, applied: null, deferred: 'awaiting-port-snapshot' } });
+      auditRequest(request, { eventType: 'data.write', userId, resourceType: 'dev_preview', resourceId, details: { route, ...audited, applied: null, deferred: 'awaiting-port-snapshot' } });
       return NextResponse.json({ ok: true, applied: null, deferred: 'awaiting-port-snapshot' });
     }
     return NextResponse.json(
@@ -48,6 +56,6 @@ export function respondToDevPreviewUserAction({
       { status: 404 },
     );
   }
-  auditRequest(request, { eventType: 'data.write', userId, resourceType: 'dev_preview', resourceId, details: { route, action, applied: result.applied?.action ?? null } });
+  auditRequest(request, { eventType: 'data.write', userId, resourceType: 'dev_preview', resourceId, details: { route, ...audited, applied: result.applied?.action ?? null } });
   return NextResponse.json({ ok: true, applied: result.applied });
 }

--- a/apps/web/src/lib/dev-preview/action-response.ts
+++ b/apps/web/src/lib/dev-preview/action-response.ts
@@ -35,6 +35,9 @@ export function respondToDevPreviewUserAction({
     }
     // Neither of these is "there is nothing to switch", and answering 404
     // would tell the user their preview does not exist when it plainly does.
+    if (result.reason === 'instance-changed') {
+      return NextResponse.json({ error: 'This sandbox was rebuilt since the preview was shown. Check what is running and share it again.', reason: result.reason }, { status: 409 });
+    }
     if (result.reason === 'port-changed') {
       return NextResponse.json({ error: 'The dev server has moved to a different port since this was shown. Check the port and share it again.', reason: result.reason }, { status: 409 });
     }

--- a/apps/web/src/lib/dev-preview/action-response.ts
+++ b/apps/web/src/lib/dev-preview/action-response.ts
@@ -41,12 +41,11 @@ export function respondToDevPreviewUserAction({
     // `slot-unknown` IS NOT A FAILURE, and answering 4xx made the UI say it
     // was. The user's intent is already written — the resume cleared the stop,
     // the approval recorded the consent — and only the relay work deferred,
-    // because no `ports/watch` snapshot proved 8080 free; the detector's next
-    // frame starts it against a real snapshot. `post()` THROWS on any 4xx, so
-    // the pane toasted "Could not switch the preview on" over a click that had
-    // taken effect. It is therefore the same success shape an attach-less
-    // action already returns (`applied: null`), with the deferral named so a
-    // caller can say "starting shortly" if it wants.
+    // because no `ports/watch` snapshot proved 8080 free. That is precisely
+    // the shape `lockContended` already reports as a success, and `post()`
+    // THROWS on any 4xx, so the pane toasted "Could not switch the preview on"
+    // over a click that had taken effect. Same status, same body shape, with
+    // the deferral named so a caller can say "starting shortly" if it wants.
     if (result.reason === 'slot-unknown') {
       auditRequest(request, { eventType: 'data.write', userId, resourceType: 'dev_preview', resourceId, details: { route, ...audited, applied: null, deferred: 'awaiting-port-snapshot' } });
       return NextResponse.json({ ok: true, applied: null, deferred: 'awaiting-port-snapshot' });

--- a/apps/web/src/lib/dev-preview/action-response.ts
+++ b/apps/web/src/lib/dev-preview/action-response.ts
@@ -58,6 +58,14 @@ export function respondToDevPreviewUserAction({
       { status: 404 },
     );
   }
-  auditRequest(request, { eventType: 'data.write', userId, resourceType: 'dev_preview', resourceId, details: { route, ...audited, applied: result.applied?.action ?? null } });
-  return NextResponse.json({ ok: true, applied: result.applied });
+  // A CONTENDED action is the same answer as `slot-unknown` and was left
+  // silent one branch away from it: the intent landed, only the relay work
+  // waits — here for the holder's lock rather than for a ports snapshot. The
+  // pane only speaks when the body NAMES a deferral, so without a marker the
+  // click produced nothing while the pane still read "not running". The two
+  // markers stay distinct because the wait is not the same wait, and the copy
+  // that explains it should not have to guess.
+  const deferred = result.lockContended === true ? { deferred: 'awaiting-reconcile' as const } : {};
+  auditRequest(request, { eventType: 'data.write', userId, resourceType: 'dev_preview', resourceId, details: { route, ...audited, applied: result.applied?.action ?? null, ...deferred } });
+  return NextResponse.json({ ok: true, applied: result.applied, ...deferred });
 }

--- a/apps/web/src/lib/dev-preview/listeners-source.ts
+++ b/apps/web/src/lib/dev-preview/listeners-source.ts
@@ -11,36 +11,52 @@
  * bounded by a short timeout, and answers `null` for every failure: no
  * snapshot, realtime down, feature dark, `INTERNAL_REALTIME_URL` unset.
  * `null` renders as "slot unknown, last-known state" — never as "free" and
- * never as an error the user has to see. The answer is parsed with the same
+ * never as an error the user has to see.
+ *
+ * The answer also carries whether realtime is WATCHING this holder at all.
+ * Every failure path here reports `detection: 'unavailable'`, which is the
+ * honest fact in each case: realtime could not be asked, so nothing is known
+ * to be watching. That is a different statement from "no ports are bound",
+ * and the UI is allowed to say so. The answer is parsed with the same
  * reader the watch channel itself uses (`readPortsWatchFrame`), so "a valid
  * listener" means one thing on both tiers.
  */
 
 import { loggers } from '@pagespace/lib/logging/logger-config';
-import type { DevPreviewHolderRef, ListeningPort } from '@pagespace/lib/services/sandbox/preview/dev-preview-core';
+import type { DevPreviewHolderRef } from '@pagespace/lib/services/sandbox/preview/dev-preview-core';
+import type { DevPreviewDetection, DevPreviewListenersRead } from '@pagespace/lib/services/sandbox/preview/dev-preview-status';
 import { readPortsWatchFrame } from '@pagespace/lib/services/sandbox/preview/ports-watch';
 import { postSignedDevPreviewCall } from './realtime-call';
 
 /** A status render must stay cheap: a slow realtime answer is a null answer. */
 const LISTENERS_TIMEOUT_MS = 2_500;
 
-export async function readDevPreviewListeners(holder: DevPreviewHolderRef, fetchImpl: typeof fetch = fetch): Promise<ListeningPort[] | null> {
+/** Nothing known, nothing watching — the answer for every failure path below. */
+const UNKNOWN: DevPreviewListenersRead = { detection: 'unavailable', listeners: null };
+
+/** Pure: narrow realtime's answer onto the union, treating anything unrecognised as unavailable. */
+function readDetection(value: unknown): DevPreviewDetection {
+  return value === 'watching' || value === 'arming' ? value : 'unavailable';
+}
+
+export async function readDevPreviewListeners(holder: DevPreviewHolderRef, fetchImpl: typeof fetch = fetch): Promise<DevPreviewListenersRead> {
   const call = postSignedDevPreviewCall('/api/dev-preview/listeners', JSON.stringify({ holder }), { timeoutMs: LISTENERS_TIMEOUT_MS, fetchImpl });
-  if (call === null) return null;
+  if (call === null) return UNKNOWN;
   try {
     const response = await call;
-    if (!response.ok) return null;
-    const parsed: unknown = await response.json();
-    const listeners = (parsed as { listeners?: unknown } | null)?.listeners;
-    if (!Array.isArray(listeners)) return null;
+    if (!response.ok) return UNKNOWN;
+    const parsed = (await response.json()) as { listeners?: unknown; detection?: unknown } | null;
+    const detection = readDetection(parsed?.detection);
+    const listeners = parsed?.listeners;
+    if (!Array.isArray(listeners)) return { detection, listeners: null };
     const frame = readPortsWatchFrame({ type: 'port_list', ports: listeners });
-    return frame?.type === 'port_list' ? frame.ports : null;
+    return { detection, listeners: frame?.type === 'port_list' ? frame.ports : null };
   } catch (error) {
     loggers.realtime.warn('dev-preview: listeners read failed', {
       holderKind: holder.kind,
       holderId: holder.id,
       error: error instanceof Error ? error.message : String(error),
     });
-    return null;
+    return UNKNOWN;
   }
 }

--- a/apps/web/src/lib/dev-preview/manage-decision.ts
+++ b/apps/web/src/lib/dev-preview/manage-decision.ts
@@ -12,6 +12,12 @@
  *  - a SESSION's own preview (an ephemeral session on its own sprite) is the
  *    session OWNER's — the end-session precedent: the person whose compute it
  *    is may always release it, and nobody else gets to flip it under them.
+ *
+ * This same bar governs APPROVING an unlisted port for sharing, which is the
+ * strictest thing the action route does — it makes a port reachable by
+ * everyone the preview is reachable by. So a plain drive member may VIEW an
+ * env's approved preview and can never approve one; the person who agrees is
+ * the person who could already stop it.
  */
 
 import type { AuthResult } from '@/lib/auth';

--- a/apps/web/src/lib/dev-preview/preview-runtime.ts
+++ b/apps/web/src/lib/dev-preview/preview-runtime.ts
@@ -19,6 +19,7 @@ import { resolveDriveMembership } from '@pagespace/lib/services/agent-workspaces
 import { isDevPreviewEnabled, resolveDevPreviewApex } from '@pagespace/lib/services/sandbox/preview/dev-preview-env';
 import { createDbDevPreviewStore, type DevPreviewStore } from '@pagespace/lib/services/sandbox/preview/dev-preview-store';
 import { createDevPreviewLock, DEV_PREVIEW_USER_ACTION_RETRIES, type DevPreviewLock } from '@pagespace/lib/services/sandbox/preview/dev-preview-lock';
+import { reconcileStoppedDevPreviews, type DevPreviewReconcileRun } from '@pagespace/lib/services/sandbox/preview/dev-preview-reconcile';
 import { createDbDevPreviewGrantsStore, type DevPreviewGrantsStore } from '@pagespace/lib/services/sandbox/preview/dev-preview-grants-store';
 import {
   authorizePreviewHolder,
@@ -251,5 +252,25 @@ export function applyDevPreviewUserActionForHolder({
     userId,
     wakeSubject,
     deps: { previewStore: deps.previewStore, attach: deps.attach, readListeners: readDevPreviewListeners, canRunCode: deps.canRunCode, lock: getPreviewLock(), now: deps.now },
+  });
+}
+
+/**
+ * The backstop sweep, bound to the real store, host and lock — see
+ * `dev-preview-reconcile.ts` for why it exists and why it can only ever stop
+ * a relay, never start one. The lock takes NO retries here: busy means a live
+ * path already owns the holder and is doing the same work.
+ */
+export function reconcileStoppedDevPreviewsForCron(): Promise<DevPreviewReconcileRun> {
+  const deps = buildPreviewAccessDeps();
+  const store = deps.previewStore;
+  return reconcileStoppedDevPreviews({
+    findStoppedWithRelay: ({ staleAfterMs, limit }) => store.findStoppedWithRelay({ staleAfterMs, limit, now: new Date() }),
+    attach: deps.attach,
+    previewStore: store,
+    lock: createDevPreviewLock({ retries: [], log: loggers.realtime }),
+    featureEnabled: isDevPreviewEnabled,
+    now: deps.now,
+    log: loggers.realtime,
   });
 }

--- a/apps/web/src/lib/dev-preview/preview-runtime.ts
+++ b/apps/web/src/lib/dev-preview/preview-runtime.ts
@@ -13,6 +13,7 @@
 import { NextResponse } from 'next/server';
 import { loggers } from '@pagespace/lib/logging/logger-config';
 import { canRunCode } from '@pagespace/lib/services/sandbox/can-run-code';
+import { sessionService } from '@pagespace/lib/auth/session-service';
 import { getSandboxSessionSecret } from '@pagespace/lib/services/sandbox/machine-session-manager';
 import { resolveDriveMembership } from '@pagespace/lib/services/agent-workspaces/agent-workspace-tenant';
 import { isDevPreviewEnabled, resolveDevPreviewApex } from '@pagespace/lib/services/sandbox/preview/dev-preview-env';
@@ -106,6 +107,7 @@ function buildPreviewAccessDeps(): PreviewAccessDeps {
       return payer ? { payerId: payer.payerId } : null;
     },
     canRunCode: ({ userId, driveId, ownerId }) => canRunCode({ userId, driveId: driveId ?? undefined, ownerId, requestOrigin: 'user' }),
+    isSessionUsable: ({ sessionId, userId }) => sessionService.isSessionUsableById(sessionId, userId),
     attach: async (sandboxId) => {
       const host = await createRequestScopedSandboxHost();
       return host.attach({ sandboxId }).catch(() => null);
@@ -116,9 +118,9 @@ function buildPreviewAccessDeps(): PreviewAccessDeps {
   };
 }
 
-/** The whole gather for one proxied request. */
-export function resolvePreviewTargetForRequest(holder: DevPreviewHolderRef, userId: string): Promise<PreviewTarget> {
-  return resolvePreviewTarget({ holder, userId, deps: buildPreviewAccessDeps() });
+/** The whole gather for one proxied request. `sessionId` comes from the cookie's claims. */
+export function resolvePreviewTargetForRequest(holder: DevPreviewHolderRef, userId: string, sessionId: string): Promise<PreviewTarget> {
+  return resolvePreviewTarget({ holder, userId, sessionId, deps: buildPreviewAccessDeps() });
 }
 
 /**
@@ -182,18 +184,21 @@ export async function openPreviewForUser({
   authorizeAs,
   mintFor = authorizeAs,
   userId,
+  sessionId,
 }: {
   /** The holder whose access decision governs — the session the user came through, or the env. */
   authorizeAs: DevPreviewHolderRef;
   /** The holder whose preview origin the grant opens — the env for an env-bound session (the holder rule). */
   mintFor?: DevPreviewHolderRef;
   userId: string;
+  /** The session doing the opening; carried into the grant and the cookie so revoking it cuts the preview. */
+  sessionId: string;
 }): Promise<OpenPreviewResult> {
   const apex = isDevPreviewEnabled() ? resolveDevPreviewApex() : null;
   if (apex === null) return { ok: false, reason: 'not-configured' };
   const authorization: PreviewAuthorization = await authorizePreviewHolder({ holder: authorizeAs, userId, deps: buildPreviewAccessDeps() });
   if (!authorization.allowed) return { ok: false, reason: 'not-authorized', detail: authorization.reason };
-  const grant = await getPreviewGrantsStore().mint({ holder: mintFor, userId, now: new Date() });
+  const grant = await getPreviewGrantsStore().mint({ holder: mintFor, userId, sessionId, now: new Date() });
   return { ok: true, redirectTo: buildPreviewAuthRedirect(buildPreviewHost(mintFor, apex), grant.id) };
 }
 

--- a/apps/web/src/lib/dev-preview/preview-runtime.ts
+++ b/apps/web/src/lib/dev-preview/preview-runtime.ts
@@ -11,11 +11,13 @@
  */
 
 import { NextResponse } from 'next/server';
+import { loggers } from '@pagespace/lib/logging/logger-config';
 import { canRunCode } from '@pagespace/lib/services/sandbox/can-run-code';
 import { getSandboxSessionSecret } from '@pagespace/lib/services/sandbox/machine-session-manager';
 import { resolveDriveMembership } from '@pagespace/lib/services/agent-workspaces/agent-workspace-tenant';
 import { isDevPreviewEnabled, resolveDevPreviewApex } from '@pagespace/lib/services/sandbox/preview/dev-preview-env';
 import { createDbDevPreviewStore, type DevPreviewStore } from '@pagespace/lib/services/sandbox/preview/dev-preview-store';
+import { createDevPreviewLock, DEV_PREVIEW_USER_ACTION_RETRIES, type DevPreviewLock } from '@pagespace/lib/services/sandbox/preview/dev-preview-lock';
 import { createDbDevPreviewGrantsStore, type DevPreviewGrantsStore } from '@pagespace/lib/services/sandbox/preview/dev-preview-grants-store';
 import {
   authorizePreviewHolder,
@@ -44,6 +46,19 @@ import { getDriveEnvStore, resolveDriveEnvPayer } from '@/lib/drive-envs/drive-e
 import { readDevPreviewListeners } from './listeners-source';
 
 let previewStore: DevPreviewStore | null = null;
+let previewLock: DevPreviewLock | null = null;
+
+/**
+ * The user-action lock, bound lazily — building it resolves the advisory-lock
+ * pool, and this module is imported by routes that never take a lock. The
+ * retry budget is human-latency shaped: a click contends with at most a
+ * handful of control-plane calls, so it almost always acquires, and past the
+ * budget the action records the intent and defers the relay work.
+ */
+function getPreviewLock(): DevPreviewLock {
+  previewLock ??= createDevPreviewLock({ retries: DEV_PREVIEW_USER_ACTION_RETRIES, log: loggers.realtime });
+  return previewLock;
+}
 let grantsStore: DevPreviewGrantsStore | null = null;
 
 function getPreviewStore(): DevPreviewStore {
@@ -230,6 +245,6 @@ export function applyDevPreviewUserActionForHolder({
     action,
     userId,
     wakeSubject,
-    deps: { previewStore: deps.previewStore, attach: deps.attach, readListeners: readDevPreviewListeners, canRunCode: deps.canRunCode, now: deps.now },
+    deps: { previewStore: deps.previewStore, attach: deps.attach, readListeners: readDevPreviewListeners, canRunCode: deps.canRunCode, lock: getPreviewLock(), now: deps.now },
   });
 }

--- a/apps/web/src/lib/dev-preview/preview-runtime.ts
+++ b/apps/web/src/lib/dev-preview/preview-runtime.ts
@@ -266,6 +266,7 @@ export function reconcileStoppedDevPreviewsForCron(): Promise<DevPreviewReconcil
   const store = deps.previewStore;
   return reconcileStoppedDevPreviews({
     findStoppedWithRelay: ({ staleAfterMs, limit }) => store.findStoppedWithRelay({ staleAfterMs, limit, now: new Date() }),
+    markSwept: (holder) => store.markSwept(holder),
     attach: deps.attach,
     previewStore: store,
     lock: createDevPreviewLock({ retries: [], log: loggers.realtime }),

--- a/apps/web/src/lib/dev-preview/user-action-body.ts
+++ b/apps/web/src/lib/dev-preview/user-action-body.ts
@@ -1,14 +1,15 @@
 /**
  * The body of a dev-preview user action (`POST …/preview/actions`):
- * `{ action: 'stop' | 'resume' }`, or `{ action: 'approve', port }`. One
+ * `{ action: 'stop' | 'resume' }`, or `{ action: 'approve', port, spriteInstanceId }`. One
  * parser for the session and env routes so "well-formed" cannot drift
  * between them.
  *
- * The echoed `port` on an approve is SECURITY-RELEVANT, not a convenience:
- * it binds the click to the port the user was actually shown. A dev server
- * that moved between the render and the click therefore cannot be shared by
- * a click that meant the old one — the store's filtered write refuses it and
- * the route answers 409.
+ * The echoed `port` and `spriteInstanceId` on an approve are
+ * SECURITY-RELEVANT, not conveniences: together they bind the click to the
+ * exact thing the user was shown. A dev server that moved to another port
+ * between the render and the click cannot be shared by a click that meant the
+ * old one, and neither can a different VM's server of the same number after a
+ * rebuild. The store's filtered write refuses both and the route answers 409.
  */
 
 import type { DevPreviewUserAction } from '@pagespace/lib/services/sandbox/preview/dev-preview-status';
@@ -16,9 +17,13 @@ import type { DevPreviewUserAction } from '@pagespace/lib/services/sandbox/previ
 /** Pure: the action named by a request body, or null for anything else. */
 export function readDevPreviewUserAction(body: unknown): DevPreviewUserAction | null {
   if (typeof body !== 'object' || body === null) return null;
-  const { action, port } = body as { action?: unknown; port?: unknown };
+  const { action, port, spriteInstanceId } = body as { action?: unknown; port?: unknown; spriteInstanceId?: unknown };
   if (action === 'stop' || action === 'resume') return { kind: action };
   if (action !== 'approve') return null;
   if (typeof port !== 'number' || !Number.isInteger(port) || port < 1 || port > 65535) return null;
-  return { kind: 'approve', port };
+  // The INSTANCE is echoed for the same reason the port is, one level up: a
+  // rebuild replaces the row and can detect the same port again, so a click
+  // made against the old sandbox must not approve the new one's server.
+  if (typeof spriteInstanceId !== 'string' || spriteInstanceId.length === 0 || spriteInstanceId.length > 200) return null;
+  return { kind: 'approve', port, spriteInstanceId };
 }

--- a/apps/web/src/lib/dev-preview/user-action-body.ts
+++ b/apps/web/src/lib/dev-preview/user-action-body.ts
@@ -1,7 +1,14 @@
 /**
- * The body of a dev-preview user action (`POST …/preview/actions`): exactly
- * `{ action: 'stop' | 'resume' }`. One parser for the session and env routes
- * so "well-formed" cannot drift between them.
+ * The body of a dev-preview user action (`POST …/preview/actions`):
+ * `{ action: 'stop' | 'resume' }`, or `{ action: 'approve', port }`. One
+ * parser for the session and env routes so "well-formed" cannot drift
+ * between them.
+ *
+ * The echoed `port` on an approve is SECURITY-RELEVANT, not a convenience:
+ * it binds the click to the port the user was actually shown. A dev server
+ * that moved between the render and the click therefore cannot be shared by
+ * a click that meant the old one — the store's filtered write refuses it and
+ * the route answers 409.
  */
 
 import type { DevPreviewUserAction } from '@pagespace/lib/services/sandbox/preview/dev-preview-status';
@@ -9,6 +16,9 @@ import type { DevPreviewUserAction } from '@pagespace/lib/services/sandbox/previ
 /** Pure: the action named by a request body, or null for anything else. */
 export function readDevPreviewUserAction(body: unknown): DevPreviewUserAction | null {
   if (typeof body !== 'object' || body === null) return null;
-  const action = (body as { action?: unknown }).action;
-  return action === 'stop' || action === 'resume' ? action : null;
+  const { action, port } = body as { action?: unknown; port?: unknown };
+  if (action === 'stop' || action === 'resume') return { kind: action };
+  if (action !== 'approve') return null;
+  if (typeof port !== 'number' || !Number.isInteger(port) || port < 1 || port > 65535) return null;
+  return { kind: 'approve', port };
 }

--- a/docker/cron/crontab
+++ b/docker/cron/crontab
@@ -116,6 +116,16 @@
 */30 * * * * flock -n /run/reconcile-orphaned-sprites.lock cron-curl GET __WEB_URL__/api/cron/reconcile-orphaned-sprites >> /var/log/cron/reconcile-orphaned-sprites.log 2>&1 || echo "$(date -u) tick skipped (lock held) or request failed" >> /var/log/cron/reconcile-orphaned-sprites.log
 
 
+# Dev-preview backstop - Every 5 minutes
+# Converges previews a user switched OFF whose relay is somehow still up. A Stop
+# is durable the moment it is written, and the relay work is normally done by the
+# realtime detector's next ports/watch frame — but a holder nobody is watching
+# produces no frames, and a stop is exactly when a dev server goes quiet. This
+# sweep can only ever STOP a relay (it plans with no listener snapshot, which
+# makes any start a refusal) and never wakes a sprite. Dark deployments no-op.
+*/5 * * * * flock -n /run/reconcile-dev-previews.lock cron-curl GET __WEB_URL__/api/cron/reconcile-dev-previews >> /var/log/cron/reconcile-dev-previews.log 2>&1 || echo "$(date -u) tick skipped (lock held) or request failed" >> /var/log/cron/reconcile-dev-previews.log
+
+
 # Expired row sweep - Every 15 minutes
 # Reaps expired tombstones from append-with-TTL tables (revoked_service_tokens;
 # rate_limit_buckets in PR3; ai_pending_abort_intents). Short cadence matches the 5-minute default

--- a/docs/sprites/dev-preview-runbook.md
+++ b/docs/sprites/dev-preview-runbook.md
@@ -1,0 +1,102 @@
+# Dev-server preview: turning it on
+
+The dev-server preview ships **dark**. Every layer fails closed on a missing
+variable, so a half-configured deployment shows nothing rather than something
+wrong. This is the list of what has to be true, in order, and what is still
+undecided.
+
+Preview apex: **`pagespace.io`** — chosen because it shares no registrable
+domain with `pagespace.ai`. A dev server's own JavaScript running on
+`preview.pagespace.ai` could set `Domain=.pagespace.ai` cookies and toss
+cookies at the dashboard; a separate registrable domain makes that
+impossible rather than merely discouraged.
+
+## 1. The edge
+
+`PageSpace-Deploy` PR #27 (`pu/dev-preview-ingress`) adds two host-matched
+blocks on `*.preview.{$DEV_PREVIEW_APEX}` to `fly/Caddyfile.fly`:
+
+- WebSocket upgrades → `pagespace-realtime.flycast` (the HMR tunnel; a Next
+  route handler cannot carry an upgrade).
+- Everything else → `pagespace-web.flycast` (the authenticated proxy, which
+  re-runs the drive/session gate on every request).
+
+Both are matched **before** the dashboard's own routing, so a preview request
+never falls through to the auth redirect and never picks up the app's security
+headers — `X-Frame-Options: DENY` would break the pane, and the preview
+response carries its own `frame-ancestors`.
+
+Merge that PR and deploy `pagespace-proxy`.
+
+## 2. Environment
+
+Set the same apex on every app that participates. There is no default
+anywhere: an app that misses the variable keeps the feature dark, which is the
+failure mode you want.
+
+```
+fly secrets set --app pagespace-proxy    DEV_PREVIEW_APEX=pagespace.io
+fly secrets set --app pagespace-web      DEV_PREVIEW_APEX=pagespace.io DEV_PREVIEW_ENABLED=true
+fly secrets set --app pagespace-realtime DEV_PREVIEW_APEX=pagespace.io DEV_PREVIEW_ENABLED=true
+```
+
+`SANDBOX_SESSION_SECRET` must already be set on web and realtime: the preview
+cookie's signing key is derived from it, and rotating it invalidates every
+live preview cookie at once (which self-heals through the re-mint path).
+
+## 3. DNS and TLS
+
+```
+# wildcard A/AAAA (or CNAME) record
+*.preview.pagespace.io  →  the proxy app
+
+fly certs add "*.preview.pagespace.io" -a pagespace-proxy
+```
+
+A wildcard certificate is DNS-01 only, so delegate `_acme-challenge` per Fly's
+documentation and wait for the certificate to verify before step 4.
+
+## 4. The cron
+
+`docker/cron/crontab` already carries the backstop sweep
+(`/api/cron/reconcile-dev-previews`, every five minutes). It no-ops while the
+feature is dark, so nothing about it needs sequencing.
+
+## 5. The browser smoke
+
+`apps/e2e/tests/21-dev-preview.spec.ts`. It skips itself unless
+`E2E_SANDBOX=1`, and skips again if `/api/dev-preview/capability` reports the
+feature dark, so it can be left in the suite safely. It covers the whole
+journey: session → dev server in the sandbox → the affordance appearing on its
+own → Preview → the app rendering through the preview origin → an edit
+hot-reloading the frame → open-in-new-tab minting its own grant; plus the
+unlisted-port consent path and the revoked-session cutoff.
+
+```
+E2E_SANDBOX=1 E2E_BASE_URL=https://<target> bun run --filter '@pagespace/e2e' test:e2e -- 21-dev-preview
+```
+
+It also covers the `allowedHosts` case in both directions. The preview reaches
+the dev server through PageSpace's hostname, and Vite 6+ rejects a `Host` it
+does not know, so the spec starts a server without the allow-list first and
+records what the user actually sees, then starts one with
+`server.allowedHosts` and asserts the app renders.
+
+## What is NOT ready — the smoke has no target yet
+
+**Staging cannot run it as configured**, and this is the open item:
+
+- `fly/fly.web.staging.toml` deliberately leaves `CODE_EXECUTION_ENABLED` and
+  `SANDBOX_CONTAINMENT_VERIFIED` unset, with the reason written into the file:
+  "no sandbox egress review has been done for a staging network path". No
+  sandbox means no dev server means nothing to preview.
+- There is **no staging realtime app**. Detection *is* the realtime tier's
+  `ports/watch` channel, and the HMR half of the proxy is its upgrade handler.
+  Without it the preview never appears.
+- There is **no staging proxy**, so whether staging fronts through
+  `pagespace-proxy` or gets its own is an open decision, and it determines
+  where the wildcard record points.
+
+Three decisions, then the smoke has somewhere to run. Until it passes,
+production stays dark: nothing in this document should be applied to
+`pagespace-web` before a real browser has loaded a real dev server somewhere.

--- a/docs/sprites/dev-preview-runbook.md
+++ b/docs/sprites/dev-preview-runbook.md
@@ -92,6 +92,23 @@ does not know, so the spec starts a server without the allow-list first and
 records what the user actually sees, then starts one with
 `server.allowedHosts` and asserts the app renders.
 
+### Verify this against a real sprite before the flag goes on
+
+The proxy authenticates to the sprite edge with the **org-scoped Sprites
+bearer token** (`preview-forward.ts`, and the WebSocket tunnel does the same),
+and the in-sprite relay is a byte-for-byte TCP pipe — it copies whatever
+arrives on 8080 straight to the dev server. So the whole question is whether
+the sprite edge STRIPS that `Authorization` header before proxying inward. The
+spike verified the edge *accepts* the header; it did not verify that the
+header stops there.
+
+If it does not stop there, a previewed dev server — which is agent-authored or
+npm-supply-chain code — can read an org-wide credential out of its own request
+headers. That is worth one direct check against a real sprite (curl through
+the preview origin to a server that echoes its request headers) before this is
+enabled anywhere, and it is cheap. Nothing in the application can fix it if the
+answer is bad; the mitigation would be an edge change or a header-stripping hop.
+
 ## What is NOT ready — the smoke has no target yet
 
 **Staging cannot run it as configured**, and this is the open item:

--- a/docs/sprites/dev-preview-runbook.md
+++ b/docs/sprites/dev-preview-runbook.md
@@ -56,6 +56,16 @@ fly certs add "*.preview.pagespace.io" -a pagespace-proxy
 A wildcard certificate is DNS-01 only, so delegate `_acme-challenge` per Fly's
 documentation and wait for the certificate to verify before step 4.
 
+### A note on the migration
+
+`0287` adds a NOT NULL `sessionId` to `dev_preview_grants` and **clears the
+table first**. That is deliberate and costs nothing: a grant is a single-use
+sixty-second handshake token, so the worst any holder sees is "this preview
+link has expired, reopen the preview from PageSpace", and the next click mints
+a fresh one. Without the clear the migration would fail outright (23502) on
+any database that has ever held a grant — and all pending migrations run in
+one invocation, so it would take the whole release with it.
+
 ## 4. The cron
 
 `docker/cron/crontab` already carries the backstop sweep

--- a/knip.json
+++ b/knip.json
@@ -480,6 +480,7 @@
         "src/services/sandbox/preview/ports-watch.ts",
         "src/services/sandbox/preview/dev-preview-detection.ts",
         "src/services/sandbox/preview/dev-preview-status.ts",
+        "src/services/sandbox/preview/dev-preview-lock.ts",
         "src/services/sandbox/preview/dev-preview-contract.ts",
         "src/services/sandbox/preview/preview-access.ts",
         "src/services/sandbox/preview/preview-ws-tunnel.ts",

--- a/packages/db/drizzle/0287_nappy_secret_warriors.sql
+++ b/packages/db/drizzle/0287_nappy_secret_warriors.sql
@@ -1,2 +1,11 @@
+--> Hand-added, deliberately: `ADD COLUMN ... NOT NULL` with no default fails
+--> (23502) on any database that already holds a grant row, and grants are not
+--> deleted after redemption or expiry — so a dev or staging database where the
+--> feature was ever switched on would break the whole migration run, and all
+--> pending migrations run in one invocation. Clearing them is free: a grant is
+--> a single-use, sixty-second handshake token, so the worst case for anyone
+--> holding one is that their preview link says "expired, reopen from
+--> PageSpace" and the next click mints a fresh one.
+DELETE FROM "dev_preview_grants";--> statement-breakpoint
 ALTER TABLE "dev_preview_grants" ADD COLUMN "sessionId" text NOT NULL;--> statement-breakpoint
 ALTER TABLE "dev_preview_grants" ADD CONSTRAINT "dev_preview_grants_sessionId_sessions_id_fk" FOREIGN KEY ("sessionId") REFERENCES "public"."sessions"("id") ON DELETE cascade ON UPDATE no action;

--- a/packages/db/drizzle/0287_nappy_secret_warriors.sql
+++ b/packages/db/drizzle/0287_nappy_secret_warriors.sql
@@ -1,0 +1,2 @@
+ALTER TABLE "dev_preview_grants" ADD COLUMN "sessionId" text NOT NULL;--> statement-breakpoint
+ALTER TABLE "dev_preview_grants" ADD CONSTRAINT "dev_preview_grants_sessionId_sessions_id_fk" FOREIGN KEY ("sessionId") REFERENCES "public"."sessions"("id") ON DELETE cascade ON UPDATE no action;

--- a/packages/db/drizzle/0287_nappy_secret_warriors.sql
+++ b/packages/db/drizzle/0287_nappy_secret_warriors.sql
@@ -1,11 +1,23 @@
---> Hand-added, deliberately: `ADD COLUMN ... NOT NULL` with no default fails
---> (23502) on any database that already holds a grant row, and grants are not
---> deleted after redemption or expiry — so a dev or staging database where the
---> feature was ever switched on would break the whole migration run, and all
---> pending migrations run in one invocation. Clearing them is free: a grant is
---> a single-use, sixty-second handshake token, so the worst case for anyone
---> holding one is that their preview link says "expired, reopen from
---> PageSpace" and the next click mints a fresh one.
+--> Hand-written rather than generated, for two reasons, both learned the hard way.
+-->
+--> 1. `ADD COLUMN ... NOT NULL` with no default fails (23502) on any database
+-->    that already holds a grant row, and grants are not deleted after
+-->    redemption or expiry. All pending migrations run in ONE invocation, so a
+-->    dev or staging database where the feature was ever switched on would
+-->    take the whole release down with it. Clearing the table costs nothing: a
+-->    grant is a single-use, sixty-second handshake token, so the worst case
+-->    for anyone holding one is "this preview link has expired, reopen the
+-->    preview from PageSpace" and the next click mints a fresh one.
+-->
+--> 2. This runner keys applied migrations BY HASH of the file text, so editing
+-->    this file at all makes every database that already applied the earlier
+-->    version run it again. Every statement below is therefore written to be
+-->    safe on a second pass — which is also what makes the fix in (1) reach
+-->    the databases that need it without breaking the ones that do not.
 DELETE FROM "dev_preview_grants";--> statement-breakpoint
-ALTER TABLE "dev_preview_grants" ADD COLUMN "sessionId" text NOT NULL;--> statement-breakpoint
-ALTER TABLE "dev_preview_grants" ADD CONSTRAINT "dev_preview_grants_sessionId_sessions_id_fk" FOREIGN KEY ("sessionId") REFERENCES "public"."sessions"("id") ON DELETE cascade ON UPDATE no action;
+ALTER TABLE "dev_preview_grants" ADD COLUMN IF NOT EXISTS "sessionId" text NOT NULL;--> statement-breakpoint
+DO $$ BEGIN
+	IF NOT EXISTS (SELECT 1 FROM pg_constraint WHERE conname = 'dev_preview_grants_sessionId_sessions_id_fk') THEN
+		ALTER TABLE "dev_preview_grants" ADD CONSTRAINT "dev_preview_grants_sessionId_sessions_id_fk" FOREIGN KEY ("sessionId") REFERENCES "public"."sessions"("id") ON DELETE cascade ON UPDATE no action;
+	END IF;
+END $$;

--- a/packages/db/drizzle/0287_nappy_secret_warriors.sql
+++ b/packages/db/drizzle/0287_nappy_secret_warriors.sql
@@ -17,7 +17,7 @@
 DELETE FROM "dev_preview_grants";--> statement-breakpoint
 ALTER TABLE "dev_preview_grants" ADD COLUMN IF NOT EXISTS "sessionId" text NOT NULL;--> statement-breakpoint
 DO $$ BEGIN
-	IF NOT EXISTS (SELECT 1 FROM pg_constraint WHERE conname = 'dev_preview_grants_sessionId_sessions_id_fk') THEN
+	IF NOT EXISTS (SELECT 1 FROM pg_constraint WHERE conname = 'dev_preview_grants_sessionId_sessions_id_fk' AND conrelid = '"dev_preview_grants"'::regclass) THEN
 		ALTER TABLE "dev_preview_grants" ADD CONSTRAINT "dev_preview_grants_sessionId_sessions_id_fk" FOREIGN KEY ("sessionId") REFERENCES "public"."sessions"("id") ON DELETE cascade ON UPDATE no action;
 	END IF;
 END $$;

--- a/packages/db/drizzle/0288_misty_lifeguard.sql
+++ b/packages/db/drizzle/0288_misty_lifeguard.sql
@@ -1,8 +1,30 @@
-ALTER TABLE "dev_preview_services" DROP CONSTRAINT "dev_preview_services_relay_iff_not_8080_check";--> statement-breakpoint
-ALTER TABLE "dev_preview_services" ADD COLUMN "approvedPort" integer;--> statement-breakpoint
-ALTER TABLE "dev_preview_services" ADD COLUMN "approvedAt" timestamp;--> statement-breakpoint
-ALTER TABLE "dev_preview_services" ADD COLUMN "approvedByUserId" text;--> statement-breakpoint
-ALTER TABLE "dev_preview_services" ADD CONSTRAINT "dev_preview_services_approvedByUserId_users_id_fk" FOREIGN KEY ("approvedByUserId") REFERENCES "public"."users"("id") ON DELETE set null ON UPDATE no action;--> statement-breakpoint
-ALTER TABLE "dev_preview_services" ADD CONSTRAINT "dev_preview_services_relay_never_8080_check" CHECK ("dev_preview_services"."relayServiceName" IS NULL OR "dev_preview_services"."targetPort" <> 8080);--> statement-breakpoint
-ALTER TABLE "dev_preview_services" ADD CONSTRAINT "dev_preview_services_approved_port_range_check" CHECK ("dev_preview_services"."approvedPort" IS NULL OR "dev_preview_services"."approvedPort" BETWEEN 1 AND 65535);--> statement-breakpoint
-ALTER TABLE "dev_preview_services" ADD CONSTRAINT "dev_preview_services_approved_paired_check" CHECK (("dev_preview_services"."approvedPort" IS NULL) = ("dev_preview_services"."approvedAt" IS NULL));
+--> Written to be RE-RUNNABLE, for the reason 0287 records: this runner keys
+--> applied migrations by a hash of the file text, so any edit to a file some
+--> database has already applied makes that database run it again — and
+--> `Dockerfile.migrate` runs `db:migrate` as the deployment command, so a
+--> second pass that fails blocks the rollout rather than just the migration.
+--> Every statement below is therefore guarded.
+ALTER TABLE "dev_preview_services" DROP CONSTRAINT IF EXISTS "dev_preview_services_relay_iff_not_8080_check";--> statement-breakpoint
+ALTER TABLE "dev_preview_services" ADD COLUMN IF NOT EXISTS "approvedPort" integer;--> statement-breakpoint
+ALTER TABLE "dev_preview_services" ADD COLUMN IF NOT EXISTS "approvedAt" timestamp;--> statement-breakpoint
+ALTER TABLE "dev_preview_services" ADD COLUMN IF NOT EXISTS "approvedByUserId" text;--> statement-breakpoint
+DO $$ BEGIN
+	IF NOT EXISTS (SELECT 1 FROM pg_constraint WHERE conname = 'dev_preview_services_approvedByUserId_users_id_fk' AND conrelid = '"dev_preview_services"'::regclass) THEN
+		ALTER TABLE "dev_preview_services" ADD CONSTRAINT "dev_preview_services_approvedByUserId_users_id_fk" FOREIGN KEY ("approvedByUserId") REFERENCES "public"."users"("id") ON DELETE set null ON UPDATE no action;
+	END IF;
+END $$;--> statement-breakpoint
+DO $$ BEGIN
+	IF NOT EXISTS (SELECT 1 FROM pg_constraint WHERE conname = 'dev_preview_services_relay_never_8080_check' AND conrelid = '"dev_preview_services"'::regclass) THEN
+		ALTER TABLE "dev_preview_services" ADD CONSTRAINT "dev_preview_services_relay_never_8080_check" CHECK ("dev_preview_services"."relayServiceName" IS NULL OR "dev_preview_services"."targetPort" <> 8080);
+	END IF;
+END $$;--> statement-breakpoint
+DO $$ BEGIN
+	IF NOT EXISTS (SELECT 1 FROM pg_constraint WHERE conname = 'dev_preview_services_approved_port_range_check' AND conrelid = '"dev_preview_services"'::regclass) THEN
+		ALTER TABLE "dev_preview_services" ADD CONSTRAINT "dev_preview_services_approved_port_range_check" CHECK ("dev_preview_services"."approvedPort" IS NULL OR "dev_preview_services"."approvedPort" BETWEEN 1 AND 65535);
+	END IF;
+END $$;--> statement-breakpoint
+DO $$ BEGIN
+	IF NOT EXISTS (SELECT 1 FROM pg_constraint WHERE conname = 'dev_preview_services_approved_paired_check' AND conrelid = '"dev_preview_services"'::regclass) THEN
+		ALTER TABLE "dev_preview_services" ADD CONSTRAINT "dev_preview_services_approved_paired_check" CHECK (("dev_preview_services"."approvedPort" IS NULL) = ("dev_preview_services"."approvedAt" IS NULL));
+	END IF;
+END $$;

--- a/packages/db/drizzle/0288_misty_lifeguard.sql
+++ b/packages/db/drizzle/0288_misty_lifeguard.sql
@@ -1,0 +1,8 @@
+ALTER TABLE "dev_preview_services" DROP CONSTRAINT "dev_preview_services_relay_iff_not_8080_check";--> statement-breakpoint
+ALTER TABLE "dev_preview_services" ADD COLUMN "approvedPort" integer;--> statement-breakpoint
+ALTER TABLE "dev_preview_services" ADD COLUMN "approvedAt" timestamp;--> statement-breakpoint
+ALTER TABLE "dev_preview_services" ADD COLUMN "approvedByUserId" text;--> statement-breakpoint
+ALTER TABLE "dev_preview_services" ADD CONSTRAINT "dev_preview_services_approvedByUserId_users_id_fk" FOREIGN KEY ("approvedByUserId") REFERENCES "public"."users"("id") ON DELETE set null ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "dev_preview_services" ADD CONSTRAINT "dev_preview_services_relay_never_8080_check" CHECK ("dev_preview_services"."relayServiceName" IS NULL OR "dev_preview_services"."targetPort" <> 8080);--> statement-breakpoint
+ALTER TABLE "dev_preview_services" ADD CONSTRAINT "dev_preview_services_approved_port_range_check" CHECK ("dev_preview_services"."approvedPort" IS NULL OR "dev_preview_services"."approvedPort" BETWEEN 1 AND 65535);--> statement-breakpoint
+ALTER TABLE "dev_preview_services" ADD CONSTRAINT "dev_preview_services_approved_paired_check" CHECK (("dev_preview_services"."approvedPort" IS NULL) = ("dev_preview_services"."approvedAt" IS NULL));

--- a/packages/db/drizzle/meta/0287_snapshot.json
+++ b/packages/db/drizzle/meta/0287_snapshot.json
@@ -1,0 +1,24119 @@
+{
+  "id": "e42391fc-8a22-4ace-9842-a9180bd33521",
+  "prevId": "4165033d-c951-4c0a-b31c-ffc91068a962",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.device_tokens": {
+      "name": "device_tokens",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tokenHash": {
+          "name": "tokenHash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tokenPrefix": {
+          "name": "tokenPrefix",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expiresAt": {
+          "name": "expiresAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "lastUsedAt": {
+          "name": "lastUsedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deviceId": {
+          "name": "deviceId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "platform": {
+          "name": "platform",
+          "type": "PlatformType",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "deviceName": {
+          "name": "deviceName",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tokenVersion": {
+          "name": "tokenVersion",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "userAgent": {
+          "name": "userAgent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ipAddress": {
+          "name": "ipAddress",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lastIpAddress": {
+          "name": "lastIpAddress",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "location": {
+          "name": "location",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "trustScore": {
+          "name": "trustScore",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "suspiciousActivityCount": {
+          "name": "suspiciousActivityCount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "revokedAt": {
+          "name": "revokedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revokedReason": {
+          "name": "revokedReason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "replacedByTokenId": {
+          "name": "replacedByTokenId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "device_tokens_user_id_idx": {
+          "name": "device_tokens_user_id_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "device_tokens_token_hash_idx": {
+          "name": "device_tokens_token_hash_idx",
+          "columns": [
+            {
+              "expression": "tokenHash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "device_tokens_device_id_idx": {
+          "name": "device_tokens_device_id_idx",
+          "columns": [
+            {
+              "expression": "deviceId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "device_tokens_expires_at_idx": {
+          "name": "device_tokens_expires_at_idx",
+          "columns": [
+            {
+              "expression": "expiresAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "device_tokens_active_device_idx": {
+          "name": "device_tokens_active_device_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deviceId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "platform",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"device_tokens\".\"revokedAt\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "device_tokens_userId_users_id_fk": {
+          "name": "device_tokens_userId_users_id_fk",
+          "tableFrom": "device_tokens",
+          "tableTo": "users",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "device_tokens_tokenHash_unique": {
+          "name": "device_tokens_tokenHash_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "tokenHash"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.email_unsubscribe_tokens": {
+      "name": "email_unsubscribe_tokens",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_prefix": {
+          "name": "token_prefix",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "notification_type": {
+          "name": "notification_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "used_at": {
+          "name": "used_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "email_unsubscribe_tokens_token_hash_idx": {
+          "name": "email_unsubscribe_tokens_token_hash_idx",
+          "columns": [
+            {
+              "expression": "token_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "email_unsubscribe_tokens_user_id_idx": {
+          "name": "email_unsubscribe_tokens_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "email_unsubscribe_tokens_expires_at_idx": {
+          "name": "email_unsubscribe_tokens_expires_at_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "email_unsubscribe_tokens_user_id_users_id_fk": {
+          "name": "email_unsubscribe_tokens_user_id_users_id_fk",
+          "tableFrom": "email_unsubscribe_tokens",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "email_unsubscribe_tokens_token_hash_unique": {
+          "name": "email_unsubscribe_tokens_token_hash_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token_hash"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.mcp_tokens": {
+      "name": "mcp_tokens",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tokenHash": {
+          "name": "tokenHash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tokenPrefix": {
+          "name": "tokenPrefix",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "isScoped": {
+          "name": "isScoped",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "lastUsed": {
+          "name": "lastUsed",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "revokedAt": {
+          "name": "revokedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "mcp_tokens_user_id_idx": {
+          "name": "mcp_tokens_user_id_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "mcp_tokens_token_hash_idx": {
+          "name": "mcp_tokens_token_hash_idx",
+          "columns": [
+            {
+              "expression": "tokenHash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "mcp_tokens_userId_users_id_fk": {
+          "name": "mcp_tokens_userId_users_id_fk",
+          "tableFrom": "mcp_tokens",
+          "tableTo": "users",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "mcp_tokens_tokenHash_unique": {
+          "name": "mcp_tokens_tokenHash_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "tokenHash"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.passkeys": {
+      "name": "passkeys",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "credential_id": {
+          "name": "credential_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "public_key": {
+          "name": "public_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "counter": {
+          "name": "counter",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "device_type": {
+          "name": "device_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "transports": {
+          "name": "transports",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "backed_up": {
+          "name": "backed_up",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "passkeys_user_id_idx": {
+          "name": "passkeys_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "passkeys_credential_id_idx": {
+          "name": "passkeys_credential_id_idx",
+          "columns": [
+            {
+              "expression": "credential_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "passkeys_user_id_users_id_fk": {
+          "name": "passkeys_user_id_users_id_fk",
+          "tableFrom": "passkeys",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "passkeys_credential_id_unique": {
+          "name": "passkeys_credential_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "credential_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.socket_tokens": {
+      "name": "socket_tokens",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tokenHash": {
+          "name": "tokenHash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expiresAt": {
+          "name": "expiresAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "socket_tokens_user_id_idx": {
+          "name": "socket_tokens_user_id_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "socket_tokens_token_hash_idx": {
+          "name": "socket_tokens_token_hash_idx",
+          "columns": [
+            {
+              "expression": "tokenHash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "socket_tokens_expires_at_idx": {
+          "name": "socket_tokens_expires_at_idx",
+          "columns": [
+            {
+              "expression": "expiresAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "socket_tokens_userId_users_id_fk": {
+          "name": "socket_tokens_userId_users_id_fk",
+          "tableFrom": "socket_tokens",
+          "tableTo": "users",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "socket_tokens_tokenHash_unique": {
+          "name": "socket_tokens_tokenHash_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "tokenHash"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "emailBidx": {
+          "name": "emailBidx",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "emailVerified": {
+          "name": "emailVerified",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "googleId": {
+          "name": "googleId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "appleId": {
+          "name": "appleId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider": {
+          "name": "provider",
+          "type": "AuthProvider",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'email'"
+        },
+        "tokenVersion": {
+          "name": "tokenVersion",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "role": {
+          "name": "role",
+          "type": "UserRole",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'user'"
+        },
+        "adminRoleVersion": {
+          "name": "adminRoleVersion",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "currentAiProvider": {
+          "name": "currentAiProvider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'zai'"
+        },
+        "currentAiModel": {
+          "name": "currentAiModel",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'z-ai/glm-5.3-flash'"
+        },
+        "imageGenerationModel": {
+          "name": "imageGenerationModel",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "storageUsedBytes": {
+          "name": "storageUsedBytes",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "activeUploads": {
+          "name": "activeUploads",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "lastStorageCalculated": {
+          "name": "lastStorageCalculated",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stripeCustomerId": {
+          "name": "stripeCustomerId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "subscriptionTier": {
+          "name": "subscriptionTier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'free'"
+        },
+        "tosAcceptedAt": {
+          "name": "tosAcceptedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "failedLoginAttempts": {
+          "name": "failedLoginAttempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "lockedUntil": {
+          "name": "lockedUntil",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "suspendedAt": {
+          "name": "suspendedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "suspendedReason": {
+          "name": "suspendedReason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "timezone": {
+          "name": "timezone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "starterSkillsInstalledAt": {
+          "name": "starterSkillsInstalledAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "onboardingCompletedAt": {
+          "name": "onboardingCompletedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "users_email_bidx_idx": {
+          "name": "users_email_bidx_idx",
+          "columns": [
+            {
+              "expression": "emailBidx",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        },
+        "users_googleId_unique": {
+          "name": "users_googleId_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "googleId"
+          ]
+        },
+        "users_appleId_unique": {
+          "name": "users_appleId_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "appleId"
+          ]
+        },
+        "users_stripeCustomerId_unique": {
+          "name": "users_stripeCustomerId_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "stripeCustomerId"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.verification_tokens": {
+      "name": "verification_tokens",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tokenHash": {
+          "name": "tokenHash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tokenPrefix": {
+          "name": "tokenPrefix",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expiresAt": {
+          "name": "expiresAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "usedAt": {
+          "name": "usedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "verification_tokens_user_id_idx": {
+          "name": "verification_tokens_user_id_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "verification_tokens_token_hash_idx": {
+          "name": "verification_tokens_token_hash_idx",
+          "columns": [
+            {
+              "expression": "tokenHash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "verification_tokens_type_idx": {
+          "name": "verification_tokens_type_idx",
+          "columns": [
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "verification_tokens_userId_users_id_fk": {
+          "name": "verification_tokens_userId_users_id_fk",
+          "tableFrom": "verification_tokens",
+          "tableTo": "users",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "verification_tokens_tokenHash_unique": {
+          "name": "verification_tokens_tokenHash_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "tokenHash"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sessions": {
+      "name": "sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_prefix": {
+          "name": "token_prefix",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "device_id": {
+          "name": "device_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "ARRAY[]::text[]"
+        },
+        "resource_type": {
+          "name": "resource_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resource_id": {
+          "name": "resource_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "drive_id": {
+          "name": "drive_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "token_version": {
+          "name": "token_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "admin_role_version": {
+          "name": "admin_role_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_by_service": {
+          "name": "created_by_service",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by_ip": {
+          "name": "created_by_ip",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_used_ip": {
+          "name": "last_used_ip",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revoked_reason": {
+          "name": "revoked_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "sessions_user_id_idx": {
+          "name": "sessions_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sessions_expires_at_idx": {
+          "name": "sessions_expires_at_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sessions_user_active_idx": {
+          "name": "sessions_user_active_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "revoked_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sessions_user_device_idx": {
+          "name": "sessions_user_device_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "device_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "sessions_user_id_users_id_fk": {
+          "name": "sessions_user_id_users_id_fk",
+          "tableFrom": "sessions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "sessions_token_hash_unique": {
+          "name": "sessions_token_hash_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token_hash"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.drives": {
+      "name": "drives",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ownerId": {
+          "name": "ownerId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "DriveKind",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'STANDARD'"
+        },
+        "isTrashed": {
+          "name": "isTrashed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "trashedAt": {
+          "name": "trashedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "drivePrompt": {
+          "name": "drivePrompt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "publishSubdomain": {
+          "name": "publishSubdomain",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "homePageId": {
+          "name": "homePageId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "publish_default_og_image_url": {
+          "name": "publish_default_og_image_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "not_found_page_id": {
+          "name": "not_found_page_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "publish_favicon_url": {
+          "name": "publish_favicon_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "drives_owner_id_idx": {
+          "name": "drives_owner_id_idx",
+          "columns": [
+            {
+              "expression": "ownerId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "drives_owner_id_slug_key": {
+          "name": "drives_owner_id_slug_key",
+          "columns": [
+            {
+              "expression": "ownerId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "drives_owner_home_unique": {
+          "name": "drives_owner_home_unique",
+          "columns": [
+            {
+              "expression": "ownerId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"drives\".\"kind\" = 'HOME'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "drives_ownerId_users_id_fk": {
+          "name": "drives_ownerId_users_id_fk",
+          "tableFrom": "drives",
+          "tableTo": "users",
+          "columnsFrom": [
+            "ownerId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "drives_homePageId_pages_id_fk": {
+          "name": "drives_homePageId_pages_id_fk",
+          "tableFrom": "drives",
+          "tableTo": "pages",
+          "columnsFrom": [
+            "homePageId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "drives_not_found_page_id_pages_id_fk": {
+          "name": "drives_not_found_page_id_pages_id_fk",
+          "tableFrom": "drives",
+          "tableTo": "pages",
+          "columnsFrom": [
+            "not_found_page_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "drives_publishSubdomain_unique": {
+          "name": "drives_publishSubdomain_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "publishSubdomain"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.favorites": {
+      "name": "favorites",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "itemType": {
+          "name": "itemType",
+          "type": "FavoriteItemType",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'page'"
+        },
+        "pageId": {
+          "name": "pageId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "driveId": {
+          "name": "driveId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "favorites_user_id_page_id_key": {
+          "name": "favorites_user_id_page_id_key",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "pageId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "favorites_user_id_drive_id_key": {
+          "name": "favorites_user_id_drive_id_key",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "driveId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "favorites_user_id_position_idx": {
+          "name": "favorites_user_id_position_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "position",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "favorites_userId_users_id_fk": {
+          "name": "favorites_userId_users_id_fk",
+          "tableFrom": "favorites",
+          "tableTo": "users",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "favorites_pageId_pages_id_fk": {
+          "name": "favorites_pageId_pages_id_fk",
+          "tableFrom": "favorites",
+          "tableTo": "pages",
+          "columnsFrom": [
+            "pageId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "favorites_driveId_drives_id_fk": {
+          "name": "favorites_driveId_drives_id_fk",
+          "tableFrom": "favorites",
+          "tableTo": "drives",
+          "columnsFrom": [
+            "driveId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "favorites_item_type_consistency_chk": {
+          "name": "favorites_item_type_consistency_chk",
+          "value": "((\"itemType\" = 'page' AND \"pageId\" IS NOT NULL AND \"driveId\" IS NULL) OR (\"itemType\" = 'drive' AND \"driveId\" IS NOT NULL AND \"pageId\" IS NULL))"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.mentions": {
+      "name": "mentions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "sourcePageId": {
+          "name": "sourcePageId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "targetPageId": {
+          "name": "targetPageId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "mentions_source_page_id_target_page_id_key": {
+          "name": "mentions_source_page_id_target_page_id_key",
+          "columns": [
+            {
+              "expression": "sourcePageId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "targetPageId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "mentions_source_page_id_idx": {
+          "name": "mentions_source_page_id_idx",
+          "columns": [
+            {
+              "expression": "sourcePageId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "mentions_target_page_id_idx": {
+          "name": "mentions_target_page_id_idx",
+          "columns": [
+            {
+              "expression": "targetPageId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "mentions_sourcePageId_pages_id_fk": {
+          "name": "mentions_sourcePageId_pages_id_fk",
+          "tableFrom": "mentions",
+          "tableTo": "pages",
+          "columnsFrom": [
+            "sourcePageId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "mentions_targetPageId_pages_id_fk": {
+          "name": "mentions_targetPageId_pages_id_fk",
+          "tableFrom": "mentions",
+          "tableTo": "pages",
+          "columnsFrom": [
+            "targetPageId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.pages": {
+      "name": "pages",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "PageType",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "contentMode": {
+          "name": "contentMode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'html'"
+        },
+        "isPaginated": {
+          "name": "isPaginated",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "position": {
+          "name": "position",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "isTrashed": {
+          "name": "isTrashed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "aiProvider": {
+          "name": "aiProvider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "aiModel": {
+          "name": "aiModel",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "systemPrompt": {
+          "name": "systemPrompt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "enabledTools": {
+          "name": "enabledTools",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "includeDrivePrompt": {
+          "name": "includeDrivePrompt",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "agentDefinition": {
+          "name": "agentDefinition",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "visibleToGlobalAssistant": {
+          "name": "visibleToGlobalAssistant",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "includePageTree": {
+          "name": "includePageTree",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "pageTreeScope": {
+          "name": "pageTreeScope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'children'"
+        },
+        "toolExposureMode": {
+          "name": "toolExposureMode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'upfront'"
+        },
+        "sandboxEnabled": {
+          "name": "sandboxEnabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "defaultEnvId": {
+          "name": "defaultEnvId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "userScopedAccess": {
+          "name": "userScopedAccess",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "siteMode": {
+          "name": "siteMode",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "fileSize": {
+          "name": "fileSize",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mimeType": {
+          "name": "mimeType",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "originalFileName": {
+          "name": "originalFileName",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "filePath": {
+          "name": "filePath",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "fileMetadata": {
+          "name": "fileMetadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "processingStatus": {
+          "name": "processingStatus",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'pending'"
+        },
+        "processingError": {
+          "name": "processingError",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "processedAt": {
+          "name": "processedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "extractionMethod": {
+          "name": "extractionMethod",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "extractionMetadata": {
+          "name": "extractionMetadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "contentHash": {
+          "name": "contentHash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "excludeFromSearch": {
+          "name": "excludeFromSearch",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "isPrivate": {
+          "name": "isPrivate",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "createdBy": {
+          "name": "createdBy",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "trashedAt": {
+          "name": "trashedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revision": {
+          "name": "revision",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "stateHash": {
+          "name": "stateHash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "driveId": {
+          "name": "driveId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "parentId": {
+          "name": "parentId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "originalParentId": {
+          "name": "originalParentId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "pages_drive_id_idx": {
+          "name": "pages_drive_id_idx",
+          "columns": [
+            {
+              "expression": "driveId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "pages_parent_id_idx": {
+          "name": "pages_parent_id_idx",
+          "columns": [
+            {
+              "expression": "parentId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "pages_parent_id_position_idx": {
+          "name": "pages_parent_id_position_idx",
+          "columns": [
+            {
+              "expression": "parentId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "position",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "pages_drive_id_is_trashed_type_idx": {
+          "name": "pages_drive_id_is_trashed_type_idx",
+          "columns": [
+            {
+              "expression": "driveId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "isTrashed",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "pages_defaultEnvId_drive_envs_id_fk": {
+          "name": "pages_defaultEnvId_drive_envs_id_fk",
+          "tableFrom": "pages",
+          "tableTo": "drive_envs",
+          "columnsFrom": [
+            "defaultEnvId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "pages_createdBy_users_id_fk": {
+          "name": "pages_createdBy_users_id_fk",
+          "tableFrom": "pages",
+          "tableTo": "users",
+          "columnsFrom": [
+            "createdBy"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "pages_driveId_drives_id_fk": {
+          "name": "pages_driveId_drives_id_fk",
+          "tableFrom": "pages",
+          "tableTo": "drives",
+          "columnsFrom": [
+            "driveId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.storage_events": {
+      "name": "storage_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pageId": {
+          "name": "pageId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "eventType": {
+          "name": "eventType",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sizeDelta": {
+          "name": "sizeDelta",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "totalSizeAfter": {
+          "name": "totalSizeAfter",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "storage_events_user_id_idx": {
+          "name": "storage_events_user_id_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "storage_events_created_at_idx": {
+          "name": "storage_events_created_at_idx",
+          "columns": [
+            {
+              "expression": "createdAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "storage_events_userId_users_id_fk": {
+          "name": "storage_events_userId_users_id_fk",
+          "tableFrom": "storage_events",
+          "tableTo": "users",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "storage_events_pageId_pages_id_fk": {
+          "name": "storage_events_pageId_pages_id_fk",
+          "tableFrom": "storage_events",
+          "tableTo": "pages",
+          "columnsFrom": [
+            "pageId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.tags": {
+      "name": "tags",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "driveId": {
+          "name": "driveId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "normalizedKey": {
+          "name": "normalizedKey",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "color": {
+          "name": "color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdBy": {
+          "name": "createdBy",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "tags_drive_id_idx": {
+          "name": "tags_drive_id_idx",
+          "columns": [
+            {
+              "expression": "driveId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "tags_driveId_drives_id_fk": {
+          "name": "tags_driveId_drives_id_fk",
+          "tableFrom": "tags",
+          "tableTo": "drives",
+          "columnsFrom": [
+            "driveId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "tags_createdBy_users_id_fk": {
+          "name": "tags_createdBy_users_id_fk",
+          "tableFrom": "tags",
+          "tableTo": "users",
+          "columnsFrom": [
+            "createdBy"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "tags_drive_id_normalized_key_key": {
+          "name": "tags_drive_id_normalized_key_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "driveId",
+            "normalizedKey"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_mentions": {
+      "name": "user_mentions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "sourcePageId": {
+          "name": "sourcePageId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "targetUserId": {
+          "name": "targetUserId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "mentionedByUserId": {
+          "name": "mentionedByUserId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "user_mentions_source_page_id_target_user_id_key": {
+          "name": "user_mentions_source_page_id_target_user_id_key",
+          "columns": [
+            {
+              "expression": "sourcePageId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "targetUserId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_mentions_source_page_id_idx": {
+          "name": "user_mentions_source_page_id_idx",
+          "columns": [
+            {
+              "expression": "sourcePageId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_mentions_target_user_id_idx": {
+          "name": "user_mentions_target_user_id_idx",
+          "columns": [
+            {
+              "expression": "targetUserId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_mentions_sourcePageId_pages_id_fk": {
+          "name": "user_mentions_sourcePageId_pages_id_fk",
+          "tableFrom": "user_mentions",
+          "tableTo": "pages",
+          "columnsFrom": [
+            "sourcePageId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "user_mentions_targetUserId_users_id_fk": {
+          "name": "user_mentions_targetUserId_users_id_fk",
+          "tableFrom": "user_mentions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "targetUserId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "user_mentions_mentionedByUserId_users_id_fk": {
+          "name": "user_mentions_mentionedByUserId_users_id_fk",
+          "tableFrom": "user_mentions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "mentionedByUserId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.drive_agent_members": {
+      "name": "drive_agent_members",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "driveId": {
+          "name": "driveId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agentPageId": {
+          "name": "agentPageId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "MemberRole",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'MEMBER'"
+        },
+        "customRoleId": {
+          "name": "customRoleId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "includeContext": {
+          "name": "includeContext",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "addedBy": {
+          "name": "addedBy",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "addedAt": {
+          "name": "addedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "drive_agent_members_drive_id_idx": {
+          "name": "drive_agent_members_drive_id_idx",
+          "columns": [
+            {
+              "expression": "driveId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "drive_agent_members_agent_page_id_idx": {
+          "name": "drive_agent_members_agent_page_id_idx",
+          "columns": [
+            {
+              "expression": "agentPageId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "drive_agent_members_driveId_drives_id_fk": {
+          "name": "drive_agent_members_driveId_drives_id_fk",
+          "tableFrom": "drive_agent_members",
+          "tableTo": "drives",
+          "columnsFrom": [
+            "driveId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "drive_agent_members_agentPageId_pages_id_fk": {
+          "name": "drive_agent_members_agentPageId_pages_id_fk",
+          "tableFrom": "drive_agent_members",
+          "tableTo": "pages",
+          "columnsFrom": [
+            "agentPageId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "drive_agent_members_customRoleId_drive_roles_id_fk": {
+          "name": "drive_agent_members_customRoleId_drive_roles_id_fk",
+          "tableFrom": "drive_agent_members",
+          "tableTo": "drive_roles",
+          "columnsFrom": [
+            "customRoleId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "drive_agent_members_addedBy_users_id_fk": {
+          "name": "drive_agent_members_addedBy_users_id_fk",
+          "tableFrom": "drive_agent_members",
+          "tableTo": "users",
+          "columnsFrom": [
+            "addedBy"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "drive_agent_members_drive_agent_key": {
+          "name": "drive_agent_members_drive_agent_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "driveId",
+            "agentPageId"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.drive_members": {
+      "name": "drive_members",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "driveId": {
+          "name": "driveId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "MemberRole",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'MEMBER'"
+        },
+        "customRoleId": {
+          "name": "customRoleId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "invitedBy": {
+          "name": "invitedBy",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "invitedAt": {
+          "name": "invitedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "acceptedAt": {
+          "name": "acceptedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lastAccessedAt": {
+          "name": "lastAccessedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "drive_members_drive_id_idx": {
+          "name": "drive_members_drive_id_idx",
+          "columns": [
+            {
+              "expression": "driveId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "drive_members_user_id_idx": {
+          "name": "drive_members_user_id_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "drive_members_role_idx": {
+          "name": "drive_members_role_idx",
+          "columns": [
+            {
+              "expression": "role",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "drive_members_custom_role_id_idx": {
+          "name": "drive_members_custom_role_id_idx",
+          "columns": [
+            {
+              "expression": "customRoleId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "drive_members_driveId_drives_id_fk": {
+          "name": "drive_members_driveId_drives_id_fk",
+          "tableFrom": "drive_members",
+          "tableTo": "drives",
+          "columnsFrom": [
+            "driveId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "drive_members_userId_users_id_fk": {
+          "name": "drive_members_userId_users_id_fk",
+          "tableFrom": "drive_members",
+          "tableTo": "users",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "drive_members_customRoleId_drive_roles_id_fk": {
+          "name": "drive_members_customRoleId_drive_roles_id_fk",
+          "tableFrom": "drive_members",
+          "tableTo": "drive_roles",
+          "columnsFrom": [
+            "customRoleId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "drive_members_invitedBy_users_id_fk": {
+          "name": "drive_members_invitedBy_users_id_fk",
+          "tableFrom": "drive_members",
+          "tableTo": "users",
+          "columnsFrom": [
+            "invitedBy"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "drive_members_drive_user_key": {
+          "name": "drive_members_drive_user_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "driveId",
+            "userId"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.drive_roles": {
+      "name": "drive_roles",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "driveId": {
+          "name": "driveId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "color": {
+          "name": "color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "isDefault": {
+          "name": "isDefault",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "permissions": {
+          "name": "permissions",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "drive_wide_permissions": {
+          "name": "drive_wide_permissions",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "NULL"
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "drive_roles_drive_id_idx": {
+          "name": "drive_roles_drive_id_idx",
+          "columns": [
+            {
+              "expression": "driveId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "drive_roles_position_idx": {
+          "name": "drive_roles_position_idx",
+          "columns": [
+            {
+              "expression": "position",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "drive_roles_driveId_drives_id_fk": {
+          "name": "drive_roles_driveId_drives_id_fk",
+          "tableFrom": "drive_roles",
+          "tableTo": "drives",
+          "columnsFrom": [
+            "driveId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "drive_roles_drive_name_key": {
+          "name": "drive_roles_drive_name_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "driveId",
+            "name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.mcp_token_drives": {
+      "name": "mcp_token_drives",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "tokenId": {
+          "name": "tokenId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "driveId": {
+          "name": "driveId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "MemberRole",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "customRoleId": {
+          "name": "customRoleId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "addedBy": {
+          "name": "addedBy",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "mcp_token_drives_token_id_idx": {
+          "name": "mcp_token_drives_token_id_idx",
+          "columns": [
+            {
+              "expression": "tokenId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "mcp_token_drives_drive_id_idx": {
+          "name": "mcp_token_drives_drive_id_idx",
+          "columns": [
+            {
+              "expression": "driveId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "mcp_token_drives_token_drive_unique": {
+          "name": "mcp_token_drives_token_drive_unique",
+          "columns": [
+            {
+              "expression": "tokenId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "driveId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "mcp_token_drives_tokenId_mcp_tokens_id_fk": {
+          "name": "mcp_token_drives_tokenId_mcp_tokens_id_fk",
+          "tableFrom": "mcp_token_drives",
+          "tableTo": "mcp_tokens",
+          "columnsFrom": [
+            "tokenId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "mcp_token_drives_driveId_drives_id_fk": {
+          "name": "mcp_token_drives_driveId_drives_id_fk",
+          "tableFrom": "mcp_token_drives",
+          "tableTo": "drives",
+          "columnsFrom": [
+            "driveId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "mcp_token_drives_customRoleId_drive_roles_id_fk": {
+          "name": "mcp_token_drives_customRoleId_drive_roles_id_fk",
+          "tableFrom": "mcp_token_drives",
+          "tableTo": "drive_roles",
+          "columnsFrom": [
+            "customRoleId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "mcp_token_drives_addedBy_users_id_fk": {
+          "name": "mcp_token_drives_addedBy_users_id_fk",
+          "tableFrom": "mcp_token_drives",
+          "tableTo": "users",
+          "columnsFrom": [
+            "addedBy"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.page_permissions": {
+      "name": "page_permissions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "pageId": {
+          "name": "pageId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "canView": {
+          "name": "canView",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "canEdit": {
+          "name": "canEdit",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "canShare": {
+          "name": "canShare",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "canDelete": {
+          "name": "canDelete",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "grantedBy": {
+          "name": "grantedBy",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "grantedAt": {
+          "name": "grantedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expiresAt": {
+          "name": "expiresAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "note": {
+          "name": "note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "page_permissions_page_id_idx": {
+          "name": "page_permissions_page_id_idx",
+          "columns": [
+            {
+              "expression": "pageId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "page_permissions_user_id_idx": {
+          "name": "page_permissions_user_id_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "page_permissions_expires_at_idx": {
+          "name": "page_permissions_expires_at_idx",
+          "columns": [
+            {
+              "expression": "expiresAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "page_permissions_pageId_pages_id_fk": {
+          "name": "page_permissions_pageId_pages_id_fk",
+          "tableFrom": "page_permissions",
+          "tableTo": "pages",
+          "columnsFrom": [
+            "pageId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "page_permissions_userId_users_id_fk": {
+          "name": "page_permissions_userId_users_id_fk",
+          "tableFrom": "page_permissions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "page_permissions_grantedBy_users_id_fk": {
+          "name": "page_permissions_grantedBy_users_id_fk",
+          "tableFrom": "page_permissions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "grantedBy"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "page_permissions_page_user_key": {
+          "name": "page_permissions_page_user_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "pageId",
+            "userId"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_profiles": {
+      "name": "user_profiles",
+      "schema": "",
+      "columns": {
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "username": {
+          "name": "username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "displayName": {
+          "name": "displayName",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "bio": {
+          "name": "bio",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "avatarUrl": {
+          "name": "avatarUrl",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "isPublic": {
+          "name": "isPublic",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "user_profiles_is_public_idx": {
+          "name": "user_profiles_is_public_idx",
+          "columns": [
+            {
+              "expression": "isPublic",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_profiles_userId_users_id_fk": {
+          "name": "user_profiles_userId_users_id_fk",
+          "tableFrom": "user_profiles",
+          "tableTo": "users",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.channel_message_reactions": {
+      "name": "channel_message_reactions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "messageId": {
+          "name": "messageId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "emoji": {
+          "name": "emoji",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "unique_reaction_idx": {
+          "name": "unique_reaction_idx",
+          "columns": [
+            {
+              "expression": "messageId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "emoji",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "reaction_message_idx": {
+          "name": "reaction_message_idx",
+          "columns": [
+            {
+              "expression": "messageId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "channel_message_reactions_messageId_channel_messages_id_fk": {
+          "name": "channel_message_reactions_messageId_channel_messages_id_fk",
+          "tableFrom": "channel_message_reactions",
+          "tableTo": "channel_messages",
+          "columnsFrom": [
+            "messageId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "channel_message_reactions_userId_users_id_fk": {
+          "name": "channel_message_reactions_userId_users_id_fk",
+          "tableFrom": "channel_message_reactions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.channel_messages": {
+      "name": "channel_messages",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "pageId": {
+          "name": "pageId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "fileId": {
+          "name": "fileId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "attachmentMeta": {
+          "name": "attachmentMeta",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "isActive": {
+          "name": "isActive",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "editedAt": {
+          "name": "editedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "aiMeta": {
+          "name": "aiMeta",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "parentId": {
+          "name": "parentId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "replyCount": {
+          "name": "replyCount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "lastReplyAt": {
+          "name": "lastReplyAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mirroredFromId": {
+          "name": "mirroredFromId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "quotedMessageId": {
+          "name": "quotedMessageId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "channel_messages_page_id_idx": {
+          "name": "channel_messages_page_id_idx",
+          "columns": [
+            {
+              "expression": "pageId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "channel_messages_file_id_idx": {
+          "name": "channel_messages_file_id_idx",
+          "columns": [
+            {
+              "expression": "fileId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "channel_messages_parent_created_idx": {
+          "name": "channel_messages_parent_created_idx",
+          "columns": [
+            {
+              "expression": "parentId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "createdAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "channel_messages_quoted_id_idx": {
+          "name": "channel_messages_quoted_id_idx",
+          "columns": [
+            {
+              "expression": "quotedMessageId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "channel_messages_pageId_pages_id_fk": {
+          "name": "channel_messages_pageId_pages_id_fk",
+          "tableFrom": "channel_messages",
+          "tableTo": "pages",
+          "columnsFrom": [
+            "pageId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "channel_messages_userId_users_id_fk": {
+          "name": "channel_messages_userId_users_id_fk",
+          "tableFrom": "channel_messages",
+          "tableTo": "users",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "channel_messages_fileId_files_id_fk": {
+          "name": "channel_messages_fileId_files_id_fk",
+          "tableFrom": "channel_messages",
+          "tableTo": "files",
+          "columnsFrom": [
+            "fileId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "channel_messages_parentId_channel_messages_id_fk": {
+          "name": "channel_messages_parentId_channel_messages_id_fk",
+          "tableFrom": "channel_messages",
+          "tableTo": "channel_messages",
+          "columnsFrom": [
+            "parentId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "channel_messages_mirroredFromId_channel_messages_id_fk": {
+          "name": "channel_messages_mirroredFromId_channel_messages_id_fk",
+          "tableFrom": "channel_messages",
+          "tableTo": "channel_messages",
+          "columnsFrom": [
+            "mirroredFromId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "channel_messages_quotedMessageId_channel_messages_id_fk": {
+          "name": "channel_messages_quotedMessageId_channel_messages_id_fk",
+          "tableFrom": "channel_messages",
+          "tableTo": "channel_messages",
+          "columnsFrom": [
+            "quotedMessageId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.channel_read_status": {
+      "name": "channel_read_status",
+      "schema": "",
+      "columns": {
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "channelId": {
+          "name": "channelId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "lastReadAt": {
+          "name": "lastReadAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "channel_read_status_user_id_idx": {
+          "name": "channel_read_status_user_id_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "channel_read_status_channel_id_idx": {
+          "name": "channel_read_status_channel_id_idx",
+          "columns": [
+            {
+              "expression": "channelId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "channel_read_status_userId_users_id_fk": {
+          "name": "channel_read_status_userId_users_id_fk",
+          "tableFrom": "channel_read_status",
+          "tableTo": "users",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "channel_read_status_channelId_pages_id_fk": {
+          "name": "channel_read_status_channelId_pages_id_fk",
+          "tableFrom": "channel_read_status",
+          "tableTo": "pages",
+          "columnsFrom": [
+            "channelId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "channel_read_status_userId_channelId_pk": {
+          "name": "channel_read_status_userId_channelId_pk",
+          "columns": [
+            "userId",
+            "channelId"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.channel_thread_followers": {
+      "name": "channel_thread_followers",
+      "schema": "",
+      "columns": {
+        "rootMessageId": {
+          "name": "rootMessageId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "channel_thread_followers_user_id_idx": {
+          "name": "channel_thread_followers_user_id_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "channel_thread_followers_rootMessageId_channel_messages_id_fk": {
+          "name": "channel_thread_followers_rootMessageId_channel_messages_id_fk",
+          "tableFrom": "channel_thread_followers",
+          "tableTo": "channel_messages",
+          "columnsFrom": [
+            "rootMessageId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "channel_thread_followers_userId_users_id_fk": {
+          "name": "channel_thread_followers_userId_users_id_fk",
+          "tableFrom": "channel_thread_followers",
+          "tableTo": "users",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "channel_thread_followers_rootMessageId_userId_pk": {
+          "name": "channel_thread_followers_rootMessageId_userId_pk",
+          "columns": [
+            "rootMessageId",
+            "userId"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.pulse_summaries": {
+      "name": "pulse_summaries",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "summary": {
+          "name": "summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "greeting": {
+          "name": "greeting",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "type": {
+          "name": "type",
+          "type": "pulse_summary_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'scheduled'"
+        },
+        "contextData": {
+          "name": "contextData",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "aiProvider": {
+          "name": "aiProvider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "aiModel": {
+          "name": "aiModel",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "periodStart": {
+          "name": "periodStart",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "periodEnd": {
+          "name": "periodEnd",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "generatedAt": {
+          "name": "generatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expiresAt": {
+          "name": "expiresAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_pulse_summaries_user_id": {
+          "name": "idx_pulse_summaries_user_id",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_pulse_summaries_generated_at": {
+          "name": "idx_pulse_summaries_generated_at",
+          "columns": [
+            {
+              "expression": "generatedAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_pulse_summaries_expires_at": {
+          "name": "idx_pulse_summaries_expires_at",
+          "columns": [
+            {
+              "expression": "expiresAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_pulse_summaries_user_generated": {
+          "name": "idx_pulse_summaries_user_generated",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "generatedAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "pulse_summaries_userId_users_id_fk": {
+          "name": "pulse_summaries_userId_users_id_fk",
+          "tableFrom": "pulse_summaries",
+          "tableTo": "users",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_dashboards": {
+      "name": "user_dashboards",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_dashboards_userId_users_id_fk": {
+          "name": "user_dashboards_userId_users_id_fk",
+          "tableFrom": "user_dashboards",
+          "tableTo": "users",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_dashboards_userId_unique": {
+          "name": "user_dashboards_userId_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "userId"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.conversations": {
+      "name": "conversations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "contextId": {
+          "name": "contextId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "agentPageId": {
+          "name": "agentPageId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rev": {
+          "name": "rev",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "planPageId": {
+          "name": "planPageId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lastMessageAt": {
+          "name": "lastMessageAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "isActive": {
+          "name": "isActive",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "isShared": {
+          "name": "isShared",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        }
+      },
+      "indexes": {
+        "conversations_user_id_idx": {
+          "name": "conversations_user_id_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "conversations_user_id_type_idx": {
+          "name": "conversations_user_id_type_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "conversations_user_id_last_message_at_idx": {
+          "name": "conversations_user_id_last_message_at_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "lastMessageAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "conversations_context_id_idx": {
+          "name": "conversations_context_id_idx",
+          "columns": [
+            {
+              "expression": "contextId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "conversations_plan_page_id_idx": {
+          "name": "conversations_plan_page_id_idx",
+          "columns": [
+            {
+              "expression": "planPageId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "conversations_agent_page_id_idx": {
+          "name": "conversations_agent_page_id_idx",
+          "columns": [
+            {
+              "expression": "agentPageId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "conversations_userId_users_id_fk": {
+          "name": "conversations_userId_users_id_fk",
+          "tableFrom": "conversations",
+          "tableTo": "users",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "conversations_agentPageId_pages_id_fk": {
+          "name": "conversations_agentPageId_pages_id_fk",
+          "tableFrom": "conversations",
+          "tableTo": "pages",
+          "columnsFrom": [
+            "agentPageId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "conversations_planPageId_pages_id_fk": {
+          "name": "conversations_planPageId_pages_id_fk",
+          "tableFrom": "conversations",
+          "tableTo": "pages",
+          "columnsFrom": [
+            "planPageId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "conversations_global_context_null_chk": {
+          "name": "conversations_global_context_null_chk",
+          "value": "\"conversations\".\"type\" <> 'global' OR \"conversations\".\"contextId\" IS NULL"
+        },
+        "conversations_page_context_present_chk": {
+          "name": "conversations_page_context_present_chk",
+          "value": "\"conversations\".\"type\" <> 'page' OR \"conversations\".\"contextId\" IS NOT NULL"
+        },
+        "conversations_drive_context_present_chk": {
+          "name": "conversations_drive_context_present_chk",
+          "value": "\"conversations\".\"type\" <> 'drive' OR \"conversations\".\"contextId\" IS NOT NULL"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.messages": {
+      "name": "messages",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "conversationId": {
+          "name": "conversationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "messageType": {
+          "name": "messageType",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'standard'"
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "toolCalls": {
+          "name": "toolCalls",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "toolResults": {
+          "name": "toolResults",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "isActive": {
+          "name": "isActive",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "editedAt": {
+          "name": "editedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'complete'"
+        },
+        "sourceAgentId": {
+          "name": "sourceAgentId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "messages_conversation_id_idx": {
+          "name": "messages_conversation_id_idx",
+          "columns": [
+            {
+              "expression": "conversationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "messages_conversation_id_created_at_idx": {
+          "name": "messages_conversation_id_created_at_idx",
+          "columns": [
+            {
+              "expression": "conversationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "createdAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "messages_user_id_idx": {
+          "name": "messages_user_id_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "messages_conversationId_conversations_id_fk": {
+          "name": "messages_conversationId_conversations_id_fk",
+          "tableFrom": "messages",
+          "tableTo": "conversations",
+          "columnsFrom": [
+            "conversationId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "messages_userId_users_id_fk": {
+          "name": "messages_userId_users_id_fk",
+          "tableFrom": "messages",
+          "tableTo": "users",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "messages_sourceAgentId_pages_id_fk": {
+          "name": "messages_sourceAgentId_pages_id_fk",
+          "tableFrom": "messages",
+          "tableTo": "pages",
+          "columnsFrom": [
+            "sourceAgentId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.notifications": {
+      "name": "notifications",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "NotificationType",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "message": {
+          "name": "message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "isRead": {
+          "name": "isRead",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "readAt": {
+          "name": "readAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pageId": {
+          "name": "pageId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "driveId": {
+          "name": "driveId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "triggeredByUserId": {
+          "name": "triggeredByUserId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "notifications_user_id_idx": {
+          "name": "notifications_user_id_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "notifications_user_id_is_read_idx": {
+          "name": "notifications_user_id_is_read_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "isRead",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "notifications_user_id_is_read_created_at_idx": {
+          "name": "notifications_user_id_is_read_created_at_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "isRead",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "createdAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "notifications_created_at_idx": {
+          "name": "notifications_created_at_idx",
+          "columns": [
+            {
+              "expression": "createdAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "notifications_type_idx": {
+          "name": "notifications_type_idx",
+          "columns": [
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "notifications_userId_users_id_fk": {
+          "name": "notifications_userId_users_id_fk",
+          "tableFrom": "notifications",
+          "tableTo": "users",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "notifications_pageId_pages_id_fk": {
+          "name": "notifications_pageId_pages_id_fk",
+          "tableFrom": "notifications",
+          "tableTo": "pages",
+          "columnsFrom": [
+            "pageId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "notifications_driveId_drives_id_fk": {
+          "name": "notifications_driveId_drives_id_fk",
+          "tableFrom": "notifications",
+          "tableTo": "drives",
+          "columnsFrom": [
+            "driveId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "notifications_triggeredByUserId_users_id_fk": {
+          "name": "notifications_triggeredByUserId_users_id_fk",
+          "tableFrom": "notifications",
+          "tableTo": "users",
+          "columnsFrom": [
+            "triggeredByUserId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.email_notification_log": {
+      "name": "email_notification_log",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "notificationId": {
+          "name": "notificationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notificationType": {
+          "name": "notificationType",
+          "type": "NotificationType",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "recipientEmail": {
+          "name": "recipientEmail",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "success": {
+          "name": "success",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "errorMessage": {
+          "name": "errorMessage",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sentAt": {
+          "name": "sentAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "email_notification_log_user_idx": {
+          "name": "email_notification_log_user_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "email_notification_log_sent_at_idx": {
+          "name": "email_notification_log_sent_at_idx",
+          "columns": [
+            {
+              "expression": "sentAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "email_notification_log_notification_id_idx": {
+          "name": "email_notification_log_notification_id_idx",
+          "columns": [
+            {
+              "expression": "notificationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "email_notification_log_userId_users_id_fk": {
+          "name": "email_notification_log_userId_users_id_fk",
+          "tableFrom": "email_notification_log",
+          "tableTo": "users",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.email_notification_preferences": {
+      "name": "email_notification_preferences",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "notificationType": {
+          "name": "notificationType",
+          "type": "NotificationType",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "emailEnabled": {
+          "name": "emailEnabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "email_notification_preferences_user_type_idx": {
+          "name": "email_notification_preferences_user_type_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "notificationType",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "email_notification_preferences_userId_users_id_fk": {
+          "name": "email_notification_preferences_userId_users_id_fk",
+          "tableFrom": "email_notification_preferences",
+          "tableTo": "users",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_toast_notification_preferences": {
+      "name": "user_toast_notification_preferences",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "level": {
+          "name": "level",
+          "type": "toast_notification_level",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'all'"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "user_toast_notification_preferences_user_idx": {
+          "name": "user_toast_notification_preferences_user_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_toast_notification_preferences_userId_users_id_fk": {
+          "name": "user_toast_notification_preferences_userId_users_id_fk",
+          "tableFrom": "user_toast_notification_preferences",
+          "tableTo": "users",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.display_preferences": {
+      "name": "display_preferences",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "preferenceType": {
+          "name": "preferenceType",
+          "type": "display_preference_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "display_preferences_user_type_idx": {
+          "name": "display_preferences_user_type_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "preferenceType",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "display_preferences_userId_users_id_fk": {
+          "name": "display_preferences_userId_users_id_fk",
+          "tableFrom": "display_preferences",
+          "tableTo": "users",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.activity_logs": {
+      "name": "activity_logs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "actorEmail": {
+          "name": "actorEmail",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'legacy@unknown'"
+        },
+        "actorDisplayName": {
+          "name": "actorDisplayName",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "isAiGenerated": {
+          "name": "isAiGenerated",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "aiProvider": {
+          "name": "aiProvider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "aiModel": {
+          "name": "aiModel",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "aiConversationId": {
+          "name": "aiConversationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "operation": {
+          "name": "operation",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "resourceType": {
+          "name": "resourceType",
+          "type": "activity_resource",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "resourceId": {
+          "name": "resourceId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "resourceTitle": {
+          "name": "resourceTitle",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "driveId": {
+          "name": "driveId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pageId": {
+          "name": "pageId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "contentSnapshot": {
+          "name": "contentSnapshot",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "contentFormat": {
+          "name": "contentFormat",
+          "type": "content_format",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "contentRef": {
+          "name": "contentRef",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "contentSize": {
+          "name": "contentSize",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rollbackFromActivityId": {
+          "name": "rollbackFromActivityId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rollbackSourceOperation": {
+          "name": "rollbackSourceOperation",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rollbackSourceTimestamp": {
+          "name": "rollbackSourceTimestamp",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rollbackSourceTitle": {
+          "name": "rollbackSourceTitle",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updatedFields": {
+          "name": "updatedFields",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "previousValues": {
+          "name": "previousValues",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "newValues": {
+          "name": "newValues",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "streamId": {
+          "name": "streamId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "streamSeq": {
+          "name": "streamSeq",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "changeGroupId": {
+          "name": "changeGroupId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "changeGroupType": {
+          "name": "changeGroupType",
+          "type": "activity_change_group_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stateHashBefore": {
+          "name": "stateHashBefore",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stateHashAfter": {
+          "name": "stateHashAfter",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "dataCategory": {
+          "name": "dataCategory",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "legalBasis": {
+          "name": "legalBasis",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "retentionPolicy": {
+          "name": "retentionPolicy",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "recipients": {
+          "name": "recipients",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "isArchived": {
+          "name": "isArchived",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "chainSeq": {
+          "name": "chainSeq",
+          "type": "bigserial",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "previousLogHash": {
+          "name": "previousLogHash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "logHash": {
+          "name": "logHash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "chainSeed": {
+          "name": "chainSeed",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_activity_logs_timestamp": {
+          "name": "idx_activity_logs_timestamp",
+          "columns": [
+            {
+              "expression": "timestamp",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_activity_logs_user_timestamp": {
+          "name": "idx_activity_logs_user_timestamp",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "timestamp",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_activity_logs_drive_timestamp": {
+          "name": "idx_activity_logs_drive_timestamp",
+          "columns": [
+            {
+              "expression": "driveId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "timestamp",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_activity_logs_page_timestamp": {
+          "name": "idx_activity_logs_page_timestamp",
+          "columns": [
+            {
+              "expression": "pageId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "timestamp",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_activity_logs_archived": {
+          "name": "idx_activity_logs_archived",
+          "columns": [
+            {
+              "expression": "isArchived",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_activity_logs_rollback_from": {
+          "name": "idx_activity_logs_rollback_from",
+          "columns": [
+            {
+              "expression": "rollbackFromActivityId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_activity_logs_stream": {
+          "name": "idx_activity_logs_stream",
+          "columns": [
+            {
+              "expression": "streamId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "streamSeq",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"activity_logs\".\"streamId\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_activity_logs_change_group": {
+          "name": "idx_activity_logs_change_group",
+          "columns": [
+            {
+              "expression": "changeGroupId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"activity_logs\".\"changeGroupId\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_activity_logs_log_hash": {
+          "name": "idx_activity_logs_log_hash",
+          "columns": [
+            {
+              "expression": "logHash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"activity_logs\".\"logHash\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_activity_logs_chain_seq": {
+          "name": "idx_activity_logs_chain_seq",
+          "columns": [
+            {
+              "expression": "chainSeq",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "activity_logs_userId_users_id_fk": {
+          "name": "activity_logs_userId_users_id_fk",
+          "tableFrom": "activity_logs",
+          "tableTo": "users",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "activity_logs_driveId_drives_id_fk": {
+          "name": "activity_logs_driveId_drives_id_fk",
+          "tableFrom": "activity_logs",
+          "tableTo": "drives",
+          "columnsFrom": [
+            "driveId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "activity_logs_pageId_pages_id_fk": {
+          "name": "activity_logs_pageId_pages_id_fk",
+          "tableFrom": "activity_logs",
+          "tableTo": "pages",
+          "columnsFrom": [
+            "pageId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "activity_logs_content_size_limit": {
+          "name": "activity_logs_content_size_limit",
+          "value": "\"activity_logs\".\"contentRef\" IS NOT NULL OR \"activity_logs\".\"contentSize\" IS NULL OR \"activity_logs\".\"contentSize\" <= 1048576"
+        },
+        "activity_logs_stream_pair": {
+          "name": "activity_logs_stream_pair",
+          "value": "(\"activity_logs\".\"streamId\" IS NULL) = (\"activity_logs\".\"streamSeq\" IS NULL)"
+        },
+        "activity_logs_change_group_pair": {
+          "name": "activity_logs_change_group_pair",
+          "value": "(\"activity_logs\".\"changeGroupId\" IS NULL) = (\"activity_logs\".\"changeGroupType\" IS NULL)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.ai_usage_logs": {
+      "name": "ai_usage_logs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "input_tokens": {
+          "name": "input_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "output_tokens": {
+          "name": "output_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "total_tokens": {
+          "name": "total_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cost": {
+          "name": "cost",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "currency": {
+          "name": "currency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'USD'"
+        },
+        "duration": {
+          "name": "duration",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "streaming_duration": {
+          "name": "streaming_duration",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "message_id": {
+          "name": "message_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "page_id": {
+          "name": "page_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "drive_id": {
+          "name": "drive_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "success": {
+          "name": "success",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": true
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "context_messages": {
+          "name": "context_messages",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "context_size": {
+          "name": "context_size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "system_prompt_tokens": {
+          "name": "system_prompt_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tool_definition_tokens": {
+          "name": "tool_definition_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "conversation_tokens": {
+          "name": "conversation_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "message_count": {
+          "name": "message_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "was_truncated": {
+          "name": "was_truncated",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "truncation_strategy": {
+          "name": "truncation_strategy",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reconcile_status": {
+          "name": "reconcile_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reconcile_attempts": {
+          "name": "reconcile_attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "reconciled_at": {
+          "name": "reconciled_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_ai_usage_timestamp": {
+          "name": "idx_ai_usage_timestamp",
+          "columns": [
+            {
+              "expression": "timestamp",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_ai_usage_user_id": {
+          "name": "idx_ai_usage_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "timestamp",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_ai_usage_user_source": {
+          "name": "idx_ai_usage_user_source",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "source",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "timestamp",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_ai_usage_provider": {
+          "name": "idx_ai_usage_provider",
+          "columns": [
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "model",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "timestamp",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_ai_usage_cost": {
+          "name": "idx_ai_usage_cost",
+          "columns": [
+            {
+              "expression": "cost",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_ai_usage_conversation": {
+          "name": "idx_ai_usage_conversation",
+          "columns": [
+            {
+              "expression": "conversation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_ai_usage_context": {
+          "name": "idx_ai_usage_context",
+          "columns": [
+            {
+              "expression": "conversation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "timestamp",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_ai_usage_context_size": {
+          "name": "idx_ai_usage_context_size",
+          "columns": [
+            {
+              "expression": "context_size",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_ai_usage_expires_at": {
+          "name": "idx_ai_usage_expires_at",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_ai_usage_reconcile": {
+          "name": "idx_ai_usage_reconcile",
+          "columns": [
+            {
+              "expression": "reconcile_status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "timestamp",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "reconcile_status = 'pending'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.api_metrics": {
+      "name": "api_metrics",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "endpoint": {
+          "name": "endpoint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "method": {
+          "name": "method",
+          "type": "http_method",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status_code": {
+          "name": "status_code",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "duration": {
+          "name": "duration",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "request_size": {
+          "name": "request_size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "response_size": {
+          "name": "response_size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ip": {
+          "name": "ip",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "request_id": {
+          "name": "request_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cache_hit": {
+          "name": "cache_hit",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "cache_key": {
+          "name": "cache_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_api_metrics_timestamp": {
+          "name": "idx_api_metrics_timestamp",
+          "columns": [
+            {
+              "expression": "timestamp",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_api_metrics_endpoint": {
+          "name": "idx_api_metrics_endpoint",
+          "columns": [
+            {
+              "expression": "endpoint",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "timestamp",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_api_metrics_user_id": {
+          "name": "idx_api_metrics_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "timestamp",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_api_metrics_status": {
+          "name": "idx_api_metrics_status",
+          "columns": [
+            {
+              "expression": "status_code",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "timestamp",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_api_metrics_duration": {
+          "name": "idx_api_metrics_duration",
+          "columns": [
+            {
+              "expression": "duration",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.error_logs": {
+      "name": "error_logs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "message": {
+          "name": "message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stack": {
+          "name": "stack",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "request_id": {
+          "name": "request_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "endpoint": {
+          "name": "endpoint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "method": {
+          "name": "method",
+          "type": "http_method",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "file": {
+          "name": "file",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "line": {
+          "name": "line",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "column": {
+          "name": "column",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ip": {
+          "name": "ip",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolved": {
+          "name": "resolved",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "resolved_at": {
+          "name": "resolved_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolved_by": {
+          "name": "resolved_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolution": {
+          "name": "resolution",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_errors_timestamp": {
+          "name": "idx_errors_timestamp",
+          "columns": [
+            {
+              "expression": "timestamp",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_errors_name": {
+          "name": "idx_errors_name",
+          "columns": [
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "timestamp",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_errors_user_id": {
+          "name": "idx_errors_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_errors_resolved": {
+          "name": "idx_errors_resolved",
+          "columns": [
+            {
+              "expression": "resolved",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_errors_endpoint": {
+          "name": "idx_errors_endpoint",
+          "columns": [
+            {
+              "expression": "endpoint",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.error_resolutions": {
+      "name": "error_resolutions",
+      "schema": "",
+      "columns": {
+        "error_id": {
+          "name": "error_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "resolved": {
+          "name": "resolved",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "resolved_at": {
+          "name": "resolved_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "resolved_by": {
+          "name": "resolved_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolution": {
+          "name": "resolution",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.siem_delivery_cursors": {
+      "name": "siem_delivery_cursors",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "lastDeliveredId": {
+          "name": "lastDeliveredId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lastDeliveredAt": {
+          "name": "lastDeliveredAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lastError": {
+          "name": "lastError",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lastErrorAt": {
+          "name": "lastErrorAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deliveryCount": {
+          "name": "deliveryCount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "siem_delivery_cursors_delivered_cursor_pair": {
+          "name": "siem_delivery_cursors_delivered_cursor_pair",
+          "value": "(\"siem_delivery_cursors\".\"lastDeliveredId\" IS NULL) = (\"siem_delivery_cursors\".\"lastDeliveredAt\" IS NULL)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.siem_delivery_receipts": {
+      "name": "siem_delivery_receipts",
+      "schema": "",
+      "columns": {
+        "receiptId": {
+          "name": "receiptId",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "deliveryId": {
+          "name": "deliveryId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "firstEntryId": {
+          "name": "firstEntryId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "lastEntryId": {
+          "name": "lastEntryId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "firstEntryTimestamp": {
+          "name": "firstEntryTimestamp",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "lastEntryTimestamp": {
+          "name": "lastEntryTimestamp",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entryCount": {
+          "name": "entryCount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "deliveredAt": {
+          "name": "deliveredAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "webhookStatus": {
+          "name": "webhookStatus",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "webhookResponseHash": {
+          "name": "webhookResponseHash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ackReceivedAt": {
+          "name": "ackReceivedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "siem_delivery_receipts_delivery_source_unique": {
+          "name": "siem_delivery_receipts_delivery_source_unique",
+          "columns": [
+            {
+              "expression": "deliveryId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "source",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_siem_receipts_delivery_id": {
+          "name": "idx_siem_receipts_delivery_id",
+          "columns": [
+            {
+              "expression": "deliveryId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_siem_receipts_first_entry": {
+          "name": "idx_siem_receipts_first_entry",
+          "columns": [
+            {
+              "expression": "firstEntryId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_siem_receipts_last_entry": {
+          "name": "idx_siem_receipts_last_entry",
+          "columns": [
+            {
+              "expression": "lastEntryId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_siem_receipts_delivered_at": {
+          "name": "idx_siem_receipts_delivered_at",
+          "columns": [
+            {
+              "expression": "deliveredAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_siem_receipts_source_range": {
+          "name": "idx_siem_receipts_source_range",
+          "columns": [
+            {
+              "expression": "source",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "firstEntryTimestamp",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "lastEntryTimestamp",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.system_logs": {
+      "name": "system_logs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "level": {
+          "name": "level",
+          "type": "log_level",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "message": {
+          "name": "message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "category": {
+          "name": "category",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "request_id": {
+          "name": "request_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "drive_id": {
+          "name": "drive_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "page_id": {
+          "name": "page_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "endpoint": {
+          "name": "endpoint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "method": {
+          "name": "method",
+          "type": "http_method",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ip": {
+          "name": "ip",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_name": {
+          "name": "error_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_stack": {
+          "name": "error_stack",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "duration": {
+          "name": "duration",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "memory_used": {
+          "name": "memory_used",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "memory_total": {
+          "name": "memory_total",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hostname": {
+          "name": "hostname",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pid": {
+          "name": "pid",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "version": {
+          "name": "version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_system_logs_timestamp": {
+          "name": "idx_system_logs_timestamp",
+          "columns": [
+            {
+              "expression": "timestamp",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_system_logs_level": {
+          "name": "idx_system_logs_level",
+          "columns": [
+            {
+              "expression": "level",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_system_logs_category": {
+          "name": "idx_system_logs_category",
+          "columns": [
+            {
+              "expression": "category",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_system_logs_user_id": {
+          "name": "idx_system_logs_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_system_logs_request_id": {
+          "name": "idx_system_logs_request_id",
+          "columns": [
+            {
+              "expression": "request_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_system_logs_error": {
+          "name": "idx_system_logs_error",
+          "columns": [
+            {
+              "expression": "error_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "timestamp",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_activities": {
+      "name": "user_activities",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "action": {
+          "name": "action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "resource": {
+          "name": "resource",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resource_id": {
+          "name": "resource_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "drive_id": {
+          "name": "drive_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "page_id": {
+          "name": "page_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ip": {
+          "name": "ip",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_user_activities_timestamp": {
+          "name": "idx_user_activities_timestamp",
+          "columns": [
+            {
+              "expression": "timestamp",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_user_activities_user_id": {
+          "name": "idx_user_activities_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "timestamp",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_user_activities_action": {
+          "name": "idx_user_activities_action",
+          "columns": [
+            {
+              "expression": "action",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "timestamp",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_user_activities_resource": {
+          "name": "idx_user_activities_resource",
+          "columns": [
+            {
+              "expression": "resource",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "resource_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.drive_backup_files": {
+      "name": "drive_backup_files",
+      "schema": "",
+      "columns": {
+        "backupId": {
+          "name": "backupId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "fileId": {
+          "name": "fileId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "storagePath": {
+          "name": "storagePath",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sizeBytes": {
+          "name": "sizeBytes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mimeType": {
+          "name": "mimeType",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "checksumVersion": {
+          "name": "checksumVersion",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "drive_backup_files_backup_idx": {
+          "name": "drive_backup_files_backup_idx",
+          "columns": [
+            {
+              "expression": "backupId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "drive_backup_files_backupId_drive_backups_id_fk": {
+          "name": "drive_backup_files_backupId_drive_backups_id_fk",
+          "tableFrom": "drive_backup_files",
+          "tableTo": "drive_backups",
+          "columnsFrom": [
+            "backupId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "drive_backup_files_backupId_fileId_pk": {
+          "name": "drive_backup_files_backupId_fileId_pk",
+          "columns": [
+            "backupId",
+            "fileId"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.drive_backup_members": {
+      "name": "drive_backup_members",
+      "schema": "",
+      "columns": {
+        "backupId": {
+          "name": "backupId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "customRoleId": {
+          "name": "customRoleId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "invitedBy": {
+          "name": "invitedBy",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "invitedAt": {
+          "name": "invitedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "acceptedAt": {
+          "name": "acceptedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "drive_backup_members_backup_idx": {
+          "name": "drive_backup_members_backup_idx",
+          "columns": [
+            {
+              "expression": "backupId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "drive_backup_members_backupId_drive_backups_id_fk": {
+          "name": "drive_backup_members_backupId_drive_backups_id_fk",
+          "tableFrom": "drive_backup_members",
+          "tableTo": "drive_backups",
+          "columnsFrom": [
+            "backupId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "drive_backup_members_backupId_userId_pk": {
+          "name": "drive_backup_members_backupId_userId_pk",
+          "columns": [
+            "backupId",
+            "userId"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.drive_backup_pages": {
+      "name": "drive_backup_pages",
+      "schema": "",
+      "columns": {
+        "backupId": {
+          "name": "backupId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pageId": {
+          "name": "pageId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pageVersionId": {
+          "name": "pageVersionId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "parentId": {
+          "name": "parentId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "originalParentId": {
+          "name": "originalParentId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "position": {
+          "name": "position",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "isTrashed": {
+          "name": "isTrashed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "trashedAt": {
+          "name": "trashedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "drive_backup_pages_backup_idx": {
+          "name": "drive_backup_pages_backup_idx",
+          "columns": [
+            {
+              "expression": "backupId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "drive_backup_pages_backupId_drive_backups_id_fk": {
+          "name": "drive_backup_pages_backupId_drive_backups_id_fk",
+          "tableFrom": "drive_backup_pages",
+          "tableTo": "drive_backups",
+          "columnsFrom": [
+            "backupId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "drive_backup_pages_pageVersionId_page_versions_id_fk": {
+          "name": "drive_backup_pages_pageVersionId_page_versions_id_fk",
+          "tableFrom": "drive_backup_pages",
+          "tableTo": "page_versions",
+          "columnsFrom": [
+            "pageVersionId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "drive_backup_pages_backupId_pageId_pk": {
+          "name": "drive_backup_pages_backupId_pageId_pk",
+          "columns": [
+            "backupId",
+            "pageId"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.drive_backup_permissions": {
+      "name": "drive_backup_permissions",
+      "schema": "",
+      "columns": {
+        "backupId": {
+          "name": "backupId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pageId": {
+          "name": "pageId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "canView": {
+          "name": "canView",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "canEdit": {
+          "name": "canEdit",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "canShare": {
+          "name": "canShare",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "canDelete": {
+          "name": "canDelete",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "grantedBy": {
+          "name": "grantedBy",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "note": {
+          "name": "note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expiresAt": {
+          "name": "expiresAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "drive_backup_permissions_backup_idx": {
+          "name": "drive_backup_permissions_backup_idx",
+          "columns": [
+            {
+              "expression": "backupId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "drive_backup_permissions_backupId_drive_backups_id_fk": {
+          "name": "drive_backup_permissions_backupId_drive_backups_id_fk",
+          "tableFrom": "drive_backup_permissions",
+          "tableTo": "drive_backups",
+          "columnsFrom": [
+            "backupId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "drive_backup_permissions_backupId_pageId_userId_pk": {
+          "name": "drive_backup_permissions_backupId_pageId_userId_pk",
+          "columns": [
+            "backupId",
+            "pageId",
+            "userId"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.drive_backup_roles": {
+      "name": "drive_backup_roles",
+      "schema": "",
+      "columns": {
+        "backupId": {
+          "name": "backupId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "roleId": {
+          "name": "roleId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "color": {
+          "name": "color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "isDefault": {
+          "name": "isDefault",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "permissions": {
+          "name": "permissions",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "drive_wide_permissions": {
+          "name": "drive_wide_permissions",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "NULL"
+        },
+        "position": {
+          "name": "position",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "drive_backup_roles_backup_idx": {
+          "name": "drive_backup_roles_backup_idx",
+          "columns": [
+            {
+              "expression": "backupId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "drive_backup_roles_backupId_drive_backups_id_fk": {
+          "name": "drive_backup_roles_backupId_drive_backups_id_fk",
+          "tableFrom": "drive_backup_roles",
+          "tableTo": "drive_backups",
+          "columnsFrom": [
+            "backupId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "drive_backup_roles_backupId_roleId_pk": {
+          "name": "drive_backup_roles_backupId_roleId_pk",
+          "columns": [
+            "backupId",
+            "roleId"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.drive_backup_schedules": {
+      "name": "drive_backup_schedules",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "driveId": {
+          "name": "driveId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "frequency": {
+          "name": "frequency",
+          "type": "drive_backup_schedule_frequency",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'daily'"
+        },
+        "timezone": {
+          "name": "timezone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'UTC'"
+        },
+        "nextRunAt": {
+          "name": "nextRunAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lastRunAt": {
+          "name": "lastRunAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "drive_backup_schedules_enabled_next_run_idx": {
+          "name": "drive_backup_schedules_enabled_next_run_idx",
+          "columns": [
+            {
+              "expression": "enabled",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "nextRunAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "drive_backup_schedules_driveId_drives_id_fk": {
+          "name": "drive_backup_schedules_driveId_drives_id_fk",
+          "tableFrom": "drive_backup_schedules",
+          "tableTo": "drives",
+          "columnsFrom": [
+            "driveId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "drive_backup_schedules_driveId_unique": {
+          "name": "drive_backup_schedules_driveId_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "driveId"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.drive_backups": {
+      "name": "drive_backups",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "driveId": {
+          "name": "driveId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "createdBy": {
+          "name": "createdBy",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source": {
+          "name": "source",
+          "type": "drive_backup_source",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'manual'"
+        },
+        "status": {
+          "name": "status",
+          "type": "drive_backup_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "changeGroupId": {
+          "name": "changeGroupId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "changeGroupType": {
+          "name": "changeGroupType",
+          "type": "activity_change_group_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "isPinned": {
+          "name": "isPinned",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "expiresAt": {
+          "name": "expiresAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completedAt": {
+          "name": "completedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "failedAt": {
+          "name": "failedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "failureReason": {
+          "name": "failureReason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "drive_backups_drive_created_at_idx": {
+          "name": "drive_backups_drive_created_at_idx",
+          "columns": [
+            {
+              "expression": "driveId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "createdAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "drive_backups_status_idx": {
+          "name": "drive_backups_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "drive_backups_driveId_drives_id_fk": {
+          "name": "drive_backups_driveId_drives_id_fk",
+          "tableFrom": "drive_backups",
+          "tableTo": "drives",
+          "columnsFrom": [
+            "driveId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "drive_backups_createdBy_users_id_fk": {
+          "name": "drive_backups_createdBy_users_id_fk",
+          "tableFrom": "drive_backups",
+          "tableTo": "users",
+          "columnsFrom": [
+            "createdBy"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "drive_backups_change_group_pair": {
+          "name": "drive_backups_change_group_pair",
+          "value": "(\"drive_backups\".\"changeGroupId\" IS NULL) = (\"drive_backups\".\"changeGroupType\" IS NULL)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.page_versions": {
+      "name": "page_versions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "pageId": {
+          "name": "pageId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "driveId": {
+          "name": "driveId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "createdBy": {
+          "name": "createdBy",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source": {
+          "name": "source",
+          "type": "page_version_source",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'auto'"
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "changeGroupId": {
+          "name": "changeGroupId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "changeGroupType": {
+          "name": "changeGroupType",
+          "type": "activity_change_group_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "contentRef": {
+          "name": "contentRef",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "contentFormat": {
+          "name": "contentFormat",
+          "type": "content_format",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "contentSize": {
+          "name": "contentSize",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stateHash": {
+          "name": "stateHash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pageRevision": {
+          "name": "pageRevision",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "isPinned": {
+          "name": "isPinned",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "expiresAt": {
+          "name": "expiresAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "page_versions_page_created_at_idx": {
+          "name": "page_versions_page_created_at_idx",
+          "columns": [
+            {
+              "expression": "pageId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "createdAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "page_versions_drive_created_at_idx": {
+          "name": "page_versions_drive_created_at_idx",
+          "columns": [
+            {
+              "expression": "driveId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "createdAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "page_versions_pinned_idx": {
+          "name": "page_versions_pinned_idx",
+          "columns": [
+            {
+              "expression": "isPinned",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "page_versions_page_id_is_pinned_created_at_idx": {
+          "name": "page_versions_page_id_is_pinned_created_at_idx",
+          "columns": [
+            {
+              "expression": "pageId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "isPinned",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "createdAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "page_versions_pageId_pages_id_fk": {
+          "name": "page_versions_pageId_pages_id_fk",
+          "tableFrom": "page_versions",
+          "tableTo": "pages",
+          "columnsFrom": [
+            "pageId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "page_versions_driveId_drives_id_fk": {
+          "name": "page_versions_driveId_drives_id_fk",
+          "tableFrom": "page_versions",
+          "tableTo": "drives",
+          "columnsFrom": [
+            "driveId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "page_versions_createdBy_users_id_fk": {
+          "name": "page_versions_createdBy_users_id_fk",
+          "tableFrom": "page_versions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "createdBy"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "page_versions_change_group_pair": {
+          "name": "page_versions_change_group_pair",
+          "value": "(\"page_versions\".\"changeGroupId\" IS NULL) = (\"page_versions\".\"changeGroupType\" IS NULL)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.connections": {
+      "name": "connections",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user1Id": {
+          "name": "user1Id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user2Id": {
+          "name": "user2Id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "ConnectionStatus",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'PENDING'"
+        },
+        "requestedBy": {
+          "name": "requestedBy",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "requestMessage": {
+          "name": "requestMessage",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "requestedAt": {
+          "name": "requestedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "acceptedAt": {
+          "name": "acceptedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "blockedBy": {
+          "name": "blockedBy",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "blockedAt": {
+          "name": "blockedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "connections_user1_id_idx": {
+          "name": "connections_user1_id_idx",
+          "columns": [
+            {
+              "expression": "user1Id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "connections_user2_id_idx": {
+          "name": "connections_user2_id_idx",
+          "columns": [
+            {
+              "expression": "user2Id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "connections_status_idx": {
+          "name": "connections_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "connections_user1_status_idx": {
+          "name": "connections_user1_status_idx",
+          "columns": [
+            {
+              "expression": "user1Id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "connections_user2_status_idx": {
+          "name": "connections_user2_status_idx",
+          "columns": [
+            {
+              "expression": "user2Id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "connections_user1Id_users_id_fk": {
+          "name": "connections_user1Id_users_id_fk",
+          "tableFrom": "connections",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user1Id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "connections_user2Id_users_id_fk": {
+          "name": "connections_user2Id_users_id_fk",
+          "tableFrom": "connections",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user2Id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "connections_requestedBy_users_id_fk": {
+          "name": "connections_requestedBy_users_id_fk",
+          "tableFrom": "connections",
+          "tableTo": "users",
+          "columnsFrom": [
+            "requestedBy"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "connections_blockedBy_users_id_fk": {
+          "name": "connections_blockedBy_users_id_fk",
+          "tableFrom": "connections",
+          "tableTo": "users",
+          "columnsFrom": [
+            "blockedBy"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "connections_user_pair_key": {
+          "name": "connections_user_pair_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user1Id",
+            "user2Id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.direct_messages": {
+      "name": "direct_messages",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "conversationId": {
+          "name": "conversationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "senderId": {
+          "name": "senderId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "fileId": {
+          "name": "fileId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "attachmentMeta": {
+          "name": "attachmentMeta",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "isRead": {
+          "name": "isRead",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "readAt": {
+          "name": "readAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "isEdited": {
+          "name": "isEdited",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "editedAt": {
+          "name": "editedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "isActive": {
+          "name": "isActive",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "deletedAt": {
+          "name": "deletedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "parentId": {
+          "name": "parentId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "replyCount": {
+          "name": "replyCount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "lastReplyAt": {
+          "name": "lastReplyAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mirroredFromId": {
+          "name": "mirroredFromId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "quotedMessageId": {
+          "name": "quotedMessageId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "direct_messages_conversation_id_idx": {
+          "name": "direct_messages_conversation_id_idx",
+          "columns": [
+            {
+              "expression": "conversationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "direct_messages_sender_id_idx": {
+          "name": "direct_messages_sender_id_idx",
+          "columns": [
+            {
+              "expression": "senderId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "direct_messages_created_at_idx": {
+          "name": "direct_messages_created_at_idx",
+          "columns": [
+            {
+              "expression": "createdAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "direct_messages_file_id_idx": {
+          "name": "direct_messages_file_id_idx",
+          "columns": [
+            {
+              "expression": "fileId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "direct_messages_conversation_active_created_idx": {
+          "name": "direct_messages_conversation_active_created_idx",
+          "columns": [
+            {
+              "expression": "conversationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "isActive",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "createdAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "direct_messages_inactive_deleted_at_idx": {
+          "name": "direct_messages_inactive_deleted_at_idx",
+          "columns": [
+            {
+              "expression": "isActive",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deletedAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "direct_messages_conversation_created_idx": {
+          "name": "direct_messages_conversation_created_idx",
+          "columns": [
+            {
+              "expression": "conversationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "createdAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "direct_messages_conversation_is_read_idx": {
+          "name": "direct_messages_conversation_is_read_idx",
+          "columns": [
+            {
+              "expression": "conversationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "isRead",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "direct_messages_unread_count_idx": {
+          "name": "direct_messages_unread_count_idx",
+          "columns": [
+            {
+              "expression": "conversationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "senderId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "isRead",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "direct_messages_parent_created_idx": {
+          "name": "direct_messages_parent_created_idx",
+          "columns": [
+            {
+              "expression": "parentId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "createdAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "direct_messages_quoted_id_idx": {
+          "name": "direct_messages_quoted_id_idx",
+          "columns": [
+            {
+              "expression": "quotedMessageId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "direct_messages_conversationId_dm_conversations_id_fk": {
+          "name": "direct_messages_conversationId_dm_conversations_id_fk",
+          "tableFrom": "direct_messages",
+          "tableTo": "dm_conversations",
+          "columnsFrom": [
+            "conversationId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "direct_messages_senderId_users_id_fk": {
+          "name": "direct_messages_senderId_users_id_fk",
+          "tableFrom": "direct_messages",
+          "tableTo": "users",
+          "columnsFrom": [
+            "senderId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "direct_messages_fileId_files_id_fk": {
+          "name": "direct_messages_fileId_files_id_fk",
+          "tableFrom": "direct_messages",
+          "tableTo": "files",
+          "columnsFrom": [
+            "fileId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "direct_messages_parentId_direct_messages_id_fk": {
+          "name": "direct_messages_parentId_direct_messages_id_fk",
+          "tableFrom": "direct_messages",
+          "tableTo": "direct_messages",
+          "columnsFrom": [
+            "parentId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "direct_messages_mirroredFromId_direct_messages_id_fk": {
+          "name": "direct_messages_mirroredFromId_direct_messages_id_fk",
+          "tableFrom": "direct_messages",
+          "tableTo": "direct_messages",
+          "columnsFrom": [
+            "mirroredFromId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "direct_messages_quotedMessageId_direct_messages_id_fk": {
+          "name": "direct_messages_quotedMessageId_direct_messages_id_fk",
+          "tableFrom": "direct_messages",
+          "tableTo": "direct_messages",
+          "columnsFrom": [
+            "quotedMessageId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.dm_conversations": {
+      "name": "dm_conversations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "participant1Id": {
+          "name": "participant1Id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "participant2Id": {
+          "name": "participant2Id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "lastMessageAt": {
+          "name": "lastMessageAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lastMessagePreview": {
+          "name": "lastMessagePreview",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "participant1LastRead": {
+          "name": "participant1LastRead",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "participant2LastRead": {
+          "name": "participant2LastRead",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "dm_conversations_participant1_id_idx": {
+          "name": "dm_conversations_participant1_id_idx",
+          "columns": [
+            {
+              "expression": "participant1Id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "dm_conversations_participant2_id_idx": {
+          "name": "dm_conversations_participant2_id_idx",
+          "columns": [
+            {
+              "expression": "participant2Id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "dm_conversations_last_message_at_idx": {
+          "name": "dm_conversations_last_message_at_idx",
+          "columns": [
+            {
+              "expression": "lastMessageAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "dm_conversations_participant1_last_message_idx": {
+          "name": "dm_conversations_participant1_last_message_idx",
+          "columns": [
+            {
+              "expression": "participant1Id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "lastMessageAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "dm_conversations_participant2_last_message_idx": {
+          "name": "dm_conversations_participant2_last_message_idx",
+          "columns": [
+            {
+              "expression": "participant2Id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "lastMessageAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "dm_conversations_participant1Id_users_id_fk": {
+          "name": "dm_conversations_participant1Id_users_id_fk",
+          "tableFrom": "dm_conversations",
+          "tableTo": "users",
+          "columnsFrom": [
+            "participant1Id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "dm_conversations_participant2Id_users_id_fk": {
+          "name": "dm_conversations_participant2Id_users_id_fk",
+          "tableFrom": "dm_conversations",
+          "tableTo": "users",
+          "columnsFrom": [
+            "participant2Id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "dm_conversations_participant_pair_key": {
+          "name": "dm_conversations_participant_pair_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "participant1Id",
+            "participant2Id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.dm_message_reactions": {
+      "name": "dm_message_reactions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "messageId": {
+          "name": "messageId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "emoji": {
+          "name": "emoji",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "dm_unique_reaction_idx": {
+          "name": "dm_unique_reaction_idx",
+          "columns": [
+            {
+              "expression": "messageId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "emoji",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "dm_reaction_message_idx": {
+          "name": "dm_reaction_message_idx",
+          "columns": [
+            {
+              "expression": "messageId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "dm_message_reactions_messageId_direct_messages_id_fk": {
+          "name": "dm_message_reactions_messageId_direct_messages_id_fk",
+          "tableFrom": "dm_message_reactions",
+          "tableTo": "direct_messages",
+          "columnsFrom": [
+            "messageId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "dm_message_reactions_userId_users_id_fk": {
+          "name": "dm_message_reactions_userId_users_id_fk",
+          "tableFrom": "dm_message_reactions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.dm_thread_followers": {
+      "name": "dm_thread_followers",
+      "schema": "",
+      "columns": {
+        "rootMessageId": {
+          "name": "rootMessageId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "dm_thread_followers_user_id_idx": {
+          "name": "dm_thread_followers_user_id_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "dm_thread_followers_rootMessageId_direct_messages_id_fk": {
+          "name": "dm_thread_followers_rootMessageId_direct_messages_id_fk",
+          "tableFrom": "dm_thread_followers",
+          "tableTo": "direct_messages",
+          "columnsFrom": [
+            "rootMessageId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "dm_thread_followers_userId_users_id_fk": {
+          "name": "dm_thread_followers_userId_users_id_fk",
+          "tableFrom": "dm_thread_followers",
+          "tableTo": "users",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "dm_thread_followers_rootMessageId_userId_pk": {
+          "name": "dm_thread_followers_rootMessageId_userId_pk",
+          "columns": [
+            "rootMessageId",
+            "userId"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.stripe_events": {
+      "name": "stripe_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "processedAt": {
+          "name": "processedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "stripe_events_type_idx": {
+          "name": "stripe_events_type_idx",
+          "columns": [
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "stripe_events_processed_at_idx": {
+          "name": "stripe_events_processed_at_idx",
+          "columns": [
+            {
+              "expression": "processedAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.subscriptions": {
+      "name": "subscriptions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stripeSubscriptionId": {
+          "name": "stripeSubscriptionId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stripePriceId": {
+          "name": "stripePriceId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "currentPeriodStart": {
+          "name": "currentPeriodStart",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "currentPeriodEnd": {
+          "name": "currentPeriodEnd",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cancelAtPeriodEnd": {
+          "name": "cancelAtPeriodEnd",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "gifted": {
+          "name": "gifted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "stripeScheduleId": {
+          "name": "stripeScheduleId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scheduledPriceId": {
+          "name": "scheduledPriceId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scheduledChangeDate": {
+          "name": "scheduledChangeDate",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "subscriptions_user_id_idx": {
+          "name": "subscriptions_user_id_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "subscriptions_stripe_subscription_id_idx": {
+          "name": "subscriptions_stripe_subscription_id_idx",
+          "columns": [
+            {
+              "expression": "stripeSubscriptionId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "subscriptions_stripe_schedule_id_idx": {
+          "name": "subscriptions_stripe_schedule_id_idx",
+          "columns": [
+            {
+              "expression": "stripeScheduleId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "subscriptions_userId_users_id_fk": {
+          "name": "subscriptions_userId_users_id_fk",
+          "tableFrom": "subscriptions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "subscriptions_stripeSubscriptionId_unique": {
+          "name": "subscriptions_stripeSubscriptionId_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "stripeSubscriptionId"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.contact_submissions": {
+      "name": "contact_submissions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subject": {
+          "name": "subject",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "message": {
+          "name": "message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "resolvedAt": {
+          "name": "resolvedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "contact_submissions_email_idx": {
+          "name": "contact_submissions_email_idx",
+          "columns": [
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "contact_submissions_created_at_idx": {
+          "name": "contact_submissions_created_at_idx",
+          "columns": [
+            {
+              "expression": "createdAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.feedback_submissions": {
+      "name": "feedback_submissions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "message": {
+          "name": "message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "attachments": {
+          "name": "attachments",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "page_url": {
+          "name": "page_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "screen_size": {
+          "name": "screen_size",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "viewport_size": {
+          "name": "viewport_size",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "app_version": {
+          "name": "app_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "console_errors": {
+          "name": "console_errors",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'new'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "feedback_submissions_user_id_idx": {
+          "name": "feedback_submissions_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "feedback_submissions_status_idx": {
+          "name": "feedback_submissions_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "feedback_submissions_created_at_idx": {
+          "name": "feedback_submissions_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "feedback_submissions_user_id_users_id_fk": {
+          "name": "feedback_submissions_user_id_users_id_fk",
+          "tableFrom": "feedback_submissions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.file_conversations": {
+      "name": "file_conversations",
+      "schema": "",
+      "columns": {
+        "fileId": {
+          "name": "fileId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "conversationId": {
+          "name": "conversationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "linkedBy": {
+          "name": "linkedBy",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "linkedAt": {
+          "name": "linkedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "linkSource": {
+          "name": "linkSource",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "file_conversations_file_id_idx": {
+          "name": "file_conversations_file_id_idx",
+          "columns": [
+            {
+              "expression": "fileId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "file_conversations_conversation_id_idx": {
+          "name": "file_conversations_conversation_id_idx",
+          "columns": [
+            {
+              "expression": "conversationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "file_conversations_fileId_files_id_fk": {
+          "name": "file_conversations_fileId_files_id_fk",
+          "tableFrom": "file_conversations",
+          "tableTo": "files",
+          "columnsFrom": [
+            "fileId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "file_conversations_conversationId_dm_conversations_id_fk": {
+          "name": "file_conversations_conversationId_dm_conversations_id_fk",
+          "tableFrom": "file_conversations",
+          "tableTo": "dm_conversations",
+          "columnsFrom": [
+            "conversationId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "file_conversations_linkedBy_users_id_fk": {
+          "name": "file_conversations_linkedBy_users_id_fk",
+          "tableFrom": "file_conversations",
+          "tableTo": "users",
+          "columnsFrom": [
+            "linkedBy"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "file_conversations_fileId_conversationId_pk": {
+          "name": "file_conversations_fileId_conversationId_pk",
+          "columns": [
+            "fileId",
+            "conversationId"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.file_pages": {
+      "name": "file_pages",
+      "schema": "",
+      "columns": {
+        "fileId": {
+          "name": "fileId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pageId": {
+          "name": "pageId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "linkedBy": {
+          "name": "linkedBy",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "linkedAt": {
+          "name": "linkedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "linkSource": {
+          "name": "linkSource",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "file_pages_file_id_idx": {
+          "name": "file_pages_file_id_idx",
+          "columns": [
+            {
+              "expression": "fileId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "file_pages_page_id_idx": {
+          "name": "file_pages_page_id_idx",
+          "columns": [
+            {
+              "expression": "pageId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "file_pages_fileId_files_id_fk": {
+          "name": "file_pages_fileId_files_id_fk",
+          "tableFrom": "file_pages",
+          "tableTo": "files",
+          "columnsFrom": [
+            "fileId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "file_pages_pageId_pages_id_fk": {
+          "name": "file_pages_pageId_pages_id_fk",
+          "tableFrom": "file_pages",
+          "tableTo": "pages",
+          "columnsFrom": [
+            "pageId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "file_pages_linkedBy_users_id_fk": {
+          "name": "file_pages_linkedBy_users_id_fk",
+          "tableFrom": "file_pages",
+          "tableTo": "users",
+          "columnsFrom": [
+            "linkedBy"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "file_pages_fileId_pageId_pk": {
+          "name": "file_pages_fileId_pageId_pk",
+          "columns": [
+            "fileId",
+            "pageId"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.files": {
+      "name": "files",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "driveId": {
+          "name": "driveId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sizeBytes": {
+          "name": "sizeBytes",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "mimeType": {
+          "name": "mimeType",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "storagePath": {
+          "name": "storagePath",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "checksumVersion": {
+          "name": "checksumVersion",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "createdBy": {
+          "name": "createdBy",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lastAccessedAt": {
+          "name": "lastAccessedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "files_drive_id_idx": {
+          "name": "files_drive_id_idx",
+          "columns": [
+            {
+              "expression": "driveId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "files_driveId_drives_id_fk": {
+          "name": "files_driveId_drives_id_fk",
+          "tableFrom": "files",
+          "tableTo": "drives",
+          "columnsFrom": [
+            "driveId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "files_createdBy_users_id_fk": {
+          "name": "files_createdBy_users_id_fk",
+          "tableFrom": "files",
+          "tableTo": "users",
+          "columnsFrom": [
+            "createdBy"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.pending_uploads": {
+      "name": "pending_uploads",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "fileSize": {
+          "name": "fileSize",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expiresAt": {
+          "name": "expiresAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "pending_uploads_user_expires_idx": {
+          "name": "pending_uploads_user_expires_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "expiresAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "pending_uploads_expires_idx": {
+          "name": "pending_uploads_expires_idx",
+          "columns": [
+            {
+              "expression": "expiresAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "pending_uploads_userId_users_id_fk": {
+          "name": "pending_uploads_userId_users_id_fk",
+          "tableFrom": "pending_uploads",
+          "tableTo": "users",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.task_assignees": {
+      "name": "task_assignees",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "taskId": {
+          "name": "taskId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "agentPageId": {
+          "name": "agentPageId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "task_assignees_task_id_idx": {
+          "name": "task_assignees_task_id_idx",
+          "columns": [
+            {
+              "expression": "taskId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "task_assignees_user_id_idx": {
+          "name": "task_assignees_user_id_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "task_assignees_agent_page_id_idx": {
+          "name": "task_assignees_agent_page_id_idx",
+          "columns": [
+            {
+              "expression": "agentPageId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "task_assignees_taskId_task_items_id_fk": {
+          "name": "task_assignees_taskId_task_items_id_fk",
+          "tableFrom": "task_assignees",
+          "tableTo": "task_items",
+          "columnsFrom": [
+            "taskId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "task_assignees_userId_users_id_fk": {
+          "name": "task_assignees_userId_users_id_fk",
+          "tableFrom": "task_assignees",
+          "tableTo": "users",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "task_assignees_agentPageId_pages_id_fk": {
+          "name": "task_assignees_agentPageId_pages_id_fk",
+          "tableFrom": "task_assignees",
+          "tableTo": "pages",
+          "columnsFrom": [
+            "agentPageId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "task_assignees_task_user": {
+          "name": "task_assignees_task_user",
+          "nullsNotDistinct": false,
+          "columns": [
+            "taskId",
+            "userId"
+          ]
+        },
+        "task_assignees_task_agent": {
+          "name": "task_assignees_task_agent",
+          "nullsNotDistinct": false,
+          "columns": [
+            "taskId",
+            "agentPageId"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "task_assignees_has_assignee": {
+          "name": "task_assignees_has_assignee",
+          "value": "(\"userId\" IS NOT NULL OR \"agentPageId\" IS NOT NULL)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.task_items": {
+      "name": "task_items",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "assigneeId": {
+          "name": "assigneeId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "assigneeAgentId": {
+          "name": "assigneeAgentId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pageId": {
+          "name": "pageId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "priority": {
+          "name": "priority",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'medium'"
+        },
+        "dueDate": {
+          "name": "dueDate",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completedAt": {
+          "name": "completedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "task_items_assignee_id_idx": {
+          "name": "task_items_assignee_id_idx",
+          "columns": [
+            {
+              "expression": "assigneeId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "task_items_assignee_agent_id_idx": {
+          "name": "task_items_assignee_agent_id_idx",
+          "columns": [
+            {
+              "expression": "assigneeAgentId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "task_items_page_id_idx": {
+          "name": "task_items_page_id_idx",
+          "columns": [
+            {
+              "expression": "pageId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "task_items_due_date_idx": {
+          "name": "task_items_due_date_idx",
+          "columns": [
+            {
+              "expression": "dueDate",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "task_items_userId_users_id_fk": {
+          "name": "task_items_userId_users_id_fk",
+          "tableFrom": "task_items",
+          "tableTo": "users",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "task_items_assigneeId_users_id_fk": {
+          "name": "task_items_assigneeId_users_id_fk",
+          "tableFrom": "task_items",
+          "tableTo": "users",
+          "columnsFrom": [
+            "assigneeId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "task_items_assigneeAgentId_pages_id_fk": {
+          "name": "task_items_assigneeAgentId_pages_id_fk",
+          "tableFrom": "task_items",
+          "tableTo": "pages",
+          "columnsFrom": [
+            "assigneeAgentId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "task_items_pageId_pages_id_fk": {
+          "name": "task_items_pageId_pages_id_fk",
+          "tableFrom": "task_items",
+          "tableTo": "pages",
+          "columnsFrom": [
+            "pageId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "task_items_pageId_unique": {
+          "name": "task_items_pageId_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "pageId"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.task_lists": {
+      "name": "task_lists",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pageId": {
+          "name": "pageId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "conversationId": {
+          "name": "conversationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "task_lists_page_id_idx": {
+          "name": "task_lists_page_id_idx",
+          "columns": [
+            {
+              "expression": "pageId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "task_lists_conversation_id_idx": {
+          "name": "task_lists_conversation_id_idx",
+          "columns": [
+            {
+              "expression": "conversationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "task_lists_user_id_idx": {
+          "name": "task_lists_user_id_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "task_lists_userId_users_id_fk": {
+          "name": "task_lists_userId_users_id_fk",
+          "tableFrom": "task_lists",
+          "tableTo": "users",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "task_lists_pageId_pages_id_fk": {
+          "name": "task_lists_pageId_pages_id_fk",
+          "tableFrom": "task_lists",
+          "tableTo": "pages",
+          "columnsFrom": [
+            "pageId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.task_status_configs": {
+      "name": "task_status_configs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "taskListId": {
+          "name": "taskListId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "color": {
+          "name": "color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "group": {
+          "name": "group",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "task_status_configs_task_list_id_idx": {
+          "name": "task_status_configs_task_list_id_idx",
+          "columns": [
+            {
+              "expression": "taskListId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "task_status_configs_taskListId_task_lists_id_fk": {
+          "name": "task_status_configs_taskListId_task_lists_id_fk",
+          "tableFrom": "task_status_configs",
+          "tableTo": "task_lists",
+          "columnsFrom": [
+            "taskListId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "task_status_configs_task_list_slug": {
+          "name": "task_status_configs_task_list_slug",
+          "nullsNotDistinct": false,
+          "columns": [
+            "taskListId",
+            "slug"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sheet_cell_deps": {
+      "name": "sheet_cell_deps",
+      "schema": "",
+      "columns": {
+        "tabId": {
+          "name": "tabId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "address": {
+          "name": "address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "dependsOn": {
+          "name": "dependsOn",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "dependents": {
+          "name": "dependents",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "sheet_cell_deps_tab_idx": {
+          "name": "sheet_cell_deps_tab_idx",
+          "columns": [
+            {
+              "expression": "tabId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "sheet_cell_deps_tabId_sheet_tabs_id_fk": {
+          "name": "sheet_cell_deps_tabId_sheet_tabs_id_fk",
+          "tableFrom": "sheet_cell_deps",
+          "tableTo": "sheet_tabs",
+          "columnsFrom": [
+            "tabId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "sheet_cell_deps_tabId_address_pk": {
+          "name": "sheet_cell_deps_tabId_address_pk",
+          "columns": [
+            "tabId",
+            "address"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sheet_changes": {
+      "name": "sheet_changes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "pageId": {
+          "name": "pageId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tabId": {
+          "name": "tabId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "seq": {
+          "name": "seq",
+          "type": "bigserial",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actorUserId": {
+          "name": "actorUserId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "actorEmail": {
+          "name": "actorEmail",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "changeGroupId": {
+          "name": "changeGroupId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "op": {
+          "name": "op",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "address": {
+          "name": "address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rowIndex": {
+          "name": "rowIndex",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "before": {
+          "name": "before",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "after": {
+          "name": "after",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "sheet_changes_page_seq_idx": {
+          "name": "sheet_changes_page_seq_idx",
+          "columns": [
+            {
+              "expression": "pageId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "seq",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sheet_changes_tab_seq_idx": {
+          "name": "sheet_changes_tab_seq_idx",
+          "columns": [
+            {
+              "expression": "tabId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "seq",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sheet_changes_created_at_idx": {
+          "name": "sheet_changes_created_at_idx",
+          "columns": [
+            {
+              "expression": "createdAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "sheet_changes_pageId_pages_id_fk": {
+          "name": "sheet_changes_pageId_pages_id_fk",
+          "tableFrom": "sheet_changes",
+          "tableTo": "pages",
+          "columnsFrom": [
+            "pageId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "sheet_changes_actorUserId_users_id_fk": {
+          "name": "sheet_changes_actorUserId_users_id_fk",
+          "tableFrom": "sheet_changes",
+          "tableTo": "users",
+          "columnsFrom": [
+            "actorUserId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sheet_range_deps": {
+      "name": "sheet_range_deps",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "tabId": {
+          "name": "tabId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "formulaAddress": {
+          "name": "formulaAddress",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rowStart": {
+          "name": "rowStart",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rowEnd": {
+          "name": "rowEnd",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "colStart": {
+          "name": "colStart",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "colEnd": {
+          "name": "colEnd",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "sheet_range_deps_tab_idx": {
+          "name": "sheet_range_deps_tab_idx",
+          "columns": [
+            {
+              "expression": "tabId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sheet_range_deps_cover_idx": {
+          "name": "sheet_range_deps_cover_idx",
+          "columns": [
+            {
+              "expression": "tabId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "rowStart",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "rowEnd",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sheet_range_deps_formula_idx": {
+          "name": "sheet_range_deps_formula_idx",
+          "columns": [
+            {
+              "expression": "tabId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "formulaAddress",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "sheet_range_deps_tabId_sheet_tabs_id_fk": {
+          "name": "sheet_range_deps_tabId_sheet_tabs_id_fk",
+          "tableFrom": "sheet_range_deps",
+          "tableTo": "sheet_tabs",
+          "columnsFrom": [
+            "tabId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "sheet_range_deps_bounds_ordered": {
+          "name": "sheet_range_deps_bounds_ordered",
+          "value": "(\"sheet_range_deps\".\"rowEnd\" IS NULL OR \"sheet_range_deps\".\"rowEnd\" >= \"sheet_range_deps\".\"rowStart\") AND (\"sheet_range_deps\".\"colEnd\" IS NULL OR \"sheet_range_deps\".\"colEnd\" >= \"sheet_range_deps\".\"colStart\")"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.sheet_rows": {
+      "name": "sheet_rows",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "tabId": {
+          "name": "tabId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pageId": {
+          "name": "pageId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rowIndex": {
+          "name": "rowIndex",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cells": {
+          "name": "cells",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "sheet_rows_page_row_idx": {
+          "name": "sheet_rows_page_row_idx",
+          "columns": [
+            {
+              "expression": "pageId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "rowIndex",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sheet_rows_tab_row_idx": {
+          "name": "sheet_rows_tab_row_idx",
+          "columns": [
+            {
+              "expression": "tabId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "rowIndex",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sheet_rows_cells_gin": {
+          "name": "sheet_rows_cells_gin",
+          "columns": [
+            {
+              "expression": "cells",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "sheet_rows_tabId_sheet_tabs_id_fk": {
+          "name": "sheet_rows_tabId_sheet_tabs_id_fk",
+          "tableFrom": "sheet_rows",
+          "tableTo": "sheet_tabs",
+          "columnsFrom": [
+            "tabId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "sheet_rows_pageId_pages_id_fk": {
+          "name": "sheet_rows_pageId_pages_id_fk",
+          "tableFrom": "sheet_rows",
+          "tableTo": "pages",
+          "columnsFrom": [
+            "pageId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "sheet_rows_tab_row_unique": {
+          "name": "sheet_rows_tab_row_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "tabId",
+            "rowIndex"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "sheet_rows_row_index_non_negative": {
+          "name": "sheet_rows_row_index_non_negative",
+          "value": "\"sheet_rows\".\"rowIndex\" >= 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.sheet_tabs": {
+      "name": "sheet_tabs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "pageId": {
+          "name": "pageId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tabIndex": {
+          "name": "tabIndex",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rowCount": {
+          "name": "rowCount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "columnCount": {
+          "name": "columnCount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "frozenRows": {
+          "name": "frozenRows",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "frozenColumns": {
+          "name": "frozenColumns",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "columnFormats": {
+          "name": "columnFormats",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "columnWidths": {
+          "name": "columnWidths",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rowHeights": {
+          "name": "rowHeights",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ranges": {
+          "name": "ranges",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "conditionalFormats": {
+          "name": "conditionalFormats",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "sheet_tabs_page_id_idx": {
+          "name": "sheet_tabs_page_id_idx",
+          "columns": [
+            {
+              "expression": "pageId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "sheet_tabs_pageId_pages_id_fk": {
+          "name": "sheet_tabs_pageId_pages_id_fk",
+          "tableFrom": "sheet_tabs",
+          "tableTo": "pages",
+          "columnsFrom": [
+            "pageId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "sheet_tabs_page_tab_unique": {
+          "name": "sheet_tabs_page_tab_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "pageId",
+            "tabIndex"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "sheet_tabs_extent_non_negative": {
+          "name": "sheet_tabs_extent_non_negative",
+          "value": "\"sheet_tabs\".\"rowCount\" >= 0 AND \"sheet_tabs\".\"columnCount\" >= 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.security_audit_log": {
+      "name": "security_audit_log",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "service_id": {
+          "name": "service_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resource_type": {
+          "name": "resource_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resource_id": {
+          "name": "resource_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ip_bidx": {
+          "name": "ip_bidx",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "geo_location": {
+          "name": "geo_location",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "details": {
+          "name": "details",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "risk_score": {
+          "name": "risk_score",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "anomaly_flags": {
+          "name": "anomaly_flags",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "chain_seq": {
+          "name": "chain_seq",
+          "type": "bigserial",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "previous_hash": {
+          "name": "previous_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_hash": {
+          "name": "event_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_security_audit_timestamp": {
+          "name": "idx_security_audit_timestamp",
+          "columns": [
+            {
+              "expression": "timestamp",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_security_audit_user_timestamp": {
+          "name": "idx_security_audit_user_timestamp",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "timestamp",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_security_audit_event_type": {
+          "name": "idx_security_audit_event_type",
+          "columns": [
+            {
+              "expression": "event_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "timestamp",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_security_audit_resource": {
+          "name": "idx_security_audit_resource",
+          "columns": [
+            {
+              "expression": "resource_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "resource_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "timestamp",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_security_audit_ip": {
+          "name": "idx_security_audit_ip",
+          "columns": [
+            {
+              "expression": "ip_address",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "timestamp",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_security_audit_ip_bidx": {
+          "name": "idx_security_audit_ip_bidx",
+          "columns": [
+            {
+              "expression": "ip_bidx",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "timestamp",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_security_audit_event_hash": {
+          "name": "idx_security_audit_event_hash",
+          "columns": [
+            {
+              "expression": "event_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_security_audit_chain_seq": {
+          "name": "idx_security_audit_chain_seq",
+          "columns": [
+            {
+              "expression": "chain_seq",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_security_audit_risk_score": {
+          "name": "idx_security_audit_risk_score",
+          "columns": [
+            {
+              "expression": "risk_score",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_security_audit_session": {
+          "name": "idx_security_audit_session",
+          "columns": [
+            {
+              "expression": "session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "timestamp",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "security_audit_log_user_id_users_id_fk": {
+          "name": "security_audit_log_user_id_users_id_fk",
+          "tableFrom": "security_audit_log",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_page_views": {
+      "name": "user_page_views",
+      "schema": "",
+      "columns": {
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pageId": {
+          "name": "pageId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "viewedAt": {
+          "name": "viewedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "user_page_views_user_id_idx": {
+          "name": "user_page_views_user_id_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_page_views_page_id_idx": {
+          "name": "user_page_views_page_id_idx",
+          "columns": [
+            {
+              "expression": "pageId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_page_views_user_page_idx": {
+          "name": "user_page_views_user_page_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "pageId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_page_views_userId_users_id_fk": {
+          "name": "user_page_views_userId_users_id_fk",
+          "tableFrom": "user_page_views",
+          "tableTo": "users",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "user_page_views_pageId_pages_id_fk": {
+          "name": "user_page_views_pageId_pages_id_fk",
+          "tableFrom": "user_page_views",
+          "tableTo": "pages",
+          "columnsFrom": [
+            "pageId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "user_page_views_userId_pageId_pk": {
+          "name": "user_page_views_userId_pageId_pk",
+          "columns": [
+            "userId",
+            "pageId"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_hotkey_preferences": {
+      "name": "user_hotkey_preferences",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "hotkeyId": {
+          "name": "hotkeyId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "binding": {
+          "name": "binding",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "user_hotkey_preferences_user_hotkey_idx": {
+          "name": "user_hotkey_preferences_user_hotkey_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "hotkeyId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_hotkey_preferences_user_idx": {
+          "name": "user_hotkey_preferences_user_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_hotkey_preferences_userId_users_id_fk": {
+          "name": "user_hotkey_preferences_userId_users_id_fk",
+          "tableFrom": "user_hotkey_preferences",
+          "tableTo": "users",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.push_notification_tokens": {
+      "name": "push_notification_tokens",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "platform": {
+          "name": "platform",
+          "type": "PushPlatformType",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "deviceId": {
+          "name": "deviceId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deviceName": {
+          "name": "deviceName",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "isActive": {
+          "name": "isActive",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "webPushSubscription": {
+          "name": "webPushSubscription",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "lastUsedAt": {
+          "name": "lastUsedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "failedAttempts": {
+          "name": "failedAttempts",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'0'"
+        },
+        "lastFailedAt": {
+          "name": "lastFailedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "push_notification_tokens_user_id_idx": {
+          "name": "push_notification_tokens_user_id_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "push_notification_tokens_token_idx": {
+          "name": "push_notification_tokens_token_idx",
+          "columns": [
+            {
+              "expression": "token",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "push_notification_tokens_platform_idx": {
+          "name": "push_notification_tokens_platform_idx",
+          "columns": [
+            {
+              "expression": "platform",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "push_notification_tokens_active_idx": {
+          "name": "push_notification_tokens_active_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "isActive",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "push_notification_tokens_userId_users_id_fk": {
+          "name": "push_notification_tokens_userId_users_id_fk",
+          "tableFrom": "push_notification_tokens",
+          "tableTo": "users",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.global_assistant_config": {
+      "name": "global_assistant_config",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "enabled_user_integrations": {
+          "name": "enabled_user_integrations",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "drive_overrides": {
+          "name": "drive_overrides",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "inherit_drive_integrations": {
+          "name": "inherit_drive_integrations",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "global_assistant_config_user_id_users_id_fk": {
+          "name": "global_assistant_config_user_id_users_id_fk",
+          "tableFrom": "global_assistant_config",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "global_assistant_config_user_id_unique": {
+          "name": "global_assistant_config_user_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.integration_audit_log": {
+      "name": "integration_audit_log",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "drive_id": {
+          "name": "drive_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "connection_id": {
+          "name": "connection_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tool_name": {
+          "name": "tool_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "input_summary": {
+          "name": "input_summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "success": {
+          "name": "success",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "response_code": {
+          "name": "response_code",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_type": {
+          "name": "error_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "duration_ms": {
+          "name": "duration_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "integration_audit_log_drive_id_idx": {
+          "name": "integration_audit_log_drive_id_idx",
+          "columns": [
+            {
+              "expression": "drive_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "integration_audit_log_connection_id_idx": {
+          "name": "integration_audit_log_connection_id_idx",
+          "columns": [
+            {
+              "expression": "connection_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "integration_audit_log_created_at_idx": {
+          "name": "integration_audit_log_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "integration_audit_log_drive_created_at_idx": {
+          "name": "integration_audit_log_drive_created_at_idx",
+          "columns": [
+            {
+              "expression": "drive_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "integration_audit_log_drive_id_drives_id_fk": {
+          "name": "integration_audit_log_drive_id_drives_id_fk",
+          "tableFrom": "integration_audit_log",
+          "tableTo": "drives",
+          "columnsFrom": [
+            "drive_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "integration_audit_log_agent_id_pages_id_fk": {
+          "name": "integration_audit_log_agent_id_pages_id_fk",
+          "tableFrom": "integration_audit_log",
+          "tableTo": "pages",
+          "columnsFrom": [
+            "agent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "integration_audit_log_user_id_users_id_fk": {
+          "name": "integration_audit_log_user_id_users_id_fk",
+          "tableFrom": "integration_audit_log",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "integration_audit_log_connection_id_integration_connections_id_fk": {
+          "name": "integration_audit_log_connection_id_integration_connections_id_fk",
+          "tableFrom": "integration_audit_log",
+          "tableTo": "integration_connections",
+          "columnsFrom": [
+            "connection_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.integration_connections": {
+      "name": "integration_connections",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "drive_id": {
+          "name": "drive_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "integration_connection_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "status_message": {
+          "name": "status_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "credentials": {
+          "name": "credentials",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "base_url_override": {
+          "name": "base_url_override",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "config_overrides": {
+          "name": "config_overrides",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "account_metadata": {
+          "name": "account_metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "visibility": {
+          "name": "visibility",
+          "type": "integration_visibility",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'owned_drives'"
+        },
+        "oauth_state": {
+          "name": "oauth_state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "connected_by": {
+          "name": "connected_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "connected_at": {
+          "name": "connected_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_health_check": {
+          "name": "last_health_check",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "integration_connections_provider_id_idx": {
+          "name": "integration_connections_provider_id_idx",
+          "columns": [
+            {
+              "expression": "provider_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "integration_connections_user_id_idx": {
+          "name": "integration_connections_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "integration_connections_drive_id_idx": {
+          "name": "integration_connections_drive_id_idx",
+          "columns": [
+            {
+              "expression": "drive_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "integration_connections_provider_id_integration_providers_id_fk": {
+          "name": "integration_connections_provider_id_integration_providers_id_fk",
+          "tableFrom": "integration_connections",
+          "tableTo": "integration_providers",
+          "columnsFrom": [
+            "provider_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "integration_connections_user_id_users_id_fk": {
+          "name": "integration_connections_user_id_users_id_fk",
+          "tableFrom": "integration_connections",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "integration_connections_drive_id_drives_id_fk": {
+          "name": "integration_connections_drive_id_drives_id_fk",
+          "tableFrom": "integration_connections",
+          "tableTo": "drives",
+          "columnsFrom": [
+            "drive_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "integration_connections_connected_by_users_id_fk": {
+          "name": "integration_connections_connected_by_users_id_fk",
+          "tableFrom": "integration_connections",
+          "tableTo": "users",
+          "columnsFrom": [
+            "connected_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "integration_connections_user_provider": {
+          "name": "integration_connections_user_provider",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "provider_id"
+          ]
+        },
+        "integration_connections_drive_provider": {
+          "name": "integration_connections_drive_provider",
+          "nullsNotDistinct": false,
+          "columns": [
+            "drive_id",
+            "provider_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "integration_connections_scope_chk": {
+          "name": "integration_connections_scope_chk",
+          "value": "(\"integration_connections\".\"user_id\" IS NOT NULL AND \"integration_connections\".\"drive_id\" IS NULL) OR (\"integration_connections\".\"user_id\" IS NULL AND \"integration_connections\".\"drive_id\" IS NOT NULL)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.integration_providers": {
+      "name": "integration_providers",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "icon_url": {
+          "name": "icon_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "documentation_url": {
+          "name": "documentation_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider_type": {
+          "name": "provider_type",
+          "type": "integration_provider_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "config": {
+          "name": "config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "openapi_spec": {
+          "name": "openapi_spec",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_system": {
+          "name": "is_system",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "drive_id": {
+          "name": "drive_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "integration_providers_slug_idx": {
+          "name": "integration_providers_slug_idx",
+          "columns": [
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "integration_providers_drive_id_idx": {
+          "name": "integration_providers_drive_id_idx",
+          "columns": [
+            {
+              "expression": "drive_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "integration_providers_created_by_users_id_fk": {
+          "name": "integration_providers_created_by_users_id_fk",
+          "tableFrom": "integration_providers",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "integration_providers_drive_id_drives_id_fk": {
+          "name": "integration_providers_drive_id_drives_id_fk",
+          "tableFrom": "integration_providers",
+          "tableTo": "drives",
+          "columnsFrom": [
+            "drive_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "integration_providers_slug_unique": {
+          "name": "integration_providers_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.integration_tool_grants": {
+      "name": "integration_tool_grants",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "connection_id": {
+          "name": "connection_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "allowed_tools": {
+          "name": "allowed_tools",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "denied_tools": {
+          "name": "denied_tools",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "read_only": {
+          "name": "read_only",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "rate_limit_override": {
+          "name": "rate_limit_override",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "integration_tool_grants_agent_id_idx": {
+          "name": "integration_tool_grants_agent_id_idx",
+          "columns": [
+            {
+              "expression": "agent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "integration_tool_grants_connection_id_idx": {
+          "name": "integration_tool_grants_connection_id_idx",
+          "columns": [
+            {
+              "expression": "connection_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "integration_tool_grants_agent_id_pages_id_fk": {
+          "name": "integration_tool_grants_agent_id_pages_id_fk",
+          "tableFrom": "integration_tool_grants",
+          "tableTo": "pages",
+          "columnsFrom": [
+            "agent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "integration_tool_grants_connection_id_integration_connections_id_fk": {
+          "name": "integration_tool_grants_connection_id_integration_connections_id_fk",
+          "tableFrom": "integration_tool_grants",
+          "tableTo": "integration_connections",
+          "columnsFrom": [
+            "connection_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "integration_tool_grants_agent_connection": {
+          "name": "integration_tool_grants_agent_connection",
+          "nullsNotDistinct": false,
+          "columns": [
+            "agent_id",
+            "connection_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.personalization_candidates": {
+      "name": "personalization_candidates",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "field": {
+          "name": "field",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "claim": {
+          "name": "claim",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "claimKey": {
+          "name": "claimKey",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "evidence": {
+          "name": "evidence",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "occurrences": {
+          "name": "occurrences",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "firstSeenAt": {
+          "name": "firstSeenAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "lastSeenAt": {
+          "name": "lastSeenAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "promotedAt": {
+          "name": "promotedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rejectedAt": {
+          "name": "rejectedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "personalization_candidates_user_field_claim_idx": {
+          "name": "personalization_candidates_user_field_claim_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "field",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "claimKey",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "personalization_candidates_userId_users_id_fk": {
+          "name": "personalization_candidates_userId_users_id_fk",
+          "tableFrom": "personalization_candidates",
+          "tableTo": "users",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "personalization_candidates_field_chk": {
+          "name": "personalization_candidates_field_chk",
+          "value": "\"personalization_candidates\".\"field\" IN ('bio', 'writingStyle', 'rules')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.user_personalization": {
+      "name": "user_personalization",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "bio": {
+          "name": "bio",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "writingStyle": {
+          "name": "writingStyle",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rules": {
+          "name": "rules",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "memoryFolderId": {
+          "name": "memoryFolderId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bioPageId": {
+          "name": "bioPageId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "writingStylePageId": {
+          "name": "writingStylePageId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rulesPageId": {
+          "name": "rulesPageId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "user_personalization_user_idx": {
+          "name": "user_personalization_user_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_personalization_userId_users_id_fk": {
+          "name": "user_personalization_userId_users_id_fk",
+          "tableFrom": "user_personalization",
+          "tableTo": "users",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "user_personalization_memoryFolderId_pages_id_fk": {
+          "name": "user_personalization_memoryFolderId_pages_id_fk",
+          "tableFrom": "user_personalization",
+          "tableTo": "pages",
+          "columnsFrom": [
+            "memoryFolderId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "user_personalization_bioPageId_pages_id_fk": {
+          "name": "user_personalization_bioPageId_pages_id_fk",
+          "tableFrom": "user_personalization",
+          "tableTo": "pages",
+          "columnsFrom": [
+            "bioPageId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "user_personalization_writingStylePageId_pages_id_fk": {
+          "name": "user_personalization_writingStylePageId_pages_id_fk",
+          "tableFrom": "user_personalization",
+          "tableTo": "pages",
+          "columnsFrom": [
+            "writingStylePageId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "user_personalization_rulesPageId_pages_id_fk": {
+          "name": "user_personalization_rulesPageId_pages_id_fk",
+          "tableFrom": "user_personalization",
+          "tableTo": "pages",
+          "columnsFrom": [
+            "rulesPageId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_automation_preferences": {
+      "name": "user_automation_preferences",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pulseEnabled": {
+          "name": "pulseEnabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "user_automation_preferences_user_idx": {
+          "name": "user_automation_preferences_user_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_automation_preferences_userId_users_id_fk": {
+          "name": "user_automation_preferences_userId_users_id_fk",
+          "tableFrom": "user_automation_preferences",
+          "tableTo": "users",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.calendar_event_drives": {
+      "name": "calendar_event_drives",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "eventId": {
+          "name": "eventId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "driveId": {
+          "name": "driveId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sharedBy": {
+          "name": "sharedBy",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sharedAt": {
+          "name": "sharedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "calendar_event_drives_event_id_idx": {
+          "name": "calendar_event_drives_event_id_idx",
+          "columns": [
+            {
+              "expression": "eventId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "calendar_event_drives_drive_id_idx": {
+          "name": "calendar_event_drives_drive_id_idx",
+          "columns": [
+            {
+              "expression": "driveId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "calendar_event_drives_eventId_calendar_events_id_fk": {
+          "name": "calendar_event_drives_eventId_calendar_events_id_fk",
+          "tableFrom": "calendar_event_drives",
+          "tableTo": "calendar_events",
+          "columnsFrom": [
+            "eventId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "calendar_event_drives_driveId_drives_id_fk": {
+          "name": "calendar_event_drives_driveId_drives_id_fk",
+          "tableFrom": "calendar_event_drives",
+          "tableTo": "drives",
+          "columnsFrom": [
+            "driveId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "calendar_event_drives_sharedBy_users_id_fk": {
+          "name": "calendar_event_drives_sharedBy_users_id_fk",
+          "tableFrom": "calendar_event_drives",
+          "tableTo": "users",
+          "columnsFrom": [
+            "sharedBy"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "calendar_event_drives_event_drive_key": {
+          "name": "calendar_event_drives_event_drive_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "eventId",
+            "driveId"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.calendar_events": {
+      "name": "calendar_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "driveId": {
+          "name": "driveId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdById": {
+          "name": "createdById",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pageId": {
+          "name": "pageId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "location": {
+          "name": "location",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "startAt": {
+          "name": "startAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "endAt": {
+          "name": "endAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "allDay": {
+          "name": "allDay",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "timezone": {
+          "name": "timezone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'UTC'"
+        },
+        "recurrenceRule": {
+          "name": "recurrenceRule",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "recurrenceExceptions": {
+          "name": "recurrenceExceptions",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'[]'::jsonb"
+        },
+        "recurringEventId": {
+          "name": "recurringEventId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "originalStartAt": {
+          "name": "originalStartAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "visibility": {
+          "name": "visibility",
+          "type": "EventVisibility",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'DRIVE'"
+        },
+        "color": {
+          "name": "color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'default'"
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "isTrashed": {
+          "name": "isTrashed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "trashedAt": {
+          "name": "trashedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "googleEventId": {
+          "name": "googleEventId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "googleCalendarId": {
+          "name": "googleCalendarId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "syncedFromGoogle": {
+          "name": "syncedFromGoogle",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "lastGoogleSync": {
+          "name": "lastGoogleSync",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "googleSyncReadOnly": {
+          "name": "googleSyncReadOnly",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "calendar_events_drive_id_idx": {
+          "name": "calendar_events_drive_id_idx",
+          "columns": [
+            {
+              "expression": "driveId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "calendar_events_created_by_id_idx": {
+          "name": "calendar_events_created_by_id_idx",
+          "columns": [
+            {
+              "expression": "createdById",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "calendar_events_page_id_idx": {
+          "name": "calendar_events_page_id_idx",
+          "columns": [
+            {
+              "expression": "pageId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "calendar_events_start_at_idx": {
+          "name": "calendar_events_start_at_idx",
+          "columns": [
+            {
+              "expression": "startAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "calendar_events_end_at_idx": {
+          "name": "calendar_events_end_at_idx",
+          "columns": [
+            {
+              "expression": "endAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "calendar_events_drive_id_start_at_idx": {
+          "name": "calendar_events_drive_id_start_at_idx",
+          "columns": [
+            {
+              "expression": "driveId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "startAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "calendar_events_recurring_event_id_idx": {
+          "name": "calendar_events_recurring_event_id_idx",
+          "columns": [
+            {
+              "expression": "recurringEventId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "calendar_events_is_trashed_idx": {
+          "name": "calendar_events_is_trashed_idx",
+          "columns": [
+            {
+              "expression": "isTrashed",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "calendar_events_google_event_id_idx": {
+          "name": "calendar_events_google_event_id_idx",
+          "columns": [
+            {
+              "expression": "googleEventId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "calendar_events_synced_from_google_idx": {
+          "name": "calendar_events_synced_from_google_idx",
+          "columns": [
+            {
+              "expression": "syncedFromGoogle",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "calendar_events_driveId_drives_id_fk": {
+          "name": "calendar_events_driveId_drives_id_fk",
+          "tableFrom": "calendar_events",
+          "tableTo": "drives",
+          "columnsFrom": [
+            "driveId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "calendar_events_createdById_users_id_fk": {
+          "name": "calendar_events_createdById_users_id_fk",
+          "tableFrom": "calendar_events",
+          "tableTo": "users",
+          "columnsFrom": [
+            "createdById"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "calendar_events_pageId_pages_id_fk": {
+          "name": "calendar_events_pageId_pages_id_fk",
+          "tableFrom": "calendar_events",
+          "tableTo": "pages",
+          "columnsFrom": [
+            "pageId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "calendar_events_google_source_per_user_key": {
+          "name": "calendar_events_google_source_per_user_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "createdById",
+            "googleCalendarId",
+            "googleEventId"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.event_attendees": {
+      "name": "event_attendees",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "eventId": {
+          "name": "eventId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "AttendeeStatus",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'PENDING'"
+        },
+        "responseNote": {
+          "name": "responseNote",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "isOrganizer": {
+          "name": "isOrganizer",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "isOptional": {
+          "name": "isOptional",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "invitedAt": {
+          "name": "invitedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "respondedAt": {
+          "name": "respondedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "event_attendees_event_id_idx": {
+          "name": "event_attendees_event_id_idx",
+          "columns": [
+            {
+              "expression": "eventId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "event_attendees_user_id_idx": {
+          "name": "event_attendees_user_id_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "event_attendees_status_idx": {
+          "name": "event_attendees_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "event_attendees_user_id_status_idx": {
+          "name": "event_attendees_user_id_status_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "event_attendees_eventId_calendar_events_id_fk": {
+          "name": "event_attendees_eventId_calendar_events_id_fk",
+          "tableFrom": "event_attendees",
+          "tableTo": "calendar_events",
+          "columnsFrom": [
+            "eventId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "event_attendees_userId_users_id_fk": {
+          "name": "event_attendees_userId_users_id_fk",
+          "tableFrom": "event_attendees",
+          "tableTo": "users",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "event_attendees_event_user_key": {
+          "name": "event_attendees_event_user_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "eventId",
+            "userId"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.google_calendar_connections": {
+      "name": "google_calendar_connections",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "accessToken": {
+          "name": "accessToken",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "refreshToken": {
+          "name": "refreshToken",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tokenExpiresAt": {
+          "name": "tokenExpiresAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "googleEmail": {
+          "name": "googleEmail",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "googleAccountId": {
+          "name": "googleAccountId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "GoogleCalendarConnectionStatus",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "statusMessage": {
+          "name": "statusMessage",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "targetDriveId": {
+          "name": "targetDriveId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "selectedCalendars": {
+          "name": "selectedCalendars",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'[]'::jsonb"
+        },
+        "syncFrequencyMinutes": {
+          "name": "syncFrequencyMinutes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 15
+        },
+        "markAsReadOnly": {
+          "name": "markAsReadOnly",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "lastSyncAt": {
+          "name": "lastSyncAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lastSyncError": {
+          "name": "lastSyncError",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "syncCursor": {
+          "name": "syncCursor",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "webhookChannels": {
+          "name": "webhookChannels",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "google_calendar_connections_user_id_idx": {
+          "name": "google_calendar_connections_user_id_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "google_calendar_connections_status_idx": {
+          "name": "google_calendar_connections_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "google_calendar_connections_target_drive_id_idx": {
+          "name": "google_calendar_connections_target_drive_id_idx",
+          "columns": [
+            {
+              "expression": "targetDriveId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "google_calendar_connections_userId_users_id_fk": {
+          "name": "google_calendar_connections_userId_users_id_fk",
+          "tableFrom": "google_calendar_connections",
+          "tableTo": "users",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "google_calendar_connections_targetDriveId_drives_id_fk": {
+          "name": "google_calendar_connections_targetDriveId_drives_id_fk",
+          "tableFrom": "google_calendar_connections",
+          "tableTo": "drives",
+          "columnsFrom": [
+            "targetDriveId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "google_calendar_connections_userId_unique": {
+          "name": "google_calendar_connections_userId_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "userId"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.calendar_triggers": {
+      "name": "calendar_triggers",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "workflowId": {
+          "name": "workflowId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "calendarEventId": {
+          "name": "calendarEventId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "driveId": {
+          "name": "driveId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scheduledById": {
+          "name": "scheduledById",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "triggerAt": {
+          "name": "triggerAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "occurrenceDate": {
+          "name": "occurrenceDate",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'1970-01-01T00:00:00.000Z'"
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "calendar_triggers_trigger_at_idx": {
+          "name": "calendar_triggers_trigger_at_idx",
+          "columns": [
+            {
+              "expression": "triggerAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "calendar_triggers_scheduled_by_idx": {
+          "name": "calendar_triggers_scheduled_by_idx",
+          "columns": [
+            {
+              "expression": "scheduledById",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "calendar_triggers_calendar_event_idx": {
+          "name": "calendar_triggers_calendar_event_idx",
+          "columns": [
+            {
+              "expression": "calendarEventId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "calendar_triggers_workflow_id_idx": {
+          "name": "calendar_triggers_workflow_id_idx",
+          "columns": [
+            {
+              "expression": "workflowId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "calendar_triggers_workflowId_workflows_id_fk": {
+          "name": "calendar_triggers_workflowId_workflows_id_fk",
+          "tableFrom": "calendar_triggers",
+          "tableTo": "workflows",
+          "columnsFrom": [
+            "workflowId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "calendar_triggers_calendarEventId_calendar_events_id_fk": {
+          "name": "calendar_triggers_calendarEventId_calendar_events_id_fk",
+          "tableFrom": "calendar_triggers",
+          "tableTo": "calendar_events",
+          "columnsFrom": [
+            "calendarEventId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "calendar_triggers_driveId_drives_id_fk": {
+          "name": "calendar_triggers_driveId_drives_id_fk",
+          "tableFrom": "calendar_triggers",
+          "tableTo": "drives",
+          "columnsFrom": [
+            "driveId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "calendar_triggers_scheduledById_users_id_fk": {
+          "name": "calendar_triggers_scheduledById_users_id_fk",
+          "tableFrom": "calendar_triggers",
+          "tableTo": "users",
+          "columnsFrom": [
+            "scheduledById"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "calendar_triggers_event_occurrence_key": {
+          "name": "calendar_triggers_event_occurrence_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "calendarEventId",
+            "occurrenceDate"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.workflows": {
+      "name": "workflows",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "driveId": {
+          "name": "driveId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdBy": {
+          "name": "createdBy",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agentPageId": {
+          "name": "agentPageId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "prompt": {
+          "name": "prompt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "steps": {
+          "name": "steps",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "contextPageIds": {
+          "name": "contextPageIds",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'[]'::jsonb"
+        },
+        "cronExpression": {
+          "name": "cronExpression",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "timezone": {
+          "name": "timezone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'UTC'"
+        },
+        "triggerType": {
+          "name": "triggerType",
+          "type": "WorkflowTriggerType",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'cron'"
+        },
+        "eventTriggers": {
+          "name": "eventTriggers",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "watchedFolderIds": {
+          "name": "watchedFolderIds",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "eventDebounceSecs": {
+          "name": "eventDebounceSecs",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 30
+        },
+        "instructionPageId": {
+          "name": "instructionPageId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "isEnabled": {
+          "name": "isEnabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "nextRunAt": {
+          "name": "nextRunAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "workflows_drive_id_idx": {
+          "name": "workflows_drive_id_idx",
+          "columns": [
+            {
+              "expression": "driveId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "workflows_created_by_idx": {
+          "name": "workflows_created_by_idx",
+          "columns": [
+            {
+              "expression": "createdBy",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "workflows_agent_page_id_idx": {
+          "name": "workflows_agent_page_id_idx",
+          "columns": [
+            {
+              "expression": "agentPageId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "workflows_enabled_next_run_idx": {
+          "name": "workflows_enabled_next_run_idx",
+          "columns": [
+            {
+              "expression": "isEnabled",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "nextRunAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "workflows_enabled_trigger_type_idx": {
+          "name": "workflows_enabled_trigger_type_idx",
+          "columns": [
+            {
+              "expression": "isEnabled",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "triggerType",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "workflows_driveId_drives_id_fk": {
+          "name": "workflows_driveId_drives_id_fk",
+          "tableFrom": "workflows",
+          "tableTo": "drives",
+          "columnsFrom": [
+            "driveId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "workflows_createdBy_users_id_fk": {
+          "name": "workflows_createdBy_users_id_fk",
+          "tableFrom": "workflows",
+          "tableTo": "users",
+          "columnsFrom": [
+            "createdBy"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "workflows_agentPageId_pages_id_fk": {
+          "name": "workflows_agentPageId_pages_id_fk",
+          "tableFrom": "workflows",
+          "tableTo": "pages",
+          "columnsFrom": [
+            "agentPageId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "workflows_instructionPageId_pages_id_fk": {
+          "name": "workflows_instructionPageId_pages_id_fk",
+          "tableFrom": "workflows",
+          "tableTo": "pages",
+          "columnsFrom": [
+            "instructionPageId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.workflow_runs": {
+      "name": "workflow_runs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "workflowId": {
+          "name": "workflowId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sourceTable": {
+          "name": "sourceTable",
+          "type": "WorkflowRunSourceTable",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sourceId": {
+          "name": "sourceId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "triggerAt": {
+          "name": "triggerAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "startedAt": {
+          "name": "startedAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "endedAt": {
+          "name": "endedAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "WorkflowRunStatus",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'running'"
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "durationMs": {
+          "name": "durationMs",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "conversationId": {
+          "name": "conversationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "workflow_runs_workflow_started_at_idx": {
+          "name": "workflow_runs_workflow_started_at_idx",
+          "columns": [
+            {
+              "expression": "workflowId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "startedAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "workflow_runs_source_lookup_idx": {
+          "name": "workflow_runs_source_lookup_idx",
+          "columns": [
+            {
+              "expression": "sourceTable",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "sourceId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "workflow_runs_stuck_run_idx": {
+          "name": "workflow_runs_stuck_run_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "startedAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "workflow_runs_running_claim_idx": {
+          "name": "workflow_runs_running_claim_idx",
+          "columns": [
+            {
+              "expression": "workflowId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"workflow_runs\".\"status\" = 'running'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "workflow_runs_workflowId_workflows_id_fk": {
+          "name": "workflow_runs_workflowId_workflows_id_fk",
+          "tableFrom": "workflow_runs",
+          "tableTo": "workflows",
+          "columnsFrom": [
+            "workflowId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.workflow_run_steps": {
+      "name": "workflow_run_steps",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "runId": {
+          "name": "runId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "toolName": {
+          "name": "toolName",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "WorkflowRunStepStatus",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'running'"
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "durationMs": {
+          "name": "durationMs",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "startedAt": {
+          "name": "startedAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "endedAt": {
+          "name": "endedAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "workflow_run_steps_run_position_idx": {
+          "name": "workflow_run_steps_run_position_idx",
+          "columns": [
+            {
+              "expression": "runId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "position",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "workflow_run_steps_runId_workflow_runs_id_fk": {
+          "name": "workflow_run_steps_runId_workflow_runs_id_fk",
+          "tableFrom": "workflow_run_steps",
+          "tableTo": "workflow_runs",
+          "columnsFrom": [
+            "runId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.task_triggers": {
+      "name": "task_triggers",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "workflowId": {
+          "name": "workflowId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "taskItemId": {
+          "name": "taskItemId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "triggerType": {
+          "name": "triggerType",
+          "type": "TaskTriggerType",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "nextRunAt": {
+          "name": "nextRunAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lastFiredAt": {
+          "name": "lastFiredAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lastFireError": {
+          "name": "lastFireError",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "isEnabled": {
+          "name": "isEnabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "task_triggers_workflow_id_idx": {
+          "name": "task_triggers_workflow_id_idx",
+          "columns": [
+            {
+              "expression": "workflowId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "task_triggers_task_item_id_idx": {
+          "name": "task_triggers_task_item_id_idx",
+          "columns": [
+            {
+              "expression": "taskItemId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "task_triggers_enabled_next_run_idx": {
+          "name": "task_triggers_enabled_next_run_idx",
+          "columns": [
+            {
+              "expression": "isEnabled",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "nextRunAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "task_triggers_workflowId_workflows_id_fk": {
+          "name": "task_triggers_workflowId_workflows_id_fk",
+          "tableFrom": "task_triggers",
+          "tableTo": "workflows",
+          "columnsFrom": [
+            "workflowId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "task_triggers_taskItemId_task_items_id_fk": {
+          "name": "task_triggers_taskItemId_task_items_id_fk",
+          "tableFrom": "task_triggers",
+          "tableTo": "task_items",
+          "columnsFrom": [
+            "taskItemId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "task_triggers_task_item_trigger_type_key": {
+          "name": "task_triggers_task_item_trigger_type_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "taskItemId",
+            "triggerType"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.rate_limit_buckets": {
+      "name": "rate_limit_buckets",
+      "schema": "",
+      "columns": {
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "window_start": {
+          "name": "window_start",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "count": {
+          "name": "count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "rate_limit_buckets_expires_at_idx": {
+          "name": "rate_limit_buckets_expires_at_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "rate_limit_buckets_key_window_start_pk": {
+          "name": "rate_limit_buckets_key_window_start_pk",
+          "columns": [
+            "key",
+            "window_start"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.revoked_service_tokens": {
+      "name": "revoked_service_tokens",
+      "schema": "",
+      "columns": {
+        "jti": {
+          "name": "jti",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "revoked_service_tokens_expires_at_idx": {
+          "name": "revoked_service_tokens_expires_at_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.auth_handoff_tokens": {
+      "name": "auth_handoff_tokens",
+      "schema": "",
+      "columns": {
+        "token_hash": {
+          "name": "token_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "auth_handoff_tokens_expires_at_idx": {
+          "name": "auth_handoff_tokens_expires_at_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "auth_handoff_tokens_kind_expires_at_idx": {
+          "name": "auth_handoff_tokens_kind_expires_at_idx",
+          "columns": [
+            {
+              "expression": "kind",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "auth_handoff_tokens_token_hash_kind_pk": {
+          "name": "auth_handoff_tokens_token_hash_kind_pk",
+          "columns": [
+            "token_hash",
+            "kind"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.pending_invites": {
+      "name": "pending_invites",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "drive_id": {
+          "name": "drive_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "MemberRole",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "custom_role_id": {
+          "name": "custom_role_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "invited_by": {
+          "name": "invited_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "consumed_at": {
+          "name": "consumed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "pending_invites_drive_id_idx": {
+          "name": "pending_invites_drive_id_idx",
+          "columns": [
+            {
+              "expression": "drive_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "pending_invites_email_idx": {
+          "name": "pending_invites_email_idx",
+          "columns": [
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "pending_invites_expires_at_idx": {
+          "name": "pending_invites_expires_at_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "pending_invites_custom_role_id_idx": {
+          "name": "pending_invites_custom_role_id_idx",
+          "columns": [
+            {
+              "expression": "custom_role_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "pending_invites_active_drive_email_idx": {
+          "name": "pending_invites_active_drive_email_idx",
+          "columns": [
+            {
+              "expression": "drive_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"pending_invites\".\"consumed_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "pending_invites_drive_id_drives_id_fk": {
+          "name": "pending_invites_drive_id_drives_id_fk",
+          "tableFrom": "pending_invites",
+          "tableTo": "drives",
+          "columnsFrom": [
+            "drive_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "pending_invites_custom_role_id_drive_roles_id_fk": {
+          "name": "pending_invites_custom_role_id_drive_roles_id_fk",
+          "tableFrom": "pending_invites",
+          "tableTo": "drive_roles",
+          "columnsFrom": [
+            "custom_role_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "pending_invites_invited_by_users_id_fk": {
+          "name": "pending_invites_invited_by_users_id_fk",
+          "tableFrom": "pending_invites",
+          "tableTo": "users",
+          "columnsFrom": [
+            "invited_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "pending_invites_token_hash_unique": {
+          "name": "pending_invites_token_hash_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token_hash"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.pending_page_invites": {
+      "name": "pending_page_invites",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "invited_by": {
+          "name": "invited_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "page_id": {
+          "name": "page_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "permissions": {
+          "name": "permissions",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "consumed_at": {
+          "name": "consumed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "pending_page_invites_page_id_idx": {
+          "name": "pending_page_invites_page_id_idx",
+          "columns": [
+            {
+              "expression": "page_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "pending_page_invites_email_idx": {
+          "name": "pending_page_invites_email_idx",
+          "columns": [
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "pending_page_invites_expires_at_idx": {
+          "name": "pending_page_invites_expires_at_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "pending_page_invites_active_page_email_idx": {
+          "name": "pending_page_invites_active_page_email_idx",
+          "columns": [
+            {
+              "expression": "page_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"pending_page_invites\".\"consumed_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "pending_page_invites_invited_by_users_id_fk": {
+          "name": "pending_page_invites_invited_by_users_id_fk",
+          "tableFrom": "pending_page_invites",
+          "tableTo": "users",
+          "columnsFrom": [
+            "invited_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "pending_page_invites_page_id_pages_id_fk": {
+          "name": "pending_page_invites_page_id_pages_id_fk",
+          "tableFrom": "pending_page_invites",
+          "tableTo": "pages",
+          "columnsFrom": [
+            "page_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "pending_page_invites_token_hash_unique": {
+          "name": "pending_page_invites_token_hash_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token_hash"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.pending_connection_invites": {
+      "name": "pending_connection_invites",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "invited_by": {
+          "name": "invited_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "request_message": {
+          "name": "request_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "consumed_at": {
+          "name": "consumed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "pending_connection_invites_invited_by_idx": {
+          "name": "pending_connection_invites_invited_by_idx",
+          "columns": [
+            {
+              "expression": "invited_by",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "pending_connection_invites_email_idx": {
+          "name": "pending_connection_invites_email_idx",
+          "columns": [
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "pending_connection_invites_expires_at_idx": {
+          "name": "pending_connection_invites_expires_at_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "pending_connection_invites_active_inviter_email_idx": {
+          "name": "pending_connection_invites_active_inviter_email_idx",
+          "columns": [
+            {
+              "expression": "invited_by",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"pending_connection_invites\".\"consumed_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "pending_connection_invites_invited_by_users_id_fk": {
+          "name": "pending_connection_invites_invited_by_users_id_fk",
+          "tableFrom": "pending_connection_invites",
+          "tableTo": "users",
+          "columnsFrom": [
+            "invited_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "pending_connection_invites_token_hash_unique": {
+          "name": "pending_connection_invites_token_hash_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token_hash"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ai_pending_abort_intents": {
+      "name": "ai_pending_abort_intents",
+      "schema": "",
+      "columns": {
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "ai_pending_abort_intents_conversation_id_user_id_pk": {
+          "name": "ai_pending_abort_intents_conversation_id_user_id_pk",
+          "columns": [
+            "conversation_id",
+            "user_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ai_stream_frames": {
+      "name": "ai_stream_frames",
+      "schema": "",
+      "columns": {
+        "message_id": {
+          "name": "message_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "from_seq": {
+          "name": "from_seq",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "frame_count": {
+          "name": "frame_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "frames": {
+          "name": "frames",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "byte_size": {
+          "name": "byte_size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "ai_stream_frames_created_at_idx": {
+          "name": "ai_stream_frames_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "ai_stream_frames_conversation_id_conversations_id_fk": {
+          "name": "ai_stream_frames_conversation_id_conversations_id_fk",
+          "tableFrom": "ai_stream_frames",
+          "tableTo": "conversations",
+          "columnsFrom": [
+            "conversation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "ai_stream_frames_message_id_from_seq_pk": {
+          "name": "ai_stream_frames_message_id_from_seq_pk",
+          "columns": [
+            "message_id",
+            "from_seq"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ai_stream_sessions": {
+      "name": "ai_stream_sessions",
+      "schema": "",
+      "columns": {
+        "message_id": {
+          "name": "message_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "channel_id": {
+          "name": "channel_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'Someone'"
+        },
+        "browser_session_id": {
+          "name": "browser_session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'streaming'"
+        },
+        "parts": {
+          "name": "parts",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "raw_parts_count": {
+          "name": "raw_parts_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_heartbeat_at": {
+          "name": "last_heartbeat_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stream_id": {
+          "name": "stream_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "abort_requested_at": {
+          "name": "abort_requested_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reap_claimed_at": {
+          "name": "reap_claimed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "ai_stream_sessions_channel_status_idx": {
+          "name": "ai_stream_sessions_channel_status_idx",
+          "columns": [
+            {
+              "expression": "channel_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ai_stream_sessions_conversation_status_idx": {
+          "name": "ai_stream_sessions_conversation_status_idx",
+          "columns": [
+            {
+              "expression": "conversation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ai_stream_sessions_user_status_idx": {
+          "name": "ai_stream_sessions_user_status_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ai_stream_sessions_stream_id_idx": {
+          "name": "ai_stream_sessions_stream_id_idx",
+          "columns": [
+            {
+              "expression": "stream_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "ai_stream_sessions_conversation_id_conversations_id_fk": {
+          "name": "ai_stream_sessions_conversation_id_conversations_id_fk",
+          "tableFrom": "ai_stream_sessions",
+          "tableTo": "conversations",
+          "columnsFrom": [
+            "conversation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.drive_share_links": {
+      "name": "drive_share_links",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "drive_id": {
+          "name": "drive_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "MemberRole",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'MEMBER'"
+        },
+        "custom_role_id": {
+          "name": "custom_role_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "use_count": {
+          "name": "use_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        }
+      },
+      "indexes": {
+        "drive_share_links_drive_id_idx": {
+          "name": "drive_share_links_drive_id_idx",
+          "columns": [
+            {
+              "expression": "drive_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "drive_share_links_expires_at_idx": {
+          "name": "drive_share_links_expires_at_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "drive_share_links_is_active_idx": {
+          "name": "drive_share_links_is_active_idx",
+          "columns": [
+            {
+              "expression": "is_active",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "drive_share_links_custom_role_id_idx": {
+          "name": "drive_share_links_custom_role_id_idx",
+          "columns": [
+            {
+              "expression": "custom_role_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "drive_share_links_drive_id_drives_id_fk": {
+          "name": "drive_share_links_drive_id_drives_id_fk",
+          "tableFrom": "drive_share_links",
+          "tableTo": "drives",
+          "columnsFrom": [
+            "drive_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "drive_share_links_custom_role_id_drive_roles_id_fk": {
+          "name": "drive_share_links_custom_role_id_drive_roles_id_fk",
+          "tableFrom": "drive_share_links",
+          "tableTo": "drive_roles",
+          "columnsFrom": [
+            "custom_role_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "drive_share_links_created_by_users_id_fk": {
+          "name": "drive_share_links_created_by_users_id_fk",
+          "tableFrom": "drive_share_links",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "drive_share_links_token_unique": {
+          "name": "drive_share_links_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.page_share_links": {
+      "name": "page_share_links",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "page_id": {
+          "name": "page_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "permissions": {
+          "name": "permissions",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "use_count": {
+          "name": "use_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        }
+      },
+      "indexes": {
+        "page_share_links_page_id_idx": {
+          "name": "page_share_links_page_id_idx",
+          "columns": [
+            {
+              "expression": "page_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "page_share_links_expires_at_idx": {
+          "name": "page_share_links_expires_at_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "page_share_links_is_active_idx": {
+          "name": "page_share_links_is_active_idx",
+          "columns": [
+            {
+              "expression": "is_active",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "page_share_links_page_id_pages_id_fk": {
+          "name": "page_share_links_page_id_pages_id_fk",
+          "tableFrom": "page_share_links",
+          "tableTo": "pages",
+          "columnsFrom": [
+            "page_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "page_share_links_created_by_users_id_fk": {
+          "name": "page_share_links_created_by_users_id_fk",
+          "tableFrom": "page_share_links",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "page_share_links_token_unique": {
+          "name": "page_share_links_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.zoom_connections": {
+      "name": "zoom_connections",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "accessToken": {
+          "name": "accessToken",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "refreshToken": {
+          "name": "refreshToken",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tokenExpiresAt": {
+          "name": "tokenExpiresAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "zoomUserId": {
+          "name": "zoomUserId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "zoomAccountId": {
+          "name": "zoomAccountId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "zoomEmail": {
+          "name": "zoomEmail",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "ZoomConnectionStatus",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "targetDriveId": {
+          "name": "targetDriveId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "targetFolderId": {
+          "name": "targetFolderId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scopeVersion": {
+          "name": "scopeVersion",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "includeAiSummary": {
+          "name": "includeAiSummary",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "includeActionItems": {
+          "name": "includeActionItems",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "includeTranscript": {
+          "name": "includeTranscript",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "zoom_connections_user_id_idx": {
+          "name": "zoom_connections_user_id_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "zoom_connections_status_idx": {
+          "name": "zoom_connections_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "zoom_connections_account_id_idx": {
+          "name": "zoom_connections_account_id_idx",
+          "columns": [
+            {
+              "expression": "zoomAccountId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "zoom_connections_target_drive_id_idx": {
+          "name": "zoom_connections_target_drive_id_idx",
+          "columns": [
+            {
+              "expression": "targetDriveId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "zoom_connections_userId_users_id_fk": {
+          "name": "zoom_connections_userId_users_id_fk",
+          "tableFrom": "zoom_connections",
+          "tableTo": "users",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "zoom_connections_targetDriveId_drives_id_fk": {
+          "name": "zoom_connections_targetDriveId_drives_id_fk",
+          "tableFrom": "zoom_connections",
+          "tableTo": "drives",
+          "columnsFrom": [
+            "targetDriveId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "zoom_connections_userId_unique": {
+          "name": "zoom_connections_userId_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "userId"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.webhook_triggers": {
+      "name": "webhook_triggers",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "workflowId": {
+          "name": "workflowId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "connectionId": {
+          "name": "connectionId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pageWebhookId": {
+          "name": "pageWebhookId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "eventType": {
+          "name": "eventType",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "isEnabled": {
+          "name": "isEnabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "lastFiredAt": {
+          "name": "lastFiredAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lastFireError": {
+          "name": "lastFireError",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "webhook_triggers_workflow_id_idx": {
+          "name": "webhook_triggers_workflow_id_idx",
+          "columns": [
+            {
+              "expression": "workflowId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "webhook_triggers_provider_event_idx": {
+          "name": "webhook_triggers_provider_event_idx",
+          "columns": [
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "eventType",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "isEnabled",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "webhook_triggers_connection_id_idx": {
+          "name": "webhook_triggers_connection_id_idx",
+          "columns": [
+            {
+              "expression": "connectionId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "webhook_triggers_page_webhook_id_idx": {
+          "name": "webhook_triggers_page_webhook_id_idx",
+          "columns": [
+            {
+              "expression": "pageWebhookId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "webhook_triggers_page_webhook_workflow_unique": {
+          "name": "webhook_triggers_page_webhook_workflow_unique",
+          "columns": [
+            {
+              "expression": "pageWebhookId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "workflowId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"webhook_triggers\".\"pageWebhookId\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "webhook_triggers_workflowId_workflows_id_fk": {
+          "name": "webhook_triggers_workflowId_workflows_id_fk",
+          "tableFrom": "webhook_triggers",
+          "tableTo": "workflows",
+          "columnsFrom": [
+            "workflowId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "webhook_triggers_connectionId_zoom_connections_id_fk": {
+          "name": "webhook_triggers_connectionId_zoom_connections_id_fk",
+          "tableFrom": "webhook_triggers",
+          "tableTo": "zoom_connections",
+          "columnsFrom": [
+            "connectionId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "webhook_triggers_pageWebhookId_page_webhooks_id_fk": {
+          "name": "webhook_triggers_pageWebhookId_page_webhooks_id_fk",
+          "tableFrom": "webhook_triggers",
+          "tableTo": "page_webhooks",
+          "columnsFrom": [
+            "pageWebhookId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "webhook_triggers_connection_workflow_event_unique": {
+          "name": "webhook_triggers_connection_workflow_event_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "connectionId",
+            "workflowId",
+            "eventType"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "webhook_triggers_anchor_chk": {
+          "name": "webhook_triggers_anchor_chk",
+          "value": "(\"webhook_triggers\".\"connectionId\" IS NOT NULL AND \"webhook_triggers\".\"pageWebhookId\" IS NULL) OR (\"webhook_triggers\".\"connectionId\" IS NULL AND \"webhook_triggers\".\"pageWebhookId\" IS NOT NULL)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.message_drafts": {
+      "name": "message_drafts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "contextKey": {
+          "name": "contextKey",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expiresAt": {
+          "name": "expiresAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "message_drafts_user_context_key": {
+          "name": "message_drafts_user_context_key",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "contextKey",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "message_drafts_expires_at_idx": {
+          "name": "message_drafts_expires_at_idx",
+          "columns": [
+            {
+              "expression": "expiresAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "message_drafts_userId_users_id_fk": {
+          "name": "message_drafts_userId_users_id_fk",
+          "tableFrom": "message_drafts",
+          "tableTo": "users",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.published_pages": {
+      "name": "published_pages",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "drive_id": {
+          "name": "drive_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "page_id": {
+          "name": "page_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "path": {
+          "name": "path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "artifact_key": {
+          "name": "artifact_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "publish_title": {
+          "name": "publish_title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "publish_description": {
+          "name": "publish_description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "publish_og_image_url": {
+          "name": "publish_og_image_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "noindex": {
+          "name": "noindex",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "theme_bridge_enabled": {
+          "name": "theme_bridge_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "published_by": {
+          "name": "published_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "published_at": {
+          "name": "published_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "published_pages_drive_id_idx": {
+          "name": "published_pages_drive_id_idx",
+          "columns": [
+            {
+              "expression": "drive_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "published_pages_page_id_idx": {
+          "name": "published_pages_page_id_idx",
+          "columns": [
+            {
+              "expression": "page_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "published_pages_drive_id_drives_id_fk": {
+          "name": "published_pages_drive_id_drives_id_fk",
+          "tableFrom": "published_pages",
+          "tableTo": "drives",
+          "columnsFrom": [
+            "drive_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "published_pages_page_id_pages_id_fk": {
+          "name": "published_pages_page_id_pages_id_fk",
+          "tableFrom": "published_pages",
+          "tableTo": "pages",
+          "columnsFrom": [
+            "page_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "published_pages_published_by_users_id_fk": {
+          "name": "published_pages_published_by_users_id_fk",
+          "tableFrom": "published_pages",
+          "tableTo": "users",
+          "columnsFrom": [
+            "published_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "published_pages_page_id_key": {
+          "name": "published_pages_page_id_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "page_id"
+          ]
+        },
+        "published_pages_drive_id_path_key": {
+          "name": "published_pages_drive_id_path_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "drive_id",
+            "path"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.credit_balances": {
+      "name": "credit_balances",
+      "schema": "",
+      "columns": {
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "monthlyRemainingCents": {
+          "name": "monthlyRemainingCents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "monthlyAllowanceCents": {
+          "name": "monthlyAllowanceCents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "topupRemainingCents": {
+          "name": "topupRemainingCents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "debtCents": {
+          "name": "debtCents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "pendingMillicents": {
+          "name": "pendingMillicents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "monthlyPeriodStart": {
+          "name": "monthlyPeriodStart",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "monthlyPeriodEnd": {
+          "name": "monthlyPeriodEnd",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "credit_balances_userId_users_id_fk": {
+          "name": "credit_balances_userId_users_id_fk",
+          "tableFrom": "credit_balances",
+          "tableTo": "users",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "credit_balances_monthly_remaining_nonneg": {
+          "name": "credit_balances_monthly_remaining_nonneg",
+          "value": "\"credit_balances\".\"monthlyRemainingCents\" >= 0"
+        },
+        "credit_balances_monthly_allowance_nonneg": {
+          "name": "credit_balances_monthly_allowance_nonneg",
+          "value": "\"credit_balances\".\"monthlyAllowanceCents\" >= 0"
+        },
+        "credit_balances_topup_remaining_nonneg": {
+          "name": "credit_balances_topup_remaining_nonneg",
+          "value": "\"credit_balances\".\"topupRemainingCents\" >= 0"
+        },
+        "credit_balances_debt_cents_nonneg": {
+          "name": "credit_balances_debt_cents_nonneg",
+          "value": "\"credit_balances\".\"debtCents\" >= 0"
+        },
+        "credit_balances_pending_millicents_range": {
+          "name": "credit_balances_pending_millicents_range",
+          "value": "\"credit_balances\".\"pendingMillicents\" >= 0 AND \"credit_balances\".\"pendingMillicents\" < 1000"
+        },
+        "credit_balances_period_order": {
+          "name": "credit_balances_period_order",
+          "value": "\"credit_balances\".\"monthlyPeriodStart\" IS NULL OR \"credit_balances\".\"monthlyPeriodEnd\" IS NULL OR \"credit_balances\".\"monthlyPeriodStart\" <= \"credit_balances\".\"monthlyPeriodEnd\""
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.credit_holds": {
+      "name": "credit_holds",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "estCents": {
+          "name": "estCents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "aiUsageLogId": {
+          "name": "aiUsageLogId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expiresAt": {
+          "name": "expiresAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "credit_holds_user_idx": {
+          "name": "credit_holds_user_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "credit_holds_expires_idx": {
+          "name": "credit_holds_expires_idx",
+          "columns": [
+            {
+              "expression": "expiresAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "credit_holds_userId_users_id_fk": {
+          "name": "credit_holds_userId_users_id_fk",
+          "tableFrom": "credit_holds",
+          "tableTo": "users",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "credit_holds_est_cents_nonneg": {
+          "name": "credit_holds_est_cents_nonneg",
+          "value": "\"credit_holds\".\"estCents\" >= 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.credit_ledger": {
+      "name": "credit_ledger",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entryType": {
+          "name": "entryType",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "bucket": {
+          "name": "bucket",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amountCents": {
+          "name": "amountCents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "appliedCents": {
+          "name": "appliedCents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "chargeMillicents": {
+          "name": "chargeMillicents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "aiUsageLogId": {
+          "name": "aiUsageLogId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "realCostCents": {
+          "name": "realCostCents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "markupBps": {
+          "name": "markupBps",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 15000
+        },
+        "stripeRef": {
+          "name": "stripeRef",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "consumeStatus": {
+          "name": "consumeStatus",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "consumeError": {
+          "name": "consumeError",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reconcileGenerationKey": {
+          "name": "reconcileGenerationKey",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "credit_ledger_user_idx": {
+          "name": "credit_ledger_user_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "createdAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "credit_ledger_usage_log_unique": {
+          "name": "credit_ledger_usage_log_unique",
+          "columns": [
+            {
+              "expression": "aiUsageLogId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"credit_ledger\".\"aiUsageLogId\" IS NOT NULL AND \"credit_ledger\".\"entryType\" = 'usage'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "credit_ledger_stripe_ref_unique": {
+          "name": "credit_ledger_stripe_ref_unique",
+          "columns": [
+            {
+              "expression": "stripeRef",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"credit_ledger\".\"stripeRef\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "credit_ledger_reconcile_key_unique": {
+          "name": "credit_ledger_reconcile_key_unique",
+          "columns": [
+            {
+              "expression": "reconcileGenerationKey",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"credit_ledger\".\"reconcileGenerationKey\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "credit_ledger_consume_status_idx": {
+          "name": "credit_ledger_consume_status_idx",
+          "columns": [
+            {
+              "expression": "consumeStatus",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "createdAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "credit_ledger_userId_users_id_fk": {
+          "name": "credit_ledger_userId_users_id_fk",
+          "tableFrom": "credit_ledger",
+          "tableTo": "users",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.commands": {
+      "name": "commands",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "drive_id": {
+          "name": "drive_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by_id": {
+          "name": "created_by_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "trigger": {
+          "name": "trigger",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entry_page_id": {
+          "name": "entry_page_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'document'"
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "commands_user_id_idx": {
+          "name": "commands_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "commands_drive_id_idx": {
+          "name": "commands_drive_id_idx",
+          "columns": [
+            {
+              "expression": "drive_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "commands_entry_page_id_idx": {
+          "name": "commands_entry_page_id_idx",
+          "columns": [
+            {
+              "expression": "entry_page_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "commands_user_id_users_id_fk": {
+          "name": "commands_user_id_users_id_fk",
+          "tableFrom": "commands",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "commands_drive_id_drives_id_fk": {
+          "name": "commands_drive_id_drives_id_fk",
+          "tableFrom": "commands",
+          "tableTo": "drives",
+          "columnsFrom": [
+            "drive_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "commands_created_by_id_users_id_fk": {
+          "name": "commands_created_by_id_users_id_fk",
+          "tableFrom": "commands",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "commands_entry_page_id_pages_id_fk": {
+          "name": "commands_entry_page_id_pages_id_fk",
+          "tableFrom": "commands",
+          "tableTo": "pages",
+          "columnsFrom": [
+            "entry_page_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "commands_user_trigger": {
+          "name": "commands_user_trigger",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "trigger"
+          ]
+        },
+        "commands_drive_trigger": {
+          "name": "commands_drive_trigger",
+          "nullsNotDistinct": false,
+          "columns": [
+            "drive_id",
+            "trigger"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "commands_scope_chk": {
+          "name": "commands_scope_chk",
+          "value": "(\"commands\".\"user_id\" IS NOT NULL AND \"commands\".\"drive_id\" IS NULL) OR (\"commands\".\"user_id\" IS NULL AND \"commands\".\"drive_id\" IS NOT NULL)"
+        },
+        "commands_type_chk": {
+          "name": "commands_type_chk",
+          "value": "\"commands\".\"type\" IN ('document', 'prompt_template', 'builtin')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.content_tags": {
+      "name": "content_tags",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "tagId": {
+          "name": "tagId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pageId": {
+          "name": "pageId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "targetKind": {
+          "name": "targetKind",
+          "type": "ContentTagTargetKind",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "anchor": {
+          "name": "anchor",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "anchorStatus": {
+          "name": "anchorStatus",
+          "type": "ContentTagAnchorStatus",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "channelMessageId": {
+          "name": "channelMessageId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "aiMessageId": {
+          "name": "aiMessageId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source": {
+          "name": "source",
+          "type": "ContentTagSource",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "confidence": {
+          "name": "confidence",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdBy": {
+          "name": "createdBy",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "content_tags_page_id_idx": {
+          "name": "content_tags_page_id_idx",
+          "columns": [
+            {
+              "expression": "pageId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "content_tags_tag_id_idx": {
+          "name": "content_tags_tag_id_idx",
+          "columns": [
+            {
+              "expression": "tagId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "content_tags_created_by_idx": {
+          "name": "content_tags_created_by_idx",
+          "columns": [
+            {
+              "expression": "createdBy",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "content_tags_page_target_unique": {
+          "name": "content_tags_page_target_unique",
+          "columns": [
+            {
+              "expression": "pageId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "tagId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"content_tags\".\"targetKind\" = 'page'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "content_tags_channel_message_target_unique": {
+          "name": "content_tags_channel_message_target_unique",
+          "columns": [
+            {
+              "expression": "channelMessageId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "tagId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"content_tags\".\"targetKind\" = 'channel_message'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "content_tags_ai_message_target_unique": {
+          "name": "content_tags_ai_message_target_unique",
+          "columns": [
+            {
+              "expression": "aiMessageId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "tagId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"content_tags\".\"targetKind\" = 'ai_message'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "content_tags_tagId_tags_id_fk": {
+          "name": "content_tags_tagId_tags_id_fk",
+          "tableFrom": "content_tags",
+          "tableTo": "tags",
+          "columnsFrom": [
+            "tagId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "content_tags_pageId_pages_id_fk": {
+          "name": "content_tags_pageId_pages_id_fk",
+          "tableFrom": "content_tags",
+          "tableTo": "pages",
+          "columnsFrom": [
+            "pageId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "content_tags_channelMessageId_channel_messages_id_fk": {
+          "name": "content_tags_channelMessageId_channel_messages_id_fk",
+          "tableFrom": "content_tags",
+          "tableTo": "channel_messages",
+          "columnsFrom": [
+            "channelMessageId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "content_tags_aiMessageId_messages_id_fk": {
+          "name": "content_tags_aiMessageId_messages_id_fk",
+          "tableFrom": "content_tags",
+          "tableTo": "messages",
+          "columnsFrom": [
+            "aiMessageId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "content_tags_createdBy_users_id_fk": {
+          "name": "content_tags_createdBy_users_id_fk",
+          "tableFrom": "content_tags",
+          "tableTo": "users",
+          "columnsFrom": [
+            "createdBy"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "content_tags_target_chk": {
+          "name": "content_tags_target_chk",
+          "value": "(\n        (\"content_tags\".\"targetKind\" = 'page' AND \"content_tags\".\"anchor\" IS NULL AND \"content_tags\".\"anchorStatus\" IS NULL AND \"content_tags\".\"channelMessageId\" IS NULL AND \"content_tags\".\"aiMessageId\" IS NULL)\n        OR (\"content_tags\".\"targetKind\" = 'text' AND \"content_tags\".\"anchor\" IS NOT NULL AND \"content_tags\".\"anchorStatus\" IS NOT NULL AND \"content_tags\".\"channelMessageId\" IS NULL AND \"content_tags\".\"aiMessageId\" IS NULL)\n        OR (\"content_tags\".\"targetKind\" = 'sheet_cell' AND \"content_tags\".\"anchor\" IS NOT NULL AND \"content_tags\".\"anchorStatus\" IS NULL AND \"content_tags\".\"channelMessageId\" IS NULL AND \"content_tags\".\"aiMessageId\" IS NULL)\n        OR (\"content_tags\".\"targetKind\" = 'channel_message' AND \"content_tags\".\"anchor\" IS NULL AND \"content_tags\".\"anchorStatus\" IS NULL AND \"content_tags\".\"channelMessageId\" IS NOT NULL AND \"content_tags\".\"aiMessageId\" IS NULL)\n        OR (\"content_tags\".\"targetKind\" = 'ai_message' AND \"content_tags\".\"anchor\" IS NULL AND \"content_tags\".\"anchorStatus\" IS NULL AND \"content_tags\".\"channelMessageId\" IS NULL AND \"content_tags\".\"aiMessageId\" IS NOT NULL)\n      )"
+        },
+        "content_tags_confidence_range_chk": {
+          "name": "content_tags_confidence_range_chk",
+          "value": "\"content_tags\".\"confidence\" IS NULL OR (\"content_tags\".\"confidence\" >= 0 AND \"content_tags\".\"confidence\" <= 1)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.conversation_compactions": {
+      "name": "conversation_compactions",
+      "schema": "",
+      "columns": {
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "page_id": {
+          "name": "page_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "summary": {
+          "name": "summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "summary_tokens": {
+          "name": "summary_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "compacted_up_to_message_id": {
+          "name": "compacted_up_to_message_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "compacted_up_to_created_at": {
+          "name": "compacted_up_to_created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "summary_version": {
+          "name": "summary_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "summarizer_model": {
+          "name": "summarizer_model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_compacted_at": {
+          "name": "last_compacted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "conversation_compactions_page_id_idx": {
+          "name": "conversation_compactions_page_id_idx",
+          "columns": [
+            {
+              "expression": "page_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "conversation_compactions_conversation_id_source_pk": {
+          "name": "conversation_compactions_conversation_id_source_pk",
+          "columns": [
+            "conversation_id",
+            "source"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "conversation_compactions_source_chk": {
+          "name": "conversation_compactions_source_chk",
+          "value": "\"conversation_compactions\".\"source\" IN ('page', 'global')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.custom_domains": {
+      "name": "custom_domains",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "drive_id": {
+          "name": "drive_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "hostname": {
+          "name": "hostname",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "custom_domain_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "is_primary": {
+          "name": "is_primary",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "platform_owned": {
+          "name": "platform_owned",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "publish_landing_page_id": {
+          "name": "publish_landing_page_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "publish_not_found_page_id": {
+          "name": "publish_not_found_page_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "published_app_id": {
+          "name": "published_app_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "custom_domains_hostname_key": {
+          "name": "custom_domains_hostname_key",
+          "columns": [
+            {
+              "expression": "hostname",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "custom_domains_drive_id_idx": {
+          "name": "custom_domains_drive_id_idx",
+          "columns": [
+            {
+              "expression": "drive_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "custom_domains_published_app_id_idx": {
+          "name": "custom_domains_published_app_id_idx",
+          "columns": [
+            {
+              "expression": "published_app_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "custom_domains_primary_per_drive": {
+          "name": "custom_domains_primary_per_drive",
+          "columns": [
+            {
+              "expression": "drive_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"custom_domains\".\"is_primary\"",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "custom_domains_drive_id_drives_id_fk": {
+          "name": "custom_domains_drive_id_drives_id_fk",
+          "tableFrom": "custom_domains",
+          "tableTo": "drives",
+          "columnsFrom": [
+            "drive_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "custom_domains_publish_landing_page_id_pages_id_fk": {
+          "name": "custom_domains_publish_landing_page_id_pages_id_fk",
+          "tableFrom": "custom_domains",
+          "tableTo": "pages",
+          "columnsFrom": [
+            "publish_landing_page_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "custom_domains_publish_not_found_page_id_pages_id_fk": {
+          "name": "custom_domains_publish_not_found_page_id_pages_id_fk",
+          "tableFrom": "custom_domains",
+          "tableTo": "pages",
+          "columnsFrom": [
+            "publish_not_found_page_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "custom_domains_published_app_id_published_apps_id_fk": {
+          "name": "custom_domains_published_app_id_published_apps_id_fk",
+          "tableFrom": "custom_domains",
+          "tableTo": "published_apps",
+          "columnsFrom": [
+            "published_app_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.incidents": {
+      "name": "incidents",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "severity": {
+          "name": "severity",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'detected'"
+        },
+        "category": {
+          "name": "category",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "detectedAt": {
+          "name": "detectedAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "reportedBy": {
+          "name": "reportedBy",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "affectedUserCount": {
+          "name": "affectedUserCount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "affectedScope": {
+          "name": "affectedScope",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "riskLevel": {
+          "name": "riskLevel",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "requiresAuthorityNotification": {
+          "name": "requiresAuthorityNotification",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "authorityNotificationDeadline": {
+          "name": "authorityNotificationDeadline",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "authorityNotifiedAt": {
+          "name": "authorityNotifiedAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "requiresSubjectNotification": {
+          "name": "requiresSubjectNotification",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "subjectsNotifiedAt": {
+          "name": "subjectsNotifiedAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "closedAt": {
+          "name": "closedAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_incidents_status": {
+          "name": "idx_incidents_status",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_incidents_detected_at": {
+          "name": "idx_incidents_detected_at",
+          "columns": [
+            {
+              "expression": "detectedAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_incidents_authority_deadline": {
+          "name": "idx_incidents_authority_deadline",
+          "columns": [
+            {
+              "expression": "authorityNotificationDeadline",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "incidents_reportedBy_users_id_fk": {
+          "name": "incidents_reportedBy_users_id_fk",
+          "tableFrom": "incidents",
+          "tableTo": "users",
+          "columnsFrom": [
+            "reportedBy"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.data_subject_requests": {
+      "name": "data_subject_requests",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "subject_email": {
+          "name": "subject_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "request_type": {
+          "name": "request_type",
+          "type": "data_subject_request_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'erasure'"
+        },
+        "status": {
+          "name": "status",
+          "type": "data_subject_request_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "force_delete": {
+          "name": "force_delete",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "requested_by_user_id": {
+          "name": "requested_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "requested_by_type": {
+          "name": "requested_by_type",
+          "type": "data_subject_requester_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'self'"
+        },
+        "legal_basis": {
+          "name": "legal_basis",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "received_at": {
+          "name": "received_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "sla_deadline": {
+          "name": "sla_deadline",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "blocked_reason": {
+          "name": "blocked_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "job_id": {
+          "name": "job_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "attempts": {
+          "name": "attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "last_error": {
+          "name": "last_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "step_results": {
+          "name": "step_results",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "data_subject_requests_status_idx": {
+          "name": "data_subject_requests_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "data_subject_requests_sla_deadline_idx": {
+          "name": "data_subject_requests_sla_deadline_idx",
+          "columns": [
+            {
+              "expression": "sla_deadline",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "data_subject_requests_user_id_idx": {
+          "name": "data_subject_requests_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "data_subject_requests_user_id_users_id_fk": {
+          "name": "data_subject_requests_user_id_users_id_fk",
+          "tableFrom": "data_subject_requests",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "data_subject_requests_requested_by_user_id_users_id_fk": {
+          "name": "data_subject_requests_requested_by_user_id_users_id_fk",
+          "tableFrom": "data_subject_requests",
+          "tableTo": "users",
+          "columnsFrom": [
+            "requested_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.oauth_access_tokens": {
+      "name": "oauth_access_tokens",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "tokenHash": {
+          "name": "tokenHash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tokenPrefix": {
+          "name": "tokenPrefix",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "familyId": {
+          "name": "familyId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "clientId": {
+          "name": "clientId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tokenVersion": {
+          "name": "tokenVersion",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expiresAt": {
+          "name": "expiresAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "revokedAt": {
+          "name": "revokedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revokedReason": {
+          "name": "revokedReason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "oauth_access_tokens_family_id_idx": {
+          "name": "oauth_access_tokens_family_id_idx",
+          "columns": [
+            {
+              "expression": "familyId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "oauth_access_tokens_user_id_idx": {
+          "name": "oauth_access_tokens_user_id_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "oauth_access_tokens_client_id_idx": {
+          "name": "oauth_access_tokens_client_id_idx",
+          "columns": [
+            {
+              "expression": "clientId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "oauth_access_tokens_token_hash_idx": {
+          "name": "oauth_access_tokens_token_hash_idx",
+          "columns": [
+            {
+              "expression": "tokenHash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "oauth_access_tokens_expires_at_idx": {
+          "name": "oauth_access_tokens_expires_at_idx",
+          "columns": [
+            {
+              "expression": "expiresAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "oauth_access_tokens_clientId_oauth_clients_id_fk": {
+          "name": "oauth_access_tokens_clientId_oauth_clients_id_fk",
+          "tableFrom": "oauth_access_tokens",
+          "tableTo": "oauth_clients",
+          "columnsFrom": [
+            "clientId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "oauth_access_tokens_userId_users_id_fk": {
+          "name": "oauth_access_tokens_userId_users_id_fk",
+          "tableFrom": "oauth_access_tokens",
+          "tableTo": "users",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "oauth_access_tokens_tokenHash_unique": {
+          "name": "oauth_access_tokens_tokenHash_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "tokenHash"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.oauth_authorization_codes": {
+      "name": "oauth_authorization_codes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "codeHash": {
+          "name": "codeHash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "codePrefix": {
+          "name": "codePrefix",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "clientId": {
+          "name": "clientId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "redirectUri": {
+          "name": "redirectUri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "codeChallenge": {
+          "name": "codeChallenge",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "codeChallengeMethod": {
+          "name": "codeChallengeMethod",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expiresAt": {
+          "name": "expiresAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "consumedAt": {
+          "name": "consumedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "issuedFamilyId": {
+          "name": "issuedFamilyId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "oauth_authorization_codes_client_id_idx": {
+          "name": "oauth_authorization_codes_client_id_idx",
+          "columns": [
+            {
+              "expression": "clientId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "oauth_authorization_codes_user_id_idx": {
+          "name": "oauth_authorization_codes_user_id_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "oauth_authorization_codes_code_hash_idx": {
+          "name": "oauth_authorization_codes_code_hash_idx",
+          "columns": [
+            {
+              "expression": "codeHash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "oauth_authorization_codes_expires_at_idx": {
+          "name": "oauth_authorization_codes_expires_at_idx",
+          "columns": [
+            {
+              "expression": "expiresAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "oauth_authorization_codes_clientId_oauth_clients_id_fk": {
+          "name": "oauth_authorization_codes_clientId_oauth_clients_id_fk",
+          "tableFrom": "oauth_authorization_codes",
+          "tableTo": "oauth_clients",
+          "columnsFrom": [
+            "clientId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "oauth_authorization_codes_userId_users_id_fk": {
+          "name": "oauth_authorization_codes_userId_users_id_fk",
+          "tableFrom": "oauth_authorization_codes",
+          "tableTo": "users",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "oauth_authorization_codes_codeHash_unique": {
+          "name": "oauth_authorization_codes_codeHash_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "codeHash"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.oauth_clients": {
+      "name": "oauth_clients",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "clientId": {
+          "name": "clientId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "clientType": {
+          "name": "clientType",
+          "type": "OAuthClientType",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "redirectUris": {
+          "name": "redirectUris",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "isFirstParty": {
+          "name": "isFirstParty",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "disabledAt": {
+          "name": "disabledAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "oauth_clients_client_id_idx": {
+          "name": "oauth_clients_client_id_idx",
+          "columns": [
+            {
+              "expression": "clientId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "oauth_clients_clientId_unique": {
+          "name": "oauth_clients_clientId_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "clientId"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.oauth_device_codes": {
+      "name": "oauth_device_codes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "deviceCodeHash": {
+          "name": "deviceCodeHash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "deviceCodePrefix": {
+          "name": "deviceCodePrefix",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "userCodeHash": {
+          "name": "userCodeHash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "userCodePrefix": {
+          "name": "userCodePrefix",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "clientId": {
+          "name": "clientId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expiresAt": {
+          "name": "expiresAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "approvedAt": {
+          "name": "approvedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deniedAt": {
+          "name": "deniedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "redeemedAt": {
+          "name": "redeemedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lastPolledAt": {
+          "name": "lastPolledAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pollIntervalSeconds": {
+          "name": "pollIntervalSeconds",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 5
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "oauth_device_codes_client_id_idx": {
+          "name": "oauth_device_codes_client_id_idx",
+          "columns": [
+            {
+              "expression": "clientId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "oauth_device_codes_user_id_idx": {
+          "name": "oauth_device_codes_user_id_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "oauth_device_codes_device_code_hash_idx": {
+          "name": "oauth_device_codes_device_code_hash_idx",
+          "columns": [
+            {
+              "expression": "deviceCodeHash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "oauth_device_codes_user_code_hash_idx": {
+          "name": "oauth_device_codes_user_code_hash_idx",
+          "columns": [
+            {
+              "expression": "userCodeHash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "oauth_device_codes_expires_at_idx": {
+          "name": "oauth_device_codes_expires_at_idx",
+          "columns": [
+            {
+              "expression": "expiresAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "oauth_device_codes_clientId_oauth_clients_id_fk": {
+          "name": "oauth_device_codes_clientId_oauth_clients_id_fk",
+          "tableFrom": "oauth_device_codes",
+          "tableTo": "oauth_clients",
+          "columnsFrom": [
+            "clientId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "oauth_device_codes_userId_users_id_fk": {
+          "name": "oauth_device_codes_userId_users_id_fk",
+          "tableFrom": "oauth_device_codes",
+          "tableTo": "users",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "oauth_device_codes_deviceCodeHash_unique": {
+          "name": "oauth_device_codes_deviceCodeHash_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "deviceCodeHash"
+          ]
+        },
+        "oauth_device_codes_userCodeHash_unique": {
+          "name": "oauth_device_codes_userCodeHash_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "userCodeHash"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.oauth_refresh_tokens": {
+      "name": "oauth_refresh_tokens",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "tokenHash": {
+          "name": "tokenHash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tokenPrefix": {
+          "name": "tokenPrefix",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "familyId": {
+          "name": "familyId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "clientId": {
+          "name": "clientId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tokenVersion": {
+          "name": "tokenVersion",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expiresAt": {
+          "name": "expiresAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "familyExpiresAt": {
+          "name": "familyExpiresAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "replacedByTokenId": {
+          "name": "replacedByTokenId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revokedAt": {
+          "name": "revokedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revokedReason": {
+          "name": "revokedReason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "oauth_refresh_tokens_family_id_idx": {
+          "name": "oauth_refresh_tokens_family_id_idx",
+          "columns": [
+            {
+              "expression": "familyId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "oauth_refresh_tokens_user_id_idx": {
+          "name": "oauth_refresh_tokens_user_id_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "oauth_refresh_tokens_client_id_idx": {
+          "name": "oauth_refresh_tokens_client_id_idx",
+          "columns": [
+            {
+              "expression": "clientId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "oauth_refresh_tokens_token_hash_idx": {
+          "name": "oauth_refresh_tokens_token_hash_idx",
+          "columns": [
+            {
+              "expression": "tokenHash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "oauth_refresh_tokens_expires_at_idx": {
+          "name": "oauth_refresh_tokens_expires_at_idx",
+          "columns": [
+            {
+              "expression": "expiresAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "oauth_refresh_tokens_clientId_oauth_clients_id_fk": {
+          "name": "oauth_refresh_tokens_clientId_oauth_clients_id_fk",
+          "tableFrom": "oauth_refresh_tokens",
+          "tableTo": "oauth_clients",
+          "columnsFrom": [
+            "clientId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "oauth_refresh_tokens_userId_users_id_fk": {
+          "name": "oauth_refresh_tokens_userId_users_id_fk",
+          "tableFrom": "oauth_refresh_tokens",
+          "tableTo": "users",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "oauth_refresh_tokens_tokenHash_unique": {
+          "name": "oauth_refresh_tokens_tokenHash_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "tokenHash"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.form_targets": {
+      "name": "form_targets",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_prefix": {
+          "name": "token_prefix",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "drive_id": {
+          "name": "drive_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "page_id": {
+          "name": "page_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "action": {
+          "name": "action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'sheet:append'"
+        },
+        "canvas_page_id": {
+          "name": "canvas_page_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "fields": {
+          "name": "fields",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "header_row": {
+          "name": "header_row",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "next_row": {
+          "name": "next_row",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "notification_email": {
+          "name": "notification_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "status_reason": {
+          "name": "status_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_submitted_at": {
+          "name": "last_submitted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "submission_count": {
+          "name": "submission_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        }
+      },
+      "indexes": {
+        "form_targets_page_id_idx": {
+          "name": "form_targets_page_id_idx",
+          "columns": [
+            {
+              "expression": "page_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "form_targets_drive_id_idx": {
+          "name": "form_targets_drive_id_idx",
+          "columns": [
+            {
+              "expression": "drive_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "form_targets_status_idx": {
+          "name": "form_targets_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "form_targets_canvas_page_id_idx": {
+          "name": "form_targets_canvas_page_id_idx",
+          "columns": [
+            {
+              "expression": "canvas_page_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "form_targets_one_active_per_page_idx": {
+          "name": "form_targets_one_active_per_page_idx",
+          "columns": [
+            {
+              "expression": "page_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"form_targets\".\"status\" = 'active'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "form_targets_drive_id_drives_id_fk": {
+          "name": "form_targets_drive_id_drives_id_fk",
+          "tableFrom": "form_targets",
+          "tableTo": "drives",
+          "columnsFrom": [
+            "drive_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "form_targets_page_id_pages_id_fk": {
+          "name": "form_targets_page_id_pages_id_fk",
+          "tableFrom": "form_targets",
+          "tableTo": "pages",
+          "columnsFrom": [
+            "page_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "form_targets_canvas_page_id_pages_id_fk": {
+          "name": "form_targets_canvas_page_id_pages_id_fk",
+          "tableFrom": "form_targets",
+          "tableTo": "pages",
+          "columnsFrom": [
+            "canvas_page_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "form_targets_created_by_users_id_fk": {
+          "name": "form_targets_created_by_users_id_fk",
+          "tableFrom": "form_targets",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "form_targets_token_hash_unique": {
+          "name": "form_targets_token_hash_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token_hash"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.machine_sprite_reclaims": {
+      "name": "machine_sprite_reclaims",
+      "schema": "",
+      "columns": {
+        "sandboxId": {
+          "name": "sandboxId",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "spriteInstanceId": {
+          "name": "spriteInstanceId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "recordedAt": {
+          "name": "recordedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "attempts": {
+          "name": "attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "lastAttemptAt": {
+          "name": "lastAttemptAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lastError": {
+          "name": "lastError",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "machine_sprite_reclaims_recorded_at_idx": {
+          "name": "machine_sprite_reclaims_recorded_at_idx",
+          "columns": [
+            {
+              "expression": "recordedAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.app_deploy_token_mints": {
+      "name": "app_deploy_token_mints",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "publishedAppId": {
+          "name": "publishedAppId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "flyAppName": {
+          "name": "flyAppName",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "mintedAt": {
+          "name": "mintedAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "outcome": {
+          "name": "outcome",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "settledAt": {
+          "name": "settledAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expiry": {
+          "name": "expiry",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "purpose": {
+          "name": "purpose",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "app_deploy_token_mints_app_idx": {
+          "name": "app_deploy_token_mints_app_idx",
+          "columns": [
+            {
+              "expression": "publishedAppId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "mintedAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "app_deploy_token_mints_publishedAppId_published_apps_id_fk": {
+          "name": "app_deploy_token_mints_publishedAppId_published_apps_id_fk",
+          "tableFrom": "app_deploy_token_mints",
+          "tableTo": "published_apps",
+          "columnsFrom": [
+            "publishedAppId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "app_deploy_token_mints_expiry_nonempty": {
+          "name": "app_deploy_token_mints_expiry_nonempty",
+          "value": "length(\"app_deploy_token_mints\".\"expiry\") > 0"
+        },
+        "app_deploy_token_mints_purpose_nonempty": {
+          "name": "app_deploy_token_mints_purpose_nonempty",
+          "value": "length(\"app_deploy_token_mints\".\"purpose\") > 0"
+        },
+        "app_deploy_token_mints_outcome_allowed": {
+          "name": "app_deploy_token_mints_outcome_allowed",
+          "value": "\"app_deploy_token_mints\".\"outcome\" IN ('pending', 'minted', 'failed')"
+        },
+        "app_deploy_token_mints_settled_coherent": {
+          "name": "app_deploy_token_mints_settled_coherent",
+          "value": "(\"app_deploy_token_mints\".\"outcome\" = 'pending') = (\"app_deploy_token_mints\".\"settledAt\" IS NULL)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.app_hosting_reclaims": {
+      "name": "app_hosting_reclaims",
+      "schema": "",
+      "columns": {
+        "flyAppName": {
+          "name": "flyAppName",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "publishedAppId": {
+          "name": "publishedAppId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "machineId": {
+          "name": "machineId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "recordedAt": {
+          "name": "recordedAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "attempts": {
+          "name": "attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "lastAttemptAt": {
+          "name": "lastAttemptAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lastError": {
+          "name": "lastError",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "app_hosting_reclaims_recorded_at_idx": {
+          "name": "app_hosting_reclaims_recorded_at_idx",
+          "columns": [
+            {
+              "expression": "recordedAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "app_hosting_reclaims_attempts_nonneg": {
+          "name": "app_hosting_reclaims_attempts_nonneg",
+          "value": "\"app_hosting_reclaims\".\"attempts\" >= 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.published_app_machine_events": {
+      "name": "published_app_machine_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "publishedAppId": {
+          "name": "publishedAppId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "flyAppName": {
+          "name": "flyAppName",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "machineId": {
+          "name": "machineId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "origin": {
+          "name": "origin",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "action": {
+          "name": "action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "flyEventId": {
+          "name": "flyEventId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "flyEventType": {
+          "name": "flyEventType",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "flyEventStatus": {
+          "name": "flyEventStatus",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "occurredAt": {
+          "name": "occurredAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "recordedAt": {
+          "name": "recordedAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "published_app_machine_events_app_idx": {
+          "name": "published_app_machine_events_app_idx",
+          "columns": [
+            {
+              "expression": "publishedAppId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "occurredAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "published_app_machine_events_fly_event_unique": {
+          "name": "published_app_machine_events_fly_event_unique",
+          "columns": [
+            {
+              "expression": "machineId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "flyEventId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"flyEventId\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "published_app_machine_events_publishedAppId_published_apps_id_fk": {
+          "name": "published_app_machine_events_publishedAppId_published_apps_id_fk",
+          "tableFrom": "published_app_machine_events",
+          "tableTo": "published_apps",
+          "columnsFrom": [
+            "publishedAppId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "published_app_machine_events_origin_allowed": {
+          "name": "published_app_machine_events_origin_allowed",
+          "value": "\"published_app_machine_events\".\"origin\" IN ('orchestrator', 'fly')"
+        },
+        "published_app_machine_events_action_allowed": {
+          "name": "published_app_machine_events_action_allowed",
+          "value": "\"published_app_machine_events\".\"action\" IN ('start', 'stop')"
+        },
+        "published_app_machine_events_fly_event_id_coherent": {
+          "name": "published_app_machine_events_fly_event_id_coherent",
+          "value": "(\"published_app_machine_events\".\"origin\" = 'fly') = (\"published_app_machine_events\".\"flyEventId\" IS NOT NULL)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.published_apps": {
+      "name": "published_apps",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "envId": {
+          "name": "envId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "driveId": {
+          "name": "driveId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ownerId": {
+          "name": "ownerId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "flyAppName": {
+          "name": "flyAppName",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "networkName": {
+          "name": "networkName",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subdomain": {
+          "name": "subdomain",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "published_app_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'provisioning'"
+        },
+        "guestPreset": {
+          "name": "guestPreset",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'shared-cpu-1x-512'"
+        },
+        "imageDigest": {
+          "name": "imageDigest",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "imageSizeBytes": {
+          "name": "imageSizeBytes",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "imageSizeMeasuredAt": {
+          "name": "imageSizeMeasuredAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tier": {
+          "name": "tier",
+          "type": "published_app_tier",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'metered'"
+        },
+        "machineId": {
+          "name": "machineId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lastWakeAt": {
+          "name": "lastWakeAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lastStopAt": {
+          "name": "lastStopAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lastHitAt": {
+          "name": "lastHitAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "awakeSecondsDay": {
+          "name": "awakeSecondsDay",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "awakeSecondsToday": {
+          "name": "awakeSecondsToday",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "awakeBilledThrough": {
+          "name": "awakeBilledThrough",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "awakeHoldId": {
+          "name": "awakeHoldId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "storageLastBilledAt": {
+          "name": "storageLastBilledAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "lastError": {
+          "name": "lastError",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "claimedAt": {
+          "name": "claimedAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "claimedBy": {
+          "name": "claimedBy",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "published_apps_drive_idx": {
+          "name": "published_apps_drive_idx",
+          "columns": [
+            {
+              "expression": "driveId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "published_apps_owner_idx": {
+          "name": "published_apps_owner_idx",
+          "columns": [
+            {
+              "expression": "ownerId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "published_apps_status_idx": {
+          "name": "published_apps_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "updatedAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "published_apps_idle_idx": {
+          "name": "published_apps_idle_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "lastHitAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "published_apps_envId_drive_envs_id_fk": {
+          "name": "published_apps_envId_drive_envs_id_fk",
+          "tableFrom": "published_apps",
+          "tableTo": "drive_envs",
+          "columnsFrom": [
+            "envId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "published_apps_driveId_drives_id_fk": {
+          "name": "published_apps_driveId_drives_id_fk",
+          "tableFrom": "published_apps",
+          "tableTo": "drives",
+          "columnsFrom": [
+            "driveId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "published_apps_ownerId_users_id_fk": {
+          "name": "published_apps_ownerId_users_id_fk",
+          "tableFrom": "published_apps",
+          "tableTo": "users",
+          "columnsFrom": [
+            "ownerId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "published_apps_envId_unique": {
+          "name": "published_apps_envId_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "envId"
+          ]
+        },
+        "published_apps_flyAppName_unique": {
+          "name": "published_apps_flyAppName_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "flyAppName"
+          ]
+        },
+        "published_apps_subdomain_unique": {
+          "name": "published_apps_subdomain_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "subdomain"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "published_apps_serving_requires_image": {
+          "name": "published_apps_serving_requires_image",
+          "value": "\"published_apps\".\"status\" NOT IN ('running', 'deploying') OR \"published_apps\".\"imageDigest\" IS NOT NULL"
+        },
+        "published_apps_running_requires_machine": {
+          "name": "published_apps_running_requires_machine",
+          "value": "\"published_apps\".\"status\" <> 'running' OR \"published_apps\".\"machineId\" IS NOT NULL"
+        },
+        "published_apps_parked_is_metered_only": {
+          "name": "published_apps_parked_is_metered_only",
+          "value": "\"published_apps\".\"status\" <> 'parked' OR \"published_apps\".\"tier\" = 'metered'"
+        },
+        "published_apps_guest_preset_allowed": {
+          "name": "published_apps_guest_preset_allowed",
+          "value": "\"published_apps\".\"guestPreset\" IN ('shared-cpu-1x-512', 'shared-cpu-1x-1024', 'shared-cpu-2x-2048', 'shared-cpu-4x-4096')"
+        },
+        "published_apps_metered_guest_preset": {
+          "name": "published_apps_metered_guest_preset",
+          "value": "\"published_apps\".\"tier\" <> 'metered' OR \"published_apps\".\"guestPreset\" = 'shared-cpu-1x-512'"
+        },
+        "published_apps_image_size_nonneg": {
+          "name": "published_apps_image_size_nonneg",
+          "value": "\"published_apps\".\"imageSizeBytes\" IS NULL OR \"published_apps\".\"imageSizeBytes\" >= 0"
+        },
+        "published_apps_subdomain_nonempty": {
+          "name": "published_apps_subdomain_nonempty",
+          "value": "length(\"published_apps\".\"subdomain\") > 0"
+        },
+        "published_apps_claim_coherent": {
+          "name": "published_apps_claim_coherent",
+          "value": "(\"published_apps\".\"claimedAt\" IS NULL) = (\"published_apps\".\"claimedBy\" IS NULL)"
+        },
+        "published_apps_image_size_measured_coherent": {
+          "name": "published_apps_image_size_measured_coherent",
+          "value": "(\"published_apps\".\"imageSizeBytes\" IS NULL) = (\"published_apps\".\"imageSizeMeasuredAt\" IS NULL)"
+        },
+        "published_apps_awake_seconds_today_nonneg": {
+          "name": "published_apps_awake_seconds_today_nonneg",
+          "value": "\"published_apps\".\"awakeSecondsToday\" >= 0"
+        },
+        "published_apps_awake_counter_needs_day": {
+          "name": "published_apps_awake_counter_needs_day",
+          "value": "\"published_apps\".\"awakeSecondsDay\" IS NOT NULL OR \"published_apps\".\"awakeSecondsToday\" = 0"
+        },
+        "published_apps_awake_window_needs_wake": {
+          "name": "published_apps_awake_window_needs_wake",
+          "value": "\"published_apps\".\"awakeBilledThrough\" IS NULL OR \"published_apps\".\"lastWakeAt\" IS NOT NULL"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.published_app_subscriptions": {
+      "name": "published_app_subscriptions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "publishedAppId": {
+          "name": "publishedAppId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stripeSubscriptionId": {
+          "name": "stripeSubscriptionId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stripePriceId": {
+          "name": "stripePriceId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "guestPreset": {
+          "name": "guestPreset",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stripeEventCreated": {
+          "name": "stripeEventCreated",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "currentPeriodStart": {
+          "name": "currentPeriodStart",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "currentPeriodEnd": {
+          "name": "currentPeriodEnd",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cancelAtPeriodEnd": {
+          "name": "cancelAtPeriodEnd",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "published_app_subscriptions_user_idx": {
+          "name": "published_app_subscriptions_user_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "published_app_subscriptions_stripe_subscription_idx": {
+          "name": "published_app_subscriptions_stripe_subscription_idx",
+          "columns": [
+            {
+              "expression": "stripeSubscriptionId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "published_app_subscriptions_publishedAppId_published_apps_id_fk": {
+          "name": "published_app_subscriptions_publishedAppId_published_apps_id_fk",
+          "tableFrom": "published_app_subscriptions",
+          "tableTo": "published_apps",
+          "columnsFrom": [
+            "publishedAppId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "published_app_subscriptions_userId_users_id_fk": {
+          "name": "published_app_subscriptions_userId_users_id_fk",
+          "tableFrom": "published_app_subscriptions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "published_app_subscriptions_publishedAppId_unique": {
+          "name": "published_app_subscriptions_publishedAppId_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "publishedAppId"
+          ]
+        },
+        "published_app_subscriptions_stripeSubscriptionId_unique": {
+          "name": "published_app_subscriptions_stripeSubscriptionId_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "stripeSubscriptionId"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "published_app_subscriptions_status_nonempty": {
+          "name": "published_app_subscriptions_status_nonempty",
+          "value": "length(\"published_app_subscriptions\".\"status\") > 0"
+        },
+        "published_app_subscriptions_period_ordered": {
+          "name": "published_app_subscriptions_period_ordered",
+          "value": "\"published_app_subscriptions\".\"currentPeriodEnd\" >= \"published_app_subscriptions\".\"currentPeriodStart\""
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.app_hosting_stripe_reclaims": {
+      "name": "app_hosting_stripe_reclaims",
+      "schema": "",
+      "columns": {
+        "stripeSubscriptionId": {
+          "name": "stripeSubscriptionId",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "publishedAppId": {
+          "name": "publishedAppId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "recordedAt": {
+          "name": "recordedAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "attempts": {
+          "name": "attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "lastAttemptAt": {
+          "name": "lastAttemptAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lastError": {
+          "name": "lastError",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "app_hosting_stripe_reclaims_recorded_at_idx": {
+          "name": "app_hosting_stripe_reclaims_recorded_at_idx",
+          "columns": [
+            {
+              "expression": "recordedAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "app_hosting_stripe_reclaims_attempts_nonneg": {
+          "name": "app_hosting_stripe_reclaims_attempts_nonneg",
+          "value": "\"app_hosting_stripe_reclaims\".\"attempts\" >= 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.broadcast_recipients": {
+      "name": "broadcast_recipients",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "broadcast_id": {
+          "name": "broadcast_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "recipient_email": {
+          "name": "recipient_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "broadcast_recipient_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "skip_reason": {
+          "name": "skip_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "attempts": {
+          "name": "attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "sent_at": {
+          "name": "sent_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "claimed_at": {
+          "name": "claimed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "claimed_by": {
+          "name": "claimed_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "broadcast_recipients_broadcast_user_unique": {
+          "name": "broadcast_recipients_broadcast_user_unique",
+          "columns": [
+            {
+              "expression": "broadcast_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "broadcast_recipients_broadcast_status_idx": {
+          "name": "broadcast_recipients_broadcast_status_idx",
+          "columns": [
+            {
+              "expression": "broadcast_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "broadcast_recipients_broadcast_id_email_broadcasts_id_fk": {
+          "name": "broadcast_recipients_broadcast_id_email_broadcasts_id_fk",
+          "tableFrom": "broadcast_recipients",
+          "tableTo": "email_broadcasts",
+          "columnsFrom": [
+            "broadcast_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "broadcast_recipients_user_id_users_id_fk": {
+          "name": "broadcast_recipients_user_id_users_id_fk",
+          "tableFrom": "broadcast_recipients",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.broadcast_templates": {
+      "name": "broadcast_templates",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subject": {
+          "name": "subject",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "body_markdown": {
+          "name": "body_markdown",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "broadcast_templates_active_idx": {
+          "name": "broadcast_templates_active_idx",
+          "columns": [
+            {
+              "expression": "is_active",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "broadcast_templates_created_by_user_id_users_id_fk": {
+          "name": "broadcast_templates_created_by_user_id_users_id_fk",
+          "tableFrom": "broadcast_templates",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.email_broadcasts": {
+      "name": "email_broadcasts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "subject": {
+          "name": "subject",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "engine": {
+          "name": "engine",
+          "type": "email_broadcast_engine",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'transactional'"
+        },
+        "content_mode": {
+          "name": "content_mode",
+          "type": "email_broadcast_content_mode",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'compose'"
+        },
+        "template_id": {
+          "name": "template_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "body_markdown": {
+          "name": "body_markdown",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notification_type": {
+          "name": "notification_type",
+          "type": "NotificationType",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'PRODUCT_UPDATE'"
+        },
+        "audience_definition": {
+          "name": "audience_definition",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "status": {
+          "name": "status",
+          "type": "email_broadcast_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'draft'"
+        },
+        "dry_run": {
+          "name": "dry_run",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "send_limit": {
+          "name": "send_limit",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "delay_ms": {
+          "name": "delay_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 120
+        },
+        "total_targeted": {
+          "name": "total_targeted",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "sent_count": {
+          "name": "sent_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "skipped_count": {
+          "name": "skipped_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "failed_count": {
+          "name": "failed_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "step_results": {
+          "name": "step_results",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "job_id": {
+          "name": "job_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "attempts": {
+          "name": "attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "last_error": {
+          "name": "last_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "blocked_reason": {
+          "name": "blocked_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "email_broadcasts_status_idx": {
+          "name": "email_broadcasts_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "email_broadcasts_created_at_idx": {
+          "name": "email_broadcasts_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "email_broadcasts_created_by_idx": {
+          "name": "email_broadcasts_created_by_idx",
+          "columns": [
+            {
+              "expression": "created_by_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "email_broadcasts_template_id_broadcast_templates_id_fk": {
+          "name": "email_broadcasts_template_id_broadcast_templates_id_fk",
+          "tableFrom": "email_broadcasts",
+          "tableTo": "broadcast_templates",
+          "columnsFrom": [
+            "template_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "email_broadcasts_created_by_user_id_users_id_fk": {
+          "name": "email_broadcasts_created_by_user_id_users_id_fk",
+          "tableFrom": "email_broadcasts",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.page_webhooks": {
+      "name": "page_webhooks",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "pageId": {
+          "name": "pageId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "webhookToken": {
+          "name": "webhookToken",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "webhookSecretEncrypted": {
+          "name": "webhookSecretEncrypted",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "isEnabled": {
+          "name": "isEnabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "createdBy": {
+          "name": "createdBy",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "lastFiredAt": {
+          "name": "lastFiredAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lastFireError": {
+          "name": "lastFireError",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "page_webhooks_page_id_idx": {
+          "name": "page_webhooks_page_id_idx",
+          "columns": [
+            {
+              "expression": "pageId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "page_webhooks_token_idx": {
+          "name": "page_webhooks_token_idx",
+          "columns": [
+            {
+              "expression": "webhookToken",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "page_webhooks_pageId_pages_id_fk": {
+          "name": "page_webhooks_pageId_pages_id_fk",
+          "tableFrom": "page_webhooks",
+          "tableTo": "pages",
+          "columnsFrom": [
+            "pageId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "page_webhooks_createdBy_users_id_fk": {
+          "name": "page_webhooks_createdBy_users_id_fk",
+          "tableFrom": "page_webhooks",
+          "tableTo": "users",
+          "columnsFrom": [
+            "createdBy"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "page_webhooks_webhookToken_unique": {
+          "name": "page_webhooks_webhookToken_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "webhookToken"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agent_workspace_shells": {
+      "name": "agent_workspace_shells",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "workspaceId": {
+          "name": "workspaceId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ownerId": {
+          "name": "ownerId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agentType": {
+          "name": "agentType",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "command": {
+          "name": "command",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "spriteExecId": {
+          "name": "spriteExecId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "coldTail": {
+          "name": "coldTail",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "coldTailAt": {
+          "name": "coldTailAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "coldTailHasOutput": {
+          "name": "coldTailHasOutput",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "agent_workspace_shells_workspace_id_idx": {
+          "name": "agent_workspace_shells_workspace_id_idx",
+          "columns": [
+            {
+              "expression": "workspaceId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "agent_workspace_shells_workspace_name_idx": {
+          "name": "agent_workspace_shells_workspace_name_idx",
+          "columns": [
+            {
+              "expression": "workspaceId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "agent_workspace_shells_workspaceId_agent_workspaces_id_fk": {
+          "name": "agent_workspace_shells_workspaceId_agent_workspaces_id_fk",
+          "tableFrom": "agent_workspace_shells",
+          "tableTo": "agent_workspaces",
+          "columnsFrom": [
+            "workspaceId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "agent_workspace_shells_ownerId_users_id_fk": {
+          "name": "agent_workspace_shells_ownerId_users_id_fk",
+          "tableFrom": "agent_workspace_shells",
+          "tableTo": "users",
+          "columnsFrom": [
+            "ownerId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agent_workspaces": {
+      "name": "agent_workspaces",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "driveId": {
+          "name": "driveId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ownerId": {
+          "name": "ownerId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "envId": {
+          "name": "envId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "spriteKey": {
+          "name": "spriteKey",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sandboxId": {
+          "name": "sandboxId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "spriteInstanceId": {
+          "name": "spriteInstanceId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "egressPolicyToken": {
+          "name": "egressPolicyToken",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "teardownRequestedAt": {
+          "name": "teardownRequestedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "spriteTornDownAt": {
+          "name": "spriteTornDownAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "storageLastBilledAt": {
+          "name": "storageLastBilledAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "storageMeasuredBytes": {
+          "name": "storageMeasuredBytes",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "storageMeasuredAt": {
+          "name": "storageMeasuredAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lastActiveAt": {
+          "name": "lastActiveAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "endedAt": {
+          "name": "endedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "agent_workspaces_drive_id_idx": {
+          "name": "agent_workspaces_drive_id_idx",
+          "columns": [
+            {
+              "expression": "driveId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "agent_workspaces_owner_id_idx": {
+          "name": "agent_workspaces_owner_id_idx",
+          "columns": [
+            {
+              "expression": "ownerId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "agent_workspaces_live_sprite_idx": {
+          "name": "agent_workspaces_live_sprite_idx",
+          "columns": [
+            {
+              "expression": "sandboxId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "spriteTornDownAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"agent_workspaces\".\"sandboxId\" IS NOT NULL AND \"agent_workspaces\".\"spriteTornDownAt\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "agent_workspaces_env_id_idx": {
+          "name": "agent_workspaces_env_id_idx",
+          "columns": [
+            {
+              "expression": "envId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "agent_workspaces_driveId_drives_id_fk": {
+          "name": "agent_workspaces_driveId_drives_id_fk",
+          "tableFrom": "agent_workspaces",
+          "tableTo": "drives",
+          "columnsFrom": [
+            "driveId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "agent_workspaces_ownerId_users_id_fk": {
+          "name": "agent_workspaces_ownerId_users_id_fk",
+          "tableFrom": "agent_workspaces",
+          "tableTo": "users",
+          "columnsFrom": [
+            "ownerId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "agent_workspaces_envId_drive_envs_id_fk": {
+          "name": "agent_workspaces_envId_drive_envs_id_fk",
+          "tableFrom": "agent_workspaces",
+          "tableTo": "drive_envs",
+          "columnsFrom": [
+            "envId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "agent_workspaces_env_no_sprite_check": {
+          "name": "agent_workspaces_env_no_sprite_check",
+          "value": "\"agent_workspaces\".\"envId\" IS NULL OR (\"agent_workspaces\".\"sandboxId\" IS NULL AND \"agent_workspaces\".\"spriteKey\" IS NULL AND \"agent_workspaces\".\"spriteInstanceId\" IS NULL)"
+        },
+        "agent_workspaces_env_needs_drive_check": {
+          "name": "agent_workspaces_env_needs_drive_check",
+          "value": "\"agent_workspaces\".\"envId\" IS NULL OR \"agent_workspaces\".\"driveId\" IS NOT NULL"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.agent_workspace_node_revs": {
+      "name": "agent_workspace_node_revs",
+      "schema": "",
+      "columns": {
+        "rootId": {
+          "name": "rootId",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "rev": {
+          "name": "rev",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "agent_workspace_node_revs_rootId_agent_workspaces_id_fk": {
+          "name": "agent_workspace_node_revs_rootId_agent_workspaces_id_fk",
+          "tableFrom": "agent_workspace_node_revs",
+          "tableTo": "agent_workspaces",
+          "columnsFrom": [
+            "rootId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agent_workspace_nodes": {
+      "name": "agent_workspace_nodes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rootId": {
+          "name": "rootId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "parentId": {
+          "name": "parentId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "nodeType": {
+          "name": "nodeType",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "axis": {
+          "name": "axis",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "fraction": {
+          "name": "fraction",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "targetKind": {
+          "name": "targetKind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "targetId": {
+          "name": "targetId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "agent_workspace_nodes_one_root_idx": {
+          "name": "agent_workspace_nodes_one_root_idx",
+          "columns": [
+            {
+              "expression": "rootId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"agent_workspace_nodes\".\"nodeType\" = 'root'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "agent_workspace_nodes_chat_target_idx": {
+          "name": "agent_workspace_nodes_chat_target_idx",
+          "columns": [
+            {
+              "expression": "targetId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"agent_workspace_nodes\".\"targetKind\" = 'chat'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "agent_workspace_nodes_parent_idx": {
+          "name": "agent_workspace_nodes_parent_idx",
+          "columns": [
+            {
+              "expression": "rootId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "parentId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "agent_workspace_nodes_rootId_agent_workspaces_id_fk": {
+          "name": "agent_workspace_nodes_rootId_agent_workspaces_id_fk",
+          "tableFrom": "agent_workspace_nodes",
+          "tableTo": "agent_workspaces",
+          "columnsFrom": [
+            "rootId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "agent_workspace_nodes_rootId_parentId_agent_workspace_nodes_rootId_id_fk": {
+          "name": "agent_workspace_nodes_rootId_parentId_agent_workspace_nodes_rootId_id_fk",
+          "tableFrom": "agent_workspace_nodes",
+          "tableTo": "agent_workspace_nodes",
+          "columnsFrom": [
+            "rootId",
+            "parentId"
+          ],
+          "columnsTo": [
+            "rootId",
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "agent_workspace_nodes_rootId_id_pk": {
+          "name": "agent_workspace_nodes_rootId_id_pk",
+          "columns": [
+            "rootId",
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "agent_workspace_nodes_root_no_parent_chk": {
+          "name": "agent_workspace_nodes_root_no_parent_chk",
+          "value": "(\"agent_workspace_nodes\".\"nodeType\" = 'root') = (\"agent_workspace_nodes\".\"parentId\" IS NULL)"
+        },
+        "agent_workspace_nodes_node_type_chk": {
+          "name": "agent_workspace_nodes_node_type_chk",
+          "value": "\"agent_workspace_nodes\".\"nodeType\" IN ('root', 'split', 'pane')"
+        },
+        "agent_workspace_nodes_target_kind_chk": {
+          "name": "agent_workspace_nodes_target_kind_chk",
+          "value": "\"agent_workspace_nodes\".\"targetKind\" IS NULL OR \"agent_workspace_nodes\".\"targetKind\" IN ('chat', 'terminal', 'page')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.drive_envs": {
+      "name": "drive_envs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "driveId": {
+          "name": "driveId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "substrate": {
+          "name": "substrate",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'sprite'"
+        },
+        "createdBy": {
+          "name": "createdBy",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "spriteKey": {
+          "name": "spriteKey",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sandboxId": {
+          "name": "sandboxId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "spriteInstanceId": {
+          "name": "spriteInstanceId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "egressPolicyToken": {
+          "name": "egressPolicyToken",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "teardownRequestedAt": {
+          "name": "teardownRequestedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "spriteTornDownAt": {
+          "name": "spriteTornDownAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "storageLastBilledAt": {
+          "name": "storageLastBilledAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "storageMeasuredBytes": {
+          "name": "storageMeasuredBytes",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "storageMeasuredAt": {
+          "name": "storageMeasuredAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lastActiveAt": {
+          "name": "lastActiveAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "drive_envs_drive_id_idx": {
+          "name": "drive_envs_drive_id_idx",
+          "columns": [
+            {
+              "expression": "driveId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "drive_envs_drive_name_idx": {
+          "name": "drive_envs_drive_name_idx",
+          "columns": [
+            {
+              "expression": "driveId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "drive_envs_live_sprite_idx": {
+          "name": "drive_envs_live_sprite_idx",
+          "columns": [
+            {
+              "expression": "sandboxId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "spriteTornDownAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"drive_envs\".\"sandboxId\" IS NOT NULL AND \"drive_envs\".\"spriteTornDownAt\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "drive_envs_driveId_drives_id_fk": {
+          "name": "drive_envs_driveId_drives_id_fk",
+          "tableFrom": "drive_envs",
+          "tableTo": "drives",
+          "columnsFrom": [
+            "driveId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "drive_envs_createdBy_users_id_fk": {
+          "name": "drive_envs_createdBy_users_id_fk",
+          "tableFrom": "drive_envs",
+          "tableTo": "users",
+          "columnsFrom": [
+            "createdBy"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "drive_envs_id_substrate_unique": {
+          "name": "drive_envs_id_substrate_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "id",
+            "substrate"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "drive_envs_substrate_check": {
+          "name": "drive_envs_substrate_check",
+          "value": "\"drive_envs\".\"substrate\" IN ('sprite', 'local')"
+        },
+        "drive_envs_local_no_sprite_check": {
+          "name": "drive_envs_local_no_sprite_check",
+          "value": "\"drive_envs\".\"substrate\" = 'sprite' OR (\"drive_envs\".\"spriteKey\" IS NULL AND \"drive_envs\".\"sandboxId\" IS NULL AND \"drive_envs\".\"spriteInstanceId\" IS NULL)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.drive_env_local": {
+      "name": "drive_env_local",
+      "schema": "",
+      "columns": {
+        "envId": {
+          "name": "envId",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "substrate": {
+          "name": "substrate",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'local'"
+        },
+        "ownerId": {
+          "name": "ownerId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "enrollmentId": {
+          "name": "enrollmentId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "machinePublicKey": {
+          "name": "machinePublicKey",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "machineKeyFingerprint": {
+          "name": "machineKeyFingerprint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "serverKeyId": {
+          "name": "serverKeyId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "enrollmentCodeHash": {
+          "name": "enrollmentCodeHash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "enrollmentCodeExpiresAt": {
+          "name": "enrollmentCodeExpiresAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "enrollmentCodeUsedAt": {
+          "name": "enrollmentCodeUsedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "challengeNonce": {
+          "name": "challengeNonce",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "challengeIssuedAt": {
+          "name": "challengeIssuedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "challengeExpiresAt": {
+          "name": "challengeExpiresAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "challengeUsedAt": {
+          "name": "challengeUsedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "capabilities": {
+          "name": "capabilities",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "serverPolicy": {
+          "name": "serverPolicy",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{\"ops\":[],\"checkpoint\":false}'::jsonb"
+        },
+        "bindPolicy": {
+          "name": "bindPolicy",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'owner'"
+        },
+        "lastSeenAt": {
+          "name": "lastSeenAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "enrolledAt": {
+          "name": "enrolledAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revokedAt": {
+          "name": "revokedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "drive_env_local_owner_id_idx": {
+          "name": "drive_env_local_owner_id_idx",
+          "columns": [
+            {
+              "expression": "ownerId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "drive_env_local_ownerId_users_id_fk": {
+          "name": "drive_env_local_ownerId_users_id_fk",
+          "tableFrom": "drive_env_local",
+          "tableTo": "users",
+          "columnsFrom": [
+            "ownerId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "drive_env_local_envId_substrate_drive_envs_id_substrate_fk": {
+          "name": "drive_env_local_envId_substrate_drive_envs_id_substrate_fk",
+          "tableFrom": "drive_env_local",
+          "tableTo": "drive_envs",
+          "columnsFrom": [
+            "envId",
+            "substrate"
+          ],
+          "columnsTo": [
+            "id",
+            "substrate"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "drive_env_local_enrollment_id_unique": {
+          "name": "drive_env_local_enrollment_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "enrollmentId"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "drive_env_local_substrate_check": {
+          "name": "drive_env_local_substrate_check",
+          "value": "\"drive_env_local\".\"substrate\" = 'local'"
+        },
+        "drive_env_local_enrolled_has_key_check": {
+          "name": "drive_env_local_enrolled_has_key_check",
+          "value": "\"drive_env_local\".\"enrolledAt\" IS NULL OR (\"drive_env_local\".\"machinePublicKey\" IS NOT NULL AND \"drive_env_local\".\"machineKeyFingerprint\" IS NOT NULL AND \"drive_env_local\".\"serverKeyId\" IS NOT NULL)"
+        },
+        "drive_env_local_bind_policy_check": {
+          "name": "drive_env_local_bind_policy_check",
+          "value": "\"drive_env_local\".\"bindPolicy\" IN ('owner', 'admins', 'members')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.dev_preview_services": {
+      "name": "dev_preview_services",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "workspaceId": {
+          "name": "workspaceId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "envId": {
+          "name": "envId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "spriteInstanceId": {
+          "name": "spriteInstanceId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sandboxId": {
+          "name": "sandboxId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "targetPort": {
+          "name": "targetPort",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "relayServiceName": {
+          "name": "relayServiceName",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "detectedAt": {
+          "name": "detectedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stoppedByUserAt": {
+          "name": "stoppedByUserAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "dev_preview_services_sprite_instance_idx": {
+          "name": "dev_preview_services_sprite_instance_idx",
+          "columns": [
+            {
+              "expression": "spriteInstanceId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "dev_preview_services_workspace_id_idx": {
+          "name": "dev_preview_services_workspace_id_idx",
+          "columns": [
+            {
+              "expression": "workspaceId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"dev_preview_services\".\"workspaceId\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "dev_preview_services_env_id_idx": {
+          "name": "dev_preview_services_env_id_idx",
+          "columns": [
+            {
+              "expression": "envId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"dev_preview_services\".\"envId\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "dev_preview_services_workspaceId_agent_workspaces_id_fk": {
+          "name": "dev_preview_services_workspaceId_agent_workspaces_id_fk",
+          "tableFrom": "dev_preview_services",
+          "tableTo": "agent_workspaces",
+          "columnsFrom": [
+            "workspaceId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "dev_preview_services_envId_drive_envs_id_fk": {
+          "name": "dev_preview_services_envId_drive_envs_id_fk",
+          "tableFrom": "dev_preview_services",
+          "tableTo": "drive_envs",
+          "columnsFrom": [
+            "envId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "dev_preview_services_one_holder_check": {
+          "name": "dev_preview_services_one_holder_check",
+          "value": "(\"dev_preview_services\".\"workspaceId\" IS NULL) <> (\"dev_preview_services\".\"envId\" IS NULL)"
+        },
+        "dev_preview_services_target_port_range_check": {
+          "name": "dev_preview_services_target_port_range_check",
+          "value": "\"dev_preview_services\".\"targetPort\" BETWEEN 1 AND 65535"
+        },
+        "dev_preview_services_relay_iff_not_8080_check": {
+          "name": "dev_preview_services_relay_iff_not_8080_check",
+          "value": "(\"dev_preview_services\".\"targetPort\" = 8080) = (\"dev_preview_services\".\"relayServiceName\" IS NULL)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.dev_preview_grants": {
+      "name": "dev_preview_grants",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "holderKind": {
+          "name": "holderKind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "holderId": {
+          "name": "holderId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sessionId": {
+          "name": "sessionId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expiresAt": {
+          "name": "expiresAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cookieExpiresAt": {
+          "name": "cookieExpiresAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "consumedAt": {
+          "name": "consumedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "dev_preview_grants_expires_at_idx": {
+          "name": "dev_preview_grants_expires_at_idx",
+          "columns": [
+            {
+              "expression": "expiresAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "dev_preview_grants_userId_users_id_fk": {
+          "name": "dev_preview_grants_userId_users_id_fk",
+          "tableFrom": "dev_preview_grants",
+          "tableTo": "users",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "dev_preview_grants_sessionId_sessions_id_fk": {
+          "name": "dev_preview_grants_sessionId_sessions_id_fk",
+          "tableFrom": "dev_preview_grants",
+          "tableTo": "sessions",
+          "columnsFrom": [
+            "sessionId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "dev_preview_grants_holder_kind_check": {
+          "name": "dev_preview_grants_holder_kind_check",
+          "value": "\"dev_preview_grants\".\"holderKind\" IN ('workspace', 'env')"
+        }
+      },
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.AuthProvider": {
+      "name": "AuthProvider",
+      "schema": "public",
+      "values": [
+        "email",
+        "google",
+        "apple"
+      ]
+    },
+    "public.PlatformType": {
+      "name": "PlatformType",
+      "schema": "public",
+      "values": [
+        "web",
+        "desktop",
+        "ios",
+        "android"
+      ]
+    },
+    "public.UserRole": {
+      "name": "UserRole",
+      "schema": "public",
+      "values": [
+        "user",
+        "admin"
+      ]
+    },
+    "public.DriveKind": {
+      "name": "DriveKind",
+      "schema": "public",
+      "values": [
+        "STANDARD",
+        "HOME"
+      ]
+    },
+    "public.FavoriteItemType": {
+      "name": "FavoriteItemType",
+      "schema": "public",
+      "values": [
+        "page",
+        "drive"
+      ]
+    },
+    "public.PageType": {
+      "name": "PageType",
+      "schema": "public",
+      "values": [
+        "FOLDER",
+        "DOCUMENT",
+        "CHANNEL",
+        "AI_CHAT",
+        "CANVAS",
+        "FILE",
+        "SHEET",
+        "TASK_LIST",
+        "CODE",
+        "MACHINE"
+      ]
+    },
+    "public.MemberRole": {
+      "name": "MemberRole",
+      "schema": "public",
+      "values": [
+        "OWNER",
+        "ADMIN",
+        "MEMBER"
+      ]
+    },
+    "public.pulse_summary_type": {
+      "name": "pulse_summary_type",
+      "schema": "public",
+      "values": [
+        "scheduled",
+        "on_demand",
+        "welcome"
+      ]
+    },
+    "public.NotificationType": {
+      "name": "NotificationType",
+      "schema": "public",
+      "values": [
+        "PERMISSION_GRANTED",
+        "PERMISSION_REVOKED",
+        "PERMISSION_UPDATED",
+        "PAGE_SHARED",
+        "DRIVE_INVITED",
+        "DRIVE_JOINED",
+        "DRIVE_ROLE_CHANGED",
+        "CONNECTION_REQUEST",
+        "CONNECTION_ACCEPTED",
+        "CONNECTION_REJECTED",
+        "NEW_DIRECT_MESSAGE",
+        "EMAIL_VERIFICATION_REQUIRED",
+        "TOS_PRIVACY_UPDATED",
+        "MENTION",
+        "TASK_ASSIGNED",
+        "PRODUCT_UPDATE"
+      ]
+    },
+    "public.toast_notification_level": {
+      "name": "toast_notification_level",
+      "schema": "public",
+      "values": [
+        "all",
+        "mentions",
+        "off"
+      ]
+    },
+    "public.display_preference_type": {
+      "name": "display_preference_type",
+      "schema": "public",
+      "values": [
+        "SHOW_TOKEN_COUNTS",
+        "SHOW_CODE_TOGGLE",
+        "DEFAULT_MARKDOWN_MODE"
+      ]
+    },
+    "public.activity_change_group_type": {
+      "name": "activity_change_group_type",
+      "schema": "public",
+      "values": [
+        "user",
+        "ai",
+        "automation",
+        "system"
+      ]
+    },
+    "public.activity_resource": {
+      "name": "activity_resource",
+      "schema": "public",
+      "values": [
+        "page",
+        "drive",
+        "permission",
+        "agent",
+        "user",
+        "member",
+        "role",
+        "file",
+        "token",
+        "device",
+        "message",
+        "conversation"
+      ]
+    },
+    "public.content_format": {
+      "name": "content_format",
+      "schema": "public",
+      "values": [
+        "text",
+        "html",
+        "json",
+        "tiptap"
+      ]
+    },
+    "public.http_method": {
+      "name": "http_method",
+      "schema": "public",
+      "values": [
+        "GET",
+        "POST",
+        "PUT",
+        "DELETE",
+        "PATCH",
+        "HEAD",
+        "OPTIONS"
+      ]
+    },
+    "public.log_level": {
+      "name": "log_level",
+      "schema": "public",
+      "values": [
+        "trace",
+        "debug",
+        "info",
+        "warn",
+        "error",
+        "fatal"
+      ]
+    },
+    "public.drive_backup_schedule_frequency": {
+      "name": "drive_backup_schedule_frequency",
+      "schema": "public",
+      "values": [
+        "daily",
+        "weekly",
+        "monthly"
+      ]
+    },
+    "public.drive_backup_source": {
+      "name": "drive_backup_source",
+      "schema": "public",
+      "values": [
+        "manual",
+        "scheduled",
+        "pre_restore",
+        "system"
+      ]
+    },
+    "public.drive_backup_status": {
+      "name": "drive_backup_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "ready",
+        "failed"
+      ]
+    },
+    "public.page_version_source": {
+      "name": "page_version_source",
+      "schema": "public",
+      "values": [
+        "manual",
+        "auto",
+        "pre_ai",
+        "pre_restore",
+        "restore",
+        "system"
+      ]
+    },
+    "public.ConnectionStatus": {
+      "name": "ConnectionStatus",
+      "schema": "public",
+      "values": [
+        "PENDING",
+        "ACCEPTED",
+        "BLOCKED"
+      ]
+    },
+    "public.PushPlatformType": {
+      "name": "PushPlatformType",
+      "schema": "public",
+      "values": [
+        "ios",
+        "android",
+        "web"
+      ]
+    },
+    "public.integration_connection_status": {
+      "name": "integration_connection_status",
+      "schema": "public",
+      "values": [
+        "active",
+        "expired",
+        "error",
+        "pending",
+        "revoked"
+      ]
+    },
+    "public.integration_provider_type": {
+      "name": "integration_provider_type",
+      "schema": "public",
+      "values": [
+        "builtin",
+        "openapi",
+        "custom",
+        "mcp",
+        "webhook"
+      ]
+    },
+    "public.integration_visibility": {
+      "name": "integration_visibility",
+      "schema": "public",
+      "values": [
+        "private",
+        "owned_drives",
+        "all_drives"
+      ]
+    },
+    "public.AttendeeStatus": {
+      "name": "AttendeeStatus",
+      "schema": "public",
+      "values": [
+        "PENDING",
+        "ACCEPTED",
+        "DECLINED",
+        "TENTATIVE"
+      ]
+    },
+    "public.EventVisibility": {
+      "name": "EventVisibility",
+      "schema": "public",
+      "values": [
+        "DRIVE",
+        "ATTENDEES_ONLY",
+        "PRIVATE"
+      ]
+    },
+    "public.GoogleCalendarConnectionStatus": {
+      "name": "GoogleCalendarConnectionStatus",
+      "schema": "public",
+      "values": [
+        "active",
+        "expired",
+        "error",
+        "disconnected"
+      ]
+    },
+    "public.RecurrenceFrequency": {
+      "name": "RecurrenceFrequency",
+      "schema": "public",
+      "values": [
+        "DAILY",
+        "WEEKLY",
+        "MONTHLY",
+        "YEARLY"
+      ]
+    },
+    "public.WorkflowTriggerType": {
+      "name": "WorkflowTriggerType",
+      "schema": "public",
+      "values": [
+        "cron",
+        "event"
+      ]
+    },
+    "public.WorkflowRunSourceTable": {
+      "name": "WorkflowRunSourceTable",
+      "schema": "public",
+      "values": [
+        "taskTriggers",
+        "calendarTriggers",
+        "webhookTriggers",
+        "cron",
+        "manual"
+      ]
+    },
+    "public.WorkflowRunStatus": {
+      "name": "WorkflowRunStatus",
+      "schema": "public",
+      "values": [
+        "running",
+        "success",
+        "error",
+        "cancelled"
+      ]
+    },
+    "public.WorkflowRunStepStatus": {
+      "name": "WorkflowRunStepStatus",
+      "schema": "public",
+      "values": [
+        "running",
+        "success",
+        "error",
+        "skipped"
+      ]
+    },
+    "public.TaskTriggerType": {
+      "name": "TaskTriggerType",
+      "schema": "public",
+      "values": [
+        "due_date",
+        "completion"
+      ]
+    },
+    "public.ZoomConnectionStatus": {
+      "name": "ZoomConnectionStatus",
+      "schema": "public",
+      "values": [
+        "active",
+        "expired",
+        "error",
+        "disconnected"
+      ]
+    },
+    "public.ContentTagAnchorStatus": {
+      "name": "ContentTagAnchorStatus",
+      "schema": "public",
+      "values": [
+        "exact",
+        "shifted",
+        "fuzzy",
+        "orphaned"
+      ]
+    },
+    "public.ContentTagSource": {
+      "name": "ContentTagSource",
+      "schema": "public",
+      "values": [
+        "user",
+        "ai",
+        "system",
+        "rule"
+      ]
+    },
+    "public.ContentTagTargetKind": {
+      "name": "ContentTagTargetKind",
+      "schema": "public",
+      "values": [
+        "page",
+        "text",
+        "sheet_cell",
+        "channel_message",
+        "ai_message"
+      ]
+    },
+    "public.custom_domain_status": {
+      "name": "custom_domain_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "verified",
+        "failed",
+        "provisioning",
+        "active",
+        "dns_failed",
+        "cert_failed"
+      ]
+    },
+    "public.data_subject_request_status": {
+      "name": "data_subject_request_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "queued",
+        "in_progress",
+        "blocked",
+        "completed",
+        "failed",
+        "cancelled"
+      ]
+    },
+    "public.data_subject_request_type": {
+      "name": "data_subject_request_type",
+      "schema": "public",
+      "values": [
+        "erasure",
+        "export",
+        "access",
+        "rectification",
+        "restriction",
+        "portability",
+        "objection"
+      ]
+    },
+    "public.data_subject_requester_type": {
+      "name": "data_subject_requester_type",
+      "schema": "public",
+      "values": [
+        "self",
+        "admin"
+      ]
+    },
+    "public.OAuthClientType": {
+      "name": "OAuthClientType",
+      "schema": "public",
+      "values": [
+        "public",
+        "confidential"
+      ]
+    },
+    "public.published_app_status": {
+      "name": "published_app_status",
+      "schema": "public",
+      "values": [
+        "provisioning",
+        "building",
+        "deploying",
+        "running",
+        "stopped",
+        "parked",
+        "destroying",
+        "failed"
+      ]
+    },
+    "public.published_app_tier": {
+      "name": "published_app_tier",
+      "schema": "public",
+      "values": [
+        "metered",
+        "dedicated"
+      ]
+    },
+    "public.broadcast_recipient_status": {
+      "name": "broadcast_recipient_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "sent",
+        "skipped",
+        "failed"
+      ]
+    },
+    "public.email_broadcast_content_mode": {
+      "name": "email_broadcast_content_mode",
+      "schema": "public",
+      "values": [
+        "compose",
+        "template"
+      ]
+    },
+    "public.email_broadcast_engine": {
+      "name": "email_broadcast_engine",
+      "schema": "public",
+      "values": [
+        "transactional",
+        "resend_broadcast"
+      ]
+    },
+    "public.email_broadcast_status": {
+      "name": "email_broadcast_status",
+      "schema": "public",
+      "values": [
+        "draft",
+        "pending",
+        "queued",
+        "in_progress",
+        "paused",
+        "completed",
+        "failed",
+        "cancelled"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/packages/db/drizzle/meta/0288_snapshot.json
+++ b/packages/db/drizzle/meta/0288_snapshot.json
@@ -1,0 +1,24158 @@
+{
+  "id": "30b8b7cb-7331-400a-82e8-5bbf86221973",
+  "prevId": "e42391fc-8a22-4ace-9842-a9180bd33521",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.device_tokens": {
+      "name": "device_tokens",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tokenHash": {
+          "name": "tokenHash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tokenPrefix": {
+          "name": "tokenPrefix",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expiresAt": {
+          "name": "expiresAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "lastUsedAt": {
+          "name": "lastUsedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deviceId": {
+          "name": "deviceId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "platform": {
+          "name": "platform",
+          "type": "PlatformType",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "deviceName": {
+          "name": "deviceName",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tokenVersion": {
+          "name": "tokenVersion",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "userAgent": {
+          "name": "userAgent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ipAddress": {
+          "name": "ipAddress",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lastIpAddress": {
+          "name": "lastIpAddress",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "location": {
+          "name": "location",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "trustScore": {
+          "name": "trustScore",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "suspiciousActivityCount": {
+          "name": "suspiciousActivityCount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "revokedAt": {
+          "name": "revokedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revokedReason": {
+          "name": "revokedReason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "replacedByTokenId": {
+          "name": "replacedByTokenId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "device_tokens_user_id_idx": {
+          "name": "device_tokens_user_id_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "device_tokens_token_hash_idx": {
+          "name": "device_tokens_token_hash_idx",
+          "columns": [
+            {
+              "expression": "tokenHash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "device_tokens_device_id_idx": {
+          "name": "device_tokens_device_id_idx",
+          "columns": [
+            {
+              "expression": "deviceId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "device_tokens_expires_at_idx": {
+          "name": "device_tokens_expires_at_idx",
+          "columns": [
+            {
+              "expression": "expiresAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "device_tokens_active_device_idx": {
+          "name": "device_tokens_active_device_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deviceId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "platform",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"device_tokens\".\"revokedAt\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "device_tokens_userId_users_id_fk": {
+          "name": "device_tokens_userId_users_id_fk",
+          "tableFrom": "device_tokens",
+          "tableTo": "users",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "device_tokens_tokenHash_unique": {
+          "name": "device_tokens_tokenHash_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "tokenHash"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.email_unsubscribe_tokens": {
+      "name": "email_unsubscribe_tokens",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_prefix": {
+          "name": "token_prefix",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "notification_type": {
+          "name": "notification_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "used_at": {
+          "name": "used_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "email_unsubscribe_tokens_token_hash_idx": {
+          "name": "email_unsubscribe_tokens_token_hash_idx",
+          "columns": [
+            {
+              "expression": "token_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "email_unsubscribe_tokens_user_id_idx": {
+          "name": "email_unsubscribe_tokens_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "email_unsubscribe_tokens_expires_at_idx": {
+          "name": "email_unsubscribe_tokens_expires_at_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "email_unsubscribe_tokens_user_id_users_id_fk": {
+          "name": "email_unsubscribe_tokens_user_id_users_id_fk",
+          "tableFrom": "email_unsubscribe_tokens",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "email_unsubscribe_tokens_token_hash_unique": {
+          "name": "email_unsubscribe_tokens_token_hash_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token_hash"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.mcp_tokens": {
+      "name": "mcp_tokens",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tokenHash": {
+          "name": "tokenHash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tokenPrefix": {
+          "name": "tokenPrefix",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "isScoped": {
+          "name": "isScoped",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "lastUsed": {
+          "name": "lastUsed",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "revokedAt": {
+          "name": "revokedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "mcp_tokens_user_id_idx": {
+          "name": "mcp_tokens_user_id_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "mcp_tokens_token_hash_idx": {
+          "name": "mcp_tokens_token_hash_idx",
+          "columns": [
+            {
+              "expression": "tokenHash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "mcp_tokens_userId_users_id_fk": {
+          "name": "mcp_tokens_userId_users_id_fk",
+          "tableFrom": "mcp_tokens",
+          "tableTo": "users",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "mcp_tokens_tokenHash_unique": {
+          "name": "mcp_tokens_tokenHash_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "tokenHash"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.passkeys": {
+      "name": "passkeys",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "credential_id": {
+          "name": "credential_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "public_key": {
+          "name": "public_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "counter": {
+          "name": "counter",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "device_type": {
+          "name": "device_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "transports": {
+          "name": "transports",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "backed_up": {
+          "name": "backed_up",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "passkeys_user_id_idx": {
+          "name": "passkeys_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "passkeys_credential_id_idx": {
+          "name": "passkeys_credential_id_idx",
+          "columns": [
+            {
+              "expression": "credential_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "passkeys_user_id_users_id_fk": {
+          "name": "passkeys_user_id_users_id_fk",
+          "tableFrom": "passkeys",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "passkeys_credential_id_unique": {
+          "name": "passkeys_credential_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "credential_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.socket_tokens": {
+      "name": "socket_tokens",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tokenHash": {
+          "name": "tokenHash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expiresAt": {
+          "name": "expiresAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "socket_tokens_user_id_idx": {
+          "name": "socket_tokens_user_id_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "socket_tokens_token_hash_idx": {
+          "name": "socket_tokens_token_hash_idx",
+          "columns": [
+            {
+              "expression": "tokenHash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "socket_tokens_expires_at_idx": {
+          "name": "socket_tokens_expires_at_idx",
+          "columns": [
+            {
+              "expression": "expiresAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "socket_tokens_userId_users_id_fk": {
+          "name": "socket_tokens_userId_users_id_fk",
+          "tableFrom": "socket_tokens",
+          "tableTo": "users",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "socket_tokens_tokenHash_unique": {
+          "name": "socket_tokens_tokenHash_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "tokenHash"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "emailBidx": {
+          "name": "emailBidx",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "emailVerified": {
+          "name": "emailVerified",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "googleId": {
+          "name": "googleId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "appleId": {
+          "name": "appleId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider": {
+          "name": "provider",
+          "type": "AuthProvider",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'email'"
+        },
+        "tokenVersion": {
+          "name": "tokenVersion",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "role": {
+          "name": "role",
+          "type": "UserRole",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'user'"
+        },
+        "adminRoleVersion": {
+          "name": "adminRoleVersion",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "currentAiProvider": {
+          "name": "currentAiProvider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'zai'"
+        },
+        "currentAiModel": {
+          "name": "currentAiModel",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'z-ai/glm-5.3-flash'"
+        },
+        "imageGenerationModel": {
+          "name": "imageGenerationModel",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "storageUsedBytes": {
+          "name": "storageUsedBytes",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "activeUploads": {
+          "name": "activeUploads",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "lastStorageCalculated": {
+          "name": "lastStorageCalculated",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stripeCustomerId": {
+          "name": "stripeCustomerId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "subscriptionTier": {
+          "name": "subscriptionTier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'free'"
+        },
+        "tosAcceptedAt": {
+          "name": "tosAcceptedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "failedLoginAttempts": {
+          "name": "failedLoginAttempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "lockedUntil": {
+          "name": "lockedUntil",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "suspendedAt": {
+          "name": "suspendedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "suspendedReason": {
+          "name": "suspendedReason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "timezone": {
+          "name": "timezone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "starterSkillsInstalledAt": {
+          "name": "starterSkillsInstalledAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "onboardingCompletedAt": {
+          "name": "onboardingCompletedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "users_email_bidx_idx": {
+          "name": "users_email_bidx_idx",
+          "columns": [
+            {
+              "expression": "emailBidx",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        },
+        "users_googleId_unique": {
+          "name": "users_googleId_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "googleId"
+          ]
+        },
+        "users_appleId_unique": {
+          "name": "users_appleId_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "appleId"
+          ]
+        },
+        "users_stripeCustomerId_unique": {
+          "name": "users_stripeCustomerId_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "stripeCustomerId"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.verification_tokens": {
+      "name": "verification_tokens",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tokenHash": {
+          "name": "tokenHash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tokenPrefix": {
+          "name": "tokenPrefix",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expiresAt": {
+          "name": "expiresAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "usedAt": {
+          "name": "usedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "verification_tokens_user_id_idx": {
+          "name": "verification_tokens_user_id_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "verification_tokens_token_hash_idx": {
+          "name": "verification_tokens_token_hash_idx",
+          "columns": [
+            {
+              "expression": "tokenHash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "verification_tokens_type_idx": {
+          "name": "verification_tokens_type_idx",
+          "columns": [
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "verification_tokens_userId_users_id_fk": {
+          "name": "verification_tokens_userId_users_id_fk",
+          "tableFrom": "verification_tokens",
+          "tableTo": "users",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "verification_tokens_tokenHash_unique": {
+          "name": "verification_tokens_tokenHash_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "tokenHash"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sessions": {
+      "name": "sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_prefix": {
+          "name": "token_prefix",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "device_id": {
+          "name": "device_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "ARRAY[]::text[]"
+        },
+        "resource_type": {
+          "name": "resource_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resource_id": {
+          "name": "resource_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "drive_id": {
+          "name": "drive_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "token_version": {
+          "name": "token_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "admin_role_version": {
+          "name": "admin_role_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_by_service": {
+          "name": "created_by_service",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by_ip": {
+          "name": "created_by_ip",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_used_ip": {
+          "name": "last_used_ip",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revoked_reason": {
+          "name": "revoked_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "sessions_user_id_idx": {
+          "name": "sessions_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sessions_expires_at_idx": {
+          "name": "sessions_expires_at_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sessions_user_active_idx": {
+          "name": "sessions_user_active_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "revoked_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sessions_user_device_idx": {
+          "name": "sessions_user_device_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "device_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "sessions_user_id_users_id_fk": {
+          "name": "sessions_user_id_users_id_fk",
+          "tableFrom": "sessions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "sessions_token_hash_unique": {
+          "name": "sessions_token_hash_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token_hash"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.drives": {
+      "name": "drives",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ownerId": {
+          "name": "ownerId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "DriveKind",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'STANDARD'"
+        },
+        "isTrashed": {
+          "name": "isTrashed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "trashedAt": {
+          "name": "trashedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "drivePrompt": {
+          "name": "drivePrompt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "publishSubdomain": {
+          "name": "publishSubdomain",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "homePageId": {
+          "name": "homePageId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "publish_default_og_image_url": {
+          "name": "publish_default_og_image_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "not_found_page_id": {
+          "name": "not_found_page_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "publish_favicon_url": {
+          "name": "publish_favicon_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "drives_owner_id_idx": {
+          "name": "drives_owner_id_idx",
+          "columns": [
+            {
+              "expression": "ownerId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "drives_owner_id_slug_key": {
+          "name": "drives_owner_id_slug_key",
+          "columns": [
+            {
+              "expression": "ownerId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "drives_owner_home_unique": {
+          "name": "drives_owner_home_unique",
+          "columns": [
+            {
+              "expression": "ownerId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"drives\".\"kind\" = 'HOME'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "drives_ownerId_users_id_fk": {
+          "name": "drives_ownerId_users_id_fk",
+          "tableFrom": "drives",
+          "tableTo": "users",
+          "columnsFrom": [
+            "ownerId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "drives_homePageId_pages_id_fk": {
+          "name": "drives_homePageId_pages_id_fk",
+          "tableFrom": "drives",
+          "tableTo": "pages",
+          "columnsFrom": [
+            "homePageId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "drives_not_found_page_id_pages_id_fk": {
+          "name": "drives_not_found_page_id_pages_id_fk",
+          "tableFrom": "drives",
+          "tableTo": "pages",
+          "columnsFrom": [
+            "not_found_page_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "drives_publishSubdomain_unique": {
+          "name": "drives_publishSubdomain_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "publishSubdomain"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.favorites": {
+      "name": "favorites",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "itemType": {
+          "name": "itemType",
+          "type": "FavoriteItemType",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'page'"
+        },
+        "pageId": {
+          "name": "pageId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "driveId": {
+          "name": "driveId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "favorites_user_id_page_id_key": {
+          "name": "favorites_user_id_page_id_key",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "pageId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "favorites_user_id_drive_id_key": {
+          "name": "favorites_user_id_drive_id_key",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "driveId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "favorites_user_id_position_idx": {
+          "name": "favorites_user_id_position_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "position",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "favorites_userId_users_id_fk": {
+          "name": "favorites_userId_users_id_fk",
+          "tableFrom": "favorites",
+          "tableTo": "users",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "favorites_pageId_pages_id_fk": {
+          "name": "favorites_pageId_pages_id_fk",
+          "tableFrom": "favorites",
+          "tableTo": "pages",
+          "columnsFrom": [
+            "pageId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "favorites_driveId_drives_id_fk": {
+          "name": "favorites_driveId_drives_id_fk",
+          "tableFrom": "favorites",
+          "tableTo": "drives",
+          "columnsFrom": [
+            "driveId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "favorites_item_type_consistency_chk": {
+          "name": "favorites_item_type_consistency_chk",
+          "value": "((\"itemType\" = 'page' AND \"pageId\" IS NOT NULL AND \"driveId\" IS NULL) OR (\"itemType\" = 'drive' AND \"driveId\" IS NOT NULL AND \"pageId\" IS NULL))"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.mentions": {
+      "name": "mentions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "sourcePageId": {
+          "name": "sourcePageId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "targetPageId": {
+          "name": "targetPageId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "mentions_source_page_id_target_page_id_key": {
+          "name": "mentions_source_page_id_target_page_id_key",
+          "columns": [
+            {
+              "expression": "sourcePageId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "targetPageId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "mentions_source_page_id_idx": {
+          "name": "mentions_source_page_id_idx",
+          "columns": [
+            {
+              "expression": "sourcePageId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "mentions_target_page_id_idx": {
+          "name": "mentions_target_page_id_idx",
+          "columns": [
+            {
+              "expression": "targetPageId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "mentions_sourcePageId_pages_id_fk": {
+          "name": "mentions_sourcePageId_pages_id_fk",
+          "tableFrom": "mentions",
+          "tableTo": "pages",
+          "columnsFrom": [
+            "sourcePageId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "mentions_targetPageId_pages_id_fk": {
+          "name": "mentions_targetPageId_pages_id_fk",
+          "tableFrom": "mentions",
+          "tableTo": "pages",
+          "columnsFrom": [
+            "targetPageId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.pages": {
+      "name": "pages",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "PageType",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "contentMode": {
+          "name": "contentMode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'html'"
+        },
+        "isPaginated": {
+          "name": "isPaginated",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "position": {
+          "name": "position",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "isTrashed": {
+          "name": "isTrashed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "aiProvider": {
+          "name": "aiProvider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "aiModel": {
+          "name": "aiModel",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "systemPrompt": {
+          "name": "systemPrompt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "enabledTools": {
+          "name": "enabledTools",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "includeDrivePrompt": {
+          "name": "includeDrivePrompt",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "agentDefinition": {
+          "name": "agentDefinition",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "visibleToGlobalAssistant": {
+          "name": "visibleToGlobalAssistant",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "includePageTree": {
+          "name": "includePageTree",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "pageTreeScope": {
+          "name": "pageTreeScope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'children'"
+        },
+        "toolExposureMode": {
+          "name": "toolExposureMode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'upfront'"
+        },
+        "sandboxEnabled": {
+          "name": "sandboxEnabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "defaultEnvId": {
+          "name": "defaultEnvId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "userScopedAccess": {
+          "name": "userScopedAccess",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "siteMode": {
+          "name": "siteMode",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "fileSize": {
+          "name": "fileSize",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mimeType": {
+          "name": "mimeType",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "originalFileName": {
+          "name": "originalFileName",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "filePath": {
+          "name": "filePath",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "fileMetadata": {
+          "name": "fileMetadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "processingStatus": {
+          "name": "processingStatus",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'pending'"
+        },
+        "processingError": {
+          "name": "processingError",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "processedAt": {
+          "name": "processedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "extractionMethod": {
+          "name": "extractionMethod",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "extractionMetadata": {
+          "name": "extractionMetadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "contentHash": {
+          "name": "contentHash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "excludeFromSearch": {
+          "name": "excludeFromSearch",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "isPrivate": {
+          "name": "isPrivate",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "createdBy": {
+          "name": "createdBy",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "trashedAt": {
+          "name": "trashedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revision": {
+          "name": "revision",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "stateHash": {
+          "name": "stateHash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "driveId": {
+          "name": "driveId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "parentId": {
+          "name": "parentId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "originalParentId": {
+          "name": "originalParentId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "pages_drive_id_idx": {
+          "name": "pages_drive_id_idx",
+          "columns": [
+            {
+              "expression": "driveId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "pages_parent_id_idx": {
+          "name": "pages_parent_id_idx",
+          "columns": [
+            {
+              "expression": "parentId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "pages_parent_id_position_idx": {
+          "name": "pages_parent_id_position_idx",
+          "columns": [
+            {
+              "expression": "parentId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "position",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "pages_drive_id_is_trashed_type_idx": {
+          "name": "pages_drive_id_is_trashed_type_idx",
+          "columns": [
+            {
+              "expression": "driveId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "isTrashed",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "pages_defaultEnvId_drive_envs_id_fk": {
+          "name": "pages_defaultEnvId_drive_envs_id_fk",
+          "tableFrom": "pages",
+          "tableTo": "drive_envs",
+          "columnsFrom": [
+            "defaultEnvId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "pages_createdBy_users_id_fk": {
+          "name": "pages_createdBy_users_id_fk",
+          "tableFrom": "pages",
+          "tableTo": "users",
+          "columnsFrom": [
+            "createdBy"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "pages_driveId_drives_id_fk": {
+          "name": "pages_driveId_drives_id_fk",
+          "tableFrom": "pages",
+          "tableTo": "drives",
+          "columnsFrom": [
+            "driveId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.storage_events": {
+      "name": "storage_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pageId": {
+          "name": "pageId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "eventType": {
+          "name": "eventType",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sizeDelta": {
+          "name": "sizeDelta",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "totalSizeAfter": {
+          "name": "totalSizeAfter",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "storage_events_user_id_idx": {
+          "name": "storage_events_user_id_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "storage_events_created_at_idx": {
+          "name": "storage_events_created_at_idx",
+          "columns": [
+            {
+              "expression": "createdAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "storage_events_userId_users_id_fk": {
+          "name": "storage_events_userId_users_id_fk",
+          "tableFrom": "storage_events",
+          "tableTo": "users",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "storage_events_pageId_pages_id_fk": {
+          "name": "storage_events_pageId_pages_id_fk",
+          "tableFrom": "storage_events",
+          "tableTo": "pages",
+          "columnsFrom": [
+            "pageId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.tags": {
+      "name": "tags",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "driveId": {
+          "name": "driveId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "normalizedKey": {
+          "name": "normalizedKey",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "color": {
+          "name": "color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdBy": {
+          "name": "createdBy",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "tags_drive_id_idx": {
+          "name": "tags_drive_id_idx",
+          "columns": [
+            {
+              "expression": "driveId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "tags_driveId_drives_id_fk": {
+          "name": "tags_driveId_drives_id_fk",
+          "tableFrom": "tags",
+          "tableTo": "drives",
+          "columnsFrom": [
+            "driveId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "tags_createdBy_users_id_fk": {
+          "name": "tags_createdBy_users_id_fk",
+          "tableFrom": "tags",
+          "tableTo": "users",
+          "columnsFrom": [
+            "createdBy"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "tags_drive_id_normalized_key_key": {
+          "name": "tags_drive_id_normalized_key_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "driveId",
+            "normalizedKey"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_mentions": {
+      "name": "user_mentions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "sourcePageId": {
+          "name": "sourcePageId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "targetUserId": {
+          "name": "targetUserId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "mentionedByUserId": {
+          "name": "mentionedByUserId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "user_mentions_source_page_id_target_user_id_key": {
+          "name": "user_mentions_source_page_id_target_user_id_key",
+          "columns": [
+            {
+              "expression": "sourcePageId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "targetUserId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_mentions_source_page_id_idx": {
+          "name": "user_mentions_source_page_id_idx",
+          "columns": [
+            {
+              "expression": "sourcePageId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_mentions_target_user_id_idx": {
+          "name": "user_mentions_target_user_id_idx",
+          "columns": [
+            {
+              "expression": "targetUserId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_mentions_sourcePageId_pages_id_fk": {
+          "name": "user_mentions_sourcePageId_pages_id_fk",
+          "tableFrom": "user_mentions",
+          "tableTo": "pages",
+          "columnsFrom": [
+            "sourcePageId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "user_mentions_targetUserId_users_id_fk": {
+          "name": "user_mentions_targetUserId_users_id_fk",
+          "tableFrom": "user_mentions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "targetUserId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "user_mentions_mentionedByUserId_users_id_fk": {
+          "name": "user_mentions_mentionedByUserId_users_id_fk",
+          "tableFrom": "user_mentions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "mentionedByUserId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.drive_agent_members": {
+      "name": "drive_agent_members",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "driveId": {
+          "name": "driveId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agentPageId": {
+          "name": "agentPageId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "MemberRole",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'MEMBER'"
+        },
+        "customRoleId": {
+          "name": "customRoleId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "includeContext": {
+          "name": "includeContext",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "addedBy": {
+          "name": "addedBy",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "addedAt": {
+          "name": "addedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "drive_agent_members_drive_id_idx": {
+          "name": "drive_agent_members_drive_id_idx",
+          "columns": [
+            {
+              "expression": "driveId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "drive_agent_members_agent_page_id_idx": {
+          "name": "drive_agent_members_agent_page_id_idx",
+          "columns": [
+            {
+              "expression": "agentPageId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "drive_agent_members_driveId_drives_id_fk": {
+          "name": "drive_agent_members_driveId_drives_id_fk",
+          "tableFrom": "drive_agent_members",
+          "tableTo": "drives",
+          "columnsFrom": [
+            "driveId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "drive_agent_members_agentPageId_pages_id_fk": {
+          "name": "drive_agent_members_agentPageId_pages_id_fk",
+          "tableFrom": "drive_agent_members",
+          "tableTo": "pages",
+          "columnsFrom": [
+            "agentPageId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "drive_agent_members_customRoleId_drive_roles_id_fk": {
+          "name": "drive_agent_members_customRoleId_drive_roles_id_fk",
+          "tableFrom": "drive_agent_members",
+          "tableTo": "drive_roles",
+          "columnsFrom": [
+            "customRoleId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "drive_agent_members_addedBy_users_id_fk": {
+          "name": "drive_agent_members_addedBy_users_id_fk",
+          "tableFrom": "drive_agent_members",
+          "tableTo": "users",
+          "columnsFrom": [
+            "addedBy"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "drive_agent_members_drive_agent_key": {
+          "name": "drive_agent_members_drive_agent_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "driveId",
+            "agentPageId"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.drive_members": {
+      "name": "drive_members",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "driveId": {
+          "name": "driveId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "MemberRole",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'MEMBER'"
+        },
+        "customRoleId": {
+          "name": "customRoleId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "invitedBy": {
+          "name": "invitedBy",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "invitedAt": {
+          "name": "invitedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "acceptedAt": {
+          "name": "acceptedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lastAccessedAt": {
+          "name": "lastAccessedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "drive_members_drive_id_idx": {
+          "name": "drive_members_drive_id_idx",
+          "columns": [
+            {
+              "expression": "driveId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "drive_members_user_id_idx": {
+          "name": "drive_members_user_id_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "drive_members_role_idx": {
+          "name": "drive_members_role_idx",
+          "columns": [
+            {
+              "expression": "role",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "drive_members_custom_role_id_idx": {
+          "name": "drive_members_custom_role_id_idx",
+          "columns": [
+            {
+              "expression": "customRoleId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "drive_members_driveId_drives_id_fk": {
+          "name": "drive_members_driveId_drives_id_fk",
+          "tableFrom": "drive_members",
+          "tableTo": "drives",
+          "columnsFrom": [
+            "driveId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "drive_members_userId_users_id_fk": {
+          "name": "drive_members_userId_users_id_fk",
+          "tableFrom": "drive_members",
+          "tableTo": "users",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "drive_members_customRoleId_drive_roles_id_fk": {
+          "name": "drive_members_customRoleId_drive_roles_id_fk",
+          "tableFrom": "drive_members",
+          "tableTo": "drive_roles",
+          "columnsFrom": [
+            "customRoleId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "drive_members_invitedBy_users_id_fk": {
+          "name": "drive_members_invitedBy_users_id_fk",
+          "tableFrom": "drive_members",
+          "tableTo": "users",
+          "columnsFrom": [
+            "invitedBy"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "drive_members_drive_user_key": {
+          "name": "drive_members_drive_user_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "driveId",
+            "userId"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.drive_roles": {
+      "name": "drive_roles",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "driveId": {
+          "name": "driveId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "color": {
+          "name": "color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "isDefault": {
+          "name": "isDefault",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "permissions": {
+          "name": "permissions",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "drive_wide_permissions": {
+          "name": "drive_wide_permissions",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "NULL"
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "drive_roles_drive_id_idx": {
+          "name": "drive_roles_drive_id_idx",
+          "columns": [
+            {
+              "expression": "driveId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "drive_roles_position_idx": {
+          "name": "drive_roles_position_idx",
+          "columns": [
+            {
+              "expression": "position",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "drive_roles_driveId_drives_id_fk": {
+          "name": "drive_roles_driveId_drives_id_fk",
+          "tableFrom": "drive_roles",
+          "tableTo": "drives",
+          "columnsFrom": [
+            "driveId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "drive_roles_drive_name_key": {
+          "name": "drive_roles_drive_name_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "driveId",
+            "name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.mcp_token_drives": {
+      "name": "mcp_token_drives",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "tokenId": {
+          "name": "tokenId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "driveId": {
+          "name": "driveId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "MemberRole",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "customRoleId": {
+          "name": "customRoleId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "addedBy": {
+          "name": "addedBy",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "mcp_token_drives_token_id_idx": {
+          "name": "mcp_token_drives_token_id_idx",
+          "columns": [
+            {
+              "expression": "tokenId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "mcp_token_drives_drive_id_idx": {
+          "name": "mcp_token_drives_drive_id_idx",
+          "columns": [
+            {
+              "expression": "driveId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "mcp_token_drives_token_drive_unique": {
+          "name": "mcp_token_drives_token_drive_unique",
+          "columns": [
+            {
+              "expression": "tokenId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "driveId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "mcp_token_drives_tokenId_mcp_tokens_id_fk": {
+          "name": "mcp_token_drives_tokenId_mcp_tokens_id_fk",
+          "tableFrom": "mcp_token_drives",
+          "tableTo": "mcp_tokens",
+          "columnsFrom": [
+            "tokenId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "mcp_token_drives_driveId_drives_id_fk": {
+          "name": "mcp_token_drives_driveId_drives_id_fk",
+          "tableFrom": "mcp_token_drives",
+          "tableTo": "drives",
+          "columnsFrom": [
+            "driveId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "mcp_token_drives_customRoleId_drive_roles_id_fk": {
+          "name": "mcp_token_drives_customRoleId_drive_roles_id_fk",
+          "tableFrom": "mcp_token_drives",
+          "tableTo": "drive_roles",
+          "columnsFrom": [
+            "customRoleId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "mcp_token_drives_addedBy_users_id_fk": {
+          "name": "mcp_token_drives_addedBy_users_id_fk",
+          "tableFrom": "mcp_token_drives",
+          "tableTo": "users",
+          "columnsFrom": [
+            "addedBy"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.page_permissions": {
+      "name": "page_permissions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "pageId": {
+          "name": "pageId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "canView": {
+          "name": "canView",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "canEdit": {
+          "name": "canEdit",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "canShare": {
+          "name": "canShare",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "canDelete": {
+          "name": "canDelete",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "grantedBy": {
+          "name": "grantedBy",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "grantedAt": {
+          "name": "grantedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expiresAt": {
+          "name": "expiresAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "note": {
+          "name": "note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "page_permissions_page_id_idx": {
+          "name": "page_permissions_page_id_idx",
+          "columns": [
+            {
+              "expression": "pageId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "page_permissions_user_id_idx": {
+          "name": "page_permissions_user_id_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "page_permissions_expires_at_idx": {
+          "name": "page_permissions_expires_at_idx",
+          "columns": [
+            {
+              "expression": "expiresAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "page_permissions_pageId_pages_id_fk": {
+          "name": "page_permissions_pageId_pages_id_fk",
+          "tableFrom": "page_permissions",
+          "tableTo": "pages",
+          "columnsFrom": [
+            "pageId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "page_permissions_userId_users_id_fk": {
+          "name": "page_permissions_userId_users_id_fk",
+          "tableFrom": "page_permissions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "page_permissions_grantedBy_users_id_fk": {
+          "name": "page_permissions_grantedBy_users_id_fk",
+          "tableFrom": "page_permissions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "grantedBy"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "page_permissions_page_user_key": {
+          "name": "page_permissions_page_user_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "pageId",
+            "userId"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_profiles": {
+      "name": "user_profiles",
+      "schema": "",
+      "columns": {
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "username": {
+          "name": "username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "displayName": {
+          "name": "displayName",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "bio": {
+          "name": "bio",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "avatarUrl": {
+          "name": "avatarUrl",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "isPublic": {
+          "name": "isPublic",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "user_profiles_is_public_idx": {
+          "name": "user_profiles_is_public_idx",
+          "columns": [
+            {
+              "expression": "isPublic",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_profiles_userId_users_id_fk": {
+          "name": "user_profiles_userId_users_id_fk",
+          "tableFrom": "user_profiles",
+          "tableTo": "users",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.channel_message_reactions": {
+      "name": "channel_message_reactions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "messageId": {
+          "name": "messageId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "emoji": {
+          "name": "emoji",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "unique_reaction_idx": {
+          "name": "unique_reaction_idx",
+          "columns": [
+            {
+              "expression": "messageId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "emoji",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "reaction_message_idx": {
+          "name": "reaction_message_idx",
+          "columns": [
+            {
+              "expression": "messageId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "channel_message_reactions_messageId_channel_messages_id_fk": {
+          "name": "channel_message_reactions_messageId_channel_messages_id_fk",
+          "tableFrom": "channel_message_reactions",
+          "tableTo": "channel_messages",
+          "columnsFrom": [
+            "messageId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "channel_message_reactions_userId_users_id_fk": {
+          "name": "channel_message_reactions_userId_users_id_fk",
+          "tableFrom": "channel_message_reactions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.channel_messages": {
+      "name": "channel_messages",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "pageId": {
+          "name": "pageId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "fileId": {
+          "name": "fileId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "attachmentMeta": {
+          "name": "attachmentMeta",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "isActive": {
+          "name": "isActive",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "editedAt": {
+          "name": "editedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "aiMeta": {
+          "name": "aiMeta",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "parentId": {
+          "name": "parentId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "replyCount": {
+          "name": "replyCount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "lastReplyAt": {
+          "name": "lastReplyAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mirroredFromId": {
+          "name": "mirroredFromId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "quotedMessageId": {
+          "name": "quotedMessageId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "channel_messages_page_id_idx": {
+          "name": "channel_messages_page_id_idx",
+          "columns": [
+            {
+              "expression": "pageId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "channel_messages_file_id_idx": {
+          "name": "channel_messages_file_id_idx",
+          "columns": [
+            {
+              "expression": "fileId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "channel_messages_parent_created_idx": {
+          "name": "channel_messages_parent_created_idx",
+          "columns": [
+            {
+              "expression": "parentId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "createdAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "channel_messages_quoted_id_idx": {
+          "name": "channel_messages_quoted_id_idx",
+          "columns": [
+            {
+              "expression": "quotedMessageId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "channel_messages_pageId_pages_id_fk": {
+          "name": "channel_messages_pageId_pages_id_fk",
+          "tableFrom": "channel_messages",
+          "tableTo": "pages",
+          "columnsFrom": [
+            "pageId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "channel_messages_userId_users_id_fk": {
+          "name": "channel_messages_userId_users_id_fk",
+          "tableFrom": "channel_messages",
+          "tableTo": "users",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "channel_messages_fileId_files_id_fk": {
+          "name": "channel_messages_fileId_files_id_fk",
+          "tableFrom": "channel_messages",
+          "tableTo": "files",
+          "columnsFrom": [
+            "fileId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "channel_messages_parentId_channel_messages_id_fk": {
+          "name": "channel_messages_parentId_channel_messages_id_fk",
+          "tableFrom": "channel_messages",
+          "tableTo": "channel_messages",
+          "columnsFrom": [
+            "parentId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "channel_messages_mirroredFromId_channel_messages_id_fk": {
+          "name": "channel_messages_mirroredFromId_channel_messages_id_fk",
+          "tableFrom": "channel_messages",
+          "tableTo": "channel_messages",
+          "columnsFrom": [
+            "mirroredFromId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "channel_messages_quotedMessageId_channel_messages_id_fk": {
+          "name": "channel_messages_quotedMessageId_channel_messages_id_fk",
+          "tableFrom": "channel_messages",
+          "tableTo": "channel_messages",
+          "columnsFrom": [
+            "quotedMessageId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.channel_read_status": {
+      "name": "channel_read_status",
+      "schema": "",
+      "columns": {
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "channelId": {
+          "name": "channelId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "lastReadAt": {
+          "name": "lastReadAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "channel_read_status_user_id_idx": {
+          "name": "channel_read_status_user_id_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "channel_read_status_channel_id_idx": {
+          "name": "channel_read_status_channel_id_idx",
+          "columns": [
+            {
+              "expression": "channelId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "channel_read_status_userId_users_id_fk": {
+          "name": "channel_read_status_userId_users_id_fk",
+          "tableFrom": "channel_read_status",
+          "tableTo": "users",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "channel_read_status_channelId_pages_id_fk": {
+          "name": "channel_read_status_channelId_pages_id_fk",
+          "tableFrom": "channel_read_status",
+          "tableTo": "pages",
+          "columnsFrom": [
+            "channelId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "channel_read_status_userId_channelId_pk": {
+          "name": "channel_read_status_userId_channelId_pk",
+          "columns": [
+            "userId",
+            "channelId"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.channel_thread_followers": {
+      "name": "channel_thread_followers",
+      "schema": "",
+      "columns": {
+        "rootMessageId": {
+          "name": "rootMessageId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "channel_thread_followers_user_id_idx": {
+          "name": "channel_thread_followers_user_id_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "channel_thread_followers_rootMessageId_channel_messages_id_fk": {
+          "name": "channel_thread_followers_rootMessageId_channel_messages_id_fk",
+          "tableFrom": "channel_thread_followers",
+          "tableTo": "channel_messages",
+          "columnsFrom": [
+            "rootMessageId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "channel_thread_followers_userId_users_id_fk": {
+          "name": "channel_thread_followers_userId_users_id_fk",
+          "tableFrom": "channel_thread_followers",
+          "tableTo": "users",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "channel_thread_followers_rootMessageId_userId_pk": {
+          "name": "channel_thread_followers_rootMessageId_userId_pk",
+          "columns": [
+            "rootMessageId",
+            "userId"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.pulse_summaries": {
+      "name": "pulse_summaries",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "summary": {
+          "name": "summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "greeting": {
+          "name": "greeting",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "type": {
+          "name": "type",
+          "type": "pulse_summary_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'scheduled'"
+        },
+        "contextData": {
+          "name": "contextData",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "aiProvider": {
+          "name": "aiProvider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "aiModel": {
+          "name": "aiModel",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "periodStart": {
+          "name": "periodStart",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "periodEnd": {
+          "name": "periodEnd",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "generatedAt": {
+          "name": "generatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expiresAt": {
+          "name": "expiresAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_pulse_summaries_user_id": {
+          "name": "idx_pulse_summaries_user_id",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_pulse_summaries_generated_at": {
+          "name": "idx_pulse_summaries_generated_at",
+          "columns": [
+            {
+              "expression": "generatedAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_pulse_summaries_expires_at": {
+          "name": "idx_pulse_summaries_expires_at",
+          "columns": [
+            {
+              "expression": "expiresAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_pulse_summaries_user_generated": {
+          "name": "idx_pulse_summaries_user_generated",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "generatedAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "pulse_summaries_userId_users_id_fk": {
+          "name": "pulse_summaries_userId_users_id_fk",
+          "tableFrom": "pulse_summaries",
+          "tableTo": "users",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_dashboards": {
+      "name": "user_dashboards",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_dashboards_userId_users_id_fk": {
+          "name": "user_dashboards_userId_users_id_fk",
+          "tableFrom": "user_dashboards",
+          "tableTo": "users",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_dashboards_userId_unique": {
+          "name": "user_dashboards_userId_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "userId"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.conversations": {
+      "name": "conversations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "contextId": {
+          "name": "contextId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "agentPageId": {
+          "name": "agentPageId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rev": {
+          "name": "rev",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "planPageId": {
+          "name": "planPageId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lastMessageAt": {
+          "name": "lastMessageAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "isActive": {
+          "name": "isActive",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "isShared": {
+          "name": "isShared",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        }
+      },
+      "indexes": {
+        "conversations_user_id_idx": {
+          "name": "conversations_user_id_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "conversations_user_id_type_idx": {
+          "name": "conversations_user_id_type_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "conversations_user_id_last_message_at_idx": {
+          "name": "conversations_user_id_last_message_at_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "lastMessageAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "conversations_context_id_idx": {
+          "name": "conversations_context_id_idx",
+          "columns": [
+            {
+              "expression": "contextId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "conversations_plan_page_id_idx": {
+          "name": "conversations_plan_page_id_idx",
+          "columns": [
+            {
+              "expression": "planPageId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "conversations_agent_page_id_idx": {
+          "name": "conversations_agent_page_id_idx",
+          "columns": [
+            {
+              "expression": "agentPageId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "conversations_userId_users_id_fk": {
+          "name": "conversations_userId_users_id_fk",
+          "tableFrom": "conversations",
+          "tableTo": "users",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "conversations_agentPageId_pages_id_fk": {
+          "name": "conversations_agentPageId_pages_id_fk",
+          "tableFrom": "conversations",
+          "tableTo": "pages",
+          "columnsFrom": [
+            "agentPageId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "conversations_planPageId_pages_id_fk": {
+          "name": "conversations_planPageId_pages_id_fk",
+          "tableFrom": "conversations",
+          "tableTo": "pages",
+          "columnsFrom": [
+            "planPageId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "conversations_global_context_null_chk": {
+          "name": "conversations_global_context_null_chk",
+          "value": "\"conversations\".\"type\" <> 'global' OR \"conversations\".\"contextId\" IS NULL"
+        },
+        "conversations_page_context_present_chk": {
+          "name": "conversations_page_context_present_chk",
+          "value": "\"conversations\".\"type\" <> 'page' OR \"conversations\".\"contextId\" IS NOT NULL"
+        },
+        "conversations_drive_context_present_chk": {
+          "name": "conversations_drive_context_present_chk",
+          "value": "\"conversations\".\"type\" <> 'drive' OR \"conversations\".\"contextId\" IS NOT NULL"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.messages": {
+      "name": "messages",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "conversationId": {
+          "name": "conversationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "messageType": {
+          "name": "messageType",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'standard'"
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "toolCalls": {
+          "name": "toolCalls",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "toolResults": {
+          "name": "toolResults",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "isActive": {
+          "name": "isActive",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "editedAt": {
+          "name": "editedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'complete'"
+        },
+        "sourceAgentId": {
+          "name": "sourceAgentId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "messages_conversation_id_idx": {
+          "name": "messages_conversation_id_idx",
+          "columns": [
+            {
+              "expression": "conversationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "messages_conversation_id_created_at_idx": {
+          "name": "messages_conversation_id_created_at_idx",
+          "columns": [
+            {
+              "expression": "conversationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "createdAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "messages_user_id_idx": {
+          "name": "messages_user_id_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "messages_conversationId_conversations_id_fk": {
+          "name": "messages_conversationId_conversations_id_fk",
+          "tableFrom": "messages",
+          "tableTo": "conversations",
+          "columnsFrom": [
+            "conversationId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "messages_userId_users_id_fk": {
+          "name": "messages_userId_users_id_fk",
+          "tableFrom": "messages",
+          "tableTo": "users",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "messages_sourceAgentId_pages_id_fk": {
+          "name": "messages_sourceAgentId_pages_id_fk",
+          "tableFrom": "messages",
+          "tableTo": "pages",
+          "columnsFrom": [
+            "sourceAgentId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.notifications": {
+      "name": "notifications",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "NotificationType",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "message": {
+          "name": "message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "isRead": {
+          "name": "isRead",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "readAt": {
+          "name": "readAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pageId": {
+          "name": "pageId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "driveId": {
+          "name": "driveId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "triggeredByUserId": {
+          "name": "triggeredByUserId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "notifications_user_id_idx": {
+          "name": "notifications_user_id_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "notifications_user_id_is_read_idx": {
+          "name": "notifications_user_id_is_read_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "isRead",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "notifications_user_id_is_read_created_at_idx": {
+          "name": "notifications_user_id_is_read_created_at_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "isRead",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "createdAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "notifications_created_at_idx": {
+          "name": "notifications_created_at_idx",
+          "columns": [
+            {
+              "expression": "createdAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "notifications_type_idx": {
+          "name": "notifications_type_idx",
+          "columns": [
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "notifications_userId_users_id_fk": {
+          "name": "notifications_userId_users_id_fk",
+          "tableFrom": "notifications",
+          "tableTo": "users",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "notifications_pageId_pages_id_fk": {
+          "name": "notifications_pageId_pages_id_fk",
+          "tableFrom": "notifications",
+          "tableTo": "pages",
+          "columnsFrom": [
+            "pageId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "notifications_driveId_drives_id_fk": {
+          "name": "notifications_driveId_drives_id_fk",
+          "tableFrom": "notifications",
+          "tableTo": "drives",
+          "columnsFrom": [
+            "driveId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "notifications_triggeredByUserId_users_id_fk": {
+          "name": "notifications_triggeredByUserId_users_id_fk",
+          "tableFrom": "notifications",
+          "tableTo": "users",
+          "columnsFrom": [
+            "triggeredByUserId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.email_notification_log": {
+      "name": "email_notification_log",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "notificationId": {
+          "name": "notificationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notificationType": {
+          "name": "notificationType",
+          "type": "NotificationType",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "recipientEmail": {
+          "name": "recipientEmail",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "success": {
+          "name": "success",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "errorMessage": {
+          "name": "errorMessage",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sentAt": {
+          "name": "sentAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "email_notification_log_user_idx": {
+          "name": "email_notification_log_user_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "email_notification_log_sent_at_idx": {
+          "name": "email_notification_log_sent_at_idx",
+          "columns": [
+            {
+              "expression": "sentAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "email_notification_log_notification_id_idx": {
+          "name": "email_notification_log_notification_id_idx",
+          "columns": [
+            {
+              "expression": "notificationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "email_notification_log_userId_users_id_fk": {
+          "name": "email_notification_log_userId_users_id_fk",
+          "tableFrom": "email_notification_log",
+          "tableTo": "users",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.email_notification_preferences": {
+      "name": "email_notification_preferences",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "notificationType": {
+          "name": "notificationType",
+          "type": "NotificationType",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "emailEnabled": {
+          "name": "emailEnabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "email_notification_preferences_user_type_idx": {
+          "name": "email_notification_preferences_user_type_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "notificationType",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "email_notification_preferences_userId_users_id_fk": {
+          "name": "email_notification_preferences_userId_users_id_fk",
+          "tableFrom": "email_notification_preferences",
+          "tableTo": "users",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_toast_notification_preferences": {
+      "name": "user_toast_notification_preferences",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "level": {
+          "name": "level",
+          "type": "toast_notification_level",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'all'"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "user_toast_notification_preferences_user_idx": {
+          "name": "user_toast_notification_preferences_user_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_toast_notification_preferences_userId_users_id_fk": {
+          "name": "user_toast_notification_preferences_userId_users_id_fk",
+          "tableFrom": "user_toast_notification_preferences",
+          "tableTo": "users",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.display_preferences": {
+      "name": "display_preferences",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "preferenceType": {
+          "name": "preferenceType",
+          "type": "display_preference_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "display_preferences_user_type_idx": {
+          "name": "display_preferences_user_type_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "preferenceType",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "display_preferences_userId_users_id_fk": {
+          "name": "display_preferences_userId_users_id_fk",
+          "tableFrom": "display_preferences",
+          "tableTo": "users",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.activity_logs": {
+      "name": "activity_logs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "actorEmail": {
+          "name": "actorEmail",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'legacy@unknown'"
+        },
+        "actorDisplayName": {
+          "name": "actorDisplayName",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "isAiGenerated": {
+          "name": "isAiGenerated",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "aiProvider": {
+          "name": "aiProvider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "aiModel": {
+          "name": "aiModel",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "aiConversationId": {
+          "name": "aiConversationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "operation": {
+          "name": "operation",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "resourceType": {
+          "name": "resourceType",
+          "type": "activity_resource",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "resourceId": {
+          "name": "resourceId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "resourceTitle": {
+          "name": "resourceTitle",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "driveId": {
+          "name": "driveId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pageId": {
+          "name": "pageId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "contentSnapshot": {
+          "name": "contentSnapshot",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "contentFormat": {
+          "name": "contentFormat",
+          "type": "content_format",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "contentRef": {
+          "name": "contentRef",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "contentSize": {
+          "name": "contentSize",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rollbackFromActivityId": {
+          "name": "rollbackFromActivityId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rollbackSourceOperation": {
+          "name": "rollbackSourceOperation",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rollbackSourceTimestamp": {
+          "name": "rollbackSourceTimestamp",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rollbackSourceTitle": {
+          "name": "rollbackSourceTitle",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updatedFields": {
+          "name": "updatedFields",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "previousValues": {
+          "name": "previousValues",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "newValues": {
+          "name": "newValues",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "streamId": {
+          "name": "streamId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "streamSeq": {
+          "name": "streamSeq",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "changeGroupId": {
+          "name": "changeGroupId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "changeGroupType": {
+          "name": "changeGroupType",
+          "type": "activity_change_group_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stateHashBefore": {
+          "name": "stateHashBefore",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stateHashAfter": {
+          "name": "stateHashAfter",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "dataCategory": {
+          "name": "dataCategory",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "legalBasis": {
+          "name": "legalBasis",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "retentionPolicy": {
+          "name": "retentionPolicy",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "recipients": {
+          "name": "recipients",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "isArchived": {
+          "name": "isArchived",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "chainSeq": {
+          "name": "chainSeq",
+          "type": "bigserial",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "previousLogHash": {
+          "name": "previousLogHash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "logHash": {
+          "name": "logHash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "chainSeed": {
+          "name": "chainSeed",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_activity_logs_timestamp": {
+          "name": "idx_activity_logs_timestamp",
+          "columns": [
+            {
+              "expression": "timestamp",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_activity_logs_user_timestamp": {
+          "name": "idx_activity_logs_user_timestamp",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "timestamp",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_activity_logs_drive_timestamp": {
+          "name": "idx_activity_logs_drive_timestamp",
+          "columns": [
+            {
+              "expression": "driveId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "timestamp",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_activity_logs_page_timestamp": {
+          "name": "idx_activity_logs_page_timestamp",
+          "columns": [
+            {
+              "expression": "pageId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "timestamp",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_activity_logs_archived": {
+          "name": "idx_activity_logs_archived",
+          "columns": [
+            {
+              "expression": "isArchived",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_activity_logs_rollback_from": {
+          "name": "idx_activity_logs_rollback_from",
+          "columns": [
+            {
+              "expression": "rollbackFromActivityId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_activity_logs_stream": {
+          "name": "idx_activity_logs_stream",
+          "columns": [
+            {
+              "expression": "streamId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "streamSeq",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"activity_logs\".\"streamId\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_activity_logs_change_group": {
+          "name": "idx_activity_logs_change_group",
+          "columns": [
+            {
+              "expression": "changeGroupId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"activity_logs\".\"changeGroupId\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_activity_logs_log_hash": {
+          "name": "idx_activity_logs_log_hash",
+          "columns": [
+            {
+              "expression": "logHash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"activity_logs\".\"logHash\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_activity_logs_chain_seq": {
+          "name": "idx_activity_logs_chain_seq",
+          "columns": [
+            {
+              "expression": "chainSeq",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "activity_logs_userId_users_id_fk": {
+          "name": "activity_logs_userId_users_id_fk",
+          "tableFrom": "activity_logs",
+          "tableTo": "users",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "activity_logs_driveId_drives_id_fk": {
+          "name": "activity_logs_driveId_drives_id_fk",
+          "tableFrom": "activity_logs",
+          "tableTo": "drives",
+          "columnsFrom": [
+            "driveId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "activity_logs_pageId_pages_id_fk": {
+          "name": "activity_logs_pageId_pages_id_fk",
+          "tableFrom": "activity_logs",
+          "tableTo": "pages",
+          "columnsFrom": [
+            "pageId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "activity_logs_content_size_limit": {
+          "name": "activity_logs_content_size_limit",
+          "value": "\"activity_logs\".\"contentRef\" IS NOT NULL OR \"activity_logs\".\"contentSize\" IS NULL OR \"activity_logs\".\"contentSize\" <= 1048576"
+        },
+        "activity_logs_stream_pair": {
+          "name": "activity_logs_stream_pair",
+          "value": "(\"activity_logs\".\"streamId\" IS NULL) = (\"activity_logs\".\"streamSeq\" IS NULL)"
+        },
+        "activity_logs_change_group_pair": {
+          "name": "activity_logs_change_group_pair",
+          "value": "(\"activity_logs\".\"changeGroupId\" IS NULL) = (\"activity_logs\".\"changeGroupType\" IS NULL)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.ai_usage_logs": {
+      "name": "ai_usage_logs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "input_tokens": {
+          "name": "input_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "output_tokens": {
+          "name": "output_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "total_tokens": {
+          "name": "total_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cost": {
+          "name": "cost",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "currency": {
+          "name": "currency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'USD'"
+        },
+        "duration": {
+          "name": "duration",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "streaming_duration": {
+          "name": "streaming_duration",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "message_id": {
+          "name": "message_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "page_id": {
+          "name": "page_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "drive_id": {
+          "name": "drive_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "success": {
+          "name": "success",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": true
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "context_messages": {
+          "name": "context_messages",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "context_size": {
+          "name": "context_size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "system_prompt_tokens": {
+          "name": "system_prompt_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tool_definition_tokens": {
+          "name": "tool_definition_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "conversation_tokens": {
+          "name": "conversation_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "message_count": {
+          "name": "message_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "was_truncated": {
+          "name": "was_truncated",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "truncation_strategy": {
+          "name": "truncation_strategy",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reconcile_status": {
+          "name": "reconcile_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reconcile_attempts": {
+          "name": "reconcile_attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "reconciled_at": {
+          "name": "reconciled_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_ai_usage_timestamp": {
+          "name": "idx_ai_usage_timestamp",
+          "columns": [
+            {
+              "expression": "timestamp",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_ai_usage_user_id": {
+          "name": "idx_ai_usage_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "timestamp",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_ai_usage_user_source": {
+          "name": "idx_ai_usage_user_source",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "source",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "timestamp",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_ai_usage_provider": {
+          "name": "idx_ai_usage_provider",
+          "columns": [
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "model",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "timestamp",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_ai_usage_cost": {
+          "name": "idx_ai_usage_cost",
+          "columns": [
+            {
+              "expression": "cost",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_ai_usage_conversation": {
+          "name": "idx_ai_usage_conversation",
+          "columns": [
+            {
+              "expression": "conversation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_ai_usage_context": {
+          "name": "idx_ai_usage_context",
+          "columns": [
+            {
+              "expression": "conversation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "timestamp",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_ai_usage_context_size": {
+          "name": "idx_ai_usage_context_size",
+          "columns": [
+            {
+              "expression": "context_size",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_ai_usage_expires_at": {
+          "name": "idx_ai_usage_expires_at",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_ai_usage_reconcile": {
+          "name": "idx_ai_usage_reconcile",
+          "columns": [
+            {
+              "expression": "reconcile_status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "timestamp",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "reconcile_status = 'pending'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.api_metrics": {
+      "name": "api_metrics",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "endpoint": {
+          "name": "endpoint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "method": {
+          "name": "method",
+          "type": "http_method",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status_code": {
+          "name": "status_code",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "duration": {
+          "name": "duration",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "request_size": {
+          "name": "request_size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "response_size": {
+          "name": "response_size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ip": {
+          "name": "ip",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "request_id": {
+          "name": "request_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cache_hit": {
+          "name": "cache_hit",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "cache_key": {
+          "name": "cache_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_api_metrics_timestamp": {
+          "name": "idx_api_metrics_timestamp",
+          "columns": [
+            {
+              "expression": "timestamp",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_api_metrics_endpoint": {
+          "name": "idx_api_metrics_endpoint",
+          "columns": [
+            {
+              "expression": "endpoint",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "timestamp",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_api_metrics_user_id": {
+          "name": "idx_api_metrics_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "timestamp",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_api_metrics_status": {
+          "name": "idx_api_metrics_status",
+          "columns": [
+            {
+              "expression": "status_code",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "timestamp",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_api_metrics_duration": {
+          "name": "idx_api_metrics_duration",
+          "columns": [
+            {
+              "expression": "duration",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.error_logs": {
+      "name": "error_logs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "message": {
+          "name": "message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stack": {
+          "name": "stack",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "request_id": {
+          "name": "request_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "endpoint": {
+          "name": "endpoint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "method": {
+          "name": "method",
+          "type": "http_method",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "file": {
+          "name": "file",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "line": {
+          "name": "line",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "column": {
+          "name": "column",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ip": {
+          "name": "ip",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolved": {
+          "name": "resolved",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "resolved_at": {
+          "name": "resolved_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolved_by": {
+          "name": "resolved_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolution": {
+          "name": "resolution",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_errors_timestamp": {
+          "name": "idx_errors_timestamp",
+          "columns": [
+            {
+              "expression": "timestamp",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_errors_name": {
+          "name": "idx_errors_name",
+          "columns": [
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "timestamp",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_errors_user_id": {
+          "name": "idx_errors_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_errors_resolved": {
+          "name": "idx_errors_resolved",
+          "columns": [
+            {
+              "expression": "resolved",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_errors_endpoint": {
+          "name": "idx_errors_endpoint",
+          "columns": [
+            {
+              "expression": "endpoint",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.error_resolutions": {
+      "name": "error_resolutions",
+      "schema": "",
+      "columns": {
+        "error_id": {
+          "name": "error_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "resolved": {
+          "name": "resolved",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "resolved_at": {
+          "name": "resolved_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "resolved_by": {
+          "name": "resolved_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolution": {
+          "name": "resolution",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.siem_delivery_cursors": {
+      "name": "siem_delivery_cursors",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "lastDeliveredId": {
+          "name": "lastDeliveredId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lastDeliveredAt": {
+          "name": "lastDeliveredAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lastError": {
+          "name": "lastError",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lastErrorAt": {
+          "name": "lastErrorAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deliveryCount": {
+          "name": "deliveryCount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "siem_delivery_cursors_delivered_cursor_pair": {
+          "name": "siem_delivery_cursors_delivered_cursor_pair",
+          "value": "(\"siem_delivery_cursors\".\"lastDeliveredId\" IS NULL) = (\"siem_delivery_cursors\".\"lastDeliveredAt\" IS NULL)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.siem_delivery_receipts": {
+      "name": "siem_delivery_receipts",
+      "schema": "",
+      "columns": {
+        "receiptId": {
+          "name": "receiptId",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "deliveryId": {
+          "name": "deliveryId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "firstEntryId": {
+          "name": "firstEntryId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "lastEntryId": {
+          "name": "lastEntryId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "firstEntryTimestamp": {
+          "name": "firstEntryTimestamp",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "lastEntryTimestamp": {
+          "name": "lastEntryTimestamp",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entryCount": {
+          "name": "entryCount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "deliveredAt": {
+          "name": "deliveredAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "webhookStatus": {
+          "name": "webhookStatus",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "webhookResponseHash": {
+          "name": "webhookResponseHash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ackReceivedAt": {
+          "name": "ackReceivedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "siem_delivery_receipts_delivery_source_unique": {
+          "name": "siem_delivery_receipts_delivery_source_unique",
+          "columns": [
+            {
+              "expression": "deliveryId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "source",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_siem_receipts_delivery_id": {
+          "name": "idx_siem_receipts_delivery_id",
+          "columns": [
+            {
+              "expression": "deliveryId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_siem_receipts_first_entry": {
+          "name": "idx_siem_receipts_first_entry",
+          "columns": [
+            {
+              "expression": "firstEntryId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_siem_receipts_last_entry": {
+          "name": "idx_siem_receipts_last_entry",
+          "columns": [
+            {
+              "expression": "lastEntryId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_siem_receipts_delivered_at": {
+          "name": "idx_siem_receipts_delivered_at",
+          "columns": [
+            {
+              "expression": "deliveredAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_siem_receipts_source_range": {
+          "name": "idx_siem_receipts_source_range",
+          "columns": [
+            {
+              "expression": "source",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "firstEntryTimestamp",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "lastEntryTimestamp",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.system_logs": {
+      "name": "system_logs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "level": {
+          "name": "level",
+          "type": "log_level",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "message": {
+          "name": "message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "category": {
+          "name": "category",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "request_id": {
+          "name": "request_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "drive_id": {
+          "name": "drive_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "page_id": {
+          "name": "page_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "endpoint": {
+          "name": "endpoint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "method": {
+          "name": "method",
+          "type": "http_method",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ip": {
+          "name": "ip",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_name": {
+          "name": "error_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_stack": {
+          "name": "error_stack",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "duration": {
+          "name": "duration",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "memory_used": {
+          "name": "memory_used",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "memory_total": {
+          "name": "memory_total",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hostname": {
+          "name": "hostname",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pid": {
+          "name": "pid",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "version": {
+          "name": "version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_system_logs_timestamp": {
+          "name": "idx_system_logs_timestamp",
+          "columns": [
+            {
+              "expression": "timestamp",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_system_logs_level": {
+          "name": "idx_system_logs_level",
+          "columns": [
+            {
+              "expression": "level",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_system_logs_category": {
+          "name": "idx_system_logs_category",
+          "columns": [
+            {
+              "expression": "category",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_system_logs_user_id": {
+          "name": "idx_system_logs_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_system_logs_request_id": {
+          "name": "idx_system_logs_request_id",
+          "columns": [
+            {
+              "expression": "request_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_system_logs_error": {
+          "name": "idx_system_logs_error",
+          "columns": [
+            {
+              "expression": "error_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "timestamp",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_activities": {
+      "name": "user_activities",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "action": {
+          "name": "action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "resource": {
+          "name": "resource",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resource_id": {
+          "name": "resource_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "drive_id": {
+          "name": "drive_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "page_id": {
+          "name": "page_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ip": {
+          "name": "ip",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_user_activities_timestamp": {
+          "name": "idx_user_activities_timestamp",
+          "columns": [
+            {
+              "expression": "timestamp",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_user_activities_user_id": {
+          "name": "idx_user_activities_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "timestamp",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_user_activities_action": {
+          "name": "idx_user_activities_action",
+          "columns": [
+            {
+              "expression": "action",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "timestamp",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_user_activities_resource": {
+          "name": "idx_user_activities_resource",
+          "columns": [
+            {
+              "expression": "resource",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "resource_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.drive_backup_files": {
+      "name": "drive_backup_files",
+      "schema": "",
+      "columns": {
+        "backupId": {
+          "name": "backupId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "fileId": {
+          "name": "fileId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "storagePath": {
+          "name": "storagePath",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sizeBytes": {
+          "name": "sizeBytes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mimeType": {
+          "name": "mimeType",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "checksumVersion": {
+          "name": "checksumVersion",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "drive_backup_files_backup_idx": {
+          "name": "drive_backup_files_backup_idx",
+          "columns": [
+            {
+              "expression": "backupId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "drive_backup_files_backupId_drive_backups_id_fk": {
+          "name": "drive_backup_files_backupId_drive_backups_id_fk",
+          "tableFrom": "drive_backup_files",
+          "tableTo": "drive_backups",
+          "columnsFrom": [
+            "backupId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "drive_backup_files_backupId_fileId_pk": {
+          "name": "drive_backup_files_backupId_fileId_pk",
+          "columns": [
+            "backupId",
+            "fileId"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.drive_backup_members": {
+      "name": "drive_backup_members",
+      "schema": "",
+      "columns": {
+        "backupId": {
+          "name": "backupId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "customRoleId": {
+          "name": "customRoleId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "invitedBy": {
+          "name": "invitedBy",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "invitedAt": {
+          "name": "invitedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "acceptedAt": {
+          "name": "acceptedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "drive_backup_members_backup_idx": {
+          "name": "drive_backup_members_backup_idx",
+          "columns": [
+            {
+              "expression": "backupId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "drive_backup_members_backupId_drive_backups_id_fk": {
+          "name": "drive_backup_members_backupId_drive_backups_id_fk",
+          "tableFrom": "drive_backup_members",
+          "tableTo": "drive_backups",
+          "columnsFrom": [
+            "backupId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "drive_backup_members_backupId_userId_pk": {
+          "name": "drive_backup_members_backupId_userId_pk",
+          "columns": [
+            "backupId",
+            "userId"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.drive_backup_pages": {
+      "name": "drive_backup_pages",
+      "schema": "",
+      "columns": {
+        "backupId": {
+          "name": "backupId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pageId": {
+          "name": "pageId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pageVersionId": {
+          "name": "pageVersionId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "parentId": {
+          "name": "parentId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "originalParentId": {
+          "name": "originalParentId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "position": {
+          "name": "position",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "isTrashed": {
+          "name": "isTrashed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "trashedAt": {
+          "name": "trashedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "drive_backup_pages_backup_idx": {
+          "name": "drive_backup_pages_backup_idx",
+          "columns": [
+            {
+              "expression": "backupId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "drive_backup_pages_backupId_drive_backups_id_fk": {
+          "name": "drive_backup_pages_backupId_drive_backups_id_fk",
+          "tableFrom": "drive_backup_pages",
+          "tableTo": "drive_backups",
+          "columnsFrom": [
+            "backupId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "drive_backup_pages_pageVersionId_page_versions_id_fk": {
+          "name": "drive_backup_pages_pageVersionId_page_versions_id_fk",
+          "tableFrom": "drive_backup_pages",
+          "tableTo": "page_versions",
+          "columnsFrom": [
+            "pageVersionId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "drive_backup_pages_backupId_pageId_pk": {
+          "name": "drive_backup_pages_backupId_pageId_pk",
+          "columns": [
+            "backupId",
+            "pageId"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.drive_backup_permissions": {
+      "name": "drive_backup_permissions",
+      "schema": "",
+      "columns": {
+        "backupId": {
+          "name": "backupId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pageId": {
+          "name": "pageId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "canView": {
+          "name": "canView",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "canEdit": {
+          "name": "canEdit",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "canShare": {
+          "name": "canShare",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "canDelete": {
+          "name": "canDelete",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "grantedBy": {
+          "name": "grantedBy",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "note": {
+          "name": "note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expiresAt": {
+          "name": "expiresAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "drive_backup_permissions_backup_idx": {
+          "name": "drive_backup_permissions_backup_idx",
+          "columns": [
+            {
+              "expression": "backupId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "drive_backup_permissions_backupId_drive_backups_id_fk": {
+          "name": "drive_backup_permissions_backupId_drive_backups_id_fk",
+          "tableFrom": "drive_backup_permissions",
+          "tableTo": "drive_backups",
+          "columnsFrom": [
+            "backupId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "drive_backup_permissions_backupId_pageId_userId_pk": {
+          "name": "drive_backup_permissions_backupId_pageId_userId_pk",
+          "columns": [
+            "backupId",
+            "pageId",
+            "userId"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.drive_backup_roles": {
+      "name": "drive_backup_roles",
+      "schema": "",
+      "columns": {
+        "backupId": {
+          "name": "backupId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "roleId": {
+          "name": "roleId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "color": {
+          "name": "color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "isDefault": {
+          "name": "isDefault",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "permissions": {
+          "name": "permissions",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "drive_wide_permissions": {
+          "name": "drive_wide_permissions",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "NULL"
+        },
+        "position": {
+          "name": "position",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "drive_backup_roles_backup_idx": {
+          "name": "drive_backup_roles_backup_idx",
+          "columns": [
+            {
+              "expression": "backupId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "drive_backup_roles_backupId_drive_backups_id_fk": {
+          "name": "drive_backup_roles_backupId_drive_backups_id_fk",
+          "tableFrom": "drive_backup_roles",
+          "tableTo": "drive_backups",
+          "columnsFrom": [
+            "backupId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "drive_backup_roles_backupId_roleId_pk": {
+          "name": "drive_backup_roles_backupId_roleId_pk",
+          "columns": [
+            "backupId",
+            "roleId"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.drive_backup_schedules": {
+      "name": "drive_backup_schedules",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "driveId": {
+          "name": "driveId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "frequency": {
+          "name": "frequency",
+          "type": "drive_backup_schedule_frequency",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'daily'"
+        },
+        "timezone": {
+          "name": "timezone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'UTC'"
+        },
+        "nextRunAt": {
+          "name": "nextRunAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lastRunAt": {
+          "name": "lastRunAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "drive_backup_schedules_enabled_next_run_idx": {
+          "name": "drive_backup_schedules_enabled_next_run_idx",
+          "columns": [
+            {
+              "expression": "enabled",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "nextRunAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "drive_backup_schedules_driveId_drives_id_fk": {
+          "name": "drive_backup_schedules_driveId_drives_id_fk",
+          "tableFrom": "drive_backup_schedules",
+          "tableTo": "drives",
+          "columnsFrom": [
+            "driveId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "drive_backup_schedules_driveId_unique": {
+          "name": "drive_backup_schedules_driveId_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "driveId"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.drive_backups": {
+      "name": "drive_backups",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "driveId": {
+          "name": "driveId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "createdBy": {
+          "name": "createdBy",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source": {
+          "name": "source",
+          "type": "drive_backup_source",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'manual'"
+        },
+        "status": {
+          "name": "status",
+          "type": "drive_backup_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "changeGroupId": {
+          "name": "changeGroupId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "changeGroupType": {
+          "name": "changeGroupType",
+          "type": "activity_change_group_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "isPinned": {
+          "name": "isPinned",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "expiresAt": {
+          "name": "expiresAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completedAt": {
+          "name": "completedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "failedAt": {
+          "name": "failedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "failureReason": {
+          "name": "failureReason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "drive_backups_drive_created_at_idx": {
+          "name": "drive_backups_drive_created_at_idx",
+          "columns": [
+            {
+              "expression": "driveId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "createdAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "drive_backups_status_idx": {
+          "name": "drive_backups_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "drive_backups_driveId_drives_id_fk": {
+          "name": "drive_backups_driveId_drives_id_fk",
+          "tableFrom": "drive_backups",
+          "tableTo": "drives",
+          "columnsFrom": [
+            "driveId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "drive_backups_createdBy_users_id_fk": {
+          "name": "drive_backups_createdBy_users_id_fk",
+          "tableFrom": "drive_backups",
+          "tableTo": "users",
+          "columnsFrom": [
+            "createdBy"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "drive_backups_change_group_pair": {
+          "name": "drive_backups_change_group_pair",
+          "value": "(\"drive_backups\".\"changeGroupId\" IS NULL) = (\"drive_backups\".\"changeGroupType\" IS NULL)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.page_versions": {
+      "name": "page_versions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "pageId": {
+          "name": "pageId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "driveId": {
+          "name": "driveId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "createdBy": {
+          "name": "createdBy",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source": {
+          "name": "source",
+          "type": "page_version_source",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'auto'"
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "changeGroupId": {
+          "name": "changeGroupId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "changeGroupType": {
+          "name": "changeGroupType",
+          "type": "activity_change_group_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "contentRef": {
+          "name": "contentRef",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "contentFormat": {
+          "name": "contentFormat",
+          "type": "content_format",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "contentSize": {
+          "name": "contentSize",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stateHash": {
+          "name": "stateHash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pageRevision": {
+          "name": "pageRevision",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "isPinned": {
+          "name": "isPinned",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "expiresAt": {
+          "name": "expiresAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "page_versions_page_created_at_idx": {
+          "name": "page_versions_page_created_at_idx",
+          "columns": [
+            {
+              "expression": "pageId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "createdAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "page_versions_drive_created_at_idx": {
+          "name": "page_versions_drive_created_at_idx",
+          "columns": [
+            {
+              "expression": "driveId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "createdAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "page_versions_pinned_idx": {
+          "name": "page_versions_pinned_idx",
+          "columns": [
+            {
+              "expression": "isPinned",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "page_versions_page_id_is_pinned_created_at_idx": {
+          "name": "page_versions_page_id_is_pinned_created_at_idx",
+          "columns": [
+            {
+              "expression": "pageId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "isPinned",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "createdAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "page_versions_pageId_pages_id_fk": {
+          "name": "page_versions_pageId_pages_id_fk",
+          "tableFrom": "page_versions",
+          "tableTo": "pages",
+          "columnsFrom": [
+            "pageId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "page_versions_driveId_drives_id_fk": {
+          "name": "page_versions_driveId_drives_id_fk",
+          "tableFrom": "page_versions",
+          "tableTo": "drives",
+          "columnsFrom": [
+            "driveId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "page_versions_createdBy_users_id_fk": {
+          "name": "page_versions_createdBy_users_id_fk",
+          "tableFrom": "page_versions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "createdBy"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "page_versions_change_group_pair": {
+          "name": "page_versions_change_group_pair",
+          "value": "(\"page_versions\".\"changeGroupId\" IS NULL) = (\"page_versions\".\"changeGroupType\" IS NULL)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.connections": {
+      "name": "connections",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user1Id": {
+          "name": "user1Id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user2Id": {
+          "name": "user2Id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "ConnectionStatus",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'PENDING'"
+        },
+        "requestedBy": {
+          "name": "requestedBy",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "requestMessage": {
+          "name": "requestMessage",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "requestedAt": {
+          "name": "requestedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "acceptedAt": {
+          "name": "acceptedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "blockedBy": {
+          "name": "blockedBy",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "blockedAt": {
+          "name": "blockedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "connections_user1_id_idx": {
+          "name": "connections_user1_id_idx",
+          "columns": [
+            {
+              "expression": "user1Id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "connections_user2_id_idx": {
+          "name": "connections_user2_id_idx",
+          "columns": [
+            {
+              "expression": "user2Id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "connections_status_idx": {
+          "name": "connections_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "connections_user1_status_idx": {
+          "name": "connections_user1_status_idx",
+          "columns": [
+            {
+              "expression": "user1Id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "connections_user2_status_idx": {
+          "name": "connections_user2_status_idx",
+          "columns": [
+            {
+              "expression": "user2Id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "connections_user1Id_users_id_fk": {
+          "name": "connections_user1Id_users_id_fk",
+          "tableFrom": "connections",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user1Id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "connections_user2Id_users_id_fk": {
+          "name": "connections_user2Id_users_id_fk",
+          "tableFrom": "connections",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user2Id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "connections_requestedBy_users_id_fk": {
+          "name": "connections_requestedBy_users_id_fk",
+          "tableFrom": "connections",
+          "tableTo": "users",
+          "columnsFrom": [
+            "requestedBy"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "connections_blockedBy_users_id_fk": {
+          "name": "connections_blockedBy_users_id_fk",
+          "tableFrom": "connections",
+          "tableTo": "users",
+          "columnsFrom": [
+            "blockedBy"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "connections_user_pair_key": {
+          "name": "connections_user_pair_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user1Id",
+            "user2Id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.direct_messages": {
+      "name": "direct_messages",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "conversationId": {
+          "name": "conversationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "senderId": {
+          "name": "senderId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "fileId": {
+          "name": "fileId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "attachmentMeta": {
+          "name": "attachmentMeta",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "isRead": {
+          "name": "isRead",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "readAt": {
+          "name": "readAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "isEdited": {
+          "name": "isEdited",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "editedAt": {
+          "name": "editedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "isActive": {
+          "name": "isActive",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "deletedAt": {
+          "name": "deletedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "parentId": {
+          "name": "parentId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "replyCount": {
+          "name": "replyCount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "lastReplyAt": {
+          "name": "lastReplyAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mirroredFromId": {
+          "name": "mirroredFromId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "quotedMessageId": {
+          "name": "quotedMessageId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "direct_messages_conversation_id_idx": {
+          "name": "direct_messages_conversation_id_idx",
+          "columns": [
+            {
+              "expression": "conversationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "direct_messages_sender_id_idx": {
+          "name": "direct_messages_sender_id_idx",
+          "columns": [
+            {
+              "expression": "senderId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "direct_messages_created_at_idx": {
+          "name": "direct_messages_created_at_idx",
+          "columns": [
+            {
+              "expression": "createdAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "direct_messages_file_id_idx": {
+          "name": "direct_messages_file_id_idx",
+          "columns": [
+            {
+              "expression": "fileId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "direct_messages_conversation_active_created_idx": {
+          "name": "direct_messages_conversation_active_created_idx",
+          "columns": [
+            {
+              "expression": "conversationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "isActive",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "createdAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "direct_messages_inactive_deleted_at_idx": {
+          "name": "direct_messages_inactive_deleted_at_idx",
+          "columns": [
+            {
+              "expression": "isActive",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deletedAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "direct_messages_conversation_created_idx": {
+          "name": "direct_messages_conversation_created_idx",
+          "columns": [
+            {
+              "expression": "conversationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "createdAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "direct_messages_conversation_is_read_idx": {
+          "name": "direct_messages_conversation_is_read_idx",
+          "columns": [
+            {
+              "expression": "conversationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "isRead",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "direct_messages_unread_count_idx": {
+          "name": "direct_messages_unread_count_idx",
+          "columns": [
+            {
+              "expression": "conversationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "senderId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "isRead",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "direct_messages_parent_created_idx": {
+          "name": "direct_messages_parent_created_idx",
+          "columns": [
+            {
+              "expression": "parentId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "createdAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "direct_messages_quoted_id_idx": {
+          "name": "direct_messages_quoted_id_idx",
+          "columns": [
+            {
+              "expression": "quotedMessageId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "direct_messages_conversationId_dm_conversations_id_fk": {
+          "name": "direct_messages_conversationId_dm_conversations_id_fk",
+          "tableFrom": "direct_messages",
+          "tableTo": "dm_conversations",
+          "columnsFrom": [
+            "conversationId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "direct_messages_senderId_users_id_fk": {
+          "name": "direct_messages_senderId_users_id_fk",
+          "tableFrom": "direct_messages",
+          "tableTo": "users",
+          "columnsFrom": [
+            "senderId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "direct_messages_fileId_files_id_fk": {
+          "name": "direct_messages_fileId_files_id_fk",
+          "tableFrom": "direct_messages",
+          "tableTo": "files",
+          "columnsFrom": [
+            "fileId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "direct_messages_parentId_direct_messages_id_fk": {
+          "name": "direct_messages_parentId_direct_messages_id_fk",
+          "tableFrom": "direct_messages",
+          "tableTo": "direct_messages",
+          "columnsFrom": [
+            "parentId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "direct_messages_mirroredFromId_direct_messages_id_fk": {
+          "name": "direct_messages_mirroredFromId_direct_messages_id_fk",
+          "tableFrom": "direct_messages",
+          "tableTo": "direct_messages",
+          "columnsFrom": [
+            "mirroredFromId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "direct_messages_quotedMessageId_direct_messages_id_fk": {
+          "name": "direct_messages_quotedMessageId_direct_messages_id_fk",
+          "tableFrom": "direct_messages",
+          "tableTo": "direct_messages",
+          "columnsFrom": [
+            "quotedMessageId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.dm_conversations": {
+      "name": "dm_conversations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "participant1Id": {
+          "name": "participant1Id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "participant2Id": {
+          "name": "participant2Id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "lastMessageAt": {
+          "name": "lastMessageAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lastMessagePreview": {
+          "name": "lastMessagePreview",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "participant1LastRead": {
+          "name": "participant1LastRead",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "participant2LastRead": {
+          "name": "participant2LastRead",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "dm_conversations_participant1_id_idx": {
+          "name": "dm_conversations_participant1_id_idx",
+          "columns": [
+            {
+              "expression": "participant1Id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "dm_conversations_participant2_id_idx": {
+          "name": "dm_conversations_participant2_id_idx",
+          "columns": [
+            {
+              "expression": "participant2Id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "dm_conversations_last_message_at_idx": {
+          "name": "dm_conversations_last_message_at_idx",
+          "columns": [
+            {
+              "expression": "lastMessageAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "dm_conversations_participant1_last_message_idx": {
+          "name": "dm_conversations_participant1_last_message_idx",
+          "columns": [
+            {
+              "expression": "participant1Id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "lastMessageAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "dm_conversations_participant2_last_message_idx": {
+          "name": "dm_conversations_participant2_last_message_idx",
+          "columns": [
+            {
+              "expression": "participant2Id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "lastMessageAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "dm_conversations_participant1Id_users_id_fk": {
+          "name": "dm_conversations_participant1Id_users_id_fk",
+          "tableFrom": "dm_conversations",
+          "tableTo": "users",
+          "columnsFrom": [
+            "participant1Id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "dm_conversations_participant2Id_users_id_fk": {
+          "name": "dm_conversations_participant2Id_users_id_fk",
+          "tableFrom": "dm_conversations",
+          "tableTo": "users",
+          "columnsFrom": [
+            "participant2Id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "dm_conversations_participant_pair_key": {
+          "name": "dm_conversations_participant_pair_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "participant1Id",
+            "participant2Id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.dm_message_reactions": {
+      "name": "dm_message_reactions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "messageId": {
+          "name": "messageId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "emoji": {
+          "name": "emoji",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "dm_unique_reaction_idx": {
+          "name": "dm_unique_reaction_idx",
+          "columns": [
+            {
+              "expression": "messageId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "emoji",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "dm_reaction_message_idx": {
+          "name": "dm_reaction_message_idx",
+          "columns": [
+            {
+              "expression": "messageId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "dm_message_reactions_messageId_direct_messages_id_fk": {
+          "name": "dm_message_reactions_messageId_direct_messages_id_fk",
+          "tableFrom": "dm_message_reactions",
+          "tableTo": "direct_messages",
+          "columnsFrom": [
+            "messageId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "dm_message_reactions_userId_users_id_fk": {
+          "name": "dm_message_reactions_userId_users_id_fk",
+          "tableFrom": "dm_message_reactions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.dm_thread_followers": {
+      "name": "dm_thread_followers",
+      "schema": "",
+      "columns": {
+        "rootMessageId": {
+          "name": "rootMessageId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "dm_thread_followers_user_id_idx": {
+          "name": "dm_thread_followers_user_id_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "dm_thread_followers_rootMessageId_direct_messages_id_fk": {
+          "name": "dm_thread_followers_rootMessageId_direct_messages_id_fk",
+          "tableFrom": "dm_thread_followers",
+          "tableTo": "direct_messages",
+          "columnsFrom": [
+            "rootMessageId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "dm_thread_followers_userId_users_id_fk": {
+          "name": "dm_thread_followers_userId_users_id_fk",
+          "tableFrom": "dm_thread_followers",
+          "tableTo": "users",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "dm_thread_followers_rootMessageId_userId_pk": {
+          "name": "dm_thread_followers_rootMessageId_userId_pk",
+          "columns": [
+            "rootMessageId",
+            "userId"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.stripe_events": {
+      "name": "stripe_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "processedAt": {
+          "name": "processedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "stripe_events_type_idx": {
+          "name": "stripe_events_type_idx",
+          "columns": [
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "stripe_events_processed_at_idx": {
+          "name": "stripe_events_processed_at_idx",
+          "columns": [
+            {
+              "expression": "processedAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.subscriptions": {
+      "name": "subscriptions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stripeSubscriptionId": {
+          "name": "stripeSubscriptionId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stripePriceId": {
+          "name": "stripePriceId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "currentPeriodStart": {
+          "name": "currentPeriodStart",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "currentPeriodEnd": {
+          "name": "currentPeriodEnd",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cancelAtPeriodEnd": {
+          "name": "cancelAtPeriodEnd",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "gifted": {
+          "name": "gifted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "stripeScheduleId": {
+          "name": "stripeScheduleId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scheduledPriceId": {
+          "name": "scheduledPriceId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scheduledChangeDate": {
+          "name": "scheduledChangeDate",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "subscriptions_user_id_idx": {
+          "name": "subscriptions_user_id_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "subscriptions_stripe_subscription_id_idx": {
+          "name": "subscriptions_stripe_subscription_id_idx",
+          "columns": [
+            {
+              "expression": "stripeSubscriptionId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "subscriptions_stripe_schedule_id_idx": {
+          "name": "subscriptions_stripe_schedule_id_idx",
+          "columns": [
+            {
+              "expression": "stripeScheduleId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "subscriptions_userId_users_id_fk": {
+          "name": "subscriptions_userId_users_id_fk",
+          "tableFrom": "subscriptions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "subscriptions_stripeSubscriptionId_unique": {
+          "name": "subscriptions_stripeSubscriptionId_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "stripeSubscriptionId"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.contact_submissions": {
+      "name": "contact_submissions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subject": {
+          "name": "subject",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "message": {
+          "name": "message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "resolvedAt": {
+          "name": "resolvedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "contact_submissions_email_idx": {
+          "name": "contact_submissions_email_idx",
+          "columns": [
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "contact_submissions_created_at_idx": {
+          "name": "contact_submissions_created_at_idx",
+          "columns": [
+            {
+              "expression": "createdAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.feedback_submissions": {
+      "name": "feedback_submissions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "message": {
+          "name": "message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "attachments": {
+          "name": "attachments",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "page_url": {
+          "name": "page_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "screen_size": {
+          "name": "screen_size",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "viewport_size": {
+          "name": "viewport_size",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "app_version": {
+          "name": "app_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "console_errors": {
+          "name": "console_errors",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'new'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "feedback_submissions_user_id_idx": {
+          "name": "feedback_submissions_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "feedback_submissions_status_idx": {
+          "name": "feedback_submissions_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "feedback_submissions_created_at_idx": {
+          "name": "feedback_submissions_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "feedback_submissions_user_id_users_id_fk": {
+          "name": "feedback_submissions_user_id_users_id_fk",
+          "tableFrom": "feedback_submissions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.file_conversations": {
+      "name": "file_conversations",
+      "schema": "",
+      "columns": {
+        "fileId": {
+          "name": "fileId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "conversationId": {
+          "name": "conversationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "linkedBy": {
+          "name": "linkedBy",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "linkedAt": {
+          "name": "linkedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "linkSource": {
+          "name": "linkSource",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "file_conversations_file_id_idx": {
+          "name": "file_conversations_file_id_idx",
+          "columns": [
+            {
+              "expression": "fileId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "file_conversations_conversation_id_idx": {
+          "name": "file_conversations_conversation_id_idx",
+          "columns": [
+            {
+              "expression": "conversationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "file_conversations_fileId_files_id_fk": {
+          "name": "file_conversations_fileId_files_id_fk",
+          "tableFrom": "file_conversations",
+          "tableTo": "files",
+          "columnsFrom": [
+            "fileId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "file_conversations_conversationId_dm_conversations_id_fk": {
+          "name": "file_conversations_conversationId_dm_conversations_id_fk",
+          "tableFrom": "file_conversations",
+          "tableTo": "dm_conversations",
+          "columnsFrom": [
+            "conversationId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "file_conversations_linkedBy_users_id_fk": {
+          "name": "file_conversations_linkedBy_users_id_fk",
+          "tableFrom": "file_conversations",
+          "tableTo": "users",
+          "columnsFrom": [
+            "linkedBy"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "file_conversations_fileId_conversationId_pk": {
+          "name": "file_conversations_fileId_conversationId_pk",
+          "columns": [
+            "fileId",
+            "conversationId"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.file_pages": {
+      "name": "file_pages",
+      "schema": "",
+      "columns": {
+        "fileId": {
+          "name": "fileId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pageId": {
+          "name": "pageId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "linkedBy": {
+          "name": "linkedBy",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "linkedAt": {
+          "name": "linkedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "linkSource": {
+          "name": "linkSource",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "file_pages_file_id_idx": {
+          "name": "file_pages_file_id_idx",
+          "columns": [
+            {
+              "expression": "fileId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "file_pages_page_id_idx": {
+          "name": "file_pages_page_id_idx",
+          "columns": [
+            {
+              "expression": "pageId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "file_pages_fileId_files_id_fk": {
+          "name": "file_pages_fileId_files_id_fk",
+          "tableFrom": "file_pages",
+          "tableTo": "files",
+          "columnsFrom": [
+            "fileId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "file_pages_pageId_pages_id_fk": {
+          "name": "file_pages_pageId_pages_id_fk",
+          "tableFrom": "file_pages",
+          "tableTo": "pages",
+          "columnsFrom": [
+            "pageId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "file_pages_linkedBy_users_id_fk": {
+          "name": "file_pages_linkedBy_users_id_fk",
+          "tableFrom": "file_pages",
+          "tableTo": "users",
+          "columnsFrom": [
+            "linkedBy"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "file_pages_fileId_pageId_pk": {
+          "name": "file_pages_fileId_pageId_pk",
+          "columns": [
+            "fileId",
+            "pageId"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.files": {
+      "name": "files",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "driveId": {
+          "name": "driveId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sizeBytes": {
+          "name": "sizeBytes",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "mimeType": {
+          "name": "mimeType",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "storagePath": {
+          "name": "storagePath",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "checksumVersion": {
+          "name": "checksumVersion",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "createdBy": {
+          "name": "createdBy",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lastAccessedAt": {
+          "name": "lastAccessedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "files_drive_id_idx": {
+          "name": "files_drive_id_idx",
+          "columns": [
+            {
+              "expression": "driveId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "files_driveId_drives_id_fk": {
+          "name": "files_driveId_drives_id_fk",
+          "tableFrom": "files",
+          "tableTo": "drives",
+          "columnsFrom": [
+            "driveId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "files_createdBy_users_id_fk": {
+          "name": "files_createdBy_users_id_fk",
+          "tableFrom": "files",
+          "tableTo": "users",
+          "columnsFrom": [
+            "createdBy"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.pending_uploads": {
+      "name": "pending_uploads",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "fileSize": {
+          "name": "fileSize",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expiresAt": {
+          "name": "expiresAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "pending_uploads_user_expires_idx": {
+          "name": "pending_uploads_user_expires_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "expiresAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "pending_uploads_expires_idx": {
+          "name": "pending_uploads_expires_idx",
+          "columns": [
+            {
+              "expression": "expiresAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "pending_uploads_userId_users_id_fk": {
+          "name": "pending_uploads_userId_users_id_fk",
+          "tableFrom": "pending_uploads",
+          "tableTo": "users",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.task_assignees": {
+      "name": "task_assignees",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "taskId": {
+          "name": "taskId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "agentPageId": {
+          "name": "agentPageId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "task_assignees_task_id_idx": {
+          "name": "task_assignees_task_id_idx",
+          "columns": [
+            {
+              "expression": "taskId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "task_assignees_user_id_idx": {
+          "name": "task_assignees_user_id_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "task_assignees_agent_page_id_idx": {
+          "name": "task_assignees_agent_page_id_idx",
+          "columns": [
+            {
+              "expression": "agentPageId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "task_assignees_taskId_task_items_id_fk": {
+          "name": "task_assignees_taskId_task_items_id_fk",
+          "tableFrom": "task_assignees",
+          "tableTo": "task_items",
+          "columnsFrom": [
+            "taskId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "task_assignees_userId_users_id_fk": {
+          "name": "task_assignees_userId_users_id_fk",
+          "tableFrom": "task_assignees",
+          "tableTo": "users",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "task_assignees_agentPageId_pages_id_fk": {
+          "name": "task_assignees_agentPageId_pages_id_fk",
+          "tableFrom": "task_assignees",
+          "tableTo": "pages",
+          "columnsFrom": [
+            "agentPageId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "task_assignees_task_user": {
+          "name": "task_assignees_task_user",
+          "nullsNotDistinct": false,
+          "columns": [
+            "taskId",
+            "userId"
+          ]
+        },
+        "task_assignees_task_agent": {
+          "name": "task_assignees_task_agent",
+          "nullsNotDistinct": false,
+          "columns": [
+            "taskId",
+            "agentPageId"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "task_assignees_has_assignee": {
+          "name": "task_assignees_has_assignee",
+          "value": "(\"userId\" IS NOT NULL OR \"agentPageId\" IS NOT NULL)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.task_items": {
+      "name": "task_items",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "assigneeId": {
+          "name": "assigneeId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "assigneeAgentId": {
+          "name": "assigneeAgentId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pageId": {
+          "name": "pageId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "priority": {
+          "name": "priority",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'medium'"
+        },
+        "dueDate": {
+          "name": "dueDate",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completedAt": {
+          "name": "completedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "task_items_assignee_id_idx": {
+          "name": "task_items_assignee_id_idx",
+          "columns": [
+            {
+              "expression": "assigneeId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "task_items_assignee_agent_id_idx": {
+          "name": "task_items_assignee_agent_id_idx",
+          "columns": [
+            {
+              "expression": "assigneeAgentId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "task_items_page_id_idx": {
+          "name": "task_items_page_id_idx",
+          "columns": [
+            {
+              "expression": "pageId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "task_items_due_date_idx": {
+          "name": "task_items_due_date_idx",
+          "columns": [
+            {
+              "expression": "dueDate",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "task_items_userId_users_id_fk": {
+          "name": "task_items_userId_users_id_fk",
+          "tableFrom": "task_items",
+          "tableTo": "users",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "task_items_assigneeId_users_id_fk": {
+          "name": "task_items_assigneeId_users_id_fk",
+          "tableFrom": "task_items",
+          "tableTo": "users",
+          "columnsFrom": [
+            "assigneeId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "task_items_assigneeAgentId_pages_id_fk": {
+          "name": "task_items_assigneeAgentId_pages_id_fk",
+          "tableFrom": "task_items",
+          "tableTo": "pages",
+          "columnsFrom": [
+            "assigneeAgentId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "task_items_pageId_pages_id_fk": {
+          "name": "task_items_pageId_pages_id_fk",
+          "tableFrom": "task_items",
+          "tableTo": "pages",
+          "columnsFrom": [
+            "pageId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "task_items_pageId_unique": {
+          "name": "task_items_pageId_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "pageId"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.task_lists": {
+      "name": "task_lists",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pageId": {
+          "name": "pageId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "conversationId": {
+          "name": "conversationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "task_lists_page_id_idx": {
+          "name": "task_lists_page_id_idx",
+          "columns": [
+            {
+              "expression": "pageId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "task_lists_conversation_id_idx": {
+          "name": "task_lists_conversation_id_idx",
+          "columns": [
+            {
+              "expression": "conversationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "task_lists_user_id_idx": {
+          "name": "task_lists_user_id_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "task_lists_userId_users_id_fk": {
+          "name": "task_lists_userId_users_id_fk",
+          "tableFrom": "task_lists",
+          "tableTo": "users",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "task_lists_pageId_pages_id_fk": {
+          "name": "task_lists_pageId_pages_id_fk",
+          "tableFrom": "task_lists",
+          "tableTo": "pages",
+          "columnsFrom": [
+            "pageId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.task_status_configs": {
+      "name": "task_status_configs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "taskListId": {
+          "name": "taskListId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "color": {
+          "name": "color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "group": {
+          "name": "group",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "task_status_configs_task_list_id_idx": {
+          "name": "task_status_configs_task_list_id_idx",
+          "columns": [
+            {
+              "expression": "taskListId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "task_status_configs_taskListId_task_lists_id_fk": {
+          "name": "task_status_configs_taskListId_task_lists_id_fk",
+          "tableFrom": "task_status_configs",
+          "tableTo": "task_lists",
+          "columnsFrom": [
+            "taskListId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "task_status_configs_task_list_slug": {
+          "name": "task_status_configs_task_list_slug",
+          "nullsNotDistinct": false,
+          "columns": [
+            "taskListId",
+            "slug"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sheet_cell_deps": {
+      "name": "sheet_cell_deps",
+      "schema": "",
+      "columns": {
+        "tabId": {
+          "name": "tabId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "address": {
+          "name": "address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "dependsOn": {
+          "name": "dependsOn",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "dependents": {
+          "name": "dependents",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "sheet_cell_deps_tab_idx": {
+          "name": "sheet_cell_deps_tab_idx",
+          "columns": [
+            {
+              "expression": "tabId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "sheet_cell_deps_tabId_sheet_tabs_id_fk": {
+          "name": "sheet_cell_deps_tabId_sheet_tabs_id_fk",
+          "tableFrom": "sheet_cell_deps",
+          "tableTo": "sheet_tabs",
+          "columnsFrom": [
+            "tabId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "sheet_cell_deps_tabId_address_pk": {
+          "name": "sheet_cell_deps_tabId_address_pk",
+          "columns": [
+            "tabId",
+            "address"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sheet_changes": {
+      "name": "sheet_changes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "pageId": {
+          "name": "pageId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tabId": {
+          "name": "tabId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "seq": {
+          "name": "seq",
+          "type": "bigserial",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actorUserId": {
+          "name": "actorUserId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "actorEmail": {
+          "name": "actorEmail",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "changeGroupId": {
+          "name": "changeGroupId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "op": {
+          "name": "op",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "address": {
+          "name": "address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rowIndex": {
+          "name": "rowIndex",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "before": {
+          "name": "before",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "after": {
+          "name": "after",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "sheet_changes_page_seq_idx": {
+          "name": "sheet_changes_page_seq_idx",
+          "columns": [
+            {
+              "expression": "pageId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "seq",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sheet_changes_tab_seq_idx": {
+          "name": "sheet_changes_tab_seq_idx",
+          "columns": [
+            {
+              "expression": "tabId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "seq",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sheet_changes_created_at_idx": {
+          "name": "sheet_changes_created_at_idx",
+          "columns": [
+            {
+              "expression": "createdAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "sheet_changes_pageId_pages_id_fk": {
+          "name": "sheet_changes_pageId_pages_id_fk",
+          "tableFrom": "sheet_changes",
+          "tableTo": "pages",
+          "columnsFrom": [
+            "pageId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "sheet_changes_actorUserId_users_id_fk": {
+          "name": "sheet_changes_actorUserId_users_id_fk",
+          "tableFrom": "sheet_changes",
+          "tableTo": "users",
+          "columnsFrom": [
+            "actorUserId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sheet_range_deps": {
+      "name": "sheet_range_deps",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "tabId": {
+          "name": "tabId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "formulaAddress": {
+          "name": "formulaAddress",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rowStart": {
+          "name": "rowStart",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rowEnd": {
+          "name": "rowEnd",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "colStart": {
+          "name": "colStart",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "colEnd": {
+          "name": "colEnd",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "sheet_range_deps_tab_idx": {
+          "name": "sheet_range_deps_tab_idx",
+          "columns": [
+            {
+              "expression": "tabId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sheet_range_deps_cover_idx": {
+          "name": "sheet_range_deps_cover_idx",
+          "columns": [
+            {
+              "expression": "tabId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "rowStart",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "rowEnd",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sheet_range_deps_formula_idx": {
+          "name": "sheet_range_deps_formula_idx",
+          "columns": [
+            {
+              "expression": "tabId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "formulaAddress",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "sheet_range_deps_tabId_sheet_tabs_id_fk": {
+          "name": "sheet_range_deps_tabId_sheet_tabs_id_fk",
+          "tableFrom": "sheet_range_deps",
+          "tableTo": "sheet_tabs",
+          "columnsFrom": [
+            "tabId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "sheet_range_deps_bounds_ordered": {
+          "name": "sheet_range_deps_bounds_ordered",
+          "value": "(\"sheet_range_deps\".\"rowEnd\" IS NULL OR \"sheet_range_deps\".\"rowEnd\" >= \"sheet_range_deps\".\"rowStart\") AND (\"sheet_range_deps\".\"colEnd\" IS NULL OR \"sheet_range_deps\".\"colEnd\" >= \"sheet_range_deps\".\"colStart\")"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.sheet_rows": {
+      "name": "sheet_rows",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "tabId": {
+          "name": "tabId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pageId": {
+          "name": "pageId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rowIndex": {
+          "name": "rowIndex",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cells": {
+          "name": "cells",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "sheet_rows_page_row_idx": {
+          "name": "sheet_rows_page_row_idx",
+          "columns": [
+            {
+              "expression": "pageId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "rowIndex",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sheet_rows_tab_row_idx": {
+          "name": "sheet_rows_tab_row_idx",
+          "columns": [
+            {
+              "expression": "tabId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "rowIndex",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sheet_rows_cells_gin": {
+          "name": "sheet_rows_cells_gin",
+          "columns": [
+            {
+              "expression": "cells",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "sheet_rows_tabId_sheet_tabs_id_fk": {
+          "name": "sheet_rows_tabId_sheet_tabs_id_fk",
+          "tableFrom": "sheet_rows",
+          "tableTo": "sheet_tabs",
+          "columnsFrom": [
+            "tabId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "sheet_rows_pageId_pages_id_fk": {
+          "name": "sheet_rows_pageId_pages_id_fk",
+          "tableFrom": "sheet_rows",
+          "tableTo": "pages",
+          "columnsFrom": [
+            "pageId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "sheet_rows_tab_row_unique": {
+          "name": "sheet_rows_tab_row_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "tabId",
+            "rowIndex"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "sheet_rows_row_index_non_negative": {
+          "name": "sheet_rows_row_index_non_negative",
+          "value": "\"sheet_rows\".\"rowIndex\" >= 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.sheet_tabs": {
+      "name": "sheet_tabs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "pageId": {
+          "name": "pageId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tabIndex": {
+          "name": "tabIndex",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rowCount": {
+          "name": "rowCount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "columnCount": {
+          "name": "columnCount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "frozenRows": {
+          "name": "frozenRows",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "frozenColumns": {
+          "name": "frozenColumns",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "columnFormats": {
+          "name": "columnFormats",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "columnWidths": {
+          "name": "columnWidths",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rowHeights": {
+          "name": "rowHeights",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ranges": {
+          "name": "ranges",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "conditionalFormats": {
+          "name": "conditionalFormats",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "sheet_tabs_page_id_idx": {
+          "name": "sheet_tabs_page_id_idx",
+          "columns": [
+            {
+              "expression": "pageId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "sheet_tabs_pageId_pages_id_fk": {
+          "name": "sheet_tabs_pageId_pages_id_fk",
+          "tableFrom": "sheet_tabs",
+          "tableTo": "pages",
+          "columnsFrom": [
+            "pageId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "sheet_tabs_page_tab_unique": {
+          "name": "sheet_tabs_page_tab_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "pageId",
+            "tabIndex"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "sheet_tabs_extent_non_negative": {
+          "name": "sheet_tabs_extent_non_negative",
+          "value": "\"sheet_tabs\".\"rowCount\" >= 0 AND \"sheet_tabs\".\"columnCount\" >= 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.security_audit_log": {
+      "name": "security_audit_log",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "service_id": {
+          "name": "service_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resource_type": {
+          "name": "resource_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resource_id": {
+          "name": "resource_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ip_bidx": {
+          "name": "ip_bidx",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "geo_location": {
+          "name": "geo_location",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "details": {
+          "name": "details",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "risk_score": {
+          "name": "risk_score",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "anomaly_flags": {
+          "name": "anomaly_flags",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "chain_seq": {
+          "name": "chain_seq",
+          "type": "bigserial",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "previous_hash": {
+          "name": "previous_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_hash": {
+          "name": "event_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_security_audit_timestamp": {
+          "name": "idx_security_audit_timestamp",
+          "columns": [
+            {
+              "expression": "timestamp",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_security_audit_user_timestamp": {
+          "name": "idx_security_audit_user_timestamp",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "timestamp",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_security_audit_event_type": {
+          "name": "idx_security_audit_event_type",
+          "columns": [
+            {
+              "expression": "event_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "timestamp",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_security_audit_resource": {
+          "name": "idx_security_audit_resource",
+          "columns": [
+            {
+              "expression": "resource_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "resource_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "timestamp",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_security_audit_ip": {
+          "name": "idx_security_audit_ip",
+          "columns": [
+            {
+              "expression": "ip_address",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "timestamp",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_security_audit_ip_bidx": {
+          "name": "idx_security_audit_ip_bidx",
+          "columns": [
+            {
+              "expression": "ip_bidx",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "timestamp",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_security_audit_event_hash": {
+          "name": "idx_security_audit_event_hash",
+          "columns": [
+            {
+              "expression": "event_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_security_audit_chain_seq": {
+          "name": "idx_security_audit_chain_seq",
+          "columns": [
+            {
+              "expression": "chain_seq",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_security_audit_risk_score": {
+          "name": "idx_security_audit_risk_score",
+          "columns": [
+            {
+              "expression": "risk_score",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_security_audit_session": {
+          "name": "idx_security_audit_session",
+          "columns": [
+            {
+              "expression": "session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "timestamp",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "security_audit_log_user_id_users_id_fk": {
+          "name": "security_audit_log_user_id_users_id_fk",
+          "tableFrom": "security_audit_log",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_page_views": {
+      "name": "user_page_views",
+      "schema": "",
+      "columns": {
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pageId": {
+          "name": "pageId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "viewedAt": {
+          "name": "viewedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "user_page_views_user_id_idx": {
+          "name": "user_page_views_user_id_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_page_views_page_id_idx": {
+          "name": "user_page_views_page_id_idx",
+          "columns": [
+            {
+              "expression": "pageId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_page_views_user_page_idx": {
+          "name": "user_page_views_user_page_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "pageId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_page_views_userId_users_id_fk": {
+          "name": "user_page_views_userId_users_id_fk",
+          "tableFrom": "user_page_views",
+          "tableTo": "users",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "user_page_views_pageId_pages_id_fk": {
+          "name": "user_page_views_pageId_pages_id_fk",
+          "tableFrom": "user_page_views",
+          "tableTo": "pages",
+          "columnsFrom": [
+            "pageId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "user_page_views_userId_pageId_pk": {
+          "name": "user_page_views_userId_pageId_pk",
+          "columns": [
+            "userId",
+            "pageId"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_hotkey_preferences": {
+      "name": "user_hotkey_preferences",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "hotkeyId": {
+          "name": "hotkeyId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "binding": {
+          "name": "binding",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "user_hotkey_preferences_user_hotkey_idx": {
+          "name": "user_hotkey_preferences_user_hotkey_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "hotkeyId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_hotkey_preferences_user_idx": {
+          "name": "user_hotkey_preferences_user_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_hotkey_preferences_userId_users_id_fk": {
+          "name": "user_hotkey_preferences_userId_users_id_fk",
+          "tableFrom": "user_hotkey_preferences",
+          "tableTo": "users",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.push_notification_tokens": {
+      "name": "push_notification_tokens",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "platform": {
+          "name": "platform",
+          "type": "PushPlatformType",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "deviceId": {
+          "name": "deviceId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deviceName": {
+          "name": "deviceName",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "isActive": {
+          "name": "isActive",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "webPushSubscription": {
+          "name": "webPushSubscription",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "lastUsedAt": {
+          "name": "lastUsedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "failedAttempts": {
+          "name": "failedAttempts",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'0'"
+        },
+        "lastFailedAt": {
+          "name": "lastFailedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "push_notification_tokens_user_id_idx": {
+          "name": "push_notification_tokens_user_id_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "push_notification_tokens_token_idx": {
+          "name": "push_notification_tokens_token_idx",
+          "columns": [
+            {
+              "expression": "token",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "push_notification_tokens_platform_idx": {
+          "name": "push_notification_tokens_platform_idx",
+          "columns": [
+            {
+              "expression": "platform",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "push_notification_tokens_active_idx": {
+          "name": "push_notification_tokens_active_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "isActive",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "push_notification_tokens_userId_users_id_fk": {
+          "name": "push_notification_tokens_userId_users_id_fk",
+          "tableFrom": "push_notification_tokens",
+          "tableTo": "users",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.global_assistant_config": {
+      "name": "global_assistant_config",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "enabled_user_integrations": {
+          "name": "enabled_user_integrations",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "drive_overrides": {
+          "name": "drive_overrides",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "inherit_drive_integrations": {
+          "name": "inherit_drive_integrations",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "global_assistant_config_user_id_users_id_fk": {
+          "name": "global_assistant_config_user_id_users_id_fk",
+          "tableFrom": "global_assistant_config",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "global_assistant_config_user_id_unique": {
+          "name": "global_assistant_config_user_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.integration_audit_log": {
+      "name": "integration_audit_log",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "drive_id": {
+          "name": "drive_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "connection_id": {
+          "name": "connection_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tool_name": {
+          "name": "tool_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "input_summary": {
+          "name": "input_summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "success": {
+          "name": "success",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "response_code": {
+          "name": "response_code",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_type": {
+          "name": "error_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "duration_ms": {
+          "name": "duration_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "integration_audit_log_drive_id_idx": {
+          "name": "integration_audit_log_drive_id_idx",
+          "columns": [
+            {
+              "expression": "drive_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "integration_audit_log_connection_id_idx": {
+          "name": "integration_audit_log_connection_id_idx",
+          "columns": [
+            {
+              "expression": "connection_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "integration_audit_log_created_at_idx": {
+          "name": "integration_audit_log_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "integration_audit_log_drive_created_at_idx": {
+          "name": "integration_audit_log_drive_created_at_idx",
+          "columns": [
+            {
+              "expression": "drive_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "integration_audit_log_drive_id_drives_id_fk": {
+          "name": "integration_audit_log_drive_id_drives_id_fk",
+          "tableFrom": "integration_audit_log",
+          "tableTo": "drives",
+          "columnsFrom": [
+            "drive_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "integration_audit_log_agent_id_pages_id_fk": {
+          "name": "integration_audit_log_agent_id_pages_id_fk",
+          "tableFrom": "integration_audit_log",
+          "tableTo": "pages",
+          "columnsFrom": [
+            "agent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "integration_audit_log_user_id_users_id_fk": {
+          "name": "integration_audit_log_user_id_users_id_fk",
+          "tableFrom": "integration_audit_log",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "integration_audit_log_connection_id_integration_connections_id_fk": {
+          "name": "integration_audit_log_connection_id_integration_connections_id_fk",
+          "tableFrom": "integration_audit_log",
+          "tableTo": "integration_connections",
+          "columnsFrom": [
+            "connection_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.integration_connections": {
+      "name": "integration_connections",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "drive_id": {
+          "name": "drive_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "integration_connection_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "status_message": {
+          "name": "status_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "credentials": {
+          "name": "credentials",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "base_url_override": {
+          "name": "base_url_override",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "config_overrides": {
+          "name": "config_overrides",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "account_metadata": {
+          "name": "account_metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "visibility": {
+          "name": "visibility",
+          "type": "integration_visibility",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'owned_drives'"
+        },
+        "oauth_state": {
+          "name": "oauth_state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "connected_by": {
+          "name": "connected_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "connected_at": {
+          "name": "connected_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_health_check": {
+          "name": "last_health_check",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "integration_connections_provider_id_idx": {
+          "name": "integration_connections_provider_id_idx",
+          "columns": [
+            {
+              "expression": "provider_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "integration_connections_user_id_idx": {
+          "name": "integration_connections_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "integration_connections_drive_id_idx": {
+          "name": "integration_connections_drive_id_idx",
+          "columns": [
+            {
+              "expression": "drive_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "integration_connections_provider_id_integration_providers_id_fk": {
+          "name": "integration_connections_provider_id_integration_providers_id_fk",
+          "tableFrom": "integration_connections",
+          "tableTo": "integration_providers",
+          "columnsFrom": [
+            "provider_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "integration_connections_user_id_users_id_fk": {
+          "name": "integration_connections_user_id_users_id_fk",
+          "tableFrom": "integration_connections",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "integration_connections_drive_id_drives_id_fk": {
+          "name": "integration_connections_drive_id_drives_id_fk",
+          "tableFrom": "integration_connections",
+          "tableTo": "drives",
+          "columnsFrom": [
+            "drive_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "integration_connections_connected_by_users_id_fk": {
+          "name": "integration_connections_connected_by_users_id_fk",
+          "tableFrom": "integration_connections",
+          "tableTo": "users",
+          "columnsFrom": [
+            "connected_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "integration_connections_user_provider": {
+          "name": "integration_connections_user_provider",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "provider_id"
+          ]
+        },
+        "integration_connections_drive_provider": {
+          "name": "integration_connections_drive_provider",
+          "nullsNotDistinct": false,
+          "columns": [
+            "drive_id",
+            "provider_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "integration_connections_scope_chk": {
+          "name": "integration_connections_scope_chk",
+          "value": "(\"integration_connections\".\"user_id\" IS NOT NULL AND \"integration_connections\".\"drive_id\" IS NULL) OR (\"integration_connections\".\"user_id\" IS NULL AND \"integration_connections\".\"drive_id\" IS NOT NULL)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.integration_providers": {
+      "name": "integration_providers",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "icon_url": {
+          "name": "icon_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "documentation_url": {
+          "name": "documentation_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider_type": {
+          "name": "provider_type",
+          "type": "integration_provider_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "config": {
+          "name": "config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "openapi_spec": {
+          "name": "openapi_spec",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_system": {
+          "name": "is_system",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "drive_id": {
+          "name": "drive_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "integration_providers_slug_idx": {
+          "name": "integration_providers_slug_idx",
+          "columns": [
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "integration_providers_drive_id_idx": {
+          "name": "integration_providers_drive_id_idx",
+          "columns": [
+            {
+              "expression": "drive_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "integration_providers_created_by_users_id_fk": {
+          "name": "integration_providers_created_by_users_id_fk",
+          "tableFrom": "integration_providers",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "integration_providers_drive_id_drives_id_fk": {
+          "name": "integration_providers_drive_id_drives_id_fk",
+          "tableFrom": "integration_providers",
+          "tableTo": "drives",
+          "columnsFrom": [
+            "drive_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "integration_providers_slug_unique": {
+          "name": "integration_providers_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.integration_tool_grants": {
+      "name": "integration_tool_grants",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "connection_id": {
+          "name": "connection_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "allowed_tools": {
+          "name": "allowed_tools",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "denied_tools": {
+          "name": "denied_tools",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "read_only": {
+          "name": "read_only",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "rate_limit_override": {
+          "name": "rate_limit_override",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "integration_tool_grants_agent_id_idx": {
+          "name": "integration_tool_grants_agent_id_idx",
+          "columns": [
+            {
+              "expression": "agent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "integration_tool_grants_connection_id_idx": {
+          "name": "integration_tool_grants_connection_id_idx",
+          "columns": [
+            {
+              "expression": "connection_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "integration_tool_grants_agent_id_pages_id_fk": {
+          "name": "integration_tool_grants_agent_id_pages_id_fk",
+          "tableFrom": "integration_tool_grants",
+          "tableTo": "pages",
+          "columnsFrom": [
+            "agent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "integration_tool_grants_connection_id_integration_connections_id_fk": {
+          "name": "integration_tool_grants_connection_id_integration_connections_id_fk",
+          "tableFrom": "integration_tool_grants",
+          "tableTo": "integration_connections",
+          "columnsFrom": [
+            "connection_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "integration_tool_grants_agent_connection": {
+          "name": "integration_tool_grants_agent_connection",
+          "nullsNotDistinct": false,
+          "columns": [
+            "agent_id",
+            "connection_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.personalization_candidates": {
+      "name": "personalization_candidates",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "field": {
+          "name": "field",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "claim": {
+          "name": "claim",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "claimKey": {
+          "name": "claimKey",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "evidence": {
+          "name": "evidence",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "occurrences": {
+          "name": "occurrences",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "firstSeenAt": {
+          "name": "firstSeenAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "lastSeenAt": {
+          "name": "lastSeenAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "promotedAt": {
+          "name": "promotedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rejectedAt": {
+          "name": "rejectedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "personalization_candidates_user_field_claim_idx": {
+          "name": "personalization_candidates_user_field_claim_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "field",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "claimKey",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "personalization_candidates_userId_users_id_fk": {
+          "name": "personalization_candidates_userId_users_id_fk",
+          "tableFrom": "personalization_candidates",
+          "tableTo": "users",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "personalization_candidates_field_chk": {
+          "name": "personalization_candidates_field_chk",
+          "value": "\"personalization_candidates\".\"field\" IN ('bio', 'writingStyle', 'rules')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.user_personalization": {
+      "name": "user_personalization",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "bio": {
+          "name": "bio",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "writingStyle": {
+          "name": "writingStyle",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rules": {
+          "name": "rules",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "memoryFolderId": {
+          "name": "memoryFolderId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bioPageId": {
+          "name": "bioPageId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "writingStylePageId": {
+          "name": "writingStylePageId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rulesPageId": {
+          "name": "rulesPageId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "user_personalization_user_idx": {
+          "name": "user_personalization_user_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_personalization_userId_users_id_fk": {
+          "name": "user_personalization_userId_users_id_fk",
+          "tableFrom": "user_personalization",
+          "tableTo": "users",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "user_personalization_memoryFolderId_pages_id_fk": {
+          "name": "user_personalization_memoryFolderId_pages_id_fk",
+          "tableFrom": "user_personalization",
+          "tableTo": "pages",
+          "columnsFrom": [
+            "memoryFolderId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "user_personalization_bioPageId_pages_id_fk": {
+          "name": "user_personalization_bioPageId_pages_id_fk",
+          "tableFrom": "user_personalization",
+          "tableTo": "pages",
+          "columnsFrom": [
+            "bioPageId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "user_personalization_writingStylePageId_pages_id_fk": {
+          "name": "user_personalization_writingStylePageId_pages_id_fk",
+          "tableFrom": "user_personalization",
+          "tableTo": "pages",
+          "columnsFrom": [
+            "writingStylePageId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "user_personalization_rulesPageId_pages_id_fk": {
+          "name": "user_personalization_rulesPageId_pages_id_fk",
+          "tableFrom": "user_personalization",
+          "tableTo": "pages",
+          "columnsFrom": [
+            "rulesPageId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_automation_preferences": {
+      "name": "user_automation_preferences",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pulseEnabled": {
+          "name": "pulseEnabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "user_automation_preferences_user_idx": {
+          "name": "user_automation_preferences_user_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_automation_preferences_userId_users_id_fk": {
+          "name": "user_automation_preferences_userId_users_id_fk",
+          "tableFrom": "user_automation_preferences",
+          "tableTo": "users",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.calendar_event_drives": {
+      "name": "calendar_event_drives",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "eventId": {
+          "name": "eventId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "driveId": {
+          "name": "driveId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sharedBy": {
+          "name": "sharedBy",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sharedAt": {
+          "name": "sharedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "calendar_event_drives_event_id_idx": {
+          "name": "calendar_event_drives_event_id_idx",
+          "columns": [
+            {
+              "expression": "eventId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "calendar_event_drives_drive_id_idx": {
+          "name": "calendar_event_drives_drive_id_idx",
+          "columns": [
+            {
+              "expression": "driveId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "calendar_event_drives_eventId_calendar_events_id_fk": {
+          "name": "calendar_event_drives_eventId_calendar_events_id_fk",
+          "tableFrom": "calendar_event_drives",
+          "tableTo": "calendar_events",
+          "columnsFrom": [
+            "eventId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "calendar_event_drives_driveId_drives_id_fk": {
+          "name": "calendar_event_drives_driveId_drives_id_fk",
+          "tableFrom": "calendar_event_drives",
+          "tableTo": "drives",
+          "columnsFrom": [
+            "driveId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "calendar_event_drives_sharedBy_users_id_fk": {
+          "name": "calendar_event_drives_sharedBy_users_id_fk",
+          "tableFrom": "calendar_event_drives",
+          "tableTo": "users",
+          "columnsFrom": [
+            "sharedBy"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "calendar_event_drives_event_drive_key": {
+          "name": "calendar_event_drives_event_drive_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "eventId",
+            "driveId"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.calendar_events": {
+      "name": "calendar_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "driveId": {
+          "name": "driveId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdById": {
+          "name": "createdById",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pageId": {
+          "name": "pageId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "location": {
+          "name": "location",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "startAt": {
+          "name": "startAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "endAt": {
+          "name": "endAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "allDay": {
+          "name": "allDay",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "timezone": {
+          "name": "timezone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'UTC'"
+        },
+        "recurrenceRule": {
+          "name": "recurrenceRule",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "recurrenceExceptions": {
+          "name": "recurrenceExceptions",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'[]'::jsonb"
+        },
+        "recurringEventId": {
+          "name": "recurringEventId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "originalStartAt": {
+          "name": "originalStartAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "visibility": {
+          "name": "visibility",
+          "type": "EventVisibility",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'DRIVE'"
+        },
+        "color": {
+          "name": "color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'default'"
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "isTrashed": {
+          "name": "isTrashed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "trashedAt": {
+          "name": "trashedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "googleEventId": {
+          "name": "googleEventId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "googleCalendarId": {
+          "name": "googleCalendarId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "syncedFromGoogle": {
+          "name": "syncedFromGoogle",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "lastGoogleSync": {
+          "name": "lastGoogleSync",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "googleSyncReadOnly": {
+          "name": "googleSyncReadOnly",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "calendar_events_drive_id_idx": {
+          "name": "calendar_events_drive_id_idx",
+          "columns": [
+            {
+              "expression": "driveId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "calendar_events_created_by_id_idx": {
+          "name": "calendar_events_created_by_id_idx",
+          "columns": [
+            {
+              "expression": "createdById",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "calendar_events_page_id_idx": {
+          "name": "calendar_events_page_id_idx",
+          "columns": [
+            {
+              "expression": "pageId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "calendar_events_start_at_idx": {
+          "name": "calendar_events_start_at_idx",
+          "columns": [
+            {
+              "expression": "startAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "calendar_events_end_at_idx": {
+          "name": "calendar_events_end_at_idx",
+          "columns": [
+            {
+              "expression": "endAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "calendar_events_drive_id_start_at_idx": {
+          "name": "calendar_events_drive_id_start_at_idx",
+          "columns": [
+            {
+              "expression": "driveId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "startAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "calendar_events_recurring_event_id_idx": {
+          "name": "calendar_events_recurring_event_id_idx",
+          "columns": [
+            {
+              "expression": "recurringEventId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "calendar_events_is_trashed_idx": {
+          "name": "calendar_events_is_trashed_idx",
+          "columns": [
+            {
+              "expression": "isTrashed",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "calendar_events_google_event_id_idx": {
+          "name": "calendar_events_google_event_id_idx",
+          "columns": [
+            {
+              "expression": "googleEventId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "calendar_events_synced_from_google_idx": {
+          "name": "calendar_events_synced_from_google_idx",
+          "columns": [
+            {
+              "expression": "syncedFromGoogle",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "calendar_events_driveId_drives_id_fk": {
+          "name": "calendar_events_driveId_drives_id_fk",
+          "tableFrom": "calendar_events",
+          "tableTo": "drives",
+          "columnsFrom": [
+            "driveId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "calendar_events_createdById_users_id_fk": {
+          "name": "calendar_events_createdById_users_id_fk",
+          "tableFrom": "calendar_events",
+          "tableTo": "users",
+          "columnsFrom": [
+            "createdById"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "calendar_events_pageId_pages_id_fk": {
+          "name": "calendar_events_pageId_pages_id_fk",
+          "tableFrom": "calendar_events",
+          "tableTo": "pages",
+          "columnsFrom": [
+            "pageId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "calendar_events_google_source_per_user_key": {
+          "name": "calendar_events_google_source_per_user_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "createdById",
+            "googleCalendarId",
+            "googleEventId"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.event_attendees": {
+      "name": "event_attendees",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "eventId": {
+          "name": "eventId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "AttendeeStatus",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'PENDING'"
+        },
+        "responseNote": {
+          "name": "responseNote",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "isOrganizer": {
+          "name": "isOrganizer",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "isOptional": {
+          "name": "isOptional",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "invitedAt": {
+          "name": "invitedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "respondedAt": {
+          "name": "respondedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "event_attendees_event_id_idx": {
+          "name": "event_attendees_event_id_idx",
+          "columns": [
+            {
+              "expression": "eventId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "event_attendees_user_id_idx": {
+          "name": "event_attendees_user_id_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "event_attendees_status_idx": {
+          "name": "event_attendees_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "event_attendees_user_id_status_idx": {
+          "name": "event_attendees_user_id_status_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "event_attendees_eventId_calendar_events_id_fk": {
+          "name": "event_attendees_eventId_calendar_events_id_fk",
+          "tableFrom": "event_attendees",
+          "tableTo": "calendar_events",
+          "columnsFrom": [
+            "eventId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "event_attendees_userId_users_id_fk": {
+          "name": "event_attendees_userId_users_id_fk",
+          "tableFrom": "event_attendees",
+          "tableTo": "users",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "event_attendees_event_user_key": {
+          "name": "event_attendees_event_user_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "eventId",
+            "userId"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.google_calendar_connections": {
+      "name": "google_calendar_connections",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "accessToken": {
+          "name": "accessToken",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "refreshToken": {
+          "name": "refreshToken",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tokenExpiresAt": {
+          "name": "tokenExpiresAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "googleEmail": {
+          "name": "googleEmail",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "googleAccountId": {
+          "name": "googleAccountId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "GoogleCalendarConnectionStatus",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "statusMessage": {
+          "name": "statusMessage",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "targetDriveId": {
+          "name": "targetDriveId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "selectedCalendars": {
+          "name": "selectedCalendars",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'[]'::jsonb"
+        },
+        "syncFrequencyMinutes": {
+          "name": "syncFrequencyMinutes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 15
+        },
+        "markAsReadOnly": {
+          "name": "markAsReadOnly",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "lastSyncAt": {
+          "name": "lastSyncAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lastSyncError": {
+          "name": "lastSyncError",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "syncCursor": {
+          "name": "syncCursor",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "webhookChannels": {
+          "name": "webhookChannels",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "google_calendar_connections_user_id_idx": {
+          "name": "google_calendar_connections_user_id_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "google_calendar_connections_status_idx": {
+          "name": "google_calendar_connections_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "google_calendar_connections_target_drive_id_idx": {
+          "name": "google_calendar_connections_target_drive_id_idx",
+          "columns": [
+            {
+              "expression": "targetDriveId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "google_calendar_connections_userId_users_id_fk": {
+          "name": "google_calendar_connections_userId_users_id_fk",
+          "tableFrom": "google_calendar_connections",
+          "tableTo": "users",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "google_calendar_connections_targetDriveId_drives_id_fk": {
+          "name": "google_calendar_connections_targetDriveId_drives_id_fk",
+          "tableFrom": "google_calendar_connections",
+          "tableTo": "drives",
+          "columnsFrom": [
+            "targetDriveId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "google_calendar_connections_userId_unique": {
+          "name": "google_calendar_connections_userId_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "userId"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.calendar_triggers": {
+      "name": "calendar_triggers",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "workflowId": {
+          "name": "workflowId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "calendarEventId": {
+          "name": "calendarEventId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "driveId": {
+          "name": "driveId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scheduledById": {
+          "name": "scheduledById",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "triggerAt": {
+          "name": "triggerAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "occurrenceDate": {
+          "name": "occurrenceDate",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'1970-01-01T00:00:00.000Z'"
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "calendar_triggers_trigger_at_idx": {
+          "name": "calendar_triggers_trigger_at_idx",
+          "columns": [
+            {
+              "expression": "triggerAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "calendar_triggers_scheduled_by_idx": {
+          "name": "calendar_triggers_scheduled_by_idx",
+          "columns": [
+            {
+              "expression": "scheduledById",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "calendar_triggers_calendar_event_idx": {
+          "name": "calendar_triggers_calendar_event_idx",
+          "columns": [
+            {
+              "expression": "calendarEventId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "calendar_triggers_workflow_id_idx": {
+          "name": "calendar_triggers_workflow_id_idx",
+          "columns": [
+            {
+              "expression": "workflowId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "calendar_triggers_workflowId_workflows_id_fk": {
+          "name": "calendar_triggers_workflowId_workflows_id_fk",
+          "tableFrom": "calendar_triggers",
+          "tableTo": "workflows",
+          "columnsFrom": [
+            "workflowId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "calendar_triggers_calendarEventId_calendar_events_id_fk": {
+          "name": "calendar_triggers_calendarEventId_calendar_events_id_fk",
+          "tableFrom": "calendar_triggers",
+          "tableTo": "calendar_events",
+          "columnsFrom": [
+            "calendarEventId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "calendar_triggers_driveId_drives_id_fk": {
+          "name": "calendar_triggers_driveId_drives_id_fk",
+          "tableFrom": "calendar_triggers",
+          "tableTo": "drives",
+          "columnsFrom": [
+            "driveId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "calendar_triggers_scheduledById_users_id_fk": {
+          "name": "calendar_triggers_scheduledById_users_id_fk",
+          "tableFrom": "calendar_triggers",
+          "tableTo": "users",
+          "columnsFrom": [
+            "scheduledById"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "calendar_triggers_event_occurrence_key": {
+          "name": "calendar_triggers_event_occurrence_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "calendarEventId",
+            "occurrenceDate"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.workflows": {
+      "name": "workflows",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "driveId": {
+          "name": "driveId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdBy": {
+          "name": "createdBy",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agentPageId": {
+          "name": "agentPageId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "prompt": {
+          "name": "prompt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "steps": {
+          "name": "steps",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "contextPageIds": {
+          "name": "contextPageIds",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'[]'::jsonb"
+        },
+        "cronExpression": {
+          "name": "cronExpression",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "timezone": {
+          "name": "timezone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'UTC'"
+        },
+        "triggerType": {
+          "name": "triggerType",
+          "type": "WorkflowTriggerType",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'cron'"
+        },
+        "eventTriggers": {
+          "name": "eventTriggers",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "watchedFolderIds": {
+          "name": "watchedFolderIds",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "eventDebounceSecs": {
+          "name": "eventDebounceSecs",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 30
+        },
+        "instructionPageId": {
+          "name": "instructionPageId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "isEnabled": {
+          "name": "isEnabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "nextRunAt": {
+          "name": "nextRunAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "workflows_drive_id_idx": {
+          "name": "workflows_drive_id_idx",
+          "columns": [
+            {
+              "expression": "driveId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "workflows_created_by_idx": {
+          "name": "workflows_created_by_idx",
+          "columns": [
+            {
+              "expression": "createdBy",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "workflows_agent_page_id_idx": {
+          "name": "workflows_agent_page_id_idx",
+          "columns": [
+            {
+              "expression": "agentPageId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "workflows_enabled_next_run_idx": {
+          "name": "workflows_enabled_next_run_idx",
+          "columns": [
+            {
+              "expression": "isEnabled",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "nextRunAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "workflows_enabled_trigger_type_idx": {
+          "name": "workflows_enabled_trigger_type_idx",
+          "columns": [
+            {
+              "expression": "isEnabled",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "triggerType",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "workflows_driveId_drives_id_fk": {
+          "name": "workflows_driveId_drives_id_fk",
+          "tableFrom": "workflows",
+          "tableTo": "drives",
+          "columnsFrom": [
+            "driveId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "workflows_createdBy_users_id_fk": {
+          "name": "workflows_createdBy_users_id_fk",
+          "tableFrom": "workflows",
+          "tableTo": "users",
+          "columnsFrom": [
+            "createdBy"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "workflows_agentPageId_pages_id_fk": {
+          "name": "workflows_agentPageId_pages_id_fk",
+          "tableFrom": "workflows",
+          "tableTo": "pages",
+          "columnsFrom": [
+            "agentPageId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "workflows_instructionPageId_pages_id_fk": {
+          "name": "workflows_instructionPageId_pages_id_fk",
+          "tableFrom": "workflows",
+          "tableTo": "pages",
+          "columnsFrom": [
+            "instructionPageId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.workflow_runs": {
+      "name": "workflow_runs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "workflowId": {
+          "name": "workflowId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sourceTable": {
+          "name": "sourceTable",
+          "type": "WorkflowRunSourceTable",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sourceId": {
+          "name": "sourceId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "triggerAt": {
+          "name": "triggerAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "startedAt": {
+          "name": "startedAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "endedAt": {
+          "name": "endedAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "WorkflowRunStatus",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'running'"
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "durationMs": {
+          "name": "durationMs",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "conversationId": {
+          "name": "conversationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "workflow_runs_workflow_started_at_idx": {
+          "name": "workflow_runs_workflow_started_at_idx",
+          "columns": [
+            {
+              "expression": "workflowId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "startedAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "workflow_runs_source_lookup_idx": {
+          "name": "workflow_runs_source_lookup_idx",
+          "columns": [
+            {
+              "expression": "sourceTable",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "sourceId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "workflow_runs_stuck_run_idx": {
+          "name": "workflow_runs_stuck_run_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "startedAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "workflow_runs_running_claim_idx": {
+          "name": "workflow_runs_running_claim_idx",
+          "columns": [
+            {
+              "expression": "workflowId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"workflow_runs\".\"status\" = 'running'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "workflow_runs_workflowId_workflows_id_fk": {
+          "name": "workflow_runs_workflowId_workflows_id_fk",
+          "tableFrom": "workflow_runs",
+          "tableTo": "workflows",
+          "columnsFrom": [
+            "workflowId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.workflow_run_steps": {
+      "name": "workflow_run_steps",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "runId": {
+          "name": "runId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "toolName": {
+          "name": "toolName",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "WorkflowRunStepStatus",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'running'"
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "durationMs": {
+          "name": "durationMs",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "startedAt": {
+          "name": "startedAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "endedAt": {
+          "name": "endedAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "workflow_run_steps_run_position_idx": {
+          "name": "workflow_run_steps_run_position_idx",
+          "columns": [
+            {
+              "expression": "runId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "position",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "workflow_run_steps_runId_workflow_runs_id_fk": {
+          "name": "workflow_run_steps_runId_workflow_runs_id_fk",
+          "tableFrom": "workflow_run_steps",
+          "tableTo": "workflow_runs",
+          "columnsFrom": [
+            "runId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.task_triggers": {
+      "name": "task_triggers",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "workflowId": {
+          "name": "workflowId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "taskItemId": {
+          "name": "taskItemId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "triggerType": {
+          "name": "triggerType",
+          "type": "TaskTriggerType",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "nextRunAt": {
+          "name": "nextRunAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lastFiredAt": {
+          "name": "lastFiredAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lastFireError": {
+          "name": "lastFireError",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "isEnabled": {
+          "name": "isEnabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "task_triggers_workflow_id_idx": {
+          "name": "task_triggers_workflow_id_idx",
+          "columns": [
+            {
+              "expression": "workflowId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "task_triggers_task_item_id_idx": {
+          "name": "task_triggers_task_item_id_idx",
+          "columns": [
+            {
+              "expression": "taskItemId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "task_triggers_enabled_next_run_idx": {
+          "name": "task_triggers_enabled_next_run_idx",
+          "columns": [
+            {
+              "expression": "isEnabled",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "nextRunAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "task_triggers_workflowId_workflows_id_fk": {
+          "name": "task_triggers_workflowId_workflows_id_fk",
+          "tableFrom": "task_triggers",
+          "tableTo": "workflows",
+          "columnsFrom": [
+            "workflowId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "task_triggers_taskItemId_task_items_id_fk": {
+          "name": "task_triggers_taskItemId_task_items_id_fk",
+          "tableFrom": "task_triggers",
+          "tableTo": "task_items",
+          "columnsFrom": [
+            "taskItemId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "task_triggers_task_item_trigger_type_key": {
+          "name": "task_triggers_task_item_trigger_type_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "taskItemId",
+            "triggerType"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.rate_limit_buckets": {
+      "name": "rate_limit_buckets",
+      "schema": "",
+      "columns": {
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "window_start": {
+          "name": "window_start",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "count": {
+          "name": "count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "rate_limit_buckets_expires_at_idx": {
+          "name": "rate_limit_buckets_expires_at_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "rate_limit_buckets_key_window_start_pk": {
+          "name": "rate_limit_buckets_key_window_start_pk",
+          "columns": [
+            "key",
+            "window_start"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.revoked_service_tokens": {
+      "name": "revoked_service_tokens",
+      "schema": "",
+      "columns": {
+        "jti": {
+          "name": "jti",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "revoked_service_tokens_expires_at_idx": {
+          "name": "revoked_service_tokens_expires_at_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.auth_handoff_tokens": {
+      "name": "auth_handoff_tokens",
+      "schema": "",
+      "columns": {
+        "token_hash": {
+          "name": "token_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "auth_handoff_tokens_expires_at_idx": {
+          "name": "auth_handoff_tokens_expires_at_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "auth_handoff_tokens_kind_expires_at_idx": {
+          "name": "auth_handoff_tokens_kind_expires_at_idx",
+          "columns": [
+            {
+              "expression": "kind",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "auth_handoff_tokens_token_hash_kind_pk": {
+          "name": "auth_handoff_tokens_token_hash_kind_pk",
+          "columns": [
+            "token_hash",
+            "kind"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.pending_invites": {
+      "name": "pending_invites",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "drive_id": {
+          "name": "drive_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "MemberRole",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "custom_role_id": {
+          "name": "custom_role_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "invited_by": {
+          "name": "invited_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "consumed_at": {
+          "name": "consumed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "pending_invites_drive_id_idx": {
+          "name": "pending_invites_drive_id_idx",
+          "columns": [
+            {
+              "expression": "drive_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "pending_invites_email_idx": {
+          "name": "pending_invites_email_idx",
+          "columns": [
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "pending_invites_expires_at_idx": {
+          "name": "pending_invites_expires_at_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "pending_invites_custom_role_id_idx": {
+          "name": "pending_invites_custom_role_id_idx",
+          "columns": [
+            {
+              "expression": "custom_role_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "pending_invites_active_drive_email_idx": {
+          "name": "pending_invites_active_drive_email_idx",
+          "columns": [
+            {
+              "expression": "drive_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"pending_invites\".\"consumed_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "pending_invites_drive_id_drives_id_fk": {
+          "name": "pending_invites_drive_id_drives_id_fk",
+          "tableFrom": "pending_invites",
+          "tableTo": "drives",
+          "columnsFrom": [
+            "drive_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "pending_invites_custom_role_id_drive_roles_id_fk": {
+          "name": "pending_invites_custom_role_id_drive_roles_id_fk",
+          "tableFrom": "pending_invites",
+          "tableTo": "drive_roles",
+          "columnsFrom": [
+            "custom_role_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "pending_invites_invited_by_users_id_fk": {
+          "name": "pending_invites_invited_by_users_id_fk",
+          "tableFrom": "pending_invites",
+          "tableTo": "users",
+          "columnsFrom": [
+            "invited_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "pending_invites_token_hash_unique": {
+          "name": "pending_invites_token_hash_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token_hash"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.pending_page_invites": {
+      "name": "pending_page_invites",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "invited_by": {
+          "name": "invited_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "page_id": {
+          "name": "page_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "permissions": {
+          "name": "permissions",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "consumed_at": {
+          "name": "consumed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "pending_page_invites_page_id_idx": {
+          "name": "pending_page_invites_page_id_idx",
+          "columns": [
+            {
+              "expression": "page_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "pending_page_invites_email_idx": {
+          "name": "pending_page_invites_email_idx",
+          "columns": [
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "pending_page_invites_expires_at_idx": {
+          "name": "pending_page_invites_expires_at_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "pending_page_invites_active_page_email_idx": {
+          "name": "pending_page_invites_active_page_email_idx",
+          "columns": [
+            {
+              "expression": "page_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"pending_page_invites\".\"consumed_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "pending_page_invites_invited_by_users_id_fk": {
+          "name": "pending_page_invites_invited_by_users_id_fk",
+          "tableFrom": "pending_page_invites",
+          "tableTo": "users",
+          "columnsFrom": [
+            "invited_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "pending_page_invites_page_id_pages_id_fk": {
+          "name": "pending_page_invites_page_id_pages_id_fk",
+          "tableFrom": "pending_page_invites",
+          "tableTo": "pages",
+          "columnsFrom": [
+            "page_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "pending_page_invites_token_hash_unique": {
+          "name": "pending_page_invites_token_hash_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token_hash"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.pending_connection_invites": {
+      "name": "pending_connection_invites",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "invited_by": {
+          "name": "invited_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "request_message": {
+          "name": "request_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "consumed_at": {
+          "name": "consumed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "pending_connection_invites_invited_by_idx": {
+          "name": "pending_connection_invites_invited_by_idx",
+          "columns": [
+            {
+              "expression": "invited_by",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "pending_connection_invites_email_idx": {
+          "name": "pending_connection_invites_email_idx",
+          "columns": [
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "pending_connection_invites_expires_at_idx": {
+          "name": "pending_connection_invites_expires_at_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "pending_connection_invites_active_inviter_email_idx": {
+          "name": "pending_connection_invites_active_inviter_email_idx",
+          "columns": [
+            {
+              "expression": "invited_by",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"pending_connection_invites\".\"consumed_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "pending_connection_invites_invited_by_users_id_fk": {
+          "name": "pending_connection_invites_invited_by_users_id_fk",
+          "tableFrom": "pending_connection_invites",
+          "tableTo": "users",
+          "columnsFrom": [
+            "invited_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "pending_connection_invites_token_hash_unique": {
+          "name": "pending_connection_invites_token_hash_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token_hash"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ai_pending_abort_intents": {
+      "name": "ai_pending_abort_intents",
+      "schema": "",
+      "columns": {
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "ai_pending_abort_intents_conversation_id_user_id_pk": {
+          "name": "ai_pending_abort_intents_conversation_id_user_id_pk",
+          "columns": [
+            "conversation_id",
+            "user_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ai_stream_frames": {
+      "name": "ai_stream_frames",
+      "schema": "",
+      "columns": {
+        "message_id": {
+          "name": "message_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "from_seq": {
+          "name": "from_seq",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "frame_count": {
+          "name": "frame_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "frames": {
+          "name": "frames",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "byte_size": {
+          "name": "byte_size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "ai_stream_frames_created_at_idx": {
+          "name": "ai_stream_frames_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "ai_stream_frames_conversation_id_conversations_id_fk": {
+          "name": "ai_stream_frames_conversation_id_conversations_id_fk",
+          "tableFrom": "ai_stream_frames",
+          "tableTo": "conversations",
+          "columnsFrom": [
+            "conversation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "ai_stream_frames_message_id_from_seq_pk": {
+          "name": "ai_stream_frames_message_id_from_seq_pk",
+          "columns": [
+            "message_id",
+            "from_seq"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ai_stream_sessions": {
+      "name": "ai_stream_sessions",
+      "schema": "",
+      "columns": {
+        "message_id": {
+          "name": "message_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "channel_id": {
+          "name": "channel_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'Someone'"
+        },
+        "browser_session_id": {
+          "name": "browser_session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'streaming'"
+        },
+        "parts": {
+          "name": "parts",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "raw_parts_count": {
+          "name": "raw_parts_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_heartbeat_at": {
+          "name": "last_heartbeat_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stream_id": {
+          "name": "stream_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "abort_requested_at": {
+          "name": "abort_requested_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reap_claimed_at": {
+          "name": "reap_claimed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "ai_stream_sessions_channel_status_idx": {
+          "name": "ai_stream_sessions_channel_status_idx",
+          "columns": [
+            {
+              "expression": "channel_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ai_stream_sessions_conversation_status_idx": {
+          "name": "ai_stream_sessions_conversation_status_idx",
+          "columns": [
+            {
+              "expression": "conversation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ai_stream_sessions_user_status_idx": {
+          "name": "ai_stream_sessions_user_status_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ai_stream_sessions_stream_id_idx": {
+          "name": "ai_stream_sessions_stream_id_idx",
+          "columns": [
+            {
+              "expression": "stream_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "ai_stream_sessions_conversation_id_conversations_id_fk": {
+          "name": "ai_stream_sessions_conversation_id_conversations_id_fk",
+          "tableFrom": "ai_stream_sessions",
+          "tableTo": "conversations",
+          "columnsFrom": [
+            "conversation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.drive_share_links": {
+      "name": "drive_share_links",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "drive_id": {
+          "name": "drive_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "MemberRole",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'MEMBER'"
+        },
+        "custom_role_id": {
+          "name": "custom_role_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "use_count": {
+          "name": "use_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        }
+      },
+      "indexes": {
+        "drive_share_links_drive_id_idx": {
+          "name": "drive_share_links_drive_id_idx",
+          "columns": [
+            {
+              "expression": "drive_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "drive_share_links_expires_at_idx": {
+          "name": "drive_share_links_expires_at_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "drive_share_links_is_active_idx": {
+          "name": "drive_share_links_is_active_idx",
+          "columns": [
+            {
+              "expression": "is_active",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "drive_share_links_custom_role_id_idx": {
+          "name": "drive_share_links_custom_role_id_idx",
+          "columns": [
+            {
+              "expression": "custom_role_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "drive_share_links_drive_id_drives_id_fk": {
+          "name": "drive_share_links_drive_id_drives_id_fk",
+          "tableFrom": "drive_share_links",
+          "tableTo": "drives",
+          "columnsFrom": [
+            "drive_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "drive_share_links_custom_role_id_drive_roles_id_fk": {
+          "name": "drive_share_links_custom_role_id_drive_roles_id_fk",
+          "tableFrom": "drive_share_links",
+          "tableTo": "drive_roles",
+          "columnsFrom": [
+            "custom_role_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "drive_share_links_created_by_users_id_fk": {
+          "name": "drive_share_links_created_by_users_id_fk",
+          "tableFrom": "drive_share_links",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "drive_share_links_token_unique": {
+          "name": "drive_share_links_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.page_share_links": {
+      "name": "page_share_links",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "page_id": {
+          "name": "page_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "permissions": {
+          "name": "permissions",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "use_count": {
+          "name": "use_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        }
+      },
+      "indexes": {
+        "page_share_links_page_id_idx": {
+          "name": "page_share_links_page_id_idx",
+          "columns": [
+            {
+              "expression": "page_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "page_share_links_expires_at_idx": {
+          "name": "page_share_links_expires_at_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "page_share_links_is_active_idx": {
+          "name": "page_share_links_is_active_idx",
+          "columns": [
+            {
+              "expression": "is_active",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "page_share_links_page_id_pages_id_fk": {
+          "name": "page_share_links_page_id_pages_id_fk",
+          "tableFrom": "page_share_links",
+          "tableTo": "pages",
+          "columnsFrom": [
+            "page_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "page_share_links_created_by_users_id_fk": {
+          "name": "page_share_links_created_by_users_id_fk",
+          "tableFrom": "page_share_links",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "page_share_links_token_unique": {
+          "name": "page_share_links_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.zoom_connections": {
+      "name": "zoom_connections",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "accessToken": {
+          "name": "accessToken",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "refreshToken": {
+          "name": "refreshToken",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tokenExpiresAt": {
+          "name": "tokenExpiresAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "zoomUserId": {
+          "name": "zoomUserId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "zoomAccountId": {
+          "name": "zoomAccountId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "zoomEmail": {
+          "name": "zoomEmail",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "ZoomConnectionStatus",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "targetDriveId": {
+          "name": "targetDriveId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "targetFolderId": {
+          "name": "targetFolderId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scopeVersion": {
+          "name": "scopeVersion",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "includeAiSummary": {
+          "name": "includeAiSummary",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "includeActionItems": {
+          "name": "includeActionItems",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "includeTranscript": {
+          "name": "includeTranscript",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "zoom_connections_user_id_idx": {
+          "name": "zoom_connections_user_id_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "zoom_connections_status_idx": {
+          "name": "zoom_connections_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "zoom_connections_account_id_idx": {
+          "name": "zoom_connections_account_id_idx",
+          "columns": [
+            {
+              "expression": "zoomAccountId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "zoom_connections_target_drive_id_idx": {
+          "name": "zoom_connections_target_drive_id_idx",
+          "columns": [
+            {
+              "expression": "targetDriveId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "zoom_connections_userId_users_id_fk": {
+          "name": "zoom_connections_userId_users_id_fk",
+          "tableFrom": "zoom_connections",
+          "tableTo": "users",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "zoom_connections_targetDriveId_drives_id_fk": {
+          "name": "zoom_connections_targetDriveId_drives_id_fk",
+          "tableFrom": "zoom_connections",
+          "tableTo": "drives",
+          "columnsFrom": [
+            "targetDriveId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "zoom_connections_userId_unique": {
+          "name": "zoom_connections_userId_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "userId"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.webhook_triggers": {
+      "name": "webhook_triggers",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "workflowId": {
+          "name": "workflowId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "connectionId": {
+          "name": "connectionId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pageWebhookId": {
+          "name": "pageWebhookId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "eventType": {
+          "name": "eventType",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "isEnabled": {
+          "name": "isEnabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "lastFiredAt": {
+          "name": "lastFiredAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lastFireError": {
+          "name": "lastFireError",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "webhook_triggers_workflow_id_idx": {
+          "name": "webhook_triggers_workflow_id_idx",
+          "columns": [
+            {
+              "expression": "workflowId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "webhook_triggers_provider_event_idx": {
+          "name": "webhook_triggers_provider_event_idx",
+          "columns": [
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "eventType",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "isEnabled",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "webhook_triggers_connection_id_idx": {
+          "name": "webhook_triggers_connection_id_idx",
+          "columns": [
+            {
+              "expression": "connectionId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "webhook_triggers_page_webhook_id_idx": {
+          "name": "webhook_triggers_page_webhook_id_idx",
+          "columns": [
+            {
+              "expression": "pageWebhookId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "webhook_triggers_page_webhook_workflow_unique": {
+          "name": "webhook_triggers_page_webhook_workflow_unique",
+          "columns": [
+            {
+              "expression": "pageWebhookId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "workflowId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"webhook_triggers\".\"pageWebhookId\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "webhook_triggers_workflowId_workflows_id_fk": {
+          "name": "webhook_triggers_workflowId_workflows_id_fk",
+          "tableFrom": "webhook_triggers",
+          "tableTo": "workflows",
+          "columnsFrom": [
+            "workflowId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "webhook_triggers_connectionId_zoom_connections_id_fk": {
+          "name": "webhook_triggers_connectionId_zoom_connections_id_fk",
+          "tableFrom": "webhook_triggers",
+          "tableTo": "zoom_connections",
+          "columnsFrom": [
+            "connectionId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "webhook_triggers_pageWebhookId_page_webhooks_id_fk": {
+          "name": "webhook_triggers_pageWebhookId_page_webhooks_id_fk",
+          "tableFrom": "webhook_triggers",
+          "tableTo": "page_webhooks",
+          "columnsFrom": [
+            "pageWebhookId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "webhook_triggers_connection_workflow_event_unique": {
+          "name": "webhook_triggers_connection_workflow_event_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "connectionId",
+            "workflowId",
+            "eventType"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "webhook_triggers_anchor_chk": {
+          "name": "webhook_triggers_anchor_chk",
+          "value": "(\"webhook_triggers\".\"connectionId\" IS NOT NULL AND \"webhook_triggers\".\"pageWebhookId\" IS NULL) OR (\"webhook_triggers\".\"connectionId\" IS NULL AND \"webhook_triggers\".\"pageWebhookId\" IS NOT NULL)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.message_drafts": {
+      "name": "message_drafts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "contextKey": {
+          "name": "contextKey",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expiresAt": {
+          "name": "expiresAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "message_drafts_user_context_key": {
+          "name": "message_drafts_user_context_key",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "contextKey",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "message_drafts_expires_at_idx": {
+          "name": "message_drafts_expires_at_idx",
+          "columns": [
+            {
+              "expression": "expiresAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "message_drafts_userId_users_id_fk": {
+          "name": "message_drafts_userId_users_id_fk",
+          "tableFrom": "message_drafts",
+          "tableTo": "users",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.published_pages": {
+      "name": "published_pages",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "drive_id": {
+          "name": "drive_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "page_id": {
+          "name": "page_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "path": {
+          "name": "path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "artifact_key": {
+          "name": "artifact_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "publish_title": {
+          "name": "publish_title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "publish_description": {
+          "name": "publish_description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "publish_og_image_url": {
+          "name": "publish_og_image_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "noindex": {
+          "name": "noindex",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "theme_bridge_enabled": {
+          "name": "theme_bridge_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "published_by": {
+          "name": "published_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "published_at": {
+          "name": "published_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "published_pages_drive_id_idx": {
+          "name": "published_pages_drive_id_idx",
+          "columns": [
+            {
+              "expression": "drive_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "published_pages_page_id_idx": {
+          "name": "published_pages_page_id_idx",
+          "columns": [
+            {
+              "expression": "page_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "published_pages_drive_id_drives_id_fk": {
+          "name": "published_pages_drive_id_drives_id_fk",
+          "tableFrom": "published_pages",
+          "tableTo": "drives",
+          "columnsFrom": [
+            "drive_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "published_pages_page_id_pages_id_fk": {
+          "name": "published_pages_page_id_pages_id_fk",
+          "tableFrom": "published_pages",
+          "tableTo": "pages",
+          "columnsFrom": [
+            "page_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "published_pages_published_by_users_id_fk": {
+          "name": "published_pages_published_by_users_id_fk",
+          "tableFrom": "published_pages",
+          "tableTo": "users",
+          "columnsFrom": [
+            "published_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "published_pages_page_id_key": {
+          "name": "published_pages_page_id_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "page_id"
+          ]
+        },
+        "published_pages_drive_id_path_key": {
+          "name": "published_pages_drive_id_path_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "drive_id",
+            "path"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.credit_balances": {
+      "name": "credit_balances",
+      "schema": "",
+      "columns": {
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "monthlyRemainingCents": {
+          "name": "monthlyRemainingCents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "monthlyAllowanceCents": {
+          "name": "monthlyAllowanceCents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "topupRemainingCents": {
+          "name": "topupRemainingCents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "debtCents": {
+          "name": "debtCents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "pendingMillicents": {
+          "name": "pendingMillicents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "monthlyPeriodStart": {
+          "name": "monthlyPeriodStart",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "monthlyPeriodEnd": {
+          "name": "monthlyPeriodEnd",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "credit_balances_userId_users_id_fk": {
+          "name": "credit_balances_userId_users_id_fk",
+          "tableFrom": "credit_balances",
+          "tableTo": "users",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "credit_balances_monthly_remaining_nonneg": {
+          "name": "credit_balances_monthly_remaining_nonneg",
+          "value": "\"credit_balances\".\"monthlyRemainingCents\" >= 0"
+        },
+        "credit_balances_monthly_allowance_nonneg": {
+          "name": "credit_balances_monthly_allowance_nonneg",
+          "value": "\"credit_balances\".\"monthlyAllowanceCents\" >= 0"
+        },
+        "credit_balances_topup_remaining_nonneg": {
+          "name": "credit_balances_topup_remaining_nonneg",
+          "value": "\"credit_balances\".\"topupRemainingCents\" >= 0"
+        },
+        "credit_balances_debt_cents_nonneg": {
+          "name": "credit_balances_debt_cents_nonneg",
+          "value": "\"credit_balances\".\"debtCents\" >= 0"
+        },
+        "credit_balances_pending_millicents_range": {
+          "name": "credit_balances_pending_millicents_range",
+          "value": "\"credit_balances\".\"pendingMillicents\" >= 0 AND \"credit_balances\".\"pendingMillicents\" < 1000"
+        },
+        "credit_balances_period_order": {
+          "name": "credit_balances_period_order",
+          "value": "\"credit_balances\".\"monthlyPeriodStart\" IS NULL OR \"credit_balances\".\"monthlyPeriodEnd\" IS NULL OR \"credit_balances\".\"monthlyPeriodStart\" <= \"credit_balances\".\"monthlyPeriodEnd\""
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.credit_holds": {
+      "name": "credit_holds",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "estCents": {
+          "name": "estCents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "aiUsageLogId": {
+          "name": "aiUsageLogId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expiresAt": {
+          "name": "expiresAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "credit_holds_user_idx": {
+          "name": "credit_holds_user_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "credit_holds_expires_idx": {
+          "name": "credit_holds_expires_idx",
+          "columns": [
+            {
+              "expression": "expiresAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "credit_holds_userId_users_id_fk": {
+          "name": "credit_holds_userId_users_id_fk",
+          "tableFrom": "credit_holds",
+          "tableTo": "users",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "credit_holds_est_cents_nonneg": {
+          "name": "credit_holds_est_cents_nonneg",
+          "value": "\"credit_holds\".\"estCents\" >= 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.credit_ledger": {
+      "name": "credit_ledger",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entryType": {
+          "name": "entryType",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "bucket": {
+          "name": "bucket",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amountCents": {
+          "name": "amountCents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "appliedCents": {
+          "name": "appliedCents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "chargeMillicents": {
+          "name": "chargeMillicents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "aiUsageLogId": {
+          "name": "aiUsageLogId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "realCostCents": {
+          "name": "realCostCents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "markupBps": {
+          "name": "markupBps",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 15000
+        },
+        "stripeRef": {
+          "name": "stripeRef",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "consumeStatus": {
+          "name": "consumeStatus",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "consumeError": {
+          "name": "consumeError",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reconcileGenerationKey": {
+          "name": "reconcileGenerationKey",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "credit_ledger_user_idx": {
+          "name": "credit_ledger_user_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "createdAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "credit_ledger_usage_log_unique": {
+          "name": "credit_ledger_usage_log_unique",
+          "columns": [
+            {
+              "expression": "aiUsageLogId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"credit_ledger\".\"aiUsageLogId\" IS NOT NULL AND \"credit_ledger\".\"entryType\" = 'usage'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "credit_ledger_stripe_ref_unique": {
+          "name": "credit_ledger_stripe_ref_unique",
+          "columns": [
+            {
+              "expression": "stripeRef",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"credit_ledger\".\"stripeRef\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "credit_ledger_reconcile_key_unique": {
+          "name": "credit_ledger_reconcile_key_unique",
+          "columns": [
+            {
+              "expression": "reconcileGenerationKey",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"credit_ledger\".\"reconcileGenerationKey\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "credit_ledger_consume_status_idx": {
+          "name": "credit_ledger_consume_status_idx",
+          "columns": [
+            {
+              "expression": "consumeStatus",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "createdAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "credit_ledger_userId_users_id_fk": {
+          "name": "credit_ledger_userId_users_id_fk",
+          "tableFrom": "credit_ledger",
+          "tableTo": "users",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.commands": {
+      "name": "commands",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "drive_id": {
+          "name": "drive_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by_id": {
+          "name": "created_by_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "trigger": {
+          "name": "trigger",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entry_page_id": {
+          "name": "entry_page_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'document'"
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "commands_user_id_idx": {
+          "name": "commands_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "commands_drive_id_idx": {
+          "name": "commands_drive_id_idx",
+          "columns": [
+            {
+              "expression": "drive_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "commands_entry_page_id_idx": {
+          "name": "commands_entry_page_id_idx",
+          "columns": [
+            {
+              "expression": "entry_page_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "commands_user_id_users_id_fk": {
+          "name": "commands_user_id_users_id_fk",
+          "tableFrom": "commands",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "commands_drive_id_drives_id_fk": {
+          "name": "commands_drive_id_drives_id_fk",
+          "tableFrom": "commands",
+          "tableTo": "drives",
+          "columnsFrom": [
+            "drive_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "commands_created_by_id_users_id_fk": {
+          "name": "commands_created_by_id_users_id_fk",
+          "tableFrom": "commands",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "commands_entry_page_id_pages_id_fk": {
+          "name": "commands_entry_page_id_pages_id_fk",
+          "tableFrom": "commands",
+          "tableTo": "pages",
+          "columnsFrom": [
+            "entry_page_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "commands_user_trigger": {
+          "name": "commands_user_trigger",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "trigger"
+          ]
+        },
+        "commands_drive_trigger": {
+          "name": "commands_drive_trigger",
+          "nullsNotDistinct": false,
+          "columns": [
+            "drive_id",
+            "trigger"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "commands_scope_chk": {
+          "name": "commands_scope_chk",
+          "value": "(\"commands\".\"user_id\" IS NOT NULL AND \"commands\".\"drive_id\" IS NULL) OR (\"commands\".\"user_id\" IS NULL AND \"commands\".\"drive_id\" IS NOT NULL)"
+        },
+        "commands_type_chk": {
+          "name": "commands_type_chk",
+          "value": "\"commands\".\"type\" IN ('document', 'prompt_template', 'builtin')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.content_tags": {
+      "name": "content_tags",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "tagId": {
+          "name": "tagId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pageId": {
+          "name": "pageId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "targetKind": {
+          "name": "targetKind",
+          "type": "ContentTagTargetKind",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "anchor": {
+          "name": "anchor",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "anchorStatus": {
+          "name": "anchorStatus",
+          "type": "ContentTagAnchorStatus",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "channelMessageId": {
+          "name": "channelMessageId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "aiMessageId": {
+          "name": "aiMessageId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source": {
+          "name": "source",
+          "type": "ContentTagSource",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "confidence": {
+          "name": "confidence",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdBy": {
+          "name": "createdBy",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "content_tags_page_id_idx": {
+          "name": "content_tags_page_id_idx",
+          "columns": [
+            {
+              "expression": "pageId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "content_tags_tag_id_idx": {
+          "name": "content_tags_tag_id_idx",
+          "columns": [
+            {
+              "expression": "tagId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "content_tags_created_by_idx": {
+          "name": "content_tags_created_by_idx",
+          "columns": [
+            {
+              "expression": "createdBy",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "content_tags_page_target_unique": {
+          "name": "content_tags_page_target_unique",
+          "columns": [
+            {
+              "expression": "pageId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "tagId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"content_tags\".\"targetKind\" = 'page'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "content_tags_channel_message_target_unique": {
+          "name": "content_tags_channel_message_target_unique",
+          "columns": [
+            {
+              "expression": "channelMessageId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "tagId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"content_tags\".\"targetKind\" = 'channel_message'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "content_tags_ai_message_target_unique": {
+          "name": "content_tags_ai_message_target_unique",
+          "columns": [
+            {
+              "expression": "aiMessageId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "tagId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"content_tags\".\"targetKind\" = 'ai_message'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "content_tags_tagId_tags_id_fk": {
+          "name": "content_tags_tagId_tags_id_fk",
+          "tableFrom": "content_tags",
+          "tableTo": "tags",
+          "columnsFrom": [
+            "tagId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "content_tags_pageId_pages_id_fk": {
+          "name": "content_tags_pageId_pages_id_fk",
+          "tableFrom": "content_tags",
+          "tableTo": "pages",
+          "columnsFrom": [
+            "pageId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "content_tags_channelMessageId_channel_messages_id_fk": {
+          "name": "content_tags_channelMessageId_channel_messages_id_fk",
+          "tableFrom": "content_tags",
+          "tableTo": "channel_messages",
+          "columnsFrom": [
+            "channelMessageId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "content_tags_aiMessageId_messages_id_fk": {
+          "name": "content_tags_aiMessageId_messages_id_fk",
+          "tableFrom": "content_tags",
+          "tableTo": "messages",
+          "columnsFrom": [
+            "aiMessageId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "content_tags_createdBy_users_id_fk": {
+          "name": "content_tags_createdBy_users_id_fk",
+          "tableFrom": "content_tags",
+          "tableTo": "users",
+          "columnsFrom": [
+            "createdBy"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "content_tags_target_chk": {
+          "name": "content_tags_target_chk",
+          "value": "(\n        (\"content_tags\".\"targetKind\" = 'page' AND \"content_tags\".\"anchor\" IS NULL AND \"content_tags\".\"anchorStatus\" IS NULL AND \"content_tags\".\"channelMessageId\" IS NULL AND \"content_tags\".\"aiMessageId\" IS NULL)\n        OR (\"content_tags\".\"targetKind\" = 'text' AND \"content_tags\".\"anchor\" IS NOT NULL AND \"content_tags\".\"anchorStatus\" IS NOT NULL AND \"content_tags\".\"channelMessageId\" IS NULL AND \"content_tags\".\"aiMessageId\" IS NULL)\n        OR (\"content_tags\".\"targetKind\" = 'sheet_cell' AND \"content_tags\".\"anchor\" IS NOT NULL AND \"content_tags\".\"anchorStatus\" IS NULL AND \"content_tags\".\"channelMessageId\" IS NULL AND \"content_tags\".\"aiMessageId\" IS NULL)\n        OR (\"content_tags\".\"targetKind\" = 'channel_message' AND \"content_tags\".\"anchor\" IS NULL AND \"content_tags\".\"anchorStatus\" IS NULL AND \"content_tags\".\"channelMessageId\" IS NOT NULL AND \"content_tags\".\"aiMessageId\" IS NULL)\n        OR (\"content_tags\".\"targetKind\" = 'ai_message' AND \"content_tags\".\"anchor\" IS NULL AND \"content_tags\".\"anchorStatus\" IS NULL AND \"content_tags\".\"channelMessageId\" IS NULL AND \"content_tags\".\"aiMessageId\" IS NOT NULL)\n      )"
+        },
+        "content_tags_confidence_range_chk": {
+          "name": "content_tags_confidence_range_chk",
+          "value": "\"content_tags\".\"confidence\" IS NULL OR (\"content_tags\".\"confidence\" >= 0 AND \"content_tags\".\"confidence\" <= 1)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.conversation_compactions": {
+      "name": "conversation_compactions",
+      "schema": "",
+      "columns": {
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "page_id": {
+          "name": "page_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "summary": {
+          "name": "summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "summary_tokens": {
+          "name": "summary_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "compacted_up_to_message_id": {
+          "name": "compacted_up_to_message_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "compacted_up_to_created_at": {
+          "name": "compacted_up_to_created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "summary_version": {
+          "name": "summary_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "summarizer_model": {
+          "name": "summarizer_model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_compacted_at": {
+          "name": "last_compacted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "conversation_compactions_page_id_idx": {
+          "name": "conversation_compactions_page_id_idx",
+          "columns": [
+            {
+              "expression": "page_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "conversation_compactions_conversation_id_source_pk": {
+          "name": "conversation_compactions_conversation_id_source_pk",
+          "columns": [
+            "conversation_id",
+            "source"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "conversation_compactions_source_chk": {
+          "name": "conversation_compactions_source_chk",
+          "value": "\"conversation_compactions\".\"source\" IN ('page', 'global')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.custom_domains": {
+      "name": "custom_domains",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "drive_id": {
+          "name": "drive_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "hostname": {
+          "name": "hostname",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "custom_domain_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "is_primary": {
+          "name": "is_primary",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "platform_owned": {
+          "name": "platform_owned",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "publish_landing_page_id": {
+          "name": "publish_landing_page_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "publish_not_found_page_id": {
+          "name": "publish_not_found_page_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "published_app_id": {
+          "name": "published_app_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "custom_domains_hostname_key": {
+          "name": "custom_domains_hostname_key",
+          "columns": [
+            {
+              "expression": "hostname",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "custom_domains_drive_id_idx": {
+          "name": "custom_domains_drive_id_idx",
+          "columns": [
+            {
+              "expression": "drive_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "custom_domains_published_app_id_idx": {
+          "name": "custom_domains_published_app_id_idx",
+          "columns": [
+            {
+              "expression": "published_app_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "custom_domains_primary_per_drive": {
+          "name": "custom_domains_primary_per_drive",
+          "columns": [
+            {
+              "expression": "drive_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"custom_domains\".\"is_primary\"",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "custom_domains_drive_id_drives_id_fk": {
+          "name": "custom_domains_drive_id_drives_id_fk",
+          "tableFrom": "custom_domains",
+          "tableTo": "drives",
+          "columnsFrom": [
+            "drive_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "custom_domains_publish_landing_page_id_pages_id_fk": {
+          "name": "custom_domains_publish_landing_page_id_pages_id_fk",
+          "tableFrom": "custom_domains",
+          "tableTo": "pages",
+          "columnsFrom": [
+            "publish_landing_page_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "custom_domains_publish_not_found_page_id_pages_id_fk": {
+          "name": "custom_domains_publish_not_found_page_id_pages_id_fk",
+          "tableFrom": "custom_domains",
+          "tableTo": "pages",
+          "columnsFrom": [
+            "publish_not_found_page_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "custom_domains_published_app_id_published_apps_id_fk": {
+          "name": "custom_domains_published_app_id_published_apps_id_fk",
+          "tableFrom": "custom_domains",
+          "tableTo": "published_apps",
+          "columnsFrom": [
+            "published_app_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.incidents": {
+      "name": "incidents",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "severity": {
+          "name": "severity",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'detected'"
+        },
+        "category": {
+          "name": "category",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "detectedAt": {
+          "name": "detectedAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "reportedBy": {
+          "name": "reportedBy",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "affectedUserCount": {
+          "name": "affectedUserCount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "affectedScope": {
+          "name": "affectedScope",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "riskLevel": {
+          "name": "riskLevel",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "requiresAuthorityNotification": {
+          "name": "requiresAuthorityNotification",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "authorityNotificationDeadline": {
+          "name": "authorityNotificationDeadline",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "authorityNotifiedAt": {
+          "name": "authorityNotifiedAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "requiresSubjectNotification": {
+          "name": "requiresSubjectNotification",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "subjectsNotifiedAt": {
+          "name": "subjectsNotifiedAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "closedAt": {
+          "name": "closedAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_incidents_status": {
+          "name": "idx_incidents_status",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_incidents_detected_at": {
+          "name": "idx_incidents_detected_at",
+          "columns": [
+            {
+              "expression": "detectedAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_incidents_authority_deadline": {
+          "name": "idx_incidents_authority_deadline",
+          "columns": [
+            {
+              "expression": "authorityNotificationDeadline",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "incidents_reportedBy_users_id_fk": {
+          "name": "incidents_reportedBy_users_id_fk",
+          "tableFrom": "incidents",
+          "tableTo": "users",
+          "columnsFrom": [
+            "reportedBy"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.data_subject_requests": {
+      "name": "data_subject_requests",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "subject_email": {
+          "name": "subject_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "request_type": {
+          "name": "request_type",
+          "type": "data_subject_request_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'erasure'"
+        },
+        "status": {
+          "name": "status",
+          "type": "data_subject_request_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "force_delete": {
+          "name": "force_delete",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "requested_by_user_id": {
+          "name": "requested_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "requested_by_type": {
+          "name": "requested_by_type",
+          "type": "data_subject_requester_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'self'"
+        },
+        "legal_basis": {
+          "name": "legal_basis",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "received_at": {
+          "name": "received_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "sla_deadline": {
+          "name": "sla_deadline",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "blocked_reason": {
+          "name": "blocked_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "job_id": {
+          "name": "job_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "attempts": {
+          "name": "attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "last_error": {
+          "name": "last_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "step_results": {
+          "name": "step_results",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "data_subject_requests_status_idx": {
+          "name": "data_subject_requests_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "data_subject_requests_sla_deadline_idx": {
+          "name": "data_subject_requests_sla_deadline_idx",
+          "columns": [
+            {
+              "expression": "sla_deadline",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "data_subject_requests_user_id_idx": {
+          "name": "data_subject_requests_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "data_subject_requests_user_id_users_id_fk": {
+          "name": "data_subject_requests_user_id_users_id_fk",
+          "tableFrom": "data_subject_requests",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "data_subject_requests_requested_by_user_id_users_id_fk": {
+          "name": "data_subject_requests_requested_by_user_id_users_id_fk",
+          "tableFrom": "data_subject_requests",
+          "tableTo": "users",
+          "columnsFrom": [
+            "requested_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.oauth_access_tokens": {
+      "name": "oauth_access_tokens",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "tokenHash": {
+          "name": "tokenHash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tokenPrefix": {
+          "name": "tokenPrefix",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "familyId": {
+          "name": "familyId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "clientId": {
+          "name": "clientId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tokenVersion": {
+          "name": "tokenVersion",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expiresAt": {
+          "name": "expiresAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "revokedAt": {
+          "name": "revokedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revokedReason": {
+          "name": "revokedReason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "oauth_access_tokens_family_id_idx": {
+          "name": "oauth_access_tokens_family_id_idx",
+          "columns": [
+            {
+              "expression": "familyId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "oauth_access_tokens_user_id_idx": {
+          "name": "oauth_access_tokens_user_id_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "oauth_access_tokens_client_id_idx": {
+          "name": "oauth_access_tokens_client_id_idx",
+          "columns": [
+            {
+              "expression": "clientId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "oauth_access_tokens_token_hash_idx": {
+          "name": "oauth_access_tokens_token_hash_idx",
+          "columns": [
+            {
+              "expression": "tokenHash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "oauth_access_tokens_expires_at_idx": {
+          "name": "oauth_access_tokens_expires_at_idx",
+          "columns": [
+            {
+              "expression": "expiresAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "oauth_access_tokens_clientId_oauth_clients_id_fk": {
+          "name": "oauth_access_tokens_clientId_oauth_clients_id_fk",
+          "tableFrom": "oauth_access_tokens",
+          "tableTo": "oauth_clients",
+          "columnsFrom": [
+            "clientId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "oauth_access_tokens_userId_users_id_fk": {
+          "name": "oauth_access_tokens_userId_users_id_fk",
+          "tableFrom": "oauth_access_tokens",
+          "tableTo": "users",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "oauth_access_tokens_tokenHash_unique": {
+          "name": "oauth_access_tokens_tokenHash_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "tokenHash"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.oauth_authorization_codes": {
+      "name": "oauth_authorization_codes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "codeHash": {
+          "name": "codeHash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "codePrefix": {
+          "name": "codePrefix",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "clientId": {
+          "name": "clientId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "redirectUri": {
+          "name": "redirectUri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "codeChallenge": {
+          "name": "codeChallenge",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "codeChallengeMethod": {
+          "name": "codeChallengeMethod",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expiresAt": {
+          "name": "expiresAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "consumedAt": {
+          "name": "consumedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "issuedFamilyId": {
+          "name": "issuedFamilyId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "oauth_authorization_codes_client_id_idx": {
+          "name": "oauth_authorization_codes_client_id_idx",
+          "columns": [
+            {
+              "expression": "clientId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "oauth_authorization_codes_user_id_idx": {
+          "name": "oauth_authorization_codes_user_id_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "oauth_authorization_codes_code_hash_idx": {
+          "name": "oauth_authorization_codes_code_hash_idx",
+          "columns": [
+            {
+              "expression": "codeHash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "oauth_authorization_codes_expires_at_idx": {
+          "name": "oauth_authorization_codes_expires_at_idx",
+          "columns": [
+            {
+              "expression": "expiresAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "oauth_authorization_codes_clientId_oauth_clients_id_fk": {
+          "name": "oauth_authorization_codes_clientId_oauth_clients_id_fk",
+          "tableFrom": "oauth_authorization_codes",
+          "tableTo": "oauth_clients",
+          "columnsFrom": [
+            "clientId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "oauth_authorization_codes_userId_users_id_fk": {
+          "name": "oauth_authorization_codes_userId_users_id_fk",
+          "tableFrom": "oauth_authorization_codes",
+          "tableTo": "users",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "oauth_authorization_codes_codeHash_unique": {
+          "name": "oauth_authorization_codes_codeHash_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "codeHash"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.oauth_clients": {
+      "name": "oauth_clients",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "clientId": {
+          "name": "clientId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "clientType": {
+          "name": "clientType",
+          "type": "OAuthClientType",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "redirectUris": {
+          "name": "redirectUris",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "isFirstParty": {
+          "name": "isFirstParty",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "disabledAt": {
+          "name": "disabledAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "oauth_clients_client_id_idx": {
+          "name": "oauth_clients_client_id_idx",
+          "columns": [
+            {
+              "expression": "clientId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "oauth_clients_clientId_unique": {
+          "name": "oauth_clients_clientId_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "clientId"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.oauth_device_codes": {
+      "name": "oauth_device_codes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "deviceCodeHash": {
+          "name": "deviceCodeHash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "deviceCodePrefix": {
+          "name": "deviceCodePrefix",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "userCodeHash": {
+          "name": "userCodeHash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "userCodePrefix": {
+          "name": "userCodePrefix",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "clientId": {
+          "name": "clientId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expiresAt": {
+          "name": "expiresAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "approvedAt": {
+          "name": "approvedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deniedAt": {
+          "name": "deniedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "redeemedAt": {
+          "name": "redeemedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lastPolledAt": {
+          "name": "lastPolledAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pollIntervalSeconds": {
+          "name": "pollIntervalSeconds",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 5
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "oauth_device_codes_client_id_idx": {
+          "name": "oauth_device_codes_client_id_idx",
+          "columns": [
+            {
+              "expression": "clientId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "oauth_device_codes_user_id_idx": {
+          "name": "oauth_device_codes_user_id_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "oauth_device_codes_device_code_hash_idx": {
+          "name": "oauth_device_codes_device_code_hash_idx",
+          "columns": [
+            {
+              "expression": "deviceCodeHash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "oauth_device_codes_user_code_hash_idx": {
+          "name": "oauth_device_codes_user_code_hash_idx",
+          "columns": [
+            {
+              "expression": "userCodeHash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "oauth_device_codes_expires_at_idx": {
+          "name": "oauth_device_codes_expires_at_idx",
+          "columns": [
+            {
+              "expression": "expiresAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "oauth_device_codes_clientId_oauth_clients_id_fk": {
+          "name": "oauth_device_codes_clientId_oauth_clients_id_fk",
+          "tableFrom": "oauth_device_codes",
+          "tableTo": "oauth_clients",
+          "columnsFrom": [
+            "clientId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "oauth_device_codes_userId_users_id_fk": {
+          "name": "oauth_device_codes_userId_users_id_fk",
+          "tableFrom": "oauth_device_codes",
+          "tableTo": "users",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "oauth_device_codes_deviceCodeHash_unique": {
+          "name": "oauth_device_codes_deviceCodeHash_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "deviceCodeHash"
+          ]
+        },
+        "oauth_device_codes_userCodeHash_unique": {
+          "name": "oauth_device_codes_userCodeHash_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "userCodeHash"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.oauth_refresh_tokens": {
+      "name": "oauth_refresh_tokens",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "tokenHash": {
+          "name": "tokenHash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tokenPrefix": {
+          "name": "tokenPrefix",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "familyId": {
+          "name": "familyId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "clientId": {
+          "name": "clientId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tokenVersion": {
+          "name": "tokenVersion",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expiresAt": {
+          "name": "expiresAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "familyExpiresAt": {
+          "name": "familyExpiresAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "replacedByTokenId": {
+          "name": "replacedByTokenId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revokedAt": {
+          "name": "revokedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revokedReason": {
+          "name": "revokedReason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "oauth_refresh_tokens_family_id_idx": {
+          "name": "oauth_refresh_tokens_family_id_idx",
+          "columns": [
+            {
+              "expression": "familyId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "oauth_refresh_tokens_user_id_idx": {
+          "name": "oauth_refresh_tokens_user_id_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "oauth_refresh_tokens_client_id_idx": {
+          "name": "oauth_refresh_tokens_client_id_idx",
+          "columns": [
+            {
+              "expression": "clientId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "oauth_refresh_tokens_token_hash_idx": {
+          "name": "oauth_refresh_tokens_token_hash_idx",
+          "columns": [
+            {
+              "expression": "tokenHash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "oauth_refresh_tokens_expires_at_idx": {
+          "name": "oauth_refresh_tokens_expires_at_idx",
+          "columns": [
+            {
+              "expression": "expiresAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "oauth_refresh_tokens_clientId_oauth_clients_id_fk": {
+          "name": "oauth_refresh_tokens_clientId_oauth_clients_id_fk",
+          "tableFrom": "oauth_refresh_tokens",
+          "tableTo": "oauth_clients",
+          "columnsFrom": [
+            "clientId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "oauth_refresh_tokens_userId_users_id_fk": {
+          "name": "oauth_refresh_tokens_userId_users_id_fk",
+          "tableFrom": "oauth_refresh_tokens",
+          "tableTo": "users",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "oauth_refresh_tokens_tokenHash_unique": {
+          "name": "oauth_refresh_tokens_tokenHash_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "tokenHash"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.form_targets": {
+      "name": "form_targets",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_prefix": {
+          "name": "token_prefix",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "drive_id": {
+          "name": "drive_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "page_id": {
+          "name": "page_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "action": {
+          "name": "action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'sheet:append'"
+        },
+        "canvas_page_id": {
+          "name": "canvas_page_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "fields": {
+          "name": "fields",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "header_row": {
+          "name": "header_row",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "next_row": {
+          "name": "next_row",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "notification_email": {
+          "name": "notification_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "status_reason": {
+          "name": "status_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_submitted_at": {
+          "name": "last_submitted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "submission_count": {
+          "name": "submission_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        }
+      },
+      "indexes": {
+        "form_targets_page_id_idx": {
+          "name": "form_targets_page_id_idx",
+          "columns": [
+            {
+              "expression": "page_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "form_targets_drive_id_idx": {
+          "name": "form_targets_drive_id_idx",
+          "columns": [
+            {
+              "expression": "drive_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "form_targets_status_idx": {
+          "name": "form_targets_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "form_targets_canvas_page_id_idx": {
+          "name": "form_targets_canvas_page_id_idx",
+          "columns": [
+            {
+              "expression": "canvas_page_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "form_targets_one_active_per_page_idx": {
+          "name": "form_targets_one_active_per_page_idx",
+          "columns": [
+            {
+              "expression": "page_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"form_targets\".\"status\" = 'active'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "form_targets_drive_id_drives_id_fk": {
+          "name": "form_targets_drive_id_drives_id_fk",
+          "tableFrom": "form_targets",
+          "tableTo": "drives",
+          "columnsFrom": [
+            "drive_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "form_targets_page_id_pages_id_fk": {
+          "name": "form_targets_page_id_pages_id_fk",
+          "tableFrom": "form_targets",
+          "tableTo": "pages",
+          "columnsFrom": [
+            "page_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "form_targets_canvas_page_id_pages_id_fk": {
+          "name": "form_targets_canvas_page_id_pages_id_fk",
+          "tableFrom": "form_targets",
+          "tableTo": "pages",
+          "columnsFrom": [
+            "canvas_page_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "form_targets_created_by_users_id_fk": {
+          "name": "form_targets_created_by_users_id_fk",
+          "tableFrom": "form_targets",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "form_targets_token_hash_unique": {
+          "name": "form_targets_token_hash_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token_hash"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.machine_sprite_reclaims": {
+      "name": "machine_sprite_reclaims",
+      "schema": "",
+      "columns": {
+        "sandboxId": {
+          "name": "sandboxId",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "spriteInstanceId": {
+          "name": "spriteInstanceId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "recordedAt": {
+          "name": "recordedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "attempts": {
+          "name": "attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "lastAttemptAt": {
+          "name": "lastAttemptAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lastError": {
+          "name": "lastError",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "machine_sprite_reclaims_recorded_at_idx": {
+          "name": "machine_sprite_reclaims_recorded_at_idx",
+          "columns": [
+            {
+              "expression": "recordedAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.app_deploy_token_mints": {
+      "name": "app_deploy_token_mints",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "publishedAppId": {
+          "name": "publishedAppId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "flyAppName": {
+          "name": "flyAppName",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "mintedAt": {
+          "name": "mintedAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "outcome": {
+          "name": "outcome",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "settledAt": {
+          "name": "settledAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expiry": {
+          "name": "expiry",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "purpose": {
+          "name": "purpose",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "app_deploy_token_mints_app_idx": {
+          "name": "app_deploy_token_mints_app_idx",
+          "columns": [
+            {
+              "expression": "publishedAppId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "mintedAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "app_deploy_token_mints_publishedAppId_published_apps_id_fk": {
+          "name": "app_deploy_token_mints_publishedAppId_published_apps_id_fk",
+          "tableFrom": "app_deploy_token_mints",
+          "tableTo": "published_apps",
+          "columnsFrom": [
+            "publishedAppId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "app_deploy_token_mints_expiry_nonempty": {
+          "name": "app_deploy_token_mints_expiry_nonempty",
+          "value": "length(\"app_deploy_token_mints\".\"expiry\") > 0"
+        },
+        "app_deploy_token_mints_purpose_nonempty": {
+          "name": "app_deploy_token_mints_purpose_nonempty",
+          "value": "length(\"app_deploy_token_mints\".\"purpose\") > 0"
+        },
+        "app_deploy_token_mints_outcome_allowed": {
+          "name": "app_deploy_token_mints_outcome_allowed",
+          "value": "\"app_deploy_token_mints\".\"outcome\" IN ('pending', 'minted', 'failed')"
+        },
+        "app_deploy_token_mints_settled_coherent": {
+          "name": "app_deploy_token_mints_settled_coherent",
+          "value": "(\"app_deploy_token_mints\".\"outcome\" = 'pending') = (\"app_deploy_token_mints\".\"settledAt\" IS NULL)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.app_hosting_reclaims": {
+      "name": "app_hosting_reclaims",
+      "schema": "",
+      "columns": {
+        "flyAppName": {
+          "name": "flyAppName",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "publishedAppId": {
+          "name": "publishedAppId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "machineId": {
+          "name": "machineId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "recordedAt": {
+          "name": "recordedAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "attempts": {
+          "name": "attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "lastAttemptAt": {
+          "name": "lastAttemptAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lastError": {
+          "name": "lastError",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "app_hosting_reclaims_recorded_at_idx": {
+          "name": "app_hosting_reclaims_recorded_at_idx",
+          "columns": [
+            {
+              "expression": "recordedAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "app_hosting_reclaims_attempts_nonneg": {
+          "name": "app_hosting_reclaims_attempts_nonneg",
+          "value": "\"app_hosting_reclaims\".\"attempts\" >= 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.published_app_machine_events": {
+      "name": "published_app_machine_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "publishedAppId": {
+          "name": "publishedAppId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "flyAppName": {
+          "name": "flyAppName",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "machineId": {
+          "name": "machineId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "origin": {
+          "name": "origin",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "action": {
+          "name": "action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "flyEventId": {
+          "name": "flyEventId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "flyEventType": {
+          "name": "flyEventType",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "flyEventStatus": {
+          "name": "flyEventStatus",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "occurredAt": {
+          "name": "occurredAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "recordedAt": {
+          "name": "recordedAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "published_app_machine_events_app_idx": {
+          "name": "published_app_machine_events_app_idx",
+          "columns": [
+            {
+              "expression": "publishedAppId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "occurredAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "published_app_machine_events_fly_event_unique": {
+          "name": "published_app_machine_events_fly_event_unique",
+          "columns": [
+            {
+              "expression": "machineId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "flyEventId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"flyEventId\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "published_app_machine_events_publishedAppId_published_apps_id_fk": {
+          "name": "published_app_machine_events_publishedAppId_published_apps_id_fk",
+          "tableFrom": "published_app_machine_events",
+          "tableTo": "published_apps",
+          "columnsFrom": [
+            "publishedAppId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "published_app_machine_events_origin_allowed": {
+          "name": "published_app_machine_events_origin_allowed",
+          "value": "\"published_app_machine_events\".\"origin\" IN ('orchestrator', 'fly')"
+        },
+        "published_app_machine_events_action_allowed": {
+          "name": "published_app_machine_events_action_allowed",
+          "value": "\"published_app_machine_events\".\"action\" IN ('start', 'stop')"
+        },
+        "published_app_machine_events_fly_event_id_coherent": {
+          "name": "published_app_machine_events_fly_event_id_coherent",
+          "value": "(\"published_app_machine_events\".\"origin\" = 'fly') = (\"published_app_machine_events\".\"flyEventId\" IS NOT NULL)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.published_apps": {
+      "name": "published_apps",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "envId": {
+          "name": "envId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "driveId": {
+          "name": "driveId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ownerId": {
+          "name": "ownerId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "flyAppName": {
+          "name": "flyAppName",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "networkName": {
+          "name": "networkName",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subdomain": {
+          "name": "subdomain",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "published_app_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'provisioning'"
+        },
+        "guestPreset": {
+          "name": "guestPreset",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'shared-cpu-1x-512'"
+        },
+        "imageDigest": {
+          "name": "imageDigest",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "imageSizeBytes": {
+          "name": "imageSizeBytes",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "imageSizeMeasuredAt": {
+          "name": "imageSizeMeasuredAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tier": {
+          "name": "tier",
+          "type": "published_app_tier",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'metered'"
+        },
+        "machineId": {
+          "name": "machineId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lastWakeAt": {
+          "name": "lastWakeAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lastStopAt": {
+          "name": "lastStopAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lastHitAt": {
+          "name": "lastHitAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "awakeSecondsDay": {
+          "name": "awakeSecondsDay",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "awakeSecondsToday": {
+          "name": "awakeSecondsToday",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "awakeBilledThrough": {
+          "name": "awakeBilledThrough",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "awakeHoldId": {
+          "name": "awakeHoldId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "storageLastBilledAt": {
+          "name": "storageLastBilledAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "lastError": {
+          "name": "lastError",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "claimedAt": {
+          "name": "claimedAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "claimedBy": {
+          "name": "claimedBy",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "published_apps_drive_idx": {
+          "name": "published_apps_drive_idx",
+          "columns": [
+            {
+              "expression": "driveId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "published_apps_owner_idx": {
+          "name": "published_apps_owner_idx",
+          "columns": [
+            {
+              "expression": "ownerId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "published_apps_status_idx": {
+          "name": "published_apps_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "updatedAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "published_apps_idle_idx": {
+          "name": "published_apps_idle_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "lastHitAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "published_apps_envId_drive_envs_id_fk": {
+          "name": "published_apps_envId_drive_envs_id_fk",
+          "tableFrom": "published_apps",
+          "tableTo": "drive_envs",
+          "columnsFrom": [
+            "envId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "published_apps_driveId_drives_id_fk": {
+          "name": "published_apps_driveId_drives_id_fk",
+          "tableFrom": "published_apps",
+          "tableTo": "drives",
+          "columnsFrom": [
+            "driveId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "published_apps_ownerId_users_id_fk": {
+          "name": "published_apps_ownerId_users_id_fk",
+          "tableFrom": "published_apps",
+          "tableTo": "users",
+          "columnsFrom": [
+            "ownerId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "published_apps_envId_unique": {
+          "name": "published_apps_envId_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "envId"
+          ]
+        },
+        "published_apps_flyAppName_unique": {
+          "name": "published_apps_flyAppName_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "flyAppName"
+          ]
+        },
+        "published_apps_subdomain_unique": {
+          "name": "published_apps_subdomain_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "subdomain"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "published_apps_serving_requires_image": {
+          "name": "published_apps_serving_requires_image",
+          "value": "\"published_apps\".\"status\" NOT IN ('running', 'deploying') OR \"published_apps\".\"imageDigest\" IS NOT NULL"
+        },
+        "published_apps_running_requires_machine": {
+          "name": "published_apps_running_requires_machine",
+          "value": "\"published_apps\".\"status\" <> 'running' OR \"published_apps\".\"machineId\" IS NOT NULL"
+        },
+        "published_apps_parked_is_metered_only": {
+          "name": "published_apps_parked_is_metered_only",
+          "value": "\"published_apps\".\"status\" <> 'parked' OR \"published_apps\".\"tier\" = 'metered'"
+        },
+        "published_apps_guest_preset_allowed": {
+          "name": "published_apps_guest_preset_allowed",
+          "value": "\"published_apps\".\"guestPreset\" IN ('shared-cpu-1x-512', 'shared-cpu-1x-1024', 'shared-cpu-2x-2048', 'shared-cpu-4x-4096')"
+        },
+        "published_apps_metered_guest_preset": {
+          "name": "published_apps_metered_guest_preset",
+          "value": "\"published_apps\".\"tier\" <> 'metered' OR \"published_apps\".\"guestPreset\" = 'shared-cpu-1x-512'"
+        },
+        "published_apps_image_size_nonneg": {
+          "name": "published_apps_image_size_nonneg",
+          "value": "\"published_apps\".\"imageSizeBytes\" IS NULL OR \"published_apps\".\"imageSizeBytes\" >= 0"
+        },
+        "published_apps_subdomain_nonempty": {
+          "name": "published_apps_subdomain_nonempty",
+          "value": "length(\"published_apps\".\"subdomain\") > 0"
+        },
+        "published_apps_claim_coherent": {
+          "name": "published_apps_claim_coherent",
+          "value": "(\"published_apps\".\"claimedAt\" IS NULL) = (\"published_apps\".\"claimedBy\" IS NULL)"
+        },
+        "published_apps_image_size_measured_coherent": {
+          "name": "published_apps_image_size_measured_coherent",
+          "value": "(\"published_apps\".\"imageSizeBytes\" IS NULL) = (\"published_apps\".\"imageSizeMeasuredAt\" IS NULL)"
+        },
+        "published_apps_awake_seconds_today_nonneg": {
+          "name": "published_apps_awake_seconds_today_nonneg",
+          "value": "\"published_apps\".\"awakeSecondsToday\" >= 0"
+        },
+        "published_apps_awake_counter_needs_day": {
+          "name": "published_apps_awake_counter_needs_day",
+          "value": "\"published_apps\".\"awakeSecondsDay\" IS NOT NULL OR \"published_apps\".\"awakeSecondsToday\" = 0"
+        },
+        "published_apps_awake_window_needs_wake": {
+          "name": "published_apps_awake_window_needs_wake",
+          "value": "\"published_apps\".\"awakeBilledThrough\" IS NULL OR \"published_apps\".\"lastWakeAt\" IS NOT NULL"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.published_app_subscriptions": {
+      "name": "published_app_subscriptions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "publishedAppId": {
+          "name": "publishedAppId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stripeSubscriptionId": {
+          "name": "stripeSubscriptionId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stripePriceId": {
+          "name": "stripePriceId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "guestPreset": {
+          "name": "guestPreset",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stripeEventCreated": {
+          "name": "stripeEventCreated",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "currentPeriodStart": {
+          "name": "currentPeriodStart",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "currentPeriodEnd": {
+          "name": "currentPeriodEnd",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cancelAtPeriodEnd": {
+          "name": "cancelAtPeriodEnd",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "published_app_subscriptions_user_idx": {
+          "name": "published_app_subscriptions_user_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "published_app_subscriptions_stripe_subscription_idx": {
+          "name": "published_app_subscriptions_stripe_subscription_idx",
+          "columns": [
+            {
+              "expression": "stripeSubscriptionId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "published_app_subscriptions_publishedAppId_published_apps_id_fk": {
+          "name": "published_app_subscriptions_publishedAppId_published_apps_id_fk",
+          "tableFrom": "published_app_subscriptions",
+          "tableTo": "published_apps",
+          "columnsFrom": [
+            "publishedAppId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "published_app_subscriptions_userId_users_id_fk": {
+          "name": "published_app_subscriptions_userId_users_id_fk",
+          "tableFrom": "published_app_subscriptions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "published_app_subscriptions_publishedAppId_unique": {
+          "name": "published_app_subscriptions_publishedAppId_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "publishedAppId"
+          ]
+        },
+        "published_app_subscriptions_stripeSubscriptionId_unique": {
+          "name": "published_app_subscriptions_stripeSubscriptionId_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "stripeSubscriptionId"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "published_app_subscriptions_status_nonempty": {
+          "name": "published_app_subscriptions_status_nonempty",
+          "value": "length(\"published_app_subscriptions\".\"status\") > 0"
+        },
+        "published_app_subscriptions_period_ordered": {
+          "name": "published_app_subscriptions_period_ordered",
+          "value": "\"published_app_subscriptions\".\"currentPeriodEnd\" >= \"published_app_subscriptions\".\"currentPeriodStart\""
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.app_hosting_stripe_reclaims": {
+      "name": "app_hosting_stripe_reclaims",
+      "schema": "",
+      "columns": {
+        "stripeSubscriptionId": {
+          "name": "stripeSubscriptionId",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "publishedAppId": {
+          "name": "publishedAppId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "recordedAt": {
+          "name": "recordedAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "attempts": {
+          "name": "attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "lastAttemptAt": {
+          "name": "lastAttemptAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lastError": {
+          "name": "lastError",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "app_hosting_stripe_reclaims_recorded_at_idx": {
+          "name": "app_hosting_stripe_reclaims_recorded_at_idx",
+          "columns": [
+            {
+              "expression": "recordedAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "app_hosting_stripe_reclaims_attempts_nonneg": {
+          "name": "app_hosting_stripe_reclaims_attempts_nonneg",
+          "value": "\"app_hosting_stripe_reclaims\".\"attempts\" >= 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.broadcast_recipients": {
+      "name": "broadcast_recipients",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "broadcast_id": {
+          "name": "broadcast_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "recipient_email": {
+          "name": "recipient_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "broadcast_recipient_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "skip_reason": {
+          "name": "skip_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "attempts": {
+          "name": "attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "sent_at": {
+          "name": "sent_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "claimed_at": {
+          "name": "claimed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "claimed_by": {
+          "name": "claimed_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "broadcast_recipients_broadcast_user_unique": {
+          "name": "broadcast_recipients_broadcast_user_unique",
+          "columns": [
+            {
+              "expression": "broadcast_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "broadcast_recipients_broadcast_status_idx": {
+          "name": "broadcast_recipients_broadcast_status_idx",
+          "columns": [
+            {
+              "expression": "broadcast_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "broadcast_recipients_broadcast_id_email_broadcasts_id_fk": {
+          "name": "broadcast_recipients_broadcast_id_email_broadcasts_id_fk",
+          "tableFrom": "broadcast_recipients",
+          "tableTo": "email_broadcasts",
+          "columnsFrom": [
+            "broadcast_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "broadcast_recipients_user_id_users_id_fk": {
+          "name": "broadcast_recipients_user_id_users_id_fk",
+          "tableFrom": "broadcast_recipients",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.broadcast_templates": {
+      "name": "broadcast_templates",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subject": {
+          "name": "subject",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "body_markdown": {
+          "name": "body_markdown",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "broadcast_templates_active_idx": {
+          "name": "broadcast_templates_active_idx",
+          "columns": [
+            {
+              "expression": "is_active",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "broadcast_templates_created_by_user_id_users_id_fk": {
+          "name": "broadcast_templates_created_by_user_id_users_id_fk",
+          "tableFrom": "broadcast_templates",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.email_broadcasts": {
+      "name": "email_broadcasts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "subject": {
+          "name": "subject",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "engine": {
+          "name": "engine",
+          "type": "email_broadcast_engine",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'transactional'"
+        },
+        "content_mode": {
+          "name": "content_mode",
+          "type": "email_broadcast_content_mode",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'compose'"
+        },
+        "template_id": {
+          "name": "template_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "body_markdown": {
+          "name": "body_markdown",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notification_type": {
+          "name": "notification_type",
+          "type": "NotificationType",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'PRODUCT_UPDATE'"
+        },
+        "audience_definition": {
+          "name": "audience_definition",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "status": {
+          "name": "status",
+          "type": "email_broadcast_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'draft'"
+        },
+        "dry_run": {
+          "name": "dry_run",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "send_limit": {
+          "name": "send_limit",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "delay_ms": {
+          "name": "delay_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 120
+        },
+        "total_targeted": {
+          "name": "total_targeted",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "sent_count": {
+          "name": "sent_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "skipped_count": {
+          "name": "skipped_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "failed_count": {
+          "name": "failed_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "step_results": {
+          "name": "step_results",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "job_id": {
+          "name": "job_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "attempts": {
+          "name": "attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "last_error": {
+          "name": "last_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "blocked_reason": {
+          "name": "blocked_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "email_broadcasts_status_idx": {
+          "name": "email_broadcasts_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "email_broadcasts_created_at_idx": {
+          "name": "email_broadcasts_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "email_broadcasts_created_by_idx": {
+          "name": "email_broadcasts_created_by_idx",
+          "columns": [
+            {
+              "expression": "created_by_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "email_broadcasts_template_id_broadcast_templates_id_fk": {
+          "name": "email_broadcasts_template_id_broadcast_templates_id_fk",
+          "tableFrom": "email_broadcasts",
+          "tableTo": "broadcast_templates",
+          "columnsFrom": [
+            "template_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "email_broadcasts_created_by_user_id_users_id_fk": {
+          "name": "email_broadcasts_created_by_user_id_users_id_fk",
+          "tableFrom": "email_broadcasts",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.page_webhooks": {
+      "name": "page_webhooks",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "pageId": {
+          "name": "pageId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "webhookToken": {
+          "name": "webhookToken",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "webhookSecretEncrypted": {
+          "name": "webhookSecretEncrypted",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "isEnabled": {
+          "name": "isEnabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "createdBy": {
+          "name": "createdBy",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "lastFiredAt": {
+          "name": "lastFiredAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lastFireError": {
+          "name": "lastFireError",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "page_webhooks_page_id_idx": {
+          "name": "page_webhooks_page_id_idx",
+          "columns": [
+            {
+              "expression": "pageId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "page_webhooks_token_idx": {
+          "name": "page_webhooks_token_idx",
+          "columns": [
+            {
+              "expression": "webhookToken",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "page_webhooks_pageId_pages_id_fk": {
+          "name": "page_webhooks_pageId_pages_id_fk",
+          "tableFrom": "page_webhooks",
+          "tableTo": "pages",
+          "columnsFrom": [
+            "pageId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "page_webhooks_createdBy_users_id_fk": {
+          "name": "page_webhooks_createdBy_users_id_fk",
+          "tableFrom": "page_webhooks",
+          "tableTo": "users",
+          "columnsFrom": [
+            "createdBy"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "page_webhooks_webhookToken_unique": {
+          "name": "page_webhooks_webhookToken_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "webhookToken"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agent_workspace_shells": {
+      "name": "agent_workspace_shells",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "workspaceId": {
+          "name": "workspaceId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ownerId": {
+          "name": "ownerId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agentType": {
+          "name": "agentType",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "command": {
+          "name": "command",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "spriteExecId": {
+          "name": "spriteExecId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "coldTail": {
+          "name": "coldTail",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "coldTailAt": {
+          "name": "coldTailAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "coldTailHasOutput": {
+          "name": "coldTailHasOutput",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "agent_workspace_shells_workspace_id_idx": {
+          "name": "agent_workspace_shells_workspace_id_idx",
+          "columns": [
+            {
+              "expression": "workspaceId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "agent_workspace_shells_workspace_name_idx": {
+          "name": "agent_workspace_shells_workspace_name_idx",
+          "columns": [
+            {
+              "expression": "workspaceId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "agent_workspace_shells_workspaceId_agent_workspaces_id_fk": {
+          "name": "agent_workspace_shells_workspaceId_agent_workspaces_id_fk",
+          "tableFrom": "agent_workspace_shells",
+          "tableTo": "agent_workspaces",
+          "columnsFrom": [
+            "workspaceId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "agent_workspace_shells_ownerId_users_id_fk": {
+          "name": "agent_workspace_shells_ownerId_users_id_fk",
+          "tableFrom": "agent_workspace_shells",
+          "tableTo": "users",
+          "columnsFrom": [
+            "ownerId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agent_workspaces": {
+      "name": "agent_workspaces",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "driveId": {
+          "name": "driveId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ownerId": {
+          "name": "ownerId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "envId": {
+          "name": "envId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "spriteKey": {
+          "name": "spriteKey",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sandboxId": {
+          "name": "sandboxId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "spriteInstanceId": {
+          "name": "spriteInstanceId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "egressPolicyToken": {
+          "name": "egressPolicyToken",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "teardownRequestedAt": {
+          "name": "teardownRequestedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "spriteTornDownAt": {
+          "name": "spriteTornDownAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "storageLastBilledAt": {
+          "name": "storageLastBilledAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "storageMeasuredBytes": {
+          "name": "storageMeasuredBytes",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "storageMeasuredAt": {
+          "name": "storageMeasuredAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lastActiveAt": {
+          "name": "lastActiveAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "endedAt": {
+          "name": "endedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "agent_workspaces_drive_id_idx": {
+          "name": "agent_workspaces_drive_id_idx",
+          "columns": [
+            {
+              "expression": "driveId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "agent_workspaces_owner_id_idx": {
+          "name": "agent_workspaces_owner_id_idx",
+          "columns": [
+            {
+              "expression": "ownerId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "agent_workspaces_live_sprite_idx": {
+          "name": "agent_workspaces_live_sprite_idx",
+          "columns": [
+            {
+              "expression": "sandboxId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "spriteTornDownAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"agent_workspaces\".\"sandboxId\" IS NOT NULL AND \"agent_workspaces\".\"spriteTornDownAt\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "agent_workspaces_env_id_idx": {
+          "name": "agent_workspaces_env_id_idx",
+          "columns": [
+            {
+              "expression": "envId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "agent_workspaces_driveId_drives_id_fk": {
+          "name": "agent_workspaces_driveId_drives_id_fk",
+          "tableFrom": "agent_workspaces",
+          "tableTo": "drives",
+          "columnsFrom": [
+            "driveId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "agent_workspaces_ownerId_users_id_fk": {
+          "name": "agent_workspaces_ownerId_users_id_fk",
+          "tableFrom": "agent_workspaces",
+          "tableTo": "users",
+          "columnsFrom": [
+            "ownerId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "agent_workspaces_envId_drive_envs_id_fk": {
+          "name": "agent_workspaces_envId_drive_envs_id_fk",
+          "tableFrom": "agent_workspaces",
+          "tableTo": "drive_envs",
+          "columnsFrom": [
+            "envId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "agent_workspaces_env_no_sprite_check": {
+          "name": "agent_workspaces_env_no_sprite_check",
+          "value": "\"agent_workspaces\".\"envId\" IS NULL OR (\"agent_workspaces\".\"sandboxId\" IS NULL AND \"agent_workspaces\".\"spriteKey\" IS NULL AND \"agent_workspaces\".\"spriteInstanceId\" IS NULL)"
+        },
+        "agent_workspaces_env_needs_drive_check": {
+          "name": "agent_workspaces_env_needs_drive_check",
+          "value": "\"agent_workspaces\".\"envId\" IS NULL OR \"agent_workspaces\".\"driveId\" IS NOT NULL"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.agent_workspace_node_revs": {
+      "name": "agent_workspace_node_revs",
+      "schema": "",
+      "columns": {
+        "rootId": {
+          "name": "rootId",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "rev": {
+          "name": "rev",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "agent_workspace_node_revs_rootId_agent_workspaces_id_fk": {
+          "name": "agent_workspace_node_revs_rootId_agent_workspaces_id_fk",
+          "tableFrom": "agent_workspace_node_revs",
+          "tableTo": "agent_workspaces",
+          "columnsFrom": [
+            "rootId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agent_workspace_nodes": {
+      "name": "agent_workspace_nodes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rootId": {
+          "name": "rootId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "parentId": {
+          "name": "parentId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "nodeType": {
+          "name": "nodeType",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "axis": {
+          "name": "axis",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "fraction": {
+          "name": "fraction",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "targetKind": {
+          "name": "targetKind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "targetId": {
+          "name": "targetId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "agent_workspace_nodes_one_root_idx": {
+          "name": "agent_workspace_nodes_one_root_idx",
+          "columns": [
+            {
+              "expression": "rootId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"agent_workspace_nodes\".\"nodeType\" = 'root'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "agent_workspace_nodes_chat_target_idx": {
+          "name": "agent_workspace_nodes_chat_target_idx",
+          "columns": [
+            {
+              "expression": "targetId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"agent_workspace_nodes\".\"targetKind\" = 'chat'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "agent_workspace_nodes_parent_idx": {
+          "name": "agent_workspace_nodes_parent_idx",
+          "columns": [
+            {
+              "expression": "rootId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "parentId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "agent_workspace_nodes_rootId_agent_workspaces_id_fk": {
+          "name": "agent_workspace_nodes_rootId_agent_workspaces_id_fk",
+          "tableFrom": "agent_workspace_nodes",
+          "tableTo": "agent_workspaces",
+          "columnsFrom": [
+            "rootId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "agent_workspace_nodes_rootId_parentId_agent_workspace_nodes_rootId_id_fk": {
+          "name": "agent_workspace_nodes_rootId_parentId_agent_workspace_nodes_rootId_id_fk",
+          "tableFrom": "agent_workspace_nodes",
+          "tableTo": "agent_workspace_nodes",
+          "columnsFrom": [
+            "rootId",
+            "parentId"
+          ],
+          "columnsTo": [
+            "rootId",
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "agent_workspace_nodes_rootId_id_pk": {
+          "name": "agent_workspace_nodes_rootId_id_pk",
+          "columns": [
+            "rootId",
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "agent_workspace_nodes_root_no_parent_chk": {
+          "name": "agent_workspace_nodes_root_no_parent_chk",
+          "value": "(\"agent_workspace_nodes\".\"nodeType\" = 'root') = (\"agent_workspace_nodes\".\"parentId\" IS NULL)"
+        },
+        "agent_workspace_nodes_node_type_chk": {
+          "name": "agent_workspace_nodes_node_type_chk",
+          "value": "\"agent_workspace_nodes\".\"nodeType\" IN ('root', 'split', 'pane')"
+        },
+        "agent_workspace_nodes_target_kind_chk": {
+          "name": "agent_workspace_nodes_target_kind_chk",
+          "value": "\"agent_workspace_nodes\".\"targetKind\" IS NULL OR \"agent_workspace_nodes\".\"targetKind\" IN ('chat', 'terminal', 'page')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.drive_envs": {
+      "name": "drive_envs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "driveId": {
+          "name": "driveId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "substrate": {
+          "name": "substrate",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'sprite'"
+        },
+        "createdBy": {
+          "name": "createdBy",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "spriteKey": {
+          "name": "spriteKey",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sandboxId": {
+          "name": "sandboxId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "spriteInstanceId": {
+          "name": "spriteInstanceId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "egressPolicyToken": {
+          "name": "egressPolicyToken",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "teardownRequestedAt": {
+          "name": "teardownRequestedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "spriteTornDownAt": {
+          "name": "spriteTornDownAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "storageLastBilledAt": {
+          "name": "storageLastBilledAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "storageMeasuredBytes": {
+          "name": "storageMeasuredBytes",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "storageMeasuredAt": {
+          "name": "storageMeasuredAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lastActiveAt": {
+          "name": "lastActiveAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "drive_envs_drive_id_idx": {
+          "name": "drive_envs_drive_id_idx",
+          "columns": [
+            {
+              "expression": "driveId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "drive_envs_drive_name_idx": {
+          "name": "drive_envs_drive_name_idx",
+          "columns": [
+            {
+              "expression": "driveId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "drive_envs_live_sprite_idx": {
+          "name": "drive_envs_live_sprite_idx",
+          "columns": [
+            {
+              "expression": "sandboxId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "spriteTornDownAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"drive_envs\".\"sandboxId\" IS NOT NULL AND \"drive_envs\".\"spriteTornDownAt\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "drive_envs_driveId_drives_id_fk": {
+          "name": "drive_envs_driveId_drives_id_fk",
+          "tableFrom": "drive_envs",
+          "tableTo": "drives",
+          "columnsFrom": [
+            "driveId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "drive_envs_createdBy_users_id_fk": {
+          "name": "drive_envs_createdBy_users_id_fk",
+          "tableFrom": "drive_envs",
+          "tableTo": "users",
+          "columnsFrom": [
+            "createdBy"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "drive_envs_id_substrate_unique": {
+          "name": "drive_envs_id_substrate_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "id",
+            "substrate"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "drive_envs_substrate_check": {
+          "name": "drive_envs_substrate_check",
+          "value": "\"drive_envs\".\"substrate\" IN ('sprite', 'local')"
+        },
+        "drive_envs_local_no_sprite_check": {
+          "name": "drive_envs_local_no_sprite_check",
+          "value": "\"drive_envs\".\"substrate\" = 'sprite' OR (\"drive_envs\".\"spriteKey\" IS NULL AND \"drive_envs\".\"sandboxId\" IS NULL AND \"drive_envs\".\"spriteInstanceId\" IS NULL)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.drive_env_local": {
+      "name": "drive_env_local",
+      "schema": "",
+      "columns": {
+        "envId": {
+          "name": "envId",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "substrate": {
+          "name": "substrate",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'local'"
+        },
+        "ownerId": {
+          "name": "ownerId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "enrollmentId": {
+          "name": "enrollmentId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "machinePublicKey": {
+          "name": "machinePublicKey",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "machineKeyFingerprint": {
+          "name": "machineKeyFingerprint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "serverKeyId": {
+          "name": "serverKeyId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "enrollmentCodeHash": {
+          "name": "enrollmentCodeHash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "enrollmentCodeExpiresAt": {
+          "name": "enrollmentCodeExpiresAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "enrollmentCodeUsedAt": {
+          "name": "enrollmentCodeUsedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "challengeNonce": {
+          "name": "challengeNonce",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "challengeIssuedAt": {
+          "name": "challengeIssuedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "challengeExpiresAt": {
+          "name": "challengeExpiresAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "challengeUsedAt": {
+          "name": "challengeUsedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "capabilities": {
+          "name": "capabilities",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "serverPolicy": {
+          "name": "serverPolicy",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{\"ops\":[],\"checkpoint\":false}'::jsonb"
+        },
+        "bindPolicy": {
+          "name": "bindPolicy",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'owner'"
+        },
+        "lastSeenAt": {
+          "name": "lastSeenAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "enrolledAt": {
+          "name": "enrolledAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revokedAt": {
+          "name": "revokedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "drive_env_local_owner_id_idx": {
+          "name": "drive_env_local_owner_id_idx",
+          "columns": [
+            {
+              "expression": "ownerId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "drive_env_local_ownerId_users_id_fk": {
+          "name": "drive_env_local_ownerId_users_id_fk",
+          "tableFrom": "drive_env_local",
+          "tableTo": "users",
+          "columnsFrom": [
+            "ownerId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "drive_env_local_envId_substrate_drive_envs_id_substrate_fk": {
+          "name": "drive_env_local_envId_substrate_drive_envs_id_substrate_fk",
+          "tableFrom": "drive_env_local",
+          "tableTo": "drive_envs",
+          "columnsFrom": [
+            "envId",
+            "substrate"
+          ],
+          "columnsTo": [
+            "id",
+            "substrate"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "drive_env_local_enrollment_id_unique": {
+          "name": "drive_env_local_enrollment_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "enrollmentId"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "drive_env_local_substrate_check": {
+          "name": "drive_env_local_substrate_check",
+          "value": "\"drive_env_local\".\"substrate\" = 'local'"
+        },
+        "drive_env_local_enrolled_has_key_check": {
+          "name": "drive_env_local_enrolled_has_key_check",
+          "value": "\"drive_env_local\".\"enrolledAt\" IS NULL OR (\"drive_env_local\".\"machinePublicKey\" IS NOT NULL AND \"drive_env_local\".\"machineKeyFingerprint\" IS NOT NULL AND \"drive_env_local\".\"serverKeyId\" IS NOT NULL)"
+        },
+        "drive_env_local_bind_policy_check": {
+          "name": "drive_env_local_bind_policy_check",
+          "value": "\"drive_env_local\".\"bindPolicy\" IN ('owner', 'admins', 'members')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.dev_preview_services": {
+      "name": "dev_preview_services",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "workspaceId": {
+          "name": "workspaceId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "envId": {
+          "name": "envId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "spriteInstanceId": {
+          "name": "spriteInstanceId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sandboxId": {
+          "name": "sandboxId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "targetPort": {
+          "name": "targetPort",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "relayServiceName": {
+          "name": "relayServiceName",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "detectedAt": {
+          "name": "detectedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stoppedByUserAt": {
+          "name": "stoppedByUserAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "approvedPort": {
+          "name": "approvedPort",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "approvedAt": {
+          "name": "approvedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "approvedByUserId": {
+          "name": "approvedByUserId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "dev_preview_services_sprite_instance_idx": {
+          "name": "dev_preview_services_sprite_instance_idx",
+          "columns": [
+            {
+              "expression": "spriteInstanceId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "dev_preview_services_workspace_id_idx": {
+          "name": "dev_preview_services_workspace_id_idx",
+          "columns": [
+            {
+              "expression": "workspaceId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"dev_preview_services\".\"workspaceId\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "dev_preview_services_env_id_idx": {
+          "name": "dev_preview_services_env_id_idx",
+          "columns": [
+            {
+              "expression": "envId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"dev_preview_services\".\"envId\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "dev_preview_services_workspaceId_agent_workspaces_id_fk": {
+          "name": "dev_preview_services_workspaceId_agent_workspaces_id_fk",
+          "tableFrom": "dev_preview_services",
+          "tableTo": "agent_workspaces",
+          "columnsFrom": [
+            "workspaceId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "dev_preview_services_envId_drive_envs_id_fk": {
+          "name": "dev_preview_services_envId_drive_envs_id_fk",
+          "tableFrom": "dev_preview_services",
+          "tableTo": "drive_envs",
+          "columnsFrom": [
+            "envId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "dev_preview_services_approvedByUserId_users_id_fk": {
+          "name": "dev_preview_services_approvedByUserId_users_id_fk",
+          "tableFrom": "dev_preview_services",
+          "tableTo": "users",
+          "columnsFrom": [
+            "approvedByUserId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "dev_preview_services_one_holder_check": {
+          "name": "dev_preview_services_one_holder_check",
+          "value": "(\"dev_preview_services\".\"workspaceId\" IS NULL) <> (\"dev_preview_services\".\"envId\" IS NULL)"
+        },
+        "dev_preview_services_target_port_range_check": {
+          "name": "dev_preview_services_target_port_range_check",
+          "value": "\"dev_preview_services\".\"targetPort\" BETWEEN 1 AND 65535"
+        },
+        "dev_preview_services_relay_never_8080_check": {
+          "name": "dev_preview_services_relay_never_8080_check",
+          "value": "\"dev_preview_services\".\"relayServiceName\" IS NULL OR \"dev_preview_services\".\"targetPort\" <> 8080"
+        },
+        "dev_preview_services_approved_port_range_check": {
+          "name": "dev_preview_services_approved_port_range_check",
+          "value": "\"dev_preview_services\".\"approvedPort\" IS NULL OR \"dev_preview_services\".\"approvedPort\" BETWEEN 1 AND 65535"
+        },
+        "dev_preview_services_approved_paired_check": {
+          "name": "dev_preview_services_approved_paired_check",
+          "value": "(\"dev_preview_services\".\"approvedPort\" IS NULL) = (\"dev_preview_services\".\"approvedAt\" IS NULL)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.dev_preview_grants": {
+      "name": "dev_preview_grants",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "holderKind": {
+          "name": "holderKind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "holderId": {
+          "name": "holderId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sessionId": {
+          "name": "sessionId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expiresAt": {
+          "name": "expiresAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cookieExpiresAt": {
+          "name": "cookieExpiresAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "consumedAt": {
+          "name": "consumedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "dev_preview_grants_expires_at_idx": {
+          "name": "dev_preview_grants_expires_at_idx",
+          "columns": [
+            {
+              "expression": "expiresAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "dev_preview_grants_userId_users_id_fk": {
+          "name": "dev_preview_grants_userId_users_id_fk",
+          "tableFrom": "dev_preview_grants",
+          "tableTo": "users",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "dev_preview_grants_sessionId_sessions_id_fk": {
+          "name": "dev_preview_grants_sessionId_sessions_id_fk",
+          "tableFrom": "dev_preview_grants",
+          "tableTo": "sessions",
+          "columnsFrom": [
+            "sessionId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "dev_preview_grants_holder_kind_check": {
+          "name": "dev_preview_grants_holder_kind_check",
+          "value": "\"dev_preview_grants\".\"holderKind\" IN ('workspace', 'env')"
+        }
+      },
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.AuthProvider": {
+      "name": "AuthProvider",
+      "schema": "public",
+      "values": [
+        "email",
+        "google",
+        "apple"
+      ]
+    },
+    "public.PlatformType": {
+      "name": "PlatformType",
+      "schema": "public",
+      "values": [
+        "web",
+        "desktop",
+        "ios",
+        "android"
+      ]
+    },
+    "public.UserRole": {
+      "name": "UserRole",
+      "schema": "public",
+      "values": [
+        "user",
+        "admin"
+      ]
+    },
+    "public.DriveKind": {
+      "name": "DriveKind",
+      "schema": "public",
+      "values": [
+        "STANDARD",
+        "HOME"
+      ]
+    },
+    "public.FavoriteItemType": {
+      "name": "FavoriteItemType",
+      "schema": "public",
+      "values": [
+        "page",
+        "drive"
+      ]
+    },
+    "public.PageType": {
+      "name": "PageType",
+      "schema": "public",
+      "values": [
+        "FOLDER",
+        "DOCUMENT",
+        "CHANNEL",
+        "AI_CHAT",
+        "CANVAS",
+        "FILE",
+        "SHEET",
+        "TASK_LIST",
+        "CODE",
+        "MACHINE"
+      ]
+    },
+    "public.MemberRole": {
+      "name": "MemberRole",
+      "schema": "public",
+      "values": [
+        "OWNER",
+        "ADMIN",
+        "MEMBER"
+      ]
+    },
+    "public.pulse_summary_type": {
+      "name": "pulse_summary_type",
+      "schema": "public",
+      "values": [
+        "scheduled",
+        "on_demand",
+        "welcome"
+      ]
+    },
+    "public.NotificationType": {
+      "name": "NotificationType",
+      "schema": "public",
+      "values": [
+        "PERMISSION_GRANTED",
+        "PERMISSION_REVOKED",
+        "PERMISSION_UPDATED",
+        "PAGE_SHARED",
+        "DRIVE_INVITED",
+        "DRIVE_JOINED",
+        "DRIVE_ROLE_CHANGED",
+        "CONNECTION_REQUEST",
+        "CONNECTION_ACCEPTED",
+        "CONNECTION_REJECTED",
+        "NEW_DIRECT_MESSAGE",
+        "EMAIL_VERIFICATION_REQUIRED",
+        "TOS_PRIVACY_UPDATED",
+        "MENTION",
+        "TASK_ASSIGNED",
+        "PRODUCT_UPDATE"
+      ]
+    },
+    "public.toast_notification_level": {
+      "name": "toast_notification_level",
+      "schema": "public",
+      "values": [
+        "all",
+        "mentions",
+        "off"
+      ]
+    },
+    "public.display_preference_type": {
+      "name": "display_preference_type",
+      "schema": "public",
+      "values": [
+        "SHOW_TOKEN_COUNTS",
+        "SHOW_CODE_TOGGLE",
+        "DEFAULT_MARKDOWN_MODE"
+      ]
+    },
+    "public.activity_change_group_type": {
+      "name": "activity_change_group_type",
+      "schema": "public",
+      "values": [
+        "user",
+        "ai",
+        "automation",
+        "system"
+      ]
+    },
+    "public.activity_resource": {
+      "name": "activity_resource",
+      "schema": "public",
+      "values": [
+        "page",
+        "drive",
+        "permission",
+        "agent",
+        "user",
+        "member",
+        "role",
+        "file",
+        "token",
+        "device",
+        "message",
+        "conversation"
+      ]
+    },
+    "public.content_format": {
+      "name": "content_format",
+      "schema": "public",
+      "values": [
+        "text",
+        "html",
+        "json",
+        "tiptap"
+      ]
+    },
+    "public.http_method": {
+      "name": "http_method",
+      "schema": "public",
+      "values": [
+        "GET",
+        "POST",
+        "PUT",
+        "DELETE",
+        "PATCH",
+        "HEAD",
+        "OPTIONS"
+      ]
+    },
+    "public.log_level": {
+      "name": "log_level",
+      "schema": "public",
+      "values": [
+        "trace",
+        "debug",
+        "info",
+        "warn",
+        "error",
+        "fatal"
+      ]
+    },
+    "public.drive_backup_schedule_frequency": {
+      "name": "drive_backup_schedule_frequency",
+      "schema": "public",
+      "values": [
+        "daily",
+        "weekly",
+        "monthly"
+      ]
+    },
+    "public.drive_backup_source": {
+      "name": "drive_backup_source",
+      "schema": "public",
+      "values": [
+        "manual",
+        "scheduled",
+        "pre_restore",
+        "system"
+      ]
+    },
+    "public.drive_backup_status": {
+      "name": "drive_backup_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "ready",
+        "failed"
+      ]
+    },
+    "public.page_version_source": {
+      "name": "page_version_source",
+      "schema": "public",
+      "values": [
+        "manual",
+        "auto",
+        "pre_ai",
+        "pre_restore",
+        "restore",
+        "system"
+      ]
+    },
+    "public.ConnectionStatus": {
+      "name": "ConnectionStatus",
+      "schema": "public",
+      "values": [
+        "PENDING",
+        "ACCEPTED",
+        "BLOCKED"
+      ]
+    },
+    "public.PushPlatformType": {
+      "name": "PushPlatformType",
+      "schema": "public",
+      "values": [
+        "ios",
+        "android",
+        "web"
+      ]
+    },
+    "public.integration_connection_status": {
+      "name": "integration_connection_status",
+      "schema": "public",
+      "values": [
+        "active",
+        "expired",
+        "error",
+        "pending",
+        "revoked"
+      ]
+    },
+    "public.integration_provider_type": {
+      "name": "integration_provider_type",
+      "schema": "public",
+      "values": [
+        "builtin",
+        "openapi",
+        "custom",
+        "mcp",
+        "webhook"
+      ]
+    },
+    "public.integration_visibility": {
+      "name": "integration_visibility",
+      "schema": "public",
+      "values": [
+        "private",
+        "owned_drives",
+        "all_drives"
+      ]
+    },
+    "public.AttendeeStatus": {
+      "name": "AttendeeStatus",
+      "schema": "public",
+      "values": [
+        "PENDING",
+        "ACCEPTED",
+        "DECLINED",
+        "TENTATIVE"
+      ]
+    },
+    "public.EventVisibility": {
+      "name": "EventVisibility",
+      "schema": "public",
+      "values": [
+        "DRIVE",
+        "ATTENDEES_ONLY",
+        "PRIVATE"
+      ]
+    },
+    "public.GoogleCalendarConnectionStatus": {
+      "name": "GoogleCalendarConnectionStatus",
+      "schema": "public",
+      "values": [
+        "active",
+        "expired",
+        "error",
+        "disconnected"
+      ]
+    },
+    "public.RecurrenceFrequency": {
+      "name": "RecurrenceFrequency",
+      "schema": "public",
+      "values": [
+        "DAILY",
+        "WEEKLY",
+        "MONTHLY",
+        "YEARLY"
+      ]
+    },
+    "public.WorkflowTriggerType": {
+      "name": "WorkflowTriggerType",
+      "schema": "public",
+      "values": [
+        "cron",
+        "event"
+      ]
+    },
+    "public.WorkflowRunSourceTable": {
+      "name": "WorkflowRunSourceTable",
+      "schema": "public",
+      "values": [
+        "taskTriggers",
+        "calendarTriggers",
+        "webhookTriggers",
+        "cron",
+        "manual"
+      ]
+    },
+    "public.WorkflowRunStatus": {
+      "name": "WorkflowRunStatus",
+      "schema": "public",
+      "values": [
+        "running",
+        "success",
+        "error",
+        "cancelled"
+      ]
+    },
+    "public.WorkflowRunStepStatus": {
+      "name": "WorkflowRunStepStatus",
+      "schema": "public",
+      "values": [
+        "running",
+        "success",
+        "error",
+        "skipped"
+      ]
+    },
+    "public.TaskTriggerType": {
+      "name": "TaskTriggerType",
+      "schema": "public",
+      "values": [
+        "due_date",
+        "completion"
+      ]
+    },
+    "public.ZoomConnectionStatus": {
+      "name": "ZoomConnectionStatus",
+      "schema": "public",
+      "values": [
+        "active",
+        "expired",
+        "error",
+        "disconnected"
+      ]
+    },
+    "public.ContentTagAnchorStatus": {
+      "name": "ContentTagAnchorStatus",
+      "schema": "public",
+      "values": [
+        "exact",
+        "shifted",
+        "fuzzy",
+        "orphaned"
+      ]
+    },
+    "public.ContentTagSource": {
+      "name": "ContentTagSource",
+      "schema": "public",
+      "values": [
+        "user",
+        "ai",
+        "system",
+        "rule"
+      ]
+    },
+    "public.ContentTagTargetKind": {
+      "name": "ContentTagTargetKind",
+      "schema": "public",
+      "values": [
+        "page",
+        "text",
+        "sheet_cell",
+        "channel_message",
+        "ai_message"
+      ]
+    },
+    "public.custom_domain_status": {
+      "name": "custom_domain_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "verified",
+        "failed",
+        "provisioning",
+        "active",
+        "dns_failed",
+        "cert_failed"
+      ]
+    },
+    "public.data_subject_request_status": {
+      "name": "data_subject_request_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "queued",
+        "in_progress",
+        "blocked",
+        "completed",
+        "failed",
+        "cancelled"
+      ]
+    },
+    "public.data_subject_request_type": {
+      "name": "data_subject_request_type",
+      "schema": "public",
+      "values": [
+        "erasure",
+        "export",
+        "access",
+        "rectification",
+        "restriction",
+        "portability",
+        "objection"
+      ]
+    },
+    "public.data_subject_requester_type": {
+      "name": "data_subject_requester_type",
+      "schema": "public",
+      "values": [
+        "self",
+        "admin"
+      ]
+    },
+    "public.OAuthClientType": {
+      "name": "OAuthClientType",
+      "schema": "public",
+      "values": [
+        "public",
+        "confidential"
+      ]
+    },
+    "public.published_app_status": {
+      "name": "published_app_status",
+      "schema": "public",
+      "values": [
+        "provisioning",
+        "building",
+        "deploying",
+        "running",
+        "stopped",
+        "parked",
+        "destroying",
+        "failed"
+      ]
+    },
+    "public.published_app_tier": {
+      "name": "published_app_tier",
+      "schema": "public",
+      "values": [
+        "metered",
+        "dedicated"
+      ]
+    },
+    "public.broadcast_recipient_status": {
+      "name": "broadcast_recipient_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "sent",
+        "skipped",
+        "failed"
+      ]
+    },
+    "public.email_broadcast_content_mode": {
+      "name": "email_broadcast_content_mode",
+      "schema": "public",
+      "values": [
+        "compose",
+        "template"
+      ]
+    },
+    "public.email_broadcast_engine": {
+      "name": "email_broadcast_engine",
+      "schema": "public",
+      "values": [
+        "transactional",
+        "resend_broadcast"
+      ]
+    },
+    "public.email_broadcast_status": {
+      "name": "email_broadcast_status",
+      "schema": "public",
+      "values": [
+        "draft",
+        "pending",
+        "queued",
+        "in_progress",
+        "paused",
+        "completed",
+        "failed",
+        "cancelled"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/packages/db/drizzle/meta/_journal.json
+++ b/packages/db/drizzle/meta/_journal.json
@@ -2017,6 +2017,13 @@
       "when": 1788744470338,
       "tag": "0287_nappy_secret_warriors",
       "breakpoints": true
+    },
+    {
+      "idx": 288,
+      "version": "7",
+      "when": 1788745246416,
+      "tag": "0288_misty_lifeguard",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/db/drizzle/meta/_journal.json
+++ b/packages/db/drizzle/meta/_journal.json
@@ -2010,6 +2010,13 @@
       "when": 1788708142844,
       "tag": "0286_lush_nightmare",
       "breakpoints": true
+    },
+    {
+      "idx": 287,
+      "version": "7",
+      "when": 1788744470338,
+      "tag": "0287_nappy_secret_warriors",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/db/src/schema/__tests__/dev-preview-grants.test.ts
+++ b/packages/db/src/schema/__tests__/dev-preview-grants.test.ts
@@ -38,7 +38,14 @@ describe('dev_preview_grants schema', () => {
   it('cascades with the user and names the holder polymorphically', () => {
     const userFk = config.foreignKeys.find((fk) => fk.reference().foreignTable === users);
     expect(userFk?.onDelete).toBe('cascade');
-    expect(config.foreignKeys).toHaveLength(1);
+    // A grant names the SESSION that opened it, not just the person: the
+    // preview cookie it mints carries that session id, and the per-request
+    // gather refuses the cookie the moment the session is revoked. The FK
+    // cascades so a deleted session takes its unredeemed grants with it.
+    const sessionFk = config.foreignKeys.find((fk) => fk.reference().columns.some((c) => c.name === 'sessionId'));
+    expect(sessionFk?.onDelete).toBe('cascade');
+    expect(columns.sessionId.notNull).toBe(true);
+    expect(config.foreignKeys).toHaveLength(2);
     expect(columns.holderKind.notNull).toBe(true);
     expect(columns.holderId.notNull).toBe(true);
     expect(config.checks.map((c) => c.name)).toEqual(['dev_preview_grants_holder_kind_check']);

--- a/packages/db/src/schema/__tests__/dev-preview-services.test.ts
+++ b/packages/db/src/schema/__tests__/dev-preview-services.test.ts
@@ -19,10 +19,17 @@
  *    because a teardown path remembers to. If either FK loses `cascade`, or
  *    the one-holder CHECK goes, a row can outlive its sprite's owner or be
  *    owned by nobody.
- *  - **A relay iff the target is not 8080.** The CHECK is the whole "one
- *    slot, relocated to 8080" decision in one line. Relaxing it is the
- *    documented migration seam for real httpPort routing — and must be a
- *    deliberate edit here, with the constant it names.
+ *  - **A relay never points at 8080.** A relay from 8080 to 8080 is a loop.
+ *    The other half of the old biconditional — "a non-8080 target always has
+ *    a relay" — was deliberately dropped when consent arrived: a detected but
+ *    unshared port, and an approved one whose relay is not created yet, are
+ *    both legal and both serve nothing (the sprite URL routes to 8080 alone).
+ *    Relaxing this remaining half is the documented migration seam for real
+ *    httpPort routing, and must be a deliberate edit here.
+ *  - **Consent is per PORT, and paired with its time.** `approvedPort` names
+ *    the port a person agreed to share, so a dev server that moves is a new
+ *    decision rather than an inherited one, and `approvedAt` cannot drift
+ *    away from it.
  *  - **NO public-exposure column.** v1 has no public bit — not a disabled one,
  *    none. Adding one is a migration plus a containment ruling. A column whose
  *    name mentions public/expose/visibility appearing here is that decision
@@ -94,7 +101,8 @@ describe('dev_preview_services', () => {
         { column: 'envId', table: getTableConfig(driveEnvs).name, onDelete: 'cascade' },
       ]),
     );
-    expect(fks).toHaveLength(2);
+    // Plus the approver attribution FK; the holder FKs are the two that cascade.
+    expect(fks).toHaveLength(3);
     expect(columns.workspaceId.notNull).toBe(false);
     expect(columns.envId.notNull).toBe(false);
     // One row per HOLDER, structurally — the upsert's conflict targets. Partial,
@@ -111,17 +119,36 @@ describe('dev_preview_services', () => {
     expect(oneHolder.replace(/\s+/g, ' ')).toContain('workspaceId IS NULL) <> ( envId IS NULL)');
   });
 
-  it('carries a relay iff the target is not the 8080 slot, and the target is a TCP port', () => {
+  it('never points a relay at the 8080 slot itself, and the target is a TCP port', () => {
     expect(DEV_PREVIEW_SPRITE_HTTP_PORT).toBe(8080);
     expect(columns.targetPort.notNull).toBe(true);
     expect(columns.relayServiceName.notNull).toBe(false);
-    expect(checkSql('dev_preview_services_relay_iff_not_8080_check').replace(/\s+/g, ' ')).toContain('= ( relayServiceName IS NULL)');
+    expect(checkSql('dev_preview_services_relay_never_8080_check').replace(/\s+/g, ' ')).toContain('relayServiceName IS NULL OR');
     // The literal 8080 is a `sql.raw` chunk the renderer above cannot see — so
     // the migration text, which is what Postgres enforces, is asserted directly.
     expect(migrationSql).toContain(
-      'CONSTRAINT "dev_preview_services_relay_iff_not_8080_check" CHECK (("dev_preview_services"."targetPort" = 8080) = ("dev_preview_services"."relayServiceName" IS NULL))',
+      'CONSTRAINT "dev_preview_services_relay_never_8080_check" CHECK ("dev_preview_services"."relayServiceName" IS NULL OR "dev_preview_services"."targetPort" <> 8080)',
     );
+    // The biconditional it replaced is GONE from the live schema — a detected
+    // but unshared port is a legal row, and re-adding the other half would
+    // make consent unrecordable.
+    expect(config.checks.map((entry) => entry.name)).not.toContain('dev_preview_services_relay_iff_not_8080_check');
+    expect(migrationSql).toContain('DROP CONSTRAINT "dev_preview_services_relay_iff_not_8080_check"');
     expect(checkSql('dev_preview_services_target_port_range_check')).toContain('BETWEEN 1 AND 65535');
+  });
+
+  it('records CONSENT per port, paired with its time, and never lets attribution grant it', () => {
+    expect(columns.approvedPort.notNull).toBe(false);
+    expect(columns.approvedAt.notNull).toBe(false);
+    // Paired, so a port can never be approved at no time and vice versa.
+    expect(checkSql('dev_preview_services_approved_paired_check').replace(/\s+/g, ' ')).toContain('approvedPort IS NULL) = ( approvedAt IS NULL)');
+    expect(checkSql('dev_preview_services_approved_port_range_check')).toContain('BETWEEN 1 AND 65535');
+    // Attribution only: nullable, and `set null` so deleting the approver
+    // cannot cascade away a live preview — and cannot be read as authority.
+    const approver = config.foreignKeys.map((fk) => ({ column: fk.reference().columns.map((c) => c.name).join(','), onDelete: fk.onDelete }))
+      .find((fk) => fk.column === 'approvedByUserId');
+    expect(approver?.onDelete).toBe('set null');
+    expect(columns.approvedByUserId.notNull).toBe(false);
   });
 
   it('stores stopped-by-user INTENT and detection time, and no status', () => {
@@ -132,11 +159,14 @@ describe('dev_preview_services', () => {
 
   it('has NO public-exposure column at all', () => {
     const names = Object.keys(columns).map((name) => name.toLowerCase());
+    // `approved*` is consent to SHARE a port with people who already have
+    // access, which is not exposure to the public — the banned list is about
+    // a column that would make a sandbox reachable without PageSpace's gate.
     for (const banned of ['public', 'expos', 'visib', 'auth']) {
       expect(names.filter((name) => name.includes(banned)), `no column mentioning "${banned}"`).toEqual([]);
     }
     expect(Object.keys(columns).sort()).toEqual(
-      ['createdAt', 'detectedAt', 'envId', 'id', 'relayServiceName', 'sandboxId', 'spriteInstanceId', 'stoppedByUserAt', 'targetPort', 'updatedAt', 'workspaceId'],
+      ['approvedAt', 'approvedByUserId', 'approvedPort', 'createdAt', 'detectedAt', 'envId', 'id', 'relayServiceName', 'sandboxId', 'spriteInstanceId', 'stoppedByUserAt', 'targetPort', 'updatedAt', 'workspaceId'],
     );
   });
 

--- a/packages/db/src/schema/__tests__/dev-preview-services.test.ts
+++ b/packages/db/src/schema/__tests__/dev-preview-services.test.ts
@@ -129,11 +129,16 @@ describe('dev_preview_services', () => {
     expect(migrationSql).toContain(
       'CONSTRAINT "dev_preview_services_relay_never_8080_check" CHECK ("dev_preview_services"."relayServiceName" IS NULL OR "dev_preview_services"."targetPort" <> 8080)',
     );
+    // Every statement in 0288 is guarded, so a second pass is a no-op rather
+    // than a failed deployment command.
+    expect(migrationSql).toContain('ADD COLUMN IF NOT EXISTS "approvedPort"');
     // The biconditional it replaced is GONE from the live schema — a detected
     // but unshared port is a legal row, and re-adding the other half would
     // make consent unrecordable.
     expect(config.checks.map((entry) => entry.name)).not.toContain('dev_preview_services_relay_iff_not_8080_check');
-    expect(migrationSql).toContain('DROP CONSTRAINT "dev_preview_services_relay_iff_not_8080_check"');
+    // `IF EXISTS`, because the migration is written to survive the re-run its
+    // own hash change forces — see 0288's header.
+    expect(migrationSql).toContain('DROP CONSTRAINT IF EXISTS "dev_preview_services_relay_iff_not_8080_check"');
     expect(checkSql('dev_preview_services_target_port_range_check')).toContain('BETWEEN 1 AND 65535');
   });
 

--- a/packages/db/src/schema/dev-preview-grants.ts
+++ b/packages/db/src/schema/dev-preview-grants.ts
@@ -1,6 +1,7 @@
 import { pgTable, text, timestamp, index, check } from 'drizzle-orm/pg-core';
 import { sql } from 'drizzle-orm';
 import { users } from './auth';
+import { sessions } from './sessions';
 
 /**
  * Dev-preview GRANTS — the single-use handoff between the app origin and a
@@ -40,6 +41,17 @@ export const devPreviewGrants = pgTable(
     userId: text('userId')
       .notNull()
       .references(() => users.id, { onDelete: 'cascade' }),
+    /**
+     * The PageSpace session that minted this grant, carried into the cookie so
+     * the per-request gather can reject a preview whose session has been
+     * revoked. NOT NULL: grants are ephemeral (a 60-second redemption window,
+     * swept opportunistically) and the feature is dark, so there is nothing to
+     * backfill and no reason to admit a grant that cannot be revoked. Cascades
+     * like `userId` — a deleted session takes its outstanding grants with it.
+     */
+    sessionId: text('sessionId')
+      .notNull()
+      .references(() => sessions.id, { onDelete: 'cascade' }),
     /** Until when the grant may be redeemed. */
     expiresAt: timestamp('expiresAt', { mode: 'date' }).notNull(),
     /** Until when the cookie the redemption installs authenticates. */

--- a/packages/db/src/schema/dev-preview-services.ts
+++ b/packages/db/src/schema/dev-preview-services.ts
@@ -1,6 +1,7 @@
 import { pgTable, text, integer, timestamp, uniqueIndex, check } from 'drizzle-orm/pg-core';
 import { relations, sql } from 'drizzle-orm';
 import { createId } from '@paralleldrive/cuid2';
+import { users } from './auth';
 import { agentWorkspaces } from './agent-workspaces';
 import { driveEnvs } from './drive-envs';
 
@@ -187,6 +188,48 @@ export const devPreviewServices = pgTable(
      */
     stoppedByUserAt: timestamp('stoppedByUserAt', { mode: 'date' }),
 
+    // -------------------------------------------------------------------------
+    // Consent to SHARE — see `requiresPreviewApproval` in the decision core.
+    // -------------------------------------------------------------------------
+
+    /**
+     * The port a person explicitly agreed to share, or NULL for none.
+     *
+     * A dev server on a usual dev-server port (vite, next, astro…) is what the
+     * user asked for by running the tool, and is relayed on detection. Any
+     * other port is a guess — an admin UI, a debug listener, someone else's
+     * service — and starting the relay is the act of EXPOSURE: from that
+     * moment the port is reachable by everyone the holder's preview is
+     * reachable by, which for an env is every accepted member of the drive.
+     * So an unlisted port is detected and named, and shares nothing until
+     * this column names it.
+     *
+     * Named by PORT rather than a boolean flag so approval is per-port BY
+     * CONSTRUCTION: a server that moves to another unlisted port is a new
+     * decision, and no schema reading can blur the two. Like
+     * `stoppedByUserAt`, it lives on the row and therefore DIES WITH THE
+     * SPRITE INSTANCE — a replacement VM inherits nothing, which is this
+     * table's existing rule rather than a new one.
+     *
+     * The rule for WHICH ports need this is deliberately not in SQL: the port
+     * list is TypeScript, and a duplicate list in a CHECK would drift. The
+     * security property is structural regardless — the sprite URL routes to
+     * 8080 alone, so a row with no `relayServiceName` serves nothing.
+     */
+    approvedPort: integer('approvedPort'),
+
+    /** When that approval was given. Paired with `approvedPort` (CHECK below). */
+    approvedAt: timestamp('approvedAt', { mode: 'date' }),
+
+    /**
+     * Who gave it — ATTRIBUTION ONLY. Never consulted for authorization: the
+     * right to approve is decided per request by `canManageDevPreview`, so a
+     * user who later loses that right cannot lend it through this column.
+     * Nullable and `set null` on delete: a deleted user must not cascade away
+     * a live approval, because that would silently drop a working preview.
+     */
+    approvedByUserId: text('approvedByUserId').references(() => users.id, { onDelete: 'set null' }),
+
     createdAt: timestamp('createdAt', { mode: 'date' }).defaultNow().notNull(),
     updatedAt: timestamp('updatedAt', { mode: 'date' }).notNull().$onUpdate(() => new Date()),
   },
@@ -219,12 +262,30 @@ export const devPreviewServices = pgTable(
     ),
 
     /**
-     * A relay exists iff the target is not 8080. See `relayServiceName`; this
-     * is the CHECK the migration seam in the table docblock would relax.
+     * A relay NEVER points at 8080 (that would be a loop). The other half of
+     * the old biconditional — "a non-8080 target always has a relay" — is
+     * gone, because two legal states now have a non-8080 target and no relay:
+     * a detected port awaiting approval, and an approved one whose relay this
+     * reconcile has not created yet (the approval write lands before
+     * `services.create`, and forbidding that intermediate state would force a
+     * transaction across the database and the Sprites API). Nothing is
+     * exposed by either: the sprite URL routes to 8080 alone.
      */
-    relayIffNot8080Check: check(
-      'dev_preview_services_relay_iff_not_8080_check',
-      sql`(${table.targetPort} = ${sql.raw(String(DEV_PREVIEW_SPRITE_HTTP_PORT))}) = (${table.relayServiceName} IS NULL)`,
+    relayNever8080Check: check(
+      'dev_preview_services_relay_never_8080_check',
+      sql`${table.relayServiceName} IS NULL OR ${table.targetPort} <> ${sql.raw(String(DEV_PREVIEW_SPRITE_HTTP_PORT))}`,
+    ),
+
+    /** An approved port is a TCP port. */
+    approvedPortRangeCheck: check(
+      'dev_preview_services_approved_port_range_check',
+      sql`${table.approvedPort} IS NULL OR ${table.approvedPort} BETWEEN 1 AND 65535`,
+    ),
+
+    /** An approval has a time. Attribution may be NULL (the approver's account can be deleted). */
+    approvedPairedCheck: check(
+      'dev_preview_services_approved_paired_check',
+      sql`(${table.approvedPort} IS NULL) = (${table.approvedAt} IS NULL)`,
     ),
   }),
 );

--- a/packages/lib/package.json
+++ b/packages/lib/package.json
@@ -983,6 +983,11 @@
       "import": "./dist/services/sandbox/preview/dev-preview-contract.js",
       "require": "./dist/services/sandbox/preview/dev-preview-contract.js"
     },
+    "./services/sandbox/preview/dev-preview-lock": {
+      "types": "./dist/services/sandbox/preview/dev-preview-lock.d.ts",
+      "import": "./dist/services/sandbox/preview/dev-preview-lock.js",
+      "require": "./dist/services/sandbox/preview/dev-preview-lock.js"
+    },
     "./services/sandbox/preview/dev-preview-status": {
       "types": "./dist/services/sandbox/preview/dev-preview-status.d.ts",
       "import": "./dist/services/sandbox/preview/dev-preview-status.js",

--- a/packages/lib/package.json
+++ b/packages/lib/package.json
@@ -988,6 +988,11 @@
       "import": "./dist/services/sandbox/preview/dev-preview-lock.js",
       "require": "./dist/services/sandbox/preview/dev-preview-lock.js"
     },
+    "./services/sandbox/preview/dev-preview-reconcile": {
+      "types": "./dist/services/sandbox/preview/dev-preview-reconcile.d.ts",
+      "import": "./dist/services/sandbox/preview/dev-preview-reconcile.js",
+      "require": "./dist/services/sandbox/preview/dev-preview-reconcile.js"
+    },
     "./services/sandbox/preview/dev-preview-status": {
       "types": "./dist/services/sandbox/preview/dev-preview-status.d.ts",
       "import": "./dist/services/sandbox/preview/dev-preview-status.js",

--- a/packages/lib/src/auth/__tests__/session-usable-by-id.test.ts
+++ b/packages/lib/src/auth/__tests__/session-usable-by-id.test.ts
@@ -29,7 +29,7 @@ vi.mock('../session-repository', () => ({
 }));
 vi.mock('../opaque-tokens', () => ({ generateOpaqueToken: vi.fn(), isValidTokenFormat: vi.fn(() => true) }));
 vi.mock('../token-utils', () => ({ hashToken: vi.fn((t: string) => `hashed_${t}`) }));
-vi.mock('../constants', () => ({ IDLE_TIMEOUT_MS: 0 }));
+vi.mock('../constants', () => ({ IDLE_TIMEOUT_MS: 15 * 60 * 1000 }));
 
 import { SessionService } from '../session-service';
 import { sessionRepository } from '../session-repository';
@@ -91,6 +91,23 @@ describe('isSessionUsableById', () => {
 
   it('is false when the user join came back empty rather than assuming the session is fine', async () => {
     vi.mocked(sessionRepository.findActiveSessionById).mockResolvedValue(row({ user: null }) as never);
+    expect(await service.isSessionUsableById('sess_abcdef123456', 'user-1')).toBe(false);
+  });
+
+  it('is false for a session idle past the policy — the revocation a background preview frame would otherwise outlive', async () => {
+    // A preview iframe left open makes no request that reaches
+    // `validateSession`, so the lazy idle revoke never fires and the row still
+    // reads active. Checking the policy here is what stops the preview
+    // outliving it by days.
+    vi.mocked(sessionRepository.findActiveSessionById).mockResolvedValue(row({ lastUsedAt: new Date(Date.now() - 20 * 60 * 1000) }) as never);
+    expect(await service.isSessionUsableById('sess_abcdef123456', 'user-1')).toBe(false);
+
+    vi.mocked(sessionRepository.findActiveSessionById).mockResolvedValue(row({ lastUsedAt: new Date(Date.now() - 60_000) }) as never);
+    expect(await service.isSessionUsableById('sess_abcdef123456', 'user-1')).toBe(true);
+
+    // With no `lastUsedAt` the clock runs from creation, exactly as
+    // `validateSessionWithReason` does.
+    vi.mocked(sessionRepository.findActiveSessionById).mockResolvedValue(row({ lastUsedAt: null, createdAt: new Date(Date.now() - 20 * 60 * 1000) }) as never);
     expect(await service.isSessionUsableById('sess_abcdef123456', 'user-1')).toBe(false);
   });
 

--- a/packages/lib/src/auth/__tests__/session-usable-by-id.test.ts
+++ b/packages/lib/src/auth/__tests__/session-usable-by-id.test.ts
@@ -1,0 +1,106 @@
+/**
+ * `isSessionUsableById` — the read behind the dev-preview cookie.
+ *
+ * The preview cookie is signed by us and names its minting session; it never
+ * carries the session token, so the token-hash-keyed `validateSession` cannot
+ * answer for it. This read is what makes "revoke a session, lose the preview
+ * on the next request" true, so what it checks — and what it refuses to
+ * write — is the whole point.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('../session-repository', () => ({
+  sessionRepository: {
+    findUserById: vi.fn(),
+    findActiveSession: vi.fn(),
+    findActiveSessionById: vi.fn(),
+    findSessionByHashAnyState: vi.fn(),
+    getActiveSessionExpiry: vi.fn(),
+    setExpiresAtByHash: vi.fn(),
+    insertSession: vi.fn(),
+    touchSession: vi.fn(),
+    revokeByHash: vi.fn(),
+    revokeAllForUser: vi.fn(),
+    revokeWebForUser: vi.fn(),
+    revokeAdminForUser: vi.fn(),
+    revokeForUserDevice: vi.fn(),
+    deleteExpired: vi.fn(),
+  },
+}));
+vi.mock('../opaque-tokens', () => ({ generateOpaqueToken: vi.fn(), isValidTokenFormat: vi.fn(() => true) }));
+vi.mock('../token-utils', () => ({ hashToken: vi.fn((t: string) => `hashed_${t}`) }));
+vi.mock('../constants', () => ({ IDLE_TIMEOUT_MS: 0 }));
+
+import { SessionService } from '../session-service';
+import { sessionRepository } from '../session-repository';
+
+const row = (overrides: Record<string, unknown> = {}) => ({
+  id: 'sess_abcdef123456',
+  userId: 'user-1',
+  tokenHash: 'hashed_tok',
+  tokenVersion: 3,
+  adminRoleVersion: 1,
+  type: 'user',
+  scopes: ['read'],
+  expiresAt: new Date(Date.now() + 3_600_000),
+  lastUsedAt: new Date(),
+  createdAt: new Date(),
+  resourceType: null,
+  resourceId: null,
+  driveId: null,
+  user: { id: 'user-1', tokenVersion: 3, role: 'user', adminRoleVersion: 1, suspendedAt: null },
+  ...overrides,
+});
+
+describe('isSessionUsableById', () => {
+  let service: SessionService;
+  beforeEach(() => {
+    vi.clearAllMocks();
+    service = new SessionService();
+  });
+
+  it('is true for a live session belonging to the asking user', async () => {
+    vi.mocked(sessionRepository.findActiveSessionById).mockResolvedValue(row() as never);
+    expect(await service.isSessionUsableById('sess_abcdef123456', 'user-1')).toBe(true);
+    expect(sessionRepository.findActiveSessionById).toHaveBeenCalledWith('sess_abcdef123456');
+  });
+
+  it('is false when the session is gone — revoked or expired, which the query itself excludes', async () => {
+    vi.mocked(sessionRepository.findActiveSessionById).mockResolvedValue(undefined);
+    expect(await service.isSessionUsableById('sess_abcdef123456', 'user-1')).toBe(false);
+  });
+
+  it('is false for a session belonging to somebody else, even a live one', async () => {
+    vi.mocked(sessionRepository.findActiveSessionById).mockResolvedValue(row() as never);
+    expect(await service.isSessionUsableById('sess_abcdef123456', 'user-2')).toBe(false);
+  });
+
+  it('is false on a tokenVersion bump, which a password change or erasure writes BEFORE any lazy revoke', async () => {
+    vi.mocked(sessionRepository.findActiveSessionById).mockResolvedValue(
+      row({ user: { id: 'user-1', tokenVersion: 4, role: 'user', adminRoleVersion: 1, suspendedAt: null } }) as never,
+    );
+    expect(await service.isSessionUsableById('sess_abcdef123456', 'user-1')).toBe(false);
+  });
+
+  it('is false for a suspended user, whose rows may still show revokedAt: null', async () => {
+    vi.mocked(sessionRepository.findActiveSessionById).mockResolvedValue(
+      row({ user: { id: 'user-1', tokenVersion: 3, role: 'user', adminRoleVersion: 1, suspendedAt: new Date() } }) as never,
+    );
+    expect(await service.isSessionUsableById('sess_abcdef123456', 'user-1')).toBe(false);
+  });
+
+  it('is false when the user join came back empty rather than assuming the session is fine', async () => {
+    vi.mocked(sessionRepository.findActiveSessionById).mockResolvedValue(row({ user: null }) as never);
+    expect(await service.isSessionUsableById('sess_abcdef123456', 'user-1')).toBe(false);
+  });
+
+  it('WRITES NOTHING — no lazy revoke and no lastUsedAt touch, because an untrusted origin drives this path', async () => {
+    vi.mocked(sessionRepository.findActiveSessionById).mockResolvedValue(
+      row({ user: { id: 'user-1', tokenVersion: 9, role: 'user', adminRoleVersion: 1, suspendedAt: null } }) as never,
+    );
+    await service.isSessionUsableById('sess_abcdef123456', 'user-1');
+    expect(sessionRepository.touchSession).not.toHaveBeenCalled();
+    expect(sessionRepository.revokeByHash).not.toHaveBeenCalled();
+    expect(sessionRepository.setExpiresAtByHash).not.toHaveBeenCalled();
+  });
+});

--- a/packages/lib/src/auth/session-repository.ts
+++ b/packages/lib/src/auth/session-repository.ts
@@ -75,7 +75,6 @@ export const sessionRepository = {
     }) as Promise<SessionRecord | undefined>;
   },
 
-  // Look up a session by hash in ANY state (revoked, expired, or active). Used by the
   /**
    * A live session BY ID, for credentials derived from a session that do not
    * carry its token — today, the dev-preview cookie.
@@ -103,6 +102,7 @@ export const sessionRepository = {
     }) as Promise<SessionRecord | undefined>;
   },
 
+  // Look up a session by hash in ANY state (revoked, expired, or active). Used by the
   // failure-reason classifier when findActiveSession finds nothing, to split "revoked" vs
   // "grace-expired" vs "genuinely never existed". No revoked/expiry predicate, no user join.
   findSessionByHashAnyState: async (tokenHash: string): Promise<SessionAnyStateRecord | undefined> => {

--- a/packages/lib/src/auth/session-repository.ts
+++ b/packages/lib/src/auth/session-repository.ts
@@ -76,6 +76,33 @@ export const sessionRepository = {
   },
 
   // Look up a session by hash in ANY state (revoked, expired, or active). Used by the
+  /**
+   * A live session BY ID, for credentials derived from a session that do not
+   * carry its token — today, the dev-preview cookie.
+   *
+   * `findActiveSession` above is keyed on the token hash, which the preview
+   * origin never sees: it holds a signed cookie naming the session, not the
+   * session's secret. This is the read that lets a per-request gate ask "is
+   * the session that minted this still usable?" without the token.
+   *
+   * Read-only by design — no lazy revoke, no `lastUsedAt` touch. It is driven
+   * by subresource requests from an untrusted origin, so it must not write.
+   */
+  findActiveSessionById: async (sessionId: string): Promise<SessionRecord | undefined> => {
+    return db.query.sessions.findFirst({
+      where: and(
+        eq(sessions.id, sessionId),
+        isNull(sessions.revokedAt),
+        gt(sessions.expiresAt, new Date()),
+      ),
+      with: {
+        user: {
+          columns: { id: true, tokenVersion: true, role: true, adminRoleVersion: true, suspendedAt: true },
+        },
+      },
+    }) as Promise<SessionRecord | undefined>;
+  },
+
   // failure-reason classifier when findActiveSession finds nothing, to split "revoked" vs
   // "grace-expired" vs "genuinely never existed". No revoked/expiry predicate, no user join.
   findSessionByHashAnyState: async (tokenHash: string): Promise<SessionAnyStateRecord | undefined> => {

--- a/packages/lib/src/auth/session-service.ts
+++ b/packages/lib/src/auth/session-service.ts
@@ -127,6 +127,34 @@ export class SessionService {
    * only serves a single session type (e.g. 'user' for browser cookie/bearer auth) so a token
    * leaked from one surface cannot be replayed on another.
    */
+  /**
+   * Is the session that minted a DERIVED credential still usable, for this
+   * user? Read-only, and keyed on the session id rather than its token.
+   *
+   * The dev-preview cookie is the caller: it is signed by us, names its
+   * minting session, and is presented to a preview origin that never sees the
+   * session token — so `validateSession` (token-hash keyed) cannot answer.
+   * Without this, revoking a session left its preview answering until the
+   * cookie expired.
+   *
+   * `tokenVersion` and `suspendedAt` are BOTH checked, not just `revokedAt`.
+   * `validateSessionWithReason` revokes on those mismatches LAZILY — the row
+   * may still show `revokedAt: null` after a password change, an erasure or a
+   * suspension — so testing revocation alone would leave open exactly the
+   * window this exists to close.
+   *
+   * Deliberately performs no writes: no lazy revoke, no `lastUsedAt` touch.
+   * This runs per proxied subresource from an untrusted origin, and the next
+   * real session use will do the lazy revoke anyway.
+   */
+  async isSessionUsableById(sessionId: string, userId: string): Promise<boolean> {
+    const session = await sessionRepository.findActiveSessionById(sessionId);
+    if (!session?.user) return false;
+    if (session.userId !== userId) return false;
+    if (session.user.suspendedAt) return false;
+    return session.tokenVersion === session.user.tokenVersion;
+  }
+
   async validateSessionWithReason(
     token: string,
     options?: { expectedType?: SessionClaims['type'] }

--- a/packages/lib/src/auth/session-service.ts
+++ b/packages/lib/src/auth/session-service.ts
@@ -152,7 +152,20 @@ export class SessionService {
     if (!session?.user) return false;
     if (session.userId !== userId) return false;
     if (session.user.suspendedAt) return false;
-    return session.tokenVersion === session.user.tokenVersion;
+    if (session.tokenVersion !== session.user.tokenVersion) return false;
+    // THE IDLE TIMEOUT APPLIES HERE TOO, and it is the revocation most likely
+    // to matter for a preview: a frame left open in a background tab makes no
+    // request that would trigger `validateSession`'s lazy revoke, so without
+    // this an idle-policy deployment would keep proxying into the sandbox
+    // until the session's own expiry — days, not minutes. Read-only like the
+    // rest of this method: the revoke is still written by the next real
+    // session use, and the preview is refused meanwhile either way.
+    if (IDLE_TIMEOUT_MS > 0) {
+      const lastActivity = session.lastUsedAt ?? session.createdAt;
+      const lastUsed = lastActivity instanceof Date ? lastActivity : new Date(lastActivity);
+      if (Date.now() - lastUsed.getTime() > IDLE_TIMEOUT_MS) return false;
+    }
+    return true;
   }
 
   async validateSessionWithReason(

--- a/packages/lib/src/auth/session-service.ts
+++ b/packages/lib/src/auth/session-service.ts
@@ -115,19 +115,6 @@ export class SessionService {
   }
 
   /**
-   * Validate token and return claims OR the reason it failed (D5).
-   *
-   * Behaviourally identical to the historical `validateSession` — same reject conditions, same
-   * revoke/touch side effects — but instead of collapsing every failure to `null`, it names the
-   * reason. When no ACTIVE session is found, it does a secondary any-state lookup to split
-   * `revoked` vs `expired` (incl. #2176's grace-expiries: revokedAt null, expiresAt in the past)
-   * vs a genuinely unknown `not_found`.
-   *
-   * `expectedType` scopes the token to one authentication surface: pass it at every boundary that
-   * only serves a single session type (e.g. 'user' for browser cookie/bearer auth) so a token
-   * leaked from one surface cannot be replayed on another.
-   */
-  /**
    * Is the session that minted a DERIVED credential still usable, for this
    * user? Read-only, and keyed on the session id rather than its token.
    *
@@ -168,6 +155,19 @@ export class SessionService {
     return true;
   }
 
+  /**
+   * Validate token and return claims OR the reason it failed (D5).
+   *
+   * Behaviourally identical to the historical `validateSession` — same reject conditions, same
+   * revoke/touch side effects — but instead of collapsing every failure to `null`, it names the
+   * reason. When no ACTIVE session is found, it does a secondary any-state lookup to split
+   * `revoked` vs `expired` (incl. #2176's grace-expiries: revokedAt null, expiresAt in the past)
+   * vs a genuinely unknown `not_found`.
+   *
+   * `expectedType` scopes the token to one authentication surface: pass it at every boundary that
+   * only serves a single session type (e.g. 'user' for browser cookie/bearer auth) so a token
+   * leaked from one surface cannot be replayed on another.
+   */
   async validateSessionWithReason(
     token: string,
     options?: { expectedType?: SessionClaims['type'] }

--- a/packages/lib/src/services/sandbox/preview/__tests__/dev-preview-core.test.ts
+++ b/packages/lib/src/services/sandbox/preview/__tests__/dev-preview-core.test.ts
@@ -643,8 +643,13 @@ describe('sharing an UNLISTED port is a decision, not a default', () => {
     assert({ given: 'a recorded but unapproved 9000', should: 'be needs-approval naming the port', actual: [waiting.status, waiting.status === 'needs-approval' && waiting.targetPort], expected: ['needs-approval', 9000] });
     expect(waiting.message).toContain('9000');
 
+    // DOWN, not "starting…": the relay is created in the same call that
+    // records the consent, so a row in this shape means that create did not
+    // happen and nothing necessarily retries it. `down` is what keeps the
+    // Restart control on screen; "starting" would promise an arrival that
+    // never comes.
     const approved = describeServiceState({ liveInstanceId: INSTANCE, row: relayRow(9000, { relayServiceName: null, approvedPort: 9000 }), relay: null, listeners: null });
-    assert({ given: 'approved but the relay is not created yet', should: 'read as starting, never as "serving 8080 directly"', actual: approved.status, expected: 'starting' });
+    assert({ given: 'approved but no relay was created', should: 'read as down and stay recoverable', actual: [approved.status, approved.status === 'down' && approved.via], expected: ['down', 'relay'] });
 
     // The relay was planned and REFUSED because a stranger holds 8080. Saying
     // "starting…" would be a lie that never resolves and would hide the one
@@ -652,7 +657,7 @@ describe('sharing an UNLISTED port is a decision, not a default', () => {
     const held = describeServiceState({ liveInstanceId: INSTANCE, row: relayRow(9000, { relayServiceName: null, approvedPort: 9000 }), relay: null, listeners: [{ port: 8080, pid: 99 }] });
     assert({ given: 'approved while a user process holds 8080', should: 'say the port is busy, not "starting"', actual: [held.status, held.message], expected: ['blocked', HTTP_PORT_BUSY_MESSAGE] });
     // With no snapshot the slot is UNKNOWN, which is not evidence of a problem.
-    assert({ given: 'approved with no listener snapshot', should: 'stay starting rather than invent a blockage', actual: describeServiceState({ liveInstanceId: INSTANCE, row: relayRow(9000, { relayServiceName: null, approvedPort: 9000 }), relay: null, listeners: null }).status, expected: 'starting' });
+    assert({ given: 'approved with no listener snapshot', should: 'stay down rather than invent a blockage', actual: describeServiceState({ liveInstanceId: INSTANCE, row: relayRow(9000, { relayServiceName: null, approvedPort: 9000 }), relay: null, listeners: null }).status, expected: 'down' });
 
     // A row can reach the relay-less branch with an ORDINARY dev-server port:
     // a stop records that the relay is gone, and the resume clears the stop
@@ -660,7 +665,7 @@ describe('sharing an UNLISTED port is a decision, not a default', () => {
     // that never needed any — the whole Share affordance would appear on a
     // vite server the user has been previewing all along.
     const resumedKnownPort = describeServiceState({ liveInstanceId: INSTANCE, row: relayRow(5173, { relayServiceName: null }), relay: null, listeners: null });
-    assert({ given: 'a known dev port whose relay was stopped and then resumed', should: 'read as starting, never as needs-approval', actual: resumedKnownPort.status, expected: 'starting' });
+    assert({ given: 'a known dev port whose relay was stopped and then resumed', should: 'read as down — recoverable in one click — never as needs-approval', actual: resumedKnownPort.status, expected: 'down' });
 
     const off = describeServiceState({ liveInstanceId: INSTANCE, row: relayRow(9000, { relayServiceName: null, stoppedByUserAt: NOW }), relay: null, listeners: null });
     assert({ given: 'a switched-off unapproved preview', should: 'read as stopped, not as a pending decision', actual: off.status, expected: 'stopped' });

--- a/packages/lib/src/services/sandbox/preview/__tests__/dev-preview-core.test.ts
+++ b/packages/lib/src/services/sandbox/preview/__tests__/dev-preview-core.test.ts
@@ -36,6 +36,7 @@ function relayRow(targetPort: number, overrides: Partial<DevPreviewRow> = {}): D
     detectedAt: new Date('2026-09-05T11:00:00.000Z'),
     stoppedByUserAt: null,
     approvedPort: null,
+    approvedAt: null,
     ...overrides,
   };
 }
@@ -210,7 +211,7 @@ describe('planDevServerService', () => {
         action: 'start-relay',
         via: 'create',
         service: buildPreviewRelaySpec({ targetPort: 5173 }),
-        row: { holder: HOLDER, spriteInstanceId: INSTANCE, sandboxId: 'pgs-sbx-abc', targetPort: 5173, relayServiceName: PREVIEW_RELAY_SERVICE_NAME, detectedAt: NOW, stoppedByUserAt: null, approvedPort: null, basedOnStoppedByUserAt: null },
+        row: { holder: HOLDER, spriteInstanceId: INSTANCE, sandboxId: 'pgs-sbx-abc', targetPort: 5173, relayServiceName: PREVIEW_RELAY_SERVICE_NAME, detectedAt: NOW, stoppedByUserAt: null, basedOnStoppedByUserAt: null },
       },
     });
   });
@@ -282,7 +283,7 @@ describe('planDevServerService', () => {
         action: 'replace-relay',
         previousTargetPort: 5173,
         service: buildPreviewRelaySpec({ targetPort: 3000 }),
-        row: { holder: HOLDER, spriteInstanceId: INSTANCE, sandboxId: 'pgs-sbx-abc', targetPort: 3000, relayServiceName: PREVIEW_RELAY_SERVICE_NAME, detectedAt: NOW, stoppedByUserAt: null, approvedPort: null, basedOnStoppedByUserAt: null },
+        row: { holder: HOLDER, spriteInstanceId: INSTANCE, sandboxId: 'pgs-sbx-abc', targetPort: 3000, relayServiceName: PREVIEW_RELAY_SERVICE_NAME, detectedAt: NOW, stoppedByUserAt: null, basedOnStoppedByUserAt: null },
       },
     });
   });
@@ -295,7 +296,7 @@ describe('planDevServerService', () => {
       expected: {
         action: 'record-direct',
         removeRelay: false,
-        row: { holder: HOLDER, spriteInstanceId: INSTANCE, sandboxId: 'pgs-sbx-abc', targetPort: 8080, relayServiceName: null, detectedAt: NOW, stoppedByUserAt: null, approvedPort: null, basedOnStoppedByUserAt: null },
+        row: { holder: HOLDER, spriteInstanceId: INSTANCE, sandboxId: 'pgs-sbx-abc', targetPort: 8080, relayServiceName: null, detectedAt: NOW, stoppedByUserAt: null, basedOnStoppedByUserAt: null },
       },
     });
     const plan = planDevServerService(planInput({ detected: detected(8080, 5), row: relayRow(5173), relay: relayService(5173, { status: 'failed' }) }));
@@ -394,7 +395,7 @@ describe('resolveDevPreviewHolder — the holder is whoever OWNS the sprite poin
   it('has two sessions in one env converge on ONE row intent', () => {
     const envHolder = resolveDevPreviewHolder({ id: 'ws-1', envId: 'env-1' });
     const first = planDevServerService(planInput({ holder: envHolder, detected: detected(5173) }));
-    const second = planDevServerService(planInput({ holder: resolveDevPreviewHolder({ id: 'ws-2', envId: 'env-1' }), row: first.action === 'start-relay' ? { ...first.row, stoppedByUserAt: null } : null, relay: relayService(5173), detected: detected(5173) }));
+    const second = planDevServerService(planInput({ holder: resolveDevPreviewHolder({ id: 'ws-2', envId: 'env-1' }), row: first.action === 'start-relay' ? { ...first.row, stoppedByUserAt: null, approvedPort: null, approvedAt: null } : null, relay: relayService(5173), detected: detected(5173) }));
     assert({ given: 'session ws-1 detecting 5173 in env-1', should: 'write an env-keyed row', actual: first.action === 'start-relay' ? first.row.holder : first.action, expected: { kind: 'env', id: 'env-1' } });
     assert({ given: 'session ws-2 then detecting the same server', should: 'find the env row already relaying and write nothing new', actual: second, expected: { action: 'none', reason: 'already-relaying', staleRowIgnored: false } });
   });
@@ -603,7 +604,7 @@ describe('sharing an UNLISTED port is a decision, not a default', () => {
         action: 'await-approval',
         targetPort: 9000,
         removeRelay: false,
-        row: { holder: HOLDER, spriteInstanceId: INSTANCE, sandboxId: 'pgs-sbx-abc', targetPort: 9000, relayServiceName: null, detectedAt: NOW, stoppedByUserAt: null, approvedPort: null, basedOnStoppedByUserAt: null },
+        row: { holder: HOLDER, spriteInstanceId: INSTANCE, sandboxId: 'pgs-sbx-abc', targetPort: 9000, relayServiceName: null, detectedAt: NOW, stoppedByUserAt: null, basedOnStoppedByUserAt: null },
       },
     });
   });
@@ -644,6 +645,14 @@ describe('sharing an UNLISTED port is a decision, not a default', () => {
 
     const approved = describeServiceState({ liveInstanceId: INSTANCE, row: relayRow(9000, { relayServiceName: null, approvedPort: 9000 }), relay: null, listeners: null });
     assert({ given: 'approved but the relay is not created yet', should: 'read as starting, never as "serving 8080 directly"', actual: approved.status, expected: 'starting' });
+
+    // The relay was planned and REFUSED because a stranger holds 8080. Saying
+    // "starting…" would be a lie that never resolves and would hide the one
+    // thing the user can act on.
+    const held = describeServiceState({ liveInstanceId: INSTANCE, row: relayRow(9000, { relayServiceName: null, approvedPort: 9000 }), relay: null, listeners: [{ port: 8080, pid: 99 }] });
+    assert({ given: 'approved while a user process holds 8080', should: 'say the port is busy, not "starting"', actual: [held.status, held.message], expected: ['blocked', HTTP_PORT_BUSY_MESSAGE] });
+    // With no snapshot the slot is UNKNOWN, which is not evidence of a problem.
+    assert({ given: 'approved with no listener snapshot', should: 'stay starting rather than invent a blockage', actual: describeServiceState({ liveInstanceId: INSTANCE, row: relayRow(9000, { relayServiceName: null, approvedPort: 9000 }), relay: null, listeners: null }).status, expected: 'starting' });
 
     const off = describeServiceState({ liveInstanceId: INSTANCE, row: relayRow(9000, { relayServiceName: null, stoppedByUserAt: NOW }), relay: null, listeners: null });
     assert({ given: 'a switched-off unapproved preview', should: 'read as stopped, not as a pending decision', actual: off.status, expected: 'stopped' });

--- a/packages/lib/src/services/sandbox/preview/__tests__/dev-preview-core.test.ts
+++ b/packages/lib/src/services/sandbox/preview/__tests__/dev-preview-core.test.ts
@@ -8,6 +8,9 @@ import {
   describeServiceState,
   resolveDevPreviewHolder,
   HTTP_PORT_BUSY_MESSAGE,
+  requiresPreviewApproval,
+  isPreviewApproved,
+  KNOWN_DEV_SERVER_PORTS,
   type DevPreviewHolderRef,
   type DevPreviewRow,
   type PlanDevServerServiceInput,
@@ -32,6 +35,7 @@ function relayRow(targetPort: number, overrides: Partial<DevPreviewRow> = {}): D
     relayServiceName: targetPort === SPRITE_HTTP_PORT ? null : PREVIEW_RELAY_SERVICE_NAME,
     detectedAt: new Date('2026-09-05T11:00:00.000Z'),
     stoppedByUserAt: null,
+    approvedPort: null,
     ...overrides,
   };
 }
@@ -206,7 +210,7 @@ describe('planDevServerService', () => {
         action: 'start-relay',
         via: 'create',
         service: buildPreviewRelaySpec({ targetPort: 5173 }),
-        row: { holder: HOLDER, spriteInstanceId: INSTANCE, sandboxId: 'pgs-sbx-abc', targetPort: 5173, relayServiceName: PREVIEW_RELAY_SERVICE_NAME, detectedAt: NOW, stoppedByUserAt: null, basedOnStoppedByUserAt: null },
+        row: { holder: HOLDER, spriteInstanceId: INSTANCE, sandboxId: 'pgs-sbx-abc', targetPort: 5173, relayServiceName: PREVIEW_RELAY_SERVICE_NAME, detectedAt: NOW, stoppedByUserAt: null, approvedPort: null, basedOnStoppedByUserAt: null },
       },
     });
   });
@@ -278,7 +282,7 @@ describe('planDevServerService', () => {
         action: 'replace-relay',
         previousTargetPort: 5173,
         service: buildPreviewRelaySpec({ targetPort: 3000 }),
-        row: { holder: HOLDER, spriteInstanceId: INSTANCE, sandboxId: 'pgs-sbx-abc', targetPort: 3000, relayServiceName: PREVIEW_RELAY_SERVICE_NAME, detectedAt: NOW, stoppedByUserAt: null, basedOnStoppedByUserAt: null },
+        row: { holder: HOLDER, spriteInstanceId: INSTANCE, sandboxId: 'pgs-sbx-abc', targetPort: 3000, relayServiceName: PREVIEW_RELAY_SERVICE_NAME, detectedAt: NOW, stoppedByUserAt: null, approvedPort: null, basedOnStoppedByUserAt: null },
       },
     });
   });
@@ -291,7 +295,7 @@ describe('planDevServerService', () => {
       expected: {
         action: 'record-direct',
         removeRelay: false,
-        row: { holder: HOLDER, spriteInstanceId: INSTANCE, sandboxId: 'pgs-sbx-abc', targetPort: 8080, relayServiceName: null, detectedAt: NOW, stoppedByUserAt: null, basedOnStoppedByUserAt: null },
+        row: { holder: HOLDER, spriteInstanceId: INSTANCE, sandboxId: 'pgs-sbx-abc', targetPort: 8080, relayServiceName: null, detectedAt: NOW, stoppedByUserAt: null, approvedPort: null, basedOnStoppedByUserAt: null },
       },
     });
     const plan = planDevServerService(planInput({ detected: detected(8080, 5), row: relayRow(5173), relay: relayService(5173, { status: 'failed' }) }));
@@ -407,12 +411,22 @@ describe('planDevServerService — thrash guard', () => {
   });
 
   it('replaces freely once the current target stopped listening, or when the newcomer is a known dev port', () => {
+    // The guard no longer applies (5173 is gone), so 9230 becomes the target —
+    // but an unlisted target is not SHARED without a person's say-so, so the
+    // plan is to record it and take the old relay down, not to re-point it.
     const gone = planDevServerService(planInput({ row: relayRow(5173), relay: relayService(5173), listeners: [{ port: 8080, pid: 42 }], detected: { kind: 'dev-server', port: 9230, likelihood: 'unlisted' } }));
-    assert({ given: 'row=5173 no longer bound, unlisted 9230 opens', should: 'replace the relay', actual: gone.action, expected: 'replace-relay' });
+    assert({ given: 'row=5173 no longer bound, unlisted 9230 opens', should: 'take the target but await approval, removing the old relay', actual: [gone.action, gone.action === 'await-approval' && gone.removeRelay], expected: ['await-approval', true] });
+    const approvedGone = planDevServerService(planInput({ row: relayRow(5173, { approvedPort: 9230 }), relay: relayService(5173), listeners: [{ port: 8080, pid: 42 }], detected: { kind: 'dev-server', port: 9230, likelihood: 'unlisted' } }));
+    assert({ given: 'the same move with 9230 already approved', should: 'replace the relay', actual: approvedGone.action, expected: 'replace-relay' });
     const known = planDevServerService(planInput({ row: relayRow(5173), relay: relayService(5173), listeners: [{ port: 5173, pid: 1 }], detected: { kind: 'dev-server', port: 3000, likelihood: 'known-dev-port' } }));
     assert({ given: 'row=5173 still bound, known 3000 opens', should: 'replace the relay', actual: known.action, expected: 'replace-relay' });
     const unlistedCurrent = planDevServerService(planInput({ row: relayRow(7777), relay: relayService(7777), listeners: [{ port: 7777, pid: 1 }], detected: { kind: 'dev-server', port: 9230, likelihood: 'unlisted' } }));
-    assert({ given: 'row=7777 (unlisted) still bound, unlisted 9230 opens', should: 'replace (only a KNOWN current target is defended)', actual: unlistedCurrent.action, expected: 'replace-relay' });
+    assert({ given: 'row=7777 (unapproved, unlisted) still bound, unlisted 9230 opens', should: 'move to 9230 — an unapproved target is not worth defending', actual: unlistedCurrent.action, expected: 'await-approval' });
+    // But an APPROVED unlisted target IS defended: otherwise a `node --inspect`
+    // bind would knock a working, explicitly-shared preview back into
+    // needs-approval and make the user agree to it a second time.
+    const approvedCurrent = planDevServerService(planInput({ row: relayRow(7777, { approvedPort: 7777 }), relay: relayService(7777), listeners: [{ port: 7777, pid: 1 }], detected: { kind: 'dev-server', port: 9230, likelihood: 'unlisted' } }));
+    assert({ given: 'row=7777 APPROVED and still bound, unlisted 9230 opens', should: 'keep the working preview', actual: [approvedCurrent.action, approvedCurrent.action === 'none' && approvedCurrent.reason], expected: ['none', 'current-target-preferred'] });
   });
 });
 
@@ -563,5 +577,75 @@ describe('describeServiceState', () => {
     const state = describeServiceState({ liveInstanceId: INSTANCE, row: relayRow(5173), relay: relayService(5173), listeners: null });
     expect(JSON.stringify(state).toLowerCase()).not.toContain('public');
     expect(Object.keys(state)).not.toContain('url');
+  });
+});
+
+describe('sharing an UNLISTED port is a decision, not a default', () => {
+  it('draws the line at the known dev-server ports, and nowhere else', () => {
+    for (const port of KNOWN_DEV_SERVER_PORTS) {
+      assert({ given: `port ${port}`, should: 'need no approval — running the tool IS the ask', actual: requiresPreviewApproval(port), expected: false });
+    }
+    for (const port of [9000, 7777, 9230, 4444, 1]) {
+      assert({ given: `port ${port}`, should: 'need approval', actual: requiresPreviewApproval(port), expected: true });
+    }
+    assert({ given: 'no row at all', should: 'never count as approved', actual: isPreviewApproved(null, 9000), expected: false });
+    assert({ given: 'approval for another port', should: 'not carry over — approval is per PORT', actual: isPreviewApproved({ approvedPort: 9000 }, 9001), expected: false });
+    assert({ given: 'approval for this port', should: 'count', actual: isPreviewApproved({ approvedPort: 9000 }, 9000), expected: true });
+  });
+
+  it('a fresh unlisted detection is RECORDED but never relayed — the row it writes serves nothing', () => {
+    const plan = planDevServerService(planInput({ detected: { kind: 'dev-server', port: 9000, likelihood: 'unlisted' } }));
+    assert({
+      given: 'a dev server on 9000 with no approval',
+      should: 'await approval, writing a row with NO relay',
+      actual: plan,
+      expected: {
+        action: 'await-approval',
+        targetPort: 9000,
+        removeRelay: false,
+        row: { holder: HOLDER, spriteInstanceId: INSTANCE, sandboxId: 'pgs-sbx-abc', targetPort: 9000, relayServiceName: null, detectedAt: NOW, stoppedByUserAt: null, approvedPort: null, basedOnStoppedByUserAt: null },
+      },
+    });
+  });
+
+  it('the approval unlocks exactly the port it names, and the relay starts on the next plan', () => {
+    const approved = planDevServerService(planInput({ row: relayRow(9000, { relayServiceName: null, approvedPort: 9000 }), detected: { kind: 'dev-server', port: 9000, likelihood: 'unlisted' } }));
+    assert({ given: '9000 approved', should: 'create the relay', actual: [approved.action, approved.action === 'start-relay' && approved.via], expected: ['start-relay', 'create'] });
+
+    // The server moved to another unlisted port: the old approval does not
+    // travel with it, so exposure stops until the user agrees again.
+    const moved = planDevServerService(planInput({ row: relayRow(9000, { approvedPort: 9000 }), relay: relayService(9000), listeners: [{ port: 8080, pid: 42 }], detected: { kind: 'dev-server', port: 9001, likelihood: 'unlisted' } }));
+    assert({ given: 'an approved 9000 moving to 9001', should: 'await approval again AND remove the 9000 relay', actual: [moved.action, moved.action === 'await-approval' && moved.removeRelay], expected: ['await-approval', true] });
+  });
+
+  it('never asks about 8080 or a known port, and asks BEFORE the slot questions', () => {
+    const direct = planDevServerService(planInput({ detected: detected(8080, 5), listeners: [{ port: 8080, pid: 5 }] }));
+    assert({ given: 'the server on 8080 itself', should: 'record directly — 8080 is a known dev port', actual: direct.action, expected: 'record-direct' });
+    const known = planDevServerService(planInput({ detected: detected(5173) }));
+    assert({ given: 'vite on 5173', should: 'start the relay with no approval', actual: known.action, expected: 'start-relay' });
+
+    // A held slot and an unknown snapshot are both answers about STARTING
+    // something. Nothing is being started here, so neither is the honest reason.
+    const busy = planDevServerService(planInput({ detected: { kind: 'dev-server', port: 9000, likelihood: 'unlisted' }, listeners: [{ port: 8080, pid: 99 }] }));
+    assert({ given: 'an unlisted port while a stranger holds 8080', should: 'still be await-approval, not http-port-busy', actual: busy.action, expected: 'await-approval' });
+    const blind = planDevServerService(planInput({ detected: { kind: 'dev-server', port: 9000, likelihood: 'unlisted' }, listenersKnown: false }));
+    assert({ given: 'an unlisted port with no listener snapshot', should: 'still be await-approval, not slot-unknown', actual: blind.action, expected: 'await-approval' });
+  });
+
+  it('a STOP still outranks approval — the user switching it off is never overridden by a pending decision', () => {
+    const stopped = planDevServerService(planInput({ row: relayRow(9000, { relayServiceName: null, stoppedByUserAt: NOW }), detected: { kind: 'dev-server', port: 9000, likelihood: 'unlisted' } }));
+    assert({ given: 'an unlisted port on a switched-off preview', should: 'stay off', actual: [stopped.action, stopped.action === 'none' && stopped.reason], expected: ['none', 'user-stopped'] });
+  });
+
+  it('describeServiceState says needs-approval, and says STARTING once approved but not yet relayed', () => {
+    const waiting = describeServiceState({ liveInstanceId: INSTANCE, row: relayRow(9000, { relayServiceName: null }), relay: null, listeners: null });
+    assert({ given: 'a recorded but unapproved 9000', should: 'be needs-approval naming the port', actual: [waiting.status, waiting.status === 'needs-approval' && waiting.targetPort], expected: ['needs-approval', 9000] });
+    expect(waiting.message).toContain('9000');
+
+    const approved = describeServiceState({ liveInstanceId: INSTANCE, row: relayRow(9000, { relayServiceName: null, approvedPort: 9000 }), relay: null, listeners: null });
+    assert({ given: 'approved but the relay is not created yet', should: 'read as starting, never as "serving 8080 directly"', actual: approved.status, expected: 'starting' });
+
+    const off = describeServiceState({ liveInstanceId: INSTANCE, row: relayRow(9000, { relayServiceName: null, stoppedByUserAt: NOW }), relay: null, listeners: null });
+    assert({ given: 'a switched-off unapproved preview', should: 'read as stopped, not as a pending decision', actual: off.status, expected: 'stopped' });
   });
 });

--- a/packages/lib/src/services/sandbox/preview/__tests__/dev-preview-core.test.ts
+++ b/packages/lib/src/services/sandbox/preview/__tests__/dev-preview-core.test.ts
@@ -654,6 +654,14 @@ describe('sharing an UNLISTED port is a decision, not a default', () => {
     // With no snapshot the slot is UNKNOWN, which is not evidence of a problem.
     assert({ given: 'approved with no listener snapshot', should: 'stay starting rather than invent a blockage', actual: describeServiceState({ liveInstanceId: INSTANCE, row: relayRow(9000, { relayServiceName: null, approvedPort: 9000 }), relay: null, listeners: null }).status, expected: 'starting' });
 
+    // A row can reach the relay-less branch with an ORDINARY dev-server port:
+    // a stop records that the relay is gone, and the resume clears the stop
+    // before the relay is re-created. That must not demand consent for a port
+    // that never needed any — the whole Share affordance would appear on a
+    // vite server the user has been previewing all along.
+    const resumedKnownPort = describeServiceState({ liveInstanceId: INSTANCE, row: relayRow(5173, { relayServiceName: null }), relay: null, listeners: null });
+    assert({ given: 'a known dev port whose relay was stopped and then resumed', should: 'read as starting, never as needs-approval', actual: resumedKnownPort.status, expected: 'starting' });
+
     const off = describeServiceState({ liveInstanceId: INSTANCE, row: relayRow(9000, { relayServiceName: null, stoppedByUserAt: NOW }), relay: null, listeners: null });
     assert({ given: 'a switched-off unapproved preview', should: 'read as stopped, not as a pending decision', actual: off.status, expected: 'stopped' });
   });

--- a/packages/lib/src/services/sandbox/preview/__tests__/dev-preview-core.test.ts
+++ b/packages/lib/src/services/sandbox/preview/__tests__/dev-preview-core.test.ts
@@ -633,6 +633,41 @@ describe('sharing an UNLISTED port is a decision, not a default', () => {
     assert({ given: 'an unlisted port with no listener snapshot', should: 'still be await-approval, not slot-unknown', actual: blind.action, expected: 'await-approval' });
   });
 
+  it('a LIVE relay that already forwards to the target survives an unknown listener snapshot', () => {
+    // The guard exists to refuse a START planned blind. This relay is not a
+    // start: it is already running and already pointed at 5173, and it is
+    // itself what holds 8080 — so the question the guard asks is answered
+    // without a snapshot. Refusing here told a user whose preview was
+    // ALREADY SERVING that it would start shortly.
+    const serving = planDevServerService(planInput({ row: relayRow(5173), relay: relayService(5173), listenersKnown: false }));
+    assert({
+      given: 'a live relay on the row target with no listener snapshot',
+      should: 'be a no-op, not refused as slot-unknown',
+      actual: [serving.action, serving.action === 'none' && serving.reason],
+      expected: ['none', 'already-relaying'],
+    });
+
+    // Same relay, row does not name it: recording the row touches no process,
+    // so it also needs no snapshot.
+    const unrecorded = planDevServerService(planInput({ row: null, relay: relayService(5173), detected: detected(5173), listenersKnown: false }));
+    assert({
+      given: 'a live matching relay the row does not know about, snapshot unknown',
+      should: 'record it rather than refuse',
+      actual: [unrecorded.action, unrecorded.action === 'start-relay' && unrecorded.via],
+      expected: ['start-relay', 'already-running'],
+    });
+
+    // The counterweight: a relay that is NOT alive has to be started, which
+    // is a real process start on 8080, so it still waits for a snapshot.
+    const dead = planDevServerService(planInput({ row: relayRow(5173), relay: relayService(5173, { status: 'failed' }), listenersKnown: false }));
+    assert({
+      given: 'a matching but DEAD relay with no listener snapshot',
+      should: 'still refuse, because restarting it is a real start',
+      actual: [dead.action, dead.action === 'refuse' && dead.reason],
+      expected: ['refuse', 'slot-unknown'],
+    });
+  });
+
   it('a STOP still outranks approval — the user switching it off is never overridden by a pending decision', () => {
     const stopped = planDevServerService(planInput({ row: relayRow(9000, { relayServiceName: null, stoppedByUserAt: NOW }), detected: { kind: 'dev-server', port: 9000, likelihood: 'unlisted' } }));
     assert({ given: 'an unlisted port on a switched-off preview', should: 'stay off', actual: [stopped.action, stopped.action === 'none' && stopped.reason], expected: ['none', 'user-stopped'] });

--- a/packages/lib/src/services/sandbox/preview/__tests__/dev-preview-detection.test.ts
+++ b/packages/lib/src/services/sandbox/preview/__tests__/dev-preview-detection.test.ts
@@ -45,6 +45,7 @@ function harness(overrides: {
     approvePort: async () => null,
     findStoppedWithRelay: async () => [],
     markSwept: async () => {},
+    markRelayStopped: async () => {},
     // `readsAheadOfWrites` models the real race: the planner reads the row as
     // it was, and by the time the write lands the STORED row has moved on
     // (a user's stop). The write then meets the same compare-and-set the real

--- a/packages/lib/src/services/sandbox/preview/__tests__/dev-preview-detection.test.ts
+++ b/packages/lib/src/services/sandbox/preview/__tests__/dev-preview-detection.test.ts
@@ -89,7 +89,7 @@ describe('createDevPreviewDetector — port_opened', () => {
     // An (empty) snapshot first: the accumulated set is only KNOWN once a port_list has applied.
     await h.detector.onFrame({ type: 'port_list', ports: [] });
     await h.detector.onFrame({ type: 'port_opened', port: 5173, pid: 11 });
-    assert({ given: 'fresh detection', should: 'create relay → upsert', actual: h.calls, expected: ['create:5173', `upsert:5173:${PREVIEW_RELAY_SERVICE_NAME}`] });
+    assert({ given: 'fresh detection', should: 'record the row FIRST, then create the relay (a refused write must cost no sprite mutation)', actual: h.calls, expected: [`upsert:5173:${PREVIEW_RELAY_SERVICE_NAME}`, 'create:5173'] });
     assert({ given: 'fresh detection', should: 'probe exactly once', actual: h.probes(), expected: 1 });
     assert({ given: 'fresh detection', should: 'accumulate the listener', actual: h.detector.listeners(), expected: [{ port: 5173, pid: 11 }] });
   });
@@ -114,7 +114,7 @@ describe('createDevPreviewDetector — port_opened', () => {
     const stale: DevPreviewRecord = { id: 'r', spriteInstanceId: 'inst-0', sandboxId: 'sbx', targetPort: 3000, relayServiceName: PREVIEW_RELAY_SERVICE_NAME, detectedAt: NOW, stoppedByUserAt: null };
     const h = harness({ row: stale });
     await h.detector.onFrame({ type: 'port_opened', port: 5173 });
-    assert({ given: 'stale row', should: 'create for the new detection and replace the row', actual: h.calls, expected: ['create:5173', `upsert:5173:${PREVIEW_RELAY_SERVICE_NAME}`] });
+    assert({ given: 'stale row', should: 'replace the row for the live instance, then create', actual: h.calls, expected: [`upsert:5173:${PREVIEW_RELAY_SERVICE_NAME}`, 'create:5173'] });
     assert({ given: 'stale row', should: 'now name the live instance', actual: h.row()?.spriteInstanceId, expected: INSTANCE });
   });
 
@@ -143,7 +143,7 @@ describe('createDevPreviewDetector — port_opened', () => {
   it('re-points the relay when a known dev port appears on a different port', async () => {
     const h = harness({ relay: relayInfo(5173), row: { id: 'r', spriteInstanceId: INSTANCE, sandboxId: 'sbx', targetPort: 5173, relayServiceName: PREVIEW_RELAY_SERVICE_NAME, detectedAt: NOW, stoppedByUserAt: null } });
     await h.detector.onFrame({ type: 'port_opened', port: 3000 });
-    assert({ given: 'next dev after vite', should: 'remove, create 3000, upsert', actual: h.calls, expected: [`remove:${PREVIEW_RELAY_SERVICE_NAME}`, 'create:3000', `upsert:3000:${PREVIEW_RELAY_SERVICE_NAME}`] });
+    assert({ given: 'next dev after vite', should: 'upsert, then remove and re-create on the new port', actual: h.calls, expected: [`upsert:3000:${PREVIEW_RELAY_SERVICE_NAME}`, `remove:${PREVIEW_RELAY_SERVICE_NAME}`, 'create:3000'] });
   });
 });
 
@@ -154,13 +154,13 @@ describe('createDevPreviewDetector — port_list snapshot', () => {
     h.calls.length = 0;
     await h.detector.onFrame({ type: 'port_list', ports: [{ port: 9229 }, { port: 5432 }, { port: 5173, pid: 3 }] });
     assert({ given: 'a snapshot with inspector, db and vite', should: 'replace listeners', actual: h.detector.listeners(), expected: [{ port: 9229 }, { port: 5432 }, { port: 5173, pid: 3 }] });
-    assert({ given: 'the snapshot', should: 're-point the 1111 relay at vite (the inspector is never a candidate over a known port)', actual: h.calls, expected: [`remove:${PREVIEW_RELAY_SERVICE_NAME}`, 'create:5173', `upsert:5173:${PREVIEW_RELAY_SERVICE_NAME}`] });
+    assert({ given: 'the snapshot', should: 're-point the 1111 relay at vite (the inspector is never a candidate over a known port)', actual: h.calls, expected: [`upsert:5173:${PREVIEW_RELAY_SERVICE_NAME}`, `remove:${PREVIEW_RELAY_SERVICE_NAME}`, 'create:5173'] });
   });
 
   it('plans ONE candidate per snapshot: two known dev ports do not replace each other, and a still-listening row target wins', async () => {
     const h = harness();
     await h.detector.onFrame({ type: 'port_list', ports: [{ port: 5173 }, { port: 3000 }] });
-    assert({ given: 'vite and next both listening, no row', should: 'plan only the lowest known port', actual: h.calls, expected: ['create:3000', `upsert:3000:${PREVIEW_RELAY_SERVICE_NAME}`] });
+    assert({ given: 'vite and next both listening, no row', should: 'plan only the lowest known port', actual: h.calls, expected: [`upsert:3000:${PREVIEW_RELAY_SERVICE_NAME}`, 'create:3000'] });
     h.calls.length = 0;
     await h.detector.onFrame({ type: 'port_list', ports: [{ port: 5173 }, { port: 3000 }] });
     assert({ given: 'the same snapshot again (a reconnect)', should: 'change nothing', actual: h.calls, expected: [] });
@@ -172,7 +172,7 @@ describe('createDevPreviewDetector — port_list snapshot', () => {
   it('with no candidate, reconciles the row (a crashed relay is restarted; a row without a relay gets one)', async () => {
     const h = harness({ relay: relayInfo(5173, 'node', 'failed'), row: { id: 'r', spriteInstanceId: INSTANCE, sandboxId: 'sbx', targetPort: 5173, relayServiceName: PREVIEW_RELAY_SERVICE_NAME, detectedAt: NOW, stoppedByUserAt: null } });
     await h.detector.onFrame({ type: 'port_list', ports: [{ port: 5432 }] });
-    assert({ given: 'a failed relay and a row', should: 'start it again', actual: h.calls, expected: [`start:${PREVIEW_RELAY_SERVICE_NAME}`, `upsert:5173:${PREVIEW_RELAY_SERVICE_NAME}`] });
+    assert({ given: 'a failed relay and a row', should: 'start it again', actual: h.calls, expected: [`upsert:5173:${PREVIEW_RELAY_SERVICE_NAME}`, `start:${PREVIEW_RELAY_SERVICE_NAME}`] });
   });
 });
 
@@ -186,14 +186,18 @@ describe('createDevPreviewDetector — discipline', () => {
       given: 'two frames fired without awaiting',
       should: 'plan 5173 first, then replace with 3000',
       actual: h.calls,
-      expected: ['create:5173', `upsert:5173:${PREVIEW_RELAY_SERVICE_NAME}`, `remove:${PREVIEW_RELAY_SERVICE_NAME}`, 'create:3000', `upsert:3000:${PREVIEW_RELAY_SERVICE_NAME}`],
+      expected: [`upsert:5173:${PREVIEW_RELAY_SERVICE_NAME}`, 'create:5173', `upsert:3000:${PREVIEW_RELAY_SERVICE_NAME}`, `remove:${PREVIEW_RELAY_SERVICE_NAME}`, 'create:3000'],
     });
   });
 
   it('a failed effect is logged, writes no row, and does not poison the next frame', async () => {
     const h = harness({ failCreate: true });
     await h.detector.onFrame({ type: 'port_opened', port: 5173 });
-    assert({ given: 'create threw', should: 'log and write nothing', actual: { calls: h.calls, row: h.row() }, expected: { calls: ['create:5173'], row: null } });
+    // Row-first: the row IS written before the failing create, and that is
+    // what makes the failure recoverable — the next frame reads a row naming
+    // a relay the sprite lacks and plans the create again. What must not
+    // happen is a poisoned chain, which the following frame proves.
+    assert({ given: 'create threw', should: 'log, and leave the row ahead of the sprite', actual: { calls: h.calls, target: h.row()?.targetPort ?? null }, expected: { calls: [`upsert:5173:${PREVIEW_RELAY_SERVICE_NAME}`, 'create:5173'], target: 5173 } });
     expect(h.logs.some((l) => l.startsWith('error:dev-preview: frame failed:bind failed'))).toBe(true);
     await expect(h.detector.onFrame({ type: 'port_closed', port: 5173 })).resolves.toBeUndefined();
   });

--- a/packages/lib/src/services/sandbox/preview/__tests__/dev-preview-detection.test.ts
+++ b/packages/lib/src/services/sandbox/preview/__tests__/dev-preview-detection.test.ts
@@ -43,6 +43,7 @@ function harness(overrides: {
   };
   const store: DevPreviewStore = {
     approvePort: async () => null,
+    findStoppedWithRelay: async () => [],
     // `readsAheadOfWrites` models the real race: the planner reads the row as
     // it was, and by the time the write lands the STORED row has moved on
     // (a user's stop). The write then meets the same compare-and-set the real

--- a/packages/lib/src/services/sandbox/preview/__tests__/dev-preview-detection.test.ts
+++ b/packages/lib/src/services/sandbox/preview/__tests__/dev-preview-detection.test.ts
@@ -44,6 +44,7 @@ function harness(overrides: {
   const store: DevPreviewStore = {
     approvePort: async () => null,
     findStoppedWithRelay: async () => [],
+    markSwept: async () => {},
     // `readsAheadOfWrites` models the real race: the planner reads the row as
     // it was, and by the time the write lands the STORED row has moved on
     // (a user's stop). The write then meets the same compare-and-set the real
@@ -61,7 +62,7 @@ function harness(overrides: {
         calls.push('upsert-refused');
         return false;
       }
-      row = { id: 'r', spriteInstanceId: intent.spriteInstanceId, sandboxId: intent.sandboxId, targetPort: intent.targetPort, relayServiceName: intent.relayServiceName, detectedAt: intent.detectedAt, stoppedByUserAt: null, approvedPort: null };
+      row = { id: 'r', spriteInstanceId: intent.spriteInstanceId, sandboxId: intent.sandboxId, targetPort: intent.targetPort, relayServiceName: intent.relayServiceName, detectedAt: intent.detectedAt, stoppedByUserAt: null, approvedPort: null, approvedAt: null };
       return true;
     },
     setStoppedByUser: async () => null,
@@ -100,6 +101,10 @@ describe('createDevPreviewDetector — port_opened', () => {
 
   it('prefers socat when the probe finds it, and re-plans with it so the created relay IS the socat spec', async () => {
     const h = harness({ runtime: 'socat' });
+    // The platform sends a `port_list` on connect, always; without it the
+    // accumulated set is NOT a current picture of the sprite and the core
+    // refuses to plan a relay start against it.
+    await h.detector.onFrame({ type: 'port_list', ports: [] });
     await h.detector.onFrame({ type: 'port_opened', port: 5173 });
     assert({ given: 'socat present', should: 'create with the socat command', actual: h.relay()?.command, expected: 'socat' });
   });
@@ -115,15 +120,19 @@ describe('createDevPreviewDetector — port_opened', () => {
   });
 
   it('honours the core: a row for a DEAD instance is ignored and the preview is re-created on the live one', async () => {
-    const stale: DevPreviewRecord = { id: 'r', spriteInstanceId: 'inst-0', sandboxId: 'sbx', targetPort: 3000, relayServiceName: PREVIEW_RELAY_SERVICE_NAME, detectedAt: NOW, stoppedByUserAt: null, approvedPort: null };
+    const stale: DevPreviewRecord = { id: 'r', spriteInstanceId: 'inst-0', sandboxId: 'sbx', targetPort: 3000, relayServiceName: PREVIEW_RELAY_SERVICE_NAME, detectedAt: NOW, stoppedByUserAt: null, approvedPort: null, approvedAt: null };
     const h = harness({ row: stale });
+    // The platform sends a `port_list` on connect, always; without it the
+    // accumulated set is NOT a current picture of the sprite and the core
+    // refuses to plan a relay start against it.
+    await h.detector.onFrame({ type: 'port_list', ports: [] });
     await h.detector.onFrame({ type: 'port_opened', port: 5173 });
     assert({ given: 'stale row', should: 'replace the row for the live instance, then create', actual: h.calls, expected: [`upsert:5173:${PREVIEW_RELAY_SERVICE_NAME}`, 'create:5173'] });
     assert({ given: 'stale row', should: 'now name the live instance', actual: h.row()?.spriteInstanceId, expected: INSTANCE });
   });
 
   it('honours the core: a user-stopped preview is NOT restarted by a new detection', async () => {
-    const stopped: DevPreviewRecord = { id: 'r', spriteInstanceId: INSTANCE, sandboxId: 'sbx', targetPort: 5173, relayServiceName: PREVIEW_RELAY_SERVICE_NAME, detectedAt: NOW, stoppedByUserAt: NOW, approvedPort: null };
+    const stopped: DevPreviewRecord = { id: 'r', spriteInstanceId: INSTANCE, sandboxId: 'sbx', targetPort: 5173, relayServiceName: PREVIEW_RELAY_SERVICE_NAME, detectedAt: NOW, stoppedByUserAt: NOW, approvedPort: null, approvedAt: null };
     const h = harness({ row: stopped });
     await h.detector.onFrame({ type: 'port_opened', port: 5173 });
     assert({ given: 'stoppedByUserAt set, relay not alive', should: 'do nothing', actual: h.calls, expected: [] });
@@ -145,7 +154,11 @@ describe('createDevPreviewDetector — port_opened', () => {
   });
 
   it('re-points the relay when a known dev port appears on a different port', async () => {
-    const h = harness({ relay: relayInfo(5173), row: { id: 'r', spriteInstanceId: INSTANCE, sandboxId: 'sbx', targetPort: 5173, relayServiceName: PREVIEW_RELAY_SERVICE_NAME, detectedAt: NOW, stoppedByUserAt: null, approvedPort: null } });
+    const h = harness({ relay: relayInfo(5173), row: { id: 'r', spriteInstanceId: INSTANCE, sandboxId: 'sbx', targetPort: 5173, relayServiceName: PREVIEW_RELAY_SERVICE_NAME, detectedAt: NOW, stoppedByUserAt: null, approvedPort: null, approvedAt: null } });
+    // The platform sends a `port_list` on connect, always; without it the
+    // accumulated set is NOT a current picture of the sprite and the core
+    // refuses to plan a relay start against it.
+    await h.detector.onFrame({ type: 'port_list', ports: [] });
     await h.detector.onFrame({ type: 'port_opened', port: 3000 });
     assert({ given: 'next dev after vite', should: 'upsert, then remove and re-create on the new port', actual: h.calls, expected: [`upsert:3000:${PREVIEW_RELAY_SERVICE_NAME}`, `remove:${PREVIEW_RELAY_SERVICE_NAME}`, 'create:3000'] });
   });
@@ -171,13 +184,13 @@ describe('createDevPreviewDetector — port_list snapshot', () => {
     h.calls.length = 0;
     await h.detector.onFrame({ type: 'port_list', ports: [{ port: 5173 }, { port: 3000 }] });
     assert({ given: 'the same snapshot again (a reconnect)', should: 'change nothing', actual: h.calls, expected: [] });
-    const g = harness({ relay: relayInfo(5173), row: { id: 'r', spriteInstanceId: INSTANCE, sandboxId: 'sbx', targetPort: 5173, relayServiceName: PREVIEW_RELAY_SERVICE_NAME, detectedAt: NOW, stoppedByUserAt: null, approvedPort: null } });
+    const g = harness({ relay: relayInfo(5173), row: { id: 'r', spriteInstanceId: INSTANCE, sandboxId: 'sbx', targetPort: 5173, relayServiceName: PREVIEW_RELAY_SERVICE_NAME, detectedAt: NOW, stoppedByUserAt: null, approvedPort: null, approvedAt: null } });
     await g.detector.onFrame({ type: 'port_list', ports: [{ port: 3000 }, { port: 5173 }] });
     assert({ given: 'a row on 5173 still listening beside 3000', should: 'keep the working preview', actual: g.calls, expected: [] });
   });
 
   it('with no candidate, reconciles the row (a crashed relay is restarted; a row without a relay gets one)', async () => {
-    const h = harness({ relay: relayInfo(5173, 'node', 'failed'), row: { id: 'r', spriteInstanceId: INSTANCE, sandboxId: 'sbx', targetPort: 5173, relayServiceName: PREVIEW_RELAY_SERVICE_NAME, detectedAt: NOW, stoppedByUserAt: null, approvedPort: null } });
+    const h = harness({ relay: relayInfo(5173, 'node', 'failed'), row: { id: 'r', spriteInstanceId: INSTANCE, sandboxId: 'sbx', targetPort: 5173, relayServiceName: PREVIEW_RELAY_SERVICE_NAME, detectedAt: NOW, stoppedByUserAt: null, approvedPort: null, approvedAt: null } });
     await h.detector.onFrame({ type: 'port_list', ports: [{ port: 5432 }] });
     assert({ given: 'a failed relay and a row', should: 'start it again', actual: h.calls, expected: [`upsert:5173:${PREVIEW_RELAY_SERVICE_NAME}`, `start:${PREVIEW_RELAY_SERVICE_NAME}`] });
   });
@@ -186,6 +199,10 @@ describe('createDevPreviewDetector — port_list snapshot', () => {
 describe('createDevPreviewDetector — discipline', () => {
   it('processes frames strictly in order, one at a time', async () => {
     const h = harness();
+    // The platform sends a `port_list` on connect, always; without it the
+    // accumulated set is NOT a current picture of the sprite and the core
+    // refuses to plan a relay start against it.
+    await h.detector.onFrame({ type: 'port_list', ports: [] });
     const a = h.detector.onFrame({ type: 'port_opened', port: 5173 });
     const b = h.detector.onFrame({ type: 'port_opened', port: 3000 });
     await Promise.all([a, b]);
@@ -199,6 +216,10 @@ describe('createDevPreviewDetector — discipline', () => {
 
   it('a failed effect is logged, writes no row, and does not poison the next frame', async () => {
     const h = harness({ failCreate: true });
+    // The platform sends a `port_list` on connect, always; without it the
+    // accumulated set is NOT a current picture of the sprite and the core
+    // refuses to plan a relay start against it.
+    await h.detector.onFrame({ type: 'port_list', ports: [] });
     await h.detector.onFrame({ type: 'port_opened', port: 5173 });
     // Row-first: the row IS written before the failing create, and that is
     // what makes the failure recoverable — the next frame reads a row naming
@@ -234,11 +255,30 @@ describe('createDevPreviewDetector — discipline', () => {
 
   it('USER INTENT WINS THE RACE: a frame that planned from a row read BEFORE the user\'s stop starts the relay but cannot clear the stop — the click survives, and the next frame plans from the row that won', async () => {
     const stoppedAt = new Date('2026-09-06T13:00:00.000Z');
-    const stored = { id: 'r', spriteInstanceId: 'inst-1', sandboxId: 'sbx', targetPort: 5173, relayServiceName: PREVIEW_RELAY_SERVICE_NAME, detectedAt: new Date('2026-09-06T12:00:00.000Z'), stoppedByUserAt: stoppedAt, approvedPort: null };
+    const stored = { id: 'r', spriteInstanceId: 'inst-1', sandboxId: 'sbx', targetPort: 5173, relayServiceName: PREVIEW_RELAY_SERVICE_NAME, detectedAt: new Date('2026-09-06T12:00:00.000Z'), stoppedByUserAt: stoppedAt, approvedPort: null, approvedAt: null };
     // The planner reads the PRE-stop row; the store already holds the stop.
-    const h = harness({ row: stored, readsAheadOfWrites: { ...stored, stoppedByUserAt: null, approvedPort: null }, relay: relayInfo(5173, 'node', 'failed') });
+    const h = harness({ row: stored, readsAheadOfWrites: { ...stored, stoppedByUserAt: null, approvedPort: null, approvedAt: null }, relay: relayInfo(5173, 'node', 'failed') });
+    // The platform sends a `port_list` on connect, always; without it the
+    // accumulated set is NOT a current picture of the sprite and the core
+    // refuses to plan a relay start against it.
+    await h.detector.onFrame({ type: 'port_list', ports: [] });
     await h.detector.onFrame({ type: 'port_opened', port: 5173, pid: 11 });
     assert({ given: 'a stop that landed after the plan\'s read', should: 'attempt the write and be refused by the guard', actual: h.calls.includes('upsert-refused'), expected: true });
     assert({ given: 'the refused write', should: 'leave the user\'s stop intact', actual: h.row()?.stoppedByUserAt, expected: stoppedAt });
+  });
+
+  it('will not start a relay from a set that is not a CURRENT picture of the sprite', async () => {
+    // A `port_opened` before this connection's `port_list` — or one still
+    // queued behind a drop — carries no evidence about port 8080. Planning a
+    // relay start from it is exactly the "unknown read as free" the core
+    // refuses; the platform's own snapshot lands moments later and the same
+    // detection then starts for real.
+    const h = harness();
+    await h.detector.onFrame({ type: 'port_opened', port: 5173, pid: 11 });
+    assert({ given: 'a detection before any snapshot', should: 'start nothing', actual: h.calls, expected: [] });
+    assert({ given: 'no snapshot yet', should: 'report the set as unknown', actual: h.detector.listeners(), expected: null });
+
+    await h.detector.onFrame({ type: 'port_list', ports: [{ port: 5173, pid: 11 }] });
+    assert({ given: 'the snapshot arriving', should: 'start the relay for real', actual: h.calls, expected: [`upsert:5173:${PREVIEW_RELAY_SERVICE_NAME}`, 'create:5173'] });
   });
 });

--- a/packages/lib/src/services/sandbox/preview/__tests__/dev-preview-detection.test.ts
+++ b/packages/lib/src/services/sandbox/preview/__tests__/dev-preview-detection.test.ts
@@ -42,13 +42,16 @@ function harness(overrides: {
     remove: async (name) => { calls.push(`remove:${name}`); relay = null; },
   };
   const store: DevPreviewStore = {
+    approvePort: async () => null,
     // `readsAheadOfWrites` models the real race: the planner reads the row as
     // it was, and by the time the write lands the STORED row has moved on
     // (a user's stop). The write then meets the same compare-and-set the real
     // store applies.
     findByHolder: async () => overrides.readsAheadOfWrites ?? row,
     upsert: async (intent: DevPreviewRowIntent) => {
-      calls.push(`upsert:${intent.targetPort}:${intent.relayServiceName ?? 'direct'}`);
+      // No relay name means the row serves nothing through 8080: the user's
+      // own server IS 8080 ('direct'), or the port is not shared yet.
+      calls.push(`upsert:${intent.targetPort}:${intent.relayServiceName ?? (intent.targetPort === 8080 ? 'direct' : 'unshared')}`);
       const storedIntent = row === null || row.spriteInstanceId !== intent.spriteInstanceId ? null : row.stoppedByUserAt;
       const guardHolds = row !== null && row.spriteInstanceId !== intent.spriteInstanceId
         ? true
@@ -57,7 +60,7 @@ function harness(overrides: {
         calls.push('upsert-refused');
         return false;
       }
-      row = { id: 'r', spriteInstanceId: intent.spriteInstanceId, sandboxId: intent.sandboxId, targetPort: intent.targetPort, relayServiceName: intent.relayServiceName, detectedAt: intent.detectedAt, stoppedByUserAt: null };
+      row = { id: 'r', spriteInstanceId: intent.spriteInstanceId, sandboxId: intent.sandboxId, targetPort: intent.targetPort, relayServiceName: intent.relayServiceName, detectedAt: intent.detectedAt, stoppedByUserAt: null, approvedPort: null };
       return true;
     },
     setStoppedByUser: async () => null,
@@ -111,7 +114,7 @@ describe('createDevPreviewDetector — port_opened', () => {
   });
 
   it('honours the core: a row for a DEAD instance is ignored and the preview is re-created on the live one', async () => {
-    const stale: DevPreviewRecord = { id: 'r', spriteInstanceId: 'inst-0', sandboxId: 'sbx', targetPort: 3000, relayServiceName: PREVIEW_RELAY_SERVICE_NAME, detectedAt: NOW, stoppedByUserAt: null };
+    const stale: DevPreviewRecord = { id: 'r', spriteInstanceId: 'inst-0', sandboxId: 'sbx', targetPort: 3000, relayServiceName: PREVIEW_RELAY_SERVICE_NAME, detectedAt: NOW, stoppedByUserAt: null, approvedPort: null };
     const h = harness({ row: stale });
     await h.detector.onFrame({ type: 'port_opened', port: 5173 });
     assert({ given: 'stale row', should: 'replace the row for the live instance, then create', actual: h.calls, expected: [`upsert:5173:${PREVIEW_RELAY_SERVICE_NAME}`, 'create:5173'] });
@@ -119,7 +122,7 @@ describe('createDevPreviewDetector — port_opened', () => {
   });
 
   it('honours the core: a user-stopped preview is NOT restarted by a new detection', async () => {
-    const stopped: DevPreviewRecord = { id: 'r', spriteInstanceId: INSTANCE, sandboxId: 'sbx', targetPort: 5173, relayServiceName: PREVIEW_RELAY_SERVICE_NAME, detectedAt: NOW, stoppedByUserAt: NOW };
+    const stopped: DevPreviewRecord = { id: 'r', spriteInstanceId: INSTANCE, sandboxId: 'sbx', targetPort: 5173, relayServiceName: PREVIEW_RELAY_SERVICE_NAME, detectedAt: NOW, stoppedByUserAt: NOW, approvedPort: null };
     const h = harness({ row: stopped });
     await h.detector.onFrame({ type: 'port_opened', port: 5173 });
     assert({ given: 'stoppedByUserAt set, relay not alive', should: 'do nothing', actual: h.calls, expected: [] });
@@ -141,7 +144,7 @@ describe('createDevPreviewDetector — port_opened', () => {
   });
 
   it('re-points the relay when a known dev port appears on a different port', async () => {
-    const h = harness({ relay: relayInfo(5173), row: { id: 'r', spriteInstanceId: INSTANCE, sandboxId: 'sbx', targetPort: 5173, relayServiceName: PREVIEW_RELAY_SERVICE_NAME, detectedAt: NOW, stoppedByUserAt: null } });
+    const h = harness({ relay: relayInfo(5173), row: { id: 'r', spriteInstanceId: INSTANCE, sandboxId: 'sbx', targetPort: 5173, relayServiceName: PREVIEW_RELAY_SERVICE_NAME, detectedAt: NOW, stoppedByUserAt: null, approvedPort: null } });
     await h.detector.onFrame({ type: 'port_opened', port: 3000 });
     assert({ given: 'next dev after vite', should: 'upsert, then remove and re-create on the new port', actual: h.calls, expected: [`upsert:3000:${PREVIEW_RELAY_SERVICE_NAME}`, `remove:${PREVIEW_RELAY_SERVICE_NAME}`, 'create:3000'] });
   });
@@ -150,11 +153,14 @@ describe('createDevPreviewDetector — port_opened', () => {
 describe('createDevPreviewDetector — port_list snapshot', () => {
   it('replaces the listener set and plans the known dev port first', async () => {
     const h = harness();
+    // 1111 is unlisted, so it is RECORDED and nothing is started — there is
+    // no relay for the later snapshot to re-point, only a target to move.
     await h.detector.onFrame({ type: 'port_opened', port: 1111 });
+    assert({ given: 'an unlisted 1111', should: 'record the port and start nothing', actual: h.calls, expected: ['upsert:1111:unshared'] });
     h.calls.length = 0;
     await h.detector.onFrame({ type: 'port_list', ports: [{ port: 9229 }, { port: 5432 }, { port: 5173, pid: 3 }] });
     assert({ given: 'a snapshot with inspector, db and vite', should: 'replace listeners', actual: h.detector.listeners(), expected: [{ port: 9229 }, { port: 5432 }, { port: 5173, pid: 3 }] });
-    assert({ given: 'the snapshot', should: 're-point the 1111 relay at vite (the inspector is never a candidate over a known port)', actual: h.calls, expected: [`upsert:5173:${PREVIEW_RELAY_SERVICE_NAME}`, `remove:${PREVIEW_RELAY_SERVICE_NAME}`, 'create:5173'] });
+    assert({ given: 'the snapshot', should: 'take vite as the target and relay it (the inspector is never a candidate over a known port)', actual: h.calls, expected: [`upsert:5173:${PREVIEW_RELAY_SERVICE_NAME}`, 'create:5173'] });
   });
 
   it('plans ONE candidate per snapshot: two known dev ports do not replace each other, and a still-listening row target wins', async () => {
@@ -164,13 +170,13 @@ describe('createDevPreviewDetector — port_list snapshot', () => {
     h.calls.length = 0;
     await h.detector.onFrame({ type: 'port_list', ports: [{ port: 5173 }, { port: 3000 }] });
     assert({ given: 'the same snapshot again (a reconnect)', should: 'change nothing', actual: h.calls, expected: [] });
-    const g = harness({ relay: relayInfo(5173), row: { id: 'r', spriteInstanceId: INSTANCE, sandboxId: 'sbx', targetPort: 5173, relayServiceName: PREVIEW_RELAY_SERVICE_NAME, detectedAt: NOW, stoppedByUserAt: null } });
+    const g = harness({ relay: relayInfo(5173), row: { id: 'r', spriteInstanceId: INSTANCE, sandboxId: 'sbx', targetPort: 5173, relayServiceName: PREVIEW_RELAY_SERVICE_NAME, detectedAt: NOW, stoppedByUserAt: null, approvedPort: null } });
     await g.detector.onFrame({ type: 'port_list', ports: [{ port: 3000 }, { port: 5173 }] });
     assert({ given: 'a row on 5173 still listening beside 3000', should: 'keep the working preview', actual: g.calls, expected: [] });
   });
 
   it('with no candidate, reconciles the row (a crashed relay is restarted; a row without a relay gets one)', async () => {
-    const h = harness({ relay: relayInfo(5173, 'node', 'failed'), row: { id: 'r', spriteInstanceId: INSTANCE, sandboxId: 'sbx', targetPort: 5173, relayServiceName: PREVIEW_RELAY_SERVICE_NAME, detectedAt: NOW, stoppedByUserAt: null } });
+    const h = harness({ relay: relayInfo(5173, 'node', 'failed'), row: { id: 'r', spriteInstanceId: INSTANCE, sandboxId: 'sbx', targetPort: 5173, relayServiceName: PREVIEW_RELAY_SERVICE_NAME, detectedAt: NOW, stoppedByUserAt: null, approvedPort: null } });
     await h.detector.onFrame({ type: 'port_list', ports: [{ port: 5432 }] });
     assert({ given: 'a failed relay and a row', should: 'start it again', actual: h.calls, expected: [`upsert:5173:${PREVIEW_RELAY_SERVICE_NAME}`, `start:${PREVIEW_RELAY_SERVICE_NAME}`] });
   });
@@ -227,9 +233,9 @@ describe('createDevPreviewDetector — discipline', () => {
 
   it('USER INTENT WINS THE RACE: a frame that planned from a row read BEFORE the user\'s stop starts the relay but cannot clear the stop — the click survives, and the next frame plans from the row that won', async () => {
     const stoppedAt = new Date('2026-09-06T13:00:00.000Z');
-    const stored = { id: 'r', spriteInstanceId: 'inst-1', sandboxId: 'sbx', targetPort: 5173, relayServiceName: PREVIEW_RELAY_SERVICE_NAME, detectedAt: new Date('2026-09-06T12:00:00.000Z'), stoppedByUserAt: stoppedAt };
+    const stored = { id: 'r', spriteInstanceId: 'inst-1', sandboxId: 'sbx', targetPort: 5173, relayServiceName: PREVIEW_RELAY_SERVICE_NAME, detectedAt: new Date('2026-09-06T12:00:00.000Z'), stoppedByUserAt: stoppedAt, approvedPort: null };
     // The planner reads the PRE-stop row; the store already holds the stop.
-    const h = harness({ row: stored, readsAheadOfWrites: { ...stored, stoppedByUserAt: null }, relay: relayInfo(5173, 'node', 'failed') });
+    const h = harness({ row: stored, readsAheadOfWrites: { ...stored, stoppedByUserAt: null, approvedPort: null }, relay: relayInfo(5173, 'node', 'failed') });
     await h.detector.onFrame({ type: 'port_opened', port: 5173, pid: 11 });
     assert({ given: 'a stop that landed after the plan\'s read', should: 'attempt the write and be refused by the guard', actual: h.calls.includes('upsert-refused'), expected: true });
     assert({ given: 'the refused write', should: 'leave the user\'s stop intact', actual: h.row()?.stoppedByUserAt, expected: stoppedAt });

--- a/packages/lib/src/services/sandbox/preview/__tests__/dev-preview-effects.test.ts
+++ b/packages/lib/src/services/sandbox/preview/__tests__/dev-preview-effects.test.ts
@@ -3,6 +3,7 @@ import { assert } from '../../__tests__/riteway';
 import type { SandboxServicesApi } from '../../sandbox-host';
 import { applyDevServerServicePlan, probeRelayRuntime } from '../dev-preview-effects';
 import { buildPreviewRelaySpec, PREVIEW_RELAY_SERVICE_NAME } from '../preview-relay';
+import { planDevServerService } from '../dev-preview-core';
 import type { DevPreviewRowIntent, DevServerServicePlan } from '../dev-preview-core';
 
 const ROW: DevPreviewRowIntent = {
@@ -117,7 +118,7 @@ describe('applyDevServerServicePlan — obeys the plan, adds nothing', () => {
       given: 'a stop-relay for a stop the user has cleared',
       should: 'stop nothing and report skipped/resumed',
       actual: { applied: await applyDevServerServicePlan({ plan: stopPlan, services: resumed.services, store: resumedStore.store }), calls: resumed.calls },
-      expected: { applied: { action: 'skipped', reason: 'resumed' }, calls: [] },
+      expected: { applied: { action: 'skipped', reason: 'resumed', mutated: 'none' }, calls: [] },
     });
     const gone = fakeServices();
     const goneStore = fakeStore({ missing: true });
@@ -125,7 +126,7 @@ describe('applyDevServerServicePlan — obeys the plan, adds nothing', () => {
       given: 'a stop-relay for a holder whose row has gone',
       should: 'stop nothing',
       actual: { applied: await applyDevServerServicePlan({ plan: stopPlan, services: gone.services, store: goneStore.store }), calls: gone.calls },
-      expected: { applied: { action: 'skipped', reason: 'resumed' }, calls: [] },
+      expected: { applied: { action: 'skipped', reason: 'resumed', mutated: 'none' }, calls: [] },
     });
     // The write side: the service call still happened (it was planned from a
     // truthful read), but the row write is refused, so the user's stop stands.
@@ -133,23 +134,23 @@ describe('applyDevServerServicePlan — obeys the plan, adds nothing', () => {
     const refusing = fakeStore({ accepts: false });
     assert({
       given: 'a start-relay whose row write the intent guard refuses',
-      should: 'report skipped/intent-changed, having started the relay',
+      should: 'report skipped/intent-changed WITHOUT having touched the sprite — the row is written first',
       actual: { applied: await applyDevServerServicePlan({ plan: { action: 'start-relay', via: 'create', service: spec, row: ROW }, services: started.services, store: refusing.store }), calls: started.calls.length },
-      expected: { applied: { action: 'skipped', reason: 'intent-changed' }, calls: 1 },
+      expected: { applied: { action: 'skipped', reason: 'intent-changed', mutated: 'none' }, calls: 0 },
     });
     const replacing = fakeStore({ accepts: false });
     assert({
       given: 'a replace-relay the guard refuses',
       should: 'report skipped/intent-changed',
       actual: await applyDevServerServicePlan({ plan: { action: 'replace-relay', previousTargetPort: 3000, service: spec, row: ROW }, services: fakeServices().services, store: replacing.store }),
-      expected: { action: 'skipped', reason: 'intent-changed' },
+      expected: { action: 'skipped', reason: 'intent-changed', mutated: 'none' },
     });
     const direct = fakeStore({ accepts: false });
     assert({
       given: 'a record-direct the guard refuses',
       should: 'report skipped/intent-changed',
       actual: await applyDevServerServicePlan({ plan: { action: 'record-direct', removeRelay: false, row: { ...ROW, targetPort: 8080, relayServiceName: null } }, services: fakeServices().services, store: direct.store }),
-      expected: { action: 'skipped', reason: 'intent-changed' },
+      expected: { action: 'skipped', reason: 'intent-changed', mutated: 'none' },
     });
   });
 
@@ -163,11 +164,55 @@ describe('applyDevServerServicePlan — obeys the plan, adds nothing', () => {
     assert({ given: 'refuse', should: 'report with port', actual: refuse, expected: { action: 'refuse', reason: 'http-port-busy', targetPort: 5173 } });
   });
 
-  it('a failed service call aborts BEFORE the row is written — never a row for a relay that did not start', async () => {
+  it('a failed service call leaves the row AHEAD of the sprite, and the throw still propagates', async () => {
+    // This replaces the old assertion that the row was written last. The row
+    // is deliberately written first now: a row naming a relay the sprite does
+    // not have reads as `down` and is re-planned as a create (see the
+    // self-heal test below), whereas a relay with no row is invisible to the
+    // planner forever. The docblock in dev-preview-effects.ts has the full
+    // argument.
     const { services, calls } = fakeServices({ create: new Error('bind failed') });
     const { store, written } = fakeStore();
     await expect(applyDevServerServicePlan({ plan: { action: 'start-relay', via: 'create', service: spec, row: ROW }, services, store })).rejects.toThrow('bind failed');
-    assert({ given: 'create threw', should: 'write no row', actual: { calls, written }, expected: { calls: [`create:${spec.name}:node:${spec.args.length}`], written: [] } });
+    assert({ given: 'create threw', should: 'have written the row before attempting the service call', actual: { calls, written: written.length }, expected: { calls: [`create:${spec.name}:node:${spec.args.length}`], written: 1 } });
+  });
+
+  it('ROW FIRST: every refused plan leaves the sprite untouched, so a refusal costs nothing', async () => {
+    // The invariant the ordering exists for. Under the old service-first
+    // order each of these left a relay created/started/removed on the sprite
+    // with no row naming it — a relay the planner could never see again.
+    for (const plan of [
+      { action: 'start-relay', via: 'create', service: spec, row: ROW },
+      { action: 'start-relay', via: 'start', service: spec, row: ROW },
+      { action: 'replace-relay', previousTargetPort: 3000, service: spec, row: ROW },
+      { action: 'record-direct', removeRelay: true, row: { ...ROW, targetPort: 8080, relayServiceName: null } },
+    ] satisfies DevServerServicePlan[]) {
+      const { services, calls } = fakeServices();
+      const { store } = fakeStore({ accepts: false });
+      const applied = await applyDevServerServicePlan({ plan, services, store });
+      assert({ given: `a refused ${plan.action}`, should: 'touch no service at all', actual: { applied, calls }, expected: { applied: { action: 'skipped', reason: 'intent-changed', mutated: 'none' }, calls: [] } });
+    }
+  });
+
+  it('ROW AHEAD OF SPRITE SELF-HEALS: a row written before a service call that then throws is re-planned as a create — the shape that makes row-first safe', async () => {
+    const { services, calls } = fakeServices({ create: new Error('bind failed') });
+    const { store, written } = fakeStore();
+    await expect(applyDevServerServicePlan({ plan: { action: 'start-relay', via: 'create', service: spec, row: ROW }, services, store })).rejects.toThrow('bind failed');
+    assert({ given: 'a service call that threw', should: 'still have written the row first', actual: { written: written.length, calls }, expected: { written: 1, calls: [`create:${spec.name}:node:${spec.args.length}`] } });
+
+    // The row now names a relay the sprite does not have. The planner reads
+    // exactly that and plans the create again — no orphan, no dead end.
+    const replanned = planDevServerService({
+      liveInstanceId: ROW.spriteInstanceId,
+      sandboxId: ROW.sandboxId,
+      holder: ROW.holder,
+      row: { spriteInstanceId: ROW.spriteInstanceId, sandboxId: ROW.sandboxId, targetPort: ROW.targetPort, relayServiceName: ROW.relayServiceName, detectedAt: ROW.detectedAt, stoppedByUserAt: null },
+      detected: null,
+      relay: null,
+      listeners: [{ port: 5173, pid: 3 }],
+      now: new Date('2026-09-06T02:00:00Z'),
+    });
+    assert({ given: 'the row the failed attempt left behind', should: 'plan the create again', actual: replanned.action === 'start-relay' && replanned.via, expected: 'create' });
   });
 });
 

--- a/packages/lib/src/services/sandbox/preview/__tests__/dev-preview-effects.test.ts
+++ b/packages/lib/src/services/sandbox/preview/__tests__/dev-preview-effects.test.ts
@@ -45,13 +45,18 @@ function fakeServices(failing: Partial<Record<keyof SandboxServicesApi, Error>> 
 function fakeStore({ accepts = true, stoppedByUserAt = null as Date | null, missing = false } = {}) {
   const written: DevPreviewRowIntent[] = [];
   const reads: string[] = [];
+  const stopped: string[] = [];
   return {
     store: {
       upsert: async (intent: DevPreviewRowIntent) => { written.push(intent); return accepts; },
       findByHolder: async (holder: { kind: string; id: string }) => { reads.push(`${holder.kind}:${holder.id}`); return missing ? null : { stoppedByUserAt }; },
+      markRelayStopped: async ({ holder, relayServiceName }: { holder: { kind: string; id: string }; relayServiceName: string }) => {
+        stopped.push(`${holder.kind}:${holder.id}:${relayServiceName}`);
+      },
     },
     written,
     reads,
+    stopped,
   };
 }
 
@@ -101,12 +106,18 @@ describe('applyDevServerServicePlan — obeys the plan, adds nothing', () => {
 
   const stopPlan: DevServerServicePlan = { action: 'stop-relay', relayServiceName: 'pagespace-preview-relay', holder: ROW.holder, stoppedByUserAt: STOPPED_AT };
 
-  it('stop-relay: confirms the stop still stands, then stops the named relay and writes nothing (the intent is already on the row)', async () => {
+  it('stop-relay: confirms the stop still stands, stops the named relay, and RECORDS that it is stopped', async () => {
     const { services, calls } = fakeServices();
-    const { store, written, reads } = fakeStore({ stoppedByUserAt: STOPPED_AT });
+    const { store, written, reads, stopped } = fakeStore({ stoppedByUserAt: STOPPED_AT });
     const applied = await applyDevServerServicePlan({ plan: stopPlan, services, store });
-    assert({ given: 'stop plan, intent still set', should: 'read the intent then stop only', actual: { calls, written, reads }, expected: { calls: ['stop:pagespace-preview-relay'], written: [], reads: ['env:e1'] } });
+    assert({ given: 'stop plan, intent still set', should: 'read the intent, then stop, writing no ROW', actual: { calls, written, reads }, expected: { calls: ['stop:pagespace-preview-relay'], written: [], reads: ['env:e1'] } });
     assert({ given: 'the stop', should: 'report it', actual: applied, expected: { action: 'stop-relay', relayServiceName: 'pagespace-preview-relay' } });
+    // The row must stop naming a relay that is no longer running — AFTER the
+    // service call, never before. Without this the backstop sweep's candidate
+    // window never drains: the row keeps matching every few minutes for the
+    // life of the record, and a batch of stopped previews crowds out the
+    // holder who stopped one a minute ago.
+    assert({ given: 'a relay that was actually stopped', should: 'record it on the row', actual: stopped, expected: ['env:e1:pagespace-preview-relay'] });
   });
 
   it('USER INTENT WINS: a stop-relay planned before the user RESUMED stops nothing (the intent is gone), and a row write the guard refuses reports skipped', async () => {
@@ -116,9 +127,9 @@ describe('applyDevServerServicePlan — obeys the plan, adds nothing', () => {
     const resumedStore = fakeStore({ stoppedByUserAt: null });
     assert({
       given: 'a stop-relay for a stop the user has cleared',
-      should: 'stop nothing and report skipped/resumed',
-      actual: { applied: await applyDevServerServicePlan({ plan: stopPlan, services: resumed.services, store: resumedStore.store }), calls: resumed.calls },
-      expected: { applied: { action: 'skipped', reason: 'resumed', mutated: 'none' }, calls: [] },
+      should: 'stop nothing, record nothing, and report skipped/resumed',
+      actual: { applied: await applyDevServerServicePlan({ plan: stopPlan, services: resumed.services, store: resumedStore.store }), calls: resumed.calls, stopped: resumedStore.stopped },
+      expected: { applied: { action: 'skipped', reason: 'resumed', mutated: 'none' }, calls: [], stopped: [] },
     });
     const gone = fakeServices();
     const goneStore = fakeStore({ missing: true });

--- a/packages/lib/src/services/sandbox/preview/__tests__/dev-preview-effects.test.ts
+++ b/packages/lib/src/services/sandbox/preview/__tests__/dev-preview-effects.test.ts
@@ -13,7 +13,7 @@ const ROW: DevPreviewRowIntent = {
   targetPort: 5173,
   relayServiceName: PREVIEW_RELAY_SERVICE_NAME,
   detectedAt: new Date('2026-09-06T00:00:00Z'),
-  stoppedByUserAt: null, approvedPort: null,
+  stoppedByUserAt: null,
   basedOnStoppedByUserAt: null,
 };
 
@@ -206,7 +206,7 @@ describe('applyDevServerServicePlan — obeys the plan, adds nothing', () => {
       liveInstanceId: ROW.spriteInstanceId,
       sandboxId: ROW.sandboxId,
       holder: ROW.holder,
-      row: { spriteInstanceId: ROW.spriteInstanceId, sandboxId: ROW.sandboxId, targetPort: ROW.targetPort, relayServiceName: ROW.relayServiceName, detectedAt: ROW.detectedAt, stoppedByUserAt: null, approvedPort: null },
+      row: { spriteInstanceId: ROW.spriteInstanceId, sandboxId: ROW.sandboxId, targetPort: ROW.targetPort, relayServiceName: ROW.relayServiceName, detectedAt: ROW.detectedAt, stoppedByUserAt: null, approvedPort: null, approvedAt: null },
       detected: null,
       relay: null,
       listeners: [{ port: 5173, pid: 3 }],

--- a/packages/lib/src/services/sandbox/preview/__tests__/dev-preview-effects.test.ts
+++ b/packages/lib/src/services/sandbox/preview/__tests__/dev-preview-effects.test.ts
@@ -13,7 +13,7 @@ const ROW: DevPreviewRowIntent = {
   targetPort: 5173,
   relayServiceName: PREVIEW_RELAY_SERVICE_NAME,
   detectedAt: new Date('2026-09-06T00:00:00Z'),
-  stoppedByUserAt: null,
+  stoppedByUserAt: null, approvedPort: null,
   basedOnStoppedByUserAt: null,
 };
 
@@ -206,7 +206,7 @@ describe('applyDevServerServicePlan — obeys the plan, adds nothing', () => {
       liveInstanceId: ROW.spriteInstanceId,
       sandboxId: ROW.sandboxId,
       holder: ROW.holder,
-      row: { spriteInstanceId: ROW.spriteInstanceId, sandboxId: ROW.sandboxId, targetPort: ROW.targetPort, relayServiceName: ROW.relayServiceName, detectedAt: ROW.detectedAt, stoppedByUserAt: null },
+      row: { spriteInstanceId: ROW.spriteInstanceId, sandboxId: ROW.sandboxId, targetPort: ROW.targetPort, relayServiceName: ROW.relayServiceName, detectedAt: ROW.detectedAt, stoppedByUserAt: null, approvedPort: null },
       detected: null,
       relay: null,
       listeners: [{ port: 5173, pid: 3 }],

--- a/packages/lib/src/services/sandbox/preview/__tests__/dev-preview-env.test.ts
+++ b/packages/lib/src/services/sandbox/preview/__tests__/dev-preview-env.test.ts
@@ -1,0 +1,83 @@
+/**
+ * The dev-preview KILL SWITCH and the preview apex — the two reads every
+ * entry point in this feature asks first, and the reason a deployment that
+ * has not been configured has no preview surface at all rather than a broken
+ * one.
+ *
+ * Worth its own test because both fail CLOSED in ways that are easy to
+ * regress into failing open: the switch admits exactly the string `'true'`,
+ * and the apex has no default AND rejects an apex that shares a registrable
+ * domain with the app — the property that stops a dev server's own JavaScript
+ * setting cookies on the dashboard.
+ */
+import { describe, it, expect, afterEach } from 'vitest';
+import { assert } from '../../__tests__/riteway';
+import { isDevPreviewEnabled, isDevPreviewConfigured, resolveDevPreviewApex } from '../dev-preview-env';
+
+const KEYS = ['DEV_PREVIEW_ENABLED', 'DEV_PREVIEW_APEX', 'WEB_APP_URL'] as const;
+const saved = new Map<string, string | undefined>();
+
+function setEnv(values: Partial<Record<(typeof KEYS)[number], string | undefined>>) {
+  for (const key of KEYS) {
+    if (!saved.has(key)) saved.set(key, process.env[key]);
+    const next = values[key];
+    if (next === undefined) delete process.env[key];
+    else process.env[key] = next;
+  }
+}
+
+afterEach(() => {
+  for (const [key, value] of saved) {
+    if (value === undefined) delete process.env[key];
+    else process.env[key] = value;
+  }
+  saved.clear();
+});
+
+describe('the dev-preview kill switch', () => {
+  it('admits the literal string "true" and nothing else', () => {
+    for (const value of [undefined, '', 'false', 'TRUE', 'True', '1', 'yes', ' true'] as const) {
+      setEnv({ DEV_PREVIEW_ENABLED: value });
+      assert({ given: `DEV_PREVIEW_ENABLED=${JSON.stringify(value)}`, should: 'stay off', actual: isDevPreviewEnabled(), expected: false });
+    }
+    setEnv({ DEV_PREVIEW_ENABLED: 'true' });
+    assert({ given: 'the literal "true"', should: 'be on', actual: isDevPreviewEnabled(), expected: true });
+  });
+});
+
+describe('the preview apex', () => {
+  it('has NO default — unset is not configured, which is what makes the feature dark', () => {
+    setEnv({ DEV_PREVIEW_APEX: undefined, WEB_APP_URL: 'https://app.pagespace.ai' });
+    assert({ given: 'no apex', should: 'resolve to null', actual: resolveDevPreviewApex(), expected: null });
+  });
+
+  it('resolves a dedicated apex, and refuses one that shares the app\'s host', () => {
+    setEnv({ DEV_PREVIEW_APEX: 'pagespace.io', WEB_APP_URL: 'https://app.pagespace.ai' });
+    assert({ given: 'a dedicated apex', should: 'resolve it', actual: resolveDevPreviewApex(), expected: 'pagespace.io' });
+
+    // The whole point of the separate registrable domain: a dev server's own
+    // JavaScript on a preview host must not be able to set cookies the
+    // dashboard would send. An apex that IS the app's host is refused.
+    setEnv({ DEV_PREVIEW_APEX: 'app.pagespace.ai', WEB_APP_URL: 'https://app.pagespace.ai' });
+    assert({ given: "the app's own host as the apex", should: 'refuse it', actual: resolveDevPreviewApex(), expected: null });
+  });
+
+  it('survives an unparseable WEB_APP_URL rather than throwing', () => {
+    setEnv({ DEV_PREVIEW_APEX: 'pagespace.io', WEB_APP_URL: 'not a url' });
+    expect(() => resolveDevPreviewApex()).not.toThrow();
+    assert({ given: 'a malformed app URL', should: 'still resolve the apex', actual: resolveDevPreviewApex(), expected: 'pagespace.io' });
+  });
+});
+
+describe('isDevPreviewConfigured — the one question every entry point asks', () => {
+  it('needs BOTH the switch and a usable apex; either alone is dark', () => {
+    setEnv({ DEV_PREVIEW_ENABLED: 'true', DEV_PREVIEW_APEX: 'pagespace.io', WEB_APP_URL: 'https://app.pagespace.ai' });
+    assert({ given: 'both set', should: 'be configured', actual: isDevPreviewConfigured(), expected: true });
+
+    setEnv({ DEV_PREVIEW_ENABLED: 'true', DEV_PREVIEW_APEX: undefined, WEB_APP_URL: 'https://app.pagespace.ai' });
+    assert({ given: 'the switch on but no apex', should: 'be dark', actual: isDevPreviewConfigured(), expected: false });
+
+    setEnv({ DEV_PREVIEW_ENABLED: undefined, DEV_PREVIEW_APEX: 'pagespace.io', WEB_APP_URL: 'https://app.pagespace.ai' });
+    assert({ given: 'an apex but the switch off', should: 'be dark', actual: isDevPreviewConfigured(), expected: false });
+  });
+});

--- a/packages/lib/src/services/sandbox/preview/__tests__/dev-preview-lock.test.ts
+++ b/packages/lib/src/services/sandbox/preview/__tests__/dev-preview-lock.test.ts
@@ -69,7 +69,7 @@ describe('createDevPreviewLock', () => {
     const { pool } = fakePool([], { connectThrows: true });
     const outcome = await createDevPreviewLock({ pool, log: { warn: (m) => warnings.push(m) } })(HOLDER, async () => 'unreached');
     assert({ given: 'a pool that cannot connect', should: 'be busy, not an exception', actual: outcome, expected: { outcome: 'busy' } });
-    assert({ given: 'the degradation', should: 'be warned about once', actual: warnings, expected: ['dev-preview: lock unavailable, proceeding unserialized'] });
+    assert({ given: 'the degradation', should: 'be warned about once', actual: warnings, expected: ['dev-preview: lock pool unavailable, relay work deferred'] });
   });
 
   it('the no-op lock always acquires (the default where serialization is optional)', async () => {

--- a/packages/lib/src/services/sandbox/preview/__tests__/dev-preview-lock.test.ts
+++ b/packages/lib/src/services/sandbox/preview/__tests__/dev-preview-lock.test.ts
@@ -1,0 +1,78 @@
+/**
+ * The per-holder lock: distinctive keys, bounded retries, and the rule that
+ * failing to lock is never an error.
+ */
+import { describe, it, expect, vi } from 'vitest';
+import { assert } from '../../__tests__/riteway';
+import type { AdvisoryLockClient, AdvisoryLockPool } from '@pagespace/db/advisory-lock';
+import { createDevPreviewLock, devPreviewLockKeyFor, unlocked } from '../dev-preview-lock';
+
+const HOLDER = { kind: 'env', id: 'env1' } as const;
+
+/**
+ * A pool whose try-lock answers from a scripted queue. `withAdvisoryLock`
+ * issues `SELECT pg_try_advisory_lock(hashtext($1))`, so the boolean in the
+ * first row is what decides acquisition.
+ */
+function fakePool(acquisitions: readonly boolean[], { connectThrows = false } = {}) {
+  const keys: string[] = [];
+  let call = 0;
+  const pool: AdvisoryLockPool = {
+    connect: async (): Promise<AdvisoryLockClient> => {
+      if (connectThrows) throw new Error('pool exhausted');
+      return {
+        query: async (text: string, params?: unknown[]) => {
+          if (text.includes('pg_try_advisory_lock')) {
+            keys.push(String(params?.[0]));
+            const acquired = acquisitions[call] ?? false;
+            call += 1;
+            return { rows: [{ acquired }] };
+          }
+          return { rows: [{}] };
+        },
+        release: () => {},
+      };
+    },
+  };
+  return { pool, keys };
+}
+
+describe('devPreviewLockKeyFor', () => {
+  it('namespaces by feature and holder kind, so two holders can never collide', () => {
+    assert({ given: 'an env holder', should: 'name the feature and kind', actual: devPreviewLockKeyFor({ kind: 'env', id: 'x' }), expected: 'dev-preview:env:x' });
+    expect(devPreviewLockKeyFor({ kind: 'env', id: 'x' })).not.toBe(devPreviewLockKeyFor({ kind: 'workspace', id: 'x' }));
+  });
+});
+
+describe('createDevPreviewLock', () => {
+  it('runs the work under the holder key and returns its result', async () => {
+    const { pool, keys } = fakePool([true]);
+    const lock = createDevPreviewLock({ pool });
+    assert({ given: 'a free lock', should: 'run and return', actual: await lock(HOLDER, async () => 'done'), expected: { outcome: 'acquired', result: 'done' } });
+    assert({ given: 'the attempt', should: 'use the holder key', actual: keys, expected: ['dev-preview:env:env1'] });
+  });
+
+  it('retries a busy lock on the given schedule and gives up bounded — never waiting forever', async () => {
+    const waits: number[] = [];
+    const { pool } = fakePool([false, false, true]);
+    const acquired = await createDevPreviewLock({ pool, retries: [10, 20, 30], wait: async (ms) => { waits.push(ms); } })(HOLDER, async () => 'ok');
+    assert({ given: 'busy twice then free', should: 'acquire after two waits', actual: { acquired, waits }, expected: { acquired: { outcome: 'acquired', result: 'ok' }, waits: [10, 20] } });
+
+    const busyWaits: number[] = [];
+    const fn = vi.fn();
+    const busy = await createDevPreviewLock({ pool: fakePool([false, false, false]).pool, retries: [10, 20], wait: async (ms) => { busyWaits.push(ms); } })(HOLDER, async () => { fn(); return 'never'; });
+    assert({ given: 'busy on every attempt', should: 'report busy without running the work', actual: { busy, waits: busyWaits, ran: fn.mock.calls.length }, expected: { busy: { outcome: 'busy' }, waits: [10, 20], ran: 0 } });
+  });
+
+  it('a degraded lock pool reports busy and warns — it never throws into a user action or a detection frame', async () => {
+    const warnings: string[] = [];
+    const { pool } = fakePool([], { connectThrows: true });
+    const outcome = await createDevPreviewLock({ pool, log: { warn: (m) => warnings.push(m) } })(HOLDER, async () => 'unreached');
+    assert({ given: 'a pool that cannot connect', should: 'be busy, not an exception', actual: outcome, expected: { outcome: 'busy' } });
+    assert({ given: 'the degradation', should: 'be warned about once', actual: warnings, expected: ['dev-preview: lock unavailable, proceeding unserialized'] });
+  });
+
+  it('the no-op lock always acquires (the default where serialization is optional)', async () => {
+    assert({ given: 'the unlocked default', should: 'run the work', actual: await unlocked(HOLDER, async () => 7), expected: { outcome: 'acquired', result: 7 } });
+  });
+});

--- a/packages/lib/src/services/sandbox/preview/__tests__/dev-preview-reconcile.test.ts
+++ b/packages/lib/src/services/sandbox/preview/__tests__/dev-preview-reconcile.test.ts
@@ -139,6 +139,10 @@ describe('reconcileStoppedDevPreviews', () => {
     });
     assert({ given: 'an attach that throws for every candidate', should: 'count both failures and keep going', actual: await reconcileStoppedDevPreviews(thrower.deps), expected: { processed: 2, stopped: 0, skipped: 0, failed: 2 } });
     expect(warn).toHaveBeenCalledTimes(2);
+    // A holder that RELIABLY errors must still leave the window, or fifty of
+    // them sit at the head of every oldest-first batch forever — the same
+    // starvation this sweep exists to remove, narrowed to the failing rows.
+    assert({ given: 'holders whose work threw', should: 'stamp them anyway, as the retry backoff', actual: thrower.swept, expected: ['env:env1', 'workspace:ws1'] });
   });
 
   it('does nothing at all when the feature is dark — not even the listing query', async () => {
@@ -171,6 +175,11 @@ describe('reconcileStoppedDevPreviews', () => {
     const vanished = harness({ attach: async () => null });
     await reconcileStoppedDevPreviews(vanished.deps);
     assert({ given: 'a sprite the platform no longer has', should: 'stamp it rather than re-attach it every tick forever', actual: vanished.swept, expected: ['env:env1'] });
+
+    // A stamp that itself fails is bookkeeping, and must not turn a stop that
+    // DID happen into a reported failure.
+    const stampBroken = harness({ markSwept: async () => { throw new Error('db down'); }, log: { warn: () => {} } });
+    assert({ given: 'a stamp that throws after a successful stop', should: 'still report the stop', actual: await reconcileStoppedDevPreviews(stampBroken.deps), expected: { processed: 1, stopped: 1, skipped: 0, failed: 0 } });
 
     // Contended is the one case that must NOT be stamped: a live path owns the
     // holder, and if it does not finish the next tick has to be able to.

--- a/packages/lib/src/services/sandbox/preview/__tests__/dev-preview-reconcile.test.ts
+++ b/packages/lib/src/services/sandbox/preview/__tests__/dev-preview-reconcile.test.ts
@@ -4,7 +4,7 @@
  */
 import { describe, it, expect, vi } from 'vitest';
 import { assert } from '../../__tests__/riteway';
-import type { SandboxHandle, SandboxServiceInfo } from '../../sandbox-host';
+import { SPRITE_SANDBOX_CAPABILITIES, type SandboxHandle, type SandboxServiceInfo } from '../../sandbox-host';
 import {
   reconcileStoppedDevPreviews,
   DEV_PREVIEW_SWEEP_STALE_AFTER_MS,
@@ -40,6 +40,7 @@ const row = (over: Partial<DevPreviewRecord> = {}): DevPreviewRecord => ({
 function fakeHandle(calls: string[], relay: SandboxServiceInfo | null): SandboxHandle {
   return {
     sandboxId: 'sbx',
+    capabilities: SPRITE_SANDBOX_CAPABILITIES,
     spriteInstanceId: INSTANCE,
     exec: async () => ({ exitCode: 0, stdout: '', stderr: '' }),
     writeFiles: async () => {},

--- a/packages/lib/src/services/sandbox/preview/__tests__/dev-preview-reconcile.test.ts
+++ b/packages/lib/src/services/sandbox/preview/__tests__/dev-preview-reconcile.test.ts
@@ -1,0 +1,153 @@
+/**
+ * The backstop sweep: the ONE thing it may do is stop a relay whose row says
+ * the user switched it off. Everything else about it is a refusal.
+ */
+import { describe, it, expect, vi } from 'vitest';
+import { assert } from '../../__tests__/riteway';
+import type { SandboxHandle, SandboxServiceInfo } from '../../sandbox-host';
+import {
+  reconcileStoppedDevPreviews,
+  DEV_PREVIEW_SWEEP_STALE_AFTER_MS,
+  DEV_PREVIEW_SWEEP_LIMIT,
+  type DevPreviewReconcileDeps,
+} from '../dev-preview-reconcile';
+import type { DevPreviewRecord, DevPreviewStore } from '../dev-preview-store';
+import type { DevPreviewLock } from '../dev-preview-lock';
+import { buildPreviewRelaySpec, PREVIEW_RELAY_SERVICE_NAME } from '../preview-relay';
+
+const NOW = new Date('2026-09-07T12:00:00Z');
+const INSTANCE = 'sprite-live-0001';
+const HOLDER = { kind: 'env', id: 'env1' } as const;
+
+const relayService = (targetPort: number, status: SandboxServiceInfo['status'] = 'running'): SandboxServiceInfo => {
+  const spec = buildPreviewRelaySpec({ targetPort });
+  return { name: spec.name, command: spec.command, args: spec.args, status, pid: 42 };
+};
+
+const row = (over: Partial<DevPreviewRecord> = {}): DevPreviewRecord => ({
+  id: 'r1',
+  spriteInstanceId: INSTANCE,
+  sandboxId: 'sbx',
+  targetPort: 5173,
+  relayServiceName: PREVIEW_RELAY_SERVICE_NAME,
+  detectedAt: NOW,
+  stoppedByUserAt: NOW,
+  approvedPort: null,
+  ...over,
+});
+
+function fakeHandle(calls: string[], relay: SandboxServiceInfo | null): SandboxHandle {
+  return {
+    sandboxId: 'sbx',
+    spriteInstanceId: INSTANCE,
+    exec: async () => ({ exitCode: 0, stdout: '', stderr: '' }),
+    writeFiles: async () => {},
+    readFile: async () => null,
+    stream: async () => { throw new Error('unused'); },
+    listStreams: async () => [],
+    killSession: async () => {},
+    createCheckpoint: async () => {},
+    services: {
+      create: async (spec) => { calls.push(`create:${spec.name}`); },
+      list: async () => [],
+      get: async () => { calls.push('services.get'); return relay; },
+      start: async (name) => { calls.push(`start:${name}`); },
+      stop: async (name) => { calls.push(`stop:${name}`); },
+      remove: async (name) => { calls.push(`remove:${name}`); },
+    },
+    urlInfo: async () => ({ url: null, auth: 'unknown' }),
+    setUrlAuth: async () => {},
+    powerState: async () => 'running',
+  };
+}
+
+function fakeStore(current: DevPreviewRecord | null, calls: string[]): DevPreviewStore {
+  let held = current;
+  return {
+    findByHolder: async () => { calls.push('findByHolder'); return held; },
+    upsert: async () => { calls.push('upsert'); return true; },
+    setStoppedByUser: async (_h, at) => { held = held === null ? null : { ...held, stoppedByUserAt: at }; return held; },
+    approvePort: async () => null,
+    findStoppedWithRelay: async () => [],
+  };
+}
+
+function harness(over: Partial<DevPreviewReconcileDeps> & { current?: DevPreviewRecord | null; relay?: SandboxServiceInfo | null } = {}) {
+  const calls: string[] = [];
+  const store = fakeStore(over.current === undefined ? row() : over.current, calls);
+  const deps: DevPreviewReconcileDeps = {
+    findStoppedWithRelay: async () => [{ holder: HOLDER, sandboxId: 'sbx' }],
+    attach: async () => fakeHandle(calls, over.relay === undefined ? relayService(5173) : over.relay),
+    previewStore: store,
+    featureEnabled: () => true,
+    now: () => NOW,
+    ...over,
+  };
+  return { deps, calls };
+}
+
+describe('reconcileStoppedDevPreviews', () => {
+  it('stops a relay whose row says the user switched it off', async () => {
+    const { deps, calls } = harness();
+    assert({ given: 'a stopped row with a live relay', should: 'stop exactly one', actual: await reconcileStoppedDevPreviews(deps), expected: { processed: 1, stopped: 1, skipped: 0, failed: 0 } });
+    assert({ given: 'the sweep', should: 'stop the relay and nothing else', actual: calls.filter((c) => c.startsWith('stop:') || c.startsWith('create:') || c.startsWith('start:')), expected: [`stop:${PREVIEW_RELAY_SERVICE_NAME}`] });
+  });
+
+  it('CAN NEVER START ANYTHING — the property the whole module exists for', async () => {
+    // A row with the stop CLEARED and no relay defined is exactly the shape a
+    // detector would answer with `start-relay via create`. The sweep must not:
+    // the re-read refuses to act on a row that is not switched off, and even
+    // past that, it holds no snapshot proving 8080 is free.
+    const { deps, calls } = harness({ current: row({ stoppedByUserAt: null, relayServiceName: null, targetPort: 5173 }), relay: null });
+    const run = await reconcileStoppedDevPreviews(deps);
+    assert({ given: 'a row that would tempt a start', should: 'skip', actual: run, expected: { processed: 1, stopped: 0, skipped: 1, failed: 0 } });
+    assert({ given: 'the sweep', should: 'never call create or start', actual: calls.some((c) => c.startsWith('create:') || c.startsWith('start:')), expected: false });
+
+    // And even with the stop still set, a row whose relay is already gone is
+    // simply nothing to do — never a re-creation.
+    const gone = harness({ current: row({ relayServiceName: null }), relay: null });
+    await reconcileStoppedDevPreviews(gone.deps);
+    assert({ given: 'a stopped row with no relay recorded', should: 'touch the sprite not at all', actual: gone.calls.includes('services.get'), expected: false });
+  });
+
+  it('RE-READS under the lock: a resume that landed since the listing is honoured, not overridden', async () => {
+    const { deps, calls } = harness({ current: row({ stoppedByUserAt: null }) });
+    assert({ given: 'the intent cleared between listing and sweep', should: 'skip', actual: await reconcileStoppedDevPreviews(deps), expected: { processed: 1, stopped: 0, skipped: 1, failed: 0 } });
+    assert({ given: 'a resumed holder', should: 'never reach the sprite', actual: calls.includes('services.get'), expected: false });
+  });
+
+  it('skips a holder a live path already owns, without running anything', async () => {
+    const busy: DevPreviewLock = async () => ({ outcome: 'busy' });
+    const { deps, calls } = harness({ lock: busy });
+    assert({ given: 'a contended holder', should: 'skip', actual: await reconcileStoppedDevPreviews(deps), expected: { processed: 1, stopped: 0, skipped: 1, failed: 0 } });
+    assert({ given: 'a contended holder', should: 'not even read the row', actual: calls, expected: [] });
+  });
+
+  it('a vanished sprite is a skip, and a throwing one is a counted failure that does not stop the run', async () => {
+    const vanished = harness({ attach: async () => null });
+    assert({ given: 'attach → null', should: 'skip', actual: await reconcileStoppedDevPreviews(vanished.deps), expected: { processed: 1, stopped: 0, skipped: 1, failed: 0 } });
+
+    const warn = vi.fn();
+    const thrower = harness({
+      findStoppedWithRelay: async () => [{ holder: HOLDER, sandboxId: 'sbx' }, { holder: { kind: 'workspace', id: 'ws1' }, sandboxId: 'sbx' }],
+      attach: async () => { throw new Error('control plane down'); },
+      log: { warn },
+    });
+    assert({ given: 'an attach that throws for every candidate', should: 'count both failures and keep going', actual: await reconcileStoppedDevPreviews(thrower.deps), expected: { processed: 2, stopped: 0, skipped: 0, failed: 2 } });
+    expect(warn).toHaveBeenCalledTimes(2);
+  });
+
+  it('does nothing at all when the feature is dark — not even the listing query', async () => {
+    const findStoppedWithRelay = vi.fn(async () => []);
+    const { deps } = harness({ featureEnabled: () => false, findStoppedWithRelay });
+    assert({ given: 'a dark deployment', should: 'be a no-op', actual: await reconcileStoppedDevPreviews(deps), expected: { processed: 0, stopped: 0, skipped: 0, failed: 0 } });
+    expect(findStoppedWithRelay).not.toHaveBeenCalled();
+  });
+
+  it('asks for a bounded, aged batch — the two things that keep it off live work', async () => {
+    let asked: unknown;
+    const { deps } = harness({ findStoppedWithRelay: async (input) => { asked = input; return []; } });
+    await reconcileStoppedDevPreviews(deps);
+    assert({ given: 'the listing', should: 'be capped and age-bounded', actual: asked, expected: { staleAfterMs: DEV_PREVIEW_SWEEP_STALE_AFTER_MS, limit: DEV_PREVIEW_SWEEP_LIMIT } });
+  });
+});

--- a/packages/lib/src/services/sandbox/preview/__tests__/dev-preview-reconcile.test.ts
+++ b/packages/lib/src/services/sandbox/preview/__tests__/dev-preview-reconcile.test.ts
@@ -33,6 +33,7 @@ const row = (over: Partial<DevPreviewRecord> = {}): DevPreviewRecord => ({
   detectedAt: NOW,
   stoppedByUserAt: NOW,
   approvedPort: null,
+  approvedAt: null,
   ...over,
 });
 
@@ -69,21 +70,24 @@ function fakeStore(current: DevPreviewRecord | null, calls: string[]): DevPrevie
     setStoppedByUser: async (_h, at) => { held = held === null ? null : { ...held, stoppedByUserAt: at }; return held; },
     approvePort: async () => null,
     findStoppedWithRelay: async () => [],
+    markSwept: async () => {},
   };
 }
 
 function harness(over: Partial<DevPreviewReconcileDeps> & { current?: DevPreviewRecord | null; relay?: SandboxServiceInfo | null } = {}) {
   const calls: string[] = [];
   const store = fakeStore(over.current === undefined ? row() : over.current, calls);
+  const swept: string[] = [];
   const deps: DevPreviewReconcileDeps = {
     findStoppedWithRelay: async () => [{ holder: HOLDER, sandboxId: 'sbx' }],
+    markSwept: async (holder) => { swept.push(`${holder.kind}:${holder.id}`); },
     attach: async () => fakeHandle(calls, over.relay === undefined ? relayService(5173) : over.relay),
     previewStore: store,
     featureEnabled: () => true,
     now: () => NOW,
     ...over,
   };
-  return { deps, calls };
+  return { deps, calls, swept };
 }
 
 describe('reconcileStoppedDevPreviews', () => {
@@ -149,5 +153,29 @@ describe('reconcileStoppedDevPreviews', () => {
     const { deps } = harness({ findStoppedWithRelay: async (input) => { asked = input; return []; } });
     await reconcileStoppedDevPreviews(deps);
     assert({ given: 'the listing', should: 'be capped and age-bounded', actual: asked, expected: { staleAfterMs: DEV_PREVIEW_SWEEP_STALE_AFTER_MS, limit: DEV_PREVIEW_SWEEP_LIMIT } });
+  });
+
+  it('STAMPS every holder it looked at, so a converged row cannot occupy the batch forever', async () => {
+    // The stop itself writes nothing, so without the stamp a converged row
+    // keeps matching the oldest-first, capped candidate query — fifty dead
+    // rows would fill every tick and starve the holder who stopped a preview
+    // a minute ago.
+    const stopped = harness();
+    await reconcileStoppedDevPreviews(stopped.deps);
+    assert({ given: 'a relay it stopped', should: 'stamp the row out of the window', actual: stopped.swept, expected: ['env:env1'] });
+
+    const nothingToDo = harness({ current: row({ stoppedByUserAt: null }) });
+    await reconcileStoppedDevPreviews(nothingToDo.deps);
+    assert({ given: 'a row that needed nothing', should: 'still stamp it', actual: nothingToDo.swept, expected: ['env:env1'] });
+
+    const vanished = harness({ attach: async () => null });
+    await reconcileStoppedDevPreviews(vanished.deps);
+    assert({ given: 'a sprite the platform no longer has', should: 'stamp it rather than re-attach it every tick forever', actual: vanished.swept, expected: ['env:env1'] });
+
+    // Contended is the one case that must NOT be stamped: a live path owns the
+    // holder, and if it does not finish the next tick has to be able to.
+    const busy = harness({ lock: async () => ({ outcome: 'busy' }) });
+    await reconcileStoppedDevPreviews(busy.deps);
+    assert({ given: 'a holder a live path owns', should: 'leave it in the window', actual: busy.swept, expected: [] });
   });
 });

--- a/packages/lib/src/services/sandbox/preview/__tests__/dev-preview-reconcile.test.ts
+++ b/packages/lib/src/services/sandbox/preview/__tests__/dev-preview-reconcile.test.ts
@@ -71,6 +71,7 @@ function fakeStore(current: DevPreviewRecord | null, calls: string[]): DevPrevie
     approvePort: async () => null,
     findStoppedWithRelay: async () => [],
     markSwept: async () => {},
+    markRelayStopped: async () => {},
   };
 }
 

--- a/packages/lib/src/services/sandbox/preview/__tests__/dev-preview-serialization.test.ts
+++ b/packages/lib/src/services/sandbox/preview/__tests__/dev-preview-serialization.test.ts
@@ -33,6 +33,7 @@ function sharedStore(initial: DevPreviewRecord | null) {
   let pause: { promise: Promise<void>; release: () => void } | null = null;
   const store: DevPreviewStore = {
     approvePort: async () => null,
+    findStoppedWithRelay: async () => [],
     findByHolder: async () => {
       log.push('read');
       if (pause !== null) {

--- a/packages/lib/src/services/sandbox/preview/__tests__/dev-preview-serialization.test.ts
+++ b/packages/lib/src/services/sandbox/preview/__tests__/dev-preview-serialization.test.ts
@@ -35,6 +35,7 @@ function sharedStore(initial: DevPreviewRecord | null) {
     approvePort: async () => null,
     findStoppedWithRelay: async () => [],
     markSwept: async () => {},
+    markRelayStopped: async () => {},
     findByHolder: async () => {
       log.push('read');
       if (pause !== null) {

--- a/packages/lib/src/services/sandbox/preview/__tests__/dev-preview-serialization.test.ts
+++ b/packages/lib/src/services/sandbox/preview/__tests__/dev-preview-serialization.test.ts
@@ -34,6 +34,7 @@ function sharedStore(initial: DevPreviewRecord | null) {
   const store: DevPreviewStore = {
     approvePort: async () => null,
     findStoppedWithRelay: async () => [],
+    markSwept: async () => {},
     findByHolder: async () => {
       log.push('read');
       if (pause !== null) {
@@ -52,7 +53,7 @@ function sharedStore(initial: DevPreviewRecord | null) {
       }
       log.push(`upsert:${intent.targetPort}`);
       const { basedOnStoppedByUserAt: _guard, ...rest } = intent;
-      row = { id: 'r1', ...rest, stoppedByUserAt: null };
+      row = { id: 'r1', ...rest, stoppedByUserAt: null, approvedPort: null, approvedAt: null };
       return true;
     },
     setStoppedByUser: async (_holder, at) => {
@@ -128,6 +129,7 @@ function row(targetPort: number, overrides: Partial<DevPreviewRecord> = {}): Dev
     sandboxId: 'sbx',
     targetPort,
     relayServiceName: targetPort === 8080 ? null : PREVIEW_RELAY_SERVICE_NAME,
+    approvedAt: null,
     detectedAt: new Date('2026-09-07T11:00:00.000Z'),
     stoppedByUserAt: null, approvedPort: null,
     ...overrides,
@@ -148,6 +150,10 @@ describe('the web tier and the detector, serialized per holder', () => {
       probeRuntime: async () => 'node',
       lock,
     });
+
+    // The platform's connect snapshot, which the core requires before it will
+    // plan a relay start from an accumulated set.
+    await detector.onFrame({ type: 'port_list', ports: [] });
 
     // The detector enters its section and BLOCKS inside the read.
     const release = pauseNextRead();
@@ -228,6 +234,12 @@ describe('the web tier and the detector, serialized per holder', () => {
       probeRuntime: async () => 'node',
       lock: async (holder, fn) => (busy ? { outcome: 'busy' } : { outcome: 'acquired', result: await fn() }),
     });
+
+    // The connect snapshot lands while the lock is free, so the contention
+    // under test is about the port_opened frame and nothing else.
+    busy = false;
+    await detector.onFrame({ type: 'port_list', ports: [] });
+    busy = true;
 
     await detector.onFrame({ type: 'port_opened', port: 5173, pid: 3 });
     assert({ given: 'a contended frame', should: 'touch nothing', actual: calls, expected: [] });

--- a/packages/lib/src/services/sandbox/preview/__tests__/dev-preview-serialization.test.ts
+++ b/packages/lib/src/services/sandbox/preview/__tests__/dev-preview-serialization.test.ts
@@ -8,7 +8,7 @@
  */
 import { describe, it, expect, vi } from 'vitest';
 import { assert } from '../../__tests__/riteway';
-import type { SandboxHandle, SandboxServiceInfo } from '../../sandbox-host';
+import { SPRITE_SANDBOX_CAPABILITIES, type SandboxHandle, type SandboxServiceInfo } from '../../sandbox-host';
 import { planDevServerService, type DevPreviewHolderRef } from '../dev-preview-core';
 import { createDevPreviewDetector } from '../dev-preview-detection';
 import { applyDevPreviewUserAction } from '../dev-preview-status';
@@ -81,6 +81,7 @@ function relayService(targetPort: number, overrides: Partial<SandboxServiceInfo>
 function handleFor(log: string[], relay: SandboxServiceInfo | null): SandboxHandle {
   return {
     sandboxId: 'sbx',
+    capabilities: SPRITE_SANDBOX_CAPABILITIES,
     spriteInstanceId: INSTANCE,
     exec: async () => ({ exitCode: 1, stdout: '', stderr: '' }),
     writeFiles: async () => {},

--- a/packages/lib/src/services/sandbox/preview/__tests__/dev-preview-serialization.test.ts
+++ b/packages/lib/src/services/sandbox/preview/__tests__/dev-preview-serialization.test.ts
@@ -32,6 +32,7 @@ function sharedStore(initial: DevPreviewRecord | null) {
   /** Set to hold the next `findByHolder` open until the test releases it. */
   let pause: { promise: Promise<void>; release: () => void } | null = null;
   const store: DevPreviewStore = {
+    approvePort: async () => null,
     findByHolder: async () => {
       log.push('read');
       if (pause !== null) {
@@ -127,7 +128,7 @@ function row(targetPort: number, overrides: Partial<DevPreviewRecord> = {}): Dev
     targetPort,
     relayServiceName: targetPort === 8080 ? null : PREVIEW_RELAY_SERVICE_NAME,
     detectedAt: new Date('2026-09-07T11:00:00.000Z'),
-    stoppedByUserAt: null,
+    stoppedByUserAt: null, approvedPort: null,
     ...overrides,
   };
 }
@@ -160,9 +161,9 @@ describe('the web tier and the detector, serialized per holder', () => {
     // landing between the detector's read and its write.
     const action = applyDevPreviewUserAction({
       holder: HOLDER,
-      action: 'stop',
+      action: { kind: 'stop' },
       ...ACTOR,
-      deps: { previewStore: store, attach: async () => handleFor(calls, relayService(5173)), readListeners: async () => [{ port: 5173, pid: 3 }], canRunCode: async () => ({ ok: true }), lock, now: () => NOW },
+      deps: { previewStore: store, attach: async () => handleFor(calls, relayService(5173)), readListeners: async () => ({ detection: 'watching' as const, listeners: [{ port: 5173, pid: 3 }] }), canRunCode: async () => ({ ok: true }), lock, now: () => NOW },
     });
     await new Promise((resolve) => setTimeout(resolve, 5));
     release();
@@ -203,9 +204,9 @@ describe('the web tier and the detector, serialized per holder', () => {
     const { store, current } = sharedStore(row(5173));
     const result = await applyDevPreviewUserAction({
       holder: HOLDER,
-      action: 'stop',
+      action: { kind: 'stop' },
       ...ACTOR,
-      deps: { previewStore: store, attach: async () => handleFor(calls, relayService(5173)), readListeners: async () => null, canRunCode: async () => ({ ok: true }), lock: alwaysBusy, now: () => NOW },
+      deps: { previewStore: store, attach: async () => handleFor(calls, relayService(5173)), readListeners: async () => ({ detection: 'unavailable' as const, listeners: null }), canRunCode: async () => ({ ok: true }), lock: alwaysBusy, now: () => NOW },
     });
     assert({ given: 'a contended lock', should: 'record the intent and report the deferral honestly', actual: result, expected: { ok: true, applied: null, lockContended: true } });
     assert({ given: 'the deferral', should: 'still have switched the preview off', actual: current()?.stoppedByUserAt, expected: NOW });
@@ -263,12 +264,12 @@ describe('the web tier and the detector, serialized per holder', () => {
 
   it('a degraded lock pool never breaks a click: the intent lands and nothing throws', async () => {
     const { store, current } = sharedStore(row(5173));
-    const degraded: DevPreviewLock = vi.fn(async () => ({ outcome: 'busy' }));
+    const degraded: DevPreviewLock = vi.fn(async () => ({ outcome: 'busy' as const }));
     const result = await applyDevPreviewUserAction({
       holder: HOLDER,
-      action: 'resume',
+      action: { kind: 'resume' },
       ...ACTOR,
-      deps: { previewStore: store, attach: async () => { throw new Error('never reached'); }, readListeners: async () => null, canRunCode: async () => ({ ok: true }), lock: degraded, now: () => NOW },
+      deps: { previewStore: store, attach: async () => { throw new Error('never reached'); }, readListeners: async () => ({ detection: 'unavailable' as const, listeners: null }), canRunCode: async () => ({ ok: true }), lock: degraded, now: () => NOW },
     });
     assert({ given: 'a lock pool that cannot serve', should: 'still clear the stop intent', actual: { ok: result.ok, stopped: current()?.stoppedByUserAt }, expected: { ok: true, stopped: null } });
   });

--- a/packages/lib/src/services/sandbox/preview/__tests__/dev-preview-serialization.test.ts
+++ b/packages/lib/src/services/sandbox/preview/__tests__/dev-preview-serialization.test.ts
@@ -78,7 +78,14 @@ function relayService(targetPort: number, overrides: Partial<SandboxServiceInfo>
   return { name: spec.name, command: spec.command, args: spec.args, status: 'running', pid: 42, ...overrides };
 }
 
+/**
+ * The services fake TRACKS what it creates. A `get` that kept answering null
+ * after a create makes every reconcile plan another create, which shows up as
+ * duplicate work that the real platform would never do — and hides the
+ * ordering the test is actually about.
+ */
 function handleFor(log: string[], relay: SandboxServiceInfo | null): SandboxHandle {
+  let current = relay;
   return {
     sandboxId: 'sbx',
     capabilities: SPRITE_SANDBOX_CAPABILITIES,
@@ -91,9 +98,12 @@ function handleFor(log: string[], relay: SandboxServiceInfo | null): SandboxHand
     killSession: async () => {},
     createCheckpoint: async () => {},
     services: {
-      create: async (args) => { log.push(`create:${args.name}`); },
+      create: async (args) => {
+        log.push(`create:${args.name}`);
+        current = { name: args.name, command: args.command, args: args.args ?? [], status: 'running', pid: 99 };
+      },
       list: async () => [],
-      get: async () => relay,
+      get: async () => current,
       start: async (name) => { log.push(`start:${name}`); },
       stop: async (name) => { log.push(`stop:${name}`); },
       remove: async (name) => { log.push(`remove:${name}`); },
@@ -158,12 +168,16 @@ describe('the web tier and the detector, serialized per holder', () => {
     await detector.onFrame({ type: 'port_list', ports: [] });
 
     // The detector enters its section and BLOCKS inside the read.
+    const reads = () => log.filter((entry) => entry === 'read').length;
+    // COUNT, not `includes`. The `port_list` above already logged a read, so a
+    // presence check exits immediately and the click can win the lock before
+    // the frame ever reaches its critical section — the test would then assert
+    // the reverse ordering and still pass, which is the same as not testing.
+    const before = reads();
     const release = pauseNextRead();
     const frame = detector.onFrame({ type: 'port_opened', port: 5173, pid: 3 });
-    // Wait until the detector has actually ENTERED its section, otherwise the
-    // click would simply happen first and prove nothing.
-    for (let i = 0; i < 100 && !log.includes('read'); i += 1) await new Promise((resolve) => setTimeout(resolve, 1));
-    expect(log).toContain('read');
+    for (let i = 0; i < 200 && reads() === before; i += 1) await new Promise((resolve) => setTimeout(resolve, 1));
+    expect(reads()).toBeGreaterThan(before);
 
     // The user clicks Stop while the detector is mid-section. Serialized, this
     // cannot begin until the frame is done; unserialized it writes immediately,

--- a/packages/lib/src/services/sandbox/preview/__tests__/dev-preview-serialization.test.ts
+++ b/packages/lib/src/services/sandbox/preview/__tests__/dev-preview-serialization.test.ts
@@ -1,0 +1,275 @@
+/**
+ * The two writers, in one process, against one store — the interleavings the
+ * lock exists for.
+ *
+ * These are deterministic, not timing-hopeful: the lock is an injected
+ * dependency, so "the detector holds it" and "the budget is spent" are
+ * scripted facts, and the shared store is the single state both tiers see.
+ */
+import { describe, it, expect, vi } from 'vitest';
+import { assert } from '../../__tests__/riteway';
+import type { SandboxHandle, SandboxServiceInfo } from '../../sandbox-host';
+import { planDevServerService, type DevPreviewHolderRef } from '../dev-preview-core';
+import { createDevPreviewDetector } from '../dev-preview-detection';
+import { applyDevPreviewUserAction } from '../dev-preview-status';
+import type { DevPreviewLock } from '../dev-preview-lock';
+import type { DevPreviewRecord, DevPreviewStore } from '../dev-preview-store';
+import { buildPreviewRelaySpec, PREVIEW_RELAY_SERVICE_NAME } from '../preview-relay';
+
+const NOW = new Date('2026-09-07T12:00:00.000Z');
+const INSTANCE = 'inst-live';
+const HOLDER: DevPreviewHolderRef = { kind: 'env', id: 'env1' };
+const ACTOR = { userId: 'u1', wakeSubject: { driveId: 'd1', ownerId: 'owner' } };
+
+/**
+ * ONE store both tiers write to, enforcing the same compare-and-set the real
+ * one does — and able to PAUSE inside a read, which is what makes the
+ * interleaving a scripted fact instead of a timing accident.
+ */
+function sharedStore(initial: DevPreviewRecord | null) {
+  let row = initial;
+  const log: string[] = [];
+  /** Set to hold the next `findByHolder` open until the test releases it. */
+  let pause: { promise: Promise<void>; release: () => void } | null = null;
+  const store: DevPreviewStore = {
+    findByHolder: async () => {
+      log.push('read');
+      if (pause !== null) {
+        const held = pause;
+        pause = null;
+        await held.promise;
+      }
+      return row;
+    },
+    upsert: async (intent) => {
+      const sameInstance = row !== null && row.spriteInstanceId === intent.spriteInstanceId;
+      const guardHolds = !sameInstance || (row?.stoppedByUserAt?.getTime() ?? null) === (intent.basedOnStoppedByUserAt?.getTime() ?? null);
+      if (!guardHolds) {
+        log.push('upsert-refused');
+        return false;
+      }
+      log.push(`upsert:${intent.targetPort}`);
+      const { basedOnStoppedByUserAt: _guard, ...rest } = intent;
+      row = { id: 'r1', ...rest, stoppedByUserAt: null };
+      return true;
+    },
+    setStoppedByUser: async (_holder, at) => {
+      log.push(`intent:${at ? 'stop' : 'clear'}`);
+      if (row === null) return null;
+      row = { ...row, stoppedByUserAt: at };
+      return row;
+    },
+  };
+  const pauseNextRead = () => {
+    let release!: () => void;
+    const promise = new Promise<void>((resolve) => { release = resolve; });
+    pause = { promise, release };
+    return release;
+  };
+  return { store, log, current: () => row, pauseNextRead };
+}
+
+function relayService(targetPort: number, overrides: Partial<SandboxServiceInfo> = {}): SandboxServiceInfo {
+  const spec = buildPreviewRelaySpec({ targetPort });
+  return { name: spec.name, command: spec.command, args: spec.args, status: 'running', pid: 42, ...overrides };
+}
+
+function handleFor(log: string[], relay: SandboxServiceInfo | null): SandboxHandle {
+  return {
+    sandboxId: 'sbx',
+    spriteInstanceId: INSTANCE,
+    exec: async () => ({ exitCode: 1, stdout: '', stderr: '' }),
+    writeFiles: async () => {},
+    readFile: async () => null,
+    stream: async () => { throw new Error('unused'); },
+    listStreams: async () => [],
+    killSession: async () => {},
+    createCheckpoint: async () => {},
+    services: {
+      create: async (args) => { log.push(`create:${args.name}`); },
+      list: async () => [],
+      get: async () => relay,
+      start: async (name) => { log.push(`start:${name}`); },
+      stop: async (name) => { log.push(`stop:${name}`); },
+      remove: async (name) => { log.push(`remove:${name}`); },
+    },
+    urlInfo: async () => ({ url: null, auth: 'unknown' }),
+    setUrlAuth: async () => {},
+    powerState: async () => 'running',
+  };
+}
+
+/** A real per-holder mutex, so "the other tier holds it" is exact. */
+function serialLock(): DevPreviewLock {
+  const held = new Map<string, Promise<unknown>>();
+  return async (holder, fn) => {
+    const key = `${holder.kind}:${holder.id}`;
+    const previous = held.get(key) ?? Promise.resolve();
+    let release!: () => void;
+    held.set(key, new Promise<void>((resolve) => { release = resolve; }));
+    await previous;
+    try {
+      return { outcome: 'acquired', result: await fn() };
+    } finally {
+      release();
+    }
+  };
+}
+
+/** A lock that is always taken by someone else — the exhausted-budget case. */
+const alwaysBusy: DevPreviewLock = async () => ({ outcome: 'busy' });
+
+function row(targetPort: number, overrides: Partial<DevPreviewRecord> = {}): DevPreviewRecord {
+  return {
+    id: 'r1',
+    spriteInstanceId: INSTANCE,
+    sandboxId: 'sbx',
+    targetPort,
+    relayServiceName: targetPort === 8080 ? null : PREVIEW_RELAY_SERVICE_NAME,
+    detectedAt: new Date('2026-09-07T11:00:00.000Z'),
+    stoppedByUserAt: null,
+    ...overrides,
+  };
+}
+
+describe('the web tier and the detector, serialized per holder', () => {
+  it('THE REPORTED BUG, forced rather than hoped for: a detection frame paused mid-read cannot have a user stop land inside its critical section', async () => {
+    const calls: string[] = [];
+    const { store, log, current, pauseNextRead } = sharedStore(row(5173, { relayServiceName: null }));
+    const lock = serialLock();
+    const detector = createDevPreviewDetector({
+      holder: HOLDER,
+      handle: handleFor(calls, null),
+      store,
+      now: () => NOW,
+      log: { info: () => {}, warn: () => {}, error: () => {} },
+      probeRuntime: async () => 'node',
+      lock,
+    });
+
+    // The detector enters its section and BLOCKS inside the read.
+    const release = pauseNextRead();
+    const frame = detector.onFrame({ type: 'port_opened', port: 5173, pid: 3 });
+    // Wait until the detector has actually ENTERED its section, otherwise the
+    // click would simply happen first and prove nothing.
+    for (let i = 0; i < 100 && !log.includes('read'); i += 1) await new Promise((resolve) => setTimeout(resolve, 1));
+    expect(log).toContain('read');
+
+    // The user clicks Stop while the detector is mid-section. Serialized, this
+    // cannot begin until the frame is done; unserialized it writes immediately,
+    // landing between the detector's read and its write.
+    const action = applyDevPreviewUserAction({
+      holder: HOLDER,
+      action: 'stop',
+      ...ACTOR,
+      deps: { previewStore: store, attach: async () => handleFor(calls, relayService(5173)), readListeners: async () => [{ port: 5173, pid: 3 }], canRunCode: async () => ({ ok: true }), lock, now: () => NOW },
+    });
+    await new Promise((resolve) => setTimeout(resolve, 5));
+    release();
+    const [, actionResult] = await Promise.all([frame, action]);
+
+    assert({ given: 'a stop issued while a frame held the section', should: 'record the stop', actual: actionResult.ok, expected: true });
+    assert({ given: 'the stop', should: 'survive — the row ends switched off', actual: current()?.stoppedByUserAt, expected: NOW });
+
+    // ATOMICITY, and this is the assertion that discriminates. Unserialized,
+    // the click lands between the detector's read and its write, so the
+    // compare-and-set REFUSES that write — the outcome is still correct (that
+    // is row-first plus the CAS doing their job) but the frame's work is
+    // thrown away, and nothing guarantees another frame will come to redo it.
+    // Serialized, the detector's section completes as a unit and no write is
+    // ever refused.
+    // THE DISCRIMINATING ASSERTION. Unserialized, the click lands between the
+    // frame's read and its write, the compare-and-set refuses that write, and
+    // the frame's work is simply LOST — no row, no relay, and nothing
+    // guarantees another frame will ever come to redo it (a dev server that
+    // starts and then sits quiet emits no more). Serialized, the frame
+    // completes as a unit and the click then acts on what it left behind.
+    assert({
+      given: 'a click forced into the middle of a detection frame',
+      should: 'let the frame finish its own section rather than lose its work',
+      actual: { recordedRow: log.some((entry) => entry.startsWith('upsert:')), refused: log.includes('upsert-refused') },
+      expected: { recordedRow: true, refused: false },
+    });
+    assert({
+      given: 'the click that followed it',
+      should: 'stop the relay the frame had just started — no orphan, no lost intent',
+      actual: calls,
+      expected: [`create:${PREVIEW_RELAY_SERVICE_NAME}`, `stop:${PREVIEW_RELAY_SERVICE_NAME}`],
+    });
+  });
+
+  it('a user action that cannot take the lock still records the intent and says so', async () => {
+    const calls: string[] = [];
+    const { store, current } = sharedStore(row(5173));
+    const result = await applyDevPreviewUserAction({
+      holder: HOLDER,
+      action: 'stop',
+      ...ACTOR,
+      deps: { previewStore: store, attach: async () => handleFor(calls, relayService(5173)), readListeners: async () => null, canRunCode: async () => ({ ok: true }), lock: alwaysBusy, now: () => NOW },
+    });
+    assert({ given: 'a contended lock', should: 'record the intent and report the deferral honestly', actual: result, expected: { ok: true, applied: null, lockContended: true } });
+    assert({ given: 'the deferral', should: 'still have switched the preview off', actual: current()?.stoppedByUserAt, expected: NOW });
+    assert({ given: 'the deferral', should: 'touch no service', actual: calls, expected: [] });
+  });
+
+  it('a detection frame that cannot take the lock is DEFERRED, not dropped silently, and the next frame does the work', async () => {
+    const calls: string[] = [];
+    const { store } = sharedStore(null);
+    const logged: string[] = [];
+    let busy = true;
+    const detector = createDevPreviewDetector({
+      holder: HOLDER,
+      handle: handleFor(calls, null),
+      store,
+      now: () => NOW,
+      log: { info: (m, c) => logged.push(`${m}:${JSON.stringify(c ?? {})}`), warn: () => {}, error: () => {} },
+      probeRuntime: async () => 'node',
+      lock: async (holder, fn) => (busy ? { outcome: 'busy' } : { outcome: 'acquired', result: await fn() }),
+    });
+
+    await detector.onFrame({ type: 'port_opened', port: 5173, pid: 3 });
+    assert({ given: 'a contended frame', should: 'touch nothing', actual: calls, expected: [] });
+    expect(logged.some((l) => l.includes('deferred'))).toBe(true);
+
+    busy = false;
+    await detector.onFrame({ type: 'port_opened', port: 5173, pid: 3 });
+    assert({ given: 'the next frame with the lock free', should: 'do the work it deferred', actual: calls, expected: [`create:${PREVIEW_RELAY_SERVICE_NAME}`] });
+  });
+
+  it('a stop-relay planned before a RESUME stops nothing once the resume has landed', async () => {
+    const calls: string[] = [];
+    const { store } = sharedStore(row(5173, { stoppedByUserAt: NOW }));
+    // The plan is made while the stop still stands...
+    const plan = planDevServerService({
+      liveInstanceId: INSTANCE,
+      sandboxId: 'sbx',
+      holder: HOLDER,
+      row: row(5173, { stoppedByUserAt: NOW }),
+      detected: null,
+      relay: relayService(5173),
+      listeners: [{ port: 5173, pid: 3 }],
+      now: NOW,
+    });
+    assert({ given: 'a stopped row with a live relay', should: 'plan stop-relay', actual: plan.action, expected: 'stop-relay' });
+
+    // ...the user resumes...
+    await store.setStoppedByUser(HOLDER, null);
+
+    // ...and the stale plan is carried out: it must stop nothing.
+    const { applyDevServerServicePlan } = await import('../dev-preview-effects');
+    const applied = await applyDevServerServicePlan({ plan, services: handleFor(calls, relayService(5173)).services, store });
+    assert({ given: 'a stop-relay whose stop was cleared', should: 'stop nothing and say why', actual: { applied, calls }, expected: { applied: { action: 'skipped', reason: 'resumed', mutated: 'none' }, calls: [] } });
+  });
+
+  it('a degraded lock pool never breaks a click: the intent lands and nothing throws', async () => {
+    const { store, current } = sharedStore(row(5173));
+    const degraded: DevPreviewLock = vi.fn(async () => ({ outcome: 'busy' }));
+    const result = await applyDevPreviewUserAction({
+      holder: HOLDER,
+      action: 'resume',
+      ...ACTOR,
+      deps: { previewStore: store, attach: async () => { throw new Error('never reached'); }, readListeners: async () => null, canRunCode: async () => ({ ok: true }), lock: degraded, now: () => NOW },
+    });
+    assert({ given: 'a lock pool that cannot serve', should: 'still clear the stop intent', actual: { ok: result.ok, stopped: current()?.stoppedByUserAt }, expected: { ok: true, stopped: null } });
+  });
+});

--- a/packages/lib/src/services/sandbox/preview/__tests__/dev-preview-serialization.test.ts
+++ b/packages/lib/src/services/sandbox/preview/__tests__/dev-preview-serialization.test.ts
@@ -104,9 +104,21 @@ function handleFor(log: string[], relay: SandboxServiceInfo | null): SandboxHand
       },
       list: async () => [],
       get: async () => current,
-      start: async (name) => { log.push(`start:${name}`); },
-      stop: async (name) => { log.push(`stop:${name}`); },
-      remove: async (name) => { log.push(`remove:${name}`); },
+      start: async (name) => {
+        log.push(`start:${name}`);
+        if (current) current = { ...current, status: 'running' };
+      },
+      stop: async (name) => {
+        log.push(`stop:${name}`);
+        // The platform leaves a stopped service `failed`, not `stopped`
+        // (spike §4) — a fake that left it `running` would let a later plan
+        // read a dead relay as live.
+        if (current) current = { ...current, status: 'failed' };
+      },
+      remove: async (name) => {
+        log.push(`remove:${name}`);
+        current = null;
+      },
     },
     urlInfo: async () => ({ url: null, auth: 'unknown' }),
     setUrlAuth: async () => {},

--- a/packages/lib/src/services/sandbox/preview/__tests__/dev-preview-status.test.ts
+++ b/packages/lib/src/services/sandbox/preview/__tests__/dev-preview-status.test.ts
@@ -435,6 +435,22 @@ describe('approve — one explicit act, bound to the port the user was shown', (
     assert({ given: 'a refused approve', should: 'never reach the sprite', actual: calls.includes('services.get'), expected: false });
   });
 
+  it('a REBUILT sandbox is its own answer, not "the port moved" — the port is usually identical', async () => {
+    // The replacement VM commonly re-detects the same port, so collapsing this
+    // into `port-changed` would tell the user their server moved when it did
+    // not, about the exact case the instance echo exists to catch.
+    const calls: string[] = [];
+    const store = fakeStore(row(9000, { relayServiceName: null, spriteInstanceId: 'inst-new' }), calls);
+    const { deps } = actionDeps({ calls, store, attach: async () => fakeHandle({ relay: null, calls }) });
+    assert({
+      given: 'a click made against the sandbox that has since been replaced',
+      should: 'say the sandbox was rebuilt, not that the port changed',
+      actual: await applyDevPreviewUserAction({ holder: ENV, action: { kind: 'approve', port: 9000, spriteInstanceId: 'inst-old' }, ...ACTOR, deps }),
+      expected: { ok: false, reason: 'instance-changed' },
+    });
+    assert({ given: 'a refused approve', should: 'record no consent', actual: store.current()?.approvedPort, expected: null });
+  });
+
   it('a holder with no row at all is no-preview, not port-changed', async () => {
     const { deps } = actionDeps({ store: fakeStore(null) });
     assert({ given: 'no row', should: 'be no-preview', actual: await applyDevPreviewUserAction({ holder: ENV, action: { kind: 'approve', port: 9000, spriteInstanceId: INSTANCE }, ...ACTOR, deps }), expected: { ok: false, reason: 'no-preview' } });

--- a/packages/lib/src/services/sandbox/preview/__tests__/dev-preview-status.test.ts
+++ b/packages/lib/src/services/sandbox/preview/__tests__/dev-preview-status.test.ts
@@ -38,6 +38,7 @@ function row(targetPort: number, overrides: Partial<DevPreviewRecord> = {}): Dev
     relayServiceName: targetPort === SPRITE_HTTP_PORT ? null : PREVIEW_RELAY_SERVICE_NAME,
     detectedAt: new Date('2026-09-06T11:00:00.000Z'),
     stoppedByUserAt: null,
+    approvedPort: null,
     ...overrides,
   };
 }
@@ -81,6 +82,15 @@ function fakeStore(initial: DevPreviewRecord | null, calls: string[] = []): DevP
       const { basedOnStoppedByUserAt: _guard, ...row } = intent;
       current = { id: 'r1', ...row, stoppedByUserAt: null };
       return true;
+    },
+    approvePort: async (_holder, { port, at }) => {
+      calls.push(`approvePort:${port}`);
+      // The real store filters the UPDATE on the row's current target, so a
+      // port the row no longer names matches nothing.
+      if (current === null || current.targetPort !== port) return null;
+      current = { ...current, approvedPort: port, stoppedByUserAt: null };
+      void at;
+      return current;
     },
     setStoppedByUser: async (_holder, at) => {
       calls.push(`setStoppedByUser:${at ? 'stop' : 'clear'}`);
@@ -286,7 +296,7 @@ function actionDeps(over: Partial<DevPreviewUserActionDeps> & { calls?: string[]
 describe('applyDevPreviewUserAction — intent first, then ONE reconcile through the core', () => {
   it('STOP records the intent and the core stops the live relay', async () => {
     const { deps, calls, store } = actionDeps();
-    const result = await applyDevPreviewUserAction({ holder: ENV, action: 'stop', ...ACTOR, deps });
+    const result = await applyDevPreviewUserAction({ holder: ENV, action: { kind: 'stop' }, ...ACTOR, deps });
     assert({ given: 'a live relay', should: 'stop it', actual: result, expected: { ok: true, applied: { action: 'stop-relay', relayServiceName: PREVIEW_RELAY_SERVICE_NAME } } });
     assert({ given: 'the stop', should: 'write the intent BEFORE planning', actual: calls.indexOf('setStoppedByUser:stop') < calls.indexOf('services.get'), expected: true });
     assert({ given: 'the stop', should: 'leave the row stopped at now', actual: store.current()?.stoppedByUserAt, expected: NOW });
@@ -302,7 +312,7 @@ describe('applyDevPreviewUserAction — intent first, then ONE reconcile through
       // relay may honestly be started (see the slot-unknown case below).
       readListeners: async () => ({ detection: 'watching', listeners: [{ port: 5173, pid: 7 }] }),
     });
-    const result = await applyDevPreviewUserAction({ holder: ENV, action: 'resume', ...ACTOR, deps });
+    const result = await applyDevPreviewUserAction({ holder: ENV, action: { kind: 'resume' }, ...ACTOR, deps });
     assert({ given: 'a stopped relay', should: 'start it and re-record the row', actual: result, expected: { ok: true, applied: { action: 'start-relay', via: 'start', targetPort: 5173, recorded: true } } });
     assert({ given: 'the resume', should: 'call services.start', actual: trackedCalls.includes(`start:${PREVIEW_RELAY_SERVICE_NAME}`), expected: true });
     assert({ given: 'the resume', should: 'leave stoppedByUserAt cleared', actual: store.current()?.stoppedByUserAt, expected: null });
@@ -316,14 +326,14 @@ describe('applyDevPreviewUserAction — intent first, then ONE reconcile through
       attach: async () => fakeHandle({ relay: relayService(5173, { status: 'failed' }), calls: trackedCalls }),
       readListeners: async () => ({ detection: 'unavailable', listeners: null }),
     });
-    assert({ given: 'no ports/watch snapshot', should: 'refuse rather than read unknown as "8080 is free"', actual: await applyDevPreviewUserAction({ holder: ENV, action: 'resume', ...ACTOR, deps }), expected: { ok: false, reason: 'slot-unknown' } });
+    assert({ given: 'no ports/watch snapshot', should: 'refuse rather than read unknown as "8080 is free"', actual: await applyDevPreviewUserAction({ holder: ENV, action: { kind: 'resume' }, ...ACTOR, deps }), expected: { ok: false, reason: 'slot-unknown' } });
     assert({ given: 'the refusal', should: 'still have cleared the stop — the user\'s ON stands', actual: store.current()?.stoppedByUserAt, expected: null });
     assert({ given: 'the refusal', should: 'touch no service', actual: trackedCalls.some((c) => c.startsWith('start:') || c.startsWith('create:')), expected: false });
   });
 
   it('a DIRECT (8080) resume needs no snapshot — there is no relay to place', async () => {
     const { deps } = actionDeps({ store: fakeStore(row(SPRITE_HTTP_PORT, { stoppedByUserAt: NOW })), attach: async () => fakeHandle({ relay: null }), readListeners: async () => ({ detection: 'unavailable', listeners: null }) });
-    assert({ given: 'a direct row and no snapshot', should: 'converge without refusing', actual: await applyDevPreviewUserAction({ holder: ENV, action: 'resume', ...ACTOR, deps }), expected: { ok: true, applied: { action: 'none', reason: 'already-direct', staleRowIgnored: false } } });
+    assert({ given: 'a direct row and no snapshot', should: 'converge without refusing', actual: await applyDevPreviewUserAction({ holder: ENV, action: { kind: 'resume' }, ...ACTOR, deps }), expected: { ok: true, applied: { action: 'none', reason: 'already-direct', staleRowIgnored: false } } });
   });
 
   it('RESUME against a slot a user process has since taken is REFUSED by the core (with the snapshot), not planned', async () => {
@@ -333,7 +343,7 @@ describe('applyDevPreviewUserAction — intent first, then ONE reconcile through
       attach: async () => fakeHandle({ relay: relayService(5173, { status: 'failed' }), calls: trackedCalls }),
       readListeners: async () => ({ detection: 'watching', listeners: [{ port: SPRITE_HTTP_PORT, pid: 999 }] }),
     });
-    const result = await applyDevPreviewUserAction({ holder: ENV, action: 'resume', ...ACTOR, deps });
+    const result = await applyDevPreviewUserAction({ holder: ENV, action: { kind: 'resume' }, ...ACTOR, deps });
     assert({ given: 'foreign 8080 listener', should: 'refuse http-port-busy', actual: result, expected: { ok: true, applied: { action: 'refuse', reason: 'http-port-busy', targetPort: 5173 } } });
     assert({ given: 'the refusal', should: 'touch no service', actual: trackedCalls.some((c) => c.startsWith('start:') || c.startsWith('create:')), expected: false });
   });
@@ -347,7 +357,7 @@ describe('applyDevPreviewUserAction — intent first, then ONE reconcile through
       attach: async () => fakeHandle({ relay: relayService(5173, { status: 'failed' }), calls: trackedCalls }),
       canRunCode: async (input) => { trackedCalls.push(`canRunCode:${input.userId}:${input.driveId}:${input.ownerId}`); return { ok: false, reason: 'no_capability' as never }; },
     });
-    const result = await applyDevPreviewUserAction({ holder: ENV, action: 'resume', ...ACTOR, deps });
+    const result = await applyDevPreviewUserAction({ holder: ENV, action: { kind: 'resume' }, ...ACTOR, deps });
     assert({ given: 'a payer who may not run code', should: 'refuse the resume with the gate reason', actual: result, expected: { ok: false, reason: 'wake-not-allowed', detail: 'no_capability' } });
     assert({ given: 'the refusal', should: 'consult the gate on the PAYER (driveId + ownerId), not the actor as payer', actual: trackedCalls[0], expected: 'canRunCode:u1:d1:owner' });
     assert({ given: 'the refusal', should: 'leave the stop intent in place', actual: store.current()?.stoppedByUserAt, expected: NOW });
@@ -356,7 +366,7 @@ describe('applyDevPreviewUserAction — intent first, then ONE reconcile through
 
   it('STOP is never gated — stopping compute needs no spend permission', async () => {
     const { deps, calls } = actionDeps({ canRunCode: async () => { calls.push('canRunCode'); return { ok: false, reason: 'no_capability' as never }; } });
-    const result = await applyDevPreviewUserAction({ holder: ENV, action: 'stop', ...ACTOR, deps });
+    const result = await applyDevPreviewUserAction({ holder: ENV, action: { kind: 'stop' }, ...ACTOR, deps });
     assert({ given: 'a denied payer stopping', should: 'still stop', actual: result.ok, expected: true });
     assert({ given: 'a stop', should: 'not consult the gate', actual: calls.includes('canRunCode'), expected: false });
   });
@@ -364,26 +374,79 @@ describe('applyDevPreviewUserAction — intent first, then ONE reconcile through
   it('a holder with no row is no-preview and nothing is attached', async () => {
     const trackedCalls: string[] = [];
     const { deps } = actionDeps({ store: fakeStore(null), attach: async () => { trackedCalls.push('attach'); return null; } });
-    assert({ given: 'no row', should: 'be no-preview', actual: await applyDevPreviewUserAction({ holder: ENV, action: 'stop', ...ACTOR, deps }), expected: { ok: false, reason: 'no-preview' } });
+    assert({ given: 'no row', should: 'be no-preview', actual: await applyDevPreviewUserAction({ holder: ENV, action: { kind: 'stop' }, ...ACTOR, deps }), expected: { ok: false, reason: 'no-preview' } });
     assert({ given: 'no row', should: 'not attach', actual: trackedCalls, expected: [] });
   });
 
   it('a sprite the platform cannot attach still records the intent (applied: null) — the planner honours it later', async () => {
     const { deps, store } = actionDeps({ attach: async () => null });
-    assert({ given: 'attach → null', should: 'record and report no effect', actual: await applyDevPreviewUserAction({ holder: ENV, action: 'stop', ...ACTOR, deps }), expected: { ok: true, applied: null } });
+    assert({ given: 'attach → null', should: 'record and report no effect', actual: await applyDevPreviewUserAction({ holder: ENV, action: { kind: 'stop' }, ...ACTOR, deps }), expected: { ok: true, applied: null } });
     assert({ given: 'attach → null', should: 'still have written the intent', actual: store.current()?.stoppedByUserAt, expected: NOW });
   });
 
   it('a row for a DEAD instance is ignored by the core: the intent is recorded and the plan is nothing-detected', async () => {
     const { deps } = actionDeps({ store: fakeStore(row(5173, { spriteInstanceId: 'inst-dead' })) });
-    assert({ given: 'stale row', should: 'plan nothing', actual: await applyDevPreviewUserAction({ holder: ENV, action: 'stop', ...ACTOR, deps }), expected: { ok: true, applied: { action: 'none', reason: 'nothing-detected', staleRowIgnored: true } } });
+    assert({ given: 'stale row', should: 'plan nothing', actual: await applyDevPreviewUserAction({ holder: ENV, action: { kind: 'stop' }, ...ACTOR, deps }), expected: { ok: true, applied: { action: 'none', reason: 'nothing-detected', staleRowIgnored: true } } });
   });
 
   it('a direct (8080) row: stop records intent with nothing to stop; resume records direct again', async () => {
     const stopCalls: string[] = [];
     const stop = actionDeps({ store: fakeStore(row(SPRITE_HTTP_PORT)), attach: async () => fakeHandle({ relay: null, calls: stopCalls }) });
-    assert({ given: 'direct row, stop', should: 'be user-stopped with no service call', actual: await applyDevPreviewUserAction({ holder: ENV, action: 'stop', ...ACTOR, deps: stop.deps }), expected: { ok: true, applied: { action: 'none', reason: 'user-stopped', staleRowIgnored: false } } });
+    assert({ given: 'direct row, stop', should: 'be user-stopped with no service call', actual: await applyDevPreviewUserAction({ holder: ENV, action: { kind: 'stop' }, ...ACTOR, deps: stop.deps }), expected: { ok: true, applied: { action: 'none', reason: 'user-stopped', staleRowIgnored: false } } });
     const resume = actionDeps({ store: fakeStore(row(SPRITE_HTTP_PORT, { stoppedByUserAt: NOW })), attach: async () => fakeHandle({ relay: null }) });
-    assert({ given: 'direct row, resume', should: 'converge as already-direct', actual: await applyDevPreviewUserAction({ holder: ENV, action: 'resume', ...ACTOR, deps: resume.deps }), expected: { ok: true, applied: { action: 'none', reason: 'already-direct', staleRowIgnored: false } } });
+    assert({ given: 'direct row, resume', should: 'converge as already-direct', actual: await applyDevPreviewUserAction({ holder: ENV, action: { kind: 'resume' }, ...ACTOR, deps: resume.deps }), expected: { ok: true, applied: { action: 'none', reason: 'already-direct', staleRowIgnored: false } } });
+  });
+});
+
+describe('approve — one explicit act, bound to the port the user was shown', () => {
+  function pending(overrides: Partial<DevPreviewUserActionDeps> = {}) {
+    const calls: string[] = [];
+    const store = fakeStore(row(9000, { relayServiceName: null }), calls);
+    const { deps } = actionDeps({
+      calls,
+      store,
+      attach: async () => fakeHandle({ relay: null, calls }),
+      readListeners: async () => ({ detection: 'watching', listeners: [{ port: 9000, pid: 7 }] }),
+      ...overrides,
+    });
+    return { deps, calls, store };
+  }
+
+  it('records the consent, clears any stop, and the SAME call reconciles the relay up', async () => {
+    const { deps, calls, store } = pending();
+    const result = await applyDevPreviewUserAction({ holder: ENV, action: { kind: 'approve', port: 9000 }, ...ACTOR, deps });
+    assert({ given: 'an approve for the detected port', should: 'create the relay', actual: result, expected: { ok: true, applied: { action: 'start-relay', via: 'create', targetPort: 9000, recorded: true } } });
+    assert({ given: 'the approve', should: 'write the consent BEFORE planning', actual: calls.indexOf('approvePort:9000') < calls.indexOf('services.get'), expected: true });
+    assert({ given: 'the approve', should: 'leave the row approved', actual: store.current()?.approvedPort, expected: 9000 });
+  });
+
+  it('REFUSES a port the row no longer targets, and writes nothing — the echo is what binds the click to the screen', async () => {
+    const calls: string[] = [];
+    const store = fakeStore(row(9001, { relayServiceName: null }), calls);
+    const { deps } = actionDeps({ calls, store, attach: async () => fakeHandle({ relay: null, calls }) });
+    assert({ given: 'a click for 9000 while the server moved to 9001', should: 'be port-changed', actual: await applyDevPreviewUserAction({ holder: ENV, action: { kind: 'approve', port: 9000 }, ...ACTOR, deps }), expected: { ok: false, reason: 'port-changed' } });
+    assert({ given: 'a refused approve', should: 'approve nothing', actual: store.current()?.approvedPort, expected: null });
+    assert({ given: 'a refused approve', should: 'never reach the sprite', actual: calls.includes('services.get'), expected: false });
+  });
+
+  it('a holder with no row at all is no-preview, not port-changed', async () => {
+    const { deps } = actionDeps({ store: fakeStore(null) });
+    assert({ given: 'no row', should: 'be no-preview', actual: await applyDevPreviewUserAction({ holder: ENV, action: { kind: 'approve', port: 9000 }, ...ACTOR, deps }), expected: { ok: false, reason: 'no-preview' } });
+  });
+
+  it('is gated by the wake gate exactly as a resume is — sharing a port is asking for compute', async () => {
+    const { deps, store } = pending({ canRunCode: async () => ({ ok: false as const, reason: 'tier_ineligible' }) });
+    assert({ given: 'a payer that may not run code', should: 'refuse', actual: await applyDevPreviewUserAction({ holder: ENV, action: { kind: 'approve', port: 9000 }, ...ACTOR, deps }), expected: { ok: false, reason: 'wake-not-allowed', detail: 'tier_ineligible' } });
+    assert({ given: 'a refused wake gate', should: 'write no consent', actual: store.current()?.approvedPort, expected: null });
+  });
+
+  it('the status offers the decision only where it can be taken: needs-approval, on this instance', () => {
+    const base = { holder: ENV, sandbox: 'attached' as const, detection: 'watching' as const, openPath: '/o' };
+    const waiting = buildDevPreviewStatus({ ...base, liveInstanceId: INSTANCE, row: row(9000, { relayServiceName: null }), relay: null, listeners: null });
+    assert({ given: 'an unshared 9000', should: 'offer approval, naming the port, and offer no open', actual: [waiting.state.status, waiting.canApprove, waiting.pendingApprovalPort, waiting.canOpen], expected: ['needs-approval', true, 9000, false] });
+    const live = buildDevPreviewStatus({ ...base, liveInstanceId: INSTANCE, row: row(5173), relay: relayService(5173), listeners: null });
+    assert({ given: 'a live known-port preview', should: 'have nothing to approve', actual: [live.canApprove, live.pendingApprovalPort], expected: [false, null] });
+    const stale = buildDevPreviewStatus({ ...base, liveInstanceId: 'other-instance', row: row(9000, { relayServiceName: null }), relay: null, listeners: null });
+    assert({ given: 'a row from a dead VM', should: 'offer nothing to approve', actual: stale.canApprove, expected: false });
   });
 });

--- a/packages/lib/src/services/sandbox/preview/__tests__/dev-preview-status.test.ts
+++ b/packages/lib/src/services/sandbox/preview/__tests__/dev-preview-status.test.ts
@@ -87,6 +87,7 @@ function fakeStore(initial: DevPreviewRecord | null, calls: string[] = []): DevP
     },
     findStoppedWithRelay: async () => [],
     markSwept: async () => {},
+    markRelayStopped: async () => {},
     approvePort: async (_holder, { port, at }) => {
       calls.push(`approvePort:${port}`);
       // The real store filters the UPDATE on the row's current target, so a

--- a/packages/lib/src/services/sandbox/preview/__tests__/dev-preview-status.test.ts
+++ b/packages/lib/src/services/sandbox/preview/__tests__/dev-preview-status.test.ts
@@ -83,6 +83,7 @@ function fakeStore(initial: DevPreviewRecord | null, calls: string[] = []): DevP
       current = { id: 'r1', ...row, stoppedByUserAt: null };
       return true;
     },
+    findStoppedWithRelay: async () => [],
     approvePort: async (_holder, { port, at }) => {
       calls.push(`approvePort:${port}`);
       // The real store filters the UPDATE on the row's current target, so a

--- a/packages/lib/src/services/sandbox/preview/__tests__/dev-preview-status.test.ts
+++ b/packages/lib/src/services/sandbox/preview/__tests__/dev-preview-status.test.ts
@@ -454,6 +454,22 @@ describe('approve — one explicit act, bound to the port the user was shown', (
     assert({ given: 'the deferral', should: 'still have recorded the consent', actual: store.current()?.approvedPort, expected: 9000 });
   });
 
+  it('a resume that could NOT start the relay stays recoverable in one click', async () => {
+    // Resume clears the stop first, so a plan that then refuses (no ports
+    // snapshot, a contended lock, a held slot) leaves a row with no relay and
+    // no stop intent. That must offer Restart, not a Preview button onto a
+    // frame the proxy will 503 — nothing else converges it: the sweep only
+    // handles rows still switched OFF, and the detector needs a port frame a
+    // server that is already listening will not emit.
+    const calls: string[] = [];
+    const store = fakeStore(row(5173, { relayServiceName: null, stoppedByUserAt: NOW }), calls);
+    const { deps } = actionDeps({ calls, store, attach: async () => fakeHandle({ relay: null, calls }), readListeners: async () => ({ detection: 'unavailable', listeners: null }) });
+    assert({ given: 'a resume with no ports snapshot', should: 'defer the relay honestly', actual: await applyDevPreviewUserAction({ holder: ENV, action: { kind: 'resume' }, ...ACTOR, deps }), expected: { ok: false, reason: 'slot-unknown' } });
+
+    const after = buildDevPreviewStatus({ holder: ENV, sandbox: 'attached', liveInstanceId: INSTANCE, detection: 'unavailable', openPath: '/o', row: store.current(), relay: null, listeners: null });
+    assert({ given: 'the row it left behind', should: 'be down, restartable, and NOT openable', actual: [after.state.status, after.canResume, after.canOpen], expected: ['down', true, false] });
+  });
+
   it('the status offers the decision only where it can be taken: needs-approval, on this instance', () => {
     const base = { holder: ENV, sandbox: 'attached' as const, detection: 'watching' as const, openPath: '/o' };
     const waiting = buildDevPreviewStatus({ ...base, liveInstanceId: INSTANCE, row: row(9000, { relayServiceName: null }), relay: null, listeners: null });

--- a/packages/lib/src/services/sandbox/preview/__tests__/dev-preview-status.test.ts
+++ b/packages/lib/src/services/sandbox/preview/__tests__/dev-preview-status.test.ts
@@ -39,6 +39,7 @@ function row(targetPort: number, overrides: Partial<DevPreviewRecord> = {}): Dev
     detectedAt: new Date('2026-09-06T11:00:00.000Z'),
     stoppedByUserAt: null,
     approvedPort: null,
+    approvedAt: null,
     ...overrides,
   };
 }
@@ -80,10 +81,12 @@ function fakeStore(initial: DevPreviewRecord | null, calls: string[] = []): DevP
       // The real store refuses when the stored intent has moved since the plan's read.
       if (current !== null && (current.stoppedByUserAt?.getTime() ?? null) !== (intent.basedOnStoppedByUserAt?.getTime() ?? null)) return false;
       const { basedOnStoppedByUserAt: _guard, ...row } = intent;
-      current = { id: 'r1', ...row, stoppedByUserAt: null };
+      // The real store never lets a planner write the approval columns.
+      current = { id: 'r1', ...row, stoppedByUserAt: null, approvedPort: current?.approvedPort ?? null, approvedAt: current?.approvedAt ?? null };
       return true;
     },
     findStoppedWithRelay: async () => [],
+    markSwept: async () => {},
     approvePort: async (_holder, { port, at }) => {
       calls.push(`approvePort:${port}`);
       // The real store filters the UPDATE on the row's current target, so a
@@ -441,12 +444,21 @@ describe('approve — one explicit act, bound to the port the user was shown', (
     assert({ given: 'a refused wake gate', should: 'write no consent', actual: store.current()?.approvedPort, expected: null });
   });
 
+  it('with no listener snapshot the CONSENT still lands and only the relay defers — the user is not asked twice', async () => {
+    // The realtime tier is unreachable, so nothing proves 8080 is free and the
+    // core refuses a blind start. What must NOT happen is losing the approval:
+    // the user agreed, and the detector's next frame starts it for real.
+    const { deps, store } = pending({ readListeners: async () => ({ detection: 'unavailable', listeners: null }) });
+    assert({ given: 'an approve with no ports snapshot', should: 'defer the relay, honestly', actual: await applyDevPreviewUserAction({ holder: ENV, action: { kind: 'approve', port: 9000 }, ...ACTOR, deps }), expected: { ok: false, reason: 'slot-unknown' } });
+    assert({ given: 'the deferral', should: 'still have recorded the consent', actual: store.current()?.approvedPort, expected: 9000 });
+  });
+
   it('the status offers the decision only where it can be taken: needs-approval, on this instance', () => {
     const base = { holder: ENV, sandbox: 'attached' as const, detection: 'watching' as const, openPath: '/o' };
     const waiting = buildDevPreviewStatus({ ...base, liveInstanceId: INSTANCE, row: row(9000, { relayServiceName: null }), relay: null, listeners: null });
-    assert({ given: 'an unshared 9000', should: 'offer approval, naming the port, and offer no open', actual: [waiting.state.status, waiting.canApprove, waiting.pendingApprovalPort, waiting.canOpen], expected: ['needs-approval', true, 9000, false] });
+    assert({ given: 'an unshared 9000', should: 'offer approval, naming the port, and offer no open', actual: [waiting.state.status, waiting.canApprove, waiting.state.status === 'needs-approval' && waiting.state.targetPort, waiting.canOpen], expected: ['needs-approval', true, 9000, false] });
     const live = buildDevPreviewStatus({ ...base, liveInstanceId: INSTANCE, row: row(5173), relay: relayService(5173), listeners: null });
-    assert({ given: 'a live known-port preview', should: 'have nothing to approve', actual: [live.canApprove, live.pendingApprovalPort], expected: [false, null] });
+    assert({ given: 'a live known-port preview', should: 'have nothing to approve', actual: live.canApprove, expected: false });
     const stale = buildDevPreviewStatus({ ...base, liveInstanceId: 'other-instance', row: row(9000, { relayServiceName: null }), relay: null, listeners: null });
     assert({ given: 'a row from a dead VM', should: 'offer nothing to approve', actual: stale.canApprove, expected: false });
   });

--- a/packages/lib/src/services/sandbox/preview/__tests__/dev-preview-status.test.ts
+++ b/packages/lib/src/services/sandbox/preview/__tests__/dev-preview-status.test.ts
@@ -88,11 +88,12 @@ function fakeStore(initial: DevPreviewRecord | null, calls: string[] = []): DevP
     findStoppedWithRelay: async () => [],
     markSwept: async () => {},
     markRelayStopped: async () => {},
-    approvePort: async (_holder, { port, at }) => {
+    approvePort: async (_holder, { port, spriteInstanceId, at }) => {
       calls.push(`approvePort:${port}`);
-      // The real store filters the UPDATE on the row's current target, so a
-      // port the row no longer names matches nothing.
-      if (current === null || current.targetPort !== port) return null;
+      // The real store filters the UPDATE on the row's current target AND its
+      // instance, so a port the row no longer names — or a row from a VM that
+      // has since been replaced — matches nothing.
+      if (current === null || current.targetPort !== port || current.spriteInstanceId !== spriteInstanceId) return null;
       current = { ...current, approvedPort: port, stoppedByUserAt: null };
       void at;
       return current;
@@ -419,7 +420,7 @@ describe('approve — one explicit act, bound to the port the user was shown', (
 
   it('records the consent, clears any stop, and the SAME call reconciles the relay up', async () => {
     const { deps, calls, store } = pending();
-    const result = await applyDevPreviewUserAction({ holder: ENV, action: { kind: 'approve', port: 9000 }, ...ACTOR, deps });
+    const result = await applyDevPreviewUserAction({ holder: ENV, action: { kind: 'approve', port: 9000, spriteInstanceId: INSTANCE }, ...ACTOR, deps });
     assert({ given: 'an approve for the detected port', should: 'create the relay', actual: result, expected: { ok: true, applied: { action: 'start-relay', via: 'create', targetPort: 9000, recorded: true } } });
     assert({ given: 'the approve', should: 'write the consent BEFORE planning', actual: calls.indexOf('approvePort:9000') < calls.indexOf('services.get'), expected: true });
     assert({ given: 'the approve', should: 'leave the row approved', actual: store.current()?.approvedPort, expected: 9000 });
@@ -429,19 +430,19 @@ describe('approve — one explicit act, bound to the port the user was shown', (
     const calls: string[] = [];
     const store = fakeStore(row(9001, { relayServiceName: null }), calls);
     const { deps } = actionDeps({ calls, store, attach: async () => fakeHandle({ relay: null, calls }) });
-    assert({ given: 'a click for 9000 while the server moved to 9001', should: 'be port-changed', actual: await applyDevPreviewUserAction({ holder: ENV, action: { kind: 'approve', port: 9000 }, ...ACTOR, deps }), expected: { ok: false, reason: 'port-changed' } });
+    assert({ given: 'a click for 9000 while the server moved to 9001', should: 'be port-changed', actual: await applyDevPreviewUserAction({ holder: ENV, action: { kind: 'approve', port: 9000, spriteInstanceId: INSTANCE }, ...ACTOR, deps }), expected: { ok: false, reason: 'port-changed' } });
     assert({ given: 'a refused approve', should: 'approve nothing', actual: store.current()?.approvedPort, expected: null });
     assert({ given: 'a refused approve', should: 'never reach the sprite', actual: calls.includes('services.get'), expected: false });
   });
 
   it('a holder with no row at all is no-preview, not port-changed', async () => {
     const { deps } = actionDeps({ store: fakeStore(null) });
-    assert({ given: 'no row', should: 'be no-preview', actual: await applyDevPreviewUserAction({ holder: ENV, action: { kind: 'approve', port: 9000 }, ...ACTOR, deps }), expected: { ok: false, reason: 'no-preview' } });
+    assert({ given: 'no row', should: 'be no-preview', actual: await applyDevPreviewUserAction({ holder: ENV, action: { kind: 'approve', port: 9000, spriteInstanceId: INSTANCE }, ...ACTOR, deps }), expected: { ok: false, reason: 'no-preview' } });
   });
 
   it('is gated by the wake gate exactly as a resume is — sharing a port is asking for compute', async () => {
     const { deps, store } = pending({ canRunCode: async () => ({ ok: false as const, reason: 'tier_ineligible' }) });
-    assert({ given: 'a payer that may not run code', should: 'refuse', actual: await applyDevPreviewUserAction({ holder: ENV, action: { kind: 'approve', port: 9000 }, ...ACTOR, deps }), expected: { ok: false, reason: 'wake-not-allowed', detail: 'tier_ineligible' } });
+    assert({ given: 'a payer that may not run code', should: 'refuse', actual: await applyDevPreviewUserAction({ holder: ENV, action: { kind: 'approve', port: 9000, spriteInstanceId: INSTANCE }, ...ACTOR, deps }), expected: { ok: false, reason: 'wake-not-allowed', detail: 'tier_ineligible' } });
     assert({ given: 'a refused wake gate', should: 'write no consent', actual: store.current()?.approvedPort, expected: null });
   });
 
@@ -450,7 +451,7 @@ describe('approve — one explicit act, bound to the port the user was shown', (
     // core refuses a blind start. What must NOT happen is losing the approval:
     // the user agreed, and the detector's next frame starts it for real.
     const { deps, store } = pending({ readListeners: async () => ({ detection: 'unavailable', listeners: null }) });
-    assert({ given: 'an approve with no ports snapshot', should: 'defer the relay, honestly', actual: await applyDevPreviewUserAction({ holder: ENV, action: { kind: 'approve', port: 9000 }, ...ACTOR, deps }), expected: { ok: false, reason: 'slot-unknown' } });
+    assert({ given: 'an approve with no ports snapshot', should: 'defer the relay, honestly', actual: await applyDevPreviewUserAction({ holder: ENV, action: { kind: 'approve', port: 9000, spriteInstanceId: INSTANCE }, ...ACTOR, deps }), expected: { ok: false, reason: 'slot-unknown' } });
     assert({ given: 'the deferral', should: 'still have recorded the consent', actual: store.current()?.approvedPort, expected: 9000 });
   });
 

--- a/packages/lib/src/services/sandbox/preview/__tests__/dev-preview-status.test.ts
+++ b/packages/lib/src/services/sandbox/preview/__tests__/dev-preview-status.test.ts
@@ -94,7 +94,7 @@ function fakeStore(initial: DevPreviewRecord | null, calls: string[] = []): DevP
 // -----------------------------------------------------------------------------
 
 describe('buildDevPreviewStatus — pure fold', () => {
-  const base = { holder: ENV, sandbox: 'attached' as const, liveInstanceId: INSTANCE, openPath: '/api/drives/d1/envs/env1/preview/open' };
+  const base = { holder: ENV, sandbox: 'attached' as const, liveInstanceId: INSTANCE, detection: 'watching' as const, openPath: '/api/drives/d1/envs/env1/preview/open' };
 
   it('an absent sandbox is "none" with the absent message, whatever the row says', () => {
     const status = buildDevPreviewStatus({ ...base, sandbox: 'absent', liveInstanceId: null, row: row(5173), relay: null, listeners: null });
@@ -211,7 +211,7 @@ function statusDeps(over: Partial<DevPreviewStatusDeps> & { calls?: string[] } =
     resolveDrivePayer: async () => track('payer', { payerId: 'owner' }),
     attach: async () => track('attach', fakeHandle({ relay: relayService(5173), calls })),
     previewStore: fakeStore(row(5173), calls),
-    readListeners: async () => track('readListeners', [{ port: 5173, pid: 7 }, { port: SPRITE_HTTP_PORT, pid: 42 }]),
+    readListeners: async () => track('readListeners', { detection: 'watching', listeners: [{ port: 5173, pid: 7 }, { port: SPRITE_HTTP_PORT, pid: 42 }] }),
     ...over,
   };
 }
@@ -258,7 +258,7 @@ describe('gatherDevPreviewStatus — authorize, attach, fold; never a probe', ()
   });
 
   it('a null snapshot from realtime renders the LAST-KNOWN state honestly (relay status carries it) with the slot unknown', async () => {
-    const d = statusDeps({ readListeners: async () => null });
+    const d = statusDeps({ readListeners: async () => ({ detection: 'unavailable', listeners: null }) });
     const result = await gatherDevPreviewStatus({ authorizeAs: ENV, holder: ENV, userId: 'u1', deps: d });
     if (!result.ok) throw new Error('expected ok');
     assert({ given: 'no snapshot', should: 'still be live, slot unknown', actual: [result.status.state.status, result.status.slot], expected: ['live', { known: false }] });
@@ -275,7 +275,7 @@ function actionDeps(over: Partial<DevPreviewUserActionDeps> & { calls?: string[]
   const deps: DevPreviewUserActionDeps = {
     previewStore: store,
     attach: async () => fakeHandle({ relay: relayService(5173), calls }),
-    readListeners: async () => null,
+    readListeners: async () => ({ detection: 'unavailable', listeners: null }),
     canRunCode: async (input) => { calls.push(`canRunCode:${input.userId}:${input.driveId}:${input.ownerId}`); return { ok: true }; },
     now: () => NOW,
     ...over,
@@ -300,7 +300,7 @@ describe('applyDevPreviewUserAction — intent first, then ONE reconcile through
       attach: async () => fakeHandle({ relay: relayService(5173, { status: 'failed', error: 'exited with code 143' }), calls: trackedCalls }),
       // A CURRENT snapshot: the dev server is up and 8080 is free, so the
       // relay may honestly be started (see the slot-unknown case below).
-      readListeners: async () => [{ port: 5173, pid: 7 }],
+      readListeners: async () => ({ detection: 'watching', listeners: [{ port: 5173, pid: 7 }] }),
     });
     const result = await applyDevPreviewUserAction({ holder: ENV, action: 'resume', ...ACTOR, deps });
     assert({ given: 'a stopped relay', should: 'start it and re-record the row', actual: result, expected: { ok: true, applied: { action: 'start-relay', via: 'start', targetPort: 5173, recorded: true } } });
@@ -314,7 +314,7 @@ describe('applyDevPreviewUserAction — intent first, then ONE reconcile through
     const { deps } = actionDeps({
       store,
       attach: async () => fakeHandle({ relay: relayService(5173, { status: 'failed' }), calls: trackedCalls }),
-      readListeners: async () => null,
+      readListeners: async () => ({ detection: 'unavailable', listeners: null }),
     });
     assert({ given: 'no ports/watch snapshot', should: 'refuse rather than read unknown as "8080 is free"', actual: await applyDevPreviewUserAction({ holder: ENV, action: 'resume', ...ACTOR, deps }), expected: { ok: false, reason: 'slot-unknown' } });
     assert({ given: 'the refusal', should: 'still have cleared the stop — the user\'s ON stands', actual: store.current()?.stoppedByUserAt, expected: null });
@@ -322,7 +322,7 @@ describe('applyDevPreviewUserAction — intent first, then ONE reconcile through
   });
 
   it('a DIRECT (8080) resume needs no snapshot — there is no relay to place', async () => {
-    const { deps } = actionDeps({ store: fakeStore(row(SPRITE_HTTP_PORT, { stoppedByUserAt: NOW })), attach: async () => fakeHandle({ relay: null }), readListeners: async () => null });
+    const { deps } = actionDeps({ store: fakeStore(row(SPRITE_HTTP_PORT, { stoppedByUserAt: NOW })), attach: async () => fakeHandle({ relay: null }), readListeners: async () => ({ detection: 'unavailable', listeners: null }) });
     assert({ given: 'a direct row and no snapshot', should: 'converge without refusing', actual: await applyDevPreviewUserAction({ holder: ENV, action: 'resume', ...ACTOR, deps }), expected: { ok: true, applied: { action: 'none', reason: 'already-direct', staleRowIgnored: false } } });
   });
 
@@ -331,7 +331,7 @@ describe('applyDevPreviewUserAction — intent first, then ONE reconcile through
     const { deps } = actionDeps({
       store: fakeStore(row(5173, { stoppedByUserAt: NOW })),
       attach: async () => fakeHandle({ relay: relayService(5173, { status: 'failed' }), calls: trackedCalls }),
-      readListeners: async () => [{ port: SPRITE_HTTP_PORT, pid: 999 }],
+      readListeners: async () => ({ detection: 'watching', listeners: [{ port: SPRITE_HTTP_PORT, pid: 999 }] }),
     });
     const result = await applyDevPreviewUserAction({ holder: ENV, action: 'resume', ...ACTOR, deps });
     assert({ given: 'foreign 8080 listener', should: 'refuse http-port-busy', actual: result, expected: { ok: true, applied: { action: 'refuse', reason: 'http-port-busy', targetPort: 5173 } } });

--- a/packages/lib/src/services/sandbox/preview/__tests__/dev-preview-stores.integration.test.ts
+++ b/packages/lib/src/services/sandbox/preview/__tests__/dev-preview-stores.integration.test.ts
@@ -55,13 +55,13 @@ describe('createDbDevPreviewStore', () => {
   const holder = { kind: 'env', id: envId } as const;
 
   it('upserts by holder: a re-create on a new instance REPLACES the holder row and clears the stop intent', async () => {
-    await store.upsert({ holder, spriteInstanceId: 'inst-a', sandboxId: 'sbx', targetPort: 5173, relayServiceName: PREVIEW_RELAY_SERVICE_NAME, detectedAt: NOW, stoppedByUserAt: null, approvedPort: null, basedOnStoppedByUserAt: null });
+    await store.upsert({ holder, spriteInstanceId: 'inst-a', sandboxId: 'sbx', targetPort: 5173, relayServiceName: PREVIEW_RELAY_SERVICE_NAME, detectedAt: NOW, stoppedByUserAt: null, basedOnStoppedByUserAt: null });
     // Simulate the user switching it off on the old instance.
     await db.update(devPreviewServices).set({ stoppedByUserAt: NOW }).where(eq(devPreviewServices.envId, envId));
     const before = await store.findByHolder(holder);
     expect(before?.stoppedByUserAt).toEqual(NOW);
 
-    await store.upsert({ holder, spriteInstanceId: 'inst-b', sandboxId: 'sbx', targetPort: 3000, relayServiceName: PREVIEW_RELAY_SERVICE_NAME, detectedAt: NOW, stoppedByUserAt: null, approvedPort: null, basedOnStoppedByUserAt: null });
+    await store.upsert({ holder, spriteInstanceId: 'inst-b', sandboxId: 'sbx', targetPort: 3000, relayServiceName: PREVIEW_RELAY_SERVICE_NAME, detectedAt: NOW, stoppedByUserAt: null, basedOnStoppedByUserAt: null });
     const rows = await db.select().from(devPreviewServices).where(eq(devPreviewServices.envId, envId));
     expect(rows).toHaveLength(1);
     expect(rows[0]).toMatchObject({ spriteInstanceId: 'inst-b', targetPort: 3000, stoppedByUserAt: null, workspaceId: null });
@@ -71,38 +71,38 @@ describe('createDbDevPreviewStore', () => {
   });
 
   it('THE INTENT GUARD: a write planned before a user\'s stop is refused on the SAME instance (the click survives), while a re-create on a NEW instance replaces the row and the dead VM\'s stop with it', async () => {
-    await store.upsert({ holder, spriteInstanceId: 'inst-guard', sandboxId: 'sbx', targetPort: 5173, relayServiceName: PREVIEW_RELAY_SERVICE_NAME, detectedAt: NOW, stoppedByUserAt: null, approvedPort: null, basedOnStoppedByUserAt: null });
+    await store.upsert({ holder, spriteInstanceId: 'inst-guard', sandboxId: 'sbx', targetPort: 5173, relayServiceName: PREVIEW_RELAY_SERVICE_NAME, detectedAt: NOW, stoppedByUserAt: null, basedOnStoppedByUserAt: null });
     const stoppedAt = new Date('2026-09-06T13:00:00.000Z');
     await store.setStoppedByUser(holder, stoppedAt);
 
     // A detection frame that read the row BEFORE the stop (guard: null) must
     // not clear it — the write is refused and the row is untouched.
-    const refused = await store.upsert({ holder, spriteInstanceId: 'inst-guard', sandboxId: 'sbx', targetPort: 3000, relayServiceName: PREVIEW_RELAY_SERVICE_NAME, detectedAt: NOW, stoppedByUserAt: null, approvedPort: null, basedOnStoppedByUserAt: null });
+    const refused = await store.upsert({ holder, spriteInstanceId: 'inst-guard', sandboxId: 'sbx', targetPort: 3000, relayServiceName: PREVIEW_RELAY_SERVICE_NAME, detectedAt: NOW, stoppedByUserAt: null, basedOnStoppedByUserAt: null });
     expect(refused).toBe(false);
     expect(await store.findByHolder(holder)).toMatchObject({ targetPort: 5173, stoppedByUserAt: stoppedAt });
 
     // A frame that DID see the stop (guard: that timestamp) writes normally.
-    const accepted = await store.upsert({ holder, spriteInstanceId: 'inst-guard', sandboxId: 'sbx', targetPort: 3000, relayServiceName: PREVIEW_RELAY_SERVICE_NAME, detectedAt: NOW, stoppedByUserAt: null, approvedPort: null, basedOnStoppedByUserAt: stoppedAt });
+    const accepted = await store.upsert({ holder, spriteInstanceId: 'inst-guard', sandboxId: 'sbx', targetPort: 3000, relayServiceName: PREVIEW_RELAY_SERVICE_NAME, detectedAt: NOW, stoppedByUserAt: null, basedOnStoppedByUserAt: stoppedAt });
     expect(accepted).toBe(true);
     expect(await store.findByHolder(holder)).toMatchObject({ targetPort: 3000, stoppedByUserAt: null });
 
     // A REBUILD: the stored row names a dead instance, so its stop dies with
     // the VM and the re-create replaces it even with a null guard.
     await store.setStoppedByUser(holder, stoppedAt);
-    const recreated = await store.upsert({ holder, spriteInstanceId: 'inst-rebuilt', sandboxId: 'sbx', targetPort: 5173, relayServiceName: PREVIEW_RELAY_SERVICE_NAME, detectedAt: NOW, stoppedByUserAt: null, approvedPort: null, basedOnStoppedByUserAt: null });
+    const recreated = await store.upsert({ holder, spriteInstanceId: 'inst-rebuilt', sandboxId: 'sbx', targetPort: 5173, relayServiceName: PREVIEW_RELAY_SERVICE_NAME, detectedAt: NOW, stoppedByUserAt: null, basedOnStoppedByUserAt: null });
     expect(recreated).toBe(true);
     expect(await store.findByHolder(holder)).toMatchObject({ spriteInstanceId: 'inst-rebuilt', targetPort: 5173, stoppedByUserAt: null });
   });
 
   it('a direct (8080) row carries no relay name, as the CHECK requires', async () => {
-    await store.upsert({ holder, spriteInstanceId: 'inst-c', sandboxId: 'sbx', targetPort: 8080, relayServiceName: null, detectedAt: NOW, stoppedByUserAt: null, approvedPort: null, basedOnStoppedByUserAt: null });
+    await store.upsert({ holder, spriteInstanceId: 'inst-c', sandboxId: 'sbx', targetPort: 8080, relayServiceName: null, detectedAt: NOW, stoppedByUserAt: null, basedOnStoppedByUserAt: null });
     expect(await store.findByHolder(holder)).toMatchObject({ targetPort: 8080, relayServiceName: null });
   });
 
   it('an UNSHARED unlisted port is a legal row — a non-8080 target with no relay, which serves nothing', async () => {
     // The old CHECK made this shape illegal, which is why it had to be
     // relaxed: consent has to be recordable before the relay exists.
-    await store.upsert({ holder, spriteInstanceId: 'inst-u', sandboxId: 'sbx', targetPort: 9000, relayServiceName: null, detectedAt: NOW, stoppedByUserAt: null, approvedPort: null, basedOnStoppedByUserAt: null });
+    await store.upsert({ holder, spriteInstanceId: 'inst-u', sandboxId: 'sbx', targetPort: 9000, relayServiceName: null, detectedAt: NOW, stoppedByUserAt: null, basedOnStoppedByUserAt: null });
     expect(await store.findByHolder(holder)).toMatchObject({ targetPort: 9000, relayServiceName: null, approvedPort: null });
     // A relay pointed at 8080 would be a loop, and that half of the CHECK stands.
     await expect(
@@ -111,7 +111,7 @@ describe('createDbDevPreviewStore', () => {
   });
 
   it('approvePort records consent for exactly the port shown, clears the stop, and REFUSES a port the row no longer targets', async () => {
-    await store.upsert({ holder, spriteInstanceId: 'inst-ap', sandboxId: 'sbx', targetPort: 9000, relayServiceName: null, detectedAt: NOW, stoppedByUserAt: null, approvedPort: null, basedOnStoppedByUserAt: null });
+    await store.upsert({ holder, spriteInstanceId: 'inst-ap', sandboxId: 'sbx', targetPort: 9000, relayServiceName: null, detectedAt: NOW, stoppedByUserAt: null, basedOnStoppedByUserAt: null });
     await store.setStoppedByUser(holder, NOW);
 
     const at = new Date('2026-09-06T12:45:00.000Z');
@@ -125,12 +125,12 @@ describe('createDbDevPreviewStore', () => {
 
     // A later detection carries the approval and its ORIGINAL timestamp
     // forward: the planner never grants or revokes, so nothing is restamped.
-    await store.upsert({ holder, spriteInstanceId: 'inst-ap', sandboxId: 'sbx', targetPort: 9000, relayServiceName: PREVIEW_RELAY_SERVICE_NAME, detectedAt: new Date(NOW.getTime() + 60_000), stoppedByUserAt: null, approvedPort: 9000, basedOnStoppedByUserAt: null });
+    await store.upsert({ holder, spriteInstanceId: 'inst-ap', sandboxId: 'sbx', targetPort: 9000, relayServiceName: PREVIEW_RELAY_SERVICE_NAME, detectedAt: new Date(NOW.getTime() + 60_000), stoppedByUserAt: null, basedOnStoppedByUserAt: null });
     const [after] = await db.select().from(devPreviewServices).where(eq(devPreviewServices.envId, envId));
     expect(after).toMatchObject({ approvedPort: 9000, approvedAt: at });
 
     // And a REBUILD carries nothing: a new instance replaces the row wholesale.
-    await store.upsert({ holder, spriteInstanceId: 'inst-new', sandboxId: 'sbx', targetPort: 9000, relayServiceName: null, detectedAt: NOW, stoppedByUserAt: null, approvedPort: null, basedOnStoppedByUserAt: null });
+    await store.upsert({ holder, spriteInstanceId: 'inst-new', sandboxId: 'sbx', targetPort: 9000, relayServiceName: null, detectedAt: NOW, stoppedByUserAt: null, basedOnStoppedByUserAt: null });
     const [rebuilt] = await db.select().from(devPreviewServices).where(eq(devPreviewServices.envId, envId));
     expect(rebuilt).toMatchObject({ approvedPort: null, approvedAt: null });
     expect(await store.approvePort({ kind: 'workspace', id: createId() }, { port: 9000, at, byUserId: userId })).toBeNull();
@@ -144,7 +144,7 @@ describe('createDbDevPreviewStore', () => {
     const ask = () => store.findStoppedWithRelay({ staleAfterMs: 2 * 60 * 1000, limit: 50, now: new Date(Date.now() + 10 * 60 * 1000) });
 
     // Switched off with a relay: a candidate, but only once it has aged.
-    await store.upsert({ holder, spriteInstanceId: 'inst-s', sandboxId: 'sbx', targetPort: 5173, relayServiceName: PREVIEW_RELAY_SERVICE_NAME, detectedAt: NOW, stoppedByUserAt: null, approvedPort: null, basedOnStoppedByUserAt: null });
+    await store.upsert({ holder, spriteInstanceId: 'inst-s', sandboxId: 'sbx', targetPort: 5173, relayServiceName: PREVIEW_RELAY_SERVICE_NAME, detectedAt: NOW, stoppedByUserAt: null, basedOnStoppedByUserAt: null });
     await store.setStoppedByUser(holder, NOW);
     // Not yet aged: the row was written a moment ago.
     expect(await store.findStoppedWithRelay({ staleAfterMs: 2 * 60 * 1000, limit: 50, now: new Date() })).toEqual([]);
@@ -155,9 +155,24 @@ describe('createDbDevPreviewStore', () => {
     expect(await ask()).toEqual([]);
 
     // Switched off but with no relay recorded: nothing to stop.
-    await store.upsert({ holder, spriteInstanceId: 'inst-s2', sandboxId: 'sbx', targetPort: 9000, relayServiceName: null, detectedAt: NOW, stoppedByUserAt: null, approvedPort: null, basedOnStoppedByUserAt: null });
+    await store.upsert({ holder, spriteInstanceId: 'inst-s2', sandboxId: 'sbx', targetPort: 9000, relayServiceName: null, detectedAt: NOW, stoppedByUserAt: null, basedOnStoppedByUserAt: null });
     await store.setStoppedByUser(holder, NOW);
     expect(await ask()).toEqual([]);
+  });
+
+  it('markSwept re-stamps updatedAt and NOTHING else, which is what takes a converged row out of the sweep window', async () => {
+    await store.upsert({ holder, spriteInstanceId: 'inst-sw', sandboxId: 'sbx', targetPort: 5173, relayServiceName: PREVIEW_RELAY_SERVICE_NAME, detectedAt: NOW, stoppedByUserAt: null, basedOnStoppedByUserAt: null });
+    await store.setStoppedByUser(holder, NOW);
+    const before = await store.findByHolder(holder);
+    const stale = () => store.findStoppedWithRelay({ staleAfterMs: 0, limit: 50, now: new Date(Date.now() + 60_000) });
+    expect(await stale()).toHaveLength(1);
+
+    await store.markSwept(holder);
+    // The row itself is untouched — the stop intent, the target and the relay
+    // name are facts a sweep does not get to change.
+    expect(await store.findByHolder(holder)).toEqual(before);
+    // But it has left the window it was in.
+    expect(await store.findStoppedWithRelay({ staleAfterMs: 60_000, limit: 50, now: new Date() })).toEqual([]);
   });
 
   it('answers null for a holder with no row', async () => {
@@ -165,7 +180,7 @@ describe('createDbDevPreviewStore', () => {
   });
 
   it('setStoppedByUser writes ONLY the intent column and returns the row as written, clears it on null, and answers null for a holder with no row', async () => {
-    await store.upsert({ holder, spriteInstanceId: 'inst-d', sandboxId: 'sbx', targetPort: 5173, relayServiceName: PREVIEW_RELAY_SERVICE_NAME, detectedAt: NOW, stoppedByUserAt: null, approvedPort: null, basedOnStoppedByUserAt: null });
+    await store.upsert({ holder, spriteInstanceId: 'inst-d', sandboxId: 'sbx', targetPort: 5173, relayServiceName: PREVIEW_RELAY_SERVICE_NAME, detectedAt: NOW, stoppedByUserAt: null, basedOnStoppedByUserAt: null });
     const stoppedAt = new Date('2026-09-06T12:30:00.000Z');
     const written = await store.setStoppedByUser(holder, stoppedAt);
     expect(written).toMatchObject({ spriteInstanceId: 'inst-d', targetPort: 5173, relayServiceName: PREVIEW_RELAY_SERVICE_NAME, stoppedByUserAt: stoppedAt });

--- a/packages/lib/src/services/sandbox/preview/__tests__/dev-preview-stores.integration.test.ts
+++ b/packages/lib/src/services/sandbox/preview/__tests__/dev-preview-stores.integration.test.ts
@@ -175,6 +175,30 @@ describe('createDbDevPreviewStore', () => {
     expect(await store.findStoppedWithRelay({ staleAfterMs: 60_000, limit: 50, now: new Date() })).toEqual([]);
   });
 
+  it('markRelayStopped drains the sweep window, and only for the relay that was stopped while the stop still stands', async () => {
+    await store.upsert({ holder, spriteInstanceId: 'inst-rs', sandboxId: 'sbx', targetPort: 5173, relayServiceName: PREVIEW_RELAY_SERVICE_NAME, detectedAt: NOW, stoppedByUserAt: null, basedOnStoppedByUserAt: null });
+    await store.setStoppedByUser(holder, NOW);
+    const window = () => store.findStoppedWithRelay({ staleAfterMs: 0, limit: 50, now: new Date(Date.now() + 60_000) });
+    expect(await window()).toHaveLength(1);
+
+    // A relay name that is not the one on the row changes nothing — this is
+    // the guard against clearing a relay somebody else just re-pointed.
+    await store.markRelayStopped({ holder, relayServiceName: 'some-other-relay' });
+    expect(await window()).toHaveLength(1);
+
+    await store.markRelayStopped({ holder, relayServiceName: PREVIEW_RELAY_SERVICE_NAME });
+    const after = await store.findByHolder(holder);
+    expect(after).toMatchObject({ relayServiceName: null, stoppedByUserAt: NOW, targetPort: 5173 });
+    // Drained: the row no longer names a relay, so it is not a candidate at
+    // any age. Without this it re-enters every window for the life of the row.
+    expect(await window()).toEqual([]);
+
+    // And the guard the other way: a RESUMED row is not the caller's to clear.
+    await store.upsert({ holder, spriteInstanceId: 'inst-rs2', sandboxId: 'sbx', targetPort: 5173, relayServiceName: PREVIEW_RELAY_SERVICE_NAME, detectedAt: NOW, stoppedByUserAt: null, basedOnStoppedByUserAt: null });
+    await store.markRelayStopped({ holder, relayServiceName: PREVIEW_RELAY_SERVICE_NAME });
+    expect((await store.findByHolder(holder))?.relayServiceName).toBe(PREVIEW_RELAY_SERVICE_NAME);
+  });
+
   it('answers null for a holder with no row', async () => {
     expect(await store.findByHolder({ kind: 'workspace', id: createId() })).toBeNull();
   });

--- a/packages/lib/src/services/sandbox/preview/__tests__/dev-preview-stores.integration.test.ts
+++ b/packages/lib/src/services/sandbox/preview/__tests__/dev-preview-stores.integration.test.ts
@@ -136,6 +136,30 @@ describe('createDbDevPreviewStore', () => {
     expect(await store.approvePort({ kind: 'workspace', id: createId() }, { port: 9000, at, byUserId: userId })).toBeNull();
   });
 
+  it('findStoppedWithRelay lists ONLY aged rows that are switched off with a relay still recorded', async () => {
+    // `updatedAt` is stamped by the DATABASE (`now() at time zone 'utc'`), so
+    // the age window has to be measured against the real clock, not the fixed
+    // NOW the rest of these fixtures use. This is also what proves the
+    // comparison lands in the same time base the column is written in.
+    const ask = () => store.findStoppedWithRelay({ staleAfterMs: 2 * 60 * 1000, limit: 50, now: new Date(Date.now() + 10 * 60 * 1000) });
+
+    // Switched off with a relay: a candidate, but only once it has aged.
+    await store.upsert({ holder, spriteInstanceId: 'inst-s', sandboxId: 'sbx', targetPort: 5173, relayServiceName: PREVIEW_RELAY_SERVICE_NAME, detectedAt: NOW, stoppedByUserAt: null, approvedPort: null, basedOnStoppedByUserAt: null });
+    await store.setStoppedByUser(holder, NOW);
+    // Not yet aged: the row was written a moment ago.
+    expect(await store.findStoppedWithRelay({ staleAfterMs: 2 * 60 * 1000, limit: 50, now: new Date() })).toEqual([]);
+    expect(await ask()).toEqual([{ holder: { kind: 'env', id: envId }, sandboxId: 'sbx' }]);
+
+    // Resumed: no longer a candidate.
+    await store.setStoppedByUser(holder, null);
+    expect(await ask()).toEqual([]);
+
+    // Switched off but with no relay recorded: nothing to stop.
+    await store.upsert({ holder, spriteInstanceId: 'inst-s2', sandboxId: 'sbx', targetPort: 9000, relayServiceName: null, detectedAt: NOW, stoppedByUserAt: null, approvedPort: null, basedOnStoppedByUserAt: null });
+    await store.setStoppedByUser(holder, NOW);
+    expect(await ask()).toEqual([]);
+  });
+
   it('answers null for a holder with no row', async () => {
     expect(await store.findByHolder({ kind: 'workspace', id: createId() })).toBeNull();
   });

--- a/packages/lib/src/services/sandbox/preview/__tests__/dev-preview-stores.integration.test.ts
+++ b/packages/lib/src/services/sandbox/preview/__tests__/dev-preview-stores.integration.test.ts
@@ -14,6 +14,7 @@ import { createId } from '@paralleldrive/cuid2';
 import { db } from '@pagespace/db/db';
 import { eq, inArray } from '@pagespace/db/operators';
 import { users } from '@pagespace/db/schema/auth';
+import { sessions } from '@pagespace/db/schema/sessions';
 import { drives } from '@pagespace/db/schema/core';
 import { driveEnvs } from '@pagespace/db/schema/drive-envs';
 import { devPreviewServices } from '@pagespace/db/schema/dev-preview-services';
@@ -26,16 +27,24 @@ import { PREVIEW_RELAY_SERVICE_NAME } from '../preview-relay';
 const userId = createId();
 const driveId = createId();
 const envId = createId();
+const sessionId = createId();
 const NOW = new Date('2026-09-06T12:00:00.000Z');
 
 beforeAll(async () => {
   await db.insert(users).values({ id: userId, email: `${userId}@example.com`, name: 'preview-store-test' });
   await db.insert(drives).values({ id: driveId, name: 'd', slug: `d-${driveId}`, ownerId: userId });
   await db.insert(driveEnvs).values({ id: envId, driveId, name: 'main', storageLastBilledAt: NOW });
+  // A grant names the SESSION that opened it, so an integration test needs a
+  // real one: the FK is what makes revocation reach the grants table.
+  await db.insert(sessions).values({
+    id: sessionId, tokenHash: `h-${sessionId}`, tokenPrefix: 'ps_', userId, type: 'user',
+    tokenVersion: 1, expiresAt: new Date(NOW.getTime() + 86_400_000),
+  });
 });
 
 afterAll(async () => {
   await db.delete(devPreviewGrants).where(eq(devPreviewGrants.userId, userId));
+  await db.delete(sessions).where(eq(sessions.id, sessionId));
   await db.delete(driveEnvs).where(eq(driveEnvs.id, envId));
   await db.delete(drives).where(eq(drives.id, driveId));
   await db.delete(users).where(inArray(users.id, [userId]));
@@ -111,41 +120,52 @@ describe('createDbDevPreviewGrantsStore', () => {
   const holder = { kind: 'env', id: envId } as const;
 
   it('mints a grant bound to (holder, user) with the two expiries fixed at mint time', async () => {
-    const minted = await store.mint({ holder, userId, now: NOW });
+    const minted = await store.mint({ holder, userId, sessionId, now: NOW });
     expect(minted.id).toMatch(/^[A-Za-z0-9_-]{43}$/);
     expect(minted.expiresAt).toEqual(new Date(NOW.getTime() + PREVIEW_GRANT_TTL_MS));
     expect(minted.cookieExpiresAt).toEqual(new Date(NOW.getTime() + PREVIEW_COOKIE_TTL_MS));
     const [row] = await db.select().from(devPreviewGrants).where(eq(devPreviewGrants.id, minted.id));
-    expect(row).toMatchObject({ holderKind: 'env', holderId: envId, userId, consumedAt: null });
+    expect(row).toMatchObject({ holderKind: 'env', holderId: envId, userId, sessionId, consumedAt: null });
   });
 
   it('consumes exactly once: the first redemption returns the claims, the second returns null', async () => {
-    const minted = await store.mint({ holder, userId, now: NOW });
+    const minted = await store.mint({ holder, userId, sessionId, now: NOW });
     const later = new Date(NOW.getTime() + 1000);
-    expect(await store.consume({ id: minted.id, now: later })).toEqual({ holder: { kind: 'env', id: envId }, userId, cookieExpiresAt: minted.cookieExpiresAt });
+    expect(await store.consume({ id: minted.id, now: later })).toEqual({ holder: { kind: 'env', id: envId }, userId, sessionId, cookieExpiresAt: minted.cookieExpiresAt });
     expect(await store.consume({ id: minted.id, now: later })).toBeNull();
     const [row] = await db.select({ consumedAt: devPreviewGrants.consumedAt }).from(devPreviewGrants).where(eq(devPreviewGrants.id, minted.id));
     expect(row.consumedAt).toEqual(later);
   });
 
   it('under a concurrent race, exactly one of N redemptions wins', async () => {
-    const minted = await store.mint({ holder, userId, now: NOW });
+    const minted = await store.mint({ holder, userId, sessionId, now: NOW });
     const later = new Date(NOW.getTime() + 1000);
     const results = await Promise.all(Array.from({ length: 8 }, () => store.consume({ id: minted.id, now: later })));
     expect(results.filter((r) => r !== null)).toHaveLength(1);
   });
 
   it('refuses an expired grant, an unknown id, and a malformed id', async () => {
-    const minted = await store.mint({ holder, userId, now: NOW });
+    const minted = await store.mint({ holder, userId, sessionId, now: NOW });
     expect(await store.consume({ id: minted.id, now: new Date(minted.expiresAt.getTime()) })).toBeNull();
     expect(await store.consume({ id: 'A'.repeat(43), now: NOW })).toBeNull();
     expect(await store.consume({ id: 'not-a-grant', now: NOW })).toBeNull();
     expect(await store.consume({ id: `${minted.id}'; --`, now: NOW })).toBeNull();
   });
 
+  it('a deleted session takes its unredeemed grants with it (the FK cascade)', async () => {
+    const doomedSession = createId();
+    await db.insert(sessions).values({
+      id: doomedSession, tokenHash: `h-${doomedSession}`, tokenPrefix: 'ps_', userId, type: 'user',
+      tokenVersion: 1, expiresAt: new Date(NOW.getTime() + 86_400_000),
+    });
+    const minted = await store.mint({ holder, userId, sessionId: doomedSession, now: NOW });
+    await db.delete(sessions).where(eq(sessions.id, doomedSession));
+    expect(await db.select().from(devPreviewGrants).where(eq(devPreviewGrants.id, minted.id))).toHaveLength(0);
+  });
+
   it('sweeps grants an hour past expiry on the next mint', async () => {
-    const old = await store.mint({ holder, userId, now: new Date(NOW.getTime() - 3 * 60 * 60 * 1000) });
-    await store.mint({ holder, userId, now: NOW });
+    const old = await store.mint({ holder, userId, sessionId, now: new Date(NOW.getTime() - 3 * 60 * 60 * 1000) });
+    await store.mint({ holder, userId, sessionId, now: NOW });
     const rows = await db.select().from(devPreviewGrants).where(eq(devPreviewGrants.id, old.id));
     expect(rows).toHaveLength(0);
   });

--- a/packages/lib/src/services/sandbox/preview/__tests__/dev-preview-stores.integration.test.ts
+++ b/packages/lib/src/services/sandbox/preview/__tests__/dev-preview-stores.integration.test.ts
@@ -121,7 +121,6 @@ describe('createDbDevPreviewStore', () => {
     // a particular VM's server, and the replacement inherits nothing.
     expect(await store.approvePort(holder, { port: 9000, spriteInstanceId: 'inst-other', at, byUserId: userId })).toBeNull();
     expect((await store.findByHolder(holder))?.approvedPort).toBeNull();
-    expect((await store.findByHolder(holder))?.approvedPort).toBeNull();
 
     const approved = await store.approvePort(holder, { port: 9000, spriteInstanceId: 'inst-ap', at, byUserId: userId });
     expect(approved).toMatchObject({ targetPort: 9000, approvedPort: 9000, stoppedByUserAt: null });

--- a/packages/lib/src/services/sandbox/preview/__tests__/dev-preview-stores.integration.test.ts
+++ b/packages/lib/src/services/sandbox/preview/__tests__/dev-preview-stores.integration.test.ts
@@ -55,13 +55,13 @@ describe('createDbDevPreviewStore', () => {
   const holder = { kind: 'env', id: envId } as const;
 
   it('upserts by holder: a re-create on a new instance REPLACES the holder row and clears the stop intent', async () => {
-    await store.upsert({ holder, spriteInstanceId: 'inst-a', sandboxId: 'sbx', targetPort: 5173, relayServiceName: PREVIEW_RELAY_SERVICE_NAME, detectedAt: NOW, stoppedByUserAt: null, basedOnStoppedByUserAt: null });
+    await store.upsert({ holder, spriteInstanceId: 'inst-a', sandboxId: 'sbx', targetPort: 5173, relayServiceName: PREVIEW_RELAY_SERVICE_NAME, detectedAt: NOW, stoppedByUserAt: null, approvedPort: null, basedOnStoppedByUserAt: null });
     // Simulate the user switching it off on the old instance.
     await db.update(devPreviewServices).set({ stoppedByUserAt: NOW }).where(eq(devPreviewServices.envId, envId));
     const before = await store.findByHolder(holder);
     expect(before?.stoppedByUserAt).toEqual(NOW);
 
-    await store.upsert({ holder, spriteInstanceId: 'inst-b', sandboxId: 'sbx', targetPort: 3000, relayServiceName: PREVIEW_RELAY_SERVICE_NAME, detectedAt: NOW, stoppedByUserAt: null, basedOnStoppedByUserAt: null });
+    await store.upsert({ holder, spriteInstanceId: 'inst-b', sandboxId: 'sbx', targetPort: 3000, relayServiceName: PREVIEW_RELAY_SERVICE_NAME, detectedAt: NOW, stoppedByUserAt: null, approvedPort: null, basedOnStoppedByUserAt: null });
     const rows = await db.select().from(devPreviewServices).where(eq(devPreviewServices.envId, envId));
     expect(rows).toHaveLength(1);
     expect(rows[0]).toMatchObject({ spriteInstanceId: 'inst-b', targetPort: 3000, stoppedByUserAt: null, workspaceId: null });
@@ -71,32 +71,69 @@ describe('createDbDevPreviewStore', () => {
   });
 
   it('THE INTENT GUARD: a write planned before a user\'s stop is refused on the SAME instance (the click survives), while a re-create on a NEW instance replaces the row and the dead VM\'s stop with it', async () => {
-    await store.upsert({ holder, spriteInstanceId: 'inst-guard', sandboxId: 'sbx', targetPort: 5173, relayServiceName: PREVIEW_RELAY_SERVICE_NAME, detectedAt: NOW, stoppedByUserAt: null, basedOnStoppedByUserAt: null });
+    await store.upsert({ holder, spriteInstanceId: 'inst-guard', sandboxId: 'sbx', targetPort: 5173, relayServiceName: PREVIEW_RELAY_SERVICE_NAME, detectedAt: NOW, stoppedByUserAt: null, approvedPort: null, basedOnStoppedByUserAt: null });
     const stoppedAt = new Date('2026-09-06T13:00:00.000Z');
     await store.setStoppedByUser(holder, stoppedAt);
 
     // A detection frame that read the row BEFORE the stop (guard: null) must
     // not clear it — the write is refused and the row is untouched.
-    const refused = await store.upsert({ holder, spriteInstanceId: 'inst-guard', sandboxId: 'sbx', targetPort: 3000, relayServiceName: PREVIEW_RELAY_SERVICE_NAME, detectedAt: NOW, stoppedByUserAt: null, basedOnStoppedByUserAt: null });
+    const refused = await store.upsert({ holder, spriteInstanceId: 'inst-guard', sandboxId: 'sbx', targetPort: 3000, relayServiceName: PREVIEW_RELAY_SERVICE_NAME, detectedAt: NOW, stoppedByUserAt: null, approvedPort: null, basedOnStoppedByUserAt: null });
     expect(refused).toBe(false);
     expect(await store.findByHolder(holder)).toMatchObject({ targetPort: 5173, stoppedByUserAt: stoppedAt });
 
     // A frame that DID see the stop (guard: that timestamp) writes normally.
-    const accepted = await store.upsert({ holder, spriteInstanceId: 'inst-guard', sandboxId: 'sbx', targetPort: 3000, relayServiceName: PREVIEW_RELAY_SERVICE_NAME, detectedAt: NOW, stoppedByUserAt: null, basedOnStoppedByUserAt: stoppedAt });
+    const accepted = await store.upsert({ holder, spriteInstanceId: 'inst-guard', sandboxId: 'sbx', targetPort: 3000, relayServiceName: PREVIEW_RELAY_SERVICE_NAME, detectedAt: NOW, stoppedByUserAt: null, approvedPort: null, basedOnStoppedByUserAt: stoppedAt });
     expect(accepted).toBe(true);
     expect(await store.findByHolder(holder)).toMatchObject({ targetPort: 3000, stoppedByUserAt: null });
 
     // A REBUILD: the stored row names a dead instance, so its stop dies with
     // the VM and the re-create replaces it even with a null guard.
     await store.setStoppedByUser(holder, stoppedAt);
-    const recreated = await store.upsert({ holder, spriteInstanceId: 'inst-rebuilt', sandboxId: 'sbx', targetPort: 5173, relayServiceName: PREVIEW_RELAY_SERVICE_NAME, detectedAt: NOW, stoppedByUserAt: null, basedOnStoppedByUserAt: null });
+    const recreated = await store.upsert({ holder, spriteInstanceId: 'inst-rebuilt', sandboxId: 'sbx', targetPort: 5173, relayServiceName: PREVIEW_RELAY_SERVICE_NAME, detectedAt: NOW, stoppedByUserAt: null, approvedPort: null, basedOnStoppedByUserAt: null });
     expect(recreated).toBe(true);
     expect(await store.findByHolder(holder)).toMatchObject({ spriteInstanceId: 'inst-rebuilt', targetPort: 5173, stoppedByUserAt: null });
   });
 
   it('a direct (8080) row carries no relay name, as the CHECK requires', async () => {
-    await store.upsert({ holder, spriteInstanceId: 'inst-c', sandboxId: 'sbx', targetPort: 8080, relayServiceName: null, detectedAt: NOW, stoppedByUserAt: null, basedOnStoppedByUserAt: null });
+    await store.upsert({ holder, spriteInstanceId: 'inst-c', sandboxId: 'sbx', targetPort: 8080, relayServiceName: null, detectedAt: NOW, stoppedByUserAt: null, approvedPort: null, basedOnStoppedByUserAt: null });
     expect(await store.findByHolder(holder)).toMatchObject({ targetPort: 8080, relayServiceName: null });
+  });
+
+  it('an UNSHARED unlisted port is a legal row — a non-8080 target with no relay, which serves nothing', async () => {
+    // The old CHECK made this shape illegal, which is why it had to be
+    // relaxed: consent has to be recordable before the relay exists.
+    await store.upsert({ holder, spriteInstanceId: 'inst-u', sandboxId: 'sbx', targetPort: 9000, relayServiceName: null, detectedAt: NOW, stoppedByUserAt: null, approvedPort: null, basedOnStoppedByUserAt: null });
+    expect(await store.findByHolder(holder)).toMatchObject({ targetPort: 9000, relayServiceName: null, approvedPort: null });
+    // A relay pointed at 8080 would be a loop, and that half of the CHECK stands.
+    await expect(
+      db.insert(devPreviewServices).values({ envId: createId(), spriteInstanceId: createId(), sandboxId: 'sbx', targetPort: 8080, relayServiceName: PREVIEW_RELAY_SERVICE_NAME, detectedAt: NOW, updatedAt: NOW }),
+    ).rejects.toThrow();
+  });
+
+  it('approvePort records consent for exactly the port shown, clears the stop, and REFUSES a port the row no longer targets', async () => {
+    await store.upsert({ holder, spriteInstanceId: 'inst-ap', sandboxId: 'sbx', targetPort: 9000, relayServiceName: null, detectedAt: NOW, stoppedByUserAt: null, approvedPort: null, basedOnStoppedByUserAt: null });
+    await store.setStoppedByUser(holder, NOW);
+
+    const at = new Date('2026-09-06T12:45:00.000Z');
+    expect(await store.approvePort(holder, { port: 9001, at, byUserId: userId })).toBeNull();
+    expect((await store.findByHolder(holder))?.approvedPort).toBeNull();
+
+    const approved = await store.approvePort(holder, { port: 9000, at, byUserId: userId });
+    expect(approved).toMatchObject({ targetPort: 9000, approvedPort: 9000, stoppedByUserAt: null });
+    const [stored] = await db.select().from(devPreviewServices).where(eq(devPreviewServices.envId, envId));
+    expect(stored).toMatchObject({ approvedPort: 9000, approvedAt: at, approvedByUserId: userId });
+
+    // A later detection carries the approval and its ORIGINAL timestamp
+    // forward: the planner never grants or revokes, so nothing is restamped.
+    await store.upsert({ holder, spriteInstanceId: 'inst-ap', sandboxId: 'sbx', targetPort: 9000, relayServiceName: PREVIEW_RELAY_SERVICE_NAME, detectedAt: new Date(NOW.getTime() + 60_000), stoppedByUserAt: null, approvedPort: 9000, basedOnStoppedByUserAt: null });
+    const [after] = await db.select().from(devPreviewServices).where(eq(devPreviewServices.envId, envId));
+    expect(after).toMatchObject({ approvedPort: 9000, approvedAt: at });
+
+    // And a REBUILD carries nothing: a new instance replaces the row wholesale.
+    await store.upsert({ holder, spriteInstanceId: 'inst-new', sandboxId: 'sbx', targetPort: 9000, relayServiceName: null, detectedAt: NOW, stoppedByUserAt: null, approvedPort: null, basedOnStoppedByUserAt: null });
+    const [rebuilt] = await db.select().from(devPreviewServices).where(eq(devPreviewServices.envId, envId));
+    expect(rebuilt).toMatchObject({ approvedPort: null, approvedAt: null });
+    expect(await store.approvePort({ kind: 'workspace', id: createId() }, { port: 9000, at, byUserId: userId })).toBeNull();
   });
 
   it('answers null for a holder with no row', async () => {
@@ -104,7 +141,7 @@ describe('createDbDevPreviewStore', () => {
   });
 
   it('setStoppedByUser writes ONLY the intent column and returns the row as written, clears it on null, and answers null for a holder with no row', async () => {
-    await store.upsert({ holder, spriteInstanceId: 'inst-d', sandboxId: 'sbx', targetPort: 5173, relayServiceName: PREVIEW_RELAY_SERVICE_NAME, detectedAt: NOW, stoppedByUserAt: null, basedOnStoppedByUserAt: null });
+    await store.upsert({ holder, spriteInstanceId: 'inst-d', sandboxId: 'sbx', targetPort: 5173, relayServiceName: PREVIEW_RELAY_SERVICE_NAME, detectedAt: NOW, stoppedByUserAt: null, approvedPort: null, basedOnStoppedByUserAt: null });
     const stoppedAt = new Date('2026-09-06T12:30:00.000Z');
     const written = await store.setStoppedByUser(holder, stoppedAt);
     expect(written).toMatchObject({ spriteInstanceId: 'inst-d', targetPort: 5173, relayServiceName: PREVIEW_RELAY_SERVICE_NAME, stoppedByUserAt: stoppedAt });

--- a/packages/lib/src/services/sandbox/preview/__tests__/dev-preview-stores.integration.test.ts
+++ b/packages/lib/src/services/sandbox/preview/__tests__/dev-preview-stores.integration.test.ts
@@ -110,15 +110,20 @@ describe('createDbDevPreviewStore', () => {
     ).rejects.toThrow();
   });
 
-  it('approvePort records consent for exactly the port shown, clears the stop, and REFUSES a port the row no longer targets', async () => {
+  it('approvePort records consent for exactly the port shown, clears the stop, and REFUSES a port the row no longer targets or a sandbox that was rebuilt', async () => {
     await store.upsert({ holder, spriteInstanceId: 'inst-ap', sandboxId: 'sbx', targetPort: 9000, relayServiceName: null, detectedAt: NOW, stoppedByUserAt: null, basedOnStoppedByUserAt: null });
     await store.setStoppedByUser(holder, NOW);
 
     const at = new Date('2026-09-06T12:45:00.000Z');
-    expect(await store.approvePort(holder, { port: 9001, at, byUserId: userId })).toBeNull();
+    expect(await store.approvePort(holder, { port: 9001, spriteInstanceId: 'inst-ap', at, byUserId: userId })).toBeNull();
+    // And a click made against a sandbox that has since been REBUILT is
+    // refused even though the port still matches: sharing is a decision about
+    // a particular VM's server, and the replacement inherits nothing.
+    expect(await store.approvePort(holder, { port: 9000, spriteInstanceId: 'inst-other', at, byUserId: userId })).toBeNull();
+    expect((await store.findByHolder(holder))?.approvedPort).toBeNull();
     expect((await store.findByHolder(holder))?.approvedPort).toBeNull();
 
-    const approved = await store.approvePort(holder, { port: 9000, at, byUserId: userId });
+    const approved = await store.approvePort(holder, { port: 9000, spriteInstanceId: 'inst-ap', at, byUserId: userId });
     expect(approved).toMatchObject({ targetPort: 9000, approvedPort: 9000, stoppedByUserAt: null });
     const [stored] = await db.select().from(devPreviewServices).where(eq(devPreviewServices.envId, envId));
     expect(stored).toMatchObject({ approvedPort: 9000, approvedAt: at, approvedByUserId: userId });
@@ -133,7 +138,7 @@ describe('createDbDevPreviewStore', () => {
     await store.upsert({ holder, spriteInstanceId: 'inst-new', sandboxId: 'sbx', targetPort: 9000, relayServiceName: null, detectedAt: NOW, stoppedByUserAt: null, basedOnStoppedByUserAt: null });
     const [rebuilt] = await db.select().from(devPreviewServices).where(eq(devPreviewServices.envId, envId));
     expect(rebuilt).toMatchObject({ approvedPort: null, approvedAt: null });
-    expect(await store.approvePort({ kind: 'workspace', id: createId() }, { port: 9000, at, byUserId: userId })).toBeNull();
+    expect(await store.approvePort({ kind: 'workspace', id: createId() }, { port: 9000, spriteInstanceId: 'inst-ap', at, byUserId: userId })).toBeNull();
   });
 
   it('findStoppedWithRelay lists ONLY aged rows that are switched off with a relay still recorded', async () => {

--- a/packages/lib/src/services/sandbox/preview/__tests__/ports-watch.test.ts
+++ b/packages/lib/src/services/sandbox/preview/__tests__/ports-watch.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from 'vitest';
 import { assert } from '../../__tests__/riteway';
-import { buildPortsWatchUrl, openPortsWatch, readPortsWatchFrame, type PortsWatchFrame, type PortsWatchSocketLike } from '../ports-watch';
+import { buildPortsWatchUrl, openPortsWatch, readPortsWatchFrame, resolveSpritesApiBaseUrl, type PortsWatchFrame, type PortsWatchSocketLike } from '../ports-watch';
 
 describe('buildPortsWatchUrl', () => {
   it('derives the wss endpoint from the API base and encodes the sprite name', () => {
@@ -110,5 +110,44 @@ describe('openPortsWatch', () => {
     openPortsWatch({ url: 'wss://api/x', token: 't', createSocket: () => { throw new Error('no ws'); }, onFrame: () => {}, onClose: (info) => closes.push(info) });
     await new Promise((r) => setImmediate(r));
     expect(closes).toEqual([{ opened: false, reason: 'open-failed: no ws' }]);
+  });
+});
+
+describe('resolveSpritesApiBaseUrl', () => {
+  it('prefers the explicit override and falls back to the platform default', () => {
+    const saved = process.env.SPRITES_API_URL;
+    try {
+      delete process.env.SPRITES_API_URL;
+      assert({ given: 'no override', should: 'use the platform default', actual: resolveSpritesApiBaseUrl(), expected: 'https://api.sprites.dev' });
+      process.env.SPRITES_API_URL = 'https://sprites.internal';
+      assert({ given: 'an override', should: 'use it', actual: resolveSpritesApiBaseUrl(), expected: 'https://sprites.internal' });
+      // An empty string is not a base URL; falling back beats opening a watch
+      // against `wss:///v1/...`.
+      process.env.SPRITES_API_URL = '';
+      assert({ given: 'an empty override', should: 'fall back rather than accept it', actual: resolveSpritesApiBaseUrl(), expected: 'https://api.sprites.dev' });
+    } finally {
+      if (saved === undefined) delete process.env.SPRITES_API_URL;
+      else process.env.SPRITES_API_URL = saved;
+    }
+  });
+});
+
+describe('openPortsWatch — closing a watch that never opened', () => {
+  it('fires onClose EXACTLY once, whichever way it ended', async () => {
+    // The registry's reconnect budget counts `onClose` calls, so a handle that
+    // fired twice would burn two attempts for one failure — and a `close()`
+    // from `stopAll` arriving after a failure must not resurrect the callback.
+    const noToken: Array<{ reason: string }> = [];
+    const handle = openPortsWatch({ url: 'wss://x', token: '', createSocket: () => { throw new Error('unused'); }, onFrame: () => {}, onClose: (info) => noToken.push(info) });
+    handle.close();
+    handle.close();
+    await new Promise((r) => setTimeout(r, 0));
+    assert({ given: 'a no-token watch closed twice', should: 'report exactly one close', actual: noToken.length, expected: 1 });
+
+    const failed: Array<{ reason: string }> = [];
+    const broken = openPortsWatch({ url: 'wss://x', token: 't', createSocket: () => { throw new Error('no ws'); }, onFrame: () => {}, onClose: (info) => failed.push(info) });
+    broken.close();
+    await new Promise((r) => setTimeout(r, 0));
+    assert({ given: 'a watch whose socket could not be created, then closed', should: 'report exactly one close', actual: failed.length, expected: 1 });
   });
 });

--- a/packages/lib/src/services/sandbox/preview/__tests__/preview-access.test.ts
+++ b/packages/lib/src/services/sandbox/preview/__tests__/preview-access.test.ts
@@ -8,6 +8,7 @@ import { buildPreviewRelaySpec, PREVIEW_RELAY_SERVICE_NAME } from '../preview-re
 const NOW = new Date('2026-09-06T12:00:00Z');
 const USER = 'user-1';
 const OWNER = 'owner-1';
+const SESSION = 'sess-1';
 
 const session = (over: Partial<PreviewSessionRow> = {}): PreviewSessionRow => ({
   id: 'ws1', ownerId: OWNER, driveId: 'd1', envId: null, sandboxId: 'sbx-ws', spriteTornDownAt: null, endedAt: null, ...over,
@@ -52,6 +53,7 @@ function deps(over: Partial<PreviewAccessDeps> & { calls?: string[] } = {}): Pre
     resolveDriveMembership: async () => track('membership', 'member' as const),
     resolveDrivePayer: async () => track('payer', { payerId: OWNER }),
     canRunCode: async () => track('canRunCode', { ok: true as const }),
+    isSessionUsable: async () => track('isSessionUsable', true),
     attach: async () => track('attach', fakeHandle({ relay: runningRelay() })),
     previewStore: { findByHolder: async () => track('findRow', liveRow()), upsert: async () => true, setStoppedByUser: async () => null },
     featureEnabled: () => true,
@@ -109,7 +111,7 @@ describe('resolvePreviewTarget — the gather, in order', () => {
 
   it('forwards a live preview on a running sprite: no wake gate, the upstream is the control-plane URL', async () => {
     const d = deps();
-    const target = await resolvePreviewTarget({ holder, userId: USER, deps: d });
+    const target = await resolvePreviewTarget({ holder, userId: USER, sessionId: SESSION, deps: d });
     assert({ given: 'live + running', should: 'forward without wake', actual: target.decision, expected: { kind: 'forward', wake: false } });
     assert({ given: 'live + running', should: 'carry the sprite URL', actual: 'spriteUrl' in target ? target.spriteUrl : null, expected: 'https://ps-x-org.sprites.app' });
     assert({ given: 'live + running', should: 'never consult canRunCode', actual: d.calls.includes('canRunCode'), expected: false });
@@ -117,14 +119,14 @@ describe('resolvePreviewTarget — the gather, in order', () => {
 
   it('a refused user never causes a control-plane read', async () => {
     const d = deps({ resolveDriveMembership: async () => 'none' });
-    const target = await resolvePreviewTarget({ holder, userId: USER, deps: d });
+    const target = await resolvePreviewTarget({ holder, userId: USER, sessionId: SESSION, deps: d });
     assert({ given: 'denied', should: '404 not-authorized with detail', actual: target.decision, expected: { kind: 'refuse', reason: 'not-authorized', status: 404, message: 'Not found', detail: 'drive_access_denied' } });
     assert({ given: 'denied', should: 'never attach, never read the row', actual: d.calls.filter((c) => c === 'attach' || c === 'findRow'), expected: [] });
   });
 
   it('a dark feature refuses before any read at all', async () => {
     const d = deps({ featureEnabled: () => false });
-    const target = await resolvePreviewTarget({ holder, userId: USER, deps: d });
+    const target = await resolvePreviewTarget({ holder, userId: USER, sessionId: SESSION, deps: d });
     assert({ given: 'dark', should: 'feature-disabled 404', actual: target.decision.kind === 'refuse' && target.decision.reason, expected: 'feature-disabled' });
     assert({ given: 'dark', should: 'not attach', actual: d.calls.includes('attach'), expected: false });
   });
@@ -132,43 +134,43 @@ describe('resolvePreviewTarget — the gather, in order', () => {
   it('a paused sprite consults the wake gate on the PAYER and forwards as a wake when allowed', async () => {
     let seen: unknown;
     const d = deps({ attach: async () => fakeHandle({ relay: runningRelay(), power: 'paused' }), canRunCode: async (input) => { seen = input; return { ok: true }; } });
-    const target = await resolvePreviewTarget({ holder, userId: USER, deps: d });
+    const target = await resolvePreviewTarget({ holder, userId: USER, sessionId: SESSION, deps: d });
     assert({ given: 'paused + allowed', should: 'forward as a wake', actual: target.decision, expected: { kind: 'forward', wake: true } });
     assert({ given: 'paused', should: 'ask canRunCode for the payer, not the viewer', actual: seen, expected: { userId: USER, driveId: 'd1', ownerId: OWNER } });
   });
 
   it('a paused sprite with a denied wake gate is refused 403 and NOT forwarded', async () => {
     const d = deps({ attach: async () => fakeHandle({ relay: runningRelay(), power: 'paused' }), canRunCode: async () => ({ ok: false, reason: 'tier_ineligible' }) });
-    const target = await resolvePreviewTarget({ holder, userId: USER, deps: d });
+    const target = await resolvePreviewTarget({ holder, userId: USER, sessionId: SESSION, deps: d });
     assert({ given: 'paused + denied', should: 'wake-denied', actual: target.decision, expected: { kind: 'refuse', reason: 'wake-denied', status: 403, message: 'This sandbox is asleep, and you are not permitted to wake it.', detail: 'tier_ineligible' } });
     expect('spriteUrl' in target).toBe(false);
   });
 
   it('a stale row (dead instance) is refused, never routed, and never wakes', async () => {
     const d = deps({ attach: async () => fakeHandle({ relay: runningRelay(), power: 'paused', instance: 'inst-2' }) });
-    const target = await resolvePreviewTarget({ holder, userId: USER, deps: d });
+    const target = await resolvePreviewTarget({ holder, userId: USER, sessionId: SESSION, deps: d });
     assert({ given: 'row for inst-1, live inst-2', should: 'stale-instance 409', actual: target.decision.kind === 'refuse' && [target.decision.reason, target.decision.status], expected: ['stale-instance', 409] });
     assert({ given: 'stale', should: 'never consult the wake gate', actual: d.calls.includes('canRunCode'), expected: false });
   });
 
   it('no row, no sprite, or a vanished sprite is no-preview', async () => {
-    assert({ given: 'no row', should: 'no-preview', actual: (await resolvePreviewTarget({ holder, userId: USER, deps: deps({ previewStore: { findByHolder: async () => null, upsert: async () => true, setStoppedByUser: async () => null } }) })).decision.kind === 'refuse' && 'no-preview', expected: 'no-preview' });
-    const noSprite = await resolvePreviewTarget({ holder, userId: USER, deps: deps({ findEnv: async () => env({ sandboxId: null }) }) });
+    assert({ given: 'no row', should: 'no-preview', actual: (await resolvePreviewTarget({ holder, userId: USER, sessionId: SESSION, deps: deps({ previewStore: { findByHolder: async () => null, upsert: async () => true, setStoppedByUser: async () => null } }) })).decision.kind === 'refuse' && 'no-preview', expected: 'no-preview' });
+    const noSprite = await resolvePreviewTarget({ holder, userId: USER, sessionId: SESSION, deps: deps({ findEnv: async () => env({ sandboxId: null }) }) });
     assert({ given: 'no sprite pointer', should: 'no-preview without attaching', actual: noSprite.decision.kind === 'refuse' && noSprite.decision.reason, expected: 'no-preview' });
-    const vanished = await resolvePreviewTarget({ holder, userId: USER, deps: deps({ attach: async () => null }) });
+    const vanished = await resolvePreviewTarget({ holder, userId: USER, sessionId: SESSION, deps: deps({ attach: async () => null }) });
     assert({ given: 'attach returned null', should: 'no-preview', actual: vanished.decision.kind === 'refuse' && vanished.decision.reason, expected: 'no-preview' });
   });
 
   it('refuses to forward to a sprite whose URL is missing or not in private mode', async () => {
-    const noUrl = await resolvePreviewTarget({ holder, userId: USER, deps: deps({ attach: async () => fakeHandle({ relay: runningRelay(), url: null }) }) });
+    const noUrl = await resolvePreviewTarget({ holder, userId: USER, sessionId: SESSION, deps: deps({ attach: async () => fakeHandle({ relay: runningRelay(), url: null }) }) });
     assert({ given: 'no url', should: '502', actual: noUrl.decision.kind === 'refuse' && noUrl.decision.status, expected: 502 });
-    const pub = await resolvePreviewTarget({ holder, userId: USER, deps: deps({ attach: async () => fakeHandle({ relay: runningRelay(), auth: 'public' }) }) });
+    const pub = await resolvePreviewTarget({ holder, userId: USER, sessionId: SESSION, deps: deps({ attach: async () => fakeHandle({ relay: runningRelay(), auth: 'public' }) }) });
     assert({ given: 'public url', should: 'refuse rather than proxy an unproven-private URL', actual: pub.decision.kind, expected: 'refuse' });
   });
 
   it('a down relay is refused 502 (state folded with listeners: null — never a probe)', async () => {
     const d = deps({ attach: async () => fakeHandle({ relay: { ...runningRelay(), status: 'failed', error: 'exited with code 143' } }) });
-    const target = await resolvePreviewTarget({ holder, userId: USER, deps: d });
+    const target = await resolvePreviewTarget({ holder, userId: USER, sessionId: SESSION, deps: d });
     assert({ given: 'failed relay', should: 'preview-down 502', actual: target.decision.kind === 'refuse' && [target.decision.reason, target.decision.status], expected: ['preview-down', 502] });
   });
 });
@@ -194,7 +196,7 @@ describe('resolvePreviewTarget — a substrate with no preview surface', () => {
   };
 
   it('should refuse with a typed preview-unsupported reason rather than faulting on the refusing members', async () => {
-    const target = await resolvePreviewTarget({ holder, userId: USER, deps: deps({ attach: async () => localHandle() }) });
+    const target = await resolvePreviewTarget({ holder, userId: USER, sessionId: SESSION, deps: deps({ attach: async () => localHandle() }) });
 
     expect(target.decision).toMatchObject({ kind: 'refuse', reason: 'preview-unsupported', status: 409 });
   });
@@ -203,13 +205,44 @@ describe('resolvePreviewTarget — a substrate with no preview surface', () => {
     let touched = 0;
     const handle = { ...localHandle(), powerState: async () => { touched += 1; return 'running' as const; } } as SandboxHandle;
 
-    await resolvePreviewTarget({ holder, userId: USER, deps: deps({ attach: async () => handle }) });
+    await resolvePreviewTarget({ holder, userId: USER, sessionId: SESSION, deps: deps({ attach: async () => handle }) });
 
     expect(touched).toBe(0);
   });
 
   it('CONTROL: the same request against a Sprite handle still forwards — proving the refusal above is load-bearing', async () => {
-    const target = await resolvePreviewTarget({ holder, userId: USER, deps: deps() });
+    const target = await resolvePreviewTarget({ holder, userId: USER, sessionId: SESSION, deps: deps() });
     expect(target.decision.kind).toBe('forward');
+  });
+});
+
+
+describe('resolvePreviewTarget — the cookie is only as alive as its session', () => {
+  const holder = { kind: 'env', id: 'env1' } as const;
+
+  it('a revoked session is refused on the VERY NEXT request, before any holder read, attach or wake gate', async () => {
+    // The ordering is the security property: a refusal here must cost no
+    // control-plane call, exactly as an authorization refusal does.
+    const before = deps();
+    assert({ given: 'a usable session', should: 'forward', actual: (await resolvePreviewTarget({ holder, userId: USER, sessionId: SESSION, deps: before })).decision.kind, expected: 'forward' });
+
+    const after = deps({ isSessionUsable: async () => false });
+    const target = await resolvePreviewTarget({ holder, userId: USER, sessionId: SESSION, deps: after });
+    assert({ given: 'the same cookie after the session is revoked', should: 'opaque 404 with a session_revoked detail', actual: target.decision, expected: { kind: 'refuse', reason: 'not-authorized', status: 404, message: 'Not found', detail: 'session_revoked' } });
+    assert({ given: 'a revoked session', should: 'read no holder row, never attach, never ask the wake gate', actual: after.calls.filter((c) => c === 'findEnv' || c === 'findSession' || c === 'attach' || c === 'canRunCode' || c === 'findRow'), expected: [] });
+  });
+
+  it('is asked for the cookie\'s own session and user — not the holder owner', async () => {
+    let seen: unknown;
+    const d = deps({ isSessionUsable: async (input) => { seen = input; return true; } });
+    await resolvePreviewTarget({ holder, userId: USER, sessionId: SESSION, deps: d });
+    assert({ given: 'a request', should: 'name the cookie session and the cookie user', actual: seen, expected: { sessionId: SESSION, userId: USER } });
+  });
+
+  it('a dark deployment reveals nothing and does not even ask about the session', async () => {
+    const d = deps({ featureEnabled: () => false, isSessionUsable: async () => false });
+    const target = await resolvePreviewTarget({ holder, userId: USER, sessionId: SESSION, deps: d });
+    assert({ given: 'dark', should: 'still answer feature-disabled', actual: target.decision.kind === 'refuse' && target.decision.reason, expected: 'feature-disabled' });
+    assert({ given: 'dark', should: 'cost no session query', actual: d.calls.includes('isSessionUsable'), expected: false });
   });
 });

--- a/packages/lib/src/services/sandbox/preview/__tests__/preview-access.test.ts
+++ b/packages/lib/src/services/sandbox/preview/__tests__/preview-access.test.ts
@@ -17,7 +17,7 @@ const env = (over: Partial<PreviewEnvRow> = {}): PreviewEnvRow => ({
   id: 'env1', driveId: 'd1', substrate: 'sprite', sandboxId: 'sbx-env', spriteTornDownAt: null, ...over,
 });
 const liveRow = (targetPort = 5173): DevPreviewRecord => ({
-  id: 'r', spriteInstanceId: 'inst-1', sandboxId: 'sbx-env', targetPort, relayServiceName: targetPort === 8080 ? null : PREVIEW_RELAY_SERVICE_NAME, detectedAt: NOW, stoppedByUserAt: null,
+  id: 'r', spriteInstanceId: 'inst-1', sandboxId: 'sbx-env', targetPort, relayServiceName: targetPort === 8080 ? null : PREVIEW_RELAY_SERVICE_NAME, detectedAt: NOW, stoppedByUserAt: null, approvedPort: null,
 });
 const runningRelay = (targetPort = 5173): SandboxServiceInfo => {
   const spec = buildPreviewRelaySpec({ targetPort });
@@ -55,7 +55,7 @@ function deps(over: Partial<PreviewAccessDeps> & { calls?: string[] } = {}): Pre
     canRunCode: async () => track('canRunCode', { ok: true as const }),
     isSessionUsable: async () => track('isSessionUsable', true),
     attach: async () => track('attach', fakeHandle({ relay: runningRelay() })),
-    previewStore: { findByHolder: async () => track('findRow', liveRow()), upsert: async () => true, setStoppedByUser: async () => null },
+    previewStore: { findByHolder: async () => track('findRow', liveRow()), upsert: async () => true, setStoppedByUser: async () => null, approvePort: async () => null },
     featureEnabled: () => true,
     now: () => NOW,
     ...over,
@@ -154,7 +154,7 @@ describe('resolvePreviewTarget — the gather, in order', () => {
   });
 
   it('no row, no sprite, or a vanished sprite is no-preview', async () => {
-    assert({ given: 'no row', should: 'no-preview', actual: (await resolvePreviewTarget({ holder, userId: USER, sessionId: SESSION, deps: deps({ previewStore: { findByHolder: async () => null, upsert: async () => true, setStoppedByUser: async () => null } }) })).decision.kind === 'refuse' && 'no-preview', expected: 'no-preview' });
+    assert({ given: 'no row', should: 'no-preview', actual: (await resolvePreviewTarget({ holder, userId: USER, sessionId: SESSION, deps: deps({ previewStore: { findByHolder: async () => null, upsert: async () => true, setStoppedByUser: async () => null, approvePort: async () => null } }) })).decision.kind === 'refuse' && 'no-preview', expected: 'no-preview' });
     const noSprite = await resolvePreviewTarget({ holder, userId: USER, sessionId: SESSION, deps: deps({ findEnv: async () => env({ sandboxId: null }) }) });
     assert({ given: 'no sprite pointer', should: 'no-preview without attaching', actual: noSprite.decision.kind === 'refuse' && noSprite.decision.reason, expected: 'no-preview' });
     const vanished = await resolvePreviewTarget({ holder, userId: USER, sessionId: SESSION, deps: deps({ attach: async () => null }) });

--- a/packages/lib/src/services/sandbox/preview/__tests__/preview-access.test.ts
+++ b/packages/lib/src/services/sandbox/preview/__tests__/preview-access.test.ts
@@ -55,7 +55,7 @@ function deps(over: Partial<PreviewAccessDeps> & { calls?: string[] } = {}): Pre
     canRunCode: async () => track('canRunCode', { ok: true as const }),
     isSessionUsable: async () => track('isSessionUsable', true),
     attach: async () => track('attach', fakeHandle({ relay: runningRelay() })),
-    previewStore: { findByHolder: async () => track('findRow', liveRow()), upsert: async () => true, setStoppedByUser: async () => null, approvePort: async () => null, findStoppedWithRelay: async () => [], markSwept: async () => {} },
+    previewStore: { findByHolder: async () => track('findRow', liveRow()), upsert: async () => true, setStoppedByUser: async () => null, approvePort: async () => null, findStoppedWithRelay: async () => [], markSwept: async () => {}, markRelayStopped: async () => {} },
     featureEnabled: () => true,
     now: () => NOW,
     ...over,
@@ -154,7 +154,7 @@ describe('resolvePreviewTarget — the gather, in order', () => {
   });
 
   it('no row, no sprite, or a vanished sprite is no-preview', async () => {
-    assert({ given: 'no row', should: 'no-preview', actual: (await resolvePreviewTarget({ holder, userId: USER, sessionId: SESSION, deps: deps({ previewStore: { findByHolder: async () => null, upsert: async () => true, setStoppedByUser: async () => null, approvePort: async () => null, findStoppedWithRelay: async () => [], markSwept: async () => {} } }) })).decision.kind === 'refuse' && 'no-preview', expected: 'no-preview' });
+    assert({ given: 'no row', should: 'no-preview', actual: (await resolvePreviewTarget({ holder, userId: USER, sessionId: SESSION, deps: deps({ previewStore: { findByHolder: async () => null, upsert: async () => true, setStoppedByUser: async () => null, approvePort: async () => null, findStoppedWithRelay: async () => [], markSwept: async () => {}, markRelayStopped: async () => {} } }) })).decision.kind === 'refuse' && 'no-preview', expected: 'no-preview' });
     const noSprite = await resolvePreviewTarget({ holder, userId: USER, sessionId: SESSION, deps: deps({ findEnv: async () => env({ sandboxId: null }) }) });
     assert({ given: 'no sprite pointer', should: 'no-preview without attaching', actual: noSprite.decision.kind === 'refuse' && noSprite.decision.reason, expected: 'no-preview' });
     const vanished = await resolvePreviewTarget({ holder, userId: USER, sessionId: SESSION, deps: deps({ attach: async () => null }) });

--- a/packages/lib/src/services/sandbox/preview/__tests__/preview-access.test.ts
+++ b/packages/lib/src/services/sandbox/preview/__tests__/preview-access.test.ts
@@ -17,7 +17,7 @@ const env = (over: Partial<PreviewEnvRow> = {}): PreviewEnvRow => ({
   id: 'env1', driveId: 'd1', substrate: 'sprite', sandboxId: 'sbx-env', spriteTornDownAt: null, ...over,
 });
 const liveRow = (targetPort = 5173): DevPreviewRecord => ({
-  id: 'r', spriteInstanceId: 'inst-1', sandboxId: 'sbx-env', targetPort, relayServiceName: targetPort === 8080 ? null : PREVIEW_RELAY_SERVICE_NAME, detectedAt: NOW, stoppedByUserAt: null, approvedPort: null,
+  id: 'r', spriteInstanceId: 'inst-1', sandboxId: 'sbx-env', targetPort, relayServiceName: targetPort === 8080 ? null : PREVIEW_RELAY_SERVICE_NAME, detectedAt: NOW, stoppedByUserAt: null, approvedPort: null, approvedAt: null,
 });
 const runningRelay = (targetPort = 5173): SandboxServiceInfo => {
   const spec = buildPreviewRelaySpec({ targetPort });
@@ -55,7 +55,7 @@ function deps(over: Partial<PreviewAccessDeps> & { calls?: string[] } = {}): Pre
     canRunCode: async () => track('canRunCode', { ok: true as const }),
     isSessionUsable: async () => track('isSessionUsable', true),
     attach: async () => track('attach', fakeHandle({ relay: runningRelay() })),
-    previewStore: { findByHolder: async () => track('findRow', liveRow()), upsert: async () => true, setStoppedByUser: async () => null, approvePort: async () => null, findStoppedWithRelay: async () => [] },
+    previewStore: { findByHolder: async () => track('findRow', liveRow()), upsert: async () => true, setStoppedByUser: async () => null, approvePort: async () => null, findStoppedWithRelay: async () => [], markSwept: async () => {} },
     featureEnabled: () => true,
     now: () => NOW,
     ...over,
@@ -154,7 +154,7 @@ describe('resolvePreviewTarget — the gather, in order', () => {
   });
 
   it('no row, no sprite, or a vanished sprite is no-preview', async () => {
-    assert({ given: 'no row', should: 'no-preview', actual: (await resolvePreviewTarget({ holder, userId: USER, sessionId: SESSION, deps: deps({ previewStore: { findByHolder: async () => null, upsert: async () => true, setStoppedByUser: async () => null, approvePort: async () => null, findStoppedWithRelay: async () => [] } }) })).decision.kind === 'refuse' && 'no-preview', expected: 'no-preview' });
+    assert({ given: 'no row', should: 'no-preview', actual: (await resolvePreviewTarget({ holder, userId: USER, sessionId: SESSION, deps: deps({ previewStore: { findByHolder: async () => null, upsert: async () => true, setStoppedByUser: async () => null, approvePort: async () => null, findStoppedWithRelay: async () => [], markSwept: async () => {} } }) })).decision.kind === 'refuse' && 'no-preview', expected: 'no-preview' });
     const noSprite = await resolvePreviewTarget({ holder, userId: USER, sessionId: SESSION, deps: deps({ findEnv: async () => env({ sandboxId: null }) }) });
     assert({ given: 'no sprite pointer', should: 'no-preview without attaching', actual: noSprite.decision.kind === 'refuse' && noSprite.decision.reason, expected: 'no-preview' });
     const vanished = await resolvePreviewTarget({ holder, userId: USER, sessionId: SESSION, deps: deps({ attach: async () => null }) });

--- a/packages/lib/src/services/sandbox/preview/__tests__/preview-access.test.ts
+++ b/packages/lib/src/services/sandbox/preview/__tests__/preview-access.test.ts
@@ -55,7 +55,7 @@ function deps(over: Partial<PreviewAccessDeps> & { calls?: string[] } = {}): Pre
     canRunCode: async () => track('canRunCode', { ok: true as const }),
     isSessionUsable: async () => track('isSessionUsable', true),
     attach: async () => track('attach', fakeHandle({ relay: runningRelay() })),
-    previewStore: { findByHolder: async () => track('findRow', liveRow()), upsert: async () => true, setStoppedByUser: async () => null, approvePort: async () => null },
+    previewStore: { findByHolder: async () => track('findRow', liveRow()), upsert: async () => true, setStoppedByUser: async () => null, approvePort: async () => null, findStoppedWithRelay: async () => [] },
     featureEnabled: () => true,
     now: () => NOW,
     ...over,
@@ -154,7 +154,7 @@ describe('resolvePreviewTarget — the gather, in order', () => {
   });
 
   it('no row, no sprite, or a vanished sprite is no-preview', async () => {
-    assert({ given: 'no row', should: 'no-preview', actual: (await resolvePreviewTarget({ holder, userId: USER, sessionId: SESSION, deps: deps({ previewStore: { findByHolder: async () => null, upsert: async () => true, setStoppedByUser: async () => null, approvePort: async () => null } }) })).decision.kind === 'refuse' && 'no-preview', expected: 'no-preview' });
+    assert({ given: 'no row', should: 'no-preview', actual: (await resolvePreviewTarget({ holder, userId: USER, sessionId: SESSION, deps: deps({ previewStore: { findByHolder: async () => null, upsert: async () => true, setStoppedByUser: async () => null, approvePort: async () => null, findStoppedWithRelay: async () => [] } }) })).decision.kind === 'refuse' && 'no-preview', expected: 'no-preview' });
     const noSprite = await resolvePreviewTarget({ holder, userId: USER, sessionId: SESSION, deps: deps({ findEnv: async () => env({ sandboxId: null }) }) });
     assert({ given: 'no sprite pointer', should: 'no-preview without attaching', actual: noSprite.decision.kind === 'refuse' && noSprite.decision.reason, expected: 'no-preview' });
     const vanished = await resolvePreviewTarget({ holder, userId: USER, sessionId: SESSION, deps: deps({ attach: async () => null }) });

--- a/packages/lib/src/services/sandbox/preview/__tests__/preview-grant.test.ts
+++ b/packages/lib/src/services/sandbox/preview/__tests__/preview-grant.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect } from 'vitest';
+import { createHmac } from 'node:crypto';
 import { assert } from '../../__tests__/riteway';
 import {
   PREVIEW_COOKIE_NAME,
@@ -117,11 +118,13 @@ describe('the cookie token', () => {
     const result = verifyPreviewCookie(signed, KEY, NOW);
     assert({ given: 'a v2 cookie', should: 'carry the minting session', actual: result.ok && result.claims.sessionId, expected: 'sess1' });
 
-    // Re-signed under the real key, so this tests the CLAIM check and not the
-    // signature check that would otherwise mask it.
+    // Re-signed OVER THE MODIFIED BODY, which is the whole point: reusing the
+    // original signature would make every case below fail on `bad-signature`
+    // before the claim check ran, and the assertion would pass without testing
+    // anything. The MAC covers `v2.<payload>`, matching `signPreviewCookie`.
     const resign = (payload: Record<string, unknown>) => {
       const body = Buffer.from(JSON.stringify(payload)).toString('base64url');
-      const [, , sig] = signPreviewCookie(claims, KEY).split('.');
+      const sig = createHmac('sha256', KEY).update(`v2.${body}`).digest().toString('base64url');
       return { body, sig };
     };
     for (const payload of [

--- a/packages/lib/src/services/sandbox/preview/__tests__/preview-grant.test.ts
+++ b/packages/lib/src/services/sandbox/preview/__tests__/preview-grant.test.ts
@@ -80,7 +80,7 @@ describe('preview hosts', () => {
 });
 
 describe('the cookie token', () => {
-  const claims = { holder: { kind: 'workspace' as const, id: 'ws1' }, userId: 'u1', expiresAt: NOW.getTime() + 60_000 };
+  const claims = { holder: { kind: 'workspace' as const, id: 'ws1' }, userId: 'u1', sessionId: 'sess1', expiresAt: NOW.getTime() + 60_000 };
 
   it('round-trips under the same key', () => {
     const token = signPreviewCookie(claims, KEY);
@@ -95,7 +95,7 @@ describe('the cookie token', () => {
   it('rejects a payload edit (holder swap) even with the original signature', () => {
     const token = signPreviewCookie(claims, KEY);
     const [v, , sig] = token.split('.');
-    const swapped = Buffer.from(JSON.stringify({ k: 'workspace', h: 'ws2', u: 'u1', e: claims.expiresAt })).toString('base64url');
+    const swapped = Buffer.from(JSON.stringify({ k: 'workspace', h: 'ws2', u: 'u1', s: 'sess1', e: claims.expiresAt })).toString('base64url');
     assert({ given: 'a swapped holder', should: 'bad-signature', actual: verifyPreviewCookie(`${v}.${swapped}.${sig}`, KEY, NOW), expected: { ok: false, reason: 'bad-signature' } });
   });
 
@@ -107,6 +107,36 @@ describe('the cookie token', () => {
   it.each(['', 'v1', 'v0.a.b', 'v1.!!.??', 'v1.a.b.c'])('rejects malformed %s', (token) => {
     const result = verifyPreviewCookie(token, KEY, NOW);
     assert({ given: token, should: 'not verify', actual: result.ok, expected: false });
+  });
+
+  it('carries the SESSION, and refuses a payload that omits or malforms it', () => {
+    // A cookie with no session id is a v1 cookie: it would authenticate a
+    // person with nothing to revoke. It must not verify.
+    const signed = signPreviewCookie(claims, KEY);
+    expect(signed.startsWith('v2.')).toBe(true);
+    const result = verifyPreviewCookie(signed, KEY, NOW);
+    assert({ given: 'a v2 cookie', should: 'carry the minting session', actual: result.ok && result.claims.sessionId, expected: 'sess1' });
+
+    // Re-signed under the real key, so this tests the CLAIM check and not the
+    // signature check that would otherwise mask it.
+    const resign = (payload: Record<string, unknown>) => {
+      const body = Buffer.from(JSON.stringify(payload)).toString('base64url');
+      const [, , sig] = signPreviewCookie(claims, KEY).split('.');
+      return { body, sig };
+    };
+    for (const payload of [
+      { k: 'workspace', h: 'ws1', u: 'u1', e: claims.expiresAt },
+      { k: 'workspace', h: 'ws1', u: 'u1', s: '', e: claims.expiresAt },
+      { k: 'workspace', h: 'ws1', u: 'u1', s: 42, e: claims.expiresAt },
+    ]) {
+      const { body, sig } = resign(payload);
+      assert({ given: JSON.stringify(payload), should: 'not verify', actual: verifyPreviewCookie(`v2.${body}.${sig}`, KEY, NOW).ok, expected: false });
+    }
+  });
+
+  it('treats a v1 cookie as malformed, which routes to the silent re-handshake', () => {
+    const [, body, sig] = signPreviewCookie(claims, KEY).split('.');
+    assert({ given: 'a v1-versioned token', should: 'be malformed, never accepted', actual: verifyPreviewCookie(`v1.${body}.${sig}`, KEY, NOW), expected: { ok: false, reason: 'malformed' } });
   });
 
   it('never verifies with an empty key, and never signs with one', () => {

--- a/packages/lib/src/services/sandbox/preview/dev-preview-core.ts
+++ b/packages/lib/src/services/sandbox/preview/dev-preview-core.ts
@@ -714,6 +714,9 @@ export function describeServiceState({ liveInstanceId, row, relay, listeners }: 
       targetPort: row.targetPort,
       via: 'relay',
       error: null,
+      // Ours to fix, and the reason this branch says `down` at all: the row
+      // names no relay, so a reconcile plans `start-relay` via `create`.
+      repairable: true,
       message: `The preview relay for port ${row.targetPort} is not defined on this sandbox.`,
     };
   }

--- a/packages/lib/src/services/sandbox/preview/dev-preview-core.ts
+++ b/packages/lib/src/services/sandbox/preview/dev-preview-core.ts
@@ -686,7 +686,13 @@ export function describeServiceState({ liveInstanceId, row, relay, listeners }: 
   // means the sprite URL (which routes to 8080 alone) reaches nothing. Three
   // reasons land here and they read very differently to a user.
   if (row.relayServiceName === null && row.targetPort !== SPRITE_HTTP_PORT) {
-    if (!isPreviewApproved(row, row.targetPort)) {
+    // SHAREABLE, not APPROVED. A row can reach this branch with a perfectly
+    // ordinary dev-server port — a stopped preview records that its relay is
+    // no longer running, and the resume that follows clears the stop before
+    // the relay is re-created. Asking `isPreviewApproved` there would demand
+    // consent for port 5173, which needs none, and offer a Share button for a
+    // port that was never withheld.
+    if (!isPreviewShareable(row, row.targetPort)) {
       return { status: 'needs-approval', targetPort: row.targetPort, message: needsApprovalMessage(row.targetPort) };
     }
     // Approved, and the slot is TAKEN: the relay was planned and refused, and

--- a/packages/lib/src/services/sandbox/preview/dev-preview-core.ts
+++ b/packages/lib/src/services/sandbox/preview/dev-preview-core.ts
@@ -548,23 +548,35 @@ export function planDevServerService(input: PlanDevServerServiceInput): DevServe
   if (describeHttpPortSlot({ listeners, relay }) === 'user-process') {
     return { action: 'refuse', reason: 'http-port-busy', targetPort };
   }
-  // A relay is about to be started or re-pointed, and the slot can only be
-  // called free from a CURRENT snapshot. `already-relaying` returns above, so
-  // a healthy preview is unaffected — this refuses only a START planned blind.
-  if (input.listenersKnown === false) {
-    return { action: 'refuse', reason: 'slot-unknown', targetPort };
-  }
 
   const service = buildPreviewRelaySpec({ targetPort, runtime: relayRuntime });
   const rowIntent = rowFor(service.name);
 
+  // A relay that is ALREADY LIVE and already forwards to `targetPort` is
+  // decided BEFORE the unknown-slot guard, and must stay that way: neither
+  // answer below starts anything, and the question the guard exists to ask —
+  // "is 8080 free?" — has an answer that needs no snapshot, because this
+  // relay is itself the thing holding it. Ordering these the other way round
+  // refused a preview that was already serving, told the user it would start
+  // shortly, and (via `describeServiceState`) made a `down` that the planner
+  // was supposed to answer `already-relaying` for report a plan of `refuse`.
+  if (relay !== null && relayServiceMatches(relay, service) && isRelayAlive(relay)) {
+    if (row?.targetPort === targetPort) return { action: 'none', reason: 'already-relaying', staleRowIgnored };
+    // Relay is right and live but the row does not say so (a lost write, or
+    // a row from a previous target): record it without touching the process.
+    return { action: 'start-relay', via: 'already-running', service, row: rowIntent };
+  }
+
+  // Everything from here DOES mutate the sprite — a start, a re-point, a
+  // create — and the slot can only be called free from a CURRENT snapshot.
+  // This refuses only a start planned blind.
+  if (input.listenersKnown === false) {
+    return { action: 'refuse', reason: 'slot-unknown', targetPort };
+  }
+
+  // Matching but not alive: restarting it is a real process start, so it
+  // waits for the guard above.
   if (relay !== null && relayServiceMatches(relay, service)) {
-    if (isRelayAlive(relay)) {
-      if (row?.targetPort === targetPort) return { action: 'none', reason: 'already-relaying', staleRowIgnored };
-      // Relay is right and live but the row does not say so (a lost write, or
-      // a row from a previous target): record it without touching the process.
-      return { action: 'start-relay', via: 'already-running', service, row: rowIntent };
-    }
     return { action: 'start-relay', via: 'start', service, row: rowIntent };
   }
   if (relay !== null) {

--- a/packages/lib/src/services/sandbox/preview/dev-preview-core.ts
+++ b/packages/lib/src/services/sandbox/preview/dev-preview-core.ts
@@ -123,6 +123,8 @@ export interface DevPreviewRow {
    * inherited one. See {@link requiresPreviewApproval}.
    */
   approvedPort: number | null;
+  /** When that consent was given; `null` exactly when `approvedPort` is. */
+  approvedAt: Date | null;
 }
 
 /**
@@ -148,12 +150,6 @@ export interface DevPreviewRowIntent {
   relayServiceName: string | null;
   detectedAt: Date;
   stoppedByUserAt: null;
-  /**
-   * The approval to carry forward — the row's existing one, untouched. A
-   * detection never grants approval and never revokes one: only the explicit
-   * `approve` action writes this column.
-   */
-  approvedPort: number | null;
   /**
    * THE USER-INTENT GUARD (optimistic concurrency, not a value to write).
    *
@@ -497,7 +493,7 @@ export function planDevServerService(input: PlanDevServerServiceInput): DevServe
   if (
     detected !== null && row !== null && detected.port !== row.targetPort
     && detected.likelihood === 'unlisted'
-    && (KNOWN_DEV_SERVER_PORTS.has(row.targetPort) || isPreviewApproved(row, row.targetPort))
+    && isPreviewShareable(row, row.targetPort)
     && listeners.some((entry) => entry.port === row.targetPort)
   ) {
     return { action: 'none', reason: 'current-target-preferred', staleRowIgnored };
@@ -510,6 +506,20 @@ export function planDevServerService(input: PlanDevServerServiceInput): DevServe
   const detectedAt = detected ? now : row?.detectedAt ?? now;
   if (targetPort === null) return { action: 'none', reason: 'nothing-detected', staleRowIgnored };
 
+  // ONE row shape, three plans. Only `relayServiceName` differs between them,
+  // and the approval and intent guards must be identical in all three — which
+  // is exactly the kind of thing three hand-copied literals stop being.
+  const rowFor = (relayServiceName: string | null): DevPreviewRowIntent => ({
+    holder,
+    spriteInstanceId: liveInstanceId,
+    sandboxId,
+    targetPort,
+    relayServiceName,
+    detectedAt,
+    stoppedByUserAt: null,
+    basedOnStoppedByUserAt: row?.stoppedByUserAt ?? null,
+  });
+
   if (targetPort === SPRITE_HTTP_PORT) {
     // The user's own server on 8080 — reachable through the URL as-is. A relay
     // that is still defined is a leftover from an earlier target and must go.
@@ -519,7 +529,7 @@ export function planDevServerService(input: PlanDevServerServiceInput): DevServe
     return {
       action: 'record-direct',
       removeRelay: relay !== null,
-      row: { holder, spriteInstanceId: liveInstanceId, sandboxId, targetPort, relayServiceName: null, detectedAt, stoppedByUserAt: null, approvedPort: row?.approvedPort ?? null, basedOnStoppedByUserAt: row?.stoppedByUserAt ?? null },
+      row: rowFor(null),
     };
   }
 
@@ -531,7 +541,7 @@ export function planDevServerService(input: PlanDevServerServiceInput): DevServe
       action: 'await-approval',
       targetPort,
       removeRelay: relay !== null,
-      row: { holder, spriteInstanceId: liveInstanceId, sandboxId, targetPort, relayServiceName: null, detectedAt, stoppedByUserAt: null, approvedPort: row?.approvedPort ?? null, basedOnStoppedByUserAt: row?.stoppedByUserAt ?? null },
+      row: rowFor(null),
     };
   }
 
@@ -546,17 +556,7 @@ export function planDevServerService(input: PlanDevServerServiceInput): DevServe
   }
 
   const service = buildPreviewRelaySpec({ targetPort, runtime: relayRuntime });
-  const rowIntent: DevPreviewRowIntent = {
-    holder,
-    spriteInstanceId: liveInstanceId,
-    sandboxId,
-    targetPort,
-    relayServiceName: service.name,
-    detectedAt,
-    stoppedByUserAt: null,
-    approvedPort: row?.approvedPort ?? null,
-    basedOnStoppedByUserAt: row?.stoppedByUserAt ?? null,
-  };
+  const rowIntent = rowFor(service.name);
 
   if (relay !== null && relayServiceMatches(relay, service)) {
     if (isRelayAlive(relay)) {
@@ -638,6 +638,20 @@ export function needsApprovalMessage(targetPort: number): string {
   return `A dev server is running on port ${targetPort}. It is not a usual dev-server port, so it is not being shared until you say so.`;
 }
 
+/**
+ * Shown when the sandbox is live but nothing is watching its ports, so the
+ * status on screen may lag.
+ *
+ * It lives HERE, in the pure core, rather than beside the status model that
+ * produces it, because the preview PANE renders it — and importing a value
+ * from `dev-preview-status.ts` drags that module's whole dependency graph
+ * (the grant signer's `node:crypto`, the store's database client) into the
+ * browser bundle. `tsc` is perfectly happy with that; `next build` is not.
+ * The core imports nothing but types, which is what makes it safe to reach
+ * for from client code.
+ */
+export const DETECTION_UNAVAILABLE_MESSAGE = 'Dev-server detection is not running right now, so this status may be out of date.';
+
 /** The honest fallback copy for a held slot — the ONE place it is worded. */
 export const HTTP_PORT_BUSY_MESSAGE =
   `Port ${SPRITE_HTTP_PORT} is already in use by something that is not the preview relay. Run your dev server on port ${SPRITE_HTTP_PORT} to preview it, or free the port.`;
@@ -664,20 +678,26 @@ export function describeServiceState({ liveInstanceId, row, relay, listeners }: 
     };
   }
 
-  // Detected, recorded, and serving NOTHING — no relay for a non-8080 target
-  // means the sprite URL (which routes to 8080 alone) reaches nothing. Two
-  // reasons land here and they read very differently to a user: waiting on a
-  // person, or a relay this reconcile has not created yet.
-  if (row.relayServiceName === null && row.targetPort !== SPRITE_HTTP_PORT) {
-    if (isPreviewApproved(row, row.targetPort)) {
-      return { status: 'starting', targetPort: row.targetPort, via: 'relay', message: `Starting the preview relay for port ${row.targetPort}…` };
-    }
-    return { status: 'needs-approval', targetPort: row.targetPort, message: needsApprovalMessage(row.targetPort) };
-  }
-
   const targetListening = listeners === null ? null : listeners.some((entry) => entry.port === row.targetPort);
 
   const holder = describeHttpPortSlot({ listeners: listeners ?? [], relay });
+
+  // Detected, recorded, and serving NOTHING — no relay for a non-8080 target
+  // means the sprite URL (which routes to 8080 alone) reaches nothing. Three
+  // reasons land here and they read very differently to a user.
+  if (row.relayServiceName === null && row.targetPort !== SPRITE_HTTP_PORT) {
+    if (!isPreviewApproved(row, row.targetPort)) {
+      return { status: 'needs-approval', targetPort: row.targetPort, message: needsApprovalMessage(row.targetPort) };
+    }
+    // Approved, and the slot is TAKEN: the relay was planned and refused, and
+    // no future reconcile will get further while the port is held. Saying
+    // "starting…" here would be a lie that never resolves, and it would hide
+    // the one thing the user can act on — asked BEFORE the starting case, and
+    // only when a snapshot actually proves it (`listeners: null` leaves the
+    // slot unknown, which is not evidence of a problem).
+    if (holder === 'user-process') return { status: 'blocked', targetPort: row.targetPort, message: HTTP_PORT_BUSY_MESSAGE };
+    return { status: 'starting', targetPort: row.targetPort, via: 'relay', message: `Starting the preview relay for port ${row.targetPort}…` };
+  }
 
   if (row.relayServiceName === null) {
     // Direct: the user's server on 8080 is the whole path, so the slot holder

--- a/packages/lib/src/services/sandbox/preview/dev-preview-core.ts
+++ b/packages/lib/src/services/sandbox/preview/dev-preview-core.ts
@@ -695,14 +695,27 @@ export function describeServiceState({ liveInstanceId, row, relay, listeners }: 
     if (!isPreviewShareable(row, row.targetPort)) {
       return { status: 'needs-approval', targetPort: row.targetPort, message: needsApprovalMessage(row.targetPort) };
     }
-    // Approved, and the slot is TAKEN: the relay was planned and refused, and
-    // no future reconcile will get further while the port is held. Saying
-    // "starting…" here would be a lie that never resolves, and it would hide
-    // the one thing the user can act on — asked BEFORE the starting case, and
-    // only when a snapshot actually proves it (`listeners: null` leaves the
-    // slot unknown, which is not evidence of a problem).
+    // The slot is TAKEN: the relay was planned and refused, and no future
+    // reconcile gets further while the port is held. Asked BEFORE the case
+    // below, and only when a snapshot actually proves it (`listeners: null`
+    // leaves the slot unknown, which is not evidence of a problem).
     if (holder === 'user-process') return { status: 'blocked', targetPort: row.targetPort, message: HTTP_PORT_BUSY_MESSAGE };
-    return { status: 'starting', targetPort: row.targetPort, via: 'relay', message: `Starting the preview relay for port ${row.targetPort}…` };
+    // DOWN, not "starting…". A relay is normally created in the same call that
+    // clears the stop or records the consent, so this shape means that create
+    // did NOT happen — the slot could not be proven free, the holder's lock
+    // was contended, the call failed. Nothing necessarily converges it: the
+    // sweep only handles rows that are still switched OFF, and the detector
+    // needs a port frame a dev server that is already listening will not
+    // emit. Saying "starting" would promise an arrival that never comes and
+    // would take away the one control that fixes it — `down` is what puts the
+    // Restart button back.
+    return {
+      status: 'down',
+      targetPort: row.targetPort,
+      via: 'relay',
+      error: null,
+      message: `The preview relay for port ${row.targetPort} is not defined on this sandbox.`,
+    };
   }
 
   if (row.relayServiceName === null) {

--- a/packages/lib/src/services/sandbox/preview/dev-preview-core.ts
+++ b/packages/lib/src/services/sandbox/preview/dev-preview-core.ts
@@ -116,6 +116,13 @@ export interface DevPreviewRow {
   relayServiceName: string | null;
   detectedAt: Date;
   stoppedByUserAt: Date | null;
+  /**
+   * The port a person explicitly agreed to share, or `null` for none. Named
+   * by PORT rather than a boolean so approval is per-port by construction: a
+   * dev server that moves to another unlisted port is a new decision, not an
+   * inherited one. See {@link requiresPreviewApproval}.
+   */
+  approvedPort: number | null;
 }
 
 /**
@@ -141,6 +148,12 @@ export interface DevPreviewRowIntent {
   relayServiceName: string | null;
   detectedAt: Date;
   stoppedByUserAt: null;
+  /**
+   * The approval to carry forward — the row's existing one, untouched. A
+   * detection never grants approval and never revokes one: only the explicit
+   * `approve` action writes this column.
+   */
+  approvedPort: number | null;
   /**
    * THE USER-INTENT GUARD (optimistic concurrency, not a value to write).
    *
@@ -181,6 +194,41 @@ export const NON_HTTP_SERVICE_PORTS: ReadonlySet<number> = new Set([
 export const KNOWN_DEV_SERVER_PORTS: ReadonlySet<number> = new Set([
   1234, 3000, 3001, 4000, 4200, 4321, 5000, 5173, 5174, 8000, 8080, 8081, 8888,
 ]);
+
+/**
+ * Pure: does offering THIS port need a person to say yes first?
+ *
+ * Starting the relay is the act of exposure — from that moment the port is
+ * reachable by everyone the holder's preview is reachable by, which for an
+ * env is every accepted member of the drive. Detection is not exposure and
+ * is deliberately unchanged: an unlisted port is still detected, still named
+ * in the affordance, still explicable. What it does not do any more is
+ * publish itself.
+ *
+ * The line is {@link KNOWN_DEV_SERVER_PORTS}: a port whose default owner is a
+ * dev server (vite, next, astro, django…) is what the user asked for by
+ * running the tool, and auto-relaying it is the feature working. Anything
+ * else — an admin UI on 9000, a debug listener, a colleague's service — is a
+ * guess, and a guess that exposes something is one a person makes.
+ *
+ * This is the ONLY home for the rule. It deliberately does not live in SQL:
+ * the port list is TypeScript, and duplicating it into a CHECK would
+ * guarantee drift. The security property is structural anyway — the sprite
+ * URL routes to 8080 alone, so a row with no relay serves nothing at all.
+ */
+export function requiresPreviewApproval(port: number): boolean {
+  return !KNOWN_DEV_SERVER_PORTS.has(port);
+}
+
+/** Pure: has a person approved sharing exactly this port on this row? */
+export function isPreviewApproved(row: Pick<DevPreviewRow, 'approvedPort'> | null, port: number): boolean {
+  return row !== null && row.approvedPort === port;
+}
+
+/** Pure: may this row's target be relayed right now — either it needs no approval, or it has one. */
+export function isPreviewShareable(row: Pick<DevPreviewRow, 'approvedPort'> | null, port: number): boolean {
+  return !requiresPreviewApproval(port) || isPreviewApproved(row, port);
+}
 
 export type DevServerClassification =
   | {
@@ -357,6 +405,21 @@ export type DevServerServicePlan =
       row: DevPreviewRowIntent;
     }
   | {
+      /**
+       * An UNLISTED port is the target and nobody has agreed to share it.
+       * Record the detection — so the UI can name the port and offer the
+       * decision — but start NOTHING, and take down a relay left over from a
+       * previous target, because that relay is exposure the user did not ask
+       * to keep. `row.relayServiceName` is null, which is what makes the
+       * sprite serve nothing: the URL routes to 8080 alone.
+       */
+      action: 'await-approval';
+      targetPort: number;
+      /** `services.remove(...)` first — a relay for the PREVIOUS target must not outlive it. */
+      removeRelay: boolean;
+      row: DevPreviewRowIntent;
+    }
+  | {
       /** The user switched the preview off and the relay is still up: `services.stop(relayServiceName)`. */
       action: 'stop-relay';
       relayServiceName: string;
@@ -425,12 +488,16 @@ export function planDevServerService(input: PlanDevServerServiceInput): DevServe
     return { action: 'none', reason: 'user-stopped', staleRowIgnored };
   }
 
-  // Thrash guard: a fresh UNLISTED port must not displace a KNOWN dev-port
-  // target that is still serving. Everything else — a known port, or any port
-  // once the current target is gone — replaces freely.
+  // Thrash guard: a fresh UNLISTED port must not displace a target that is
+  // still serving — either a KNOWN dev port, or an unlisted one a person has
+  // APPROVED. Without the second half, a `node --inspect` bind would knock a
+  // working, explicitly-shared preview back into needs-approval and make the
+  // user agree to it all over again. Everything else — a known port, or any
+  // port once the current target is gone — replaces freely.
   if (
     detected !== null && row !== null && detected.port !== row.targetPort
-    && detected.likelihood === 'unlisted' && KNOWN_DEV_SERVER_PORTS.has(row.targetPort)
+    && detected.likelihood === 'unlisted'
+    && (KNOWN_DEV_SERVER_PORTS.has(row.targetPort) || isPreviewApproved(row, row.targetPort))
     && listeners.some((entry) => entry.port === row.targetPort)
   ) {
     return { action: 'none', reason: 'current-target-preferred', staleRowIgnored };
@@ -452,7 +519,19 @@ export function planDevServerService(input: PlanDevServerServiceInput): DevServe
     return {
       action: 'record-direct',
       removeRelay: relay !== null,
-      row: { holder, spriteInstanceId: liveInstanceId, sandboxId, targetPort, relayServiceName: null, detectedAt, stoppedByUserAt: null, basedOnStoppedByUserAt: row?.stoppedByUserAt ?? null },
+      row: { holder, spriteInstanceId: liveInstanceId, sandboxId, targetPort, relayServiceName: null, detectedAt, stoppedByUserAt: null, approvedPort: row?.approvedPort ?? null, basedOnStoppedByUserAt: row?.stoppedByUserAt ?? null },
+    };
+  }
+
+  // CONSENT BEFORE EXPOSURE, and before the slot questions: nothing is being
+  // started here, so `http-port-busy` and `slot-unknown` would both be
+  // dishonest answers to "why is my preview not up?".
+  if (!isPreviewShareable(row, targetPort)) {
+    return {
+      action: 'await-approval',
+      targetPort,
+      removeRelay: relay !== null,
+      row: { holder, spriteInstanceId: liveInstanceId, sandboxId, targetPort, relayServiceName: null, detectedAt, stoppedByUserAt: null, approvedPort: row?.approvedPort ?? null, basedOnStoppedByUserAt: row?.stoppedByUserAt ?? null },
     };
   }
 
@@ -475,6 +554,7 @@ export function planDevServerService(input: PlanDevServerServiceInput): DevServe
     relayServiceName: service.name,
     detectedAt,
     stoppedByUserAt: null,
+    approvedPort: row?.approvedPort ?? null,
     basedOnStoppedByUserAt: row?.stoppedByUserAt ?? null,
   };
 
@@ -517,6 +597,7 @@ export type DevPreviewServiceState =
   | { status: 'instance-unknown'; message: string }
   | { status: 'stale'; targetPort: number; message: string }
   | { status: 'stopped'; targetPort: number; stoppedAt: Date; message: string }
+  | { status: 'needs-approval'; targetPort: number; message: string }
   | { status: 'starting'; targetPort: number; via: 'relay'; message: string }
   | { status: 'live'; targetPort: number; via: 'relay' | 'direct'; message: string }
   | {
@@ -552,6 +633,11 @@ function relayTargets(relay: SandboxServiceInfo, targetPort: number): boolean {
   return (['node', 'socat'] as const).some((runtime) => relayServiceMatches(relay, buildPreviewRelaySpec({ targetPort, runtime })));
 }
 
+/** The copy for a detected-but-unshared port — the ONE place it is worded. */
+export function needsApprovalMessage(targetPort: number): string {
+  return `A dev server is running on port ${targetPort}. It is not a usual dev-server port, so it is not being shared until you say so.`;
+}
+
 /** The honest fallback copy for a held slot — the ONE place it is worded. */
 export const HTTP_PORT_BUSY_MESSAGE =
   `Port ${SPRITE_HTTP_PORT} is already in use by something that is not the preview relay. Run your dev server on port ${SPRITE_HTTP_PORT} to preview it, or free the port.`;
@@ -576,6 +662,17 @@ export function describeServiceState({ liveInstanceId, row, relay, listeners }: 
       stoppedAt: row.stoppedByUserAt,
       message: `Preview of port ${row.targetPort} is switched off.`,
     };
+  }
+
+  // Detected, recorded, and serving NOTHING — no relay for a non-8080 target
+  // means the sprite URL (which routes to 8080 alone) reaches nothing. Two
+  // reasons land here and they read very differently to a user: waiting on a
+  // person, or a relay this reconcile has not created yet.
+  if (row.relayServiceName === null && row.targetPort !== SPRITE_HTTP_PORT) {
+    if (isPreviewApproved(row, row.targetPort)) {
+      return { status: 'starting', targetPort: row.targetPort, via: 'relay', message: `Starting the preview relay for port ${row.targetPort}…` };
+    }
+    return { status: 'needs-approval', targetPort: row.targetPort, message: needsApprovalMessage(row.targetPort) };
   }
 
   const targetListening = listeners === null ? null : listeners.some((entry) => entry.port === row.targetPort);

--- a/packages/lib/src/services/sandbox/preview/dev-preview-detection.ts
+++ b/packages/lib/src/services/sandbox/preview/dev-preview-detection.ts
@@ -42,6 +42,7 @@ import {
   type ListeningPort,
 } from './dev-preview-core';
 import { applyDevServerServicePlan, probeRelayRuntime, type AppliedDevServerServicePlan } from './dev-preview-effects';
+import { unlocked, type DevPreviewLock } from './dev-preview-lock';
 import type { DevPreviewStore } from './dev-preview-store';
 import { PREVIEW_RELAY_SERVICE_NAME, type PreviewRelayRuntime } from './preview-relay';
 import type { PortsWatchFrame } from './ports-watch';
@@ -61,6 +62,12 @@ export interface DevPreviewDetectorDeps {
   log: DevPreviewDetectorLog;
   /** Test seam; production probes with `probeRelayRuntime`. */
   probeRuntime?: (exec: SandboxHandle['exec']) => Promise<PreviewRelayRuntime>;
+  /**
+   * Serializes this holder's read → plan → apply against the WEB tier's user
+   * actions. Defaults to no serialization so the pure unit surface needs no
+   * Postgres; the realtime binding supplies the real advisory lock.
+   */
+  lock?: DevPreviewLock;
 }
 
 export interface DevPreviewDetector {
@@ -95,6 +102,7 @@ type Detected = Extract<DevServerClassification, { kind: 'dev-server' }>;
 export function createDevPreviewDetector(deps: DevPreviewDetectorDeps): DevPreviewDetector {
   const { holder, handle, store, now, log } = deps;
   const probe = deps.probeRuntime ?? probeRelayRuntime;
+  const lock = deps.lock ?? unlocked;
   const listeners = new Map<number, ListeningPort>();
   /** True once a `port_list` has been applied and no invalidation has landed since. */
   let snapshotKnown = false;
@@ -108,7 +116,26 @@ export function createDevPreviewDetector(deps: DevPreviewDetectorDeps): DevPrevi
 
   const context = () => ({ holderKind: holder.kind, holderId: holder.id, spriteInstanceId: handle.spriteInstanceId });
 
+  /**
+   * The authoritative read → plan → apply, serialized per holder against the
+   * web tier's stop/resume (`dev-preview-lock.ts`). Only this is locked: the
+   * listener bookkeeping and `classifyDetectedDevServer` above are pure and
+   * in-process, and holding a Postgres connection across them would pin it to
+   * work that changes nothing.
+   *
+   * A bounded retry rather than a bare try-lock, because frames are not
+   * guaranteed to recur — a `port_opened` for a server that then sits quiet is
+   * often the last frame for minutes, so dropping one can mean the preview
+   * silently never appears. Past the budget the frame is DEFERRED, which the
+   * next frame or the backstop sweep converges.
+   */
   async function reconcile(detected: Detected | null): Promise<AppliedDevServerServicePlan> {
+    const outcome = await lock(holder, () => reconcileLocked(detected));
+    if (outcome.outcome === 'acquired') return outcome.result;
+    return { action: 'deferred', reason: 'reconcile-in-progress' };
+  }
+
+  async function reconcileLocked(detected: Detected | null): Promise<AppliedDevServerServicePlan> {
     const [relay, row] = await Promise.all([handle.services.get(PREVIEW_RELAY_SERVICE_NAME), store.findByHolder(holder)]);
     const input = {
       liveInstanceId: handle.spriteInstanceId,

--- a/packages/lib/src/services/sandbox/preview/dev-preview-detection.ts
+++ b/packages/lib/src/services/sandbox/preview/dev-preview-detection.ts
@@ -145,6 +145,14 @@ export function createDevPreviewDetector(deps: DevPreviewDetectorDeps): DevPrevi
       detected,
       relay,
       listeners: [...listeners.values()],
+      // UNKNOWN IS NEVER 'FREE', here too. The accumulated set is only a
+      // current picture of the sprite once THIS connection's `port_list` has
+      // landed; before that — or after `invalidateSnapshot` on a drop, while
+      // a frame is still queued on the chain — it is a dead connection's
+      // leftovers. Handing it over as if it were current is exactly what
+      // `slot-unknown` was added to prevent: the core would read 8080 as free
+      // and start a relay that cannot bind.
+      listenersKnown: snapshotKnown,
       now: now(),
     };
     let plan = planDevServerService({ ...input, relayRuntime: runtime });

--- a/packages/lib/src/services/sandbox/preview/dev-preview-effects.ts
+++ b/packages/lib/src/services/sandbox/preview/dev-preview-effects.ts
@@ -87,7 +87,13 @@ export type AppliedDevServerServicePlan =
        * re-ordering would make this a lie, and lies should not typecheck.
        */
       mutated: 'none';
-    };
+    }
+  /**
+   * Another writer holds this holder's lock and the retry budget is spent.
+   * Nothing was read, planned or done. The next frame — or the backstop
+   * sweep — converges; see `dev-preview-lock.ts`.
+   */
+  | { action: 'deferred'; reason: 'reconcile-in-progress' };
 
 /**
  * Carry out one plan: **the row first, then the service calls.**

--- a/packages/lib/src/services/sandbox/preview/dev-preview-effects.ts
+++ b/packages/lib/src/services/sandbox/preview/dev-preview-effects.ts
@@ -146,44 +146,45 @@ export async function applyDevServerServicePlan({
   services: SandboxServicesApi;
   store: DevPreviewRowWriter;
 }): Promise<AppliedDevServerServicePlan> {
+  // THE ORDER, ENCODED ONCE. Every plan that carries a row writes it here,
+  // before the switch and therefore before any service call — so a new arm
+  // cannot get the ordering wrong by forgetting to copy two lines, and a
+  // refused write costs no sprite mutation for ALL of them at once.
+  if ('row' in plan) {
+    const recorded = await store.upsert(plan.row);
+    if (!recorded) return { action: 'skipped', reason: 'intent-changed', mutated: 'none' };
+  }
+
   switch (plan.action) {
     case 'start-relay': {
-      const recorded = await store.upsert(plan.row);
-      if (!recorded) return { action: 'skipped', reason: 'intent-changed', mutated: 'none' };
       if (plan.via === 'create') {
         await services.create({ name: plan.service.name, command: plan.service.command, args: plan.service.args });
       } else if (plan.via === 'start') {
         await services.start(plan.service.name);
       }
-      return { action: 'start-relay', via: plan.via, targetPort: plan.service.targetPort, recorded };
+      return { action: 'start-relay', via: plan.via, targetPort: plan.service.targetPort, recorded: true };
     }
     case 'replace-relay': {
-      // Row first (see the docblock). A refusal here leaves the OLD relay
-      // running and the row still naming it — which is exactly right: the
-      // refusal means the user's stop landed, and the next reconcile plans
-      // `stop-relay` against a row that can still find the relay to stop.
-      const recorded = await store.upsert(plan.row);
-      if (!recorded) return { action: 'skipped', reason: 'intent-changed', mutated: 'none' };
+      // A refusal above leaves the OLD relay running and the row still naming
+      // it — which is exactly right: the refusal means the user's stop landed,
+      // and the next reconcile plans `stop-relay` against a row that can still
+      // find the relay to stop.
       // Remove-then-create, never an in-place PUT with a different command:
       // what the platform does with a DIFFERENT command under the same name is
       // unverified (`relayServiceMatches`'s doc), and the core plans around it.
       await services.remove(plan.service.name);
       await services.create({ name: plan.service.name, command: plan.service.command, args: plan.service.args });
-      return { action: 'replace-relay', previousTargetPort: plan.previousTargetPort, targetPort: plan.service.targetPort, recorded };
+      return { action: 'replace-relay', previousTargetPort: plan.previousTargetPort, targetPort: plan.service.targetPort, recorded: true };
     }
     case 'record-direct': {
-      const recorded = await store.upsert(plan.row);
-      if (!recorded) return { action: 'skipped', reason: 'intent-changed', mutated: 'none' };
       if (plan.removeRelay) await services.remove(PREVIEW_RELAY_SERVICE_NAME);
-      return { action: 'record-direct', removedRelay: plan.removeRelay, recorded };
+      return { action: 'record-direct', removedRelay: plan.removeRelay, recorded: true };
     }
     case 'await-approval': {
-      // Row first, like every other arm. A refusal means the user's stop
-      // landed in between, and a stopped preview needs no approval prompt.
-      const recorded = await store.upsert(plan.row);
-      if (!recorded) return { action: 'skipped', reason: 'intent-changed', mutated: 'none' };
+      // A refusal above means the user's stop landed in between, and a
+      // stopped preview needs no approval prompt.
       if (plan.removeRelay) await services.remove(PREVIEW_RELAY_SERVICE_NAME);
-      return { action: 'await-approval', targetPort: plan.targetPort, removedRelay: plan.removeRelay, recorded };
+      return { action: 'await-approval', targetPort: plan.targetPort, removedRelay: plan.removeRelay, recorded: true };
     }
     case 'stop-relay': {
       // The mirror of the row guard, for the effect that writes nothing: a

--- a/packages/lib/src/services/sandbox/preview/dev-preview-effects.ts
+++ b/packages/lib/src/services/sandbox/preview/dev-preview-effects.ts
@@ -76,14 +76,45 @@ export type AppliedDevServerServicePlan =
    * since cleared (`resumed`). Not an error — the next reconcile plans from
    * the row that won.
    */
-  | { action: 'skipped'; reason: 'intent-changed' | 'resumed' };
+  | {
+      action: 'skipped';
+      reason: 'intent-changed' | 'resumed';
+      /**
+       * What was done to the SPRITE before the refusal. Always `'none'`, and
+       * that is the point: the row is written before any service call, so a
+       * refused plan cannot leave a relay behind. The field exists so the
+       * type has to be changed before the ordering can be — a future
+       * re-ordering would make this a lie, and lies should not typecheck.
+       */
+      mutated: 'none';
+    };
 
 /**
- * Carry out one plan: service calls first (so a row is never written for a
- * relay that failed to start — a thrown service call aborts before the
- * upsert), then the holder-keyed upsert exactly as the core's row intent
- * specifies (every field, `stoppedByUserAt: null` included — see
- * `DevPreviewRowIntent`).
+ * Carry out one plan: **the row first, then the service calls.**
+ *
+ * THE ORDER IS THE CORRECTNESS PROPERTY, and it used to be the other way
+ * round. The two failure shapes are not symmetric:
+ *
+ *  - ROW AHEAD OF SPRITE (the row is written, the service call then fails):
+ *    `describeServiceState` folds row + live relay and reports `down` — "the
+ *    preview relay for port N is not defined on this sandbox" — and the next
+ *    plan is `start-relay via create`. **It converges**, and it never lies in
+ *    the meantime.
+ *  - SPRITE AHEAD OF ROW (service-first, and the row write is then refused by
+ *    the intent guard): a relay is left RUNNING that no future plan can see,
+ *    because `relayServiceName` was never written. `planDevServerService`
+ *    reads the row, sees a user-stopped preview with no relay recorded, and
+ *    answers `user-stopped` forever. **It never converges** — the relay is
+ *    orphaned for the life of the sprite.
+ *
+ * So a refused write must cost nothing, which it can only do if nothing has
+ * been done yet. The accepted price is a worse SECOND rather than a worse
+ * forever: between the row write and the service call the proxy may forward
+ * to 8080 with nothing listening, which reads as `down` and self-heals.
+ *
+ * Compensating service calls on refusal are deliberately NOT built: a
+ * compensation is a second effect that can itself fail, needing its own error
+ * taxonomy, and row-first removes the need for one entirely.
  *
  * USER INTENT WINS EVERY RACE. A plan is made from a row read moments
  * earlier; a user's stop or resume can land in between. Both places where
@@ -91,9 +122,7 @@ export type AppliedDevServerServicePlan =
  * plan was made against: the row write is a compare-and-set in SQL
  * (`basedOnStoppedByUserAt`), and `stop-relay` — destructive without
  * writing — re-reads the row and stops nothing if the stop has been cleared.
- * A refusal is reported as `skipped`, never thrown: the relay may be a step
- * ahead of the row for one frame, `describeServiceState` folds both and says
- * so honestly, and the next reconcile converges.
+ * A refusal is reported as `skipped`, never thrown.
  */
 export async function applyDevServerServicePlan({
   plan,
@@ -106,29 +135,33 @@ export async function applyDevServerServicePlan({
 }): Promise<AppliedDevServerServicePlan> {
   switch (plan.action) {
     case 'start-relay': {
+      const recorded = await store.upsert(plan.row);
+      if (!recorded) return { action: 'skipped', reason: 'intent-changed', mutated: 'none' };
       if (plan.via === 'create') {
         await services.create({ name: plan.service.name, command: plan.service.command, args: plan.service.args });
       } else if (plan.via === 'start') {
         await services.start(plan.service.name);
       }
-      const recorded = await store.upsert(plan.row);
-      if (!recorded) return { action: 'skipped', reason: 'intent-changed' };
       return { action: 'start-relay', via: plan.via, targetPort: plan.service.targetPort, recorded };
     }
     case 'replace-relay': {
+      // Row first (see the docblock). A refusal here leaves the OLD relay
+      // running and the row still naming it — which is exactly right: the
+      // refusal means the user's stop landed, and the next reconcile plans
+      // `stop-relay` against a row that can still find the relay to stop.
+      const recorded = await store.upsert(plan.row);
+      if (!recorded) return { action: 'skipped', reason: 'intent-changed', mutated: 'none' };
       // Remove-then-create, never an in-place PUT with a different command:
       // what the platform does with a DIFFERENT command under the same name is
       // unverified (`relayServiceMatches`'s doc), and the core plans around it.
       await services.remove(plan.service.name);
       await services.create({ name: plan.service.name, command: plan.service.command, args: plan.service.args });
-      const recorded = await store.upsert(plan.row);
-      if (!recorded) return { action: 'skipped', reason: 'intent-changed' };
       return { action: 'replace-relay', previousTargetPort: plan.previousTargetPort, targetPort: plan.service.targetPort, recorded };
     }
     case 'record-direct': {
-      if (plan.removeRelay) await services.remove(PREVIEW_RELAY_SERVICE_NAME);
       const recorded = await store.upsert(plan.row);
-      if (!recorded) return { action: 'skipped', reason: 'intent-changed' };
+      if (!recorded) return { action: 'skipped', reason: 'intent-changed', mutated: 'none' };
+      if (plan.removeRelay) await services.remove(PREVIEW_RELAY_SERVICE_NAME);
       return { action: 'record-direct', removedRelay: plan.removeRelay, recorded };
     }
     case 'stop-relay': {
@@ -137,7 +170,7 @@ export async function applyDevServerServicePlan({
       // it. Re-read the intent at the last possible moment; gone ⇒ do
       // nothing (the resume's own reconcile has the relay in hand).
       const current = await store.findByHolder(plan.holder);
-      if (current === null || current.stoppedByUserAt === null) return { action: 'skipped', reason: 'resumed' };
+      if (current === null || current.stoppedByUserAt === null) return { action: 'skipped', reason: 'resumed', mutated: 'none' };
       await services.stop(plan.relayServiceName);
       return { action: 'stop-relay', relayServiceName: plan.relayServiceName };
     }

--- a/packages/lib/src/services/sandbox/preview/dev-preview-effects.ts
+++ b/packages/lib/src/services/sandbox/preview/dev-preview-effects.ts
@@ -66,6 +66,13 @@ export type AppliedDevServerServicePlan =
   | { action: 'start-relay'; via: 'create' | 'start' | 'already-running'; targetPort: number; recorded: boolean }
   | { action: 'replace-relay'; previousTargetPort: number; targetPort: number; recorded: boolean }
   | { action: 'record-direct'; removedRelay: boolean; recorded: boolean }
+  /**
+   * The port was recorded so the UI can name it and offer the decision, and
+   * NOTHING was started — an unlisted port is not shared until a person says
+   * so (`requiresPreviewApproval`). Any relay for a PREVIOUS target was taken
+   * down, because that relay is exposure nobody asked to keep.
+   */
+  | { action: 'await-approval'; targetPort: number; removedRelay: boolean; recorded: boolean }
   | { action: 'stop-relay'; relayServiceName: string }
   | { action: 'none'; reason: string; staleRowIgnored: boolean }
   | { action: 'refuse'; reason: string; targetPort?: number }
@@ -169,6 +176,14 @@ export async function applyDevServerServicePlan({
       if (!recorded) return { action: 'skipped', reason: 'intent-changed', mutated: 'none' };
       if (plan.removeRelay) await services.remove(PREVIEW_RELAY_SERVICE_NAME);
       return { action: 'record-direct', removedRelay: plan.removeRelay, recorded };
+    }
+    case 'await-approval': {
+      // Row first, like every other arm. A refusal means the user's stop
+      // landed in between, and a stopped preview needs no approval prompt.
+      const recorded = await store.upsert(plan.row);
+      if (!recorded) return { action: 'skipped', reason: 'intent-changed', mutated: 'none' };
+      if (plan.removeRelay) await services.remove(PREVIEW_RELAY_SERVICE_NAME);
+      return { action: 'await-approval', targetPort: plan.targetPort, removedRelay: plan.removeRelay, recorded };
     }
     case 'stop-relay': {
       // The mirror of the row guard, for the effect that writes nothing: a

--- a/packages/lib/src/services/sandbox/preview/dev-preview-effects.ts
+++ b/packages/lib/src/services/sandbox/preview/dev-preview-effects.ts
@@ -43,6 +43,8 @@ import { PREVIEW_RELAY_SERVICE_NAME, type PreviewRelayRuntime } from './preview-
 export interface DevPreviewRowWriter {
   upsert(intent: DevPreviewRowIntent): Promise<boolean>;
   findByHolder(holder: DevPreviewHolderRef): Promise<{ stoppedByUserAt: Date | null } | null>;
+  /** Clear the stopped relay's name from the row — see the store's own doc for why this is not optional. */
+  markRelayStopped(input: { holder: DevPreviewHolderRef; relayServiceName: string }): Promise<void>;
 }
 
 /** Bounded so a hung probe cannot hold the detection loop. */
@@ -194,6 +196,11 @@ export async function applyDevServerServicePlan({
       const current = await store.findByHolder(plan.holder);
       if (current === null || current.stoppedByUserAt === null) return { action: 'skipped', reason: 'resumed', mutated: 'none' };
       await services.stop(plan.relayServiceName);
+      // Service-call-then-write, the one place that order is right: the row
+      // must not stop naming a relay that is still running. Recording it is
+      // what lets the backstop sweep's candidate window drain instead of
+      // re-processing this holder every few minutes forever.
+      await store.markRelayStopped({ holder: plan.holder, relayServiceName: plan.relayServiceName });
       return { action: 'stop-relay', relayServiceName: plan.relayServiceName };
     }
     case 'none':

--- a/packages/lib/src/services/sandbox/preview/dev-preview-grants-store.ts
+++ b/packages/lib/src/services/sandbox/preview/dev-preview-grants-store.ts
@@ -29,11 +29,13 @@ export interface MintedPreviewGrant {
 export interface ConsumedPreviewGrant {
   holder: DevPreviewHolderRef;
   userId: string;
+  /** The session that minted the grant — carried into the cookie so revocation can be enforced per request. */
+  sessionId: string;
   cookieExpiresAt: Date;
 }
 
 export interface DevPreviewGrantsStore {
-  mint(input: { holder: DevPreviewHolderRef; userId: string; now: Date }): Promise<MintedPreviewGrant>;
+  mint(input: { holder: DevPreviewHolderRef; userId: string; sessionId: string; now: Date }): Promise<MintedPreviewGrant>;
   /** The grant's claims if THIS call redeemed it; null if it does not exist, is expired, or was already redeemed. */
   consume(input: { id: string; now: Date }): Promise<ConsumedPreviewGrant | null>;
 }
@@ -50,7 +52,7 @@ const GRANT_ID_SHAPE = /^[A-Za-z0-9_-]{43}$/;
 
 export function createDbDevPreviewGrantsStore(): DevPreviewGrantsStore {
   return {
-    async mint({ holder, userId, now }) {
+    async mint({ holder, userId, sessionId, now }) {
       const id = generatePreviewGrantId();
       const expiresAt = new Date(now.getTime() + PREVIEW_GRANT_TTL_MS);
       const cookieExpiresAt = new Date(now.getTime() + PREVIEW_COOKIE_TTL_MS);
@@ -59,6 +61,7 @@ export function createDbDevPreviewGrantsStore(): DevPreviewGrantsStore {
         holderKind: holder.kind,
         holderId: holder.id,
         userId,
+        sessionId,
         expiresAt,
         cookieExpiresAt,
         createdAt: now,
@@ -85,11 +88,12 @@ export function createDbDevPreviewGrantsStore(): DevPreviewGrantsStore {
           holderKind: devPreviewGrants.holderKind,
           holderId: devPreviewGrants.holderId,
           userId: devPreviewGrants.userId,
+          sessionId: devPreviewGrants.sessionId,
           cookieExpiresAt: devPreviewGrants.cookieExpiresAt,
         });
       if (!row) return null;
       const kind = row.holderKind === 'workspace' ? 'workspace' : 'env';
-      return { holder: { kind, id: row.holderId }, userId: row.userId, cookieExpiresAt: row.cookieExpiresAt };
+      return { holder: { kind, id: row.holderId }, userId: row.userId, sessionId: row.sessionId, cookieExpiresAt: row.cookieExpiresAt };
     },
   };
 }

--- a/packages/lib/src/services/sandbox/preview/dev-preview-lock.ts
+++ b/packages/lib/src/services/sandbox/preview/dev-preview-lock.ts
@@ -1,0 +1,98 @@
+/**
+ * Per-holder serialization for dev-preview relay work — the one thing that
+ * makes the two tiers safe against each other.
+ *
+ * WHY A LOCK AT ALL. A plan is made from a row read moments earlier, and two
+ * writers act on the same holder: the WEB tier (a user's stop/resume) and the
+ * REALTIME tier (the `ports/watch` detector). The detector's frame chain
+ * orders one process's own frames and nothing else. Row-first ordering plus
+ * the store's compare-and-set already guarantee that a refused write costs no
+ * sprite mutation — so nothing is ever orphaned — but they cannot stop two
+ * writers from interleaving read/plan/apply and each doing half a job. This
+ * lock closes that: read → plan → apply becomes atomic per holder.
+ *
+ * Both tiers share ONE Postgres, so a Postgres advisory lock genuinely
+ * serializes across processes and containers; this is the same primitive
+ * `wakePublishedAppSerialized` uses to make one request win a wake.
+ *
+ * A TRY-LOCK WITH BOUNDED RETRIES, never a waiting one. `withWorkspaceLock`'s
+ * waiting `pg_advisory_xact_lock` is the wrong tool here twice over: waiting
+ * would stall the detector's frame chain behind a slow web request, and it
+ * holds a database TRANSACTION open across `attach` + `services.*` calls to
+ * the Sprites control plane — a transaction pinned to network latency.
+ *
+ * FAILING TO LOCK IS NEVER AN ERROR. `connection_error` (pool exhausted, a
+ * reset mid-query) is reported as `busy`, not thrown: a degraded lock pool
+ * must not break a user's Stop click or kill a detection frame. Callers have
+ * safe busy paths, and the store's compare-and-set remains the second line of
+ * defence in every case.
+ */
+
+import { getAdvisoryLockPool } from '@pagespace/db/db';
+import { withAdvisoryLock, type AdvisoryLockPool } from '@pagespace/db/advisory-lock';
+import type { DevPreviewHolderRef } from './dev-preview-core';
+
+/**
+ * Advisory-lock keys share one global keyspace with no registry
+ * (`advisory-lock.ts`'s own warning), so the key is deliberately verbose:
+ * feature, holder kind, holder id.
+ */
+export function devPreviewLockKeyFor(holder: DevPreviewHolderRef): string {
+  return `dev-preview:${holder.kind}:${holder.id}`;
+}
+
+export type DevPreviewLockOutcome<T> =
+  | { outcome: 'acquired'; result: T }
+  /** Someone else holds this holder's lock. `fn` never ran, and nothing was touched. */
+  | { outcome: 'busy' };
+
+/**
+ * Run `fn` while holding the holder's lock. Injected as a dependency
+ * everywhere it is used, so tests can script contention deterministically
+ * instead of hoping for a timing window.
+ */
+export type DevPreviewLock = <T>(holder: DevPreviewHolderRef, fn: () => Promise<T>) => Promise<DevPreviewLockOutcome<T>>;
+
+/** Sleep schedules, exported so callers state their own latency budget. */
+export const DEV_PREVIEW_USER_ACTION_RETRIES: readonly number[] = [50, 100, 200, 400, 800];
+/**
+ * The detector retries briefly rather than dropping the frame, because frames
+ * are NOT guaranteed to recur: a `port_opened` for a dev server that then sits
+ * quiet is often the last frame for minutes, so a dropped frame can mean the
+ * preview silently never appears.
+ */
+export const DEV_PREVIEW_DETECTOR_RETRIES: readonly number[] = [100, 250];
+
+export interface CreateDevPreviewLockOptions {
+  pool?: AdvisoryLockPool;
+  retries?: readonly number[];
+  wait?: (ms: number) => Promise<void>;
+  log?: { warn(message: string, context?: Record<string, unknown>): void };
+}
+
+/** A lock bound to the real pool. The pool is resolved lazily, per call, so importing this module opens nothing. */
+export function createDevPreviewLock({ pool, retries = [], wait, log }: CreateDevPreviewLockOptions = {}): DevPreviewLock {
+  const sleep = wait ?? ((ms: number) => new Promise<void>((resolve) => setTimeout(resolve, ms)));
+  return async <T>(holder: DevPreviewHolderRef, fn: () => Promise<T>): Promise<DevPreviewLockOutcome<T>> => {
+    const key = devPreviewLockKeyFor(holder);
+    // attempts = the first try plus one per retry delay.
+    for (let attempt = 0; attempt <= retries.length; attempt += 1) {
+      const locked = await withAdvisoryLock(pool ?? getAdvisoryLockPool(), key, fn);
+      if (locked.outcome === 'acquired') return { outcome: 'acquired', result: locked.result };
+      if (locked.outcome === 'connection_error') {
+        log?.warn('dev-preview: lock unavailable, proceeding unserialized', {
+          holderKind: holder.kind,
+          holderId: holder.id,
+          error: locked.error instanceof Error ? locked.error.message : String(locked.error),
+        });
+        return { outcome: 'busy' };
+      }
+      const delay = retries[attempt];
+      if (delay !== undefined) await sleep(delay);
+    }
+    return { outcome: 'busy' };
+  };
+}
+
+/** A lock that always acquires — the default where serialization is optional (pure unit surfaces, tests). */
+export const unlocked: DevPreviewLock = async (_holder, fn) => ({ outcome: 'acquired', result: await fn() });

--- a/packages/lib/src/services/sandbox/preview/dev-preview-lock.ts
+++ b/packages/lib/src/services/sandbox/preview/dev-preview-lock.ts
@@ -80,7 +80,13 @@ export function createDevPreviewLock({ pool, retries = [], wait, log }: CreateDe
       const locked = await withAdvisoryLock(pool ?? getAdvisoryLockPool(), key, fn);
       if (locked.outcome === 'acquired') return { outcome: 'acquired', result: locked.result };
       if (locked.outcome === 'connection_error') {
-        log?.warn('dev-preview: lock unavailable, proceeding unserialized', {
+        // NOT "proceeding unserialized" — nothing serialized ever runs without
+        // the lock. The detector DEFERS its reconcile entirely, and a user
+        // action records only its INTENT (one compare-and-set, safe on its
+        // own) and defers the relay work with `lockContended`. The old wording
+        // read as though the read-plan-apply sequence had gone ahead
+        // unprotected, which is the one thing that never happens here.
+        log?.warn('dev-preview: lock pool unavailable, relay work deferred', {
           holderKind: holder.kind,
           holderId: holder.id,
           error: locked.error instanceof Error ? locked.error.message : String(locked.error),

--- a/packages/lib/src/services/sandbox/preview/dev-preview-reconcile.ts
+++ b/packages/lib/src/services/sandbox/preview/dev-preview-reconcile.ts
@@ -1,0 +1,136 @@
+/**
+ * The dev-preview BACKSTOP SWEEP — the one gap the per-holder lock cannot
+ * close.
+ *
+ * A user's Stop is durable the moment it is written: `applyDevPreviewUserAction`
+ * records the intent even when the holder's lock is contended or the lock pool
+ * is degraded, and then defers the relay work. Deferring is safe only if
+ * something later re-plans, and normally something does — the realtime
+ * detector's next `ports/watch` frame. But a holder nobody is watching
+ * generates no frames at all, and a stop is exactly the moment a dev server
+ * tends to go quiet. Left alone, that row says "switched off" while the relay
+ * keeps serving until the sprite dies.
+ *
+ * So: every few minutes, take the rows that claim to be switched off while
+ * still naming a relay, and converge them.
+ *
+ * THE SWEEP CAN ONLY EVER STOP, NEVER START. Two independent things make
+ * that true, and the first is the load-bearing one:
+ *
+ *  1. It re-reads the row UNDER THE LOCK and does nothing unless that row
+ *     still carries a stop intent and still names a relay. The core answers a
+ *     stopped row with `stop-relay` or `none` and nothing else, so no plan
+ *     this module can produce starts anything. The re-read is also what makes
+ *     a resume that landed since the listing query win.
+ *  2. Belt and braces: it plans with `listenersKnown: false`, so even if (1)
+ *     were ever loosened, a plan that would START a relay is refused
+ *     (`slot-unknown`) rather than made against an assumed-empty listener
+ *     set. No `ports/watch` snapshot reaches this process, and "unknown" must
+ *     never be read as "8080 is free".
+ *
+ * NEVER WAKES A SPRITE. `attach` is a control-plane read; a paused sprite
+ * stays paused, and a relay inside a paused sprite is serving nobody anyway —
+ * it will be stopped on the next sweep after the sprite wakes.
+ *
+ * NO CRON-LEVEL LOCK, and a per-holder try-lock with NO retries: busy means a
+ * live path already owns this holder and is doing the same work, so skipping
+ * is the whole point. Every write underneath is a compare-and-set, so
+ * overlapping runs converge (the `reconcile-orphaned-sprites` posture).
+ */
+
+import { planDevServerService, type DevPreviewHolderRef } from './dev-preview-core';
+import { applyDevServerServicePlan } from './dev-preview-effects';
+import { unlocked, type DevPreviewLock } from './dev-preview-lock';
+import type { DevPreviewStore } from './dev-preview-store';
+import type { SandboxHandle } from '../sandbox-host';
+import { PREVIEW_RELAY_SERVICE_NAME } from './preview-relay';
+
+/** A candidate row: a holder whose stop intent has outlived its relay. */
+export interface DevPreviewStopCandidate {
+  holder: DevPreviewHolderRef;
+  sandboxId: string;
+}
+
+export interface DevPreviewReconcileDeps {
+  /**
+   * Rows with `stoppedByUserAt IS NOT NULL AND relayServiceName IS NOT NULL`
+   * that have not been touched for `staleAfterMs`, oldest first, capped at
+   * `limit`. The age bound is what keeps the sweep off rows a live path is
+   * still working through.
+   */
+  findStoppedWithRelay(input: { staleAfterMs: number; limit: number }): Promise<DevPreviewStopCandidate[]>;
+  /** A control-plane attach; null when the platform no longer has the sprite. MUST NOT wake. */
+  attach(sandboxId: string): Promise<SandboxHandle | null>;
+  previewStore: DevPreviewStore;
+  lock?: DevPreviewLock;
+  /** Dark deployments do no work at all. */
+  featureEnabled(): boolean;
+  now(): Date;
+  log?: { warn(message: string, context?: Record<string, unknown>): void };
+}
+
+export interface DevPreviewReconcileRun {
+  /** Candidates considered. */
+  processed: number;
+  /** Relays actually stopped. */
+  stopped: number;
+  /** Nothing to do, the holder was locked by a live path, or the sprite is gone. */
+  skipped: number;
+  /** An attach or a service call threw. The row keeps its intent and the next sweep retries. */
+  failed: number;
+}
+
+/** Two minutes: long enough that a click's own reconcile has finished or plainly failed. */
+export const DEV_PREVIEW_SWEEP_STALE_AFTER_MS = 2 * 60 * 1000;
+/** Bounded so one tick cannot hold the control plane open indefinitely. */
+export const DEV_PREVIEW_SWEEP_LIMIT = 50;
+
+export async function reconcileStoppedDevPreviews(deps: DevPreviewReconcileDeps): Promise<DevPreviewReconcileRun> {
+  const run: DevPreviewReconcileRun = { processed: 0, stopped: 0, skipped: 0, failed: 0 };
+  if (!deps.featureEnabled()) return run;
+
+  const lock = deps.lock ?? unlocked;
+  const candidates = await deps.findStoppedWithRelay({ staleAfterMs: DEV_PREVIEW_SWEEP_STALE_AFTER_MS, limit: DEV_PREVIEW_SWEEP_LIMIT });
+
+  for (const candidate of candidates) {
+    run.processed += 1;
+    try {
+      const outcome = await lock(candidate.holder, async () => {
+        // Re-read under the lock: the intent may have been cleared by a resume
+        // between the listing query and now, and the sweep must never act on a
+        // row it has not just seen.
+        const row = await deps.previewStore.findByHolder(candidate.holder);
+        if (row === null || row.stoppedByUserAt === null || row.relayServiceName === null) return 'skipped' as const;
+
+        const handle = await deps.attach(row.sandboxId);
+        if (handle === null) return 'skipped' as const;
+        const relay = await handle.services.get(PREVIEW_RELAY_SERVICE_NAME);
+        const plan = planDevServerService({
+          liveInstanceId: handle.spriteInstanceId,
+          sandboxId: handle.sandboxId,
+          row,
+          holder: candidate.holder,
+          detected: null,
+          relay,
+          listeners: [],
+          // Belt and braces beside the re-read above; see the module doc.
+          listenersKnown: false,
+          now: deps.now(),
+        });
+        const applied = await applyDevServerServicePlan({ plan, services: handle.services, store: deps.previewStore });
+        return applied.action === 'stop-relay' ? ('stopped' as const) : ('skipped' as const);
+      });
+      if (outcome.outcome === 'busy') run.skipped += 1;
+      else if (outcome.result === 'stopped') run.stopped += 1;
+      else run.skipped += 1;
+    } catch (error) {
+      run.failed += 1;
+      deps.log?.warn('dev-preview: backstop sweep failed for a holder', {
+        holderKind: candidate.holder.kind,
+        holderId: candidate.holder.id,
+        error: error instanceof Error ? error.message : String(error),
+      });
+    }
+  }
+  return run;
+}

--- a/packages/lib/src/services/sandbox/preview/dev-preview-reconcile.ts
+++ b/packages/lib/src/services/sandbox/preview/dev-preview-reconcile.ts
@@ -96,8 +96,12 @@ export async function reconcileStoppedDevPreviews(deps: DevPreviewReconcileDeps)
 
   for (const candidate of candidates) {
     run.processed += 1;
+    // Stamped unless a live path owns the holder — set inside the lock body,
+    // so a `busy` outcome (where `fn` never runs) leaves it false.
+    let stamp = false;
     try {
       const outcome = await lock(candidate.holder, async () => {
+        stamp = true;
         // Re-read under the lock: the intent may have been cleared by a resume
         // between the listing query and now, and the sweep must never act on a
         // row it has not just seen.
@@ -127,15 +131,10 @@ export async function reconcileStoppedDevPreviews(deps: DevPreviewReconcileDeps)
         // row in the window so the next tick can pick it up if that path did
         // not finish.
         run.skipped += 1;
+      } else if (outcome.result === 'stopped') {
+        run.stopped += 1;
       } else {
-        // Looked at, so stamped — otherwise this row matches forever with a
-        // permanently old `updatedAt`, and since the batch is ordered
-        // oldest-first and capped, a handful of long-dead rows would occupy
-        // every tick and starve the holder that stopped a preview a minute
-        // ago. Stamping is also the retry backoff for the failure paths.
-        await deps.markSwept(candidate.holder);
-        if (outcome.result === 'stopped') run.stopped += 1;
-        else run.skipped += 1;
+        run.skipped += 1;
       }
     } catch (error) {
       run.failed += 1;
@@ -144,6 +143,30 @@ export async function reconcileStoppedDevPreviews(deps: DevPreviewReconcileDeps)
         holderId: candidate.holder.id,
         error: error instanceof Error ? error.message : String(error),
       });
+    }
+
+    // STAMPED EVEN WHEN IT THREW, which is the whole point of doing it here
+    // rather than on the success path. A holder that reliably errors — a
+    // control plane that 500s on its relay, a `stop` the platform rejects —
+    // keeps its stop intent and its old `updatedAt`, and the candidate query
+    // is oldest-first and capped, so fifty such rows would sit at the head of
+    // every batch forever and starve the holder who stopped a preview a
+    // minute ago. That is the same head-of-line blocking this sweep was
+    // written to remove, just narrowed to the rows that fail. Stamping is the
+    // retry backoff; the row is picked up again one window later.
+    //
+    // Its own failure is swallowed on purpose: it is bookkeeping, and losing
+    // it must not turn a stop that DID happen into a reported failure.
+    if (stamp) {
+      try {
+        await deps.markSwept(candidate.holder);
+      } catch (error) {
+        deps.log?.warn('dev-preview: backstop sweep could not stamp a holder', {
+          holderKind: candidate.holder.kind,
+          holderId: candidate.holder.id,
+          error: error instanceof Error ? error.message : String(error),
+        });
+      }
     }
   }
   return run;

--- a/packages/lib/src/services/sandbox/preview/dev-preview-reconcile.ts
+++ b/packages/lib/src/services/sandbox/preview/dev-preview-reconcile.ts
@@ -59,6 +59,8 @@ export interface DevPreviewReconcileDeps {
    * still working through.
    */
   findStoppedWithRelay(input: { staleAfterMs: number; limit: number }): Promise<DevPreviewStopCandidate[]>;
+  /** Re-stamp the row so a holder this tick has looked at leaves the candidate window. */
+  markSwept(holder: DevPreviewHolderRef): Promise<void>;
   /** A control-plane attach; null when the platform no longer has the sprite. MUST NOT wake. */
   attach(sandboxId: string): Promise<SandboxHandle | null>;
   previewStore: DevPreviewStore;
@@ -120,9 +122,21 @@ export async function reconcileStoppedDevPreviews(deps: DevPreviewReconcileDeps)
         const applied = await applyDevServerServicePlan({ plan, services: handle.services, store: deps.previewStore });
         return applied.action === 'stop-relay' ? ('stopped' as const) : ('skipped' as const);
       });
-      if (outcome.outcome === 'busy') run.skipped += 1;
-      else if (outcome.result === 'stopped') run.stopped += 1;
-      else run.skipped += 1;
+      if (outcome.outcome === 'busy') {
+        // A live path owns this holder and is doing the same work. Leave the
+        // row in the window so the next tick can pick it up if that path did
+        // not finish.
+        run.skipped += 1;
+      } else {
+        // Looked at, so stamped — otherwise this row matches forever with a
+        // permanently old `updatedAt`, and since the batch is ordered
+        // oldest-first and capped, a handful of long-dead rows would occupy
+        // every tick and starve the holder that stopped a preview a minute
+        // ago. Stamping is also the retry backoff for the failure paths.
+        await deps.markSwept(candidate.holder);
+        if (outcome.result === 'stopped') run.stopped += 1;
+        else run.skipped += 1;
+      }
     } catch (error) {
       run.failed += 1;
       deps.log?.warn('dev-preview: backstop sweep failed for a holder', {

--- a/packages/lib/src/services/sandbox/preview/dev-preview-status.ts
+++ b/packages/lib/src/services/sandbox/preview/dev-preview-status.ts
@@ -130,6 +130,12 @@ export interface DevPreviewStatus {
    * of the same fact is a second thing that can disagree.
    */
   canApprove: boolean;
+  /**
+   * The sprite instance this status describes, or null when none is attached.
+   * The approve action echoes it back, so consent cannot drift onto a VM that
+   * replaced the one the user was looking at.
+   */
+  spriteInstanceId: string | null;
   /** When the dev server this row answers was detected, or null with no row. */
   detectedAt: Date | null;
   /**
@@ -232,6 +238,7 @@ export function buildDevPreviewStatus({ holder, sandbox, liveInstanceId, row, re
     canStop: actionable && row.stoppedByUserAt === null,
     canResume: actionable && (row.stoppedByUserAt !== null || (state.status === 'down' && state.repairable)),
     canApprove: actionable && state.status === 'needs-approval',
+    spriteInstanceId: sandbox === 'attached' ? liveInstanceId : null,
     detectedAt: row?.detectedAt ?? null,
     detection,
   };
@@ -316,7 +323,17 @@ export async function gatherDevPreviewStatus({
 export type DevPreviewUserAction =
   | { kind: 'stop' }
   | { kind: 'resume' }
-  | { kind: 'approve'; port: number };
+  | {
+      kind: 'approve';
+      port: number;
+      /**
+       * The sprite INSTANCE the decision was made against. Echoed for the same
+       * reason `port` is: a rebuild replaces the row and can detect the same
+       * port again, so a click made against the old sandbox would otherwise
+       * approve a different VM's server of the same number.
+       */
+      spriteInstanceId: string;
+    };
 
 export interface DevPreviewUserActionDeps {
   previewStore: DevPreviewStore;
@@ -489,7 +506,7 @@ async function writeDevPreviewIntent({
     const row = await store.setStoppedByUser(holder, action.kind === 'stop' ? now : null);
     return row === null ? { ok: false, reason: 'no-preview' } : { ok: true, row };
   }
-  const approved = await store.approvePort(holder, { port: action.port, at: now, byUserId: userId });
+  const approved = await store.approvePort(holder, { port: action.port, spriteInstanceId: action.spriteInstanceId, at: now, byUserId: userId });
   if (approved !== null) return { ok: true, row: approved };
   // Null means the filtered UPDATE matched nothing: either there is no row at
   // all, or the row moved on to another port. Only the second is a conflict.

--- a/packages/lib/src/services/sandbox/preview/dev-preview-status.ts
+++ b/packages/lib/src/services/sandbox/preview/dev-preview-status.ts
@@ -45,6 +45,7 @@ import {
   type ListeningPort,
 } from './dev-preview-core';
 import { applyDevServerServicePlan, type AppliedDevServerServicePlan } from './dev-preview-effects';
+import { unlocked, type DevPreviewLock } from './dev-preview-lock';
 import type { DevPreviewStore } from './dev-preview-store';
 import { authorizePreviewHolder, type PreviewAccessDeps, type PreviewAuthorization } from './preview-access';
 import { buildPreviewOpenPath } from './preview-grant';
@@ -274,12 +275,25 @@ export interface DevPreviewUserActionDeps {
   readListeners: DevPreviewListenersReader;
   /** The centralized code-execution gate — consulted on every RESUME (see below). */
   canRunCode(input: { userId: string; driveId: string | null; ownerId: string }): Promise<CanRunCodeResult>;
+  /**
+   * Serializes this holder's read → plan → apply against the realtime
+   * detector's. Defaults to no serialization (pure unit surfaces); the web
+   * binding supplies the real Postgres advisory lock.
+   */
+  lock?: DevPreviewLock;
   now(): Date;
 }
 
 export type DevPreviewUserActionResult =
   /** The intent is recorded and the relay was reconciled (or there was nothing to reconcile). */
-  | { ok: true; applied: AppliedDevServerServicePlan | null }
+  /**
+   * `lockContended` means the INTENT was recorded but the relay work was
+   * deferred — the detector held this holder's lock past the retry budget, or
+   * the lock pool was degraded. Deliberately not an `ok: false` reason: the
+   * action-response helper maps unrecognised refusals onto "no preview to
+   * switch", which would be a lie about a click that took effect.
+   */
+  | { ok: true; applied: AppliedDevServerServicePlan | null; lockContended?: true }
   /** The holder has no preview row — nothing to switch. */
   | { ok: false; reason: 'no-preview' }
   /** A RESUME the holder's payer may not spend compute on — the wake gate said no. Nothing was written. */
@@ -327,6 +341,7 @@ export async function applyDevPreviewUserAction({
   deps: DevPreviewUserActionDeps;
 }): Promise<DevPreviewUserActionResult> {
   const now = deps.now();
+  const lock = deps.lock ?? unlocked;
 
   // RESUME IS COMPUTE. `services.start` brings a process up inside the sprite
   // and, on a suspended sprite, is a billed wake — the same posture the proxy
@@ -343,42 +358,48 @@ export async function applyDevPreviewUserAction({
     if (!wake.ok) return { ok: false, reason: 'wake-not-allowed', detail: wake.reason };
   }
 
-  // The write returns the row as written, and the plan is made from THAT —
-  // no second read. RACE WITH THE DETECTOR, stated rather than hidden: the
-  // detector plans per `ports/watch` frame from a row it reads at frame
-  // time. A frame that read the row BEFORE this write and applies AFTER it
-  // can `start-relay` and upsert `stoppedByUserAt: null`, undoing a stop;
-  // the reverse frame can stop-relay after a resume. The window is one frame
-  // wide, it exists only while a port is opening in the same second the user
-  // clicks, and it is self-correcting in the honest direction: the very next
-  // frame plans from whichever write landed last, and the status the user
-  // sees is always the fold of the real row and the real relay — so a lost
-  // click shows as "still live" / "still off", and clicking again wins.
-  // Serializing the two writers would need a lock spanning the realtime and
-  // web tiers for a one-frame window; not worth a lock.
-  const row = await deps.previewStore.setStoppedByUser(holder, action === 'stop' ? now : null);
-  if (row === null) return { ok: false, reason: 'no-preview' };
+  // ONE CRITICAL SECTION, serialized per holder against the realtime
+  // detector (`dev-preview-lock.ts`). The two writers used to interleave
+  // read → plan → apply freely; the comment that stood here argued the window
+  // was one frame wide and self-correcting, which was wrong on both counts —
+  // convergence assumed a later frame that may never come. Under the lock the
+  // plan is made from the row it acts on.
+  const locked = await lock(holder, async (): Promise<DevPreviewUserActionResult> => {
+    // The write returns the row as written, and the plan is made from THAT —
+    // no second read.
+    const row = await deps.previewStore.setStoppedByUser(holder, action === 'stop' ? now : null);
+    if (row === null) return { ok: false, reason: 'no-preview' };
 
-  const handle = await deps.attach(row.sandboxId);
-  if (handle === null) return { ok: true, applied: null };
+    const handle = await deps.attach(row.sandboxId);
+    if (handle === null) return { ok: true, applied: null };
 
-  const [relay, listeners] = await Promise.all([handle.services.get(PREVIEW_RELAY_SERVICE_NAME), deps.readListeners(holder)]);
-  // `listeners: null` is UNKNOWN, never "nothing is bound". Coercing it to an
-  // empty set would let the core read 8080 as free and start a relay that may
-  // fail to bind; `listenersKnown` makes the core refuse that instead, and the
-  // detector — which plans on a frame it just saw — starts it a moment later.
-  const plan = planDevServerService({
-    liveInstanceId: handle.spriteInstanceId,
-    sandboxId: handle.sandboxId,
-    row,
-    holder,
-    detected: null,
-    relay,
-    listeners: listeners ?? [],
-    listenersKnown: listeners !== null,
-    now,
+    const [relay, listeners] = await Promise.all([handle.services.get(PREVIEW_RELAY_SERVICE_NAME), deps.readListeners(holder)]);
+    // `listeners: null` is UNKNOWN, never "nothing is bound". Coercing it to an
+    // empty set would let the core read 8080 as free and start a relay that may
+    // fail to bind; `listenersKnown` makes the core refuse that instead, and the
+    // detector — which plans on a frame it just saw — starts it a moment later.
+    const plan = planDevServerService({
+      liveInstanceId: handle.spriteInstanceId,
+      sandboxId: handle.sandboxId,
+      row,
+      holder,
+      detected: null,
+      relay,
+      listeners: listeners ?? [],
+      listenersKnown: listeners !== null,
+      now,
+    });
+    if (plan.action === 'refuse' && plan.reason === 'slot-unknown') return { ok: false, reason: 'slot-unknown' };
+    const applied = await applyDevServerServicePlan({ plan, services: handle.services, store: deps.previewStore });
+    return { ok: true, applied };
   });
-  if (plan.action === 'refuse' && plan.reason === 'slot-unknown') return { ok: false, reason: 'slot-unknown' };
-  const applied = await applyDevServerServicePlan({ plan, services: handle.services, store: deps.previewStore });
-  return { ok: true, applied };
+  if (locked.outcome === 'acquired') return locked.result;
+
+  // CONTENDED (or the lock pool is degraded). The user's INTENT is what they
+  // are entitled to, so record it unserialized — the row's compare-and-set
+  // keeps that write safe on its own — and defer the relay work to the
+  // detector's next frame or the backstop sweep.
+  const contendedRow = await deps.previewStore.setStoppedByUser(holder, action === 'stop' ? now : null);
+  if (contendedRow === null) return { ok: false, reason: 'no-preview' };
+  return { ok: true, applied: null, lockContended: true };
 }

--- a/packages/lib/src/services/sandbox/preview/dev-preview-status.ts
+++ b/packages/lib/src/services/sandbox/preview/dev-preview-status.ts
@@ -34,6 +34,7 @@
 import type { CanRunCodeResult } from '../can-run-code';
 import type { SandboxHandle, SandboxServiceInfo } from '../sandbox-host';
 import {
+  DETECTION_UNAVAILABLE_MESSAGE,
   HTTP_PORT_BUSY_MESSAGE,
   describeHttpPortSlot,
   describeServiceState,
@@ -124,13 +125,11 @@ export interface DevPreviewStatus {
   canResume: boolean;
   /**
    * True when this reader may turn a detected-but-unshared port into a shared
-   * one — the preview is waiting on a decision and the caller has already
-   * established the reader may manage it. The PORT is carried beside it so
-   * the click can echo back what the user was actually shown.
+   * one. The PORT is not carried beside it: `state` already names it when
+   * this is true (`needs-approval` carries `targetPort`), and a second copy
+   * of the same fact is a second thing that can disagree.
    */
   canApprove: boolean;
-  /** The port awaiting a decision, or null. Echoed by the approve action. */
-  pendingApprovalPort: number | null;
   /** When the dev server this row answers was detected, or null with no row. */
   detectedAt: Date | null;
   /**
@@ -148,8 +147,13 @@ export interface DevPreviewStatus {
  * the platform could not ATTACH to is the core's own `instance-unknown`.)
  */
 export const SANDBOX_ABSENT_MESSAGE = 'This sandbox is not running, so there is no dev server to preview.';
-/** Shown when the sandbox is live but nothing is watching its ports, so the status may lag. */
-export const DETECTION_UNAVAILABLE_MESSAGE = 'Dev-server detection is not running right now, so this status may be out of date.';
+/**
+ * Re-exported for server callers that already import this module. The value
+ * itself lives in the pure core so the PANE can import it without pulling
+ * this module's `node:crypto` and database dependencies into the browser
+ * bundle — see the constant's own doc.
+ */
+export { DETECTION_UNAVAILABLE_MESSAGE };
 
 /**
  * Pure: who holds 8080, as a fact. A user process on 8080 is the USER'S OWN
@@ -228,7 +232,6 @@ export function buildDevPreviewStatus({ holder, sandbox, liveInstanceId, row, re
     canStop: actionable && row.stoppedByUserAt === null,
     canResume: actionable && (row.stoppedByUserAt !== null || (state.status === 'down' && state.repairable)),
     canApprove: actionable && state.status === 'needs-approval',
-    pendingApprovalPort: state.status === 'needs-approval' ? state.targetPort : null,
     detectedAt: row?.detectedAt ?? null,
     detection,
   };
@@ -395,6 +398,9 @@ export async function applyDevPreviewUserAction({
 }): Promise<DevPreviewUserActionResult> {
   const now = deps.now();
   const lock = deps.lock ?? unlocked;
+  // Bound once: the locked path and the contended fallback make the SAME
+  // write, and only where it happens differs.
+  const writeIntent = () => writeDevPreviewIntent({ holder, action, now, userId, store: deps.previewStore });
 
   // RESUME IS COMPUTE. `services.start` brings a process up inside the sprite
   // and, on a suspended sprite, is a billed wake — the same posture the proxy
@@ -422,9 +428,9 @@ export async function applyDevPreviewUserAction({
   const locked = await lock(holder, async (): Promise<DevPreviewUserActionResult> => {
     // The write returns the row as written, and the plan is made from THAT —
     // no second read.
-    const row = await writeIntent(holder, action, now, userId, deps.previewStore);
-    if (row === 'port-changed') return { ok: false, reason: 'port-changed' };
-    if (row === null) return { ok: false, reason: 'no-preview' };
+    const written = await writeIntent();
+    if (!written.ok) return written;
+    const row = written.row;
 
     const handle = await deps.attach(row.sandboxId);
     if (handle === null) return { ok: true, applied: null };
@@ -456,29 +462,36 @@ export async function applyDevPreviewUserAction({
   // are entitled to, so record it unserialized — the row's compare-and-set
   // keeps that write safe on its own — and defer the relay work to the
   // detector's next frame or the backstop sweep.
-  const contendedRow = await writeIntent(holder, action, now, userId, deps.previewStore);
-  if (contendedRow === 'port-changed') return { ok: false, reason: 'port-changed' };
-  if (contendedRow === null) return { ok: false, reason: 'no-preview' };
+  const contended = await writeIntent();
+  if (!contended.ok) return contended;
   return { ok: true, applied: null, lockContended: true };
 }
 
 /**
  * The one durable write a user action makes, before any plan: the stop
- * intent, or the approval. Both return the row AS WRITTEN so the plan can be
- * made from it without a second read; `'port-changed'` is the approve-only
- * outcome where the row no longer targets the port the user was shown.
+ * intent, or the approval. Returns the row AS WRITTEN so the plan can be made
+ * from it without a second read, or the refusal to hand straight back.
  */
-async function writeIntent(
-  holder: DevPreviewHolderRef,
-  action: DevPreviewUserAction,
-  now: Date,
-  userId: string,
-  store: DevPreviewStore,
-): Promise<DevPreviewRow | null | 'port-changed'> {
-  if (action.kind !== 'approve') return store.setStoppedByUser(holder, action.kind === 'stop' ? now : null);
+async function writeDevPreviewIntent({
+  holder,
+  action,
+  now,
+  userId,
+  store,
+}: {
+  holder: DevPreviewHolderRef;
+  action: DevPreviewUserAction;
+  now: Date;
+  userId: string;
+  store: DevPreviewStore;
+}): Promise<{ ok: true; row: DevPreviewRow } | Extract<DevPreviewUserActionResult, { reason: 'port-changed' | 'no-preview' }>> {
+  if (action.kind !== 'approve') {
+    const row = await store.setStoppedByUser(holder, action.kind === 'stop' ? now : null);
+    return row === null ? { ok: false, reason: 'no-preview' } : { ok: true, row };
+  }
   const approved = await store.approvePort(holder, { port: action.port, at: now, byUserId: userId });
-  if (approved !== null) return approved;
+  if (approved !== null) return { ok: true, row: approved };
   // Null means the filtered UPDATE matched nothing: either there is no row at
   // all, or the row moved on to another port. Only the second is a conflict.
-  return (await store.findByHolder(holder)) === null ? null : 'port-changed';
+  return (await store.findByHolder(holder)) === null ? { ok: false, reason: 'no-preview' } : { ok: false, reason: 'port-changed' };
 }

--- a/packages/lib/src/services/sandbox/preview/dev-preview-status.ts
+++ b/packages/lib/src/services/sandbox/preview/dev-preview-status.ts
@@ -122,6 +122,15 @@ export interface DevPreviewStatus {
    * message already says what actually has to happen.
    */
   canResume: boolean;
+  /**
+   * True when this reader may turn a detected-but-unshared port into a shared
+   * one — the preview is waiting on a decision and the caller has already
+   * established the reader may manage it. The PORT is carried beside it so
+   * the click can echo back what the user was actually shown.
+   */
+  canApprove: boolean;
+  /** The port awaiting a decision, or null. Echoed by the approve action. */
+  pendingApprovalPort: number | null;
   /** When the dev server this row answers was detected, or null with no row. */
   detectedAt: Date | null;
   /**
@@ -218,6 +227,8 @@ export function buildDevPreviewStatus({ holder, sandbox, liveInstanceId, row, re
     canOpen: state.status === 'live' || state.status === 'starting',
     canStop: actionable && row.stoppedByUserAt === null,
     canResume: actionable && (row.stoppedByUserAt !== null || (state.status === 'down' && state.repairable)),
+    canApprove: actionable && state.status === 'needs-approval',
+    pendingApprovalPort: state.status === 'needs-approval' ? state.targetPort : null,
     detectedAt: row?.detectedAt ?? null,
     detection,
   };
@@ -292,7 +303,17 @@ export async function gatherDevPreviewStatus({
 // User actions
 // -----------------------------------------------------------------------------
 
-export type DevPreviewUserAction = 'stop' | 'resume';
+/**
+ * What a user may do to a preview. A discriminated union rather than a bare
+ * string because `approve` carries the PORT the user was shown: echoing it
+ * back is what binds the click to the thing on screen, so a dev server that
+ * moved between the render and the click can never be shared by a click that
+ * meant the old one.
+ */
+export type DevPreviewUserAction =
+  | { kind: 'stop' }
+  | { kind: 'resume' }
+  | { kind: 'approve'; port: number };
 
 export interface DevPreviewUserActionDeps {
   previewStore: DevPreviewStore;
@@ -331,7 +352,13 @@ export type DevPreviewUserActionResult =
    * detector's next frame starts the relay against a real snapshot; the
    * caller should say "starting shortly" rather than claim a failure.
    */
-  | { ok: false; reason: 'slot-unknown' };
+  | { ok: false; reason: 'slot-unknown' }
+  /**
+   * An `approve` whose echoed port is not the port the row targets any more.
+   * Nothing was written: the user agreed to share something else than what is
+   * running now, and the honest answer is to show them the new port.
+   */
+  | { ok: false; reason: 'port-changed' };
 
 /**
  * Record the intent, then reconcile ONCE through the core and the effects
@@ -379,7 +406,9 @@ export async function applyDevPreviewUserAction({
   // purpose: a refused resume that had already cleared `stoppedByUserAt`
   // would leave the row "on", and the detector's next frame would restart
   // the relay anyway — the exact bypass the gate exists to close.
-  if (action === 'resume') {
+  // An APPROVE is the same kind of act — it exists to make the relay start —
+  // so it is gated identically.
+  if (action.kind === 'resume' || action.kind === 'approve') {
     const wake = await deps.canRunCode({ userId, ...wakeSubject });
     if (!wake.ok) return { ok: false, reason: 'wake-not-allowed', detail: wake.reason };
   }
@@ -393,7 +422,8 @@ export async function applyDevPreviewUserAction({
   const locked = await lock(holder, async (): Promise<DevPreviewUserActionResult> => {
     // The write returns the row as written, and the plan is made from THAT —
     // no second read.
-    const row = await deps.previewStore.setStoppedByUser(holder, action === 'stop' ? now : null);
+    const row = await writeIntent(holder, action, now, userId, deps.previewStore);
+    if (row === 'port-changed') return { ok: false, reason: 'port-changed' };
     if (row === null) return { ok: false, reason: 'no-preview' };
 
     const handle = await deps.attach(row.sandboxId);
@@ -426,7 +456,29 @@ export async function applyDevPreviewUserAction({
   // are entitled to, so record it unserialized — the row's compare-and-set
   // keeps that write safe on its own — and defer the relay work to the
   // detector's next frame or the backstop sweep.
-  const contendedRow = await deps.previewStore.setStoppedByUser(holder, action === 'stop' ? now : null);
+  const contendedRow = await writeIntent(holder, action, now, userId, deps.previewStore);
+  if (contendedRow === 'port-changed') return { ok: false, reason: 'port-changed' };
   if (contendedRow === null) return { ok: false, reason: 'no-preview' };
   return { ok: true, applied: null, lockContended: true };
+}
+
+/**
+ * The one durable write a user action makes, before any plan: the stop
+ * intent, or the approval. Both return the row AS WRITTEN so the plan can be
+ * made from it without a second read; `'port-changed'` is the approve-only
+ * outcome where the row no longer targets the port the user was shown.
+ */
+async function writeIntent(
+  holder: DevPreviewHolderRef,
+  action: DevPreviewUserAction,
+  now: Date,
+  userId: string,
+  store: DevPreviewStore,
+): Promise<DevPreviewRow | null | 'port-changed'> {
+  if (action.kind !== 'approve') return store.setStoppedByUser(holder, action.kind === 'stop' ? now : null);
+  const approved = await store.approvePort(holder, { port: action.port, at: now, byUserId: userId });
+  if (approved !== null) return approved;
+  // Null means the filtered UPDATE matched nothing: either there is no row at
+  // all, or the row moved on to another port. Only the second is a conflict.
+  return (await store.findByHolder(holder)) === null ? null : 'port-changed';
 }

--- a/packages/lib/src/services/sandbox/preview/dev-preview-status.ts
+++ b/packages/lib/src/services/sandbox/preview/dev-preview-status.ts
@@ -67,6 +67,20 @@ export type DevPreviewSlotReport =
   | { known: false }
   | { known: true; holder: HttpPortSlotHolder; pid: number | null; message: string };
 
+/**
+ * Whether DETECTION is running for this holder — orthogonal to what the
+ * preview is doing, which is why it is a sibling field rather than a new
+ * member of the core's state union (that union is mutation-tested and
+ * switched on exhaustively by the UI copy).
+ */
+export type DevPreviewDetection = 'watching' | 'arming' | 'unavailable';
+
+/** What the realtime tier answered: the snapshot it holds, and whether it is watching at all. */
+export interface DevPreviewListenersRead {
+  detection: DevPreviewDetection;
+  listeners: readonly ListeningPort[] | null;
+}
+
 /** Whether the holder's sprite could be reached for this render. */
 export type DevPreviewSandboxReach =
   /** The holder has no live sprite right now (never provisioned, torn down, session ended). */
@@ -110,6 +124,13 @@ export interface DevPreviewStatus {
   canResume: boolean;
   /** When the dev server this row answers was detected, or null with no row. */
   detectedAt: Date | null;
+  /**
+   * Whether anything is watching this holder's ports right now. `unavailable`
+   * means the status shown may be out of date — it is NOT a claim that the
+   * sandbox is idle, which is exactly the conflation a bare `listeners: null`
+   * used to force.
+   */
+  detection: DevPreviewDetection;
 }
 
 /**
@@ -118,6 +139,8 @@ export interface DevPreviewStatus {
  * the platform could not ATTACH to is the core's own `instance-unknown`.)
  */
 export const SANDBOX_ABSENT_MESSAGE = 'This sandbox is not running, so there is no dev server to preview.';
+/** Shown when the sandbox is live but nothing is watching its ports, so the status may lag. */
+export const DETECTION_UNAVAILABLE_MESSAGE = 'Dev-server detection is not running right now, so this status may be out of date.';
 
 /**
  * Pure: who holds 8080, as a fact. A user process on 8080 is the USER'S OWN
@@ -154,11 +177,12 @@ export interface BuildDevPreviewStatusInput {
   relay: SandboxServiceInfo | null;
   /** The realtime tier's `ports/watch` snapshot, or null when none is in hand. */
   listeners: readonly ListeningPort[] | null;
+  detection: DevPreviewDetection;
   openPath: string | null;
 }
 
 /** Pure: the whole read model from what the gather collected. */
-export function buildDevPreviewStatus({ holder, sandbox, liveInstanceId, row, relay, listeners, openPath }: BuildDevPreviewStatusInput): DevPreviewStatus {
+export function buildDevPreviewStatus({ holder, sandbox, liveInstanceId, row, relay, listeners, detection, openPath }: BuildDevPreviewStatusInput): DevPreviewStatus {
   // Absent is the one reach the core cannot describe (it is asked about a
   // sprite); unreachable IS the core's `instance-unknown` (no live instance
   // id can be proven), so it is worded there and nowhere else.
@@ -195,6 +219,7 @@ export function buildDevPreviewStatus({ holder, sandbox, liveInstanceId, row, re
     canStop: actionable && row.stoppedByUserAt === null,
     canResume: actionable && (row.stoppedByUserAt !== null || (state.status === 'down' && state.repairable)),
     detectedAt: row?.detectedAt ?? null,
+    detection,
   };
 }
 
@@ -203,7 +228,7 @@ export function buildDevPreviewStatus({ holder, sandbox, liveInstanceId, row, re
 // -----------------------------------------------------------------------------
 
 /** The realtime tier's listener snapshot for a holder's sprite, or null when it holds none (or cannot be asked). Never a probe. */
-export type DevPreviewListenersReader = (holder: DevPreviewHolderRef) => Promise<readonly ListeningPort[] | null>;
+export type DevPreviewListenersReader = (holder: DevPreviewHolderRef) => Promise<DevPreviewListenersRead>;
 
 export type DevPreviewStatusDeps = Pick<
   PreviewAccessDeps,
@@ -244,21 +269,22 @@ export async function gatherDevPreviewStatus({
 
   if (authorization.sandboxId === null) {
     const row = await deps.previewStore.findByHolder(holder);
-    return { ok: true, status: buildDevPreviewStatus({ holder, sandbox: 'absent', liveInstanceId: null, row, relay: null, listeners: null, openPath }) };
+    // Realtime is deliberately not asked about a holder with no sprite.
+    return { ok: true, status: buildDevPreviewStatus({ holder, sandbox: 'absent', liveInstanceId: null, row, relay: null, listeners: null, detection: 'unavailable', openPath }) };
   }
 
-  const [handle, row, listeners] = await Promise.all([
+  const [handle, row, read] = await Promise.all([
     deps.attach(authorization.sandboxId),
     deps.previewStore.findByHolder(holder),
     deps.readListeners(holder),
   ]);
   if (handle === null) {
-    return { ok: true, status: buildDevPreviewStatus({ holder, sandbox: 'unreachable', liveInstanceId: null, row, relay: null, listeners: null, openPath }) };
+    return { ok: true, status: buildDevPreviewStatus({ holder, sandbox: 'unreachable', liveInstanceId: null, row, relay: null, listeners: null, detection: read.detection, openPath }) };
   }
   const relay = await handle.services.get(PREVIEW_RELAY_SERVICE_NAME);
   return {
     ok: true,
-    status: buildDevPreviewStatus({ holder, sandbox: 'attached', liveInstanceId: handle.spriteInstanceId, row, relay, listeners, openPath }),
+    status: buildDevPreviewStatus({ holder, sandbox: 'attached', liveInstanceId: handle.spriteInstanceId, row, relay, listeners: read.listeners, detection: read.detection, openPath }),
   };
 }
 
@@ -373,7 +399,8 @@ export async function applyDevPreviewUserAction({
     const handle = await deps.attach(row.sandboxId);
     if (handle === null) return { ok: true, applied: null };
 
-    const [relay, listeners] = await Promise.all([handle.services.get(PREVIEW_RELAY_SERVICE_NAME), deps.readListeners(holder)]);
+    const [relay, read] = await Promise.all([handle.services.get(PREVIEW_RELAY_SERVICE_NAME), deps.readListeners(holder)]);
+    const listeners = read.listeners;
     // `listeners: null` is UNKNOWN, never "nothing is bound". Coercing it to an
     // empty set would let the core read 8080 as free and start a relay that may
     // fail to bind; `listenersKnown` makes the core refuse that instead, and the

--- a/packages/lib/src/services/sandbox/preview/dev-preview-status.ts
+++ b/packages/lib/src/services/sandbox/preview/dev-preview-status.ts
@@ -378,7 +378,15 @@ export type DevPreviewUserActionResult =
    * Nothing was written: the user agreed to share something else than what is
    * running now, and the honest answer is to show them the new port.
    */
-  | { ok: false; reason: 'port-changed' };
+  | { ok: false; reason: 'port-changed' }
+  /**
+   * An `approve` whose echoed sprite INSTANCE is not the one the row belongs
+   * to any more: the sandbox was rebuilt between the render and the click.
+   * Kept separate from `port-changed` because the port may be identical — a
+   * replacement VM commonly re-detects the same one — and telling the user
+   * their server moved ports would be a plainly false sentence.
+   */
+  | { ok: false; reason: 'instance-changed' };
 
 /**
  * Record the intent, then reconcile ONCE through the core and the effects
@@ -501,14 +509,20 @@ async function writeDevPreviewIntent({
   now: Date;
   userId: string;
   store: DevPreviewStore;
-}): Promise<{ ok: true; row: DevPreviewRow } | Extract<DevPreviewUserActionResult, { reason: 'port-changed' | 'no-preview' }>> {
+}): Promise<{ ok: true; row: DevPreviewRow } | Extract<DevPreviewUserActionResult, { reason: 'port-changed' | 'instance-changed' | 'no-preview' }>> {
   if (action.kind !== 'approve') {
     const row = await store.setStoppedByUser(holder, action.kind === 'stop' ? now : null);
     return row === null ? { ok: false, reason: 'no-preview' } : { ok: true, row };
   }
   const approved = await store.approvePort(holder, { port: action.port, spriteInstanceId: action.spriteInstanceId, at: now, byUserId: userId });
   if (approved !== null) return { ok: true, row: approved };
-  // Null means the filtered UPDATE matched nothing: either there is no row at
-  // all, or the row moved on to another port. Only the second is a conflict.
-  return (await store.findByHolder(holder)) === null ? { ok: false, reason: 'no-preview' } : { ok: false, reason: 'port-changed' };
+  // Null means the filtered UPDATE matched nothing, and the three causes read
+  // very differently to a user. Re-read to say which: no row at all, the
+  // server moved to another port, or the sandbox was rebuilt under it. The
+  // last is the one the instance echo was added for, and its port is usually
+  // UNCHANGED — reporting it as "moved to a different port" would be false.
+  const row = await store.findByHolder(holder);
+  if (row === null) return { ok: false, reason: 'no-preview' };
+  if (row.spriteInstanceId !== action.spriteInstanceId) return { ok: false, reason: 'instance-changed' };
+  return { ok: false, reason: 'port-changed' };
 }

--- a/packages/lib/src/services/sandbox/preview/dev-preview-store.ts
+++ b/packages/lib/src/services/sandbox/preview/dev-preview-store.ts
@@ -40,8 +40,19 @@ export interface DevPreviewStore {
    * row — the one column the platform cannot report (an explicit stop lands a
    * service in `failed`, indistinguishable from a crash — spike §4). Writes
    * ONLY that column: the row's instance, target and relay name are facts
-   * about the sprite and a user action changes none of them. Resolves the
-   * row AS WRITTEN (the same slice `findByHolder` returns, so the caller can
+   * about the sprite and a user action changes none of them.
+   *
+   * UNCONDITIONAL, deliberately — no compare-and-set, no instance guard. This
+   * records the user's OWN intent, which is the newest fact by definition; a
+   * CAS here would let a detection frame refuse a person's Stop, inverting the
+   * rule the rest of this file exists to uphold. An instance guard would be
+   * inert as well as harmful: a stop written onto a stale row is already
+   * ignored by the planner and rendered `stale`, while requiring the live
+   * instance would mean an un-attachable sprite could no longer accept a Stop
+   * at all. The guard that belongs here is the one on `upsert`, which replaces
+   * a whole row.
+   *
+   * Resolves the row AS WRITTEN (the same slice `findByHolder` returns, so the caller can
    * plan from it without a second read), or `null` when the holder has no
    * row (nothing to switch off) — a caller never reports "switched off" for
    * a preview that does not exist.

--- a/packages/lib/src/services/sandbox/preview/dev-preview-store.ts
+++ b/packages/lib/src/services/sandbox/preview/dev-preview-store.ts
@@ -23,7 +23,7 @@
  */
 
 import { db } from '@pagespace/db/db';
-import { and, eq, eqOrIsNull, isDistinctFrom, or, sql } from '@pagespace/db/operators';
+import { and, eq, eqOrIsNull, isDistinctFrom, isNotNull, lt, or, sql } from '@pagespace/db/operators';
 import { devPreviewServices } from '@pagespace/db/schema/dev-preview-services';
 import type { DevPreviewHolderRef, DevPreviewRow, DevPreviewRowIntent } from './dev-preview-core';
 
@@ -70,6 +70,14 @@ export interface DevPreviewStore {
    * click. The caller answers a null with a conflict, never with success.
    */
   approvePort(holder: DevPreviewHolderRef, input: { port: number; at: Date; byUserId: string }): Promise<DevPreviewRecord | null>;
+  /**
+   * Holders whose STOP intent has outlived its relay for longer than
+   * `staleAfterMs` — the backstop sweep's candidate list
+   * (`dev-preview-reconcile.ts`). Oldest first and capped, so one tick is
+   * bounded; the age bound keeps the sweep off rows a live path is still
+   * working through.
+   */
+  findStoppedWithRelay(input: { staleAfterMs: number; limit: number; now: Date }): Promise<Array<{ holder: DevPreviewHolderRef; sandboxId: string }>>;
 }
 
 function holderColumn(holder: DevPreviewHolderRef) {
@@ -175,6 +183,31 @@ export function createDbDevPreviewStore(): DevPreviewStore {
           approvedPort: devPreviewServices.approvedPort,
         });
       return row ?? null;
+    },
+
+    async findStoppedWithRelay({ staleAfterMs, limit, now }) {
+      const rows = await db
+        .select({
+          workspaceId: devPreviewServices.workspaceId,
+          envId: devPreviewServices.envId,
+          sandboxId: devPreviewServices.sandboxId,
+        })
+        .from(devPreviewServices)
+        .where(
+          and(
+            isNotNull(devPreviewServices.stoppedByUserAt),
+            isNotNull(devPreviewServices.relayServiceName),
+            // `sql.param` routes the Date through the column's encoder; a bare
+            // interpolation would land offset against a wall-clock column.
+            lt(devPreviewServices.updatedAt, sql.param(new Date(now.getTime() - staleAfterMs), devPreviewServices.updatedAt)),
+          ),
+        )
+        .orderBy(devPreviewServices.updatedAt)
+        .limit(limit);
+      return rows.map((row) => ({
+        holder: (row.workspaceId !== null ? { kind: 'workspace', id: row.workspaceId } : { kind: 'env', id: row.envId as string }) as DevPreviewHolderRef,
+        sandboxId: row.sandboxId,
+      }));
     },
 
     async approvePort(holder, { port, at, byUserId }) {

--- a/packages/lib/src/services/sandbox/preview/dev-preview-store.ts
+++ b/packages/lib/src/services/sandbox/preview/dev-preview-store.ts
@@ -23,7 +23,7 @@
  */
 
 import { db } from '@pagespace/db/db';
-import { eq, eqOrIsNull, isDistinctFrom, or, sql } from '@pagespace/db/operators';
+import { and, eq, eqOrIsNull, isDistinctFrom, or, sql } from '@pagespace/db/operators';
 import { devPreviewServices } from '@pagespace/db/schema/dev-preview-services';
 import type { DevPreviewHolderRef, DevPreviewRow, DevPreviewRowIntent } from './dev-preview-core';
 
@@ -58,6 +58,18 @@ export interface DevPreviewStore {
    * a preview that does not exist.
    */
   setStoppedByUser(holder: DevPreviewHolderRef, at: Date | null): Promise<DevPreviewRecord | null>;
+  /**
+   * Record a person's consent to SHARE exactly `port` on the holder's row,
+   * and clear any stop intent — agreeing to share something is asking for it
+   * to be on, and leaving it off would answer a click with silence.
+   *
+   * Resolves the row AS WRITTEN, or `null` when the holder has no row OR the
+   * row no longer targets `port`. That second case is the point: the port is
+   * echoed back from the UI, and the write is filtered on it, so approval
+   * cannot drift onto a dev server that moved between the render and the
+   * click. The caller answers a null with a conflict, never with success.
+   */
+  approvePort(holder: DevPreviewHolderRef, input: { port: number; at: Date; byUserId: string }): Promise<DevPreviewRecord | null>;
 }
 
 function holderColumn(holder: DevPreviewHolderRef) {
@@ -76,6 +88,7 @@ export function createDbDevPreviewStore(): DevPreviewStore {
           relayServiceName: devPreviewServices.relayServiceName,
           detectedAt: devPreviewServices.detectedAt,
           stoppedByUserAt: devPreviewServices.stoppedByUserAt,
+          approvedPort: devPreviewServices.approvedPort,
         })
         .from(devPreviewServices)
         .where(eq(holderColumn(holder), holder.id))
@@ -94,6 +107,10 @@ export function createDbDevPreviewStore(): DevPreviewStore {
         relayServiceName: intent.relayServiceName,
         detectedAt: intent.detectedAt,
         stoppedByUserAt: intent.stoppedByUserAt,
+        approvedPort: intent.approvedPort ?? null,
+        // Only the INSERT path uses this, and there the planner saw no row
+        // (so it carried no approval forward). Kept paired for the CHECK.
+        approvedAt: intent.approvedPort == null ? null : intent.detectedAt,
       };
       const written = await db
         .insert(devPreviewServices)
@@ -127,6 +144,12 @@ export function createDbDevPreviewStore(): DevPreviewStore {
             relayServiceName: values.relayServiceName,
             detectedAt: values.detectedAt,
             stoppedByUserAt: values.stoppedByUserAt,
+            approvedPort: values.approvedPort,
+            // The planner never grants or revokes an approval — it only
+            // carries the row's own forward — so the stored timestamp is
+            // KEPT rather than restamped, and says when a person actually
+            // agreed. Cleared together with the port, for the CHECK.
+            approvedAt: values.approvedPort == null ? null : sql`${devPreviewServices.approvedAt}`,
             // Not `now()`: `updatedAt` is a UTC wall-clock timestamp column and
             // `now()` resolves through the session TZ (see the SQL-now rule).
             updatedAt: sql`(now() at time zone 'utc')`,
@@ -149,6 +172,29 @@ export function createDbDevPreviewStore(): DevPreviewStore {
           relayServiceName: devPreviewServices.relayServiceName,
           detectedAt: devPreviewServices.detectedAt,
           stoppedByUserAt: devPreviewServices.stoppedByUserAt,
+          approvedPort: devPreviewServices.approvedPort,
+        });
+      return row ?? null;
+    },
+
+    async approvePort(holder, { port, at, byUserId }) {
+      const [row] = await db
+        .update(devPreviewServices)
+        .set({ approvedPort: port, approvedAt: at, approvedByUserId: byUserId, stoppedByUserAt: null, updatedAt: sql`(now() at time zone 'utc')` })
+        // THE ECHOED PORT, enforced in SQL rather than by a read-then-write:
+        // the approval lands only while the row still targets the port the
+        // user was shown. A dev server that moved between the render and the
+        // click therefore cannot be approved by a click meant for the old one.
+        .where(and(eq(holderColumn(holder), holder.id), eq(devPreviewServices.targetPort, port)))
+        .returning({
+          id: devPreviewServices.id,
+          spriteInstanceId: devPreviewServices.spriteInstanceId,
+          sandboxId: devPreviewServices.sandboxId,
+          targetPort: devPreviewServices.targetPort,
+          relayServiceName: devPreviewServices.relayServiceName,
+          detectedAt: devPreviewServices.detectedAt,
+          stoppedByUserAt: devPreviewServices.stoppedByUserAt,
+          approvedPort: devPreviewServices.approvedPort,
         });
       return row ?? null;
     },

--- a/packages/lib/src/services/sandbox/preview/dev-preview-store.ts
+++ b/packages/lib/src/services/sandbox/preview/dev-preview-store.ts
@@ -100,6 +100,23 @@ export interface DevPreviewStore {
    * sweep has looked at drops out of the window for `staleAfterMs`.
    */
   markSwept(holder: DevPreviewHolderRef): Promise<void>;
+  /**
+   * Record that a relay named on the row has been STOPPED: clear
+   * `relayServiceName`, and only while the row still names that relay and
+   * still carries the stop intent the caller acted on.
+   *
+   * This is what makes the sweep's candidate window DRAIN. Stopping a relay
+   * is a service call that writes nothing, so without it a stopped row keeps
+   * naming a relay that is no longer running and re-enters the window every
+   * `staleAfterMs` for the life of the record — sixty stopped previews would
+   * burn the whole batch on rows with nothing left to do. Clearing the name
+   * is also simply true: the row no longer describes anything serving.
+   *
+   * Nothing else changes shape. A stopped row renders `stopped` before the
+   * relay is consulted at all, and a later resume plans from the LIVE service
+   * read rather than this column, so it still restarts the same relay.
+   */
+  markRelayStopped(input: { holder: DevPreviewHolderRef; relayServiceName: string }): Promise<void>;
 }
 
 /**
@@ -248,6 +265,22 @@ export function createDbDevPreviewStore(): DevPreviewStore {
         .update(devPreviewServices)
         .set({ updatedAt: sql`(now() at time zone 'utc')` })
         .where(eq(holderColumn(holder), holder.id));
+    },
+
+    async markRelayStopped({ holder, relayServiceName }) {
+      await db
+        .update(devPreviewServices)
+        .set({ relayServiceName: null, updatedAt: sql`(now() at time zone 'utc')` })
+        .where(
+          and(
+            eq(holderColumn(holder), holder.id),
+            // Only the relay we actually stopped, and only while the stop
+            // still stands: a resume or a re-point that landed in between
+            // owns this column now.
+            eq(devPreviewServices.relayServiceName, relayServiceName),
+            isNotNull(devPreviewServices.stoppedByUserAt),
+          ),
+        );
     },
 
     async approvePort(holder, { port, at, byUserId }) {

--- a/packages/lib/src/services/sandbox/preview/dev-preview-store.ts
+++ b/packages/lib/src/services/sandbox/preview/dev-preview-store.ts
@@ -78,7 +78,38 @@ export interface DevPreviewStore {
    * working through.
    */
   findStoppedWithRelay(input: { staleAfterMs: number; limit: number; now: Date }): Promise<Array<{ holder: DevPreviewHolderRef; sandboxId: string }>>;
+  /**
+   * Re-stamp `updatedAt` on the holder's row, changing nothing else.
+   *
+   * The sweep needs this because a successful stop WRITES NOTHING — stopping
+   * a relay is a service call, and the row already says what the user wants.
+   * Without a stamp, a converged row keeps matching
+   * {@link DevPreviewStore.findStoppedWithRelay} forever with a permanently
+   * old `updatedAt`, and since that query is ordered oldest-first and capped,
+   * fifty long-dead rows would occupy every batch and a preview stopped a
+   * minute ago would never be reached. Stamping is the backoff: a row the
+   * sweep has looked at drops out of the window for `staleAfterMs`.
+   */
+  markSwept(holder: DevPreviewHolderRef): Promise<void>;
 }
+
+/**
+ * The `DevPreviewRow` slice, as columns. Written once: a new field on the row
+ * would otherwise need three coordinated edits (the read, and each of the two
+ * `returning` clauses), and missing one fails only at runtime, for only that
+ * one operation.
+ */
+const rowColumns = {
+  id: devPreviewServices.id,
+  spriteInstanceId: devPreviewServices.spriteInstanceId,
+  sandboxId: devPreviewServices.sandboxId,
+  targetPort: devPreviewServices.targetPort,
+  relayServiceName: devPreviewServices.relayServiceName,
+  detectedAt: devPreviewServices.detectedAt,
+  stoppedByUserAt: devPreviewServices.stoppedByUserAt,
+  approvedPort: devPreviewServices.approvedPort,
+  approvedAt: devPreviewServices.approvedAt,
+} as const;
 
 function holderColumn(holder: DevPreviewHolderRef) {
   return holder.kind === 'workspace' ? devPreviewServices.workspaceId : devPreviewServices.envId;
@@ -88,16 +119,7 @@ export function createDbDevPreviewStore(): DevPreviewStore {
   return {
     async findByHolder(holder) {
       const [row] = await db
-        .select({
-          id: devPreviewServices.id,
-          spriteInstanceId: devPreviewServices.spriteInstanceId,
-          sandboxId: devPreviewServices.sandboxId,
-          targetPort: devPreviewServices.targetPort,
-          relayServiceName: devPreviewServices.relayServiceName,
-          detectedAt: devPreviewServices.detectedAt,
-          stoppedByUserAt: devPreviewServices.stoppedByUserAt,
-          approvedPort: devPreviewServices.approvedPort,
-        })
+        .select(rowColumns)
         .from(devPreviewServices)
         .where(eq(holderColumn(holder), holder.id))
         .limit(1);
@@ -115,10 +137,10 @@ export function createDbDevPreviewStore(): DevPreviewStore {
         relayServiceName: intent.relayServiceName,
         detectedAt: intent.detectedAt,
         stoppedByUserAt: intent.stoppedByUserAt,
-        approvedPort: intent.approvedPort ?? null,
-        // Only the INSERT path uses this, and there the planner saw no row
-        // (so it carried no approval forward). Kept paired for the CHECK.
-        approvedAt: intent.approvedPort == null ? null : intent.detectedAt,
+        // A brand-new row is a brand-new sprite instance: nothing is approved
+        // on it yet, and a detection is not consent.
+        approvedPort: null,
+        approvedAt: null,
       };
       const written = await db
         .insert(devPreviewServices)
@@ -152,12 +174,20 @@ export function createDbDevPreviewStore(): DevPreviewStore {
             relayServiceName: values.relayServiceName,
             detectedAt: values.detectedAt,
             stoppedByUserAt: values.stoppedByUserAt,
-            approvedPort: values.approvedPort,
-            // The planner never grants or revokes an approval — it only
-            // carries the row's own forward — so the stored timestamp is
-            // KEPT rather than restamped, and says when a person actually
-            // agreed. Cleared together with the port, for the CHECK.
-            approvedAt: values.approvedPort == null ? null : sql`${devPreviewServices.approvedAt}`,
+            // THE APPROVAL COLUMNS ARE NOT THE PLANNER'S TO WRITE. Only
+            // `approvePort` grants consent, so a detection frame must not
+            // carry a value it read moments ago — a user's Share landing in
+            // between would be silently wiped, and the stop guard above does
+            // not cover these columns. Expressed as SQL over the STORED row
+            // rather than a read-modify-write, so there is no window at all.
+            //
+            // The one thing a detection does decide is that a REBUILD clears
+            // consent: a replacement VM inherits nothing, this table's
+            // standing rule. Attribution is cleared with it, so the row never
+            // credits a consent that no longer exists.
+            approvedPort: sql`CASE WHEN ${devPreviewServices.spriteInstanceId} = ${sql.param(intent.spriteInstanceId, devPreviewServices.spriteInstanceId)} THEN ${devPreviewServices.approvedPort} ELSE NULL END`,
+            approvedAt: sql`CASE WHEN ${devPreviewServices.spriteInstanceId} = ${sql.param(intent.spriteInstanceId, devPreviewServices.spriteInstanceId)} THEN ${devPreviewServices.approvedAt} ELSE NULL END`,
+            approvedByUserId: sql`CASE WHEN ${devPreviewServices.spriteInstanceId} = ${sql.param(intent.spriteInstanceId, devPreviewServices.spriteInstanceId)} THEN ${devPreviewServices.approvedByUserId} ELSE NULL END`,
             // Not `now()`: `updatedAt` is a UTC wall-clock timestamp column and
             // `now()` resolves through the session TZ (see the SQL-now rule).
             updatedAt: sql`(now() at time zone 'utc')`,
@@ -172,16 +202,7 @@ export function createDbDevPreviewStore(): DevPreviewStore {
         .update(devPreviewServices)
         .set({ stoppedByUserAt: at, updatedAt: sql`(now() at time zone 'utc')` })
         .where(eq(holderColumn(holder), holder.id))
-        .returning({
-          id: devPreviewServices.id,
-          spriteInstanceId: devPreviewServices.spriteInstanceId,
-          sandboxId: devPreviewServices.sandboxId,
-          targetPort: devPreviewServices.targetPort,
-          relayServiceName: devPreviewServices.relayServiceName,
-          detectedAt: devPreviewServices.detectedAt,
-          stoppedByUserAt: devPreviewServices.stoppedByUserAt,
-          approvedPort: devPreviewServices.approvedPort,
-        });
+        .returning(rowColumns);
       return row ?? null;
     },
 
@@ -210,6 +231,16 @@ export function createDbDevPreviewStore(): DevPreviewStore {
       }));
     },
 
+    async markSwept(holder) {
+      // `updatedAt` has an `$onUpdate` hook, but an UPDATE with no changed
+      // columns still needs a SET clause — so set it explicitly, in the same
+      // UTC wall-clock terms every other write here uses.
+      await db
+        .update(devPreviewServices)
+        .set({ updatedAt: sql`(now() at time zone 'utc')` })
+        .where(eq(holderColumn(holder), holder.id));
+    },
+
     async approvePort(holder, { port, at, byUserId }) {
       const [row] = await db
         .update(devPreviewServices)
@@ -219,16 +250,7 @@ export function createDbDevPreviewStore(): DevPreviewStore {
         // user was shown. A dev server that moved between the render and the
         // click therefore cannot be approved by a click meant for the old one.
         .where(and(eq(holderColumn(holder), holder.id), eq(devPreviewServices.targetPort, port)))
-        .returning({
-          id: devPreviewServices.id,
-          spriteInstanceId: devPreviewServices.spriteInstanceId,
-          sandboxId: devPreviewServices.sandboxId,
-          targetPort: devPreviewServices.targetPort,
-          relayServiceName: devPreviewServices.relayServiceName,
-          detectedAt: devPreviewServices.detectedAt,
-          stoppedByUserAt: devPreviewServices.stoppedByUserAt,
-          approvedPort: devPreviewServices.approvedPort,
-        });
+        .returning(rowColumns);
       return row ?? null;
     },
   };

--- a/packages/lib/src/services/sandbox/preview/dev-preview-store.ts
+++ b/packages/lib/src/services/sandbox/preview/dev-preview-store.ts
@@ -63,6 +63,15 @@ export interface DevPreviewStore {
    * and clear any stop intent — agreeing to share something is asking for it
    * to be on, and leaving it off would answer a click with silence.
    *
+   * Deliberately NOT instance-guarded, for the same reason `setStoppedByUser`
+   * is not: an approval written onto a row from a dead VM is already inert
+   * (the planner ignores stale rows and `describeServiceState` renders
+   * `stale`), and requiring the live instance would mean an un-attachable
+   * sprite could no longer accept a decision at all. The cost is that the
+   * action answers 200 for a sandbox that has since been rebuilt; the status
+   * read the caller makes next says `stale`, which is the honest answer and
+   * the one the UI renders.
+   *
    * Resolves the row AS WRITTEN, or `null` when the holder has no row OR the
    * row no longer targets `port`. That second case is the point: the port is
    * echoed back from the UI, and the write is filtered on it, so approval

--- a/packages/lib/src/services/sandbox/preview/dev-preview-store.ts
+++ b/packages/lib/src/services/sandbox/preview/dev-preview-store.ts
@@ -63,22 +63,14 @@ export interface DevPreviewStore {
    * and clear any stop intent — agreeing to share something is asking for it
    * to be on, and leaving it off would answer a click with silence.
    *
-   * Deliberately NOT instance-guarded, for the same reason `setStoppedByUser`
-   * is not: an approval written onto a row from a dead VM is already inert
-   * (the planner ignores stale rows and `describeServiceState` renders
-   * `stale`), and requiring the live instance would mean an un-attachable
-   * sprite could no longer accept a decision at all. The cost is that the
-   * action answers 200 for a sandbox that has since been rebuilt; the status
-   * read the caller makes next says `stale`, which is the honest answer and
-   * the one the UI renders.
-   *
-   * Resolves the row AS WRITTEN, or `null` when the holder has no row OR the
-   * row no longer targets `port`. That second case is the point: the port is
+   * Resolves the row AS WRITTEN, or `null` when the holder has no row, the
+   * row no longer targets `port`, or it belongs to a different sprite
+   * INSTANCE than the one the decision was made against. That second case is the point: the port is
    * echoed back from the UI, and the write is filtered on it, so approval
    * cannot drift onto a dev server that moved between the render and the
    * click. The caller answers a null with a conflict, never with success.
    */
-  approvePort(holder: DevPreviewHolderRef, input: { port: number; at: Date; byUserId: string }): Promise<DevPreviewRecord | null>;
+  approvePort(holder: DevPreviewHolderRef, input: { port: number; spriteInstanceId: string; at: Date; byUserId: string }): Promise<DevPreviewRecord | null>;
   /**
    * Holders whose STOP intent has outlived its relay for longer than
    * `staleAfterMs` — the backstop sweep's candidate list
@@ -283,7 +275,7 @@ export function createDbDevPreviewStore(): DevPreviewStore {
         );
     },
 
-    async approvePort(holder, { port, at, byUserId }) {
+    async approvePort(holder, { port, spriteInstanceId, at, byUserId }) {
       const [row] = await db
         .update(devPreviewServices)
         .set({ approvedPort: port, approvedAt: at, approvedByUserId: byUserId, stoppedByUserAt: null, updatedAt: sql`(now() at time zone 'utc')` })
@@ -291,7 +283,17 @@ export function createDbDevPreviewStore(): DevPreviewStore {
         // the approval lands only while the row still targets the port the
         // user was shown. A dev server that moved between the render and the
         // click therefore cannot be approved by a click meant for the old one.
-        .where(and(eq(holderColumn(holder), holder.id), eq(devPreviewServices.targetPort, port)))
+        // The port AND the INSTANCE, both echoed from what the user was shown.
+        // The port stops a consent meant for one server landing on another;
+        // the instance stops it landing on another VM. A rebuild replaces the
+        // row and can legitimately detect the same port again, so a click made
+        // against the old sandbox would otherwise approve the new one — and
+        // sharing is exactly the decision that must not be inherited.
+        .where(and(
+          eq(holderColumn(holder), holder.id),
+          eq(devPreviewServices.targetPort, port),
+          eq(devPreviewServices.spriteInstanceId, spriteInstanceId),
+        ))
         .returning(rowColumns);
       return row ?? null;
     },

--- a/packages/lib/src/services/sandbox/preview/ports-watch.ts
+++ b/packages/lib/src/services/sandbox/preview/ports-watch.ts
@@ -111,6 +111,14 @@ export interface OpenPortsWatchInput {
   token: string;
   createSocket: PortsWatchSocketFactory;
   onFrame: (frame: PortsWatchFrame) => void;
+  /**
+   * Fired when the socket actually CONNECTS, which is not the same moment the
+   * attempt began: a handshake can take seconds. A caller judging whether a
+   * connection was healthy must measure from here, or a slow handshake counts
+   * as uptime and a channel that keeps failing looks like one that keeps
+   * working.
+   */
+  onOpen?: () => void;
   /** Fired exactly once, when the channel is gone for any reason. `opened` says whether it ever connected. */
   onClose: (info: { opened: boolean; code?: number; reason: string }) => void;
 }
@@ -120,7 +128,7 @@ export interface PortsWatchHandle {
 }
 
 /** Open the watch. Frames are delivered in order; malformed frames are dropped silently. */
-export function openPortsWatch({ url, token, createSocket, onFrame, onClose }: OpenPortsWatchInput): PortsWatchHandle {
+export function openPortsWatch({ url, token, createSocket, onFrame, onOpen, onClose }: OpenPortsWatchInput): PortsWatchHandle {
   let closed = false;
   let opened = false;
   const finish = (info: { code?: number; reason: string }) => {
@@ -142,7 +150,7 @@ export function openPortsWatch({ url, token, createSocket, onFrame, onClose }: O
     return { close() { finish({ reason: 'closed-by-caller' }); } };
   }
 
-  socket.addEventListener('open', () => { opened = true; });
+  socket.addEventListener('open', () => { opened = true; onOpen?.(); });
   socket.addEventListener('message', (event) => {
     if (closed) return;
     const frame = readPortsWatchFrame(event.data);

--- a/packages/lib/src/services/sandbox/preview/preview-access.ts
+++ b/packages/lib/src/services/sandbox/preview/preview-access.ts
@@ -66,6 +66,12 @@ export interface PreviewAccessDeps {
   resolveDrivePayer(driveId: string): Promise<{ payerId: string } | null>;
   /** The centralized code-execution gate — consulted ONLY when a forward would be a wake. */
   canRunCode(input: { userId: string; driveId: string | null; ownerId: string }): Promise<CanRunCodeResult>;
+  /**
+   * Is the PageSpace session that minted this preview's cookie still usable?
+   * The preview origin holds a signed cookie naming the session, never the
+   * session's token, so this is the only way revocation can reach it.
+   */
+  isSessionUsable(input: { sessionId: string; userId: string }): Promise<boolean>;
   /** A control-plane attach to the holder's sprite; null when the platform no longer has it. Must not wake. */
   attach(sandboxId: string): Promise<SandboxHandle | null>;
   previewStore: DevPreviewStore;
@@ -164,21 +170,48 @@ export type PreviewTarget =
 export async function resolvePreviewTarget({
   holder,
   userId,
+  sessionId,
   deps,
 }: {
   holder: DevPreviewHolderRef;
   userId: string;
+  /**
+   * The session that minted the cookie this request carries. REQUIRED, so
+   * neither tier can forget to pass it and still compile — this function is
+   * the one place both proxy entry points funnel through, which is why the
+   * check lives here rather than in each of them.
+   */
+  sessionId: string;
   deps: PreviewAccessDeps;
 }): Promise<PreviewTarget> {
   const featureEnabled = deps.featureEnabled();
+  // A dark deployment answers first and asks nothing of anyone: no session
+  // query, no row read. `decidePreviewForward` owns the copy and the status
+  // so the two proxy tiers cannot drift from the gate.
+  if (!featureEnabled) {
+    const authorization: PreviewAuthorization = { allowed: false, reason: 'feature-disabled' };
+    const decision = decidePreviewForward({ featureEnabled, authz: authorization, state: null, power: null, wakeAuthorization: 'not-consulted' });
+    return { decision: decision as Extract<PreviewForwardDecision, { kind: 'refuse' }>, authorization };
+  }
+
+  // THE SESSION MUST STILL BE USABLE, and this is checked BEFORE the holder is
+  // even looked up — the preview cookie names a session, never carries its
+  // token, so this is the only path revocation has to a live preview. Placing
+  // it here preserves this module's order property in its strongest form: a
+  // request from a killed session causes no holder read, no `getSprite` and
+  // certainly no wake. Signing out, revoking a device, or a `tokenVersion`
+  // bump therefore cuts the preview on its very next request rather than
+  // whenever the cookie happens to expire. Opaque refusal, like every other
+  // denial in this family.
+  if (!(await deps.isSessionUsable({ sessionId, userId }))) {
+    return {
+      decision: { kind: 'refuse', reason: 'not-authorized', status: 404, message: 'Not found', detail: 'session_revoked' },
+      authorization: { allowed: false, reason: 'session_revoked' },
+    };
+  }
+
   const authorization = await authorizePreviewHolder({ holder, userId, deps });
   const authz: PreviewAuthz = authorization.allowed ? { allowed: true } : authorization;
-
-  // A refused user, or a dark feature, gets its answer from rows alone.
-  const early = decidePreviewForward({ featureEnabled, authz, state: null, power: null, wakeAuthorization: 'not-consulted' });
-  if (early.kind === 'refuse' && (early.reason === 'feature-disabled' || early.reason === 'not-authorized')) {
-    return { decision: early, authorization };
-  }
   if (!authorization.allowed) return { decision: { kind: 'refuse', reason: 'not-authorized', status: 404, message: 'Not found', detail: authorization.reason }, authorization };
 
   const handle = authorization.sandboxId === null ? null : await deps.attach(authorization.sandboxId);

--- a/packages/lib/src/services/sandbox/preview/preview-forward-gate.ts
+++ b/packages/lib/src/services/sandbox/preview/preview-forward-gate.ts
@@ -86,6 +86,7 @@ export type PreviewForwardDecision =
         | 'instance-unknown'
         | 'stale-instance'
         | 'stopped-by-user'
+        | 'needs-approval'
         | 'http-port-busy'
         | 'preview-down'
         | 'preview-starting'
@@ -127,6 +128,11 @@ export function decidePreviewForward(input: PreviewForwardInput): PreviewForward
       return { kind: 'refuse', reason: 'stale-instance', status: 409, message: state.message };
     case 'stopped':
       return { kind: 'refuse', reason: 'stopped-by-user', status: 409, message: state.message };
+    case 'needs-approval':
+      // The one line that makes BOTH proxy tiers refuse an unshared port.
+      // The switch is exhaustive, so this cannot be forgotten: adding the
+      // state without this case does not compile.
+      return { kind: 'refuse', reason: 'needs-approval', status: 409, message: state.message };
     case 'blocked':
       return { kind: 'refuse', reason: 'http-port-busy', status: 409, message: state.message };
     case 'down':

--- a/packages/lib/src/services/sandbox/preview/preview-grant.ts
+++ b/packages/lib/src/services/sandbox/preview/preview-grant.ts
@@ -102,16 +102,25 @@ export const PREVIEW_GRANT_QUERY_PARAM = 'grant';
 export const PREVIEW_GRANT_TTL_MS = 60_000;
 /**
  * How long a redeemed cookie authenticates before the frame must re-open.
- * MINUTES, not hours: the cookie is not yet bound to the PageSpace session
- * that minted it (see {@link PreviewCookieClaims}), so its lifetime is the
- * window in which a logged-out user's preview keeps answering. The re-mint
+ * MINUTES, not hours, though no longer because of the session gap that used
+ * to be described here: the cookie now names its minting session and the
+ * per-request gather rejects it the moment that session is revoked
+ * ({@link PreviewCookieClaims}). A short life is simply cheap — the re-mint
  * path (a cookie-less navigation is sent back to `/preview/open`) makes an
- * expiry an invisible re-handshake, so short is cheap.
+ * expiry an invisible re-handshake — and it bounds the blast radius of the
+ * one thing a signature cannot express: a cookie copied off the wire.
  */
 export const PREVIEW_COOKIE_TTL_MS = 10 * 60 * 1000;
 
 const COOKIE_KEY_LABEL = 'pagespace:dev-preview-cookie:v1';
-const TOKEN_VERSION = 'v1';
+/**
+ * Bumped to v2 when the session id joined the claims. No compatibility shim
+ * and none is needed: the feature is dark everywhere, so no v1 cookie exists
+ * in the wild — and even if one did, it verifies as `malformed`, which routes
+ * to the re-auth page and mints a v2. That is a silent re-handshake, not an
+ * outage.
+ */
+const TOKEN_VERSION = 'v2';
 const HOLDER_ID_SHAPE = /^[a-z0-9]{1,64}$/;
 
 // -----------------------------------------------------------------------------
@@ -119,19 +128,25 @@ const HOLDER_ID_SHAPE = /^[a-z0-9]{1,64}$/;
 // -----------------------------------------------------------------------------
 
 /**
- * What the cookie asserts. KNOWN GAP, stated here: the claims name the user
- * but NOT the PageSpace session that minted the grant, so logging out (or
- * revoking that session) does not invalidate a live preview cookie — only
- * its expiry ({@link PREVIEW_COOKIE_TTL_MS}, minutes) or a change in the
- * user's drive access (re-checked on every request) does. The follow-up is
- * to carry the minting session id here and have the per-request gather
- * check it is still valid. Key rotation: rotating `SANDBOX_SESSION_SECRET`
- * invalidates every live cookie at once (the derived key changes), which
- * self-heals through the same re-mint path — there is no rotation window.
+ * What the cookie asserts: the holder, the user, the SESSION that minted it,
+ * and an expiry.
+ *
+ * The session id is what makes revocation work. Without it the cookie named a
+ * person, so signing out, revoking a device, or bumping `tokenVersion` left a
+ * live preview answering until the cookie expired — minutes during which a
+ * session someone had deliberately killed was still serving a sandbox. The
+ * per-request gather now checks the session is still usable, so revocation
+ * takes effect on the very next request.
+ *
+ * Key rotation: rotating `SANDBOX_SESSION_SECRET` invalidates every live
+ * cookie at once (the derived key changes), which self-heals through the
+ * re-mint path — there is no rotation window.
  */
 export interface PreviewCookieClaims {
   holder: DevPreviewHolderRef;
   userId: string;
+  /** The PageSpace session that minted the grant this cookie was redeemed from. */
+  sessionId: string;
   /** Epoch ms. */
   expiresAt: number;
 }
@@ -153,7 +168,7 @@ function mac(key: Buffer, payload: string): Buffer {
 /** Pure: mint the cookie value for `claims`. Throws on an empty key — minting must never produce an unverifiable token. */
 export function signPreviewCookie(claims: PreviewCookieClaims, key: Buffer): string {
   if (key.length === 0) throw new Error('preview cookie key is not configured');
-  const payload = b64url(JSON.stringify({ k: claims.holder.kind, h: claims.holder.id, u: claims.userId, e: claims.expiresAt }));
+  const payload = b64url(JSON.stringify({ k: claims.holder.kind, h: claims.holder.id, u: claims.userId, s: claims.sessionId, e: claims.expiresAt }));
   return `${TOKEN_VERSION}.${payload}.${b64url(mac(key, payload))}`;
 }
 
@@ -176,7 +191,7 @@ export function verifyPreviewCookie(token: string, key: Buffer, now: Date): Veri
   }
   if (given.length !== expected.length || !timingSafeEqual(given, expected)) return { ok: false, reason: 'bad-signature' };
 
-  let parsed: { k?: unknown; h?: unknown; u?: unknown; e?: unknown };
+  let parsed: { k?: unknown; h?: unknown; u?: unknown; s?: unknown; e?: unknown };
   try {
     parsed = JSON.parse(Buffer.from(payload, 'base64url').toString('utf8')) as typeof parsed;
   } catch {
@@ -186,12 +201,14 @@ export function verifyPreviewCookie(token: string, key: Buffer, now: Date): Veri
     (parsed.k !== 'workspace' && parsed.k !== 'env')
     || typeof parsed.h !== 'string' || !HOLDER_ID_SHAPE.test(parsed.h)
     || typeof parsed.u !== 'string' || parsed.u.length === 0
+    // Shape-checked like the holder id: this value reaches a WHERE clause.
+    || typeof parsed.s !== 'string' || !HOLDER_ID_SHAPE.test(parsed.s)
     || typeof parsed.e !== 'number' || !Number.isFinite(parsed.e)
   ) {
     return { ok: false, reason: 'malformed' };
   }
   if (parsed.e <= now.getTime()) return { ok: false, reason: 'expired' };
-  return { ok: true, claims: { holder: { kind: parsed.k, id: parsed.h }, userId: parsed.u, expiresAt: parsed.e } };
+  return { ok: true, claims: { holder: { kind: parsed.k, id: parsed.h }, userId: parsed.u, sessionId: parsed.s, expiresAt: parsed.e } };
 }
 
 /** Pure: the `Set-Cookie` header that installs `token` until `expiresAt`. */

--- a/packages/lib/src/services/sandbox/preview/preview-ws-tunnel.ts
+++ b/packages/lib/src/services/sandbox/preview/preview-ws-tunnel.ts
@@ -54,6 +54,18 @@ export interface TunnelWebSocketUpgradeInput {
   request?: UpgradeRequestFn;
   handshakeTimeoutMs?: number;
   idleTimeoutMs?: number;
+  /**
+   * A HARD CEILING on how long an established tunnel may live, whatever the
+   * traffic. The idle cut alone is not enough: HMR chatter resets it forever,
+   * so a socket authorized once at upgrade could outlive the credential that
+   * opened it — the session revoked, the member removed from the drive, the
+   * preview switched off — while the HTTP half refuses on the very next
+   * request. Tying the ceiling to the cookie's own expiry makes the socket no
+   * longer-lived than the thing that authorized it; the client reconnects
+   * through the full gather, which is where all of those checks live.
+   * Omitted ⇒ no ceiling (the pure unit surfaces).
+   */
+  maxLifetimeMs?: number;
   /** Fired once when the tunnel is fully closed, whatever the reason. */
   onClose?: (summary: TunnelSummary) => void;
 }
@@ -103,6 +115,7 @@ export function tunnelWebSocketUpgrade(input: TunnelWebSocketUpgradeInput): void
     token,
     handshakeTimeoutMs = PREVIEW_PROXY_LIMITS.upstreamHeadersTimeoutMs,
     idleTimeoutMs = PREVIEW_PROXY_LIMITS.streamIdleTimeoutMs,
+    maxLifetimeMs,
   } = input;
   const request = input.request ?? (upstreamUrl.protocol === 'https:' ? https.request : http.request);
   const startedAt = Date.now();
@@ -173,7 +186,12 @@ export function tunnelWebSocketUpgrade(input: TunnelWebSocketUpgradeInput): void
       upstreamSocket.write(head);
     }
 
+    let ceiling: ReturnType<typeof setTimeout> | null = null;
     const closeBoth = () => {
+      if (ceiling !== null) {
+        clearTimeout(ceiling);
+        ceiling = null;
+      }
       clientSocket.destroy();
       upstreamSocket.destroy();
       finish('established', 101);
@@ -185,6 +203,12 @@ export function tunnelWebSocketUpgrade(input: TunnelWebSocketUpgradeInput): void
     // (a test's PassThrough) simply has no idle cut.
     armIdleTimeout(clientSocket, idleTimeoutMs, closeBoth);
     upstreamSocket.setTimeout(idleTimeoutMs, closeBoth);
+    // The ceiling. `unref` so a pending timer cannot hold a process open, and
+    // cleared by `closeBoth` through `onClosed` below.
+    if (maxLifetimeMs !== undefined && maxLifetimeMs > 0) {
+      ceiling = setTimeout(closeBoth, maxLifetimeMs);
+      (ceiling as unknown as { unref?: () => void }).unref?.();
+    }
     clientSocket.on('error', closeBoth);
     upstreamSocket.on('error', closeBoth);
     clientSocket.on('close', closeBoth);


### PR DESCRIPTION
Includes #2548 (the fixes that missed #2545's merge) as its first two commits.
It started stacked on that branch, but a non-default base means neither the
test workflows nor CodeRabbit fire — `pull_request.branches` filters on the
BASE branch, the same mechanism `test.yml`'s own header comment documents — so
it is retargeted at `master` to get real gates. Merge #2548 first and this
rebases to nothing; merge this one first and #2548 becomes empty. Its two
commits (`8ff02382a`, `77db35381`) are already reviewed there.

Addresses the five open findings from the review of the merged dev-preview
work, plus the ops half that nothing had ever run.

## 1. Stop/resume raced with relay operations → serialize, and write the row first

Two things were wrong and only one was a race.

**The ordering was backwards.** All three mutating arms called the services API
and only then attempted the compare-and-set. The two failure shapes are not
symmetric: a row written ahead of a failed service call reports `down` and the
next plan re-creates it — it converges. A relay started ahead of a refused row
write is invisible to every future plan, because `relayServiceName` was never
written, so the planner answers `user-stopped` forever. That is a permanently
orphaned relay, not a one-frame window. Row first, and `skipped` now carries
`mutated: 'none'` in its type so a future re-ordering has to change the type
to lie.

**Then the race.** A new per-holder Postgres advisory try-lock
(`dev-preview-lock.ts`) makes read → plan → apply atomic across both tiers,
which share one database. A try-lock with bounded retries, never a waiting
one: waiting would stall the detector's frame chain and pin a transaction
across Sprites HTTP calls. A contended user action still **records the
intent** and defers only the relay work — intent durability is what the user
is entitled to. `connection_error` maps to busy and never throws: a degraded
lock pool must not break a Stop click.

`setStoppedByUser` stays unconditional, deliberately, and now says why: it
records the user's own intent, which is the newest fact by definition, and a
compare-and-set there would let a detector refuse a person's Stop.

**And the backstop.** The lock cannot help when *nobody* re-plans — a holder
with no watcher produces no frames, and a stop is exactly when a dev server
goes quiet. A five-minute sweep converges those rows. It can only ever STOP a
relay: it re-reads the row under the lock and acts only on one that is still
switched off with a relay recorded, and it plans with no listener snapshot, so
even past that guard a start is refused rather than made against an
assumed-empty listener set.

## 2. Detection could disappear until an unrelated ensure or shell open

Watchers were in-process only and every drop path was terminal — an
attach-null, reconnect exhaustion, a `stopAll`, or simply a process restart
left a holder undetected until something unrelated re-triggered it.

Detection is only ever *observable* through a status render, and that render
is already the one repeating web→realtime call. So the read re-arms its own
watcher, throttled behind a 30-second cool-down keyed by sandbox id. Every
terminal path becomes at-most-one-poll-interval, with no enumeration, no
schedule, no new route and no lease. `listeners()` becomes `read()` returning
`{ detection, listeners }`, and the status DTO gains a sibling `detection`
field — not a new member of the service-state union, because "is detection
running" is orthogonal to "what is the preview doing".

Rejected, and worth recording: a boot rehydration or DB sweep would need N
realtime instances each opening a `ports/watch` channel per sprite, and each
channel builds its own detector that independently applies relay effects.
Making that safe needs a per-sprite lease — far more machinery than the hole
warrants.

## 3. Stale listener answers from queued invalidation

Fixed in #2548 (synchronous invalidation with the epoch captured at frame
arrival, so a late frame from a closed connection cannot mark the next
connection known).

## 4. An arbitrary listener became a drive-wide preview

Every port outside a 16-entry blocklist was auto-relayed, and starting the
relay **is** the act of exposure: from that moment the port is reachable by
everyone the holder's preview is reachable by, which for an env is every
accepted member of the drive.

The line is `KNOWN_DEV_SERVER_PORTS` — a port whose default owner is a dev
server is what the user asked for by running the tool. Anything else is a
guess, and a guess that exposes something is one a person makes. Detection is
unchanged: the affordance still says "Dev server detected on :9000 — not
shared yet".

- The planner gains `await-approval`: record the port, start nothing, and take
  down a relay left over from a previous target.
- `preview-forward-gate.ts` refuses `needs-approval` with a 409. That one line
  makes **both** proxy tiers refuse an unshared port, and the exhaustive
  switch means it cannot be forgotten — the state does not compile without it.
- Approval is a per-PORT column, so a server that moves is a new decision. The
  approve action **echoes the port the user was shown** and the store filters
  its UPDATE on it, so a dev server that moved between render and click cannot
  be shared by a click that meant the old one (409 `port-changed`).
- The decision lives in the pane, which is the surface that can state who
  would then be able to reach it. Sharing should not be a side effect of
  clicking a line in a list. Stop reads "Dismiss" there, since nothing is
  running to switch off.
- The CHECK relaxes to "a relay never points at 8080". Two legal shapes now
  have a non-8080 target and no relay, and forbidding the intermediate one
  would force a transaction across the database and the Sprites API. Nothing
  is exposed by either: the sprite URL routes to 8080 alone.

## 5. Logout left the preview alive for up to ten minutes

The cookie claimed holder, user and expiry — a person, with nothing to revoke.
The session id now travels grant → cookie → gather: a `sessionId` FK on
`dev_preview_grants` (cascade), an `s` claim at token version v2, and
`sessionId` as a **required** parameter of `resolvePreviewTarget`, so neither
tier can forget it and still compile.

The check runs **before the holder is even looked up**, which is stronger than
this module's existing order property: a request from a revoked session costs
no holder read, no control-plane attach and no wake. `isSessionUsableById`
checks `tokenVersion` and `suspendedAt` as well as revocation, because those
mismatches are revoked *lazily* and testing `revokedAt` alone would leave open
exactly the window this closes. It writes nothing, and has no TTL cache — a
cache would make "revoked on the next request" false by exactly the TTL.

No compatibility shim: the feature is dark, and a v1 cookie verifies as
`malformed`, which already routes to the re-auth page. A silent re-handshake,
not an outage.

## 6. The browser journey — NOT closed, and here is exactly why

The Caddy ingress had been sitting on an **unpushed local branch** in
`PageSpace-Deploy`. It is now pushed and open as
[PageSpace-Deploy#27](https://github.com/2witstudios/PageSpace-Deploy/pull/27).

`apps/e2e/tests/21-dev-preview.spec.ts` adds the whole journey — session, a
real dev server in a real sandbox, the affordance appearing on its own,
Preview, the app rendering through the preview origin, an edit hot-reloading
the frame, open-in-new-tab minting its own grant — plus the unlisted-port
consent path and the revoked-session cutoff. It covers Vite's `allowedHosts`
in both directions rather than assuming it. It skips itself unless
`E2E_SANDBOX=1` and skips again when the capability probe says dark.

**It has not run, because staging cannot host it.**
`fly/fly.web.staging.toml` deliberately leaves `CODE_EXECUTION_ENABLED` and
`SANDBOX_CONTAINMENT_VERIFIED` unset — "no sandbox egress review has been done
for a staging network path" — there is no staging realtime app, and there is
no staging proxy. Three decisions stand between this spec and a target. They
are written down in `docs/sprites/dev-preview-runbook.md` alongside the
turn-it-on steps, and production stays dark until the smoke passes somewhere
real.

## 7. Three defects in the approve work, found by reviewing the approve work

Adding the required `spriteInstanceId` echo (§4) broke things the branch's own
green CI could not see, and the fixes are worth naming because two of them are
the same trap twice.

- **It broke the only end-to-end coverage of the approve contract.**
  `21-dev-preview.spec.ts` still posted `{ action: 'approve', port }`, which
  the stricter parser now rejects — the route would answer 400 and every
  assertion past it would fail. CI stayed green the whole time because the
  spec is gated on `E2E_SANDBOX=1`. The spec now reads the instance off the
  status it already fetches, and gained the two cases it should have had from
  the start: an approve for a *different* sandbox is refused, and one with no
  instance at all is not a well-formed action.
- **It reported the rebuild case with a sentence that is false.** `approvePort`
  returning null had three causes collapsed into `port-changed`, so the exact
  scenario the instance echo exists for — a rebuild between render and click,
  where the replacement VM re-detects **the same port** — told the user "the
  dev server has moved to a different port". It had not. There is now an
  `instance-changed` reason with its own sentence, decided by comparing the
  re-read row's instance against the echoed one.
- **The deferred action went silent.** Turning `slot-unknown` from a 4xx into a
  200 stopped the wrong toast but put nothing in its place: `runAction` ignored
  the body, so Share and Resume produced no feedback at all while the pane
  still read "not running". The deferral is now surfaced as an info toast
  naming what is being waited on.

The serialization suite's services fake also became fully stateful — `remove`
clears it, `stop` leaves the service `failed`, which is what the platform
actually does. A half-stateful fake is the kind that lies later.

## Known gaps left OPEN on purpose

Two review threads are deliberately unresolved, because the concerns are real
and I judged the fixes to belong outside this PR. Resolving them would
misrepresent them as done.

**The advisory lock can be held across unbounded Sprites calls.**
`services.get/create/stop/remove` and `getSprite` carry no timeout — only
`exec` and the stream-open path do — so a hung HTTP call holds the session
lock and one advisory-pool client for as long as it hangs. This blast radius
is new: before the lock, such a hang cost only its own caller. It is bounded
in practice, because the lock is a TRY-lock (other writers get `busy` and take
their safe paths rather than blocking) and the advisory pool is separate from
the query pool at `max: 10`. Every cheap fix is wrong: a `Promise.race` or a
destroyed client releases the lock while the mutation is still in flight,
which is precisely the interleaving the lock exists to prevent. The correct
fix is `AbortSignal` cancellation threaded through the shared Sprites client —
code this feature only consumes.

**A reconcile dropped because the lock POOL was down is not always
recoverable.** `connection_error` collapses into `busy`, so the detector
defers. A later port frame, a status read's re-arm, or the backstop sweep
usually recovers it — but none covers a holder that then goes quiet, because
the sweep only ever STOPS relays and never starts one. A distinct
`lock-unavailable` outcome with a retry queue is the right shape; it is a new
liveness mechanism with its own questions (queue bounds, ordering against live
frames, behaviour while the pool stays down) and I did not want to add one
late in a PR this size.

## Verification

Seven review passes ran over this branch, each fix commit reviewed by the
next. Between them they found: the CI-only bundle leak that made every job
red; a user's Share silently wiped by a concurrent detection write; three
distinct ways the backstop sweep failed to drain; a "Starting…" that never
resolved and took the Restart control with it; a detector planning from stale
snapshots; a preview outliving an idle-revoked session; a rotated session
dead-ending the frame on a bare 404; a WebSocket outliving the cookie that
authorized it; a rebuilt sprite keeping the dead VM's watcher; a reconnect
ceiling that retired healthy watchers; a migration that could not re-run; three
database schema tests still asserting the pre-consent shape; and three smoke
assertions that would have passed for the wrong reason. All are fixed here, and
each fix commit names the defect it answers.

Two of those came from passes reviewing my own fixes, and one test I wrote for
a race passed with the fix removed until the interleaving was scripted — both
worth knowing when judging how much the green suites are actually saying.

- `packages/lib` (full), `apps/realtime` 1259 at 98.13% branch (above the 98%
  gate), `@pagespace/db` schema suites, web dev-preview + cron +
  audit-coverage. Two unrelated integration suites (`locked-batch-reorder`,
  `gdpr-eraser`) and the CLI dist suites fail locally — by exactly the host's
  UTC offset and by missing build artifacts respectively — and pass on CI.
- `tsc --noEmit` on `packages/lib`, `packages/db`, `apps/web`,
  `apps/realtime`, `apps/e2e`. Lib typechecks its own tests in CI, which
  several fixtures on this branch did not satisfy until fixed here.
- **`bun run --filter web build`**, the only gate that sees a client bundle
  pulling in server code. It is what caught the `node:crypto` leak that made
  every CI job red, and `tsc` cannot.
- `knip:check` shows only the four known env-bridge/env-contract worktree
  phantoms.
- Store integration tests against a real Postgres, including under a non-UTC
  `TZ` — which matters twice: the sweep's window is measured against a
  database-stamped column, and the approval carry-forward is raw SQL over the
  stored row. The migration was applied twice against a real database to prove
  it is re-runnable.
- **Mutation-checked red**, each one: the session-revocation check and its
  ordering, the `tokenVersion`/`suspendedAt` checks, the idle-timeout gate,
  the approval gate in the planner, the echoed-port filter in the store, the
  port validation in the body parser, the sweep's under-lock re-read guard,
  its stamp, its failure-path stamp, the detector's snapshot flag, the
  recorded stop, and the shareable-not-approved render.

Merge-ready, do not merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01P8A8KLYCoViP7ouH5QzbnB


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Dev-server previews now support per-port sharing approval with clear status and audience messaging.
  * Common ports continue to preview automatically; unusual ports require explicit approval.
  * Preview access is tied to the active session and ends after logout or device revocation.
  * Added automatic cleanup for stopped previews.
  * Added support for agent sessions connected to local environments, with clear permission and capability refusals.

* **Bug Fixes**
  * Improved preview detection, recovery, and handling of unavailable or changing ports.
  * Prevented stale or unauthorized preview connections from remaining active.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

