### PR TITLE
Android Phase C: shell navigation hardening and the pagespace:// deep link

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,17 +7,12 @@ All notable user-facing changes to PageSpace are documented here. Format follows
 
 ### Added
 
-- **Android app: a failed load now offers a Retry, and OAuth sign-in can return to the app** —
-  the Android shell previously had no bundled error screen, so a launch with no connectivity left
-  the WebView on Chrome's own error page with nothing to do. It now falls back to a PageSpace
-  screen with a working Retry button, matching iOS. The app also registers the `pagespace://`
-  link scheme the Google and Apple sign-in redirects already use, so a native sign-in can hand
-  back to the app the way it does on iOS. Sign-in and other non-pagespace.ai hosts the app
-  navigates to are now allowlisted so they stay inside the app instead of being handed to Chrome.
-  Opening a `pagespace.ai` web link still opens your browser, unchanged — making those links open
-  the app needs a signed release build and in-app link routing that do not exist yet, and adding
-  it early would have put PageSpace in Android's "open with" chooser on Android 6–11 and then
-  dropped you on the dashboard with the link's invite or sign-in token discarded.
+- **Android app: a failed load now offers a Retry instead of a dead end** — the Android shell had
+  no bundled error screen, so launching without connectivity left the WebView on Chrome's own
+  error page with nothing to do. It now falls back to a PageSpace screen with a working Retry
+  button, matching iOS. Sign-in and the other non-pagespace.ai hosts the app navigates to are also
+  allowlisted now, so they stay inside the app instead of being handed to Chrome mid-flow. Opening
+  a `pagespace.ai` web link still opens your browser, unchanged.
 
 - **Dev-server preview: see the app you're building, live, from inside its session (ships dark)** —
   when a dev server (Vite, Next, anything that binds a port) starts inside an agent session or a

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ All notable user-facing changes to PageSpace are documented here. Format follows
 
 ### Added
 
+- **Android app: a failed load now offers a Retry, and links can open the app (groundwork)** —
+  the Android shell previously had no bundled error screen, so a launch with no connectivity left
+  the WebView on Chrome's own error page with nothing to do. It now falls back to a PageSpace
+  screen with a working Retry button, matching iOS. The app also registers deep links: the
+  `pagespace://` scheme the Google and Apple sign-in redirects already use, and Android App Links
+  for the same `pagespace.ai` paths iOS claims (`/auth/callback/`, `/api/auth/callback/`,
+  `/invite/`, `/join/`). **The App Links are inert until `/.well-known/assetlinks.json` is served
+  from pagespace.ai with the release signing certificate's fingerprint** — that certificate does
+  not exist yet, since signing and Play Console setup are separate work. Until it is served,
+  `pagespace.ai` links open in the browser exactly as they do today; no disambiguation dialog
+  appears. Sign-in and other non-pagespace.ai hosts the app navigates to are now allowlisted so
+  they stay inside the app instead of being handed to Chrome.
+
 - **Dev-server preview: see the app you're building, live, from inside its session (ships dark)** —
   when a dev server (Vite, Next, anything that binds a port) starts inside an agent session or a
   drive Environment, PageSpace notices and shows one quiet line in that session's header or beneath

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,9 +10,8 @@ All notable user-facing changes to PageSpace are documented here. Format follows
 - **Android app: a failed load now offers a Retry instead of a dead end** — the Android shell had
   no bundled error screen, so launching without connectivity left the WebView on Chrome's own
   error page with nothing to do. It now falls back to a PageSpace screen with a working Retry
-  button, matching iOS. Moving between PageSpace subdomains also stays inside the app now instead
-  of bouncing out to Chrome mid-flow. Opening a `pagespace.ai` web link from elsewhere still opens
-  your browser, unchanged.
+  button, matching iOS. Opening a `pagespace.ai` web link from elsewhere still opens your browser,
+  unchanged.
 
 - **Dev-server preview: see the app you're building, live, from inside its session (ships dark)** —
   when a dev server (Vite, Next, anything that binds a port) starts inside an agent session or a

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,9 +10,9 @@ All notable user-facing changes to PageSpace are documented here. Format follows
 - **Android app: a failed load now offers a Retry instead of a dead end** — the Android shell had
   no bundled error screen, so launching without connectivity left the WebView on Chrome's own
   error page with nothing to do. It now falls back to a PageSpace screen with a working Retry
-  button, matching iOS. Sign-in and the other non-pagespace.ai hosts the app navigates to are also
-  allowlisted now, so they stay inside the app instead of being handed to Chrome mid-flow. Opening
-  a `pagespace.ai` web link still opens your browser, unchanged.
+  button, matching iOS. Moving between PageSpace subdomains also stays inside the app now instead
+  of bouncing out to Chrome mid-flow. Opening a `pagespace.ai` web link from elsewhere still opens
+  your browser, unchanged.
 
 - **Dev-server preview: see the app you're building, live, from inside its session (ships dark)** —
   when a dev server (Vite, Next, anything that binds a port) starts inside an agent session or a

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,18 +7,17 @@ All notable user-facing changes to PageSpace are documented here. Format follows
 
 ### Added
 
-- **Android app: a failed load now offers a Retry, and links can open the app (groundwork)** —
+- **Android app: a failed load now offers a Retry, and OAuth sign-in can return to the app** —
   the Android shell previously had no bundled error screen, so a launch with no connectivity left
   the WebView on Chrome's own error page with nothing to do. It now falls back to a PageSpace
-  screen with a working Retry button, matching iOS. The app also registers deep links: the
-  `pagespace://` scheme the Google and Apple sign-in redirects already use, and Android App Links
-  for the same `pagespace.ai` paths iOS claims (`/auth/callback/`, `/api/auth/callback/`,
-  `/invite/`, `/join/`). **The App Links are inert until `/.well-known/assetlinks.json` is served
-  from pagespace.ai with the release signing certificate's fingerprint** — that certificate does
-  not exist yet, since signing and Play Console setup are separate work. Until it is served,
-  `pagespace.ai` links open in the browser exactly as they do today; no disambiguation dialog
-  appears. Sign-in and other non-pagespace.ai hosts the app navigates to are now allowlisted so
-  they stay inside the app instead of being handed to Chrome.
+  screen with a working Retry button, matching iOS. The app also registers the `pagespace://`
+  link scheme the Google and Apple sign-in redirects already use, so a native sign-in can hand
+  back to the app the way it does on iOS. Sign-in and other non-pagespace.ai hosts the app
+  navigates to are now allowlisted so they stay inside the app instead of being handed to Chrome.
+  Opening a `pagespace.ai` web link still opens your browser, unchanged — making those links open
+  the app needs a signed release build and in-app link routing that do not exist yet, and adding
+  it early would have put PageSpace in Android's "open with" chooser on Android 6–11 and then
+  dropped you on the dashboard with the link's invite or sign-in token discarded.
 
 - **Dev-server preview: see the app you're building, live, from inside its session (ships dark)** —
   when a dev server (Vite, Next, anything that binds a port) starts inside an agent session or a

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,11 +7,12 @@ All notable user-facing changes to PageSpace are documented here. Format follows
 
 ### Added
 
-- **Android app: a failed load now offers a Retry instead of a dead end** — the Android shell had
-  no bundled error screen, so launching without connectivity left the WebView on Chrome's own
-  error page with nothing to do. It now falls back to a PageSpace screen with a working Retry
-  button, matching iOS. Opening a `pagespace.ai` web link from elsewhere still opens your browser,
-  unchanged.
+- **Android app: a failed load now offers a Retry instead of a dead end (not yet distributed)** —
+  the Android shell had no bundled error screen, so launching without connectivity left the WebView
+  on Chrome's own error page with nothing to do. It now falls back to a PageSpace screen with a
+  working Retry button, matching iOS. Nobody can see this yet: the Android app has no release build
+  and is not distributed, so this lands as groundwork for the build that will be. Opening a
+  `pagespace.ai` web link from elsewhere still opens your browser, unchanged.
 
 - **Dev-server preview: see the app you're building, live, from inside its session (ships dark)** —
   when a dev server (Vite, Next, anything that binds a port) starts inside an agent session or a

--- a/apps/android/README.md
+++ b/apps/android/README.md
@@ -141,7 +141,10 @@ fingerprint of the **release** signing certificate:
 ```
 
 No release keystore exists — signing and Play Console setup are outside the Android parity epic —
-so link verification cannot succeed on any Android version today.
+so **no build we could ship can be verified**. This is a statement about release-signed artifacts,
+not about the mechanism: a debug build can be verified locally against a debug-fingerprint
+assetlinks file, and that workflow is documented below. What is missing is the release certificate,
+and with it any possibility of verification on a user's device.
 
 ### Prerequisite 2 — link routing in the web app
 
@@ -162,8 +165,10 @@ version, not of `targetSdk`:
 | 23–30 (Android 6–11) | Filter stays eligible; PageSpace appears in the disambiguation chooser. |
 
 `minSdkVersion` is 23, so the second row is in scope. On those devices a user who picks PageSpace
-from the chooser lands on `/dashboard` with the token gone — strictly worse than the browser,
-for no gain, since verification cannot succeed anyway. Hence: deferred, not shipped.
+from the chooser lands on `/dashboard` with the token gone — strictly worse than the browser, and
+for no gain, since no shipped build can be verified. Hence: deferred, not shipped. (A debug build
+can be verified locally, but that changes nothing for a user's device, which is what the filter
+would affect.)
 
 Sourcing, since the two rows are not equally well documented. The 23–30 row follows from the
 docs: unverified deep links are "subject to the system disambiguation dialog", and "on Android 11

--- a/apps/android/README.md
+++ b/apps/android/README.md
@@ -7,6 +7,69 @@ Capacitor wrapper around the web app, mirroring `apps/ios`.
 > prompt, token registration, build and signing — belongs to the Android client work and is not
 > documented here yet.
 
+## Why this config is not a copy of the iOS one
+
+`apps/ios/capacitor.config.ts` carries a long comment about `allowNavigation` and `errorPath`,
+added when the iOS shell bricked in PR #2010. Android's config sets the same two keys for
+different reasons, and its `allowNavigation` list is deliberately much shorter.
+
+### The iOS brick does not reproduce on Android
+
+iOS failed because `WebViewDelegationHandler.swift` falls back to a raw string-prefix test of the
+target URL against `server.url` — which carries the `/dashboard` path — so a top-level navigation
+to any other path failed it and was handed to Safari, leaving no document. Android's equivalent,
+`Bridge.launchIntent()`, compares host and scheme only:
+
+```java
+Uri appUri = Uri.parse(appUrl);
+if (
+    !(appUri.getHost().equals(url.getHost()) && url.getScheme().equals(appUri.getScheme())) &&
+    !appAllowNavigationMask.matches(url.getHost())
+) { /* ACTION_VIEW to the system browser */ return true; }
+```
+
+`https://pagespace.ai/signin` matches on both, so it already stayed in the WebView with no
+`allowNavigation` at all. The apex entry in the Android config states the app's own origin; it does
+not change behaviour.
+
+### `errorPath` is a real gap, and it is the reason the config changed
+
+`BridgeWebViewClient.onReceivedError` and `onReceivedHttpError` load `bridge.getErrorUrl()` for
+main-frame requests. With no `errorPath` configured that returns `null`, so a failed load left the
+WebView on its own error page. With it, Android serves `https://localhost/index.html` from the
+bundled assets — `public/index.html`, which carries the Retry button.
+
+Note that page gets **no Capacitor bridge**: `Bridge.loadWebView()` scopes
+`addDocumentStartJavaScript` to the `server.url` origin, so `Capacitor` and every plugin are
+undefined there. It uses plain DOM APIs only, and must keep doing so.
+
+### An `allowNavigation` entry grants the native plugin bridge
+
+This is the important divergence. On Android the list is not just a navigation allowlist:
+`Bridge.setAllowedOriginRules()` folds every entry into `allowedOriginRules`, and
+`MessageHandler.java:36` passes that set to
+`WebViewCompat.addWebMessageListener(webView, "androidBridge", ...)`. Any main-frame document from
+a listed origin can then call `androidBridge.postMessage()`, which reaches
+`Bridge.callPluginMethod()` and every registered plugin — including `PageSpaceKeychain`, backed by
+EncryptedSharedPreferences.
+
+So Android lists `pagespace.ai` and nothing else:
+
+- **`accounts.google.com` / `appleid.apple.com`** are not listed, though iOS lists them. Allowing
+  them would load a provider consent page in the privileged WebView. The apparent benefit was a
+  visible `disallowed_useragent` failure instead of a silent wrong-cookie-jar one when the web
+  OAuth fallback fires — not worth a native-trust grant to a third party. Provider pages belong in
+  a Custom Tab with a bound callback.
+- **`*.pagespace.ai`** is not listed either. `allowNavigation` governs top-level navigations only
+  (subresources from `assets.pagespace.ai` and friends never consult it), and the shell loads
+  `/dashboard` and stays there, so the wildcard enabled no navigation anyone could name while
+  granting the bridge to every subdomain that exists or ever will, tenant hosts included.
+
+**iOS has the same exposure and worse scoping**, and it is shipped: `JSExport.swift:20-21`
+registers the bridge as `WKUserScript(..., forMainFrameOnly: true)` on the WebView's
+`userContentController`, with no origin scoping at all, so it applies to every main-frame document
+the WebView loads. Changing that is separate work, tracked on the Android parity epic.
+
 ## Deep links: what ships, and what is deliberately deferred
 
 `AndroidManifest.xml` registers **one** deep-link intent filter: the `pagespace://` custom

