### PR TITLE
feat(sandbox): local-env SandboxHost + host registry + provision threading (M1 · t09)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,20 @@ All notable user-facing changes to PageSpace are documented here. Format follows
   preview domain to `server.allowedHosts`. Off by default: the whole surface is absent until
   `DEV_PREVIEW_ENABLED` is set with a dedicated `DEV_PREVIEW_APEX`, which needs the preview-origin
   ops work (wildcard DNS, certificate, and the Caddy block) to land first.
+- **Local Environments: an agent can now reach your own computer (opt-in groundwork)** — the two
+  ends built so far are joined. An agent session bound to a local Environment whose machine is
+  connected now runs its commands and reads and writes its files on that machine, through the same
+  tools it uses everywhere else — nothing about the agent changes. Two refusals are kept apart
+  where you will see them, because they have different owners: "no connected machine — run
+  `pagespace env connect`" is yours to fix in seconds, while "the machine owner's policy does not
+  allow you to run code here" can only be changed by whoever enrolled it, and retrying will not
+  help. What a local Environment cannot do, it now says plainly instead of pretending: terminal
+  panes, dev-server previews and filesystem checkpoints are refused with a reason rather than
+  quietly appearing empty — and because a checkpoint is the safety net taken before a destructive
+  batch of commands, a batch that would need one is refused outright rather than run without it.
+  Closing a session bound to a local Environment never touches the computer: nothing is shut down,
+  nothing is billed, and the machine's own `env disconnect` and Ctrl-C still win. Still off by
+  default (`LOCAL_ENVS_ENABLED`), and still no local terminals.
 - **Local Environments: the bridge daemon — `pagespace env connect` (opt-in groundwork)** — an
   enrolled computer can now actually serve its Environment. Running `pagespace env connect` on it
   keeps a live, outbound-only connection to PageSpace and answers requests to run a command or

--- a/apps/web/src/app/api/agent-workspaces/[workspaceId]/shells/[shellId]/__tests__/route.test.ts
+++ b/apps/web/src/app/api/agent-workspaces/[workspaceId]/shells/[shellId]/__tests__/route.test.ts
@@ -105,4 +105,21 @@ describe('DELETE /api/agent-workspaces/[workspaceId]/shells/[shellId]', () => {
     const response = await del();
     expect(response.status).toBe(502);
   });
+
+  /**
+   * 502 means "upstream hiccup, try again". A substrate with no
+   * interactive-stream surface (a local environment) has no shell process and
+   * never will, so a retry can never succeed — the status has to say something
+   * a client can act on correctly.
+   */
+  it('given an environment with NO terminal support, should 409 rather than 502 — the refusal is permanent', async () => {
+    mockKillShellById.mockResolvedValue({ ok: false, reason: 'unsupported' });
+
+    const response = await del();
+
+    expect(response.status).toBe(409);
+    expect(await response.json()).toEqual(
+      expect.objectContaining({ reason: 'unsupported', error: expect.stringContaining('does not support terminal sessions') }),
+    );
+  });
 });

--- a/apps/web/src/app/api/agent-workspaces/[workspaceId]/shells/[shellId]/route.ts
+++ b/apps/web/src/app/api/agent-workspaces/[workspaceId]/shells/[shellId]/route.ts
@@ -56,6 +56,19 @@ export async function DELETE(request: Request, context: RouteContext) {
   // the pane bound to this shell goes with the process, in the same transaction.
   const killed = await killShellById({ shellId, actingUserId: auth.userId });
   if (!killed.ok) {
+    // `unsupported` is a PERMANENT property of the machine's substrate — it has
+    // no interactive-stream surface on this seam at all (a local environment;
+    // M2 routes those PTYs elsewhere). 502 would say "upstream hiccup, try
+    // again", which is advice that can never come true, and it is logged at
+    // error level as though something broke. A 409 and a warn say what is
+    // actually the case. Everything else keeps the 502 it had.
+    if (killed.reason === 'unsupported') {
+      loggers.api.warn('Shell kill refused — this environment has no stream surface', { workspaceId, shellId });
+      return NextResponse.json(
+        { error: 'This environment does not support terminal sessions, so there is no shell process to close.', reason: killed.reason },
+        { status: 409 },
+      );
+    }
     loggers.api.error('Shell kill failed', undefined, { workspaceId, shellId });
     return NextResponse.json({ error: 'Could not close this shell', reason: killed.reason }, { status: 502 });
   }

--- a/apps/web/src/lib/agent-workspaces/__tests__/sandbox-host-registry.test.ts
+++ b/apps/web/src/lib/agent-workspaces/__tests__/sandbox-host-registry.test.ts
@@ -1,0 +1,83 @@
+/**
+ * The kind-dispatching `SandboxHost` registry (M1 · t09).
+ *
+ * Two properties carry the safety here and both are negatives: a LOCAL
+ * substrate must never reach the Sprite host, and a local host must never be
+ * cached across requests (the transport it closes over is bound to one grant
+ * principal, so a cached one would sign a second user's requests with the
+ * first user's identity). A CONTROL row proves the harness genuinely does
+ * reach the Sprite host, so "not called" means something.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const spriteHost = { provision: vi.fn(), attach: vi.fn(), kill: vi.fn() };
+const getSandboxHost = vi.fn(async () => spriteHost);
+vi.mock('../sandbox-host-runtime', () => ({ getSandboxHost: () => getSandboxHost() }));
+
+const createLocalEnvTransport = vi.fn((_options?: unknown) => ({ sendGrant: vi.fn(), isConnected: () => true, connectionEpoch: () => 'epoch-1' }));
+vi.mock('@/lib/sandbox/local-env-transport', () => ({ createLocalEnvTransport: (o?: unknown) => createLocalEnvTransport(o as never) }));
+
+import { resolveSandboxHost, resolveSandboxHostForSandboxId } from '../sandbox-host-registry';
+import { localEnvSandboxId } from '@pagespace/lib/services/sandbox/sandbox-host';
+
+const PRINCIPAL = { userId: 'u1', sessionId: 'ws1', conversationId: 'c1' };
+const ENV_ID = 'env-1';
+
+beforeEach(() => vi.clearAllMocks());
+
+describe('resolveSandboxHost', () => {
+  it('given a sprite substrate, should return the process singleton — untouched by this task', async () => {
+    expect(await resolveSandboxHost({ kind: 'sprite' }, PRINCIPAL)).toBe(spriteHost);
+  });
+
+  it('given a LOCAL substrate, should build a local host and NEVER consult the Sprite host', async () => {
+    const host = await resolveSandboxHost({ kind: 'local', envId: ENV_ID }, PRINCIPAL);
+
+    expect(host).not.toBe(spriteHost);
+    expect(getSandboxHost).not.toHaveBeenCalled();
+    expect(createLocalEnvTransport).toHaveBeenCalledWith({ principal: PRINCIPAL });
+  });
+
+  it('CONTROL: the same call with a sprite substrate DOES reach it — proving the negative above is load-bearing', async () => {
+    await resolveSandboxHost({ kind: 'sprite' }, PRINCIPAL);
+    expect(getSandboxHost).toHaveBeenCalledTimes(1);
+  });
+
+  it('should NOT process-cache a local host — a cached transport would sign one user\'s work under another\'s name', async () => {
+    const first = await resolveSandboxHost({ kind: 'local', envId: ENV_ID }, PRINCIPAL);
+    const second = await resolveSandboxHost({ kind: 'local', envId: ENV_ID }, { ...PRINCIPAL, userId: 'u2' });
+
+    expect(first).not.toBe(second);
+    expect(createLocalEnvTransport).toHaveBeenCalledTimes(2);
+    expect(createLocalEnvTransport).toHaveBeenLastCalledWith({ principal: { ...PRINCIPAL, userId: 'u2' } });
+  });
+
+  it('given no principal (a connectivity bind), should build the transport WITHOUT one rather than inventing an identity', async () => {
+    await resolveSandboxHost({ kind: 'local', envId: ENV_ID });
+    expect(createLocalEnvTransport).toHaveBeenCalledWith({});
+  });
+});
+
+describe('resolveSandboxHostForSandboxId', () => {
+  it('given a local ADDRESS, should route to the local host', async () => {
+    const host = await resolveSandboxHostForSandboxId(localEnvSandboxId(ENV_ID), PRINCIPAL);
+
+    expect(host).not.toBe(spriteHost);
+    expect(getSandboxHost).not.toHaveBeenCalled();
+  });
+
+  it('given a Sprite NAME, should route to the Sprite singleton — every id that is not a local address is one', async () => {
+    expect(await resolveSandboxHostForSandboxId('pgs-env-abc123', PRINCIPAL)).toBe(spriteHost);
+  });
+
+  it('given a bare prefix with no env id, should NOT be treated as a local address', async () => {
+    expect(await resolveSandboxHostForSandboxId('local-env:', PRINCIPAL)).toBe(spriteHost);
+  });
+});
+
+describe('the existing Sprite consumers are untouched', () => {
+  it('getSandboxHost should still be exported from its own runtime module and still answer the Sprite host', async () => {
+    const runtime = await import('../sandbox-host-runtime');
+    expect(await runtime.getSandboxHost()).toBe(spriteHost);
+  });
+});

--- a/apps/web/src/lib/agent-workspaces/__tests__/sandbox-host-registry.test.ts
+++ b/apps/web/src/lib/agent-workspaces/__tests__/sandbox-host-registry.test.ts
@@ -70,8 +70,25 @@ describe('resolveSandboxHostForSandboxId', () => {
     expect(await resolveSandboxHostForSandboxId('pgs-env-abc123', PRINCIPAL)).toBe(spriteHost);
   });
 
-  it('given a bare prefix with no env id, should NOT be treated as a local address', async () => {
-    expect(await resolveSandboxHostForSandboxId('local-env:', PRINCIPAL)).toBe(spriteHost);
+  /**
+   * The parse is what decides which substrate answers, so a Sprite name it
+   * mis-claims is a real Sprite silently routed at a machine that does not
+   * exist. Every one of these is close enough to the prefix to be a plausible
+   * near-miss, and every one must stay a Sprite.
+   */
+  it.each([
+    ['a bare prefix with no env id', 'local-env:'],
+    ['a hyphen where the colon belongs', 'local-env-abc123'],
+    ['the prefix in the middle rather than at the start', 'pgs-env-local-env:abc'],
+    ['a Sprite name that merely starts with the same letters', 'local-environment-sprite'],
+    ['the derived name of a real drive env', 'pgs-env-9f2c1ab4'],
+    ['a session Sprite name', 'pgs-ses-9f2c1ab4'],
+  ])('given %s, should resolve to the Sprite host', async (_case, sandboxId) => {
+    expect(await resolveSandboxHostForSandboxId(sandboxId, PRINCIPAL)).toBe(spriteHost);
+  });
+
+  it('CONTROL: the one shape that IS a local address does route locally — so the rows above are not vacuous', async () => {
+    expect(await resolveSandboxHostForSandboxId('local-env:env-1', PRINCIPAL)).not.toBe(spriteHost);
   });
 });
 

--- a/apps/web/src/lib/agent-workspaces/sandbox-host-registry.ts
+++ b/apps/web/src/lib/agent-workspaces/sandbox-host-registry.ts
@@ -1,0 +1,68 @@
+/**
+ * Which `SandboxHost` serves a given substrate — the kind-dispatching registry
+ * (Local Environments epic, M1 · t09).
+ *
+ * `sandbox-host.ts`'s own header states the extension contract: a second
+ * backend is one new `kind` member plus one new host, and no existing caller
+ * branches on `kind`. This module is where that dispatch happens ONCE, so it
+ * does not happen in eight places.
+ *
+ * **`getSandboxHost()` is untouched and stays exported from
+ * `sandbox-host-runtime.ts`.** Branches, the git-blob runtime, the shell
+ * runtime and half a dozen others consume it and every one of them is
+ * Sprite-only by construction; making them go through a substrate they do not
+ * have would be churn with no safety gained.
+ *
+ * The Sprite host is a process singleton (one driver, one guarded ESM import).
+ * A local host deliberately is NOT cached: it closes over a transport bound to
+ * one env AND one grant principal, so a cached instance would sign a second
+ * user's requests with the first user's identity.
+ */
+import type { GrantPrincipal } from '@pagespace/lib/env-bridge/grant';
+import { createLocalEnvSandboxHost } from '@pagespace/lib/services/sandbox/sandbox-client/local-env-sandbox-host';
+import { parseLocalEnvSandboxId, type SandboxHost, type SandboxSubstrateSpec } from '@pagespace/lib/services/sandbox/sandbox-host';
+import { createLocalEnvTransport } from '@/lib/sandbox/local-env-transport';
+import { getSandboxHost } from './sandbox-host-runtime';
+
+/**
+ * The host for `substrate`.
+ *
+ * `principal` is the identity a LOCAL env's grants are signed under. Omitting
+ * it yields a host that can BIND (provision/attach ask only whether the
+ * machine is connected) but whose first grant would be refused — see
+ * `LocalEnvNoPrincipalError`. The Sprite branch has no use for it: a Sprite is
+ * addressed by name and its authorization happened at the gate.
+ */
+export async function resolveSandboxHost(
+  substrate: SandboxSubstrateSpec,
+  principal?: GrantPrincipal,
+): Promise<SandboxHost> {
+  if (substrate.kind === 'local') {
+    return createLocalEnvSandboxHost({
+      transport: createLocalEnvTransport(principal === undefined ? {} : { principal }),
+      envId: substrate.envId,
+    });
+  }
+  return getSandboxHost();
+}
+
+/**
+ * The host for a sandbox ADDRESS — what a caller that holds only an opaque
+ * `sandboxId` needs (the agent tool runner's `reconnect`, which is handed one
+ * by `acquireSandbox` and has no substrate in hand).
+ *
+ * A local env holds no `drive_envs.sandboxId` (invariant 9), so its address is
+ * derived rather than stored — `localEnvSandboxId`. Every other id is a Sprite
+ * name, which is why the parse, not a lookup, is what decides: an id that is
+ * not a local address is a Sprite address, with no third case and no database
+ * round-trip to get it wrong.
+ */
+export async function resolveSandboxHostForSandboxId(
+  sandboxId: string,
+  principal: GrantPrincipal,
+): Promise<SandboxHost> {
+  // Required here, unlike above: every caller of this overload holds a live
+  // request and is about to RUN something.
+  const envId = parseLocalEnvSandboxId(sandboxId);
+  return resolveSandboxHost(envId === null ? { kind: 'sprite' } : { kind: 'local', envId }, principal);
+}

--- a/apps/web/src/lib/agent-workspaces/workspace-shells-runtime.ts
+++ b/apps/web/src/lib/agent-workspaces/workspace-shells-runtime.ts
@@ -94,7 +94,8 @@ export interface WorkspacePaneState {
 /** A kill's outcome, plus what it left the layout looking like. `panes` is null when there was no workspace to look at. */
 export type KillShellResult =
   | { ok: true; killed: boolean; panes: WorkspacePaneState | null }
-  | { ok: false; reason: 'error' };
+  /** `unsupported` is carried through from {@link KillSessionShellResult} rather than collapsed: it is permanent, so a caller must not advise a retry. */
+  | Extract<KillSessionShellResult, { ok: false }>;
 
 /** A spawn's outcome, plus the pane it landed in. */
 export type SpawnShellResult =
@@ -351,7 +352,10 @@ export async function killShellById(input: {
       resolveSessionSandboxId: async (workspaceId) => resolveOwningSandboxId(sessionStore, workspaceId),
     },
   });
-  if (!ptyKill.ok) return { ok: false, reason: 'error' };
+  // Passed through rather than collapsed to `error`: `unsupported` is a
+  // permanent property of the substrate, and telling the caller to retry it
+  // would be advice that can never come true.
+  if (!ptyKill.ok) return ptyKill;
 
   let killed: KillSessionShellResult = { ok: false, reason: 'error' };
   // The pane this kill closes, read from the tree the decision ran against —

--- a/apps/web/src/lib/ai/tools/__tests__/session-tools.test.ts
+++ b/apps/web/src/lib/ai/tools/__tests__/session-tools.test.ts
@@ -898,6 +898,27 @@ describe('kill_shell', () => {
     const tools = createSessionTools(deps);
     const result = await run(tools.kill_shell, { shellId: SHELL.shellId }, contextOptions());
     expect(result).toEqual(expect.objectContaining({ success: false, reason: 'error' }));
+    expect((result as { error: string }).error).toContain('Retry');
+  });
+
+  /**
+   * The MODEL reads the sentence, not the reason code. A substrate with no
+   * interactive-stream surface (a local environment) refuses permanently, so
+   * telling the model to retry instructs a loop it can never break out of —
+   * the same defect as collapsing two distinct refusals into one word, except
+   * this one actively causes the wasted work.
+   */
+  it('given a substrate with NO terminal support, should tell the model not to retry — not "its process may still be running"', async () => {
+    const deps = makeDeps({ killShell: vi.fn(async () => ({ ok: false as const, reason: 'unsupported' })) });
+    const tools = createSessionTools(deps);
+
+    const result = await run(tools.kill_shell, { shellId: SHELL.shellId }, contextOptions());
+
+    expect(result).toEqual(expect.objectContaining({ success: false, reason: 'unsupported' }));
+    const error = (result as { error: string }).error;
+    expect(error).toContain('no terminal support');
+    expect(error).toContain('Do not retry');
+    expect(error).not.toContain('may still be running');
   });
 });
 

--- a/apps/web/src/lib/ai/tools/sandbox-tools-runtime.ts
+++ b/apps/web/src/lib/ai/tools/sandbox-tools-runtime.ts
@@ -25,7 +25,7 @@ import { eq } from '@pagespace/db/operators';
 import { db } from '@pagespace/db/db';
 import { drives, pages } from '@pagespace/db/schema/core';
 import { users } from '@pagespace/db/schema/auth';
-import { defaultBuildEnv, type SandboxRunDeps } from '@pagespace/lib/services/sandbox/tool-runners';
+import { defaultBuildEnv, localRefusalToToolDenial, type SandboxRunDeps } from '@pagespace/lib/services/sandbox/tool-runners';
 import { isCodeExecutionEnabled } from '@pagespace/lib/services/sandbox/can-run-code';
 import {
   screenToolOutput,
@@ -37,6 +37,9 @@ import {
   getCheckpointState,
   recordCheckpoint,
 } from '@pagespace/lib/services/sandbox/checkpoint-policy';
+import { parseLocalEnvSandboxId } from '@pagespace/lib/services/sandbox/sandbox-host';
+import { adaptSandboxHandleToExecutableSandbox } from '@pagespace/lib/services/sandbox/sandbox-client/sandbox-host-adapter';
+import { resolveSandboxHostForSandboxId } from '@/lib/agent-workspaces/sandbox-host-registry';
 import type { ExecSandboxClient } from '@pagespace/lib/services/sandbox/sandbox-client/types';
 import {
   acquireCodeExecutionSlot,
@@ -217,6 +220,19 @@ export function buildRealSandboxRunDeps(): SandboxRunDeps {
             ? { ok: false, reason: 'no_drive_access' }
             : { ok: false, reason: 'provision_failed', cause: provisioned.denial };
         }
+        // A LOCAL env's refusal keeps its own vocabulary all the way to the
+        // agent. Collapsing every one of them into `provision_failed` is the
+        // defect this branch exists to prevent: "your computer is not
+        // connected" (the requester fixes it in seconds with
+        // `pagespace env connect`) and "the machine owner's bind policy denies
+        // you" (only the owner can fix it, elsewhere) are different problems
+        // with different owners, and an agent told the same sentence for both
+        // debugs the wrong layer. Every OTHER local refusal is a provisioning
+        // fault and keeps its detail.
+        if (provisioned.reason === 'local_refused') {
+          const denial = localRefusalToToolDenial(provisioned.refusal);
+          if (denial) return { ok: false, reason: denial };
+        }
         return { ok: false, reason: 'provision_failed', cause: provisioned.detail ?? provisioned.reason };
       }
 
@@ -239,7 +255,32 @@ export function buildRealSandboxRunDeps(): SandboxRunDeps {
         pageId: input.agentPageId,
       };
     },
