### PR TITLE
fix(email): the free-credits notice honours the product-update opt-out

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -372,8 +372,9 @@ All notable user-facing changes to PageSpace are documented here. Format follows
   to a paid plan, which includes a monthly allowance that rolls over. The credits card, the plan
   comparison, the out-of-credits message, and the pricing, FAQ, terms, and docs pages now say
   "5 credits to start" for Free rather than "5/month", and free accounts no longer show a
-  "Renews" date. Every Free account receives a one-time email explaining the change, quoting
-  the exact balance they keep, and pointing to top-ups and the Pro plan.
+  "Renews" date. Free accounts receive a one-time email explaining the change, quoting the
+  exact balance they keep and pointing to top-ups and the Pro plan; anyone who has turned
+  product-update email off is skipped, and the notice carries a one-click unsubscribe link.
 
 - **Dark mode is now a lighter charcoal instead of near-black** — every dark surface (page,
   sidebar, cards, popovers, menus, borders, and the glass panels) moved up one step so text no

--- a/packages/lib/src/email-templates/FreeCreditsChangeEmail.tsx
+++ b/packages/lib/src/email-templates/FreeCreditsChangeEmail.tsx
@@ -39,10 +39,16 @@ interface FreeCreditsChangeEmailProps {
   /** In-app usage/credits page — where top-ups are bought. */
   usageUrl: string;
   /**
-   * The sender's physical postal address. This is a RELATIONSHIP message (a notice of a
-   * change to the recipient's existing plan), which CAN-SPAM exempts from the commercial
-   * requirements — so there is deliberately no unsubscribe link, and the address is
-   * optional. Rendered in the footer when provided.
+   * One-click unsubscribe link for product-update email. The send script skips
+   * anyone who already opted out and passes this to everyone it does mail, so the
+   * footer link is the opt-out of record; it stays optional only for previews.
+   */
+  unsubscribeUrl?: string;
+  /**
+   * The sender's physical postal address, from COMPANY_POSTAL_ADDRESS. The content of
+   * this notice is a relationship message (a change to the recipient's existing plan),
+   * which CAN-SPAM exempts from the commercial requirements, so the send script warns
+   * rather than refusing when it is unset. Rendered in the footer when provided.
    */
   postalAddress?: string;
 }
@@ -101,6 +107,8 @@ const darkButton = {
   boxShadow: '0 2px 8px rgba(0, 0, 0, 0.28), 0 1px 2px rgba(0, 0, 0, 0.18)',
 };
 