--- a/apps/android/README.md
+++ b/apps/android/README.md
@@ -69,9 +69,16 @@ main-frame requests. With no `errorPath` configured that returns `null`, so a fa
 WebView on its own error page. With it, Android serves `https://localhost/index.html` from the
 bundled assets — `public/index.html`, which carries the Retry button.
 
-Note that page gets **no Capacitor bridge**: `Bridge.loadWebView()` scopes
-`addDocumentStartJavaScript` to the `server.url` origin, so `Capacitor` and every plugin are
-undefined there. It uses plain DOM APIs only, and must keep doing so.
+That page has no `window.Capacitor` — `Bridge.loadWebView()` scopes
+`addDocumentStartJavaScript` to the `server.url` origin, so the JS wrapper and its plugin proxies
+are undefined there. **It is not, however, outside the native bridge**, and it would be a mistake
+to treat it as a sandbox: `Bridge.setAllowedOriginRules()` adds `scheme://hostname` —
+`https://localhost` — to the allowed-origin set *unconditionally*, before it looks at
+`allowNavigation` at all, so `MessageHandler` exposes `androidBridge` on this origin. Code that
+knows the message protocol can call registered plugins directly.
+
+The retry page uses plain DOM APIs only and should keep doing so, but that is a discipline, not a
+boundary the platform enforces.
 
 ### An `allowNavigation` entry grants the native plugin bridge
 

--- a/apps/android/README.md
+++ b/apps/android/README.md
@@ -69,9 +69,20 @@ main-frame requests. With no `errorPath` configured that returns `null`, so a fa
 WebView on its own error page. With it, Android serves `https://localhost/index.html` from the
 bundled assets — `public/index.html`, which carries the Retry button.
 
-That page has no `window.Capacitor` — `Bridge.loadWebView()` scopes
-`addDocumentStartJavaScript` to the `server.url` origin, so the JS wrapper and its plugin proxies
-are undefined there. **It is not, however, outside the native bridge**, and it would be a mistake
+That page has no `window.Capacitor`, and it is worth knowing that this holds for two *different*
+reasons depending on the device, because only one of them is about origin scoping:
+
+- **WebView supports `DOCUMENT_START_SCRIPT`:** `Bridge.loadWebView()` registers the wrapper via
+  `addDocumentStartJavaScript` scoped to the `server.url` origin, and sets the injector to null.
+  Nothing is injected at `https://localhost`.
+- **WebView does not:** the injector stays live and `WebViewLocalServer` *does* inject the runtime
+  into locally-served HTML — at `handleLocalRequest` line 449, `ext.equals(".html") && jsInjector
+  != null`. That branch is never reached for this page, because `isErrorUrl()` is tested at line
+  374 and returns a raw, non-injected stream first.
+
+The second one is a load-bearing coincidence, so treat it as a constraint: the exemption is keyed
+on the request URL matching `bridge.getErrorUrl()` exactly. Serve this fallback from any other
+local path and legacy WebViews *will* inject the Capacitor runtime into it. **It is not, however, outside the native bridge**, and it would be a mistake
 to treat it as a sandbox: `Bridge.setAllowedOriginRules()` adds `scheme://hostname` —
 `https://localhost` — to the allowed-origin set *unconditionally*, before it looks at
 `allowNavigation` at all, so `MessageHandler` exposes `androidBridge` on this origin. Code that

--- a/apps/android/README.md
+++ b/apps/android/README.md
@@ -10,10 +10,17 @@ Capacitor wrapper around the web app, mirroring `apps/ios`.
 ## Deep links: what ships, and what is deliberately deferred
 
 `AndroidManifest.xml` registers **one** deep-link intent filter: the `pagespace://` custom
-scheme, mirroring iOS's `CFBundleURLSchemes`. This is what the Google and Apple OAuth callback
-routes redirect to (`pagespace://auth-exchange?code=…`). A custom scheme is claimed by the app
-outright — no domain verification, no server-side file — so it works as soon as the app is
+scheme, mirroring iOS's `CFBundleURLSchemes`. A custom scheme is claimed by the app outright — no
+domain verification, no server-side file — so the claim is effective as soon as the app is
 installed, on every supported API level.
+
+It is **groundwork, not a live path**. `pagespace://auth-exchange?code=…` is what the Google and
+Apple OAuth callback routes redirect to, but only on their `platform === 'ios'` branch, and
+`apps/web/src/lib/auth/oauth-state.ts` types the platform as `z.enum(['web', 'desktop', 'ios'])`
+— `'android'` is not a value it can take, so no server path emits a `pagespace://` redirect for
+Android today. (`/api/auth/google/native` does accept `'android'`, but it returns JSON to the
+native plugin rather than a deep link.) Teaching that path about Android belongs to the epic's
+native auth phase; registering the scheme now means the manifest will not be the blocker then.
 
 **Verified App Links for `https://pagespace.ai` are NOT registered.** Two prerequisites are
 missing, and the filter is a regression rather than groundwork until both land.

--- a/apps/android/README.md
+++ b/apps/android/README.md
@@ -7,19 +7,21 @@ Capacitor wrapper around the web app, mirroring `apps/ios`.
 > prompt, token registration, build and signing — belongs to the Android client work and is not
 > documented here yet.
 
-## Deep links need an assetlinks.json that does not exist yet
+## Deep links: what ships, and what is deliberately deferred
 
-`AndroidManifest.xml` registers two deep-link intent filters:
+`AndroidManifest.xml` registers **one** deep-link intent filter: the `pagespace://` custom
+scheme, mirroring iOS's `CFBundleURLSchemes`. This is what the Google and Apple OAuth callback
+routes redirect to (`pagespace://auth-exchange?code=…`). A custom scheme is claimed by the app
+outright — no domain verification, no server-side file — so it works as soon as the app is
+installed, on every supported API level.
 
-- **Verified App Links** for `https://pagespace.ai`, on the same paths iOS claims in
-  `apps/web/public/.well-known/apple-app-site-association` (`/auth/callback/*`,
-  `/api/auth/callback/*`, `/invite/*`, `/join/*`).
-- **The `pagespace://` custom scheme**, mirroring iOS's `CFBundleURLSchemes`. This is what the
-  Google and Apple OAuth callback routes redirect to (`pagespace://auth-exchange?code=…`).
+**Verified App Links for `https://pagespace.ai` are NOT registered.** Two prerequisites are
+missing, and the filter is a regression rather than groundwork until both land.
 
-The custom scheme works as soon as the app is installed. **The App Links do not, and will not
-until `/.well-known/assetlinks.json` is served from `pagespace.ai`** carrying the SHA-256
-fingerprint of the *release* signing certificate:
+### Prerequisite 1 — assetlinks.json, which needs a release signing certificate
+
+`/.well-known/assetlinks.json` must be served from `pagespace.ai` carrying the SHA-256
+fingerprint of the **release** signing certificate:
 
 ```json
 [{
@@ -32,21 +34,56 @@ fingerprint of the *release* signing certificate:
 }]
 ```
 
-That fingerprint does not exist: a release keystore and Play Console setup are deliberately
-outside the Android parity epic. Until it does, Android's link verification fails and — because
-the filter is `android:autoVerify="true"` and the app targets SDK 36 — the app is simply not
-offered as a handler and the link opens in the browser. That is the intended degradation; it is
-also why the filter must keep `autoVerify`, since without it PageSpace would appear in the
-disambiguation chooser on every `pagespace.ai` link.
+No release keystore exists — signing and Play Console setup are outside the Android parity epic —
+so link verification cannot succeed on any Android version today.
 
-To verify locally before then, serve the same file with the **debug** keystore's fingerprint
-(`keytool -list -v -keystore ~/.android/debug.keystore -alias androiddebugkey -storepass android`)
-and re-run verification with `adb shell pm verify-app-links --re-verify ai.pagespace.android`,
-then inspect `adb shell pm get-app-links ai.pagespace.android`.
+### Prerequisite 2 — link routing in the web app
 
-One further gap, shared with iOS: nothing in the web app listens for the Capacitor App plugin's
-`appUrlOpen` event, so a captured link opens the app at `server.url` (`/dashboard`) rather than at
-the linked path. Widening the host capture beyond the paths above should wait on that routing.
+Nothing listens for the `@capacitor/app` plugin's `appUrlOpen` event, on **either** platform. A
+captured link therefore opens the app at `server.url` (`/dashboard`), not at the linked path: the
+invite token or auth callback code in the URL is silently dropped.
+
+### Why `autoVerify` alone is not enough here
+
+`android:autoVerify="true"` is often described as making an unverified filter degrade safely to
+the browser. That is true only on **API 31+**, and it is a behaviour of the *device's* platform
+version, not of `targetSdk`:
+
+| Device API level | Filter present, verification fails |
+|---|---|
+| 31+ (Android 12+) | App is not a candidate; link opens in the browser. Safe. |
+| 23–30 (Android 6–11) | Filter stays eligible; PageSpace appears in the disambiguation chooser. |
+
+`minSdkVersion` is 23, so the second row is in scope. On those devices a user who picks PageSpace
+from the chooser lands on `/dashboard` with the token gone — strictly worse than the browser,
+for no gain, since verification cannot succeed anyway. Hence: deferred, not shipped.
+
+### The filter to add, once both prerequisites are met
+
+Paths mirror `apps/web/public/.well-known/apple-app-site-association` so the two platforms capture
+the same links. Widening beyond these paths should still wait on prerequisite 2 — whole-host
+capture would strand users on `/dashboard` from every marketing, blog, or docs link.
+
+```xml
+<intent-filter android:autoVerify="true">
+    <action android:name="android.intent.action.VIEW" />
+    <category android:name="android.intent.category.DEFAULT" />
+    <category android:name="android.intent.category.BROWSABLE" />
+    <data android:scheme="https" android:host="pagespace.ai" android:pathPrefix="/auth/callback/" />
+    <data android:scheme="https" android:host="pagespace.ai" android:pathPrefix="/api/auth/callback/" />
+    <data android:scheme="https" android:host="pagespace.ai" android:pathPrefix="/invite/" />
+    <data android:scheme="https" android:host="pagespace.ai" android:pathPrefix="/join/" />
+</intent-filter>
+```
+
+To exercise it before a release certificate exists, serve the same `assetlinks.json` with the
+**debug** keystore's fingerprint:
+
+```bash
+keytool -list -v -keystore ~/.android/debug.keystore -alias androiddebugkey -storepass android
+adb shell pm verify-app-links --re-verify ai.pagespace.android
+adb shell pm get-app-links ai.pagespace.android
+```
 
 ## Server-side push requirements (production `pagespace-web`)
 

--- a/apps/android/README.md
+++ b/apps/android/README.md
@@ -82,7 +82,20 @@ reasons depending on the device, because only one of them is about origin scopin
 
 The second one is a load-bearing coincidence, so treat it as a constraint: the exemption is keyed
 on the request URL matching `bridge.getErrorUrl()` exactly. Serve this fallback from any other
-local path and legacy WebViews *will* inject the Capacitor runtime into it. **It is not, however, outside the native bridge**, and it would be a mistake
+local path and legacy WebViews *will* inject the Capacitor runtime into it.
+
+**How the app itself gets its wrapper on those legacy WebViews**, since it is not obvious and is
+worth knowing before anyone touches `server.url`: `initWebView()` puts the `server.url` authority
+into `WebViewLocalServer`'s `authorities`, and with `server.url` set `isAllowedUrl()` is
+unconditionally true, so the top-level `pagespace.ai` HTML request takes `handleProxyRequest` —
+fetched through `HttpURLConnection`, with cookies copied to and from `CookieManager` by hand, and
+the runtime injected into the response. Where `DOCUMENT_START_SCRIPT` is supported the injector is
+null and that method returns null, leaving the WebView's own network stack in charge.
+
+Note this is driven by `server.url`, **not** by the `pagespace.ai` entry in `allowNavigation`:
+`initWebView()` runs at `Bridge.java:223` and adds that authority, before `setAllowedOriginRules()`
+at line 224 adds the `allowNavigation` hosts. Removing the apex entry would not change the network
+path or the injection. **It is not, however, outside the native bridge**, and it would be a mistake
 to treat it as a sandbox: `Bridge.setAllowedOriginRules()` adds `scheme://hostname` —
 `https://localhost` — to the allowed-origin set *unconditionally*, before it looks at
 `allowNavigation` at all, so `MessageHandler` exposes `androidBridge` on this origin. Code that

--- a/apps/android/README.md
+++ b/apps/android/README.md
@@ -10,8 +10,9 @@ Capacitor wrapper around the web app, mirroring `apps/ios`.
 ## Why this config is not a copy of the iOS one
 
 `apps/ios/capacitor.config.ts` carries a long comment about `allowNavigation` and `errorPath`,
-added when the iOS shell bricked in PR #2010. Android's config sets the same two keys for
-different reasons, and its `allowNavigation` list is deliberately much shorter.
+added when the iOS shell bricked in PR #2010. Android sets those two keys for different reasons,
+splits `server.url` in a way iOS does not need to, and keeps a deliberately much shorter
+`allowNavigation` list. Three divergences, in the order they matter:
 
 ### `server.url` must stay an origin — the path lives in `appStartPath`
 
