### PR TITLE
fix(test): make the ws-tunnel "upstream unreachable" case deterministic (master flake)

### DIFF
--- a/packages/lib/src/services/sandbox/preview/__tests__/preview-ws-tunnel.test.ts
+++ b/packages/lib/src/services/sandbox/preview/__tests__/preview-ws-tunnel.test.ts
@@ -10,7 +10,7 @@
 import { describe, it, expect, afterEach } from 'vitest';
 import http from 'node:http';
 import net from 'node:net';
-import { once } from 'node:events';
+import { EventEmitter, once } from 'node:events';
 import type { AddressInfo } from 'node:net';
 import { formatSocketHttpError, formatUpgradeResponse, tunnelWebSocketUpgrade, type TunnelSummary } from '../preview-ws-tunnel';
 
@@ -49,7 +49,11 @@ async function fakeSprite(mode: 'upgrade' | 'reject' | 'hang' = 'upgrade') {
 }
 
 /** A gateway that hands every upgrade on its socket to the tunnel — the realtime app's role. */
-async function gateway(upstreamUrl: URL, onClose: (s: TunnelSummary) => void, opts: { handshakeTimeoutMs?: number } = {}) {
+async function gateway(
+  upstreamUrl: URL,
+  onClose: (s: TunnelSummary) => void,
+  opts: Partial<Pick<Parameters<typeof tunnelWebSocketUpgrade>[0], 'handshakeTimeoutMs' | 'request'>> = {},
+) {
   const server = http.createServer((_req, res) => { res.writeHead(404); res.end(); });
   server.on('upgrade', (req, socket, head) => {
     const requestHeaders: Record<string, string> = {};
@@ -127,14 +131,64 @@ describe('tunnelWebSocketUpgrade', () => {
     expect(summary).toMatchObject({ outcome: 'upstream-rejected', upstreamStatus: 403 });
   });
 
+  /**
+   * "Cannot be reached" is driven by a server that OWNS its port for the whole
+   * test and drops every connection, rather than by connecting to a port we
+   * closed a moment ago.
+   *
+   * The closed-port version was a real flake and it cost master a red build
+   * (Security Tests on 8a02fef5, 2026-09-07; the identical commit passed on a
+   * re-run). Closing a listener does not RESERVE its port: between the close
+   * and the tunnel's connect, any other process on the runner — and CI runs
+   * several workspaces' suites at once, all binding port 0 — can be handed
+   * that exact ephemeral port. When that happens the connection is ACCEPTED,
+   * so the tunnel waits out its handshake bound, which defaults to
+   * `PREVIEW_PROXY_LIMITS.upstreamHeadersTimeoutMs` (60s), and vitest kills
+   * the test at 5s. That is why the failure was an opaque
+   * "Test timed out in 5000ms" with no assertion — the tell that the socket
+   * neither connected-and-failed nor was refused.
+   *
+   * A port cannot be reserved as "unbound", so the race cannot be closed while
+   * the test depends on nothing listening. Holding the port and dropping the
+   * connection instead is deterministic, and it exercises the SAME branch: the
+   * tunnel has one `req.on('error')` handler, and both ECONNREFUSED and a
+   * connection dropped before any response land in it as 502 / `upstream-error`.
+   * The literal refused errno is pinned separately, below, through the
+   * injectable `request` seam.
+   */
   it('answers 502 when the upstream cannot be reached at all', async () => {
-    const dead = net.createServer();
-    dead.listen(0, '127.0.0.1');
-    await once(dead, 'listening');
-    const deadPort = (dead.address() as AddressInfo).port;
-    await new Promise<void>((resolve) => dead.close(() => resolve()));
+    const unreachable = net.createServer((socket) => socket.destroy());
+    track(unreachable);
+    unreachable.listen(0, '127.0.0.1');
+    await once(unreachable, 'listening');
+    const deadPort = (unreachable.address() as AddressInfo).port;
+
     let summary: TunnelSummary | undefined;
     const port = await gateway(new URL(`http://127.0.0.1:${deadPort}/`), (s) => { summary = s; });
+    const c = await client(port, '/');
+    await once(c.socket, 'close');
+    expect(c.text().startsWith('HTTP/1.1 502 Bad Gateway\r\n')).toBe(true);
+    expect(summary?.outcome).toBe('upstream-error');
+  });
+
+  /**
+   * The literal ECONNREFUSED path, pinned without a socket at all. This file
+   * deliberately works against REAL sockets (see the header), and the case
+   * above keeps doing so; this one exists because the one thing real sockets
+   * cannot give us deterministically is "nothing is listening here".
+   */
+  it('answers 502 when the connection is REFUSED outright', async () => {
+    let summary: TunnelSummary | undefined;
+    const port = await gateway(new URL('http://127.0.0.1:9/'), (s) => { summary = s; }, {
+      // A `ClientRequest` double: the tunnel only ever calls `on`, `end` and
+      // `destroy` on it (nothing else is reachable before a response), so the
+      // double is complete for this path rather than a partial stand-in.
+      request: () => {
+        const req = Object.assign(new EventEmitter(), { end: () => {}, destroy: () => {} });
+        setImmediate(() => req.emit('error', Object.assign(new Error('connect ECONNREFUSED 127.0.0.1:9'), { code: 'ECONNREFUSED' })));
+        return req as unknown as http.ClientRequest;
+      },
+    });
     const c = await client(port, '/');
     await once(c.socket, 'close');
     expect(c.text().startsWith('HTTP/1.1 502 Bad Gateway\r\n')).toBe(true);


### PR DESCRIPTION
## Master's red build was this flake, not a regression

**Evidence it is a flake, not a break:** Security Tests on `8a02fef5` **failed at 03:27** and a re-run of the **identical commit succeeded at 11:19** ([failed run](https://github.com/2witstudios/PageSpace/actions/runs/34079629860), [passing run](https://github.com/2witstudios/PageSpace/actions/runs/34116031632)). The `Test Suite` workflow on the same commit passed first time. Same tree, opposite outcomes.

**Not from #2551.** The racy block dates to `9a275323` (the dev-preview proxy), which pre-dates #2551's base `91e2c22c4`. That PR touched `preview-access.ts` and `preview-forward-gate.ts`; it never touched the tunnel or its test. The merge only changed the timing of the run.

## Mechanism

```js
const dead = net.createServer();
dead.listen(0, '127.0.0.1');          // ephemeral port
await new Promise(r => dead.close(r)); // ...released back to the OS
const port = await gateway(new URL(`http://127.0.0.1:${deadPort}/`), …);
```

Closing a listener does **not reserve** its port. Between the close and the tunnel's connect, any other process on the runner can be handed that exact number — and CI runs several workspaces' suites concurrently, all binding port 0. When the port is taken, the connection is **accepted**, so the tunnel waits out its handshake bound — `PREVIEW_PROXY_LIMITS.upstreamHeadersTimeoutMs`, **60 000 ms** — while vitest kills the test at **5 000 ms**.

That gap is why the failure carried no assertion message. **An opaque `Test timed out in 5000ms` is the signature of a socket that was neither refused nor answered** — a genuine wrong-status would have failed in microseconds with a diff. The reported file duration, `6022ms`, is the 5 s cap plus teardown.

**Reproduced directly rather than inferred** — squatting the port after the close:

```
OLD shape (port stolen after close):    {"outcome":"HUNG past the 5s cap","ms":5002}
NEW shape (we hold the port, drop it):  {"outcome":"error ECONNRESET","ms":3}
```

## Fix

A port cannot be reserved as "unbound", so **the race cannot be closed while the test depends on nothing listening.** The upstream is now a server that **owns its port for the whole test and drops every connection**: nobody can take the port, and the outcome is decided in microseconds.

It exercises the same branch — the tunnel has exactly one `req.on('error')` handler, and both `ECONNREFUSED` and a connection dropped before any response land there as `502` / `upstream-error`.

The literal `ECONNREFUSED` errno is **not lost**: it moves to a second case driving the injectable `request` seam, with no socket at all. This file works against real sockets on purpose (see its header) and the first case still does — the one thing real sockets cannot give deterministically is *"nothing is listening here"*.

## Verification

- `Tests 6 passed (6)`, five consecutive runs, plus the tunnel+access suites together at `25 passed` ×5.
- **Mutation:** breaking the tunnel's error branch (`502 / upstream-error` → `504 / handshake-timeout`) turns **both** cases red; a no-op control mutant survives. The rewrite still bites.
- `bunx tsc --noEmit -p packages/lib` clean.

## One adjacent thing, not fixed here

`distributed-rate-limit.integration.test.ts` failed the other red run in this window (`pu/preview-hardening`, run 34079032964) — a separate known 5 s-timeout flake, untouched by this PR and worth its own task.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VRzMDjz6t1bPtQcJQQBG3M


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved WebSocket tunnel test reliability by using deterministic connection scenarios.
  * Added coverage for refused connections and unreachable upstream services.
  * Enabled testing with custom HTTP request implementations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->