-    reconnect: async (sandboxId) => (await getSandboxClient()).get({ sandboxId }),
+    /**
+     * Re-open the machine `acquireSandbox` just returned the address of.
+     *
+     * Routed through the host REGISTRY rather than straight at the Sprites
+     * client, which is what makes an agent tool call reach a user's own
+     * computer without a single change to any tool runner: the runner still
+     * asks for an `ExecutableSandbox` by id and still drives `runCommand` /
+     * `writeFiles` / `readFileToBuffer` on it. A local env holds no
+     * `drive_envs.sandboxId` (invariant 9), so its address is derived
+     * (`local-env:<envId>`) and the registry's parse — not a database read —
+     * decides which substrate answers.
+     *
+     * The PRINCIPAL is bound here, from the acting request, because this is
+     * the layer that has one: it is signed into every grant the machine
+     * receives and it is what the owner's local ask prompt names.
+     */
+    reconnect: async (sandboxId, principal) => {
+      if (parseLocalEnvSandboxId(sandboxId) === null) return (await getSandboxClient()).get({ sandboxId });
+      const host = await resolveSandboxHostForSandboxId(sandboxId, {
+        userId: principal.userId,
+        sessionId: principal.workspaceId,
+        conversationId: principal.conversationId,
+      });
+      const handle = await host.attach({ sandboxId });
+      return handle === null ? null : adaptSandboxHandleToExecutableSandbox(handle);
+    },
     quota: {
       acquireSlot: acquireCodeExecutionSlot,
       releaseSlot: releaseCodeExecutionSlot,

--- a/apps/web/src/lib/ai/tools/session-tools.ts
+++ b/apps/web/src/lib/ai/tools/session-tools.ts
@@ -1823,9 +1823,18 @@ export function createSessionTools(deps: SessionToolsDeps): {
 
         const killed = await deps.killShell({ shellId, actingUserId: actor.userId });
         if (!killed.ok) {
+          // The MODEL reads the sentence, not the reason code. Telling it to
+          // retry a refusal that is a permanent property of the machine's
+          // substrate is the same defect as collapsing two refusals into one
+          // word — worse, in fact, because it actively instructs a loop. A
+          // local environment has no interactive-stream surface on this seam at
+          // all, so there is no process here and there never was.
           return {
             success: false,
-            error: `Could not close shell "${shellId}" — its process may still be running. Retry.`,
+            error:
+              killed.reason === 'unsupported'
+                ? `Shell "${shellId}" runs in an environment with no terminal support, so there is no process to close. Do not retry.`
+                : `Could not close shell "${shellId}" — its process may still be running. Retry.`,
             reason: killed.reason,
           };
         }

--- a/apps/web/src/lib/drive-envs/drive-envs-runtime.ts
+++ b/apps/web/src/lib/drive-envs/drive-envs-runtime.ts
@@ -283,8 +283,33 @@ export async function ensureEnvSandboxForSession(input: {
     envId: input.envId,
     intent: input.intent,
     requesterId: input.requesterId,
-    deps: { store, host, resolvePayer: resolveDriveEnvPayer, liveConnection },
+    deps: {
+      store,
+      host,
+      resolvePayer: resolveDriveEnvPayer,
+      liveConnection,
+      resolveLocalHost: localHostResolver,
+    },
   });
+}
+
+/**
+ * The LOCAL-env `SandboxHost` factory this process hands the provisioner
+ * (t09). Loaded lazily, for the same reason `liveConnectionReader` is: the
+ * registry builds its logger at import and many suites stub the logging
+ * module.
+ *
+ * NO grant principal, deliberately. A provision is a BIND — it asks whether
+ * the machine is connected and nothing else, and it has no conversation to
+ * name. So it gets the connectivity-only transport, whose `sendGrant` refuses
+ * rather than signing under an invented identity: if some future edit tries to
+ * run a command from the provisioning path, it fails loudly instead of
+ * attributing the command to a principal nobody authorized. Grants are sent
+ * from the tool path, through a transport built for the acting principal.
+ */
+async function localHostResolver({ envId }: { envId: string }) {
+  const { resolveSandboxHost } = await import('@/lib/agent-workspaces/sandbox-host-registry');
+  return resolveSandboxHost({ kind: 'local', envId });
 }
 
 /**
@@ -312,6 +337,10 @@ export async function gateLocalEnvBind(input: { envId: string; requesterId: stri
  * exactly the same ones.
  */
 export async function rebuildEnv(input: { envId: string; requesterId: string }): Promise<RebuildDriveEnvResult> {
+  // No `resolveLocalHost` on this path, and that is not an omission:
+  // `rebuildDriveEnv` refuses a local env with `substrate_unsupported` before
+  // it ever reaches the provisioner (rebuild is destroy-and-re-mint, and a
+  // local env has no Sprite to destroy).
   const [store, host, liveConnection] = await Promise.all([getDriveEnvStore(), getSandboxHost(), liveConnectionReader()]);
   return rebuildDriveEnv({
     envId: input.envId,

--- a/apps/web/src/lib/env-bridge/__tests__/grant-signer.test.ts
+++ b/apps/web/src/lib/env-bridge/__tests__/grant-signer.test.ts
@@ -10,7 +10,8 @@ import { generateKeyPairSync, createPrivateKey, createPublicKey, createHash, sig
 import { verifyGrant, createMemoryNonceStore, canonicalizeArgs, GRANT_MAX_TTL_MS } from '@pagespace/lib/env-bridge/grant';
 import { grantRequestForFrame, type GrantFrame } from '@pagespace/lib/env-bridge/grant-args';
 import { parseServerSigningKeyring, type SigningKeyPrimitives } from '@pagespace/lib/env-bridge/server-signing-key';
-import { signGrantFrame, type UnsignedGrantFrame } from '../grant-signer';
+import type { UnsignedGrantFrame } from '@pagespace/lib/env-bridge/grant-args';
+import { signGrantFrame } from '../grant-signer';
 import { ed25519Verify, envBridgeHash } from '../crypto';
 
 const primitives: SigningKeyPrimitives = {

--- a/apps/web/src/lib/env-bridge/bridge-client.ts
+++ b/apps/web/src/lib/env-bridge/bridge-client.ts
@@ -14,13 +14,14 @@
 import type { WebSocket } from 'ws';
 import { encodeFrame } from '@pagespace/lib/env-bridge/frame-codec';
 import type { GrantPrincipal } from '@pagespace/lib/env-bridge/grant';
+import type { UnsignedGrantFrame } from '@pagespace/lib/env-bridge/grant-args';
 import type { MachineResultFrame } from '@pagespace/lib/env-bridge/machine-signatures';
 import type { ServerSigningKeyring } from '@pagespace/lib/env-bridge/server-signing-key';
 import { logger } from '@pagespace/lib/logging/logger-config';
 import { loadServerSigningKeyring } from '@pagespace/lib/auth/env-bridge-signing-key';
 import { getAuthorizedEnvConnection, getEnvConnectionMetadata, onEnvConnectionLost } from '@/lib/websocket/ws-env-connections';
 import { RequestCorrelator, CorrelationError, grantCorrelatorTimeoutMs, type CorrelationFailureKind } from './correlator';
-import { signGrantFrame, type GrantIdSource, type UnsignedGrantFrame } from './grant-signer';
+import { signGrantFrame, type GrantIdSource } from './grant-signer';
 import { verifyResultFromMachine } from './result-verifier';
 
 export type EnvBridgeFailureKind = CorrelationFailureKind | 'not_connected' | 'signing_key_unavailable' | 'ttl_too_long';

--- a/apps/web/src/lib/env-bridge/grant-signer.ts
+++ b/apps/web/src/lib/env-bridge/grant-signer.ts
@@ -21,14 +21,9 @@
  * `encodeGrant` (never re-implemented here), the clock is a parameter.
  */
 import { canonicalizeArgs, encodeGrant, GRANT_MAX_TTL_MS, type Grant, type GrantPrincipal, type HashBytes } from '@pagespace/lib/env-bridge/grant';
-import { grantRequestForFrame, type GrantFrame } from '@pagespace/lib/env-bridge/grant-args';
+import { grantRequestForFrame, type GrantFrame, type UnsignedGrantFrame } from '@pagespace/lib/env-bridge/grant-args';
 import type { ServerSigningKeyring } from '@pagespace/lib/env-bridge/server-signing-key';
 import { envBridgeHash } from './crypto';
-
-/** A grant frame before its grant + signature are attached — what a host asks the bridge to send. */
-export type UnsignedGrantFrame = {
-  [K in GrantFrame['type']]: Omit<Extract<GrantFrame, { type: K }>, 'grant' | 'sig'>;
-}[GrantFrame['type']];
 
 export interface GrantIdSource {
   grantId(): string;

--- a/apps/web/src/lib/sandbox/__tests__/local-env-transport.test.ts
+++ b/apps/web/src/lib/sandbox/__tests__/local-env-transport.test.ts
@@ -1,0 +1,127 @@
+/**
+ * The production `BridgeTransport` (M1 · t09).
+ *
+ * The behavioural assertions here are small. The one that matters most is the
+ * SOURCE assertion at the bottom: this module must remain a wrapper over
+ * t07's `EnvBridgeClient.sendGrant`, because that is where grant signing,
+ * correlation and machine-signature verification live — once each. Two
+ * verification paths cannot be caught by behaviour (both pass their own tests
+ * right up until one stops rejecting something), so it is pinned by reading
+ * the file, in the same spirit as t08's `invariants.test.ts`.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+const sendGrant = vi.fn(async () => ({ type: 'exec_result' as const, grantId: 'g1', exitCode: 0, stdoutB64: '', stderrB64: '', truncated: false, sig: 's' }));
+vi.mock('@/lib/env-bridge/bridge-client', () => ({ getEnvBridgeClient: () => ({ sendGrant }) }));
+
+const getAuthorizedEnvConnection = vi.fn<(envId: string) => object | undefined>(() => undefined);
+const getEnvConnectionMetadata = vi.fn<(ws: object) => { sessionId: string; connectedAt: Date } | undefined>(() => undefined);
+vi.mock('@/lib/websocket/ws-env-connections', () => ({
+  getAuthorizedEnvConnection: (envId: string) => getAuthorizedEnvConnection(envId),
+  getEnvConnectionMetadata: (ws: object) => getEnvConnectionMetadata(ws),
+}));
+
+import { createLocalEnvTransport, LocalEnvNoPrincipalError } from '../local-env-transport';
+
+const ENV_ID = 'env-1';
+const PRINCIPAL = { userId: 'u1', sessionId: 'ws1', conversationId: 'c1' };
+const FRAME = { type: 'grant_exec' as const, cmd: 'ls' };
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  getAuthorizedEnvConnection.mockReturnValue(undefined);
+  getEnvConnectionMetadata.mockReturnValue(undefined);
+});
+
+describe('createLocalEnvTransport', () => {
+  it('should delegate every send to the ONE bridge client, carrying the acting principal', async () => {
+    const transport = createLocalEnvTransport({ principal: PRINCIPAL });
+    await transport.sendGrant({ envId: ENV_ID, frame: FRAME });
+
+    expect(sendGrant).toHaveBeenCalledWith({ envId: ENV_ID, frame: FRAME, principal: PRINCIPAL });
+  });
+
+  it('given NO principal (a connectivity bind), should refuse to send rather than sign under an invented identity', async () => {
+    const transport = createLocalEnvTransport();
+
+    await expect(transport.sendGrant({ envId: ENV_ID, frame: FRAME })).rejects.toBeInstanceOf(LocalEnvNoPrincipalError);
+    expect(sendGrant).not.toHaveBeenCalled();
+  });
+
+  it('should report connected only for an AUTHORIZED socket (invariant 6)', () => {
+    const transport = createLocalEnvTransport({ principal: PRINCIPAL });
+    expect(transport.isConnected(ENV_ID)).toBe(false);
+
+    getAuthorizedEnvConnection.mockReturnValue({});
+    expect(transport.isConnected(ENV_ID)).toBe(true);
+    expect(getAuthorizedEnvConnection).toHaveBeenLastCalledWith(ENV_ID);
+  });
+
+  it('should derive a connection epoch that is stable for one socket and different after a reconnect', () => {
+    const transport = createLocalEnvTransport({ principal: PRINCIPAL });
+    const socket = {};
+    getAuthorizedEnvConnection.mockReturnValue(socket);
+    getEnvConnectionMetadata.mockReturnValue({ sessionId: 'sess-1', connectedAt: new Date(1_700_000_000_000) });
+
+    const first = transport.connectionEpoch(ENV_ID);
+    expect(first).toBe('sess-1:1700000000000');
+    expect(transport.connectionEpoch(ENV_ID)).toBe(first);
+
+    getEnvConnectionMetadata.mockReturnValue({ sessionId: 'sess-2', connectedAt: new Date(1_700_000_009_000) });
+    expect(transport.connectionEpoch(ENV_ID)).not.toBe(first);
+  });
+
+  it('given no socket, the epoch should be null — never a stale identity', () => {
+    expect(createLocalEnvTransport({ principal: PRINCIPAL }).connectionEpoch(ENV_ID)).toBeNull();
+  });
+});
+
+describe('exactly ONE verification path exists for env-bridge results', () => {
+  const source = readFileSync(join(__dirname, '..', 'local-env-transport.ts'), 'utf8');
+
+  it('should route through the shared bridge client rather than owning a socket', () => {
+    expect(source).toContain('getEnvBridgeClient');
+  });
+
+  it.each(['signGrantFrame', 'verifyResultFromMachine', 'verifyMachineResult', 'encodeGrant', 'ed25519Verify', 'RequestCorrelator'])(
+    'should NOT re-implement %s — it lives once, in the t07 bridge client',
+    (banned) => {
+      expect(source).not.toContain(banned);
+    },
+  );
+
+  it('should be the only module besides the bridge client that verifies a machine result', () => {
+    // `verifyResultFromMachine` is THE verifier. Exactly two production files
+    // may name it: the one that defines it and the one that calls it. A third
+    // means a result could be admitted by a path that has not kept up with the
+    // first — the drift this whole module is shaped to prevent.
+    const callers = grepProduction(join(__dirname, '..', '..', '..'), 'verifyResultFromMachine(');
+    expect(callers).toEqual(['lib/env-bridge/bridge-client.ts', 'lib/env-bridge/result-verifier.ts']);
+  });
+
+  it('should have exactly one production grant SIGNER too — the same argument, the other direction', () => {
+    const signers = grepProduction(join(__dirname, '..', '..', '..'), 'signGrantFrame(');
+    expect(signers).toEqual(['lib/env-bridge/bridge-client.ts', 'lib/env-bridge/grant-signer.ts']);
+  });
+});
+
+/** Every production (non-test) file under `src` whose text contains `needle`, repo-relative. */
+function grepProduction(root: string, needle: string): string[] {
+  const { readdirSync, statSync } = require('node:fs') as typeof import('node:fs');
+  const found: string[] = [];
+  const walk = (dir: string, prefix: string) => {
+    for (const entry of readdirSync(dir)) {
+      const full = join(dir, entry);
+      if (statSync(full).isDirectory()) {
+        if (entry === '__tests__' || entry === 'node_modules') continue;
+        walk(full, `${prefix}${entry}/`);
+      } else if (entry.endsWith('.ts') && readFileSync(full, 'utf8').includes(needle)) {
+        found.push(`${prefix}${entry}`);
+      }
+    }
+  };
+  walk(root, '');
+  return found.sort();
+}

--- a/apps/web/src/lib/sandbox/__tests__/local-env-transport.test.ts
+++ b/apps/web/src/lib/sandbox/__tests__/local-env-transport.test.ts
@@ -10,7 +10,7 @@
  * the file, in the same spirit as t08's `invariants.test.ts`.
  */
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { readdirSync, readFileSync, statSync } from 'node:fs';
+import { readdirSync, readFileSync } from 'node:fs';
 import { join } from 'node:path';
 
 const sendGrant = vi.fn(async () => ({ type: 'exec_result' as const, grantId: 'g1', exitCode: 0, stdoutB64: '', stderrB64: '', truncated: false, sig: 's' }));
@@ -107,18 +107,43 @@ describe('exactly ONE verification path exists for env-bridge results', () => {
   });
 });
 
-/** Every production (non-test) file under `src` whose text contains `needle`, repo-relative. */
+/**
+ * Every production (non-test) file under `root` whose text contains `needle`,
+ * as repo-relative paths.
+ *
+ * **Each pathname gets at most ONE direct filesystem call**, and that shape is
+ * deliberate rather than incidental: `readdirSync(…, { withFileTypes: true })`
+ * already answers "is this a directory" from the directory entry the readdir
+ * returned, so nothing here ever asks the filesystem a question about a path
+ * and then acts on that path a second time. The check-then-use pattern —
+ * `statSync(full).isDirectory()` followed by `readFileSync(full)`, or an
+ * `existsSync` guard before a read — is a filesystem race (CodeQL
+ * `js/file-system-race`), because the thing described by the first call need
+ * not still be the thing opened by the second. Tolerance for a file that
+ * vanishes between the readdir and the read belongs in a `try`/`catch` around
+ * the read, never in a second probe of the same path.
+ */
 function grepProduction(root: string, needle: string): string[] {
   const found: string[] = [];
   const walk = (dir: string, prefix: string) => {
-    for (const entry of readdirSync(dir)) {
-      const full = join(dir, entry);
-      if (statSync(full).isDirectory()) {
-        if (entry === '__tests__' || entry === 'node_modules') continue;
-        walk(full, `${prefix}${entry}/`);
-      } else if (entry.endsWith('.ts') && readFileSync(full, 'utf8').includes(needle)) {
-        found.push(`${prefix}${entry}`);
+    for (const entry of readdirSync(dir, { withFileTypes: true })) {
+      // Branch on the DIRENT readdir already gave us — never on a fresh stat.
+      if (entry.isDirectory()) {
+        if (entry.name === '__tests__' || entry.name === 'node_modules') continue;
+        walk(join(dir, entry.name), `${prefix}${entry.name}/`);
+        continue;
       }
+      if (!entry.isFile() || !entry.name.endsWith('.ts')) continue;
+      let text: string;
+      try {
+        text = readFileSync(join(dir, entry.name), 'utf8');
+      } catch {
+        // Raced away between the readdir and the read: it is not a file that
+        // can contain the needle now, and re-probing the path is the very
+        // thing this helper refuses to do.
+        continue;
+      }
+      if (text.includes(needle)) found.push(`${prefix}${entry.name}`);
     }
   };
   walk(root, '');

--- a/apps/web/src/lib/sandbox/__tests__/local-env-transport.test.ts
+++ b/apps/web/src/lib/sandbox/__tests__/local-env-transport.test.ts
@@ -10,7 +10,7 @@
  * the file, in the same spirit as t08's `invariants.test.ts`.
  */
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { readFileSync } from 'node:fs';
+import { readdirSync, readFileSync, statSync } from 'node:fs';
 import { join } from 'node:path';
 
 const sendGrant = vi.fn(async () => ({ type: 'exec_result' as const, grantId: 'g1', exitCode: 0, stdoutB64: '', stderrB64: '', truncated: false, sig: 's' }));
@@ -109,7 +109,6 @@ describe('exactly ONE verification path exists for env-bridge results', () => {
 
 /** Every production (non-test) file under `src` whose text contains `needle`, repo-relative. */
 function grepProduction(root: string, needle: string): string[] {
-  const { readdirSync, statSync } = require('node:fs') as typeof import('node:fs');
   const found: string[] = [];
   const walk = (dir: string, prefix: string) => {
     for (const entry of readdirSync(dir)) {

--- a/apps/web/src/lib/sandbox/local-env-transport.ts
+++ b/apps/web/src/lib/sandbox/local-env-transport.ts
@@ -1,0 +1,88 @@
+/**
+ * The production `BridgeTransport` — the one concrete socket the local-env
+ * `SandboxHost` (`@pagespace/lib`) sends through.
+ *
+ * **This module is a WRAPPER and must stay one.** Grant signing (invariant 3),
+ * correlation by `grantId`, and machine-signature verification (invariant 7)
+ * all live exactly once, in t07's `EnvBridgeClient.sendGrant`
+ * (`@/lib/env-bridge/bridge-client`). Nothing here re-implements any of the
+ * three, and `__tests__/local-env-transport.test.ts` asserts that by reading
+ * this file: two verification paths that can drift is the precise defect class
+ * the adversarial review on this epic caught twice, and it is not detectable
+ * from behavior — both paths pass their own tests right up until one of them
+ * stops rejecting something.
+ *
+ * A transport is built per env AND per grant principal, never cached: the
+ * principal is signed into every grant, so a shared instance would let one
+ * user's request run under another user's name.
+ */
+import type { GrantPrincipal } from '@pagespace/lib/env-bridge/grant';
+import type { BridgeTransport } from '@pagespace/lib/services/sandbox/sandbox-client/local-env-sandbox-host';
+import { getEnvBridgeClient } from '@/lib/env-bridge/bridge-client';
+import { getAuthorizedEnvConnection, getEnvConnectionMetadata } from '@/lib/websocket/ws-env-connections';
+
+/**
+ * A stable id for the CURRENT bridge connection of an env.
+ *
+ * Derived from facts the registry already holds for the live socket — the
+ * `env:bridge` session it authenticated with and the moment it connected — so
+ * it changes on every reconnect and on every supersede, and never changes
+ * while one socket lives. That is the property `SandboxHandle.spriteInstanceId`
+ * needs from it: an identity for THIS generation of the connection, so work
+ * granted to a socket that has since been replaced is not credited to its
+ * replacement. It is emphatically not a Fly machine id and nothing persists it
+ * (invariant 9 keeps `drive_envs.spriteInstanceId` NULL for a local env).
+ */
+function readConnectionEpoch(envId: string): string | null {
+  const ws = getAuthorizedEnvConnection(envId);
+  if (!ws) return null;
+  const metadata = getEnvConnectionMetadata(ws);
+  if (!metadata) return null;
+  return `${metadata.sessionId}:${metadata.connectedAt.getTime()}`;
+}
+
+/**
+ * A transport built for a bind that carries NO grant principal, and therefore
+ * may not send a grant.
+ *
+ * `SandboxHost.provision`/`attach` on a local env ask one question — is the
+ * machine connected — and a provisioning path has no conversation to name. The
+ * alternative to this type is an invented placeholder principal, which would
+ * be an identity nobody authorized riding inside a signed grant. So the
+ * refusal is structural: `sendGrant` rejects, loudly, and any future edit that
+ * tries to run a command from the provisioning path fails instead of
+ * succeeding under a fabricated name.
+ */
+export class LocalEnvNoPrincipalError extends Error {
+  constructor(readonly envId: string) {
+    super(
+      `Refusing to send a grant to ${envId}: this transport was built for a connectivity bind and carries no grant principal. `
+        + 'Build one for the acting principal (see createLocalEnvTransport).',
+    );
+    this.name = 'LocalEnvNoPrincipalError';
+  }
+}
+
+/**
+ * Build the transport for one env, acting as one principal.
+ *
+ * `principal` is the identity signed into every grant this transport sends —
+ * the acting user, and the session/conversation the request came through. The
+ * daemon's audit log keys on it, and so does the local ask/allowlist prompt
+ * the machine's owner sees. Omit it only for a connectivity bind (see
+ * {@link LocalEnvNoPrincipalError}).
+ */
+export function createLocalEnvTransport(options: { principal?: GrantPrincipal } = {}): BridgeTransport {
+  const { principal } = options;
+  return {
+    sendGrant: ({ envId, frame }) =>
+      principal === undefined
+        ? Promise.reject(new LocalEnvNoPrincipalError(envId))
+        : getEnvBridgeClient().sendGrant({ envId, frame, principal }),
+    // The AUTHORIZED socket only (invariant 6): a socket whose signed hello has
+    // not verified is not a machine we may send a grant to, so it is not a
+    // connection as far as this seam is concerned.
+    isConnected: (envId) => getAuthorizedEnvConnection(envId) !== undefined,
+    connectionEpoch: readConnectionEpoch,
+  };
+}

--- a/packages/lib/package.json
+++ b/packages/lib/package.json
@@ -1018,6 +1018,11 @@
       "import": "./dist/services/sandbox/sandbox-client/sprite-sandbox-host.js",
       "require": "./dist/services/sandbox/sandbox-client/sprite-sandbox-host.js"
     },
+    "./services/sandbox/sandbox-client/local-env-sandbox-host": {
+      "types": "./dist/services/sandbox/sandbox-client/local-env-sandbox-host.d.ts",
+      "import": "./dist/services/sandbox/sandbox-client/local-env-sandbox-host.js",
+      "require": "./dist/services/sandbox/sandbox-client/local-env-sandbox-host.js"
+    },
     "./services/sandbox/sandbox-client/sandbox-host-adapter": {
       "types": "./dist/services/sandbox/sandbox-client/sandbox-host-adapter.d.ts",
       "import": "./dist/services/sandbox/sandbox-client/sandbox-host-adapter.js",

--- a/packages/lib/src/env-bridge/grant-args.ts
+++ b/packages/lib/src/env-bridge/grant-args.ts
@@ -40,6 +40,20 @@ export type GrantFrameType = GrantFrame['type'];
 
 export const GRANT_FRAME_TYPES: readonly GrantFrameType[] = ['grant_exec', 'grant_fs_read', 'grant_fs_write', 'grant_pty_open'];
 
+/**
+ * A grant frame BEFORE its grant + signature are attached — what a caller
+ * (the local `SandboxHost`) hands the bridge to send.
+ *
+ * Defined here, beside the projection, rather than beside the signer: both the
+ * host that BUILDS one (`services/sandbox/sandbox-client/local-env-sandbox-host.ts`,
+ * in this package) and the signer that consumes one (apps/web's
+ * `grant-signer.ts`) need it, and a second declaration of the same mapped type
+ * is exactly the drift `grantRequestForFrame` exists to prevent one layer down.
+ */
+export type UnsignedGrantFrame = {
+  [K in GrantFrameType]: Omit<Extract<GrantFrame, { type: K }>, 'grant' | 'sig'>;
+}[GrantFrameType];
+
 export interface ExecGrantArgs {
   readonly cmd: string;
   readonly args: readonly string[];

--- a/packages/lib/src/services/agent-workspaces/__tests__/fakes.ts
+++ b/packages/lib/src/services/agent-workspaces/__tests__/fakes.ts
@@ -12,12 +12,7 @@
  * that it would not is visible as a duplicate.
  */
 
-import type {
-  SandboxHandle,
-  SandboxHost,
-  SandboxStream,
-  SandboxStreamSessionInfo,
-} from '../../sandbox/sandbox-host';
+import { SPRITE_SANDBOX_CAPABILITIES, type SandboxHandle, type SandboxHost, type SandboxStream, type SandboxStreamSessionInfo } from '../../sandbox/sandbox-host';
 import { SandboxSpriteReplacedError } from '../../sandbox/sandbox-host';
 import type {
   AgentSessionRecord,
@@ -332,6 +327,9 @@ export function makeHandle(
     kill: () => {},
   };
   return {
+    // Every fake in this file describes a SPRITE — the substrate that serves
+    // the whole seam. A local env advertises its own, narrower set.
+    capabilities: SPRITE_SANDBOX_CAPABILITIES,
     sandboxId,
     spriteInstanceId: instanceId,
     egressPolicyToken,

--- a/packages/lib/src/services/agent-workspaces/__tests__/workspace-shells.test.ts
+++ b/packages/lib/src/services/agent-workspaces/__tests__/workspace-shells.test.ts
@@ -9,6 +9,7 @@ import {
 import { shellDtoSchema } from '../../../agent-workspaces/shells-contract';
 import { SANDBOX_ROOT } from '../../sandbox/sandbox-paths';
 import { NOW, OWNER_ID, SESSION_ID, makeSessionShellStore, makeShellRecord, makeSpriteHost } from './fakes';
+import { LocalEnvUnsupportedError, type SandboxHandle } from '../../sandbox/sandbox-host';
 
 const SANDBOX_ID = 'pgs-ses-abc';
 
@@ -277,6 +278,73 @@ describe('killSessionShellById', () => {
 
     expect(result).toEqual({ ok: true, killed: true });
     expect(store.rows.has('shell-x')).toBe(false);
+  });
+
+  /**
+   * t09: a LOCAL environment has no interactive-stream surface on this seam
+   * (M2 routes local PTYs through apps/realtime instead), so `killSession`
+   * refuses. The row must be KEPT and the answer must be its own word:
+   * reporting success would drop the only pointer to a process this seam
+   * cannot reach, and reporting `error` would advise a retry that can never
+   * succeed.
+   */
+  describe('a substrate with no stream surface', () => {
+    const noStream = { exec: true, fs: true, stream: false, checkpoint: false, preview: false, services: false } as const;
+
+    function localDeps(store: ReturnType<typeof makeSessionShellStore>, host: ReturnType<typeof makeSpriteHost>, over: Partial<SandboxHandle> = {}) {
+      return {
+        store: store.store,
+        resolveSessionSandboxId: async () => SANDBOX_ID,
+        host: {
+          ...host.host,
+          attach: async () => ({ ...(await host.host.attach({ sandboxId: SANDBOX_ID }))!, capabilities: noStream, ...over }),
+        } as typeof host.host,
+      };
+    }
+
+    it('should answer the typed unsupported and KEEP the row', async () => {
+      const store = makeSessionShellStore([makeShellRecord({ id: 'shell-x', spriteExecId: 'stream-1' })]);
+      const host = makeSpriteHost({ seed: { [SANDBOX_ID]: { instanceId: 'inst-1' } } });
+
+      const result = await killSessionShellById({ shellId: 'shell-x', deps: localDeps(store, host) });
+
+      expect(result).toEqual({ ok: false, reason: 'unsupported' });
+      expect(store.rows.has('shell-x')).toBe(true);
+    });
+
+    it('should never CALL killSession — the advertised capability answers first', async () => {
+      const store = makeSessionShellStore([makeShellRecord({ id: 'shell-x', spriteExecId: 'stream-1' })]);
+      const host = makeSpriteHost({ seed: { [SANDBOX_ID]: { instanceId: 'inst-1' } } });
+      let called = 0;
+
+      await killSessionShellById({
+        shellId: 'shell-x',
+        deps: localDeps(store, host, { killSession: async () => { called += 1; } }),
+      });
+
+      expect(called).toBe(0);
+    });
+
+    it('given a handle that advertises nothing but THROWS the typed error, should still answer unsupported', async () => {
+      const store = makeSessionShellStore([makeShellRecord({ id: 'shell-x', spriteExecId: 'stream-1' })]);
+      const host = makeSpriteHost({ seed: { [SANDBOX_ID]: { instanceId: 'inst-1' } } });
+      const deps = {
+        store: store.store,
+        resolveSessionSandboxId: async () => SANDBOX_ID,
+        host: {
+          ...host.host,
+          attach: async () => ({
+            ...(await host.host.attach({ sandboxId: SANDBOX_ID }))!,
+            killSession: async () => {
+              throw new LocalEnvUnsupportedError('killSession', 'env-1');
+            },
+          }),
+        } as typeof host.host,
+      };
+
+      expect(await killSessionShellById({ shellId: 'shell-x', deps })).toEqual({ ok: false, reason: 'unsupported' });
+      expect(store.rows.has('shell-x')).toBe(true);
+    });
   });
 
   it('given an unreachable control plane, should KEEP the row so a retry can find the process', async () => {

--- a/packages/lib/src/services/agent-workspaces/workspace-shells.ts
+++ b/packages/lib/src/services/agent-workspaces/workspace-shells.ts
@@ -20,7 +20,7 @@
  * module executes those verdicts.
  */
 
-import type { SandboxHost } from '../sandbox/sandbox-host';
+import { LocalEnvUnsupportedError, type SandboxHost } from '../sandbox/sandbox-host';
 import { SANDBOX_ROOT } from '../sandbox/sandbox-paths';
 import { planSpawnShell, planKillTarget } from '../../agent-workspaces/plan-spawn-worker';
 import type { ShellAgentType, ShellDTO } from '../../agent-workspaces/shells-contract';
@@ -169,7 +169,9 @@ export interface KillSessionShellDeps {
 export type KillSessionShellResult =
   /** `killed: false` means there was nothing left to kill — see the 404-as-success note below. */
   | { ok: true; killed: boolean }
-  | { ok: false; reason: 'error' };
+  | { ok: false; reason: 'error' }
+  /** The machine's substrate has no stream surface to kill through — see {@link KillShellProcessResult}. Kept distinct from `error` so a caller does not advise a retry that can never succeed. */
+  | { ok: false; reason: 'unsupported' };
 
 /**
  * What {@link killShellProcess} learned. `ok: false` means we learned NOTHING —
@@ -179,7 +181,18 @@ export type KillSessionShellResult =
  * launched" and "its sandbox is gone" are the same fact to every caller, which
  * is that no process of this shell's is left to worry about.
  */
-export type KillShellProcessResult = { ok: true } | { ok: false; reason: 'error' };
+export type KillShellProcessResult =
+  | { ok: true }
+  | { ok: false; reason: 'error' }
+  /**
+   * The machine's substrate has no interactive-stream surface on this seam, so
+   * there is no `killSession` to call — a LOCAL environment (invariant 12:
+   * `stream: false` is advertised, never faked). Deliberately NOT `ok: true`:
+   * success here means "the process is confirmed gone", and every caller acts
+   * on it by dropping the row that is the only thing pointing at it. Saying
+   * so about a process this seam cannot reach would orphan it.
+   */
+  | { ok: false; reason: 'unsupported' };
 
 /**
  * THE PTY HALF, on its own — the only part of a kill that leaves the database.
@@ -223,12 +236,25 @@ export async function killShellProcess({
   // A vanished sandbox has nothing left running; the row is still dropped.
   if (!handle) return { ok: true };
 
+  // The substrate has no stream surface at all, so no id here was ever opened
+  // through it. Answered from the advertised capability rather than from the
+  // refusal below purely so the reason is named before anything is attempted.
+  //
+  // `=== false` rather than `!`: only a handle that DECLARES it cannot stream
+  // is refused here. An absent declaration is not a claim, and treating it as
+  // one would refuse every handle a caller built dynamically — the type makes
+  // the field required, so a real host that forgot it fails at compile time,
+  // which is where that mistake belongs. The typed error below is the net
+  // that catches a handle which refuses without having advertised it.
+  if (handle.capabilities?.stream === false) return { ok: false, reason: 'unsupported' };
+
   try {
     // The kill-by-id endpoint reaches this session whether or not we hold a
     // live stream to it, and is idempotent against an already-dead id — so
     // anything that throws here is a real unknown, not "already gone".
     await handle.killSession(row.spriteExecId);
-  } catch {
+  } catch (error) {
+    if (error instanceof LocalEnvUnsupportedError) return { ok: false, reason: 'unsupported' };
     return { ok: false, reason: 'error' };
   }
   return { ok: true };

--- a/packages/lib/src/services/drive-envs/__tests__/env-provision-deps.test.ts
+++ b/packages/lib/src/services/drive-envs/__tests__/env-provision-deps.test.ts
@@ -331,10 +331,63 @@ describe('ensureDriveEnvSandbox', () => {
       expect(noopStore.recordStorageMeasurement).not.toHaveBeenCalled();
     });
 
-    it('given this PROCESS holds no bridge registry (the realtime tier), should still refuse substrate_unsupported rather than fall through to the Sprite host', async () => {
+    /**
+     * `substrate_unsupported` survives t09 with ONE narrowed meaning: this
+     * PROCESS cannot reach local environments. The bridge socket terminates in
+     * apps/web and the realtime tier runs this same function, so it must
+     * refuse rather than fall through to `deps.host` — the Sprite host. It is
+     * easy to mistake for the old blanket refusal, so the distinction is
+     * pinned: an allowed, connected machine reaches this verdict ONLY when the
+     * registry seam is absent, and the same row WITH the seam binds.
+     */
+    it('given this PROCESS holds no bridge registry (the realtime tier), should refuse substrate_unsupported rather than fall through to the Sprite host', async () => {
       const { result, host } = await ensureLocal({ sibling: sibling(), local: null });
       expect(result).toEqual({ ok: false, reason: 'local_refused', refusal: 'substrate_unsupported', detail: 'substrate_unsupported' });
       expect(host.provision).not.toHaveBeenCalled();
+    });
+
+    it('substrate_unsupported should mean ONLY that — the identical row binds as soon as the registry seam is supplied', async () => {
+      const withoutRegistry = await ensureLocal({ sibling: sibling(), local: null });
+      const withRegistry = await ensureLocal({ sibling: sibling() });
+
+      expect(withoutRegistry.result).toMatchObject({ ok: false, refusal: 'substrate_unsupported' });
+      expect(withRegistry.result).toMatchObject({ ok: true });
+    });
+
+    /**
+     * Invariant 9, stated as the thing that would break it. The address a
+     * local bind hands back is DERIVED — `local-env:<envId>` — and it exists
+     * only inside the request. Persisting it anywhere would put the row into
+     * the reclaim, storage-billing and egress predicates that key on those
+     * columns, which is exactly the visibility a local env must never have.
+     */
+    it('should never hand the derived address to the STORE — not as a Sprite pointer, not in any other argument', async () => {
+      const { result } = await ensureLocal({ sibling: sibling() });
+      expect(result).toMatchObject({ ok: true, sandboxId: localEnvSandboxId(ENV_ID) });
+
+      const everyArgument = JSON.stringify(
+        Object.values(noopStore).map((fn) => fn.mock.calls),
+      );
+      expect(everyArgument).not.toContain(localEnvSandboxId(ENV_ID));
+      expect(everyArgument).not.toContain('local-env:');
+    });
+
+    it("should leave the row's sandboxId NULL after a bind, an exec and a reconnect", async () => {
+      const local = spyLocalHost();
+      const { result } = await ensureLocal({ sibling: sibling(), local });
+      if (!result.ok) throw new Error(`expected a bind, got ${JSON.stringify(result)}`);
+
+      // The full round trip a tool call makes: bind, run, re-open by address.
+      const handle = await local.host.provision({ name: ENV_ID, substrate: { kind: 'local', envId: ENV_ID }, options: {} });
+      await local.host.attach({ sandboxId: handle.sandboxId });
+
+      // The row this env provisioned from is unchanged: t05's CHECK keeps these
+      // NULL, and nothing here even attempted to write them.
+      expect(localRow.sandboxId).toBeNull();
+      expect(localRow.spriteInstanceId).toBeNull();
+      expect(localRow.spriteKey).toBeNull();
+      expect(noopStore.updateSpriteIdentity).not.toHaveBeenCalled();
+      expect(noopStore.enqueueReclaim).not.toHaveBeenCalled();
     });
 
     it('given the connection drops between the gate and the bind, should answer the SAME not_connected word the gate would have used', async () => {

--- a/packages/lib/src/services/drive-envs/__tests__/env-provision-deps.test.ts
+++ b/packages/lib/src/services/drive-envs/__tests__/env-provision-deps.test.ts
@@ -43,7 +43,13 @@ import { makeLocalRecord } from './fakes';
 import { deriveDriveEnvSpriteKey } from '../../../drive-envs/env-sprite-key';
 import { deriveAgentSessionSpriteKey } from '../../../agent-workspaces/workspace-sprite-key';
 import type { DriveEnvRecord, DriveEnvStore } from '../drive-envs-store';
-import type { SandboxHost } from '../../sandbox/sandbox-host';
+import {
+  localEnvSandboxId,
+  LOCAL_ENV_SANDBOX_CAPABILITIES,
+  LocalEnvNotConnectedError,
+  type SandboxHandle,
+  type SandboxHost,
+} from '../../sandbox/sandbox-host';
 
 const ENV_ID = 'env-1';
 const DRIVE_ID = 'drive-1';
@@ -253,8 +259,31 @@ describe('ensureDriveEnvSandbox', () => {
       return { host: { provision, attach, kill: vi.fn() } as unknown as SandboxHost, provision, attach };
     }
 
-    async function ensureLocal(input: { sibling: ReturnType<typeof makeLocalRecord> | null; liveConnection?: () => 'connecting' | 'connected' | null; flag?: boolean; role?: 'admin' | 'member' }) {
+    /**
+     * A stand-in for the local `SandboxHost` the registry builds in apps/web.
+     * It is a SEPARATE spy from the Sprite host, which is what lets every row
+     * below assert the negative — the Sprite host is never touched — while the
+     * CONTROL row proves the harness genuinely does reach it for a Sprite env.
+     */
+    function spyLocalHost(over: Partial<SandboxHost> = {}) {
+      const provision = vi.fn(
+        async (_args: Parameters<SandboxHost['provision']>[0]) =>
+          ({ sandboxId: localEnvSandboxId(ENV_ID), spriteInstanceId: 'epoch-1', capabilities: LOCAL_ENV_SANDBOX_CAPABILITIES }) as unknown as SandboxHandle,
+      );
+      const host = { provision, attach: vi.fn(async () => null), kill: vi.fn(async () => {}), ...over } as unknown as SandboxHost;
+      const resolveLocalHost = vi.fn(async () => host);
+      return { host, provision, resolveLocalHost };
+    }
+
+    async function ensureLocal(input: {
+      sibling: ReturnType<typeof makeLocalRecord> | null;
+      liveConnection?: () => 'connecting' | 'connected' | null;
+      flag?: boolean;
+      role?: 'admin' | 'member';
+      local?: ReturnType<typeof spyLocalHost> | null;
+    }) {
       const host = spyHost();
+      const local = input.local === undefined ? spyLocalHost() : input.local;
       const result = await ensureDriveEnvSandbox({
         envId: ENV_ID,
         intent: 'ensure',
@@ -266,23 +295,64 @@ describe('ensureDriveEnvSandbox', () => {
           liveConnection: input.liveConnection ?? (() => 'connected'),
           localEnvsEnabled: input.flag ?? true,
           resolveActorRole: async () => input.role ?? 'member',
+          ...(local ? { resolveLocalHost: local.resolveLocalHost } : {}),
         },
       });
-      return { result, host };
+      return { result, host, local };
     }
 
-    it('given a connected, enrolled machine the owner may bind to, should answer local_refused/substrate_unsupported (no local host yet) and NOT call the Sprite host', async () => {
-      const { result, host } = await ensureLocal({ sibling: sibling() });
-      expect(result).toEqual({ ok: false, reason: 'local_refused', refusal: 'substrate_unsupported', detail: 'substrate_unsupported' });
+    it('given a connected, enrolled machine the owner may bind to, should provision through the LOCAL host and NOT the Sprite host (t09)', async () => {
+      const { result, host, local } = await ensureLocal({ sibling: sibling() });
+
+      expect(result).toEqual({ ok: true, sandboxId: localEnvSandboxId(ENV_ID), resumed: true });
+      expect(local!.provision).toHaveBeenCalledTimes(1);
+      expect(local!.provision.mock.calls[0][0]).toMatchObject({ name: ENV_ID, substrate: { kind: 'local', envId: ENV_ID } });
       expect(host.provision).not.toHaveBeenCalled();
       expect(host.attach).not.toHaveBeenCalled();
+    });
+
+    it('should report the bind as RESUMED — PageSpace did not create this machine and could not have', async () => {
+      const { result } = await ensureLocal({ sibling: sibling() });
+      expect(result).toMatchObject({ ok: true, resumed: true });
+    });
+
+    /**
+     * Invariant 9: a local env's Sprite columns stay NULL, which is the whole
+     * reason it is structurally invisible to reclaim, storage billing and the
+     * egress predicates. A single identity/stamp/reclaim write here would put
+     * it back into queries that must never see it.
+     */
+    it('should write NOTHING to the row — no identity CAS, no stamps, no reclaim, no storage measurement', async () => {
+      await ensureLocal({ sibling: sibling() });
+
       expect(noopStore.updateSpriteIdentity).not.toHaveBeenCalled();
+      expect(noopStore.applyStamps).not.toHaveBeenCalled();
+      expect(noopStore.enqueueReclaim).not.toHaveBeenCalled();
+      expect(noopStore.recordStorageMeasurement).not.toHaveBeenCalled();
+    });
+
+    it('given this PROCESS holds no bridge registry (the realtime tier), should still refuse substrate_unsupported rather than fall through to the Sprite host', async () => {
+      const { result, host } = await ensureLocal({ sibling: sibling(), local: null });
+      expect(result).toEqual({ ok: false, reason: 'local_refused', refusal: 'substrate_unsupported', detail: 'substrate_unsupported' });
+      expect(host.provision).not.toHaveBeenCalled();
+    });
+
+    it('given the connection drops between the gate and the bind, should answer the SAME not_connected word the gate would have used', async () => {
+      const local = spyLocalHost({
+        provision: vi.fn(async () => {
+          throw new LocalEnvNotConnectedError(ENV_ID);
+        }) as unknown as SandboxHost['provision'],
+      });
+      const { result, host } = await ensureLocal({ sibling: sibling(), local });
+      expect(result).toEqual({ ok: false, reason: 'local_refused', refusal: 'not_connected', detail: 'not_connected' });
+      expect(host.provision).not.toHaveBeenCalled();
     });
 
     it('given the machine is NOT connected, should answer the typed not_connected — never a Sprite provision, never a queue', async () => {
-      const { result, host } = await ensureLocal({ sibling: sibling({ lastSeenAt: null }), liveConnection: () => null });
+      const { result, host, local } = await ensureLocal({ sibling: sibling({ lastSeenAt: null }), liveConnection: () => null });
       expect(result).toEqual({ ok: false, reason: 'local_refused', refusal: 'not_connected', detail: 'not_connected' });
       expect(host.provision).not.toHaveBeenCalled();
+      expect(local!.resolveLocalHost).not.toHaveBeenCalled();
     });
 
     it('given a revoked machine, should answer revoked and touch no host', async () => {
@@ -292,9 +362,12 @@ describe('ensureDriveEnvSandbox', () => {
     });
 
     it('given LOCAL_ENVS_ENABLED off, should answer flag_disabled (invariant 11) and touch no host', async () => {
-      const { result, host } = await ensureLocal({ sibling: sibling(), flag: false });
+      const { result, host, local } = await ensureLocal({ sibling: sibling(), flag: false });
       expect(result).toMatchObject({ ok: false, reason: 'local_refused', refusal: 'flag_disabled' });
       expect(host.provision).not.toHaveBeenCalled();
+      // Requirement: with the flag unset NO local host is ever constructed.
+      expect(local!.resolveLocalHost).not.toHaveBeenCalled();
+      expect(local!.provision).not.toHaveBeenCalled();
     });
 
     it('given canRunCode denies, should answer code_exec_denied with the cause as detail — the base gate is consulted with the DRIVE OWNER as payer', async () => {
@@ -306,9 +379,10 @@ describe('ensureDriveEnvSandbox', () => {
     });
 
     it("given a requester who is not the machine's owner under owner-only policy, should answer bind_policy", async () => {
-      const { result, host } = await ensureLocal({ sibling: sibling({ ownerId: 'someone-else' }), role: 'admin' });
+      const { result, host, local } = await ensureLocal({ sibling: sibling({ ownerId: 'someone-else' }), role: 'admin' });
       expect(result).toMatchObject({ ok: false, reason: 'local_refused', refusal: 'bind_policy' });
       expect(host.provision).not.toHaveBeenCalled();
+      expect(local!.resolveLocalHost).not.toHaveBeenCalled();
     });
 
     it('given a local env whose sibling is gone (owner erased), should answer revoked and touch no host', async () => {

--- a/packages/lib/src/services/drive-envs/env-provision-deps.ts
+++ b/packages/lib/src/services/drive-envs/env-provision-deps.ts
@@ -312,6 +312,16 @@ export async function ensureDriveEnvSandbox({
  * - **`resumed: true`, always.** The machine was already running: PageSpace
  *   did not create it and could not have. Reporting a `create` would tell the
  *   caller's revival/measurement paths that a fresh filesystem exists.
+ *
+ * The provision INTENT is deliberately not consulted, and that is not an
+ * oversight. `ensure` / `reprovision` / `attach` distinguish creating a VM,
+ * replacing one, and reconnecting without resurrecting — three things that
+ * only mean something to a substrate PageSpace mints. Here there is one
+ * machine, it exists whether or not anyone is looking at it, and binding to it
+ * creates nothing, so every intent resolves to the same read of the live
+ * socket. (`ensureAgentSessionSandbox` still refuses `attach` on an ended
+ * session before this is reached, so an ended row cannot be revived through
+ * it.)
  */
 async function ensureLocalEnvSandbox({
   row,

--- a/packages/lib/src/services/drive-envs/env-provision-deps.ts
+++ b/packages/lib/src/services/drive-envs/env-provision-deps.ts
@@ -40,7 +40,7 @@ import {
   type SpriteHolderProvisionDeps,
   type SpriteHolderProvisionIntent,
 } from '../agent-workspaces/agent-workspace-sprite';
-import type { SandboxHost } from '../sandbox/sandbox-host';
+import { LocalEnvNotConnectedError, type SandboxHost } from '../sandbox/sandbox-host';
 import type { SubscriptionTier } from '../subscription-utils';
 import type { DriveEnvRecord, DriveEnvStore } from './drive-envs-store';
 import { isLocalEnvsEnabled } from './local-envs-enabled';
@@ -196,6 +196,21 @@ export interface EnsureDriveEnvSandboxDeps {
   resolveActorRole?: (input: { userId: string; driveId: string }) => Promise<ActorRole>;
   /** LOCAL envs only. `LOCAL_ENVS_ENABLED`; read from the environment when absent. */
   localEnvsEnabled?: boolean;
+  /**
+   * LOCAL envs only (t09). The `SandboxHost` that reaches this env's machine
+   * over the bridge, built per env and per requester — never the Sprite host,
+   * and never process-cached (the transport it closes over is bound to one
+   * grant principal).
+   *
+   * OPTIONAL, and its absence is a REFUSAL rather than a fallback. The bridge
+   * socket terminates in apps/web (`ws-env-connections.ts`), so a process that
+   * holds no registry — the realtime tier, which runs this exact same
+   * `ensureDriveEnvSandbox` — genuinely cannot reach the machine. It answers
+   * `substrate_unsupported`, which is now narrowed to mean precisely that:
+   * "this process cannot reach local environments". It never falls through to
+   * the Sprite host.
+   */
+  resolveLocalHost?: (input: { envId: string; requesterId: string }) => Promise<SandboxHost>;
 }
 
 /**
@@ -261,14 +276,10 @@ export async function ensureDriveEnvSandbox({
   const row = await deps.store.findById(envId);
   if (!row) return { ok: false, reason: 'provision_failed', detail: 'env_not_found' };
   // C1: a LOCAL env never reaches the Sprite host. The pure planners decide
-  // (via the gate); an allowed, connected machine is still refused here as
-  // `substrate_unsupported` until the local SandboxHost lands (t09) — a typed
-  // refusal, never a Sprite minted for a row the t05 CHECK would reject.
-  if (row.substrate === 'local') {
-    const verdict = await gateLocalEnvForRequester({ row, requesterId, deps });
-    if (!verdict.ok) return { ok: false, reason: 'local_refused', refusal: verdict.refusal, detail: verdict.cause ?? verdict.refusal };
-    return { ok: false, reason: 'local_refused', refusal: 'substrate_unsupported', detail: 'substrate_unsupported' };
-  }
+  // (via the gate), and t09 replaces the flat refusal that stood here with the
+  // real local host — keeping every typed verdict for every case that still
+  // refuses, and changing only the connected-and-allowed one.
+  if (row.substrate === 'local') return ensureLocalEnvSandbox({ row, requesterId, deps });
   const payer = await deps.resolvePayer(row.driveId);
   if (!payer) return { ok: false, reason: 'provision_failed', detail: 'drive_not_found' };
   return ensureSpriteHolderSandbox({
@@ -279,4 +290,66 @@ export async function ensureDriveEnvSandbox({
     intent,
     deps: buildEnvProvisionDeps({ row, payer, requesterId, store: deps.store, host: deps.host }),
   });
+}
+
+/**
+ * Bind an allowed, connected LOCAL env to its machine.
+ *
+ * The shape of this function is the whole of t09's provision threading, and
+ * three things about it are load-bearing:
+ *
+ * - **The gate runs first and is unchanged.** Every refusal keeps the exact
+ *   typed verdict t06b established (`flag_disabled`, `code_exec_denied`,
+ *   `not_local`, `revoked`, `not_connected`, `bind_policy`) — this task
+ *   changes what happens after an `ok`, and nothing about what happens before.
+ * - **Nothing is written to the row.** Invariant 9 keeps every Sprite column
+ *   NULL on a local env, which is what makes it structurally invisible to
+ *   reclaim, storage billing and the egress predicates. So there is no
+ *   identity CAS, no stamp, no reclaim enqueue and no storage measurement
+ *   here — all of which the Sprite arm does, and every one of which would put
+ *   a local row into a query that must never see it. The returned `sandboxId`
+ *   is the DERIVED address (`localEnvSandboxId`), alive only for this request.
+ * - **`resumed: true`, always.** The machine was already running: PageSpace
+ *   did not create it and could not have. Reporting a `create` would tell the
+ *   caller's revival/measurement paths that a fresh filesystem exists.
+ */
+async function ensureLocalEnvSandbox({
+  row,
+  requesterId,
+  deps,
+}: {
+  row: DriveEnvRecord;
+  requesterId: string;
+  deps: EnsureDriveEnvSandboxDeps;
+}): Promise<EnsureSpriteHolderSandboxResult> {
+  const verdict = await gateLocalEnvForRequester({ row, requesterId, deps });
+  if (!verdict.ok) return { ok: false, reason: 'local_refused', refusal: verdict.refusal, detail: verdict.cause ?? verdict.refusal };
+
+  // No registry in this process (see `resolveLocalHost`). A typed refusal, and
+  // deliberately NOT a fall-through to `deps.host`, which is the Sprite host.
+  if (!deps.resolveLocalHost) {
+    return { ok: false, reason: 'local_refused', refusal: 'substrate_unsupported', detail: 'substrate_unsupported' };
+  }
+
+  const localHost = await deps.resolveLocalHost({ envId: row.id, requesterId });
+  try {
+    const handle = await localHost.provision({
+      // The env id IS the name: a local machine has one identity, its
+      // enrollment, and there is no keyspace to fold — `deriveDriveEnvSpriteKey`
+      // exists to keep two Sprite holders from colliding on a shared namespace,
+      // and a local env holds no Sprite.
+      name: row.id,
+      substrate: { kind: 'local', envId: row.id },
+      options: {},
+    });
+    return { ok: true, sandboxId: handle.sandboxId, resumed: true };
+  } catch (error) {
+    // The connection dropped between the gate's reading and the bind. The
+    // refusal is the same word the gate would have used, so a caller sees one
+    // vocabulary for one condition however it was detected.
+    if (error instanceof LocalEnvNotConnectedError) {
+      return { ok: false, reason: 'local_refused', refusal: 'not_connected', detail: 'not_connected' };
+    }
+    return { ok: false, reason: 'provision_failed', detail: error instanceof Error ? error.message : String(error) };
+  }
 }

--- a/packages/lib/src/services/sandbox/__tests__/machine-diff.test.ts
+++ b/packages/lib/src/services/sandbox/__tests__/machine-diff.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect } from 'vitest';
 import { listMachineDiffFiles, readMachineDiffPair, resolveMachineMergeBase } from '../machine-diff';
 import type { GitSandboxRunDeps } from '../git-tool-runners';
-import type { SandboxHandle } from '../sandbox-host';
+import { SPRITE_SANDBOX_CAPABILITIES, type SandboxHandle } from '../sandbox-host';
 import type { SandboxActorContext } from '../tool-runners';
 import type { ExecutableSandbox, RunCommandArgs, SandboxRunResult } from '../sandbox-client/types';
 
@@ -70,6 +70,7 @@ function scriptGit(
 function makeHandle(files: Record<string, string>): { handle: SandboxHandle; reads: string[] } {
   const reads: string[] = [];
   const handle: SandboxHandle = {
+    capabilities: SPRITE_SANDBOX_CAPABILITIES,
     sandboxId: 'sbx-1',
     spriteInstanceId: null,
     exec: async () => ({ exitCode: 0, stdout: '', stderr: '' }),

--- a/packages/lib/src/services/sandbox/__tests__/machine-fs.test.ts
+++ b/packages/lib/src/services/sandbox/__tests__/machine-fs.test.ts
@@ -9,7 +9,7 @@ import {
   deleteMachinePath,
   verifyMachinePathsWithinScope,
 } from '../machine-fs';
-import type { SandboxHandle } from '../sandbox-host';
+import { SPRITE_SANDBOX_CAPABILITIES, type SandboxHandle } from '../sandbox-host';
 import type { RunCommandArgs, SandboxRunResult } from '../sandbox-client/types';
 import type { WriteFileEntry } from '../sandbox-client/types';
 
@@ -24,6 +24,7 @@ function makeHandle(overrides: {
   writeFiles?: (files: WriteFileEntry[]) => Promise<void>;
 }): SandboxHandle {
   return {
+    capabilities: SPRITE_SANDBOX_CAPABILITIES,
     sandboxId: 'sbx-test',
     spriteInstanceId: null,
     exec: overrides.exec ?? (async () => ({ exitCode: 0, stdout: '', stderr: '' })),

--- a/packages/lib/src/services/sandbox/__tests__/tool-runners.test.ts
+++ b/packages/lib/src/services/sandbox/__tests__/tool-runners.test.ts
@@ -7,6 +7,8 @@ import {
   editSandboxFile,
   MAX_WRITE_BYTES,
   CHECKPOINT_TIMEOUT_MS,
+  DENIAL_MESSAGES,
+  localRefusalToToolDenial,
   type SandboxActorContext,
   type SandboxRunDeps,
 } from '../tool-runners';
@@ -15,6 +17,7 @@ import type { CodeExecutionAuditInput } from '../audit';
 import { SANDBOX_ROOT } from '../sandbox-paths';
 import { DEFAULT_READ_LINES, SANDBOX_MAX_OUTPUT_BYTES, MAX_LINE_BYTES } from '../execution-policy';
 import { LINE_ELISION_MARKER } from '../output-limit';
+import { LocalEnvUnsupportedError } from '../sandbox-host';
 
 const NOW = new Date('2026-06-01T12:00:00.000Z');
 
@@ -694,6 +697,87 @@ describe('runBashInSandbox — pre-batch checkpoint (Sprites Platform Alignment 
     expect(result).toMatchObject({ success: true });
     expect(created).toEqual([{ sandboxId: 'sbx-1', comment: 'pagespace-pre-agent-turn-1' }]);
     expect(order).toEqual(['checkpoint', 'run']);
+  });
+
+  /**
+   * C13 / invariant 12. A substrate that CANNOT snapshot its filesystem must
+   * not run a destructive agent batch unprotected — and the refusal has to be
+   * observable at the CALLER, not merely thrown by the host, because the
+   * caller is the thing that decides whether the command runs.
+   */
+  describe('a substrate that cannot checkpoint fails CLOSED (C13, invariant 12)', () => {
+    const localCaps = { exec: true, fs: true, stream: false, checkpoint: false, preview: false, services: false } as const;
+
+    it('given a sandbox advertising checkpoint:false, should REFUSE the batch with a typed reason and run nothing', async () => {
+      const { checkpoint, created } = makeCheckpointDeps();
+      let ran = 0;
+      const { deps } = makeDeps({
+        checkpoint,
+        reconnect: async () =>
+          makeSandbox({
+            capabilities: localCaps,
+            runCommand: async () => {
+              ran += 1;
+              return { exitCode: 0, stdout: 'ok', stderr: '' };
+            },
+          }),
+      });
+
+      const result = await runBashInSandbox({ command: 'rm -rf /workspace', ctx: makeCtx({ turnId: 'turn-1' }), deps });
+
+      expect(result).toMatchObject({ success: false, reason: 'checkpoint_unsupported' });
+      expect(ran).toBe(0);
+      expect(created).toEqual([]);
+    });
+
+    it('given the host itself throws the typed unsupported error, should ALSO refuse — never swallow it as a fail-open checkpoint failure', async () => {
+      const { checkpoint } = makeCheckpointDeps({
+        createCheckpoint: async () => {
+          throw new LocalEnvUnsupportedError('createCheckpoint', 'env-1');
+        },
+      });
+      let ran = 0;
+      const { deps } = makeDeps({
+        checkpoint,
+        // No advertised capabilities at all: the error is the ONLY signal, so
+        // this row proves the second net works on its own.
+        reconnect: async () =>
+          makeSandbox({
+            runCommand: async () => {
+              ran += 1;
+              return { exitCode: 0, stdout: 'ok', stderr: '' };
+            },
+          }),
+      });
+
+      const result = await runBashInSandbox({ command: 'rm -rf /workspace', ctx: makeCtx({ turnId: 'turn-1' }), deps });
+
+      expect(result).toMatchObject({ success: false, reason: 'checkpoint_unsupported' });
+      expect(ran).toBe(0);
+    });
+
+    it('given checkpoint:false but the POLICY wants no checkpoint (flag off), should still run — there is nothing to be unprotected about', async () => {
+      const { checkpoint, created } = makeCheckpointDeps({ isEnabled: () => false });
+      const { deps } = makeDeps({ checkpoint, reconnect: async () => makeSandbox({ capabilities: localCaps }) });
+
+      const result = await runBashInSandbox({ command: 'echo hi', ctx: makeCtx({ turnId: 'turn-1' }), deps });
+
+      expect(result).toMatchObject({ success: true });
+      expect(created).toEqual([]);
+    });
+
+    it('CONTROL: the same batch on a sandbox advertising checkpoint:true runs — proving the refusals above are load-bearing', async () => {
+      const { checkpoint, created } = makeCheckpointDeps();
+      const { deps } = makeDeps({
+        checkpoint,
+        reconnect: async () => makeSandbox({ capabilities: { ...localCaps, checkpoint: true } }),
+      });
+
+      const result = await runBashInSandbox({ command: 'rm -rf /workspace', ctx: makeCtx({ turnId: 'turn-1' }), deps });
+
+      expect(result).toMatchObject({ success: true });
+      expect(created).toEqual([{ sandboxId: 'sbx-1', comment: 'pagespace-pre-agent-turn-1' }]);
+    });
   });
 
   it('given the flag off, should never call createCheckpoint', async () => {
@@ -1834,3 +1918,46 @@ describe('readSandboxFileForCopy', () => {
     expect(result.content).toBe(tricky);
   });
 });
+
+/**
+ * Requirement 6: a caller who cannot tell "your machine is not connected" from
+ * "your machine's owner denied you" debugs the wrong layer. Both the reason
+ * word and the copy the agent actually reads are pinned here.
+ */
+describe('a LOCAL environment\'s two refusals stay distinguishable all the way to the agent', () => {
+  it('should map not_connected and bind_policy to reasons of their own', () => {
+    expect(localRefusalToToolDenial('not_connected')).toBe('local_not_connected');
+    expect(localRefusalToToolDenial('bind_policy')).toBe('local_bind_denied');
+    expect(localRefusalToToolDenial('not_connected')).not.toBe(localRefusalToToolDenial('bind_policy'));
+  });
+
+  it.each(['flag_disabled', 'code_exec_denied', 'not_local', 'revoked', 'substrate_unsupported', undefined])(
+    'should leave %s to the caller\'s generic provisioning fault — the requester can do nothing about it',
+    (refusal) => {
+      expect(localRefusalToToolDenial(refusal)).toBeNull();
+    },
+  );
+
+  it('should give each one COPY that names who can fix it, and never the same sentence twice', () => {
+    const notConnected = DENIAL_MESSAGES.local_not_connected;
+    const denied = DENIAL_MESSAGES.local_bind_denied;
+
+    expect(notConnected).toContain('pagespace env connect');
+    expect(denied).toContain('owner');
+    expect(denied).toContain('Retrying will not help');
+    expect(notConnected).not.toBe(denied);
+    expect(notConnected).not.toBe(DENIAL_MESSAGES.provision_failed);
+    expect(denied).not.toBe(DENIAL_MESSAGES.provision_failed);
+  });
+
+  it.each(['local_not_connected', 'local_bind_denied', 'checkpoint_unsupported'] as const)(
+    'given acquire answers %s, the agent should receive that reason with its own message',
+    async (reason) => {
+      const { deps } = makeDeps({ acquireSandbox: async () => ({ ok: false, reason }) });
+      const result = await runBashInSandbox({ command: 'echo hi', ctx: makeCtx(), deps });
+
+      expect(result).toEqual({ success: false, reason, error: DENIAL_MESSAGES[reason] });
+    },
+  );
+});
+

--- a/packages/lib/src/services/sandbox/__tests__/tool-runners.test.ts
+++ b/packages/lib/src/services/sandbox/__tests__/tool-runners.test.ts
@@ -766,6 +766,37 @@ describe('runBashInSandbox — pre-batch checkpoint (Sprites Platform Alignment 
       expect(created).toEqual([]);
     });
 
+    /**
+     * The refusal happens AFTER the code-execution slot is acquired, so it must
+     * go through the same `finally` every other exit does. A leaked slot is
+     * invisible — nothing downstream fails — until the semaphore fills and
+     * stops code execution for that user on EVERY substrate, not just the local
+     * one that was refused.
+     */
+    it('should RELEASE the code-execution slot it acquired — a refusal must not leak the semaphore', async () => {
+      const { checkpoint } = makeCheckpointDeps();
+      const { deps, slots } = makeDeps({ checkpoint, reconnect: async () => makeSandbox({ capabilities: localCaps }) });
+
+      const result = await runBashInSandbox({ command: 'rm -rf /workspace', ctx: makeCtx({ turnId: 'turn-1' }), deps });
+
+      expect(result).toMatchObject({ success: false, reason: 'checkpoint_unsupported' });
+      expect(slots.acquired).toBe(1);
+      expect(slots.released).toBe(slots.acquired);
+    });
+
+    it('should release it on the typed-error path too', async () => {
+      const { checkpoint } = makeCheckpointDeps({
+        createCheckpoint: async () => {
+          throw new LocalEnvUnsupportedError('createCheckpoint', 'env-1');
+        },
+      });
+      const { deps, slots } = makeDeps({ checkpoint, reconnect: async () => makeSandbox() });
+
+      await runBashInSandbox({ command: 'rm -rf /workspace', ctx: makeCtx({ turnId: 'turn-1' }), deps });
+
+      expect(slots.released).toBe(slots.acquired);
+    });
+
     it('CONTROL: the same batch on a sandbox advertising checkpoint:true runs — proving the refusals above are load-bearing', async () => {
       const { checkpoint, created } = makeCheckpointDeps();
       const { deps } = makeDeps({

--- a/packages/lib/src/services/sandbox/preview/__tests__/dev-preview-status.test.ts
+++ b/packages/lib/src/services/sandbox/preview/__tests__/dev-preview-status.test.ts
@@ -4,7 +4,7 @@
  */
 import { describe, it, expect } from 'vitest';
 import { assert } from '../../__tests__/riteway';
-import type { SandboxHandle, SandboxServiceInfo } from '../../sandbox-host';
+import { SPRITE_SANDBOX_CAPABILITIES, type SandboxHandle, type SandboxServiceInfo } from '../../sandbox-host';
 import type { DevPreviewHolderRef, DevPreviewRow } from '../dev-preview-core';
 import { HTTP_PORT_BUSY_MESSAGE, describeServiceState } from '../dev-preview-core';
 import type { DevPreviewRecord, DevPreviewStore } from '../dev-preview-store';
@@ -45,6 +45,7 @@ function row(targetPort: number, overrides: Partial<DevPreviewRecord> = {}): Dev
 function fakeHandle(over: { relay?: SandboxServiceInfo | null; instance?: string | null; calls?: string[] } = {}): SandboxHandle {
   const calls = over.calls ?? [];
   return {
+    capabilities: SPRITE_SANDBOX_CAPABILITIES,
     sandboxId: 'sbx',
     spriteInstanceId: over.instance === undefined ? INSTANCE : over.instance,
     exec: async () => { calls.push('exec'); return { exitCode: 1, stdout: '', stderr: '' }; },

--- a/packages/lib/src/services/sandbox/preview/__tests__/preview-access.test.ts
+++ b/packages/lib/src/services/sandbox/preview/__tests__/preview-access.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from 'vitest';
 import { assert } from '../../__tests__/riteway';
-import type { SandboxHandle, SandboxServiceInfo } from '../../sandbox-host';
+import { LocalEnvUnsupportedError, SPRITE_SANDBOX_CAPABILITIES, type SandboxCapabilities, type SandboxHandle, type SandboxServiceInfo } from '../../sandbox-host';
 import { authorizePreviewHolder, resolvePreviewTarget, type PreviewAccessDeps, type PreviewEnvRow, type PreviewSessionRow } from '../preview-access';
 import type { DevPreviewRecord } from '../dev-preview-store';
 import { buildPreviewRelaySpec, PREVIEW_RELAY_SERVICE_NAME } from '../preview-relay';
@@ -23,8 +23,9 @@ const runningRelay = (targetPort = 5173): SandboxServiceInfo => {
   return { name: spec.name, command: spec.command, args: spec.args, status: 'running', pid: 1 };
 };
 
-function fakeHandle(over: Partial<{ power: 'running' | 'paused' | 'unknown'; url: string | null; auth: 'sprite' | 'public' | 'unknown'; relay: SandboxServiceInfo | null; instance: string | null }> = {}): SandboxHandle {
+function fakeHandle(over: Partial<{ power: 'running' | 'paused' | 'unknown'; url: string | null; auth: 'sprite' | 'public' | 'unknown'; relay: SandboxServiceInfo | null; instance: string | null; capabilities: SandboxCapabilities }> = {}): SandboxHandle {
   return {
+    capabilities: over.capabilities ?? SPRITE_SANDBOX_CAPABILITIES,
     sandboxId: 'sbx-env',
     spriteInstanceId: over.instance === undefined ? 'inst-1' : over.instance,
     exec: async () => ({ exitCode: 0, stdout: '', stderr: '' }),
@@ -169,5 +170,46 @@ describe('resolvePreviewTarget — the gather, in order', () => {
     const d = deps({ attach: async () => fakeHandle({ relay: { ...runningRelay(), status: 'failed', error: 'exited with code 143' } }) });
     const target = await resolvePreviewTarget({ holder, userId: USER, deps: d });
     assert({ given: 'failed relay', should: 'preview-down 502', actual: target.decision.kind === 'refuse' && [target.decision.reason, target.decision.status], expected: ['preview-down', 502] });
+  });
+});
+
+/**
+ * t09: a LOCAL environment has no dev-preview surface at all — `urlInfo`,
+ * `powerState` and `services.*` all refuse with a typed error. Three of the
+ * four calls in this function's gather would reject, so without the
+ * capability check the whole flow faults on whichever lost the race.
+ */
+describe('resolvePreviewTarget — a substrate with no preview surface', () => {
+  const holder = { kind: 'env', id: 'env1' } as const;
+  const noPreview: SandboxCapabilities = { ...SPRITE_SANDBOX_CAPABILITIES, preview: false, services: false };
+
+  const localHandle = (): SandboxHandle => {
+    const refuse = () => Promise.reject(new LocalEnvUnsupportedError('urlInfo', 'env1'));
+    return {
+      ...fakeHandle({ capabilities: noPreview }),
+      urlInfo: refuse,
+      powerState: refuse,
+      services: { create: refuse, list: refuse, get: refuse, start: refuse, stop: refuse, remove: refuse },
+    } as SandboxHandle;
+  };
+
+  it('should refuse with a typed preview-unsupported reason rather than faulting on the refusing members', async () => {
+    const target = await resolvePreviewTarget({ holder, userId: USER, deps: deps({ attach: async () => localHandle() }) });
+
+    expect(target.decision).toMatchObject({ kind: 'refuse', reason: 'preview-unsupported', status: 409 });
+  });
+
+  it('should never TOUCH the refusing members — the advertised capability answers first', async () => {
+    let touched = 0;
+    const handle = { ...localHandle(), powerState: async () => { touched += 1; return 'running' as const; } } as SandboxHandle;
+
+    await resolvePreviewTarget({ holder, userId: USER, deps: deps({ attach: async () => handle }) });
+
+    expect(touched).toBe(0);
+  });
+
+  it('CONTROL: the same request against a Sprite handle still forwards — proving the refusal above is load-bearing', async () => {
+    const target = await resolvePreviewTarget({ holder, userId: USER, deps: deps() });
+    expect(target.decision.kind).toBe('forward');
   });
 });

--- a/packages/lib/src/services/sandbox/preview/preview-access.ts
+++ b/packages/lib/src/services/sandbox/preview/preview-access.ts
@@ -186,6 +186,25 @@ export async function resolvePreviewTarget({
     return { decision: decidePreviewForward({ featureEnabled, authz, state: null, power: null, wakeAuthorization: 'not-consulted' }) as Extract<PreviewForwardDecision, { kind: 'refuse' }>, authorization };
   }
 
+  // A substrate with no preview surface is refused BEFORE the gather below:
+  // three of those four calls would reject with `LocalEnvUnsupportedError`,
+  // and `Promise.all` would surface whichever lost the race as an unhandled
+  // fault rather than as an answer this function is allowed to give.
+  // `=== false` — see `workspace-shells.ts`'s `killShellProcess` for why only a
+  // DECLARED absence refuses here.
+  if (handle.capabilities?.preview === false) {
+    return {
+      decision: {
+        kind: 'refuse',
+        reason: 'preview-unsupported',
+        status: 409,
+        message: 'This environment does not support dev previews.',
+        detail: 'substrate_has_no_preview_surface',
+      },
+      authorization,
+    };
+  }
+
   const [row, relay, power, urlInfo] = await Promise.all([
     deps.previewStore.findByHolder(holder),
     handle.services.get(PREVIEW_RELAY_SERVICE_NAME),

--- a/packages/lib/src/services/sandbox/preview/preview-forward-gate.ts
+++ b/packages/lib/src/services/sandbox/preview/preview-forward-gate.ts
@@ -89,7 +89,16 @@ export type PreviewForwardDecision =
         | 'http-port-busy'
         | 'preview-down'
         | 'preview-starting'
-        | 'wake-denied';
+        | 'wake-denied'
+        /**
+         * The machine's substrate has no dev-preview surface at all — a LOCAL
+         * environment (the user's own computer) advertises `preview: false`
+         * and its `urlInfo`/`powerState`/`services` members refuse with a
+         * typed error. Distinct from `preview-down`, which means a machine
+         * that HAS the surface is not serving on it: this one will never
+         * become available, so a client must not retry.
+         */
+        | 'preview-unsupported';
       /** Suggested HTTP status; the caller's not-found/denied policy may collapse it. */
       status: 403 | 404 | 409 | 502 | 503;
       /** Human copy for the response body — never a sprite name, URL or token. */

--- a/packages/lib/src/services/sandbox/sandbox-client/__tests__/local-env-sandbox-host.test.ts
+++ b/packages/lib/src/services/sandbox/sandbox-client/__tests__/local-env-sandbox-host.test.ts
@@ -1,0 +1,302 @@
+/**
+ * The LOCAL environment `SandboxHost` (M1 · t09).
+ *
+ * Driven entirely through an in-memory `BridgeTransport`, which is the whole
+ * point of the seam: the host has no socket, no crypto and no database of its
+ * own, so everything it decides is observable from the frames it hands the
+ * transport and the answers it accepts back.
+ *
+ * Two properties here are mutation-checked in the PR (they are the task's exit
+ * criterion): a DISCONNECTED env never yields a handle, and a result the
+ * transport refused is never returned.
+ */
+import { describe, it, expect, vi } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import {
+  createLocalEnvSandboxHost,
+  LocalEnvGrantDeniedError,
+  LocalEnvUnexpectedResultError,
+  type BridgeTransport,
+} from '../local-env-sandbox-host';
+import {
+  LOCAL_ENV_SANDBOX_CAPABILITIES,
+  LocalEnvNotConnectedError,
+  LocalEnvUnsupportedError,
+  localEnvSandboxId,
+  parseLocalEnvSandboxId,
+  SPRITE_SANDBOX_CAPABILITIES,
+} from '../../sandbox-host';
+import type { MachineResultFrame } from '../../../../env-bridge/machine-signatures';
+import type { UnsignedGrantFrame } from '../../../../env-bridge/grant-args';
+
+const ENV_ID = 'env-local-1';
+const EPOCH = 'sess-1:1700000000000';
+
+const b64 = (text: string) => Buffer.from(text, 'utf8').toString('base64');
+
+interface Fake {
+  transport: BridgeTransport;
+  sent: UnsignedGrantFrame[];
+  sendGrant: ReturnType<typeof vi.fn>;
+}
+
+function fakeTransport({
+  connected = true,
+  reply,
+}: {
+  connected?: boolean;
+  reply?: (frame: UnsignedGrantFrame) => Promise<MachineResultFrame>;
+} = {}): Fake {
+  const sent: UnsignedGrantFrame[] = [];
+  const sendGrant = vi.fn(async ({ frame }: { envId: string; frame: UnsignedGrantFrame }) => {
+    sent.push(frame);
+    if (!reply) throw new Error('no reply configured');
+    return reply(frame);
+  });
+  return {
+    sent,
+    sendGrant,
+    transport: {
+      sendGrant: (input) => sendGrant(input),
+      isConnected: () => connected,
+      connectionEpoch: () => (connected ? EPOCH : null),
+    },
+  };
+}
+
+const execReply = (over: Partial<Extract<MachineResultFrame, { type: 'exec_result' }>> = {}): MachineResultFrame => ({
+  type: 'exec_result',
+  grantId: 'g1',
+  exitCode: 0,
+  stdoutB64: b64('hello\n'),
+  stderrB64: b64(''),
+  truncated: false,
+  sig: b64('sig'),
+  ...over,
+});
+
+async function connectedHandle(fake: Fake) {
+  const host = createLocalEnvSandboxHost({ transport: fake.transport, envId: ENV_ID });
+  return host.provision({ name: ENV_ID, substrate: { kind: 'local', envId: ENV_ID }, options: {} });
+}
+
+describe('createLocalEnvSandboxHost — binding to a live machine', () => {
+  it('given a connected machine, provision should bind to it and address it by its DERIVED (never persisted) sandbox id', async () => {
+    const fake = fakeTransport({ reply: async () => execReply() });
+    const handle = await connectedHandle(fake);
+
+    expect(handle.sandboxId).toBe(localEnvSandboxId(ENV_ID));
+    expect(parseLocalEnvSandboxId(handle.sandboxId)).toBe(ENV_ID);
+  });
+
+  it("should carry the connection EPOCH as spriteInstanceId — an identity for this socket's generation, not a Fly id", async () => {
+    const fake = fakeTransport({ reply: async () => execReply() });
+    expect((await connectedHandle(fake)).spriteInstanceId).toBe(EPOCH);
+  });
+
+  it('should leave egressPolicyToken undefined — there is no lockdown to prove on a machine we do not own', async () => {
+    const fake = fakeTransport({ reply: async () => execReply() });
+    expect((await connectedHandle(fake)).egressPolicyToken).toBeUndefined();
+  });
+
+  it('given a host built for one env, provision addressed at ANOTHER env should refuse rather than serve it', async () => {
+    const fake = fakeTransport({ reply: async () => execReply() });
+    const host = createLocalEnvSandboxHost({ transport: fake.transport, envId: ENV_ID });
+    await expect(host.provision({ name: 'other', substrate: { kind: 'local', envId: 'env-other' }, options: {} })).rejects.toBeInstanceOf(
+      LocalEnvNotConnectedError,
+    );
+  });
+});
+
+describe('createLocalEnvSandboxHost — a DISCONNECTED machine never falls through', () => {
+  it('given no connection, provision should throw the typed LocalEnvNotConnectedError naming the env', async () => {
+    const fake = fakeTransport({ connected: false });
+    const host = createLocalEnvSandboxHost({ transport: fake.transport, envId: ENV_ID });
+
+    await expect(host.provision({ name: ENV_ID, substrate: { kind: 'local', envId: ENV_ID }, options: {} })).rejects.toMatchObject({
+      name: 'LocalEnvNotConnectedError',
+      envId: ENV_ID,
+    });
+  });
+
+  it('given no connection, attach should answer null — the seam\'s "it has vanished"', async () => {
+    const fake = fakeTransport({ connected: false });
+    const host = createLocalEnvSandboxHost({ transport: fake.transport, envId: ENV_ID });
+    expect(await host.attach({ sandboxId: localEnvSandboxId(ENV_ID) })).toBeNull();
+  });
+
+  it('given no connection, NOTHING is sent — a bind never queues work on a machine that may never come back', async () => {
+    const fake = fakeTransport({ connected: false });
+    const host = createLocalEnvSandboxHost({ transport: fake.transport, envId: ENV_ID });
+    await host.provision({ name: ENV_ID, substrate: { kind: 'local', envId: ENV_ID }, options: {} }).catch(() => null);
+    await host.attach({ sandboxId: localEnvSandboxId(ENV_ID) });
+    expect(fake.sendGrant).not.toHaveBeenCalled();
+  });
+});
+
+describe('createLocalEnvSandboxHost — exec', () => {
+  it('should send a grant_exec carrying exactly the command it was asked to run', async () => {
+    const fake = fakeTransport({ reply: async () => execReply() });
+    const handle = await connectedHandle(fake);
+
+    await handle.exec({ cmd: 'sh', args: ['-c', 'echo hello'], cwd: '/w', env: { LANG: 'C' }, timeoutMs: 5000, maxBytes: 1024 });
+
+    expect(fake.sent).toEqual([
+      { type: 'grant_exec', cmd: 'sh', args: ['-c', 'echo hello'], cwd: '/w', env: { LANG: 'C' }, timeoutMs: 5000, maxBytes: 1024 },
+    ]);
+    expect(fake.sendGrant).toHaveBeenCalledWith(expect.objectContaining({ envId: ENV_ID }));
+  });
+
+  it('should omit fields the caller did not give, rather than sending nulls the signed projection would hash differently', async () => {
+    const fake = fakeTransport({ reply: async () => execReply() });
+    const handle = await connectedHandle(fake);
+    await handle.exec({ cmd: 'ls' });
+    expect(fake.sent[0]).toEqual({ type: 'grant_exec', cmd: 'ls' });
+  });
+
+  it('should decode the machine\'s base64 streams into the seam\'s own result shape', async () => {
+    const fake = fakeTransport({ reply: async () => execReply({ exitCode: 3, stdoutB64: b64('out'), stderrB64: b64('err') }) });
+    const handle = await connectedHandle(fake);
+    expect(await handle.exec({ cmd: 'ls' })).toEqual({ exitCode: 3, stdout: 'out', stderr: 'err' });
+  });
+
+  it('given the MACHINE denied the grant, should surface the daemon\'s own reason — the machine is the policy enforcement point', async () => {
+    const fake = fakeTransport({ reply: async () => ({ type: 'grant_denied', grantId: 'g1', reason: 'principal_not_allowed', sig: b64('s') }) });
+    const handle = await connectedHandle(fake);
+    await expect(handle.exec({ cmd: 'ls' })).rejects.toMatchObject({ name: 'LocalEnvGrantDeniedError', reason: 'principal_not_allowed' });
+  });
+
+  it('given a verified frame of the WRONG type, should throw rather than coerce an exit code out of nothing', async () => {
+    const fake = fakeTransport({ reply: async () => ({ type: 'fs_write_result', grantId: 'g1', ok: true, sig: b64('s') }) });
+    const handle = await connectedHandle(fake);
+    await expect(handle.exec({ cmd: 'ls' })).rejects.toBeInstanceOf(LocalEnvUnexpectedResultError);
+  });
+
+  /**
+   * EXIT CRITERION (mutation-checked): a result the transport refused —
+   * `sendGrant` rejects when the machine signature does not verify (invariant
+   * 7, `result-verifier.ts`) — must never reach the caller as data.
+   */
+  it('given the transport REFUSES the result (signature did not verify), should reject and return no data at all', async () => {
+    const unverified = Object.assign(new Error('failed machine-signature verification'), { kind: 'unverified_result' });
+    const fake = fakeTransport({ reply: async () => { throw unverified; } });
+    const handle = await connectedHandle(fake);
+
+    await expect(handle.exec({ cmd: 'ls' })).rejects.toBe(unverified);
+  });
+});
+
+describe('createLocalEnvSandboxHost — files', () => {
+  it('should sign the CONTENT of a write, not merely its path', async () => {
+    const fake = fakeTransport({ reply: async () => ({ type: 'fs_write_result', grantId: 'g1', ok: true, sig: b64('s') }) });
+    const handle = await connectedHandle(fake);
+
+    await handle.writeFiles([{ path: '/w/a.txt', content: 'hi', mode: 0o644 }, { path: '/w/b.bin', content: new Uint8Array([1, 2, 3]) }]);
+
+    expect(fake.sent[0]).toEqual({
+      type: 'grant_fs_write',
+      files: [
+        { path: '/w/a.txt', contentB64: b64('hi'), mode: 0o644 },
+        { path: '/w/b.bin', contentB64: Buffer.from([1, 2, 3]).toString('base64') },
+      ],
+    });
+  });
+
+  it('given the machine reports the write FAILED, should throw — writeFiles resolving is what every caller treats as proof the bytes landed', async () => {
+    const fake = fakeTransport({ reply: async () => ({ type: 'fs_write_result', grantId: 'g1', ok: false, error: 'permission_denied', sig: b64('s') }) });
+    const handle = await connectedHandle(fake);
+    await expect(handle.writeFiles([{ path: '/w/a', content: 'x' }])).rejects.toMatchObject({ reason: 'permission_denied' });
+  });
+
+  it('should read a file back through a grant_fs_read naming exactly that path', async () => {
+    const fake = fakeTransport({ reply: async () => ({ type: 'fs_read_result', grantId: 'g1', found: true, contentB64: b64('body'), sig: b64('s') }) });
+    const handle = await connectedHandle(fake);
+
+    expect(await handle.readFile({ path: '/w/a.txt' })).toEqual(Buffer.from('body'));
+    expect(fake.sent[0]).toEqual({ type: 'grant_fs_read', paths: ['/w/a.txt'] });
+  });
+
+  it('given the machine says the file is not there, should answer null — the seam\'s documented miss, not a failure', async () => {
+    const fake = fakeTransport({ reply: async () => ({ type: 'fs_read_result', grantId: 'g1', found: false, sig: b64('s') }) });
+    const handle = await connectedHandle(fake);
+    expect(await handle.readFile({ path: '/w/missing' })).toBeNull();
+  });
+});
+
+describe('createLocalEnvSandboxHost — kill is a NON-destructive disconnect (invariants 8 and 9)', () => {
+  it('should resolve successfully while sending nothing at all — no destroy, ever', async () => {
+    const fake = fakeTransport({ reply: async () => execReply() });
+    const host = createLocalEnvSandboxHost({ transport: fake.transport, envId: ENV_ID });
+
+    await expect(host.kill({ sandboxId: localEnvSandboxId(ENV_ID), expectedInstanceId: EPOCH })).resolves.toBeUndefined();
+    expect(fake.sendGrant).not.toHaveBeenCalled();
+    expect(fake.sent).toEqual([]);
+  });
+});
+
+describe('createLocalEnvSandboxHost — the seven undefined surfaces refuse LOUDLY (invariant 12)', () => {
+  const surfaces: Array<[string, (h: Awaited<ReturnType<typeof connectedHandle>>) => Promise<unknown>]> = [
+    ['stream', (h) => h.stream({})],
+    ['listStreams', (h) => h.listStreams()],
+    ['killSession', (h) => h.killSession('s1')],
+    ['createCheckpoint', (h) => h.createCheckpoint('c')],
+    ['urlInfo', (h) => h.urlInfo()],
+    ['powerState', (h) => h.powerState()],
+    ['setUrlAuth', (h) => h.setUrlAuth('sprite')],
+    ['services', (h) => h.services.list()],
+  ];
+
+  it.each(surfaces)('%s should reject with a typed LocalEnvUnsupportedError naming the op', async (op, call) => {
+    const fake = fakeTransport({ reply: async () => execReply() });
+    const handle = await connectedHandle(fake);
+
+    await expect(call(handle)).rejects.toBeInstanceOf(LocalEnvUnsupportedError);
+    await expect(call(handle)).rejects.toMatchObject({ op, envId: ENV_ID });
+  });
+
+  it.each(surfaces)('%s should REJECT rather than throw synchronously, so a caller\'s .catch() still catches it', (_op, call) => {
+    const fake = fakeTransport({ reply: async () => execReply() });
+    return connectedHandle(fake).then((handle) => {
+      // No try/catch here on purpose: a synchronous throw fails this test.
+      const promise = call(handle);
+      expect(promise).toBeInstanceOf(Promise);
+      return expect(promise).rejects.toBeInstanceOf(LocalEnvUnsupportedError);
+    });
+  });
+
+  /**
+   * The one that is NOT a matter of taste: `[]` is a claim about the machine
+   * ("no shells are running"), and a caller that believes it tears down
+   * bookkeeping for PTYs it cannot see.
+   */
+  it('listStreams must NOT answer an empty list — that is a statement about the machine, not about this seam', async () => {
+    const fake = fakeTransport({ reply: async () => execReply() });
+    const handle = await connectedHandle(fake);
+    await expect(handle.listStreams()).rejects.toBeInstanceOf(LocalEnvUnsupportedError);
+  });
+
+  it('should ADVERTISE the same set it refuses — stream/checkpoint/preview/services false, exec/fs true', async () => {
+    const fake = fakeTransport({ reply: async () => execReply() });
+    const handle = await connectedHandle(fake);
+
+    expect(handle.capabilities).toEqual(LOCAL_ENV_SANDBOX_CAPABILITIES);
+    expect(handle.capabilities).toEqual({ exec: true, fs: true, stream: false, checkpoint: false, preview: false, services: false });
+    expect(SPRITE_SANDBOX_CAPABILITIES).toEqual({ exec: true, fs: true, stream: true, checkpoint: true, preview: true, services: true });
+  });
+});
+
+describe('createLocalEnvSandboxHost — the module stays I/O-free', () => {
+  const source = readFileSync(join(__dirname, '..', 'local-env-sandbox-host.ts'), 'utf8');
+
+  it.each(["'ws'", '@fly/sprites', '@pagespace/db'])('should never import %s — the transport is injected', (forbidden) => {
+    expect(source).not.toContain(`from ${forbidden}`);
+    expect(source).not.toContain(`from '${forbidden}'`);
+  });
+
+  it('should not sign or verify anything itself — both live once, in the apps/web bridge client', () => {
+    for (const banned of ['signGrant', 'verifyMachineResult', 'ed25519', 'createHash']) {
+      expect(source).not.toContain(banned);
+    }
+  });
+});

--- a/packages/lib/src/services/sandbox/sandbox-client/__tests__/local-env-sandbox-host.test.ts
+++ b/packages/lib/src/services/sandbox/sandbox-client/__tests__/local-env-sandbox-host.test.ts
@@ -286,6 +286,31 @@ describe('createLocalEnvSandboxHost — the seven undefined surfaces refuse LOUD
   });
 });
 
+/**
+ * The address is DERIVED and never persisted (invariant 9 keeps every Sprite
+ * column NULL on a local row), so the parse is the only thing standing between
+ * a Sprite name and a local route. It must claim exactly the addresses this
+ * module mints and nothing that merely resembles one.
+ */
+describe('the local sandbox ADDRESS', () => {
+  it('should round-trip the env id it was minted from', () => {
+    expect(parseLocalEnvSandboxId(localEnvSandboxId('env-9'))).toBe('env-9');
+    expect(localEnvSandboxId('env-9')).toBe('local-env:env-9');
+  });
+
+  it.each([
+    ['a bare prefix with no env id', 'local-env:'],
+    ['a hyphen where the colon belongs', 'local-env-abc123'],
+    ['the prefix in the middle rather than at the start', 'pgs-env-local-env:abc'],
+    ['a Sprite name that merely starts with the same letters', 'local-environment-sprite'],
+    ['the derived name of a real drive env', 'pgs-env-9f2c1ab4'],
+    ['a session Sprite name', 'pgs-ses-9f2c1ab4'],
+    ['an empty id', ''],
+  ])('should NOT claim %s', (_case, sandboxId) => {
+    expect(parseLocalEnvSandboxId(sandboxId)).toBeNull();
+  });
+});
+
 describe('createLocalEnvSandboxHost — the module stays I/O-free', () => {
   const source = readFileSync(join(__dirname, '..', 'local-env-sandbox-host.ts'), 'utf8');
 

--- a/packages/lib/src/services/sandbox/sandbox-client/__tests__/sandbox-host-adapter.test.ts
+++ b/packages/lib/src/services/sandbox/sandbox-client/__tests__/sandbox-host-adapter.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from 'vitest';
 import { adaptSandboxHandleToExecutableSandbox, createExecClientFromSandboxHost } from '../sandbox-host-adapter';
-import type { SandboxHandle, SandboxHost } from '../../sandbox-host';
+import { SPRITE_SANDBOX_CAPABILITIES, type SandboxHandle, type SandboxHost } from '../../sandbox-host';
 import { SANDBOX_EGRESS_ALLOWLIST } from '../../execution-policy';
 
 const options = { egressAllowlist: SANDBOX_EGRESS_ALLOWLIST };
@@ -8,6 +8,7 @@ const substrate = { kind: 'sprite' as const };
 
 function fakeHandle(over: Partial<SandboxHandle> = {}): SandboxHandle {
   return {
+    capabilities: SPRITE_SANDBOX_CAPABILITIES,
     sandboxId: 'm1',
     spriteInstanceId: null,
     exec: async () => ({ exitCode: 0, stdout: '', stderr: '' }),
@@ -159,5 +160,24 @@ describe('adaptSandboxHandleToExecutableSandbox — the Sprite INSTANCE id must 
     const sandbox = adaptSandboxHandleToExecutableSandbox(fakeHandle({ spriteInstanceId: null }));
 
     expect(sandbox.spriteInstanceId).toBeNull();
+  });
+});
+
+/**
+ * The capability the CHECKPOINT gate reads (`tool-runners.ts`) arrives on the
+ * `ExecutableSandbox` only because this adapter carries it across. Dropping it
+ * here is invisible in exactly the way dropping `spriteInstanceId` used to be:
+ * every call still works while the gate loses its only structural signal that
+ * a substrate cannot snapshot its filesystem (invariant 12), and a destructive
+ * agent batch then runs unprotected.
+ */
+describe('adaptSandboxHandleToExecutableSandbox — advertised capabilities', () => {
+  it("should carry the handle's capabilities through, verbatim", () => {
+    const local = { exec: true, fs: true, stream: false, checkpoint: false, preview: false, services: false } as const;
+    expect(adaptSandboxHandleToExecutableSandbox(fakeHandle({ capabilities: local })).capabilities).toEqual(local);
+  });
+
+  it('should carry a Sprite handle\'s full set too — not a hard-coded default that would mask a narrower substrate', () => {
+    expect(adaptSandboxHandleToExecutableSandbox(fakeHandle()).capabilities).toEqual(SPRITE_SANDBOX_CAPABILITIES);
   });
 });

--- a/packages/lib/src/services/sandbox/sandbox-client/local-env-sandbox-host.ts
+++ b/packages/lib/src/services/sandbox/sandbox-client/local-env-sandbox-host.ts
@@ -1,0 +1,295 @@
+/**
+ * The LOCAL environment `SandboxHost` — the seam that lets an agent tool call
+ * in a web pane reach the user's own computer, with NO change to any tool
+ * runner (Local Environments epic, M1 · t09).
+ *
+ * The whole point of `sandbox-host.ts` is that adding a substrate costs one
+ * union member and one host, and nothing that CALLS a host branches on which
+ * one it got. So this file is the second host: `exec`, `writeFiles` and
+ * `readFile` build the grant frame for the op, hand it to the injected
+ * {@link BridgeTransport}, and map the machine's VERIFIED answer back into the
+ * seam's own result types.
+ *
+ * **What this module deliberately does NOT contain.** No `ws`, no
+ * `@fly/sprites`, no `@pagespace/db`, and — the load-bearing one — no grant
+ * signing, no correlation and no signature verification. All three live once,
+ * in t07's `EnvBridgeClient` (apps/web), and the transport below is a thin
+ * wrapper over its `sendGrant`. A second verifier that could drift from the
+ * first is the exact defect class the adversarial review on this epic caught
+ * twice; `transport.sendGrant` resolving is therefore the ONLY statement this
+ * module makes about a result's authenticity, and it inherits invariant 7
+ * whole (`apps/web/src/lib/env-bridge/result-verifier.ts`).
+ *
+ * **Seven members refuse, and refuse LOUDLY.** `stream`, `listStreams`,
+ * `killSession`, `services.*`, `urlInfo`, `powerState` and `setUrlAuth` throw
+ * a typed {@link LocalEnvUnsupportedError} and are advertised as `false` on
+ * `handle.capabilities`. None of them returns a degenerate value: an empty
+ * `listStreams()` would tell a caller "no shells are running on that machine",
+ * which is a claim about the machine rather than about this seam's reach, and
+ * that is precisely the silent safety degradation invariant 12 forbids.
+ *
+ * **Local terminals are permanently outside this seam** — not "not yet". The
+ * bridge socket terminates in apps/web while PTYs are driven by apps/realtime,
+ * so M2 routes a local PTY through apps/realtime with an HMAC-signed apps/web
+ * proxy and an SSE return path (t11/t12). Nobody should ever "finish"
+ * `stream()` here.
+ */
+
+import {
+  LOCAL_ENV_SANDBOX_CAPABILITIES,
+  LocalEnvNotConnectedError,
+  LocalEnvUnsupportedError,
+  localEnvSandboxId,
+  type LocalEnvUnsupportedOp,
+  type SandboxHandle,
+  type SandboxHost,
+  type SandboxServicesApi,
+} from '../sandbox-host';
+import type { MachineResultFrame } from '../../../env-bridge/machine-signatures';
+import type { UnsignedGrantFrame } from '../../../env-bridge/grant-args';
+import type { RunCommandArgs, SandboxRunResult, WriteFileEntry } from './types';
+
+/**
+ * The socket, as this host needs it: send one granted request and resolve with
+ * the machine's VERIFIED answer.
+ *
+ * Injected rather than imported so the host stays I/O-free and testable with
+ * an in-memory fake. The production implementation
+ * (`apps/web/src/lib/sandbox/local-env-transport.ts`) is bound to one env AND
+ * one grant principal, because both are security-relevant identity — which is
+ * why neither appears in a per-call argument here where a caller could vary it.
+ */
+export interface BridgeTransport {
+  /**
+   * Sign, send and correlate one grant frame. MUST reject rather than resolve
+   * when the machine's signature does not verify (invariant 7), when the env
+   * has no authorized socket, or when the request times out.
+   */
+  sendGrant(input: { envId: string; frame: UnsignedGrantFrame }): Promise<MachineResultFrame>;
+  /** Does this replica hold an AUTHORIZED bridge socket for the env right now? */
+  isConnected(envId: string): boolean;
+  /**
+   * A stable id for the CURRENT connection, or null when there is none —
+   * a new value whenever the daemon reconnects. See
+   * {@link SandboxHandle.spriteInstanceId} on the handle below for what it is
+   * used as and, more importantly, what it is not.
+   */
+  connectionEpoch(envId: string): string | null;
+}
+
+/** The machine answered a grant with `grant_denied`, or with a result the op cannot use. */
+export class LocalEnvGrantDeniedError extends Error {
+  constructor(
+    readonly envId: string,
+    /** The daemon's own deny word (`decideExecution`'s vocabulary), passed through unedited. */
+    readonly reason: string,
+  ) {
+    super(`Local environment ${envId} denied the request: ${reason}`);
+    this.name = 'LocalEnvGrantDeniedError';
+  }
+}
+
+/** A verified frame arrived, but of a type this op cannot read. Never a silent coercion. */
+export class LocalEnvUnexpectedResultError extends Error {
+  constructor(
+    readonly envId: string,
+    readonly expected: MachineResultFrame['type'],
+    readonly received: MachineResultFrame['type'],
+  ) {
+    super(`Local environment ${envId} answered a ${expected} request with a ${received} frame`);
+    this.name = 'LocalEnvUnexpectedResultError';
+  }
+}
+
+/**
+ * Narrow a verified result to the frame the op asked for.
+ *
+ * `grant_denied` becomes a typed denial carrying the DAEMON's reason — the
+ * machine is the policy enforcement point (invariant 4), so its word is the
+ * answer, not something the server re-decides. Any other mismatch throws
+ * rather than being coerced: a `fs_write_result` read as an `exec_result`
+ * would produce an exit code out of nothing.
+ */
+function expectFrame<T extends MachineResultFrame['type']>(
+  envId: string,
+  frame: MachineResultFrame,
+  expected: T,
+): Extract<MachineResultFrame, { type: T }> {
+  if (frame.type === 'grant_denied') throw new LocalEnvGrantDeniedError(envId, frame.reason);
+  if (frame.type !== expected) throw new LocalEnvUnexpectedResultError(envId, expected, frame.type);
+  return frame as Extract<MachineResultFrame, { type: T }>;
+}
+
+/**
+ * The refusal for one unsupported member.
+ *
+ * REJECTS rather than throwing synchronously, because every member it stands
+ * in for is declared `Promise`-returning: a synchronous throw from something a
+ * caller wrote `handle.listStreams().catch(...)` around would escape the catch
+ * it was written to be caught by, turning a typed refusal into a crash.
+ */
+function refuseOp(op: LocalEnvUnsupportedOp, envId: string): () => Promise<never> {
+  return () => Promise.reject(new LocalEnvUnsupportedError(op, envId));
+}
+
+/** Every `services` member refuses identically — one object, built once per handle. */
+function unsupportedServices(envId: string): SandboxServicesApi {
+  const refuse = refuseOp('services', envId);
+  return {
+    create: refuse,
+    list: refuse,
+    get: refuse,
+    start: refuse,
+    stop: refuse,
+    remove: refuse,
+  };
+}
+
+function buildHandle({ transport, envId }: { transport: BridgeTransport; envId: string }): SandboxHandle {
+  return {
+    capabilities: LOCAL_ENV_SANDBOX_CAPABILITIES,
+    /**
+     * NOT a Fly machine id, and nothing may treat it as one.
+     *
+     * The seam's identity guard exists because a Sprite NAME is reused across
+     * re-creates, so a kill or a CAS has to name the VM generation. A local
+     * env has the same hazard in a different shape — the daemon can drop and
+     * reconnect, and work granted to the old connection must not be credited
+     * to the new one — so this carries the transport's CONNECTION EPOCH: a
+     * stable value for as long as one socket lives, a different one after a
+     * reconnect. Invariant 9 keeps `drive_envs.spriteInstanceId` NULL for a
+     * local env, so this is never persisted anywhere.
+     */
+    spriteInstanceId: transport.connectionEpoch(envId),
+    sandboxId: localEnvSandboxId(envId),
+    /**
+     * Undefined, and the boundary is worth naming: `egressPolicyToken` is
+     * proof that an EGRESS LOCKDOWN was applied to a specific VM we control.
+     * There is no such lockdown here and there could not be — the machine is
+     * the user's own computer on the user's own network, and PageSpace has no
+     * standing to firewall it. Undefined is the seam's "unproven", so the
+     * caller records nothing; it must never be read as "locked down".
+     */
+    egressPolicyToken: undefined,
+
+    async exec(args: RunCommandArgs): Promise<SandboxRunResult> {
+      const frame: UnsignedGrantFrame = {
+        type: 'grant_exec',
+        cmd: args.cmd,
+        ...(args.args !== undefined && { args: args.args }),
+        ...(args.cwd !== undefined && { cwd: args.cwd }),
+        ...(args.env !== undefined && { env: args.env }),
+        ...(args.timeoutMs !== undefined && { timeoutMs: args.timeoutMs }),
+        ...(args.maxBytes !== undefined && { maxBytes: args.maxBytes }),
+      };
+      const result = expectFrame(envId, await transport.sendGrant({ envId, frame }), 'exec_result');
+      return {
+        exitCode: result.exitCode,
+        stdout: Buffer.from(result.stdoutB64, 'base64').toString('utf8'),
+        stderr: Buffer.from(result.stderrB64, 'base64').toString('utf8'),
+      };
+    },
+
+    async writeFiles(files: WriteFileEntry[]): Promise<void> {
+      // Content is part of the SIGNED projection (`grant-args.ts`), so a grant
+      // to write one thing cannot be replayed to write another to the path.
+      const frame: UnsignedGrantFrame = {
+        type: 'grant_fs_write',
+        files: files.map((file) => ({
+          path: file.path,
+          contentB64: Buffer.from(typeof file.content === 'string' ? Buffer.from(file.content, 'utf8') : file.content).toString('base64'),
+          ...(file.mode !== undefined && { mode: file.mode }),
+        })),
+      };
+      const result = expectFrame(envId, await transport.sendGrant({ envId, frame }), 'fs_write_result');
+      // The daemon reports a per-request outcome inside a verified frame; a
+      // failed write is an ERROR here because `writeFiles` resolves as proof
+      // the bytes landed and every caller acts on that.
+      if (!result.ok) throw new LocalEnvGrantDeniedError(envId, result.error ?? 'fs_write_failed');
+    },
+
+    async readFile(args: { path: string }): Promise<Buffer | null> {
+      const frame: UnsignedGrantFrame = { type: 'grant_fs_read', paths: [args.path] };
+      const result = expectFrame(envId, await transport.sendGrant({ envId, frame }), 'fs_read_result');
+      // `found: false` is the seam's documented null (a missing file), not a
+      // failure — same shape the Sprite host answers with.
+      if (!result.found) return null;
+      return Buffer.from(result.contentB64 ?? '', 'base64');
+    },
+
+    stream: refuseOp('stream', envId),
+    listStreams: refuseOp('listStreams', envId),
+    killSession: refuseOp('killSession', envId),
+    createCheckpoint: refuseOp('createCheckpoint', envId),
+    services: unsupportedServices(envId),
+    urlInfo: refuseOp('urlInfo', envId),
+    powerState: refuseOp('powerState', envId),
+    setUrlAuth: refuseOp('setUrlAuth', envId),
+  };
+}
+
+/**
+ * Build the local environment's `SandboxHost`.
+ *
+ * Per-env and per-request — deliberately NOT a process singleton like the
+ * Sprite host: the transport it closes over is bound to one env and one grant
+ * principal, and caching that across requests would let one user's host serve
+ * another user's call.
+ */
+export function createLocalEnvSandboxHost({
+  transport,
+  envId,
+}: {
+  transport: BridgeTransport;
+  envId: string;
+}): SandboxHost {
+  const handleOrThrow = (): SandboxHandle => {
+    // "Connected" is checked HERE as well as inside the transport because the
+    // two failures are different answers: no socket is `LocalEnvNotConnectedError`
+    // (run `pagespace env connect`), while a socket that drops mid-request is
+    // the transport's own typed `disconnected`.
+    if (!transport.isConnected(envId)) throw new LocalEnvNotConnectedError(envId);
+    return buildHandle({ transport, envId });
+  };
+
+  return {
+    /**
+     * Bind to the LIVE connection. There is nothing to create: the machine
+     * exists whether or not PageSpace is looking at it, and the daemon owns
+     * its own lifecycle. A disconnected env throws rather than queueing —
+     * a bind never waits on a machine that may never come back.
+     */
+    async provision({ substrate }) {
+      // Defensive, and cheap: a host built for env A must never serve a
+      // provision addressed to env B, however it was resolved.
+      if (substrate.kind === 'local' && substrate.envId !== envId) {
+        throw new LocalEnvNotConnectedError(substrate.envId);
+      }
+      return handleOrThrow();
+    },
+
+    /** Null when the daemon is not connected — the seam's "it has vanished", exactly as the Sprite host answers for a Sprite the platform no longer has. */
+    async attach() {
+      if (!transport.isConnected(envId)) return null;
+      return buildHandle({ transport, envId });
+    },
+
+    /**
+     * A NON-DESTRUCTIVE disconnect: nothing is sent, nothing is destroyed, and
+     * this resolves successfully.
+     *
+     * Three separate reasons, any one of which would be enough. The machine is
+     * the user's own computer — "kill" would mean powering down someone's
+     * laptop because a session ended. The DAEMON owns its lifecycle
+     * (`pagespace env disconnect`, Ctrl-C, revoke) and invariant 8 says the
+     * local side always wins. And invariant 9 keeps every Sprite column NULL
+     * on a local row, so there is no `sandboxId` to release, no reclaim row to
+     * enqueue, and nothing for `machine_sprite_reclaims` to gain: a local env
+     * is structurally invisible to reclaim and billing, and this method
+     * touching either would be the leak that makes it visible.
+     */
+    async kill() {
+      return;
+    },
+  };
+}

--- a/packages/lib/src/services/sandbox/sandbox-client/sandbox-host-adapter.ts
+++ b/packages/lib/src/services/sandbox/sandbox-client/sandbox-host-adapter.ts
@@ -36,6 +36,11 @@ export function adaptSandboxHandleToExecutableSandbox(handle: SandboxHandle): Ex
     // identity guard downstream silently degrades to name-only.
     spriteInstanceId: handle.spriteInstanceId ?? null,
     egressPolicyToken: handle.egressPolicyToken,
+    // WHAT this substrate can serve. Dropping it here would be invisible in
+    // exactly the way `spriteInstanceId` was: every call still "works" while
+    // the checkpoint gate silently loses its only structural signal that a
+    // local env cannot snapshot its filesystem (invariant 12).
+    capabilities: handle.capabilities,
     runCommand: (args) => handle.exec(args),
     writeFiles: (files) => handle.writeFiles(files),
     readFileToBuffer: (args) => handle.readFile(args),

--- a/packages/lib/src/services/sandbox/sandbox-client/sprite-sandbox-host.ts
+++ b/packages/lib/src/services/sandbox/sandbox-client/sprite-sandbox-host.ts
@@ -30,6 +30,7 @@ import {
   type SandboxStreamSessionInfo,
   type SandboxUrlAuth,
   type SandboxUrlInfo,
+  SPRITE_SANDBOX_CAPABILITIES,
 } from '../sandbox-host';
 import type { ExecSandboxClient, ExecutableSandbox } from './types';
 import {
@@ -329,6 +330,8 @@ function wrapSpriteHandle({
   streamOpenTimeoutMs: number;
 }): SandboxHandle {
   return {
+    // The Sprite backend serves every member of the seam — see `SandboxCapabilities`.
+    capabilities: SPRITE_SANDBOX_CAPABILITIES,
     sandboxId: exec.sandboxId,
     spriteInstanceId: exec.spriteInstanceId ?? null,
     egressPolicyToken: exec.egressPolicyToken,

--- a/packages/lib/src/services/sandbox/sandbox-client/types.ts
+++ b/packages/lib/src/services/sandbox/sandbox-client/types.ts
@@ -11,6 +11,7 @@
  */
 
 import type { SandboxClient, SandboxHandle, SandboxGetOrCreateArgs } from '../machine-session-manager';
+import type { SandboxCapabilities } from '../sandbox-host';
 
 /** Result of a single command run inside the sandbox. */
 export interface SandboxRunResult {
@@ -49,6 +50,20 @@ export interface WriteFileEntry {
  * authorized the conversation.
  */
 export interface ExecutableSandbox extends SandboxHandle {
+  /**
+   * What the substrate behind this sandbox can actually serve, carried across
+   * from `SandboxHost`'s handle by `adaptSandboxHandleToExecutableSandbox`.
+   *
+   * OPTIONAL here, unlike on `SandboxHandle`, and the asymmetry is deliberate:
+   * this interface predates the second substrate and is implemented by fakes
+   * all over the test suite that describe a Sprite. Absent therefore means
+   * "a sandbox built before capabilities existed" — i.e. the Sprite surface,
+   * which is what every such implementation is. What must never happen is a
+   * substrate that CANNOT do something leaving this absent: the local adapter
+   * always sets it, and the checkpoint gate additionally treats the typed
+   * `LocalEnvUnsupportedError` as a refusal, so neither net alone is trusted.
+   */
+  readonly capabilities?: SandboxCapabilities;
   runCommand(args: RunCommandArgs): Promise<SandboxRunResult>;
   writeFiles(files: WriteFileEntry[]): Promise<void>;
   readFileToBuffer(args: { path: string }): Promise<Buffer | null>;

--- a/packages/lib/src/services/sandbox/sandbox-host.ts
+++ b/packages/lib/src/services/sandbox/sandbox-host.ts
@@ -37,7 +37,149 @@ export type SandboxSize = 'small' | 'beefy';
  * union so a second backend adds a new `kind` member here (and nowhere else a
  * `SandboxHost` caller can see) — see the file header.
  */
-export type SandboxSubstrateSpec = { kind: 'sprite'; size?: SandboxSize };
+export type SandboxSubstrateSpec =
+  | { kind: 'sprite'; size?: SandboxSize }
+  /**
+   * A LOCAL environment — the user's own computer, reached over the zero-trust
+   * env bridge (Local Environments epic). There is no VM here and no size to
+   * ask for: the hardware is whatever the user enrolled, and its owner's
+   * daemon is the policy enforcement point (invariant 4). See
+   * `sandbox-client/local-env-sandbox-host.ts`.
+   */
+  | { kind: 'local'; envId: string };
+
+/**
+ * What a substrate can actually DO, advertised by the handle rather than
+ * assumed by the caller (invariant 12: no silent safety degradation).
+ *
+ * The point of declaring this is that `SandboxHandle` has one shape and two
+ * substrates behind it, and the local one genuinely cannot serve seven of its
+ * members. A caller that meets `false` here must REFUSE with a reason it can
+ * name; the unsupported member itself throws {@link LocalEnvUnsupportedError}
+ * rather than returning a degenerate value, because a degenerate value is a
+ * lie a caller cannot detect — `listStreams()` answering `[]` tells a caller
+ * "no shells are running", which is a statement about the machine, not about
+ * this seam's reach.
+ *
+ * `false` never means "not yet". Local terminals are PERMANENTLY outside this
+ * seam: the plan routes local PTYs through apps/realtime with a signed
+ * apps/web proxy and an SSE return path (M2), never through
+ * `SandboxHandle.stream`.
+ */
+export interface SandboxCapabilities {
+  /** `exec` — run a command and collect its output. */
+  readonly exec: boolean;
+  /** `writeFiles` / `readFile`. */
+  readonly fs: boolean;
+  /** `stream` / `listStreams` / `killSession` — interactive PTY sessions on THIS seam. */
+  readonly stream: boolean;
+  /** `createCheckpoint` — a filesystem snapshot before a destructive agent batch. */
+  readonly checkpoint: boolean;
+  /** `urlInfo` / `powerState` / `setUrlAuth` — the dev-preview surface. */
+  readonly preview: boolean;
+  /** `services.*` — runtime-managed services. */
+  readonly services: boolean;
+}
+
+/** Every member of {@link SandboxHandle} the Sprite backend serves — all of them. */
+export const SPRITE_SANDBOX_CAPABILITIES: SandboxCapabilities = {
+  exec: true,
+  fs: true,
+  stream: true,
+  checkpoint: true,
+  preview: true,
+  services: true,
+};
+
+/**
+ * What a LOCAL environment serves: exec and files, and nothing else.
+ *
+ * `checkpoint: false` is invariant 12 in one line — the machine is the user's
+ * own computer and this seam has no way to snapshot its filesystem, so the
+ * checkpoint-policy layer must fail CLOSED on it rather than run a destructive
+ * batch unprotected. `stream: false` is permanent (M2 routes local PTYs
+ * elsewhere); `preview`/`services` are Sprite platform surfaces with no local
+ * analogue.
+ */
+export const LOCAL_ENV_SANDBOX_CAPABILITIES: SandboxCapabilities = {
+  exec: true,
+  fs: true,
+  stream: false,
+  checkpoint: false,
+  preview: false,
+  services: false,
+};
+
+/** The `SandboxHandle` / `SandboxHost` members a local environment cannot serve. */
+export type LocalEnvUnsupportedOp =
+  | 'stream'
+  | 'listStreams'
+  | 'killSession'
+  | 'createCheckpoint'
+  | 'services'
+  | 'urlInfo'
+  | 'powerState'
+  | 'setUrlAuth';
+
+/**
+ * A caller reached a `SandboxHandle` member this substrate does not serve.
+ *
+ * Deliberately an ERROR carrying the op name, never a degenerate return
+ * value — see {@link SandboxCapabilities}. A caller has two correct
+ * responses and no third: consult `capabilities` first and refuse with its
+ * own typed reason, or catch this and do the same. Swallowing it and
+ * continuing is the silent degradation invariant 12 forbids.
+ */
+export class LocalEnvUnsupportedError extends Error {
+  constructor(
+    readonly op: LocalEnvUnsupportedOp,
+    readonly envId: string,
+  ) {
+    super(`Local environment ${envId} does not support "${op}" — see SandboxCapabilities`);
+    this.name = 'LocalEnvUnsupportedError';
+  }
+}
+
+/**
+ * A local environment was asked for a machine while its daemon holds no
+ * authorized bridge socket on this replica.
+ *
+ * Distinct from a policy denial ON PURPOSE, and the distinction is the whole
+ * value of the type: "your computer is not connected" is fixed by running
+ * `pagespace env connect`, while "the machine owner's bind policy denied you"
+ * is fixed by the OWNER, on a different machine, in a different place. A
+ * caller that cannot tell them apart sends the user to debug the wrong layer.
+ */
+export class LocalEnvNotConnectedError extends Error {
+  constructor(readonly envId: string) {
+    super(`Local environment ${envId} has no connected machine`);
+    this.name = 'LocalEnvNotConnectedError';
+  }
+}
+
+/**
+ * The scheme for a local environment's sandbox ADDRESS.
+ *
+ * A local env holds no `drive_envs.sandboxId` — invariant 9 keeps every Sprite
+ * column NULL so the row is structurally invisible to reclaim and billing — but
+ * the seam's existing callers address a machine by an opaque id string
+ * (`SandboxHost.attach({ sandboxId })`, the tool runner's `reconnect`). So a
+ * local machine gets an address that is DERIVED, never persisted: it exists
+ * only inside a request, and nothing writes it to a column.
+ */
+const LOCAL_ENV_SANDBOX_ID_PREFIX = 'local-env:';
+
+/** The derived, never-persisted address of a local environment's machine. */
+export function localEnvSandboxId(envId: string): string {
+  return `${LOCAL_ENV_SANDBOX_ID_PREFIX}${envId}`;
+}
+
+/** The envId inside a local address, or null for any other id (a Sprite name). */
+export function parseLocalEnvSandboxId(sandboxId: string): string | null {
+  if (!sandboxId.startsWith(LOCAL_ENV_SANDBOX_ID_PREFIX)) return null;
+  const envId = sandboxId.slice(LOCAL_ENV_SANDBOX_ID_PREFIX.length);
+  return envId.length > 0 ? envId : null;
+}
 
 /** Options for opening (or reattaching to) an interactive PTY stream on a machine. */
 export interface SandboxStreamOptions {
@@ -230,6 +372,16 @@ export interface SandboxServicesApi {
 
 /** A provisioned/attached machine session — the full surface a caller drives. */
 export interface SandboxHandle {
+  /**
+   * What this substrate can actually serve — read it BEFORE driving a member
+   * that a second backend might not have (see {@link SandboxCapabilities}).
+   * Required, not optional, for the same reason `createCheckpoint` is: a
+   * caller that could not tell whether a handle had declared its capabilities
+   * would have to guess, and the safe guess (assume nothing works) would break
+   * the Sprite path while the unsafe one (assume everything works) is exactly
+   * the silent degradation this field exists to stop.
+   */
+  readonly capabilities: SandboxCapabilities;
   /**
    * The platform's id for this Sprite INSTANCE — the VM's actual identity, unique
    * per generation. `sandboxId` below is only the reused NAME, so anything that

--- a/packages/lib/src/services/sandbox/tool-runners.ts
+++ b/packages/lib/src/services/sandbox/tool-runners.ts
@@ -45,6 +45,7 @@ import {
 } from './checkpoint-policy';
 import { getValidatedEnv } from '../../config/env-validation';
 import type { ExecutableSandbox, SandboxRunResult } from './sandbox-client/types';
+import { LocalEnvUnsupportedError } from './sandbox-host';
 import type { CodeExecutionAuditInput, CodeExecutionAnomaly } from './audit';
 import type { UsageTrackingOutcome } from '../../monitoring/ai-monitoring';
 
@@ -247,7 +248,17 @@ export interface SandboxRunDeps {
   /** Ensures the caller's agent-session sandbox is provisioned and live (lifecycle deps already injected). */
   acquireSandbox: (input: AcquireSandboxRequest) => Promise<SandboxAcquireResult>;
   /** Reconnect to the executable handle for an acquired sandbox id. */
-  reconnect: (sandboxId: string) => Promise<ExecutableSandbox | null>;
+  /**
+   * Re-open the machine `acquireSandbox` just addressed.
+   *
+   * `principal` is WHO the reconnected handle acts as, and it is a parameter
+   * rather than something the implementation infers because a second
+   * substrate needs it: a LOCAL environment (the user's own computer) signs
+   * the acting identity into every request it sends, and its owner's local
+   * approval prompt names that identity. A Sprite implementation ignores it —
+   * a Sprite is addressed by name and was authorized at the gate.
+   */
+  reconnect: (sandboxId: string, principal: SandboxReconnectPrincipal) => Promise<ExecutableSandbox | null>;
   quota: SandboxQuotaDeps;
   buildEnv: () => Record<string, string>;
   audit: (input: CodeExecutionAuditInput) => Promise<void>;
@@ -362,6 +373,17 @@ const AUTHZ_DENY_REASONS = new Set([
 ]);
 
 
+/**
+ * Who a reconnected sandbox acts as — the acting user, the session that owns
+ * the machine, and the conversation the request came through. Assembled from
+ * facts the runner already holds; see `SandboxRunDeps.reconnect`.
+ */
+export interface SandboxReconnectPrincipal {
+  userId: string;
+  workspaceId: string;
+  conversationId: string;
+}
+
 export type SandboxToolDenialReason =
   | 'kill_switch_off'
   | 'tier_ineligible'
@@ -386,6 +408,24 @@ export type SandboxToolDenialReason =
   | 'provision_failed'
   | 'execution_failed'
   | 'not_found'
+  /**
+   * The substrate cannot take a filesystem checkpoint, and the checkpoint
+   * policy says this batch needs one (invariant 12). A REFUSAL, not a
+   * fallback: proceeding would run a destructive agent batch on the user's own
+   * machine with no restore point, which is exactly the silent safety
+   * degradation the advertised `checkpoint: false` exists to stop.
+   */
+  | 'checkpoint_unsupported'
+  /**
+   * The user's own computer holds no live bridge connection. Kept DISTINCT
+   * from `local_bind_denied` on purpose: this one the requester fixes
+   * themselves in seconds (`pagespace env connect`), that one only the
+   * machine's owner can fix, elsewhere. An agent told merely "could not
+   * provision" debugs the wrong layer.
+   */
+  | 'local_not_connected'
+  /** The machine owner's bind policy denies this actor. See `local_not_connected` for why the two are separate reasons. */
+  | 'local_bind_denied'
   | 'error';
 
 export type BashToolResult =
@@ -471,8 +511,43 @@ export const DENIAL_MESSAGES: Record<SandboxToolDenialReason, string> = {
   provision_failed: 'Could not provision a sandbox for this run.',
   execution_failed: 'Command execution failed or timed out.',
   not_found: 'File not found.',
+  checkpoint_unsupported:
+    'This environment cannot take a filesystem checkpoint, and a checkpoint is required before running commands here. '
+    + 'Nothing was run — a destructive batch with no restore point is refused rather than attempted.',
+  local_not_connected:
+    'The local environment this session is bound to has no connected machine. '
+    + 'Run `pagespace env connect` on that computer, then retry.',
+  local_bind_denied:
+    "The machine owner's policy does not allow you to run code on this local environment. "
+    + 'Retrying will not help — the environment owner has to change its bind policy.',
   error: 'Code execution could not be completed.',
 };
+
+/**
+ * How a LOCAL env's server-side refusal reaches the AGENT.
+ *
+ * Two of the six verdicts get a word of their own, and the split is the whole
+ * point: `not_connected` is fixed by the requester in seconds
+ * (`pagespace env connect` on their machine), while `bind_policy` can only be
+ * fixed by the environment's OWNER, elsewhere, and retrying never helps. An
+ * agent handed the same sentence for both debugs the wrong layer — and so does
+ * the human reading its transcript.
+ *
+ * Everything else maps to `null`, meaning "keep the caller's generic
+ * provisioning fault with its detail": `flag_disabled` and `substrate_unsupported`
+ * are deployment facts the requester can do nothing about, `revoked` and
+ * `not_local` describe a row rather than an action, and `code_exec_denied`
+ * already carries `can-run-code`'s own cause.
+ *
+ * Lives here, next to `DENIAL_MESSAGES`, so the vocabulary and the copy cannot
+ * drift apart, and so every entry point that surfaces a local refusal asks one
+ * function.
+ */
+export function localRefusalToToolDenial(refusal: string | undefined): SandboxToolDenialReason | null {
+  if (refusal === 'not_connected') return 'local_not_connected';
+  if (refusal === 'bind_policy') return 'local_bind_denied';
+  return null;
+}
 
 function fail(
   reason: SandboxToolDenialReason,
@@ -681,7 +756,11 @@ export async function openSession(
       }
       return { ok: false, reason: reasonFromAcquire(acquired) };
     }
-    const sandbox = await deps.reconnect(acquired.sandboxId);
+    const sandbox = await deps.reconnect(acquired.sandboxId, {
+      userId: ctx.userId,
+      workspaceId: acquired.workspaceId,
+      conversationId: ctx.conversationId,
+    });
     if (!sandbox) {
       deps.quota.releaseSlot({ userId: ctx.userId });
       safeLogError(deps.logger, 'Sandbox reconnect returned no handle', {
@@ -784,6 +863,12 @@ function withCheckpointTimeout<T>(p: Promise<T>, ms: number): Promise<T> {
  * to create their own — see that function's doc for why this closes the race
  * regardless of exact timing between callers.
  */
+/**
+ * Whether the destructive batch may proceed. `ok: false` means NOTHING ran and
+ * the caller must refuse with the named reason — never swallow it.
+ */
+type CheckpointGateVerdict = { ok: true } | { ok: false; reason: 'checkpoint_unsupported' };
+
 async function maybeCheckpointBeforeBatch({
   ctx,
   deps,
@@ -792,9 +877,9 @@ async function maybeCheckpointBeforeBatch({
   ctx: SandboxActorContext;
   deps: SandboxRunDeps;
   sandbox: ExecutableSandbox;
-}): Promise<void> {
+}): Promise<CheckpointGateVerdict> {
   const checkpoint = deps.checkpoint;
-  if (!checkpoint || !ctx.turnId) return;
+  if (!checkpoint || !ctx.turnId) return { ok: true };
   const turnId = ctx.turnId;
 
   try {
@@ -806,7 +891,22 @@ async function maybeCheckpointBeforeBatch({
         lastCheckpointTurnId: state.lastCheckpointTurnId,
       })
     ) {
-      return;
+      return { ok: true };
+    }
+    // INVARIANT 12, and the one place fail-open flips to fail-closed. Above
+    // this line the policy has just said this batch NEEDS a restore point; a
+    // substrate that advertises it cannot make one is therefore refused, not
+    // silently run unprotected. The check sits AFTER `shouldCheckpoint` on
+    // purpose: when the policy wants no checkpoint at all (flag off, or one
+    // already taken this turn) there is nothing to be unprotected about, and
+    // refusing there would lock a local environment out of every batch for a
+    // reason unrelated to safety.
+    if (sandbox.capabilities?.checkpoint === false) {
+      safeLogWarn(deps.logger, 'Pre-agent checkpoint unsupported on this substrate — refusing the batch', {
+        sandboxId: sandbox.sandboxId,
+        turnId,
+      });
+      return { ok: false, reason: 'checkpoint_unsupported' };
     }
     await coalesceCheckpointAttempt(sandbox.sandboxId, async () => {
       await withCheckpointTimeout(
@@ -816,12 +916,27 @@ async function maybeCheckpointBeforeBatch({
       checkpoint.recordCheckpoint(sandbox.sandboxId, { lastCheckpointAt: deps.now(), lastCheckpointTurnId: turnId });
     });
   } catch (error) {
+    // The SECOND net, independent of the advertised capability: a substrate
+    // whose `createCheckpoint` says "unsupported" is refused even if it never
+    // declared a capability at all. Every OTHER failure keeps the documented
+    // fail-open behavior — a Sprite whose checkpoint call errored or timed out
+    // is still a sandbox with a restore path, and blocking agent work on
+    // checkpoint availability is what the timeout above exists to prevent.
+    if (error instanceof LocalEnvUnsupportedError) {
+      safeLogWarn(deps.logger, 'Pre-agent checkpoint unsupported on this substrate — refusing the batch', {
+        sandboxId: sandbox.sandboxId,
+        turnId,
+        error: error.message,
+      });
+      return { ok: false, reason: 'checkpoint_unsupported' };
+    }
     safeLogWarn(deps.logger, 'Pre-agent checkpoint failed (proceeding without one)', {
       sandboxId: sandbox.sandboxId,
       turnId,
       error: error instanceof Error ? error.message : String(error),
     });
   }
+  return { ok: true };
 }
 
 export async function runBashInSandbox({
@@ -878,7 +993,8 @@ export async function runBashInSandbox({
   const session = await openSession(ctx, deps);
   if (!session.ok) return fail(session.reason);
 
-  await maybeCheckpointBeforeBatch({ ctx, deps, sandbox: session.sandbox });
+  const checkpointed = await maybeCheckpointBeforeBatch({ ctx, deps, sandbox: session.sandbox });
+  if (!checkpointed.ok) return fail(checkpointed.reason);
 
   try {
     const startedAt = deps.now();

--- a/packages/lib/src/services/sandbox/tool-runners.ts
+++ b/packages/lib/src/services/sandbox/tool-runners.ts
@@ -993,10 +993,16 @@ export async function runBashInSandbox({
   const session = await openSession(ctx, deps);
   if (!session.ok) return fail(session.reason);
 
-  const checkpointed = await maybeCheckpointBeforeBatch({ ctx, deps, sandbox: session.sandbox });
-  if (!checkpointed.ok) return fail(checkpointed.reason);
-
   try {
+    // INSIDE the try, so the `finally` below releases the code-execution slot
+    // on this refusal exactly as it does on every other exit. Returning between
+    // `openSession` and this block would leak the slot for the life of the
+    // process — invisibly, since nothing downstream fails: the semaphore just
+    // fills up and eventually stops code execution for that user on EVERY
+    // substrate, not only the local one that was refused.
+    const checkpointed = await maybeCheckpointBeforeBatch({ ctx, deps, sandbox: session.sandbox });
+    if (!checkpointed.ok) return fail(checkpointed.reason);
+
     const startedAt = deps.now();
     let run: SandboxRunResult;
     try {


### PR DESCRIPTION
Epic `j945few5ssv75k5ad0bowbb4` · Task `rfintov55qywoaq73ctbt888` (board task `y04nyq7ytjkfrd03shk3rvob`).

t07 built the server end of the socket (#2543); t08 built the daemon (#2546). **This is the seam that joins them to the product**: an agent tool call in a web pane now reaches the user's own computer through the existing provider-neutral `SandboxHost`, with no change to any tool runner's logic.

---

## STEP-0 drift note (posted on the task page BEFORE any code was written)

The task page predates `preview-access.ts` (#2535) and several other things. Nine drifts were found and posted; items 4, 5, 7, 8 were not in the delegation prompt. The point guard has since ruled on 7, 8 and 9 (see below) and those rulings are implemented.

1. **`preview-access.ts` (#2535) postdates the page.** `resolvePreviewTarget` drives `powerState`, `urlInfo` and `services.get` in one `Promise.all`; the page's file list does not mention it. Handled with a capability check and a new `preview-unsupported` refuse reason.
2. **The page defines local behaviour for 6 of `SandboxHandle`'s 13 members.** The other seven are typed refusals plus an advertised capability (the carried point-guard decision). `listStreams()` deliberately does not return `[]`.
3. **The page's host signature cannot hold on master.** It asks for `createLocalEnvSandboxHost({ transport, signer, verifier, envId })`, but t07 put signing, correlation and verification inside `EnvBridgeClient` in apps/web, which `@pagespace/lib` cannot reach — and a second signer/verifier in lib is the exact drift the adversarial review caught twice on this epic. Actual signature: `{ transport, envId }`, with the apps/web transport a thin wrapper over `sendGrant`.
4. **`substrate_unsupported` has a second production site the page never mentions**: `drive-envs.ts:1045` (`rebuildDriveEnv`). Not replaced — rebuild is destroy-and-re-mint and a local env has no Sprite to rebuild. Only `env-provision-deps.ts:265-270` is replaced.
5. **`substrate_unsupported` also survives in the provisioner, narrowed** to one meaning: *this process cannot reach local environments*. See the section below — it is easy to mistake for the old refusal, so it is pinned by a test.
6. **Stale docblocks** in `local-env-gate.ts` / `env-provision-deps.ts` ("until the socket route (t07) exists", "until the local SandboxHost lands (t09)") — updated.
7. **The tool path needs an ADDRESS, not just a substrate** — see below. *Accepted in scope by the point guard with two conditions, both landed.*
8. **Session Files/Diff/Git-Blob answer `not_started` on a local env.** A typed, honest refusal, not local-env support. *Point-guard ruling: not parked in t10 (a verification gate, where a parked gap evaporates) — board task `lr1ibixjn2zlqpqq37j5vw7r`.*
9. **Splitting `SandboxHandle` into sub-interfaces** is right long-term but edits the type the Sprite host declares. *Deferred; board task `vidx34jiq7jp7hkw690msxqb`.*

---

## The gap the task page did not cover — seven undefined surfaces

`SandboxHandle` has 13 members; the page defined local behaviour for six. **Every unsupported member is a typed refusal plus an advertised capability. Never a degenerate value.**

- `capabilities` is a new readonly on the handle (`exec`, `fs`, `stream`, `checkpoint`, `preview`, `services`). The Sprite host advertises all true; the local host advertises `stream/checkpoint/preview/services: false`.
- `stream`, `listStreams`, `killSession`, `createCheckpoint`, `services.*`, `urlInfo`, `powerState`, `setUrlAuth` reject with `LocalEnvUnsupportedError(op, envId)`.
- **`listStreams()` does not return `[]`.** An empty list is a claim about the *machine* ("no shells are running"), which a caller acts on by tearing down bookkeeping for PTYs it cannot see — the silent degradation invariant 12 forbids.
- They **reject** rather than throwing synchronously: each is declared `Promise`-returning, and a sync throw escapes the `.catch` a caller wrote to catch it.
- **Local terminals are permanently outside this seam**, not temporarily. M2 routes local PTYs through apps/realtime with a signed apps/web proxy and an SSE return path. The docblock says so, so nobody "finishes" `stream()`.

`capabilities` is **required** on `SandboxHandle`, following the file's own stated reasoning for `createCheckpoint`/`services`. That cost one line in six existing Sprite fakes; **no existing assertion changed**. On `ExecutableSandbox` it is optional (that interface predates the second substrate and has many Sprite-shaped fakes), and the checkpoint gate reads it *and* catches the typed error, so neither net stands alone.

---

## Deliverables

### 1 · `SandboxSubstrateSpec |= { kind:'local'; envId }` + capabilities
`packages/lib/src/services/sandbox/sandbox-host.ts`. One union member, one host, no caller branches on `kind` — exactly what the union's own header prescribes. Adds `SandboxCapabilities`, `SPRITE_SANDBOX_CAPABILITIES`, `LOCAL_ENV_SANDBOX_CAPABILITIES`, `LocalEnvUnsupportedError`, `LocalEnvNotConnectedError`, and the derived address helpers. `UnsignedGrantFrame` also moves into the pure core beside the projection it belongs to, so signer and host share one declaration.
**Tests:** the Sprite host advertises the full set; the adapter carries capabilities verbatim. **Mutation 1/1 killed** (deleting `capabilities: handle.capabilities` from the adapter — which *survived* before the assertion was added, so it was a real gap).

### 2 · `local-env-sandbox-host.ts`
`exec`/`writeFiles`/`readFile` build the grant frame, send via the injected transport, and return only a verified result. `provision` binds or throws `LocalEnvNotConnectedError`; `attach` returns `null`. `kill` is a **non-destructive disconnect** that sends nothing (the machine is the user's computer; the daemon owns its lifecycle, invariant 8; and invariant 9 leaves no pointer to release). `egressPolicyToken: undefined` with the boundary named. `spriteInstanceId` = the transport's connection epoch, documented as **not** a Fly id. **Zero imports of `ws`, `@fly/sprites`, `@pagespace/db`** — pinned by a source test.
**Tests:** 40, in-memory transport. **Mutation 6/6 killed, no-op control survived** — un-guarding `provision`, un-guarding `attach`, dropping the `grant_denied` branch, swallowing a refused (unverified) result, returning `[]` from `listStreams`, advertising the Sprite set.

### 3 · `apps/web/src/lib/sandbox/local-env-transport.ts`
**Wraps t07's `EnvBridgeClient.sendGrant`.** Does not re-implement grant signing, correlation or result verification.
**One-verifier proof:** a source test asserts this module never names `signGrantFrame`, `verifyResultFromMachine`, `encodeGrant`, `ed25519Verify` or `RequestCorrelator`, plus a repo scan asserting exactly two production files mention the verifier (definition + its one caller) and exactly two mention the signer:
```
verifyResultFromMachine(  →  lib/env-bridge/bridge-client.ts, lib/env-bridge/result-verifier.ts
signGrantFrame(           →  lib/env-bridge/bridge-client.ts, lib/env-bridge/grant-signer.ts
```
A bind with no grant principal gets a transport whose `sendGrant` **refuses** (`LocalEnvNoPrincipalError`) rather than signing under an invented identity.
**Mutation 2/2 killed, control survived.**

### 4 · `apps/web/src/lib/agent-workspaces/sandbox-host-registry.ts`
`resolveSandboxHost(substrate, principal?)` and `resolveSandboxHostForSandboxId(sandboxId, principal)`. **`getSandboxHost()` stays exported from `sandbox-host-runtime.ts` returning the Sprite singleton** — every existing consumer's tests are green, untouched. A local host is **not** process-cached (its transport is bound to one env and one principal).
**Mutation 1/1 killed, control survived.**

### 5 · Provision threading
`env-provision-deps.ts` + `drive-envs-runtime.ts`. Replaces t06b's flat refusal. **Every typed verdict for every case that still refuses is kept verbatim**; only the connected-and-allowed case now binds. **Nothing is written to the row** — no identity CAS, no stamps, no reclaim, no storage measurement. `resumed: true` always (PageSpace did not create this machine).
**Mutation 3/3 killed, control survived** — skipping the gate, falling through to the Sprite host when no registry is present, persisting the address.

### 6 · Two local refusals the agent can tell apart
New `SandboxToolDenialReason`s `local_not_connected` and `local_bind_denied`, mapped by one exported function beside the copy so vocabulary and wording cannot drift. Both strings pinned:
- *"…has no connected machine. Run `pagespace env connect` on that computer, then retry."*
- *"The machine owner's policy does not allow you to run code on this local environment. Retrying will not help — the environment owner has to change its bind policy."*

### 7 · `LOCAL_ENVS_ENABLED` read directly
Via the existing `isLocalEnvsEnabled()`, which already reads `process.env` directly like `CODE_EXECUTION_ENABLED`.

---

## Callers that now meet a refusal (each tested at the CALLER)

| Caller | Behaviour | Mutation |
|---|---|---|
| `tool-runners.ts` destructive batch **(C13)** | Fails **closed** with `checkpoint_unsupported`; nothing runs. Fail-open is preserved for a checkpoint that merely *failed*. Two nets: advertised capability **and** the typed error. | 2/2 killed, control survived |
| `preview-access.ts` | Refuses `preview-unsupported` (409) before the `Promise.all`, so three refusing members are never touched. | 2/2 killed |
| `workspace-shells.ts` `killShellProcess` | `{ ok: false, reason: 'unsupported' }`, row kept. Not `ok: true` — that means "confirmed gone" and callers drop the only pointer. The web runtime passes the reason through rather than collapsing it to `error`. | 1/1 killed |

Both capability reads are `=== false`, so only a handle that *declares* a narrower substrate refuses; the required type catches a real host that forgets, at compile time.

---

## `substrate_unsupported`, narrowed — read this bit

It survives, meaning **only** "this process cannot reach local environments". The bridge socket terminates in apps/web, and the realtime tier runs the same `ensureDriveEnvSandbox`; without a `resolveLocalHost` seam it refuses with a typed verdict and **never** falls through to `deps.host`, which is the Sprite host. Pinned by a test asserting the *identical row* binds as soon as the seam is supplied, so the new meaning cannot be confused with the old blanket refusal.

## The address (point-guard accepted, with conditions)

A local env holds no `drive_envs.sandboxId` (invariant 9), but the seam's callers address a machine by an opaque id — including `sandbox-tools-runtime.ts`'s `reconnect`, which was hard-wired to the Sprites client. `localEnvSandboxId(envId)` → `local-env:<envId>`, **derived, never persisted**.

- **(a) Never written anywhere.** A test scans every store mock's arguments for the address and checks the row's Sprite columns are still NULL after bind → exec → reconnect. Mutant: one added `updateSpriteIdentity` write → red.
- **(b) Never over-claims a Sprite id.** Six near-miss shapes (`local-env-abc123`, `pgs-env-local-env:abc`, `local-environment-sprite`, real `pgs-env-*` / `pgs-ses-*` names, a bare prefix) resolve to the Sprite host, pinned at both the pure parse and the registry, each with a CONTROL row. Mutant: `startsWith` → `includes` → red in both suites.

`reconnect`'s dep signature gains the acting principal — the only tool-runner change, a pass-through of facts the runner already holds. No runner logic moved.

---

## Requirement → test map

| Requirement | Test |
|---|---|
| Sprite provisioning call sequence unchanged | `env-provision-deps.test.ts` → *CONTROL: the same row as a Sprite env DOES reach the Sprite host*; the whole pre-existing suite is green untouched |
| Connected local env: `exec` sends `grant_exec`, result returned only if verified | `local-env-sandbox-host.test.ts` → *should send a grant_exec carrying exactly the command*, *should decode the machine's base64 streams*, ***given the transport REFUSES the result … should reject and return no data at all*** |
| Disconnected: `provision` throws, `attach` null, **Sprite host not invoked** | `local-env-sandbox-host.test.ts` (3 rows incl. *NOTHING is sent*) + `env-provision-deps.test.ts` *given the machine is NOT connected* (asserts `host.provision` **and** `resolveLocalHost` never called) beside the CONTROL row |
| `kill`: no destroy, `sandboxId` NULL, no `machine_sprite_reclaims` row | *kill is a NON-destructive disconnect*; *should write NOTHING to the row* (`enqueueReclaim` never called); *should leave the row's sandboxId NULL after a bind, an exec and a reconnect* |
| `createCheckpoint` throws **and the caller refuses** | `tool-runners.test.ts` → *a substrate that cannot checkpoint fails CLOSED* (4 rows incl. a CONTROL) |
| `getSandboxHost()` still the Sprite singleton | `sandbox-host-registry.test.ts` → *the existing Sprite consumers are untouched* |
| Flag unset ⇒ `flag_disabled`, no local host constructed | `env-provision-deps.test.ts` → *given LOCAL_ENVS_ENABLED off* (asserts `resolveLocalHost` and `provision` never called) |
| Local host: zero `ws` / `@fly/sprites` / `@pagespace/db` imports | `local-env-sandbox-host.test.ts` → *the module stays I/O-free* |
| **Undefined surfaces**: typed refusal + advertised capability | *the seven undefined surfaces refuse LOUDLY* (8 ops × 2 rows: typed error, and rejects-not-throws) + *listStreams must NOT answer an empty list* + *should ADVERTISE the same set it refuses* |
| **Two refusals distinguishable** | `tool-runners.test.ts` → *a LOCAL environment's two refusals stay distinguishable all the way to the agent* (4 rows, both reason words and both message strings) |
| One verification path | `local-env-transport.test.ts` → *exactly ONE verification path exists for env-bridge results* (8 rows) |

## 8 · A refused checkpoint leaked a code-execution semaphore slot — **introduced by this PR**

Listed as a deliverable rather than a footnote, because it is the most consequential thing in the diff and no test would ever have failed on it.

**What leaked.** `runBashInSandbox` acquires a code-execution slot inside `openSession`; every exit after that point returns it through the `finally` of the `try` that follows. Deliverable 6's new `checkpoint_unsupported` refusal returned *between* those two, so each refused batch took a slot and never gave it back.

**Why nothing failed.** There is no error, no rejected promise, no log line — the refusal is a perfectly well-formed `BashToolResult`. The slot count simply drifts up by one per refused batch, for the life of the process. Every existing test asserting the refusal passed.

**Blast radius.** The semaphore is per USER, not per substrate. Once it fills, code execution stops for that user **everywhere** — a Sprite session would start answering `concurrency_limit` because of commands the user ran on a local environment somewhere else entirely, with nothing connecting cause to effect.

**Pre-existing or introduced?** **Introduced here.** Swept all six `openSession` call sites (five in `tool-runners.ts`, one in `git-tool-runners.ts`). Every one has the identical shape: `openSession` → `if (!session.ok) return` (safe: `openSession` releases the slot on each of its own failure paths before returning) → `try { … } finally { session.release() }`. **No other early return sits between a successful `openSession` and its `try`.** The invariant — *after a successful `openSession`, `release` must run* — held everywhere except the line this PR added.

**Fix + pin.** The gate moves inside the `try`, so the refusal unwinds exactly as every other exit does. Two new rows assert `slots.released === slots.acquired`, one for the advertised-capability path and one for the typed-error path. **Mutation-checked:** hoisting the call back above the `try` reintroduces the leak and turns both rows red, with a no-op control surviving.

Commit `0de71513`, split out from the CodeQL walker fix so it is not buried under a test-hygiene subject.

---

## Two further defects found by self-review, after CI was green

Neither was caught by a test. Recorded because the pattern is the point.

1. **A permanent refusal that told the caller to retry.** `killShellProcess`'s new `unsupported` reason was carried faithfully through the runtime and the tool — and then both surfaces said the opposite of what it means. The agent tool answered *"its process may still be running. Retry."*, which instructs a loop the model can never break out of, since the model reads the sentence and not the reason code. The DELETE route answered **502** ("upstream hiccup, try again") and logged at error level. Now: a no-retry sentence, and **409** at warn. Carrying a typed reason is not the same as being understood — a reason code the copy contradicts is worse than no reason code, because the contradiction is the part a reader acts on. *(Generalises requirement 6 to the shell path.)*
2. **`js/file-system-race` in the one-verifier proof's walker** (CodeQL, red on the first push). `statSync(full).isDirectory()` then `readFileSync(full)` on the same pathname. Fixed structurally, not with a call swap: `readdirSync(dir, { withFileTypes: true })` and branch on the `Dirent`, so each pathname gets at most one direct fs call — no child stat, no `existsSync` guard, `try`/`catch` for the racing-file case. No suppression, no CodeQL comment. The assertion was then re-verified to still **bite**: a second `verifyResultFromMachine(` caller goes red, and so does a second `signGrantFrame(` caller.

## Mutation summary

**24 mutants, 24 killed. 11 no-op control mutants, all survived.** By line index, never string replace. Per area: substrate+capabilities 1/1 · local host 6/6 · address never-persisted / never-over-claimed 3/3 · transport 2/2 · registry 1/1 · provision threading 3/3 · caller refusals 3/3 · retry copy + HTTP status 2/2 · quota-slot release 1/1 · one-verifier & one-signer proofs 2/2.

## Verification

```
packages/lib   bunx tsc --noEmit -p tsconfig.json      clean
apps/web       bunx tsc --noEmit -p tsconfig.json      clean
packages/lib   vitest run src/services                 149 files, 3593 passed
apps/web       vitest (touched dirs)                    kill-shell / registry / transport / tool suites green
               bun run knip:check                       exit 0
               eslint (touched paths)                   clean
```
Two `*.integration.test.ts` files fail locally for want of a provisioned test database (`locked-batch-reorder`, `dev-preview-stores`), as does `activity-tools.test.ts`, which says so itself. Environment-only; unrelated to this diff. **CI is the gate.**

**Exports-map check** — every `@pagespace/lib/<subpath>` imported from `apps` or `packages/cli` resolves in `packages/lib/package.json`, including the new `./services/sandbox/sandbox-client/local-env-sandbox-host` entry added here:
```
$ node scripts-check  →  exports map: all 100 subpaths present
```
(The only unmatched strings are prose fragments in comments — `@pagespace/lib/permissions/`, `@pagespace/lib/...` — all pre-existing.)

**No migration.** t09 adds no column and no constraint; the address is derived and the row is untouched.

## Not done, stated rather than narrowed

- Session Files/Diff/Git-Blob browse routes on a local env → board task `lr1ibixjn2zlqpqq37j5vw7r`.
- Splitting `SandboxHandle` into capability sub-interfaces → board task `vidx34jiq7jp7hkw690msxqb`.
- Local PTYs are M2 (t11/t12) and permanently outside this seam, by design.
- `[D-1]` and `[D-2]` are untouched founder decisions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VRzMDjz6t1bPtQcJQQBG3M