@@ -139,8 +140,9 @@ so link verification cannot succeed on any Android version today.
 ### Prerequisite 2 — link routing in the web app
 
 Nothing listens for the `@capacitor/app` plugin's `appUrlOpen` event, on **either** platform. A
-captured link therefore opens the app at `server.url` (`/dashboard`), not at the linked path: the
-invite token or auth callback code in the URL is silently dropped.
+captured link therefore opens the app at its configured start URL (`server.url` + `appStartPath`,
+so `/dashboard`), not at the linked path: the invite token or auth callback code in the URL is
+silently dropped.
 
 ### Why `autoVerify` alone is not enough here
 
@@ -189,6 +191,11 @@ keytool -list -v -keystore ~/.android/debug.keystore -alias androiddebugkey -sto
 adb shell pm verify-app-links --re-verify ai.pagespace.android
 adb shell pm get-app-links ai.pagespace.android
 ```
+
+Both `pm` subcommands arrived with the API 31 verification system, so this checks the top row of
+the table above. Confirming the API 23–30 behaviour — that an unverified filter stays chooser-
+eligible — needs an older device or emulator image, and is the row that matters for the decision
+to defer.
 
 ## Server-side push requirements (production `pagespace-web`)
 

--- a/apps/android/README.md
+++ b/apps/android/README.md
@@ -33,9 +33,15 @@ anything.
 `getServerUrl()` consumers are fine with an origin: `WebViewLocalServer.isMainUrl`/`isAllowedUrl`
 only null-check it, and `CapacitorCookieManager.getSanitizedDomain` wants a cookie domain.
 
-Whether androidx.webkit really rejects a path-bearing rule was read from the API contract, not
-observed on a device — worth confirming during device verification, and worth an upstream report to
-Capacitor if the catch turns out to be live.
+The rejection is documented, not inferred. `WebViewCompat.addWebMessageListener`'s javadoc gives
+the rule grammar as `SCHEME "://" [ HOSTNAME_PATTERN [ ":" PORT ] ]` — which has no path
+production, so `https://pagespace.ai/dashboard` is not expressible as a rule — and declares
+`@throws IllegalArgumentException If one of the allowedOriginRules is invalid`.
+
+What is still unobserved is the runtime consequence: that Capacitor's catch is therefore taken and
+`addJavascriptInterface` really does replace the origin-scoped listener on a device. Worth
+confirming during device verification, and worth an upstream report to Capacitor if so, since any
+app with a path in `server.url` inherits it silently.
 
 ### The iOS brick does not reproduce on Android
 

--- a/apps/android/README.md
+++ b/apps/android/README.md
@@ -2,9 +2,51 @@
 
 Capacitor wrapper around the web app, mirroring `apps/ios`.
 
-> **Scope of this file today:** only the server-side push requirements below, added with the FCM
-> sender. Client-side setup — the runtime permission prompt, token registration, build and signing
-> — belongs to the Android client work and is not documented here yet.
+> **Scope of this file today:** the server-side push requirements below (added with the FCM
+> sender) and the deep-link deployment dependency. Client-side setup — the runtime permission
+> prompt, token registration, build and signing — belongs to the Android client work and is not
+> documented here yet.
+
+## Deep links need an assetlinks.json that does not exist yet
+
+`AndroidManifest.xml` registers two deep-link intent filters:
+
+- **Verified App Links** for `https://pagespace.ai`, on the same paths iOS claims in
+  `apps/web/public/.well-known/apple-app-site-association` (`/auth/callback/*`,
+  `/api/auth/callback/*`, `/invite/*`, `/join/*`).
+- **The `pagespace://` custom scheme**, mirroring iOS's `CFBundleURLSchemes`. This is what the
+  Google and Apple OAuth callback routes redirect to (`pagespace://auth-exchange?code=…`).
+
+The custom scheme works as soon as the app is installed. **The App Links do not, and will not
+until `/.well-known/assetlinks.json` is served from `pagespace.ai`** carrying the SHA-256
+fingerprint of the *release* signing certificate:
+
+```json
+[{
+  "relation": ["delegate_permission/common.handle_all_urls"],
+  "target": {
+    "namespace": "android_app",
+    "package_name": "ai.pagespace.android",
+    "sha256_cert_fingerprints": ["<release cert SHA-256, colon-separated hex>"]
+  }
+}]
+```
+
+That fingerprint does not exist: a release keystore and Play Console setup are deliberately
+outside the Android parity epic. Until it does, Android's link verification fails and — because
+the filter is `android:autoVerify="true"` and the app targets SDK 36 — the app is simply not
+offered as a handler and the link opens in the browser. That is the intended degradation; it is
+also why the filter must keep `autoVerify`, since without it PageSpace would appear in the
+disambiguation chooser on every `pagespace.ai` link.
+
+To verify locally before then, serve the same file with the **debug** keystore's fingerprint
+(`keytool -list -v -keystore ~/.android/debug.keystore -alias androiddebugkey -storepass android`)
+and re-run verification with `adb shell pm verify-app-links --re-verify ai.pagespace.android`,
+then inspect `adb shell pm get-app-links ai.pagespace.android`.
+
+One further gap, shared with iOS: nothing in the web app listens for the Capacitor App plugin's
+`appUrlOpen` event, so a captured link opens the app at `server.url` (`/dashboard`) rather than at
+the linked path. Widening the host capture beyond the paths above should wait on that routing.
 
 ## Server-side push requirements (production `pagespace-web`)
 

--- a/apps/android/README.md
+++ b/apps/android/README.md
@@ -10,9 +10,15 @@ Capacitor wrapper around the web app, mirroring `apps/ios`.
 ## Deep links: what ships, and what is deliberately deferred
 
 `AndroidManifest.xml` registers **one** deep-link intent filter: the `pagespace://` custom
-scheme, mirroring iOS's `CFBundleURLSchemes`. A custom scheme is claimed by the app outright — no
-domain verification, no server-side file — so the claim is effective as soon as the app is
-installed, on every supported API level.
+scheme, mirroring iOS's `CFBundleURLSchemes`. It needs no domain verification and no server-side
+file, so the registration takes effect as soon as the app is installed, on every supported API
+level.
+
+**Registration is not ownership.** Custom schemes are not exclusive on Android: any other
+installed app can register `pagespace://` as well and be offered in the disambiguation chooser, or
+be set as the user's default handler. That no browser competes for the scheme does not mean no app
+does — which is why the scheme must not be treated as an authentication return channel until the
+handoff it carries is bound to the app that started the flow (see below).
 
 It is **groundwork, not a live path**. `pagespace://auth-exchange?code=…` is what the Google and
 Apple OAuth callback routes redirect to, but only on their `platform === 'ios'` branch, and
@@ -70,6 +76,12 @@ for no gain, since verification cannot succeed anyway. Hence: deferred, not ship
 Paths mirror `apps/web/public/.well-known/apple-app-site-association` so the two platforms capture
 the same links. Widening beyond these paths should still wait on prerequisite 2 — whole-host
 capture would strand users on `/dashboard` from every marketing, blog, or docs link.
+
+A third prerequisite applies to the auth-callback paths specifically: `/api/auth/desktop/exchange`
+authenticates possession of the one-time code alone, with no PKCE verifier and no binding to the
+app that began the flow, so whichever handler receives the code can redeem it for a session. That
+must be bound before any return channel — App Link or custom scheme — is treated as an
+authentication path.
 
 ```xml
 <intent-filter android:autoVerify="true">

--- a/apps/android/README.md
+++ b/apps/android/README.md
@@ -2,16 +2,39 @@
 
 Capacitor wrapper around the web app, mirroring `apps/ios`.
 
-> **Scope of this file today:** the server-side push requirements below (added with the FCM
-> sender) and the deep-link deployment dependency. Client-side setup — the runtime permission
-> prompt, token registration, build and signing — belongs to the Android client work and is not
-> documented here yet.
+> **Scope of this file today:** why the Capacitor config diverges from the iOS one, what deep
+> links ship and what is deferred, and the server-side push requirements. Client-side setup — the
+> runtime permission prompt, token registration, build and signing — belongs to the Android client
+> work and is not documented here yet.
 
 ## Why this config is not a copy of the iOS one
 
 `apps/ios/capacitor.config.ts` carries a long comment about `allowNavigation` and `errorPath`,
 added when the iOS shell bricked in PR #2010. Android's config sets the same two keys for
 different reasons, and its `allowNavigation` list is deliberately much shorter.
+
+### `server.url` must stay an origin — the path lives in `appStartPath`
+
+```ts
+url: 'https://pagespace.ai',
+appStartPath: '/dashboard',
+```
+
+Not cosmetic. `Bridge.setAllowedOriginRules()` puts `getServerUrl()` **verbatim** into the set
+`MessageHandler` hands to `WebViewCompat.addWebMessageListener`, and that API takes origin rules —
+`scheme://host[:port]`. A `url` carrying `/dashboard` is not one, and the catch for a rejected rule
+is `webView.addJavascriptInterface(this, "androidBridge")`, which enforces no origin restriction at
+all. Put the path back into `url` and the `allowNavigation` allowlist below may stop meaning
+anything.
+
+`Bridge` appends `appStartPath` *after* the `server.url` branch, so `appUrl` is still
+`https://pagespace.ai/dashboard` and the app still bypasses the landing page. The other
+`getServerUrl()` consumers are fine with an origin: `WebViewLocalServer.isMainUrl`/`isAllowedUrl`
+only null-check it, and `CapacitorCookieManager.getSanitizedDomain` wants a cookie domain.
+
+Whether androidx.webkit really rejects a path-bearing rule was read from the API contract, not
+observed on a device — worth confirming during device verification, and worth an upstream report to
+Capacitor if the catch turns out to be live.
 
 ### The iOS brick does not reproduce on Android
 

--- a/apps/android/README.md
+++ b/apps/android/README.md
@@ -148,10 +148,18 @@ and with it any possibility of verification on a user's device.
 
 ### Prerequisite 2 — link routing in the web app
 
-Nothing listens for the `@capacitor/app` plugin's `appUrlOpen` event, on **either** platform. A
-captured link therefore opens the app at its configured start URL (`server.url` + `appStartPath`,
-so `/dashboard`), not at the linked path: the invite token or auth callback code in the URL is
-silently dropped.
+Nothing listens for the `@capacitor/app` plugin's `appUrlOpen` event, on **either** platform, so a
+captured link never reaches the path it names. What the user sees depends on whether the app was
+already running, and the two cases differ:
+
+| Start | What happens |
+|---|---|
+| **Cold** | The app launches and loads its start URL (`server.url` + `appStartPath`, so `/dashboard`). The linked path is dropped. |
+| **Warm** (`singleTask`, app already running) | The intent arrives via `onNewIntent`; `Bridge.onNewIntent` only notifies plugins — it never calls `loadUrl` — so `AppPlugin` fires `appUrlOpen` into a void and **the WebView stays exactly where it was.** Nothing visible happens at all. |
+
+Either way the invite token or auth callback code is silently dropped. Do not rely on a
+reset-to-`/dashboard` guarantee: it holds only on a cold launch, which matters both for device
+verification and for whoever implements the routing.
 
 ### Why `autoVerify` alone is not enough here
 
@@ -165,8 +173,9 @@ version, not of `targetSdk`:
 | 23–30 (Android 6–11) | Filter stays eligible; PageSpace appears in the disambiguation chooser. |
 
 `minSdkVersion` is 23, so the second row is in scope. On those devices a user who picks PageSpace