+const darkFooterLink = { ...emailStyles.link, color: INK };
+
 // The "what you keep" card is the one fact people will look for, so it gets
 // the tinted, left-ruled treatment rather than the plain callout.
 const keepCard = {
@@ -125,6 +133,7 @@ export function FreeCreditsChangeEmail({
   minTopup,
   planUrl,
   usageUrl,
+  unsubscribeUrl,
   postalAddress,
 }: FreeCreditsChangeEmailProps) {
   return (
@@ -216,6 +225,13 @@ export function FreeCreditsChangeEmail({
               You are receiving this notice because your PageSpace account is
               on the Free plan.
             </Text>
+            {unsubscribeUrl ? (
+              <Text style={emailStyles.footerText}>
+                <Link href={unsubscribeUrl} style={darkFooterLink}>
+                  Unsubscribe from product update emails
+                </Link>
+              </Text>
+            ) : null}
             {postalAddress ? (
               <Text style={emailStyles.footerText}>{postalAddress}</Text>
             ) : null}

--- a/packages/lib/src/email-templates/__tests__/FreeCreditsChangeEmail.test.tsx
+++ b/packages/lib/src/email-templates/__tests__/FreeCreditsChangeEmail.test.tsx
@@ -10,6 +10,7 @@ const PROPS = {
   minTopup: '$5',
   planUrl: 'https://app.pagespace.ai/settings/plan',
   usageUrl: 'https://app.pagespace.ai/settings/usage',
+  unsubscribeUrl: 'https://app.pagespace.ai/api/notifications/unsubscribe/ps_unsub_abc',
   postalAddress: 'PageSpace, 1 Example St, Springfield, IL 62704',
 };
 
@@ -64,13 +65,19 @@ describe('FreeCreditsChangeEmail', () => {
     expect(html).toMatch(/includes[\s\S]{0,40}15[\s\S]{0,40}credits per month/);
   });
 
-  it('is a relationship notice, so it renders NO unsubscribe link', async () => {
-    // A change to an existing plan is a relationship message under CAN-SPAM, and it
-    // must reach every affected account — there is no opt-out to offer.
+  it('given an unsubscribe URL, should render the opt-out link', async () => {
+    // The send script skips anyone already opted out of PRODUCT_UPDATE and gives
+    // everyone it does mail a working one-click opt-out.
     const html = await render();
 
+    expect(html).toContain('/api/notifications/unsubscribe/ps_unsub_abc');
+    expect(html).toContain('Unsubscribe');
+  });
+
+  it('given no unsubscribe URL, should omit the link rather than render a dead one', async () => {
+    const html = await render({ unsubscribeUrl: undefined });
+
     expect(html).not.toContain('Unsubscribe');
-    expect(html).not.toContain('/api/notifications/unsubscribe/');
   });
 
   it('given a postal address, should print it in the footer; given none, should omit it', async () => {

--- a/scripts/send-free-credits-change-notifications.ts
+++ b/scripts/send-free-credits-change-notifications.ts
@@ -10,12 +10,16 @@
  *
  *   - AUDIENCE is `users.subscriptionTier = 'free'` only. Paid tiers are not
  *     affected and are not mailed.
- *   - This is a RELATIONSHIP message (a notice of a change to the recipient's
- *     existing plan), not a marketing broadcast. CAN-SPAM exempts it from the
- *     commercial requirements, and it has to reach every affected account, so
- *     it does NOT honour the PRODUCT_UPDATE opt-out and carries no unsubscribe
- *     link. The GDPR rights-request and erasure-suppression exclusions still
- *     apply — those are legal must-skips, not preferences.
+ *   - This is a notice of a change to the recipient's existing plan, so its
+ *     CONTENT is a relationship message rather than marketing. It is still sent
+ *     as opt-outable bulk mail by explicit decision (2026-09-07): anyone who
+ *     turned PRODUCT_UPDATE email off is SKIPPED, and every message carries a
+ *     one-click unsubscribe link plus List-Unsubscribe headers. The tradeoff is
+ *     accepted knowingly — an unsubscribed free user will not learn by email
+ *     that their credits changed; the in-app credits card, the plan page and
+ *     the marketing/terms copy all state the new contract. The GDPR
+ *     rights-request and erasure-suppression exclusions apply on top, as legal
+ *     must-skips rather than preferences.
  *   - Each email quotes the recipient's CURRENT spendable balance (one LEFT JOIN
  *     on credit_balances), so "what you keep" is a number, not a promise.
  *
@@ -39,9 +43,11 @@ import { fileURLToPath } from 'node:url';
 import { getMigrationDb } from '@pagespace/db/db';
 import { users } from '@pagespace/db/schema/auth';
 import { creditBalances } from '@pagespace/db/schema/credits';
+import { emailNotificationPreferences } from '@pagespace/db/schema/email-notifications';
 import { dataSubjectRequests } from '@pagespace/db/schema/data-subject-requests';
 import { and, eq, inArray, isNotNull, isNull, ne, or } from '@pagespace/db/operators';
 import { sendEmail } from '@pagespace/lib/services/email-service';
+import { generateUnsubscribeToken } from '@pagespace/lib/services/notification-email-service';
 import { listSuppressedEmails } from '@pagespace/lib/compliance/erasure/resend-suppression-client';
 import { decryptUserRow } from '@pagespace/lib/auth/user-repository';
 import { isValidEmail } from '@pagespace/lib/validators/email';
@@ -56,6 +62,7 @@ import {
   findUnreachableUrls,
   isLocalhostUrl,
   LedgerWriteFailed,
+  listUnsubscribeHeaders,
   loadSentEmails,
   openLedger,
   parseArgs,
@@ -77,6 +84,9 @@ interface Recipient {
 }
 
 const EMAIL_SUBJECT = 'Free plan credits are changing';
+
+/** The opt-out channel this notice belongs to; anyone who disabled it is skipped. */
+const NOTIFICATION_TYPE = 'PRODUCT_UPDATE' as const;
 
 /**
  * Namespace for the per-recipient Resend idempotency key. Stable across
@@ -105,6 +115,20 @@ function defaultLogPath(): string {
 
 function sleep(ms: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+/** userIds that have explicitly turned PRODUCT_UPDATE email off. */
+async function loadOptedOutUserIds(): Promise<Set<string>> {
+  const rows = await db
+    .select({ userId: emailNotificationPreferences.userId })
+    .from(emailNotificationPreferences)
+    .where(
+      and(
+        eq(emailNotificationPreferences.notificationType, NOTIFICATION_TYPE),
+        eq(emailNotificationPreferences.emailEnabled, false),
+      ),
+    );
+  return new Set(rows.map((r) => r.userId));
 }
 
 /** userIds we are forbidden to contact because of a GDPR rights request — see the SDK launch script's identical function for the full rationale. */
@@ -142,7 +166,7 @@ async function main(): Promise<number> {
   console.log(`  Mode:          ${opts.live ? 'LIVE SEND' : 'DRY RUN (no sends) — pass --live to send'}`);
   console.log(
     `  Audience:      FREE tier, ${opts.includeUnverified ? 'including unverified addresses' : 'verified addresses only'}` +
-      ' (suspended accounts always excluded; PRODUCT_UPDATE opt-out NOT applied — plan-change notice)',
+      ' (suspended accounts, PRODUCT_UPDATE opt-outs, suppressed and GDPR-restricted users all excluded)',
   );
   console.log(`  Ledger:        ${opts.logPath}`);
   console.log(`  Plan page:     ${planUrl}`);
@@ -202,6 +226,11 @@ async function main(): Promise<number> {
     console.log(`↩️  Resuming: ${alreadySent.size} recipient(s) already recorded in the ledger.\n`);
   }
 
+  const optedOut = await loadOptedOutUserIds();
+  if (optedOut.size > 0) {
+    console.log(`🔕 ${optedOut.size} user(s) have product-update email turned off and will be skipped.\n`);
+  }
+
   const rightsRestricted = await loadRightsRestrictedUserIds();
   if (rightsRestricted.size > 0) {
     console.log(`⚖️  ${rightsRestricted.size} user(s) excluded by a GDPR rights request.\n`);
@@ -253,7 +282,7 @@ async function main(): Promise<number> {
     );
   }
 
-  const propsFor = ({ userId, userName }: Recipient) => ({
+  const propsFor = ({ userId, userName }: Recipient, unsubscribeUrl: string) => ({
     userName,
     ...(balanceByUserId.get(userId) ?? {}),
     starterCredits,
@@ -261,21 +290,29 @@ async function main(): Promise<number> {
     minTopup,
     planUrl,
     usageUrl,
+    unsubscribeUrl,
     postalAddress,
   });
 
   const sendOne = async (recipient: Recipient): Promise<void> => {
+    const token = await generateUnsubscribeToken(recipient.userId, NOTIFICATION_TYPE);
+    const unsubscribeUrl = `${baseUrl}/api/notifications/unsubscribe/${token}`;
     await sendEmail({
       to: recipient.email,
       subject: EMAIL_SUBJECT,
-      react: FreeCreditsChangeEmail(propsFor(recipient)),
+      react: FreeCreditsChangeEmail(propsFor(recipient, unsubscribeUrl)),
+      // One-click opt-out from the mail client itself, not just the footer link.
+      headers: listUnsubscribeHeaders(unsubscribeUrl),
       idempotencyKey: `${IDEMPOTENCY_PREFIX}:${recipient.userId}`,
     });
   };
 
   /** Dry-run: render the real template so a template error still surfaces, and send nothing. */
   const renderOne = (recipient: Recipient): Promise<string> =>
-    renderEmailToHtml(FreeCreditsChangeEmail(propsFor(recipient)));
+    renderEmailToHtml(
+      // A dry run mints no token: that would be a DB write.
+      FreeCreditsChangeEmail(propsFor(recipient, `${baseUrl}/api/notifications/unsubscribe/<token>`)),
+    );
 
   let result;
   try {
@@ -288,9 +325,7 @@ async function main(): Promise<number> {
       isValidEmail,
       alreadySent,
       suppressed,
-      // Plan-change notice: reaches every Free account regardless of the
-      // PRODUCT_UPDATE preference (see the file header).
-      optedOut: new Set<string>(),
+      optedOut,
       rightsRestricted,
       sendOne,
       renderOne,
@@ -316,6 +351,7 @@ async function main(): Promise<number> {
   console.log(`  ${opts.live ? 'Sent' : 'Would send'}:            ${sent}`);
   console.log(`  Skipped (already sent):  ${skipped['already-sent']}`);
   console.log(`  Skipped (suppressed):    ${skipped.suppressed}`);
+  console.log(`  Skipped (opted out):     ${skipped['opted-out']}`);
   console.log(`  Skipped (GDPR request):  ${skipped['rights-restricted']}`);
   console.log(`  Skipped (invalid email): ${skipped['invalid-email']}`);
   console.log(`  Errors:                  ${errors.length}`);


### PR DESCRIPTION
## Summary

The Free-credits change notice (merged in #2547, not yet sent) was built as a **relationship message**: it reached every free account regardless of the `PRODUCT_UPDATE` email preference and carried no unsubscribe link. Per the owner's decision it is now sent as **opt-outable bulk mail**.

## Changes

- **Opt-outs are skipped.** `scripts/send-free-credits-change-notifications.ts` loads the users who set `emailNotificationPreferences.emailEnabled = false` for `PRODUCT_UPDATE` and passes them to `runBroadcast` as `optedOut`. The shared core's `decideRecipient` returns `opted-out` for them, so they are never mailed, and the run summary counts them next to suppressed / GDPR-restricted.
- **Every message carries a working opt-out.** `sendOne` mints a per-recipient token via `generateUnsubscribeToken(userId, 'PRODUCT_UPDATE')`, renders the footer link, and sets `List-Unsubscribe` headers for one-click opt-out from the mail client. A dry run mints no token (that would be a DB write) and renders a `<token>` placeholder, matching the sibling launch scripts.
- **The tradeoff is written down.** The script header and the CHANGELOG record that an unsubscribed free user will not learn by email that their credits changed, and finds the new contract in-app (credits card, plan page) and on the pricing/terms pages instead.

Exclusion order in the shared core is: invalid email → already-sent → erasure-suppressed → GDPR rights-restricted → opted-out.

## Verification

- Template tests updated and passing (10 in the file, 92 across `email-templates`): the opt-out link renders when a URL is given and is omitted rather than dead when it is not.
- Rendered all three body variants (has a balance / never used AI / in overage) to HTML and read them back with tags stripped; the numbers, the unsubscribe link, and the postal address all appear.
- `bun build` on the script resolves cleanly.
- Not run: a dry run against the real database, which needs prod DB access. That is the last gate before sending.

## Note

`COMPANY_POSTAL_ADDRESS` is still a **warning**, not a hard refusal, on a live send. The content is a plan-change notice rather than an ad, so CAN-SPAM's postal-address rule does not clearly bite. Say the word and I will make it a hard block like the sandbox-launch script.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Cu8Qu2V83H67gbxQueYEdv