-from the chooser lands on `/dashboard` with the token gone — strictly worse than the browser, and
-for no gain, since no shipped build can be verified. Hence: deferred, not shipped. (A debug build
+from the chooser gets, per the table above, either the dashboard (cold) or no visible change at all
+(warm) — with the token gone in both cases. Strictly worse than the browser, and for no gain, since
+no shipped build can be verified. Hence: deferred, not shipped. (A debug build
 can be verified locally, but that changes nothing for a user's device, which is what the filter
 would affect.)
 

--- a/apps/android/README.md
+++ b/apps/android/README.md
@@ -165,6 +165,20 @@ version, not of `targetSdk`:
 from the chooser lands on `/dashboard` with the token gone — strictly worse than the browser,
 for no gain, since verification cannot succeed anyway. Hence: deferred, not shipped.
 
+Sourcing, since the two rows are not equally well documented. The 23–30 row follows from the
+docs: unverified deep links are "subject to the system disambiguation dialog", and "on Android 11
+(API level 30) and lower, the system establishes your app as the default handler for the specified
+URL patterns only if it finds a matching Digital Asset Links file for all hosts in the manifest" —
+i.e. failing verification costs you *default* status, not candidacy. The 31+ row is the
+well-established behaviour change that Codex review identified; I did not find it stated in one
+quotable sentence in the official docs.
+
+That gap does not affect the decision, which is why it is recorded rather than chased: **deferring
+is the safe choice under either reading.** If 31+ really does drop the app from resolution, the
+filter is inert and costs nothing to omit; if it does not, the filter would be actively harmful on
+every supported version. The filter only becomes worth adding once verification can actually
+succeed — which is prerequisite 1.
+
 ### The filter to add, once both prerequisites are met
 
 Paths mirror `apps/web/public/.well-known/apple-app-site-association` so the two platforms capture

--- a/apps/android/README.md
+++ b/apps/android/README.md
@@ -90,6 +90,12 @@ a listed origin can then call `androidBridge.postMessage()`, which reaches
 `Bridge.callPluginMethod()` and every registered plugin — including `PageSpaceKeychain`, backed by
 EncryptedSharedPreferences.
 
+The full set is wider than `allowNavigation`, which matters if you are auditing bridge access.
+`setAllowedOriginRules()` adds, in order: `scheme://hostname` (`https://localhost`, the bundled-asset
+origin — see the `errorPath` section above), then `server.url` if set, then every `allowNavigation`
+entry. So `allowNavigation` is the only part *we* control, and shortening it is the only lever this
+config has.
+
 So Android lists `pagespace.ai` and nothing else:
 
 - **`accounts.google.com` / `appleid.apple.com`** are not listed, though iOS lists them. Allowing

--- a/apps/android/android/app/src/main/AndroidManifest.xml
+++ b/apps/android/android/app/src/main/AndroidManifest.xml
@@ -35,8 +35,15 @@
 
             <!--
                 Custom scheme, mirroring CFBundleURLSchemes `pagespace` on iOS.
-                This is the OAuth handoff target: the Google and Apple callback
-                routes redirect to `pagespace://auth-exchange?code=...`.
+
+                Groundwork, not yet live: this is the OAuth handoff target the
+                Google and Apple callback routes redirect to
+                (`pagespace://auth-exchange?code=...`), but only on the
+                `platform === 'ios'` branch, and oauth-state.ts types platform as
+                z.enum(['web','desktop','ios']) — 'android' is not a value it can
+                take. Nothing redirects here for Android until the native auth
+                work (epic phase B) teaches that path about Android. Registering
+                the scheme now means the manifest is not the blocker then.
 
                 Unlike an https App Link this needs no domain verification and no
                 assetlinks.json — a custom scheme is claimed by the app outright —

--- a/apps/android/android/app/src/main/AndroidManifest.xml
+++ b/apps/android/android/app/src/main/AndroidManifest.xml
@@ -31,8 +31,10 @@
                 chooser. No assetlinks.json can match a SHIPPED build (there is
                 no release signing certificate; a debug one can be verified
                 locally, which does not help a user's device) and nothing routes
-                appUrlOpen, so picking it there would land on /dashboard with the
-                invite or auth token dropped.
+                appUrlOpen, so picking it there drops the invite or auth token —
+                landing on /dashboard from a cold start, or doing nothing visible
+                at all if the app is already running, since Bridge.onNewIntent
+                notifies plugins without reloading the WebView.
             -->
 
             <!--
@@ -72,6 +74,11 @@
                 forwards that to Bridge.onNewIntent, and @capacitor/app's
                 AppPlugin.handleOnNewIntent turns an ACTION_VIEW intent into an
                 `appUrlOpen` event. No second task is started.
+
+                Note what that does NOT do: Bridge.onNewIntent only notifies
+                plugins, never loadUrl. So on a warm start the WebView stays on
+                whatever route it was showing — the event fires into a void while
+                no listener exists. Only a cold launch loads the start URL.
             -->
             <intent-filter>
                 <action android:name="android.intent.action.VIEW" />

--- a/apps/android/android/app/src/main/AndroidManifest.xml
+++ b/apps/android/android/app/src/main/AndroidManifest.xml
@@ -64,11 +64,12 @@
                 does take the deep-link branch.
 
                 Unlike an https App Link this needs no domain verification and no
-                assetlinks.json — a custom scheme is claimed by the app outright —
-                so it works as soon as the app is installed, on every supported
-                API level. It also cannot be hijacked into the wrong app by a
-                chooser on pre-API-31 devices the way an unverified https filter
-                can, because no browser competes for a `pagespace://` URL.
+                assetlinks.json, so the registration takes effect as soon as the
+                app is installed, on every supported API level. That is NOT the
+                same as owning the scheme: see the block above — another installed
+                app can register `pagespace://` too and be offered in the chooser
+                or set as the default handler. No browser competes for it, which
+                is not the same thing as no app competing for it.
 
                 MainActivity is already launchMode="singleTask", so an incoming
                 link reaches the running task through onNewIntent; BridgeActivity

--- a/apps/android/android/app/src/main/AndroidManifest.xml
+++ b/apps/android/android/app/src/main/AndroidManifest.xml
@@ -45,6 +45,24 @@
                 work (epic phase B) teaches that path about Android. Registering
                 the scheme now means the manifest is not the blocker then.
 
+                READ BEFORE MAKING IT LIVE. A custom scheme is not an exclusive
+                claim on Android: any installed app may declare the same
+                `pagespace://` VIEW filter and become a chooser candidate or the
+                user's default handler. /api/auth/desktop/exchange authenticates
+                nothing but possession of the one-time code — it takes { code }
+                alone, with no PKCE verifier and no binding to the app that
+                started the flow, and answers with sessionToken, csrfToken and
+                deviceToken. So the moment a server path emits
+                `pagespace://auth-exchange?code=...` for Android, an app that wins
+                the scheme can redeem that code for the user's session.
+
+                Binding the exchange (an app-held PKCE verifier, or an App Link
+                return channel that a competing app cannot claim) is a
+                prerequisite for turning the handoff on — not for shipping this
+                filter, which is inert while nothing redirects to it. The same
+                weakness is live on iOS today, which registers this scheme and
+                does take the deep-link branch.
+
                 Unlike an https App Link this needs no domain verification and no
                 assetlinks.json — a custom scheme is claimed by the app outright —
                 so it works as soon as the app is installed, on every supported

--- a/apps/android/android/app/src/main/AndroidManifest.xml
+++ b/apps/android/android/app/src/main/AndroidManifest.xml
@@ -28,9 +28,11 @@
                 first: android:autoVerify="true" only removes an unverified app
                 from link resolution on API 31+, and minSdkVersion is 23, so on
                 API 23-30 the filter would put PageSpace in the disambiguation
-                chooser. assetlinks.json cannot be served yet (no release signing
-                certificate) and nothing routes appUrlOpen, so picking it there
-                would land on /dashboard with the invite or auth token dropped.
+                chooser. No assetlinks.json can match a SHIPPED build (there is
+                no release signing certificate; a debug one can be verified
+                locally, which does not help a user's device) and nothing routes
+                appUrlOpen, so picking it there would land on /dashboard with the
+                invite or auth token dropped.
             -->
 
             <!--

--- a/apps/android/android/app/src/main/AndroidManifest.xml
+++ b/apps/android/android/app/src/main/AndroidManifest.xml
@@ -23,42 +23,47 @@
             </intent-filter>
 
             <!--
-                Verified App Links. autoVerify is what keeps the degradation safe:
-                on Android 12+ (this app targets 36) an unverified autoVerify
-                filter makes the app simply not a candidate for the link, so it
-                opens in the browser. Dropping autoVerify would instead put
-                PageSpace in the disambiguation chooser on every pagespace.ai
-                link, which is the behaviour we do not want.
+                Verified App Links for https://pagespace.ai are deliberately NOT
+                registered yet. They need two things that do not exist, and
+                shipping the filter before both would be a regression, not
+                groundwork:
 
-                Verification needs /.well-known/assetlinks.json served from
-                pagespace.ai listing the RELEASE signing certificate's SHA-256
-                fingerprint. That certificate does not exist yet (signing and Play
-                Console are out of scope for this epic), so this is inert in
-                production today — see apps/android/README.md.
+                  1. /.well-known/assetlinks.json served from pagespace.ai with
+                     the RELEASE signing certificate's SHA-256 fingerprint. No
+                     release keystore exists — signing and Play Console are
+                     outside the Android parity epic — so verification cannot
+                     succeed on ANY Android version today.
+                  2. Link routing in the web app. Nothing listens for the
+                     @capacitor/app plugin's `appUrlOpen` event (on either
+                     platform), so a captured link opens the app at server.url
+                     (/dashboard) and the linked path — an invite token, an auth
+                     callback code — is silently dropped.
 
-                Paths mirror apps/web/public/.well-known/apple-app-site-association
-                so the two platforms capture the same links. Widening the host
-                capture needs link routing first: nothing in the web app listens
-                for the App plugin's `appUrlOpen`, so a captured link opens the
-                app at server.url (/dashboard), not at the linked path.
+                android:autoVerify="true" does not make an unverified filter safe
+                on the devices this app supports. Exclusive resolution of verified
+                links is a behaviour of the DEVICE's platform version (API 31+),
+                not of targetSdk: on API 31+ a failed-verification filter takes
+                the app out of the running and the link opens in the browser, but
+                minSdkVersion is 23, and on API 23-30 the same filter stays
+                eligible and PageSpace appears in the disambiguation chooser.
+                Picking it there would land the user on /dashboard with the token
+                gone — worse than the browser, for no gain.
+
+                The exact filter to add, and the order the prerequisites have to
+                land in, are written up in apps/android/README.md.
             -->
-            <intent-filter android:autoVerify="true">
-                <action android:name="android.intent.action.VIEW" />
-                <category android:name="android.intent.category.DEFAULT" />
-                <category android:name="android.intent.category.BROWSABLE" />
-                <data android:scheme="https" android:host="pagespace.ai" android:pathPrefix="/auth/callback/" />
-                <data android:scheme="https" android:host="pagespace.ai" android:pathPrefix="/api/auth/callback/" />
-                <data android:scheme="https" android:host="pagespace.ai" android:pathPrefix="/invite/" />
-                <data android:scheme="https" android:host="pagespace.ai" android:pathPrefix="/join/" />
-            </intent-filter>
 
             <!--
                 Custom scheme, mirroring CFBundleURLSchemes `pagespace` on iOS.
                 This is the OAuth handoff target: the Google and Apple callback
-                routes redirect to `pagespace://auth-exchange?code=...`. Kept in a
-                separate filter from the App Links one — autoVerify applies to the
-                whole filter, and a non-https scheme inside a verified filter has
-                nothing to verify against.
+                routes redirect to `pagespace://auth-exchange?code=...`.
+
+                Unlike an https App Link this needs no domain verification and no
+                assetlinks.json — a custom scheme is claimed by the app outright —
+                so it works as soon as the app is installed, on every supported
+                API level. It also cannot be hijacked into the wrong app by a
+                chooser on pre-API-31 devices the way an unverified https filter
+                can, because no browser competes for a `pagespace://` URL.
 
                 MainActivity is already launchMode="singleTask", so an incoming
                 link reaches the running task through onNewIntent; BridgeActivity

--- a/apps/android/android/app/src/main/AndroidManifest.xml
+++ b/apps/android/android/app/src/main/AndroidManifest.xml
@@ -35,41 +35,35 @@
 
             <!--
                 Custom scheme, mirroring CFBundleURLSchemes `pagespace` on iOS.
+                It needs no domain verification and no assetlinks.json, so the
+                registration takes effect as soon as the app is installed, on
+                every supported API level.
 
-                Groundwork, not yet live: this is the OAuth handoff target the
-                Google and Apple callback routes redirect to
-                (`pagespace://auth-exchange?code=...`), but only on the
+                Not live yet. This is the OAuth handoff target the Google and
+                Apple callback routes redirect to
+                (`pagespace://auth-exchange?code=...`), but only on their
                 `platform === 'ios'` branch, and oauth-state.ts types platform as
                 z.enum(['web','desktop','ios']) — 'android' is not a value it can
-                take. Nothing redirects here for Android until the native auth
-                work (epic phase B) teaches that path about Android. Registering
-                the scheme now means the manifest is not the blocker then.
+                take, so nothing redirects here for Android. Registering the
+                scheme now means the manifest is not the blocker when the native
+                auth phase teaches that path about Android.
 
-                READ BEFORE MAKING IT LIVE. A custom scheme is not an exclusive
-                claim on Android: any installed app may declare the same
-                `pagespace://` VIEW filter and become a chooser candidate or the
-                user's default handler. /api/auth/desktop/exchange authenticates
-                nothing but possession of the one-time code — it takes { code }
-                alone, with no PKCE verifier and no binding to the app that
-                started the flow, and answers with sessionToken, csrfToken and
-                deviceToken. So the moment a server path emits
-                `pagespace://auth-exchange?code=...` for Android, an app that wins
-                the scheme can redeem that code for the user's session.
-
-                Binding the exchange (an app-held PKCE verifier, or an App Link
-                return channel that a competing app cannot claim) is a
-                prerequisite for turning the handoff on — not for shipping this
-                filter, which is inert while nothing redirects to it. The same
-                weakness is live on iOS today, which registers this scheme and
-                does take the deep-link branch.
-
-                Unlike an https App Link this needs no domain verification and no
-                assetlinks.json, so the registration takes effect as soon as the
-                app is installed, on every supported API level. That is NOT the
-                same as owning the scheme: see the block above — another installed
-                app can register `pagespace://` too and be offered in the chooser
-                or set as the default handler. No browser competes for it, which
-                is not the same thing as no app competing for it.
+                READ BEFORE MAKING IT LIVE. Registration is not ownership: any
+                other installed app may declare the same `pagespace://` VIEW
+                filter and be offered in the chooser or set as the user's default
+                handler. (No browser competes for the scheme, which is not the
+                same as no app competing for it.) And
+                /api/auth/desktop/exchange authenticates nothing but possession
+                of the one-time code — it takes { code } alone, with no PKCE
+                verifier and no binding to the app that started the flow, then
+                answers with sessionToken, csrfToken and deviceToken. So the
+                moment a server path emits that redirect for Android, an app that
+                wins the scheme can redeem the code for the user's session. Bind
+                the exchange first — an app-held PKCE verifier, or a return
+                channel a competing app cannot claim. Shipping this filter is
+                fine meanwhile; it is inert while nothing redirects to it. The
+                same weakness is live on iOS, which does take the deep-link
+                branch.
 
                 MainActivity is already launchMode="singleTask", so an incoming
                 link reaches the running task through onNewIntent; BridgeActivity

--- a/apps/android/android/app/src/main/AndroidManifest.xml
+++ b/apps/android/android/app/src/main/AndroidManifest.xml
@@ -22,6 +22,57 @@
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
 
+            <!--
+                Verified App Links. autoVerify is what keeps the degradation safe:
+                on Android 12+ (this app targets 36) an unverified autoVerify
+                filter makes the app simply not a candidate for the link, so it
+                opens in the browser. Dropping autoVerify would instead put
+                PageSpace in the disambiguation chooser on every pagespace.ai
+                link, which is the behaviour we do not want.
+
+                Verification needs /.well-known/assetlinks.json served from
+                pagespace.ai listing the RELEASE signing certificate's SHA-256
+                fingerprint. That certificate does not exist yet (signing and Play
+                Console are out of scope for this epic), so this is inert in
+                production today — see apps/android/README.md.
+
+                Paths mirror apps/web/public/.well-known/apple-app-site-association
+                so the two platforms capture the same links. Widening the host
+                capture needs link routing first: nothing in the web app listens
+                for the App plugin's `appUrlOpen`, so a captured link opens the
+                app at server.url (/dashboard), not at the linked path.
+            -->
+            <intent-filter android:autoVerify="true">
+                <action android:name="android.intent.action.VIEW" />
+                <category android:name="android.intent.category.DEFAULT" />
+                <category android:name="android.intent.category.BROWSABLE" />
+                <data android:scheme="https" android:host="pagespace.ai" android:pathPrefix="/auth/callback/" />
+                <data android:scheme="https" android:host="pagespace.ai" android:pathPrefix="/api/auth/callback/" />
+                <data android:scheme="https" android:host="pagespace.ai" android:pathPrefix="/invite/" />
+                <data android:scheme="https" android:host="pagespace.ai" android:pathPrefix="/join/" />
+            </intent-filter>
+
+            <!--
+                Custom scheme, mirroring CFBundleURLSchemes `pagespace` on iOS.
+                This is the OAuth handoff target: the Google and Apple callback
+                routes redirect to `pagespace://auth-exchange?code=...`. Kept in a
+                separate filter from the App Links one — autoVerify applies to the
+                whole filter, and a non-https scheme inside a verified filter has
+                nothing to verify against.
+
+                MainActivity is already launchMode="singleTask", so an incoming
+                link reaches the running task through onNewIntent; BridgeActivity
+                forwards that to Bridge.onNewIntent, and @capacitor/app's
+                AppPlugin.handleOnNewIntent turns an ACTION_VIEW intent into an
+                `appUrlOpen` event. No second task is started.
+            -->
+            <intent-filter>
+                <action android:name="android.intent.action.VIEW" />
+                <category android:name="android.intent.category.DEFAULT" />
+                <category android:name="android.intent.category.BROWSABLE" />
+                <data android:scheme="pagespace" />
+            </intent-filter>
+
         </activity>
 
         <provider

--- a/apps/android/android/app/src/main/AndroidManifest.xml
+++ b/apps/android/android/app/src/main/AndroidManifest.xml
@@ -23,34 +23,14 @@
             </intent-filter>
 
             <!--
-                Verified App Links for https://pagespace.ai are deliberately NOT
-                registered yet. They need two things that do not exist, and
-                shipping the filter before both would be a regression, not
-                groundwork:
-
-                  1. /.well-known/assetlinks.json served from pagespace.ai with
-                     the RELEASE signing certificate's SHA-256 fingerprint. No
-                     release keystore exists — signing and Play Console are
-                     outside the Android parity epic — so verification cannot
-                     succeed on ANY Android version today.
-                  2. Link routing in the web app. Nothing listens for the
-                     @capacitor/app plugin's `appUrlOpen` event (on either
-                     platform), so a captured link opens the app at server.url
-                     (/dashboard) and the linked path — an invite token, an auth
-                     callback code — is silently dropped.
-
-                android:autoVerify="true" does not make an unverified filter safe
-                on the devices this app supports. Exclusive resolution of verified
-                links is a behaviour of the DEVICE's platform version (API 31+),
-                not of targetSdk: on API 31+ a failed-verification filter takes
-                the app out of the running and the link opens in the browser, but
-                minSdkVersion is 23, and on API 23-30 the same filter stays
-                eligible and PageSpace appears in the disambiguation chooser.
-                Picking it there would land the user on /dashboard with the token
-                gone — worse than the browser, for no gain.
-
-                The exact filter to add, and the order the prerequisites have to
-                land in, are written up in apps/android/README.md.
+                No https App Links filter here, deliberately. Do not add one back
+                without reading the "Deep links" section of apps/android/README.md
+                first: android:autoVerify="true" only removes an unverified app
+                from link resolution on API 31+, and minSdkVersion is 23, so on
+                API 23-30 the filter would put PageSpace in the disambiguation
+                chooser. assetlinks.json cannot be served yet (no release signing
+                certificate) and nothing routes appUrlOpen, so picking it there
+                would land on /dashboard with the invite or auth token dropped.
             -->
 
             <!--

--- a/apps/android/capacitor.config.ts
+++ b/apps/android/capacitor.config.ts
@@ -9,8 +9,10 @@ const config: CapacitorConfig = {
     // The landing path is `appStartPath`, NOT part of `url`, and the split
     // matters on Android. Bridge.setAllowedOriginRules() puts getServerUrl()
     // verbatim into the set MessageHandler hands to addWebMessageListener, and
-    // that API takes origin rules — `scheme://host[:port]`. A `url` carrying
-    // `/dashboard` is not one, and MessageHandler's catch for a rejected rule is
+    // that API documents its rule grammar as SCHEME "://" [ HOSTNAME_PATTERN
+    // [ ":" PORT ] ] — no path production — and throws IllegalArgumentException
+    // for an invalid rule. A `url` carrying `/dashboard` is not expressible as a
+    // rule, and MessageHandler's catch for a rejected rule is
     // `webView.addJavascriptInterface(this, "androidBridge")`, which enforces no
     // origin restriction at all — so a path here risks trading the allowlist
     // below for a bridge exposed to every document the WebView loads.

--- a/apps/android/capacitor.config.ts
+++ b/apps/android/capacitor.config.ts
@@ -9,55 +9,26 @@ const config: CapacitorConfig = {
     // Production: load directly to dashboard, bypassing landing page
     url: 'https://pagespace.ai/dashboard',
     cleartext: false,
-    // NOT the same trap as iOS. iOS bricked (PR #2010) because
-    // WebViewDelegationHandler.swift falls back to a raw string-prefix test of
-    // the target URL against server.url — which carries the `/dashboard` path —
-    // so any top-level navigation to another path failed it. Android's
-    // equivalent, Bridge.launchIntent(), compares only host and scheme:
+    // Every host listed here is handed the NATIVE PLUGIN BRIDGE, not merely
+    // permission to navigate. Bridge.setAllowedOriginRules() folds each entry
+    // into allowedOriginRules, which MessageHandler passes to
+    // addWebMessageListener(webView, "androidBridge", ...), and from there
+    // postMessage reaches Bridge.callPluginMethod() and every registered plugin
+    // — PageSpaceKeychain over EncryptedSharedPreferences included. So: add a
+    // host only for a top-level navigation someone can name, never a third-party
+    // page, and never a wildcard.
     //
-    //   !(appUri.getHost().equals(url.getHost()) && url.getScheme().equals(appUri.getScheme()))
-    //     && !appAllowNavigationMask.matches(url.getHost())
+    // The apex alone is behaviourally a no-op: Bridge.launchIntent() compares
+    // host and scheme only, so every pagespace.ai path already stays in the
+    // WebView. It is listed to state the app's own origin rather than leave it
+    // implicit. If a wildcard is ever genuinely needed, the apex must stay beside
+    // it — HostMask.Simple.matches() bails when `maskSize > 1 && hostSize !=
+    // maskSize`, so '*.pagespace.ai' (3 dot components) never matches
+    // 'pagespace.ai' (2).
     //
-    // `https://pagespace.ai/signin` therefore already stays in the WebView on
-    // Android with no allowNavigation at all, and the apex is listed here to say
-    // so out loud rather than to change behaviour.
-    //
-    // '*.pagespace.ai' is deliberately NOT listed, though the epic's task asked
-    // for apex and wildcard both. allowNavigation governs TOP-LEVEL navigations
-    // only — subresources from assets.pagespace.ai and friends are unaffected —
-    // and the shell loads pagespace.ai and stays there, so the wildcard buys no
-    // navigation we can point at while granting the native plugin bridge (see
-    // below) to every pagespace.ai subdomain that exists or ever will, tenant
-    // hosts included. Least privilege wins over the parity.
-    //
-    // If a real subdomain navigation ever needs allowing, add that HOST, not the
-    // wildcard — and if the wildcard truly is wanted, the apex must stay listed
-    // beside it, because one mask cannot cover both: HostMask.Simple.matches()
-    // bails when `maskSize > 1 && hostSize != maskSize`, so '*.pagespace.ai' (3
-    // dot components) does not match 'pagespace.ai' (2).
-    //
-    // Deliberately NOT listed here: accounts.google.com and appleid.apple.com,
-    // which the iOS config does list. On Android an allowNavigation entry is not
-    // just a navigation permit — it is a grant of the native plugin bridge.
-    // Bridge.setAllowedOriginRules() folds every entry into allowedOriginRules,
-    // and MessageHandler passes that set straight to
-    // WebViewCompat.addWebMessageListener(webView, "androidBridge", ...). Any
-    // main-frame document from a listed origin can therefore call
-    // androidBridge.postMessage(), which reaches Bridge.callPluginMethod() and
-    // every registered plugin — including PageSpaceKeychain, the
-    // EncryptedSharedPreferences store. Handing that to a third-party consent
-    // page to make a broken OAuth fallback fail more visibly is not a trade worth
-    // making; the provider pages belong in a Custom Tab with a bound callback,
-    // which is the native auth phase's job.
-    //
-    // (The same two hosts in apps/ios/capacitor.config.ts are worse, not better:
-    // iOS registers the bridge as a WKUserScript with forMainFrameOnly: true and
-    // NO origin scoping, so it applies to every main-frame document the WebView
-    // loads. That is shipped behaviour and a separate change.)
-    //
-    // What stays is the app's own origin, and that is the point: every host added
-    // here is a host handed the native bridge, so this list should only ever grow
-    // for a navigation someone can name.
+    // Why this diverges from apps/ios/capacitor.config.ts — which lists a
+    // wildcard and both OAuth provider hosts — is in apps/android/README.md
+    // under "Why this config is not a copy of the iOS one".
     allowNavigation: ['pagespace.ai'],
     // Bundled retry screen (apps/android/public/index.html). Android reads this
     // in BridgeWebViewClient.onReceivedError/onReceivedHttpError for main-frame

--- a/apps/android/capacitor.config.ts
+++ b/apps/android/capacitor.config.ts
@@ -19,15 +19,22 @@ const config: CapacitorConfig = {
     //     && !appAllowNavigationMask.matches(url.getHost())
     //
     // `https://pagespace.ai/signin` therefore already stays in the WebView on
-    // Android with no allowNavigation at all. The entry that earns its place is
-    // the wildcard: a navigation to any pagespace.ai SUBDOMAIN fails the host
-    // equality test and would be handed to Chrome via ACTION_VIEW.
+    // Android with no allowNavigation at all, and the apex is listed here to say
+    // so out loud rather than to change behaviour.
     //
-    // The apex is listed alongside it because one mask cannot cover both —
-    // HostMask.Simple.matches() bails when `maskSize > 1 && hostSize != maskSize`,
-    // so '*.pagespace.ai' (3 dot components) does not match 'pagespace.ai' (2) —
-    // and because leaving the app's own host implicit here invites someone to
-    // 'tidy up' the wildcard later without noticing what it covered.
+    // '*.pagespace.ai' is deliberately NOT listed, though the epic's task asked
+    // for apex and wildcard both. allowNavigation governs TOP-LEVEL navigations
+    // only — subresources from assets.pagespace.ai and friends are unaffected —
+    // and the shell loads pagespace.ai and stays there, so the wildcard buys no
+    // navigation we can point at while granting the native plugin bridge (see
+    // below) to every pagespace.ai subdomain that exists or ever will, tenant
+    // hosts included. Least privilege wins over the parity.
+    //
+    // If a real subdomain navigation ever needs allowing, add that HOST, not the
+    // wildcard — and if the wildcard truly is wanted, the apex must stay listed
+    // beside it, because one mask cannot cover both: HostMask.Simple.matches()
+    // bails when `maskSize > 1 && hostSize != maskSize`, so '*.pagespace.ai' (3
+    // dot components) does not match 'pagespace.ai' (2).
     //
     // Deliberately NOT listed here: accounts.google.com and appleid.apple.com,
     // which the iOS config does list. On Android an allowNavigation entry is not
@@ -48,11 +55,10 @@ const config: CapacitorConfig = {
     // NO origin scoping, so it applies to every main-frame document the WebView
     // loads. That is shipped behaviour and a separate change.)
     //
-    // What stays is our own origins. Note that '*.pagespace.ai' grants the bridge
-    // to every pagespace.ai subdomain, so nothing that serves untrusted or
-    // user-authored content — a dev-preview origin, for instance — may be given a
-    // pagespace.ai hostname without revisiting this line.
-    allowNavigation: ['pagespace.ai', '*.pagespace.ai'],
+    // What stays is the app's own origin, and that is the point: every host added
+    // here is a host handed the native bridge, so this list should only ever grow
+    // for a navigation someone can name.
+    allowNavigation: ['pagespace.ai'],
     // Bundled retry screen (apps/android/public/index.html). Android reads this
     // in BridgeWebViewClient.onReceivedError/onReceivedHttpError for main-frame
     // requests and loads Bridge.getErrorUrl() — `https://localhost/index.html`,

--- a/apps/android/capacitor.config.ts
+++ b/apps/android/capacitor.config.ts
@@ -44,11 +44,12 @@ const config: CapacitorConfig = {
     //
     // Android-only caveat: Bridge.setAllowedOriginRules() also adds these hosts
     // to WebViewLocalServer's `authorities`. That only changes behaviour while
-    // Capacitor's JS injector is still live — i.e. on a WebView too old for
-    // WebViewFeature.DOCUMENT_START_SCRIPT (pre-WebView 83), where a top-level
-    // HTML GET to these hosts would be proxied through HttpURLConnection. On any
-    // current WebView the injector is null and shouldInterceptRequest returns
-    // null, leaving the native network stack in charge.
+    // Capacitor's JS injector is still live — i.e. on a WebView too old to report
+    // WebViewFeature.DOCUMENT_START_SCRIPT, where a top-level HTML GET to these
+    // hosts would be proxied through HttpURLConnection. Where the feature is
+    // supported, Bridge.loadWebView() sets the injector to null and
+    // shouldInterceptRequest returns null, leaving the native network stack in
+    // charge.
     allowNavigation: ['pagespace.ai', '*.pagespace.ai', 'accounts.google.com', 'appleid.apple.com'],
     // Bundled retry screen (apps/android/public/index.html). Android reads this
     // in BridgeWebViewClient.onReceivedError/onReceivedHttpError for main-frame

--- a/apps/android/capacitor.config.ts
+++ b/apps/android/capacitor.config.ts
@@ -19,38 +19,40 @@ const config: CapacitorConfig = {
     //     && !appAllowNavigationMask.matches(url.getHost())
     //
     // `https://pagespace.ai/signin` therefore already stays in the WebView on
-    // Android with no allowNavigation at all. This list is here for the hosts
-    // that are NOT pagespace.ai, where Android does hand the URL to the system
-    // browser via ACTION_VIEW exactly as iOS hands it to Safari.
+    // Android with no allowNavigation at all. The entry that earns its place is
+    // the wildcard: a navigation to any pagespace.ai SUBDOMAIN fails the host
+    // equality test and would be handed to Chrome via ACTION_VIEW.
     //
-    // The apex must still be listed separately: HostMask.Simple.matches() bails
-    // when `maskSize > 1 && hostSize != maskSize`, so '*.pagespace.ai' (3 dot
-    // components) does not match 'pagespace.ai' (2).
+    // The apex is listed alongside it because one mask cannot cover both —
+    // HostMask.Simple.matches() bails when `maskSize > 1 && hostSize != maskSize`,
+    // so '*.pagespace.ai' (3 dot components) does not match 'pagespace.ai' (2) —
+    // and because leaving the app's own host implicit here invites someone to
+    // 'tidy up' the wildcard later without noticing what it covered.
     //
-    // Google/Apple are deliberate but imperfect, and the reasoning differs from
-    // iOS in one important way. On iOS the web OAuth fallback should never fire,
-    // because sign-in goes through the native plugin. On Android it is currently
-    // the ONLY path: isNativeGoogleAuthAvailable() in ios-google-auth.ts is
-    // `isCapacitorApp() && getPlatform() === 'ios'`, so until the epic's native
-    // auth phase generalizes it, Android takes the browser fallback every time.
+    // Deliberately NOT listed here: accounts.google.com and appleid.apple.com,
+    // which the iOS config does list. On Android an allowNavigation entry is not
+    // just a navigation permit — it is a grant of the native plugin bridge.
+    // Bridge.setAllowedOriginRules() folds every entry into allowedOriginRules,
+    // and MessageHandler passes that set straight to
+    // WebViewCompat.addWebMessageListener(webView, "androidBridge", ...). Any
+    // main-frame document from a listed origin can therefore call
+    // androidBridge.postMessage(), which reaches Bridge.callPluginMethod() and
+    // every registered plugin — including PageSpaceKeychain, the
+    // EncryptedSharedPreferences store. Handing that to a third-party consent
+    // page to make a broken OAuth fallback fail more visibly is not a trade worth
+    // making; the provider pages belong in a Custom Tab with a bound callback,
+    // which is the native auth phase's job.
     //
-    // Both outcomes are broken, and this picks the diagnosable one. Allowlisted,
-    // the consent screen loads in the WebView and Google answers
-    // `disallowed_useragent` — a visible failure. Omitted, it goes to Chrome,
-    // where a successful sign-in drops the cookie in the WRONG cookie jar and the
-    // app stays silently logged out. Nobody is hitting either today: there is no
-    // shipped Android build (versionCode is still 1), and native auth should land
-    // before there is one. The real fix is native sign-in, not this list.
+    // (The same two hosts in apps/ios/capacitor.config.ts are worse, not better:
+    // iOS registers the bridge as a WKUserScript with forMainFrameOnly: true and
+    // NO origin scoping, so it applies to every main-frame document the WebView
+    // loads. That is shipped behaviour and a separate change.)
     //
-    // Android-only caveat: Bridge.setAllowedOriginRules() also adds these hosts
-    // to WebViewLocalServer's `authorities`. That only changes behaviour while
-    // Capacitor's JS injector is still live — i.e. on a WebView too old to report
-    // WebViewFeature.DOCUMENT_START_SCRIPT, where a top-level HTML GET to these
-    // hosts would be proxied through HttpURLConnection. Where the feature is
-    // supported, Bridge.loadWebView() sets the injector to null and
-    // shouldInterceptRequest returns null, leaving the native network stack in
-    // charge.
-    allowNavigation: ['pagespace.ai', '*.pagespace.ai', 'accounts.google.com', 'appleid.apple.com'],
+    // What stays is our own origins. Note that '*.pagespace.ai' grants the bridge
+    // to every pagespace.ai subdomain, so nothing that serves untrusted or
+    // user-authored content — a dev-preview origin, for instance — may be given a
+    // pagespace.ai hostname without revisiting this line.
+    allowNavigation: ['pagespace.ai', '*.pagespace.ai'],
     // Bundled retry screen (apps/android/public/index.html). Android reads this
     // in BridgeWebViewClient.onReceivedError/onReceivedHttpError for main-frame
     // requests and loads Bridge.getErrorUrl() — `https://localhost/index.html`,

--- a/apps/android/capacitor.config.ts
+++ b/apps/android/capacitor.config.ts
@@ -27,13 +27,20 @@ const config: CapacitorConfig = {
     // when `maskSize > 1 && hostSize != maskSize`, so '*.pagespace.ai' (3 dot
     // components) does not match 'pagespace.ai' (2).
     //
-    // Google/Apple are deliberate but imperfect, for the same reason as iOS.
-    // Android signs in through the NATIVE plugin (@capgo/capacitor-social-login),
-    // so the web fallback should never fire here. If it does, allowlisting keeps
-    // it in the WebView, where Google answers `disallowed_useragent` — a visible,
-    // diagnosable failure. Omitting them instead hands the consent screen to
-    // Chrome, where a successful sign-in drops the cookie in the WRONG cookie jar
-    // and the app stays silently logged out.
+    // Google/Apple are deliberate but imperfect, and the reasoning differs from
+    // iOS in one important way. On iOS the web OAuth fallback should never fire,
+    // because sign-in goes through the native plugin. On Android it is currently
+    // the ONLY path: isNativeGoogleAuthAvailable() in ios-google-auth.ts is
+    // `isCapacitorApp() && getPlatform() === 'ios'`, so until the epic's native
+    // auth phase generalizes it, Android takes the browser fallback every time.
+    //
+    // Both outcomes are broken, and this picks the diagnosable one. Allowlisted,
+    // the consent screen loads in the WebView and Google answers
+    // `disallowed_useragent` — a visible failure. Omitted, it goes to Chrome,
+    // where a successful sign-in drops the cookie in the WRONG cookie jar and the
+    // app stays silently logged out. Nobody is hitting either today: there is no
+    // shipped Android build (versionCode is still 1), and native auth should land
+    // before there is one. The real fix is native sign-in, not this list.
     //
     // Android-only caveat: Bridge.setAllowedOriginRules() also adds these hosts
     // to WebViewLocalServer's `authorities`. That only changes behaviour while

--- a/apps/android/capacitor.config.ts
+++ b/apps/android/capacitor.config.ts
@@ -6,8 +6,20 @@ const config: CapacitorConfig = {
   appName: 'PageSpace',
   webDir: './public', // Fallback for offline scenarios; app loads from server.url
   server: {
-    // Production: load directly to dashboard, bypassing landing page
-    url: 'https://pagespace.ai/dashboard',
+    // The landing path is `appStartPath`, NOT part of `url`, and the split
+    // matters on Android. Bridge.setAllowedOriginRules() puts getServerUrl()
+    // verbatim into the set MessageHandler hands to addWebMessageListener, and
+    // that API takes origin rules — `scheme://host[:port]`. A `url` carrying
+    // `/dashboard` is not one, and MessageHandler's catch for a rejected rule is
+    // `webView.addJavascriptInterface(this, "androidBridge")`, which enforces no
+    // origin restriction at all — so a path here risks trading the allowlist
+    // below for a bridge exposed to every document the WebView loads.
+    //
+    // Keeping `url` an origin is right either way, and Bridge appends
+    // appStartPath after the server.url branch, so appUrl is still
+    // https://pagespace.ai/dashboard and the app still bypasses the landing page.
+    url: 'https://pagespace.ai',
+    appStartPath: '/dashboard',
     cleartext: false,
     // Every host listed here is handed the NATIVE PLUGIN BRIDGE, not merely
     // permission to navigate. Bridge.setAllowedOriginRules() folds each entry

--- a/apps/android/capacitor.config.ts
+++ b/apps/android/capacitor.config.ts
@@ -9,6 +9,46 @@ const config: CapacitorConfig = {
     // Production: load directly to dashboard, bypassing landing page
     url: 'https://pagespace.ai/dashboard',
     cleartext: false,
+    // NOT the same trap as iOS. iOS bricked (PR #2010) because
+    // WebViewDelegationHandler.swift falls back to a raw string-prefix test of
+    // the target URL against server.url — which carries the `/dashboard` path —
+    // so any top-level navigation to another path failed it. Android's
+    // equivalent, Bridge.launchIntent(), compares only host and scheme:
+    //
+    //   !(appUri.getHost().equals(url.getHost()) && url.getScheme().equals(appUri.getScheme()))
+    //     && !appAllowNavigationMask.matches(url.getHost())
+    //
+    // `https://pagespace.ai/signin` therefore already stays in the WebView on
+    // Android with no allowNavigation at all. This list is here for the hosts
+    // that are NOT pagespace.ai, where Android does hand the URL to the system
+    // browser via ACTION_VIEW exactly as iOS hands it to Safari.
+    //
+    // The apex must still be listed separately: HostMask.Simple.matches() bails
+    // when `maskSize > 1 && hostSize != maskSize`, so '*.pagespace.ai' (3 dot
+    // components) does not match 'pagespace.ai' (2).
+    //
+    // Google/Apple are deliberate but imperfect, for the same reason as iOS.
+    // Android signs in through the NATIVE plugin (@capgo/capacitor-social-login),
+    // so the web fallback should never fire here. If it does, allowlisting keeps
+    // it in the WebView, where Google answers `disallowed_useragent` — a visible,
+    // diagnosable failure. Omitting them instead hands the consent screen to
+    // Chrome, where a successful sign-in drops the cookie in the WRONG cookie jar
+    // and the app stays silently logged out.
+    //
+    // Android-only caveat: Bridge.setAllowedOriginRules() also adds these hosts
+    // to WebViewLocalServer's `authorities`. That only changes behaviour while
+    // Capacitor's JS injector is still live — i.e. on a WebView too old for
+    // WebViewFeature.DOCUMENT_START_SCRIPT (pre-WebView 83), where a top-level
+    // HTML GET to these hosts would be proxied through HttpURLConnection. On any
+    // current WebView the injector is null and shouldInterceptRequest returns
+    // null, leaving the native network stack in charge.
+    allowNavigation: ['pagespace.ai', '*.pagespace.ai', 'accounts.google.com', 'appleid.apple.com'],
+    // Bundled retry screen (apps/android/public/index.html). Android reads this
+    // in BridgeWebViewClient.onReceivedError/onReceivedHttpError for main-frame
+    // requests and loads Bridge.getErrorUrl() — `https://localhost/index.html`,
+    // served from the bundled assets. Without it a failed load leaves the
+    // WebView showing its own error page.
+    errorPath: 'index.html',
   },
   android: {
     backgroundColor: '#0f0f0f',

--- a/apps/android/public/index.html
+++ b/apps/android/public/index.html
@@ -47,6 +47,11 @@
     // re-target the server explicitly. pagespace.ai is the host of server.url, so
     // Bridge.launchIntent() keeps this in-app rather than punting it to Chrome.
     // Keep in sync with server.url in capacitor.config.ts.
+    //
+    // No Capacitor API is available on this page: Bridge.loadWebView() registers
+    // the bridge script via addDocumentStartJavaScript scoped to the server.url
+    // origin only, so `Capacitor` and every plugin are undefined at
+    // https://localhost. Plain DOM APIs only.
     document.getElementById('retry').addEventListener('click', function () {
       window.location.href = 'https://pagespace.ai/dashboard';
     });

--- a/apps/android/public/index.html
+++ b/apps/android/public/index.html
@@ -48,10 +48,13 @@
     // Bridge.launchIntent() keeps this in-app rather than punting it to Chrome.
     // Keep in sync with server.url + server.appStartPath in capacitor.config.ts.
     //
-    // No Capacitor API is available on this page: Bridge.loadWebView() registers
-    // the bridge script via addDocumentStartJavaScript scoped to the server.url
-    // origin only, so `Capacitor` and every plugin are undefined at
-    // https://localhost. Plain DOM APIs only.
+    // `window.Capacitor` is undefined here: Bridge.loadWebView() registers the JS
+    // wrapper via addDocumentStartJavaScript scoped to the server.url origin, so
+    // the plugin proxies do not exist at https://localhost. That is NOT the same
+    // as being outside the bridge — setAllowedOriginRules() adds
+    // scheme://hostname unconditionally, so androidBridge is exposed on this
+    // origin and the message protocol reaches registered plugins. Keep this page
+    // plain DOM by discipline; the platform is not stopping you.
     document.getElementById('retry').addEventListener('click', function () {
       window.location.href = 'https://pagespace.ai/dashboard';
     });

--- a/apps/android/public/index.html
+++ b/apps/android/public/index.html
@@ -46,7 +46,7 @@
     // remote load fails, so reload() would only re-render this file. Retry has to
     // re-target the server explicitly. pagespace.ai is the host of server.url, so
     // Bridge.launchIntent() keeps this in-app rather than punting it to Chrome.
-    // Keep in sync with server.url in capacitor.config.ts.
+    // Keep in sync with server.url + server.appStartPath in capacitor.config.ts.
     //
     // No Capacitor API is available on this page: Bridge.loadWebView() registers
     // the bridge script via addDocumentStartJavaScript scoped to the server.url

--- a/apps/android/public/index.html
+++ b/apps/android/public/index.html
@@ -48,13 +48,19 @@
     // Bridge.launchIntent() keeps this in-app rather than punting it to Chrome.
     // Keep in sync with server.url + server.appStartPath in capacitor.config.ts.
     //
-    // `window.Capacitor` is undefined here: Bridge.loadWebView() registers the JS
-    // wrapper via addDocumentStartJavaScript scoped to the server.url origin, so
-    // the plugin proxies do not exist at https://localhost. That is NOT the same
-    // as being outside the bridge — setAllowedOriginRules() adds
-    // scheme://hostname unconditionally, so androidBridge is exposed on this
-    // origin and the message protocol reaches registered plugins. Keep this page
-    // plain DOM by discipline; the platform is not stopping you.
+    // `window.Capacitor` is undefined here, for two different reasons depending on
+    // the device: where DOCUMENT_START_SCRIPT is supported the wrapper is scoped
+    // to the server.url origin, and where it is not, WebViewLocalServer's
+    // isErrorUrl() check returns a non-injected stream before reaching the
+    // `.html && jsInjector != null` branch that would inject it. The second is
+    // keyed on this file being served at exactly bridge.getErrorUrl() — move it
+    // to another local path and legacy WebViews will inject the runtime.
+    //
+    // Either way, absence of the wrapper is NOT absence of the bridge:
+    // setAllowedOriginRules() adds scheme://hostname unconditionally, so
+    // androidBridge is exposed on this origin and the message protocol reaches
+    // registered plugins. Keep this page plain DOM by discipline; the platform is
+    // not stopping you.
     document.getElementById('retry').addEventListener('click', function () {
       window.location.href = 'https://pagespace.ai/dashboard';
     });

--- a/apps/android/public/index.html
+++ b/apps/android/public/index.html
@@ -3,32 +3,53 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover">
-  <meta name="theme-color" content="#000000">
+  <meta name="theme-color" content="#0f0f0f">
   <title>PageSpace</title>
   <style>
     * { margin: 0; padding: 0; box-sizing: border-box; }
     body {
-      font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
-      background: #000;
+      font-family: Roboto, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+      background: #0f0f0f;
       color: #fff;
       min-height: 100vh;
       display: flex;
       align-items: center;
       justify-content: center;
     }
-    .offline-message {
+    .container {
       text-align: center;
       padding: 2rem;
     }
-    .offline-message h1 { font-size: 1.5rem; margin-bottom: 1rem; }
-    .offline-message p { opacity: 0.7; }
+    h1 { font-size: 1.5rem; margin-bottom: 1rem; }
+    p { color: #888; margin-bottom: 1.5rem; }
+    button {
+      background: #fff;
+      color: #000;
+      border: none;
+      padding: 0.75rem 1.5rem;
+      border-radius: 8px;
+      font-size: 1rem;
+      cursor: pointer;
+    }
+    button:active { opacity: 0.8; }
   </style>
 </head>
 <body>
-  <div class="offline-message">
-    <h1>PageSpace</h1>
-    <p>Connecting to server...</p>
-    <p style="margin-top: 1rem; font-size: 0.875rem;">Please check your internet connection.</p>
+  <div class="container">
+    <h1>Unable to Connect</h1>
+    <p>Please check your internet connection and try again.</p>
+    <button id="retry">Retry</button>
   </div>
+  <script>
+    // This page is server.errorPath: BridgeWebViewClient loads it from the local
+    // bundle (https://localhost/index.html, served by WebViewLocalServer) when the
+    // remote load fails, so reload() would only re-render this file. Retry has to
+    // re-target the server explicitly. pagespace.ai is the host of server.url, so
+    // Bridge.launchIntent() keeps this in-app rather than punting it to Chrome.
+    // Keep in sync with server.url in capacitor.config.ts.
+    document.getElementById('retry').addEventListener('click', function () {
+      window.location.href = 'https://pagespace.ai/dashboard';
+    });
+  </script>
 </body>
 </html>


### PR DESCRIPTION
Phase C of the Android Parity Epic: the two shell-hardening tasks, **Shell navigation unbrick** and **Android deep links**. No Phase A/B/D/E work here.

## The short version

Five config lines and an HTML file. The rest is comments and README, because review turned this from a config port into a security cleanup — the reviewers were right five times and I was wrong four.

| | |
|---|---|
| **`server.url`** | Split into `url: 'https://pagespace.ai'` + `appStartPath: '/dashboard'`. A path here can silently disable the bridge's origin allowlist entirely. |
| **`allowNavigation`** | `['pagespace.ai']`. Every entry grants the **native plugin bridge**, not navigation. Three entries were added and then removed. |
| **`errorPath`** | Added — a genuine Android gap. Without it a failed load has no bundled screen. |
| **App Links filter** | Written, then **removed**. `autoVerify` does not protect API 23–30, and no `assetlinks.json` can match a shipped build without a release cert. |
| **`pagespace://` filter** | Ships, inert. No server path emits it for Android yet, and it must not carry auth until the exchange is bound. |

**What to review, in priority order:** the `appStartPath` split (biggest behavioural claim, unverifiable without a device); the `allowNavigation` reasoning; and whether the two deliberately-unmet acceptance criteria are the right calls — the wildcard listing, and shipping no App Links filter.

**Nothing ran on a device.** Every behavioural claim is read off Capacitor 7.6.5 sources, cited by file and line.


## The iOS fix does **not** transfer verbatim — checked, not assumed

The task page warned that Android's navigation handling is not iOS's. It isn't, and the difference matters.

iOS bricked (PR #2010) because `WebViewDelegationHandler.swift` falls back to a **raw string-prefix test of the target URL against `server.url`** — which carries the `/dashboard` path — so a top-level navigation to any other path fails it, gets handed to Safari, and is cancelled in the WebView, leaving no document.

Android's equivalent is `Bridge.launchIntent()` (`@capacitor/android` 7.6.5, `capacitor/src/main/java/com/getcapacitor/Bridge.java:393`):

```java
Uri appUri = Uri.parse(appUrl);
if (
    !(appUri.getHost().equals(url.getHost()) && url.getScheme().equals(appUri.getScheme())) &&
    !appAllowNavigationMask.matches(url.getHost())
) { /* ACTION_VIEW to the system browser */ return true; }
return false;
```

It compares **host and scheme only** — no path, no prefix. `https://pagespace.ai/signin` matches the host and scheme of `https://pagespace.ai/dashboard`, so it already stayed in the WebView with no `allowNavigation` at all. **Android does not exhibit the iOS symptom.** Requirement 1 of the task ("a `pagespace.ai` path outside `/dashboard` should stay inside the WebView") was already satisfied.

**So `allowNavigation` is down to `['pagespace.ai']`** — behaviourally a no-op, kept to state the app's own origin rather than leave it implicit. Two rounds of review took the other three entries out, and both were right:

- **`accounts.google.com` / `appleid.apple.com`** ([Codex](https://github.com/2witstudios/PageSpace/pull/2552#discussion_r3950171613)). On Android an `allowNavigation` entry is not a navigation permit, it is a grant of the **native plugin bridge**. `Bridge.setAllowedOriginRules()` folds every entry into `allowedOriginRules` (`Bridge.java:236-255`), and `MessageHandler.java:36` passes that set to `WebViewCompat.addWebMessageListener(webView, "androidBridge", ...)`; from there `postMessage` → `callPluginMethod` → `bridge.callPluginMethod(...)` reaches every registered plugin, `PageSpaceKeychain` over EncryptedSharedPreferences included. I had verified that `addDocumentStartJavaScript` is scoped to the `server.url` origin and wrongly generalised from that one channel.
- **`*.pagespace.ai`** ([CodeRabbit](https://github.com/2witstudios/PageSpace/pull/2552#discussion_r3950275423)). Same grant, open-ended: every subdomain that exists or ever will, tenant hosts included. `allowNavigation` governs top-level navigations only — subresources from `assets.pagespace.ai` and friends never consulted it — and the shell loads `/dashboard` and stays there, so no top-level subdomain navigation could be pointed at that the wildcard was enabling.

**This deliberately fails one stated acceptance criterion**, and I would rather flag that than quietly drop it: "Given the apex and wildcard hosts differ in dot-component count, should list both explicitly." With the wildcard gone there is nothing to pair the apex with. The reasoning behind the criterion is a real footgun, so it is preserved in the config comment rather than deleted alongside the wildcard — if a subdomain navigation ever genuinely needs allowing, the note says to add that specific host, and that a wildcard must keep the apex beside it because `HostMask.Simple.matches()` bails when `maskSize > 1 && hostSize != maskSize`.

Two other findings, both confirmed against the same source:

- **`errorPath` is a genuine Android gap, not a port.** `BridgeWebViewClient.onReceivedError` / `onReceivedHttpError` load `bridge.getErrorUrl()` for main-frame requests; with no `errorPath` that returns `null` and the WebView keeps its own error page. With it, Android loads `https://localhost/index.html` from the bundled assets.
- **The apex/wildcard dot-count rule holds on Android too.** `HostMask.Simple.matches()` returns false when `maskSize > 1 && hostSize != maskSize`, so `*.pagespace.ai` (3 components) does not match `pagespace.ai` (2). This is why the task asked for both to be listed; it is now recorded as a warning against re-adding the wildcard carelessly rather than acted on, for the security reason above.

One Android-only caveat is in the config comment: `Bridge.setAllowedOriginRules()` also adds `allowNavigation` hosts to `WebViewLocalServer`'s `authorities`. That only changes behaviour while Capacitor's JS injector is live — i.e. on a WebView too old for `WebViewFeature.DOCUMENT_START_SCRIPT` (pre-WebView 83), where a top-level HTML GET to those hosts would be proxied through `HttpURLConnection`. On any current WebView the injector is null and `shouldInterceptRequest` returns null.

## Deep links: the custom scheme ships, App Links are deferred

`AndroidManifest.xml` had one intent filter (MAIN/LAUNCHER). **One** is added: the `pagespace://` custom scheme, mirroring iOS `CFBundleURLSchemes`. A custom scheme is claimed outright — no domain verification, no server-side file — so the claim is effective as soon as the app is installed, on every supported API level.

**It is groundwork, not a live path, and the PR no longer claims otherwise.** `pagespace://auth-exchange?code=…` is what the Google and Apple callback routes redirect to — but only on their `platform === 'ios'` branch, and `apps/web/src/lib/auth/oauth-state.ts:16` types the platform as `z.enum(['web', 'desktop', 'ios'])`. `'android'` is not a value it can take, so no server path emits that redirect for Android today. (`/api/auth/google/native` does accept `'android'`, but answers the native plugin with JSON rather than a deep link.) Teaching that path about Android is Phase B's native auth work; registering the scheme now means the manifest will not be the blocker then. An earlier revision of this changelog entry claimed a native sign-in "can hand back to the app the way it does on iOS" — that was false, and is corrected.

Requirement 2 ("route into the existing task") needed no code: `MainActivity` is `launchMode="singleTask"`, `BridgeActivity.onNewIntent` forwards to `Bridge.onNewIntent`, and `@capacitor/app`'s `AppPlugin.handleOnNewIntent` turns an `ACTION_VIEW` intent into an `appUrlOpen` event.

### Why the App Links filter is not here

The first revision of this PR registered a verified App Links filter with `autoVerify="true"` and argued the degradation was safe. **That argument was wrong, and Codex review caught it** ([thread](https://github.com/2witstudios/PageSpace/pull/2552#discussion_r3949937819)). Exclusive resolution of verified links is a behaviour of the **device's** platform version, not of `targetSdk`:

| Device API level | Filter present, verification fails |
|---|---|
| 31+ (Android 12+) | App is not a candidate; link opens in the browser. Safe. |
| 23–30 (Android 6–11) | Filter stays eligible; PageSpace appears in the disambiguation chooser. |

`minSdkVersion` is 23, so the second row is in scope. Combined with two prerequisites that do not exist, that made the filter a regression rather than groundwork:

1. **No `assetlinks.json` can match a shipped build.** It needs the **release** signing certificate's SHA-256 fingerprint; no release keystore exists, because signing and Play Console setup are outside this epic. So verification fails on every API level for anything we could distribute — the filter had zero upside. (A *debug* build can be verified locally against a debug-fingerprint file, and that workflow is documented in the README; it changes nothing for a user's device, which is the only thing the filter would affect. CodeRabbit caught me overstating this as "cannot succeed on any Android version".)
2. **No link routing exists.** Nothing listens for `appUrlOpen`, on **either** platform, so a captured link never reaches the path it names. On a **cold** launch the app loads its start URL (`/dashboard`); on a **warm** one — `singleTask`, app already running — `Bridge.onNewIntent` notifies plugins without ever calling `loadUrl`, so the event fires into a void and **the WebView stays exactly where it was, with nothing visible happening at all.** The invite token or auth code is dropped either way. (Codex caught me asserting the cold case as if it were both.)

So a user on Android 6–11 who picked PageSpace from the chooser would get the dashboard (cold) or no visible response at all (warm), with their token gone either way — strictly worse than the browser. The filter is removed; the exact XML to add, both prerequisites, the per-API-level table, and the debug-keystore `adb shell pm verify-app-links` procedure are all in `apps/android/README.md`.

This means **task requirement 1 is blocked by a dependency** (it was already conditional — "once the domain is verified"), and **requirement 4 is now satisfied unconditionally**: with no https filter at all, `pagespace.ai` links go to the browser on every API level, with no disambiguation dialog.

## `server.url` is now an origin, with the path in `appStartPath`

Chasing the allowlist above turned up something that would have made all of it moot. `Bridge.setAllowedOriginRules()` puts `getServerUrl()` **verbatim** into the set `MessageHandler` hands to `WebViewCompat.addWebMessageListener`, and that API takes origin rules — `scheme://host[:port]`. `https://pagespace.ai/dashboard` is not one. `MessageHandler`'s catch for a rejected rule is:

```java
try {
    WebViewCompat.addWebMessageListener(webView, "androidBridge", bridge.getAllowedOriginRules(), capListener);
} catch (Exception ex) {
    webView.addJavascriptInterface(this, "androidBridge");   // no origin restriction whatsoever
}
```

So a path in `server.url` risked trading the allowlist for a bridge exposed to every document the WebView loads. `server.appStartPath` (typed since Capacitor 7.3.0; the CLI here is 7.6.5) is appended *after* the `server.url` branch in `Bridge`, so `appUrl` is still `https://pagespace.ai/dashboard` and the app still bypasses the landing page. `CapacitorCookieManager.getSanitizedDomain` also reads `getServerUrl()`, where an origin is likewise the more correct value.

**The rejection is documented, not inferred.** I fetched `WebViewCompat.addWebMessageListener`'s javadoc from AOSP rather than trusting a summary: the rule grammar is `SCHEME "://" [ HOSTNAME_PATTERN [ ":" PORT ] ]` — no path production, so `https://pagespace.ai/dashboard` is not expressible as a rule — and it declares `@throws IllegalArgumentException If one of the allowedOriginRules is invalid`.

**What remains unobserved** is narrower: that Capacitor's catch is consequently taken and `addJavascriptInterface` really does replace the origin-scoped listener at runtime. That needs a device. The change is behaviour-preserving for `appUrl` and correct either way — an origin is what an origin rule wants.

## Audit of this PR's "nothing does X" claims

Twice in review I asserted an absence after checking a single channel — "no Capacitor bridge on the error page" (there is one, via `androidBridge`) and the `allowNavigation` grant before it. Rather than wait for a third, I swept every absence claim in the diff against *all* the channels that could falsify it. Both survived, with better evidence than they originally had:

**"Nothing emits `pagespace://` for Android, so the filter is inert."** I had only checked server redirects. There are three further paths, all gated away from Capacitor:

| Path | Gate |
|---|---|
| Google/Apple callback redirect | `platform === 'ios'`; `oauth-state.ts:16` enum has no `'android'` |
| Magic-link → client-side trigger | `useDesktopExchangeHandler.ts:29` — `isDesktopPlatform()` |
| Passkey `pagespace://passkey-registered` | same `isDesktopPlatform()` gate |
| `desktop-shell.ts` builders | build for the Electron apps, by enum, never a caller-supplied scheme |

`isDesktopPlatform()` is `!!window.electron?.isDesktop` — the Electron preload bridge, absent under Capacitor. So the claim holds on every channel, not just the one I originally checked.

**"Nothing listens for `appUrlOpen`, on either platform."** Grep for `appUrlOpen` across `apps/` and `packages/` returns **zero** hits, and every `App.addListener` call in the tree is `appStateChange`. No indirection through a variable event name either.

## Security findings this surfaced in the shipped iOS app

Neither is introduced by this PR and neither is fixed here; both are recorded on the epic so they are not lost.

1. **iOS grants the Capacitor bridge to the OAuth provider origins with no scoping at all.** `apps/ios/capacitor.config.ts` lists both hosts, and `JSExport.swift:20-21` registers the bridge as `WKUserScript(..., forMainFrameOnly: true)` on the WebView's `userContentController` — it applies to every main-frame document, regardless of origin. Android's equivalent entries are removed in this PR; iOS still carries them.
2. **The OAuth handoff exchange code is bearer-only.** `/api/auth/desktop/exchange` takes `{ code }` alone — no PKCE verifier, no app binding — and returns `sessionToken`, `csrfToken`, `deviceToken`. Custom schemes are not exclusive on either platform, so an app that registers `pagespace://` and is chosen as handler can redeem the code. The iOS callback branch emits that deep link today. This PR registers the Android filter but leaves it inert (no server path can emit the redirect for Android), with the constraint written next to the filter as a `READ BEFORE MAKING IT LIVE` block.

## What was NOT verified

**Nothing here ran on an Android device or emulator.** I have no hardware, and the Android app's `node_modules` are not installed in this worktree, so there was no build either. Every behavioural claim above is read off the Capacitor 7.6.5 Java sources cited by file and line, and the manifest was validated as XML only. Specifically **unverified on hardware**:

- that the retry button re-targets the server successfully, and that the error shell renders at all;
- that a `pagespace://auth-exchange` redirect resolves back into the app;
- that Capacitor's `MessageHandler` catch is actually taken at runtime, replacing the origin-scoped listener with `addJavascriptInterface`. The *rejection* behind it is documented (the rule grammar has no path production and the javadoc declares `IllegalArgumentException`), but which branch executes on a real device is not something I observed.

That is device verification — the epic's own last task, deliberately separate.

## `capacitor.config.ts` is typechecked by nothing in CI

Worth knowing when reviewing a config change: `apps/android` has no `typecheck` script, so turbo's `typecheck` task skips it entirely. Green CI says nothing about whether these keys are valid.

I verified them against the CLI's own type declarations by hand (`@capacitor/cli@7.6.5`, `dist/declarations.d.ts`): the `server?: {` object opens at line 473 and closes at 565, and `url` (483), `cleartext` (497), `allowNavigation` (509), `errorPath` (517) and `appStartPath` (564) are all properties of it. `appStartPath` is `@since 7.3.0`.

Adding a `typecheck` script to `apps/android` looks like the obvious fix — `apps/android/tsconfig.json` already exists, is `strict`, and its `include` is exactly `["capacitor.config.ts"]`, so it would cover precisely the file this PR changes and nothing else. I dug into why it is not that simple:

- turbo's `typecheck` task is `dependsOn: ["^build"]`, and `apps/android` lists `"web": "workspace:*"` as a devDependency. A naive script would therefore pull **web's Next.js build** into the typecheck graph on every CI run, to typecheck one 72-line config file.
- The non-naive version — a package-specific `"apps/android#typecheck": { "dependsOn": [] }` override — means editing root `turbo.json`, which I cannot validate from here and which several concurrent branches are touching.

So it belongs with the Phase E build work, where someone can actually run it, alongside the guard test below. `apps/ios` has the identical gap and the identical single-file tsconfig, so the fix should cover both.

## No tests, deliberately — and where one would go

The repo has a good idiom for exactly the invariant this PR most wants to protect: `*.guard.test.ts` files that read a source file and assert a structural property (`sheet-read-is-read-only.guard.test.ts`, `gate-callsites.guard.test.ts`). A guard asserting that `allowNavigation` never contains a third-party host or a wildcard would catch precisely the regression two reviewers caught here.

It has no home yet. `apps/android` has no `test` script and no vitest config, so it is not in the turbo test graph; adding one means a devDependency and build wiring for an app this epic deliberately leaves unbuilt, which is scope creep of a different kind. Putting an Android-config guard inside `apps/web`'s suite would place it in a package with no relationship to the file, and there is no precedent for cross-app source guards.

`apps/android` has no `lint`, `typecheck` or `test` script, so **nothing in CI parses any file in this PR.** What I did instead, locally:

- `capacitor.config.ts` transpiled with Bun and the emitted object inspected key by key — `server` contains exactly `url: "https://pagespace.ai"`, `appStartPath: "/dashboard"`, `cleartext: false`, `allowNavigation: ["pagespace.ai"]`, `errorPath: "index.html"`. This is what `cap sync` will serialize.
- `AndroidManifest.xml` validated as XML after every edit.
- The retry button's inline script — the only executable code in the diff — parsed, and its single `getElementById("retry")` checked against the single `id="retry"` in the document.

None of that is a substitute for running the app; it just means a syntax error or a misplaced key cannot be what device verification discovers.

So the invariant is carried at the point of change instead — the `allowNavigation` comment leads with it — and a guard test is worth adding when Phase E wires an Android build and the app joins the test graph.

## A note on the commit history

19 commits, and the sequence records the review rather than hiding it — several commits undo an earlier one. Two subject lines are misleading read alone:

- `d5c4293 feat(android): register App Links and the pagespace:// custom scheme` — App Links are **not** registered in the final state; `ce77796` removes them.
- `a313eaf` / `18a4f2d` remove `allowNavigation` entries that `9858c30` had added.

I left the history intact rather than rewriting it: the corrections are the substance of this PR, and each commit explains its own reasoning. If you prefer a clean line on master, squash-merge — the PR title describes the end state accurately.

## Files

- `apps/android/capacitor.config.ts` — `url` split from `appStartPath`, `allowNavigation` cut to the app's own origin, `errorPath` added, and a comment carrying the rule for changing the list
- `apps/android/public/index.html` — retry affordance (971 → 2101 bytes; the iOS original is 1793, the extra being the note that no Capacitor bridge exists on this page)
- `apps/android/android/app/src/main/AndroidManifest.xml` — the `pagespace://` filter, a `READ BEFORE MAKING IT LIVE` block on the unbound exchange, and a comment recording why no App Links filter is present
- `apps/android/README.md` — why this config is not a copy of the iOS one, both deep-link prerequisites, the per-API-level `autoVerify` table, and the filter to add later
- `CHANGELOG.md` — user-visible note. The retry screen is the only thing here a user can observe; everything else is groundwork, and the entry says so

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01B9zpDyfGMd9FGYNrVMYJ7Z


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an Android connection-error screen with a Retry button.
  * Retrying returns to the PageSpace dashboard.
  * External PageSpace links continue opening in the device browser.
  * Added groundwork for Android deep links using the `pagespace://` scheme.

* **Improvements**
  * Updated free-plan credit-change emails to respect product-update preferences and include a one-click unsubscribe link.

* **Documentation**
  * Expanded Android setup and deep-link behavior documentation.
  * Clarified that Android distribution is not yet available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->