### PR TITLE
docs(cli): state the local-env execution boundary (D-1) + the M1 exit-gate harness (t10 · phase A)

### DIFF
--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -2,6 +2,22 @@
 
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## [Unreleased]
+
+### Changed
+
+- **The `pagespace env` documentation now states, in plain words and before the commands, what
+  approving a local-environment request actually permits.** Approving a command lets it run under
+  your own user account, with your privileges, as if you had typed it into your own terminal: it
+  can read anything you can read and change anything you can change, and there is no sandbox
+  around it. The `roots` in `env-policy.json` confine the paths an agent can *name* — the working
+  directory it asks for and the files it asks to open — not what a program does once it has
+  started. The README also now says outright that `allowlist` mode allowlists **operations**
+  (`exec`, `fs_read`, `fs_write`), not executables, and that no per-executable allowlist exists;
+  `exec` in `ops` under `allowlist` means any command runs unprompted. Behaviour is unchanged —
+  this is the boundary the daemon has always had, written down where the person deciding whether
+  to run `env connect` will read it.
+
 ## [1.9.0] — 2026-09-06
 
 ### Added

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -10,9 +10,14 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   approving a local-environment request actually permits.** Approving a command lets it run under
   your own user account, with your privileges, as if you had typed it into your own terminal: it
   can read anything you can read and change anything you can change, and there is no sandbox
-  around it. The `roots` in `env-policy.json` confine the paths an agent can *name* — the working
-  directory it asks for and the files it asks to open — not what a program does once it has
-  started. The README also now says outright that `allowlist` mode allowlists **operations**
+  around it. It also says, where the decision is actually made rather than forty lines below it,
+  that an `ask` approval is remembered per user, session and operation — **not** per command — so
+  you see the first command of each kind and approving it covers every later one of that kind in
+  that session, unseen. The `roots` in `env-policy.json` confine the paths an agent can *name* —
+  the working directory it asks for and the files it asks to open — not what a program does once
+  it has started. A short note explains the chain those two facts make possible: a file the agent
+  reads on your machine can carry text that steers the agent, and with an approval already cached
+  the resulting command runs without a prompt. The README also now says outright that `allowlist` mode allowlists **operations**
   (`exec`, `fs_read`, `fs_write`), not executables, and that no per-executable allowlist exists;
   `exec` in `ops` under `allowlist` means any command runs unprompted. Behaviour is unchanged —
   this is the boundary the daemon has always had, written down where the person deciding whether

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -226,10 +226,17 @@ ordinary status text or, with `--show-token`, exactly the one `PAGESPACE_TOKEN=�
 
 `pagespace env connect` lets PageSpace run commands and read and write files **on this computer,
 under your own user account**. Nothing runs unless a policy file you own allows it, and in `ask`
-mode you see the exact command first — but once you approve something, it runs with your
-privileges, exactly as if you had typed it into this terminal yourself. It can read any file you
-can read, change any file you can change, reach anything on your network that you can reach, and
-use any credential sitting in your home directory. There is no sandbox around it.
+mode you see the exact command before it runs. Two things follow from approving one, and the
+second surprises people:
+
+- It runs with your privileges, exactly as if you had typed it into this terminal yourself. It can
+  read any file you can read, change any file you can change, reach anything on your network that
+  you can reach, and use any credential sitting in your home directory. There is no sandbox
+  around it.
+- You see the **first** command of each kind, and approving it covers **every later command of
+  that kind for the rest of that session, unseen**. The approval is remembered per user, session
+  and operation — not per command — so after you approve one `exec`, the next `exec` from that
+  same user and session runs with no prompt at all, whatever it is.
 
 The `roots` in your policy file confine the paths an agent can **name** — the working directory it
 asks for, and the files it asks to read or write. They do **not** confine what a program does once
@@ -238,9 +245,9 @@ it has started. A command approved with a working directory inside a root can st
 daemon to open them. Actually confining a running process needs operating-system sandboxing,
 which this daemon does not do.
 
-So the question at the prompt is not "may this touch that folder". It is "may this run as me".
-Answer it the way you would answer a stranger asking you to paste a command into your own shell.
-Two practical consequences:
+So the question at the prompt is not "may this touch that folder". It is "may this, and everything
+like it for the rest of this session, run as me". Answer it the way you would answer a stranger
+asking for your shell for the afternoon. Two practical consequences:
 
 - Run the daemon as an ordinary user, never as root, and prefer a machine — or a separate account —
   that does not hold secrets you would not hand to whoever is driving the agent.
@@ -260,15 +267,24 @@ What the daemon does guarantee is narrower than "safe", and worth knowing exactl
 - Revoking the environment in PageSpace **deletes this machine's key** and stops the daemon;
   Ctrl-C and `pagespace env disconnect` stop it too, and kill anything it started.
 
+One consequence of the two facts above, worth seeing once before you pick a mode: an agent that
+reads a file on this machine can be *steered* by what that file says — a README, a dependency's
+source, a downloaded document can all contain text aimed at the agent rather than at you. If the
+agent then runs a command, and you have already approved an `exec` in that session, **that command
+runs without a prompt**. This is inherent to agents reading content nobody vetted, not a defect in
+this daemon; the defences that apply here are the ordinary ones — keep `principals` short, keep
+`ops` narrow, stop the daemon when you are not using it, and read
+`~/.pagespace/env-audit.jsonl` when you want to know what actually ran.
+
 ### The three modes, in practice
 
 - **`deny`** — nothing runs, ever. The daemon still connects, so the Environment shows as connected.
 - **`ask`** — the safe default to start with. An operation listed in `ops` runs without asking;
   anything else stops and prompts you in this terminal, showing the exact command, working
-  directory, paths, environment and limits. Approving covers further requests for that same
-  operation from the same user and session while the daemon runs — not forever, and not for
-  other people. Declining refuses that request and asks again next time. `ask` needs a terminal:
-  a headless machine cannot use it.
+  directory, paths, environment and limits. As above, approving covers further requests for that
+  same operation from the same user and session while the daemon runs — those later commands are
+  never shown to you — but not forever, and not for other people. Declining refuses that request
+  and asks again next time. `ask` needs a terminal: a headless machine cannot use it.
 - **`allowlist`** — only the operations in `ops` run; everything else is denied with no prompt.
 
 **`allowlist` allowlists operations, not executables.** `ops` holds `exec`, `fs_read` and

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -222,6 +222,62 @@ ordinary status text or, with `--show-token`, exactly the one `PAGESPACE_TOKEN=�
 
 ## `pagespace env` — this machine as a local environment
 
+### What you are agreeing to
+
+`pagespace env connect` lets PageSpace run commands and read and write files **on this computer,
+under your own user account**. Nothing runs unless a policy file you own allows it, and in `ask`
+mode you see the exact command first — but once you approve something, it runs with your
+privileges, exactly as if you had typed it into this terminal yourself. It can read any file you
+can read, change any file you can change, reach anything on your network that you can reach, and
+use any credential sitting in your home directory. There is no sandbox around it.
+
+The `roots` in your policy file confine the paths an agent can **name** — the working directory it
+asks for, and the files it asks to read or write. They do **not** confine what a program does once
+it has started. A command approved with a working directory inside a root can still read
+`/etc/passwd`, your SSH keys, or anything else your account can reach; it just cannot *ask* the
+daemon to open them. Actually confining a running process needs operating-system sandboxing,
+which this daemon does not do.
+
+So the question at the prompt is not "may this touch that folder". It is "may this run as me".
+Answer it the way you would answer a stranger asking you to paste a command into your own shell.
+Two practical consequences:
+
+- Run the daemon as an ordinary user, never as root, and prefer a machine — or a separate account —
+  that does not hold secrets you would not hand to whoever is driving the agent.
+- `principals` is the list of PageSpace users allowed to drive this machine. Keep it short, and
+  treat adding a name to it as the same decision as giving that person your shell.
+
+What the daemon does guarantee is narrower than "safe", and worth knowing exactly:
+
+- It **never listens on a port** — it dials out to PageSpace and nothing can dial in.
+- It **denies by default**. No policy file, an unreadable one, or one anybody else can write means
+  every request is refused.
+- Every request carries a **server-signed grant** bound to that exact command or path list: it is
+  single-use, expires within a minute, and cannot be replayed or edited in flight.
+- Your policy is checked **after** the grant and independently of it. A request PageSpace considers
+  allowed is still refused here if your policy does not allow it.
+- Every decision — allowed, denied, declined — is appended to `~/.pagespace/env-audit.jsonl`.
+- Revoking the environment in PageSpace **deletes this machine's key** and stops the daemon;
+  Ctrl-C and `pagespace env disconnect` stop it too, and kill anything it started.
+
+### The three modes, in practice
+
+- **`deny`** — nothing runs, ever. The daemon still connects, so the Environment shows as connected.
+- **`ask`** — the safe default to start with. An operation listed in `ops` runs without asking;
+  anything else stops and prompts you in this terminal, showing the exact command, working
+  directory, paths, environment and limits. Approving covers further requests for that same
+  operation from the same user and session while the daemon runs — not forever, and not for
+  other people. Declining refuses that request and asks again next time. `ask` needs a terminal:
+  a headless machine cannot use it.
+- **`allowlist`** — only the operations in `ops` run; everything else is denied with no prompt.
+
+**`allowlist` allowlists operations, not executables.** `ops` holds `exec`, `fs_read` and
+`fs_write` — so putting `exec` in it under `allowlist` mode means *any* command may run
+unprompted, not some approved list of programs. There is deliberately no executable allowlist:
+one was considered for this release and not adopted, because a list of program names is easy to
+walk around (`sh -c …`, an interpreter, a script inside a root) and would suggest a guarantee the
+daemon cannot keep. If you want per-command review, use `ask` and leave `exec` out of `ops`.
+
 A drive owner or admin can create an Environment with `substrate: "local"` and is shown a
 **one-time enrollment code** (valid ten minutes, single use). On the machine:
 
@@ -297,15 +353,19 @@ denied** (`no_policy`); the daemon still connects so you can see the Environment
 }
 ```
 
-- `mode` — `ask`: ops listed in `ops` run without prompting, anything else prompts in the terminal
-  (once per user + session + op; needs a TTY, so a headless machine must use another mode).
-  `allowlist`: only ops in `ops` run; anything else is denied. `deny`: nothing runs.
+- `mode` — see "The three modes, in practice" above. In short: `ask` prompts for anything not in
+  `ops` and needs a TTY; `allowlist` runs only what is in `ops` and never prompts; `deny` runs
+  nothing.
 - `principals` — PageSpace user ids allowed to drive this machine. A request from anyone else is
-  denied `principal_not_allowed`, whatever the server thinks.
-- `ops` — any of `exec`, `fs_read`, `fs_write` (`pty_open` is reserved for a later release).
+  denied `principal_not_allowed`, whatever the server thinks. Each of these users can run commands
+  as you on this machine, subject to `mode` and `ops`.
+- `ops` — any of `exec`, `fs_read`, `fs_write` (`pty_open` is reserved for a later release). These
+  are operation kinds, not programs: `exec` covers every command, and there is no per-executable
+  allowlist.
 - `roots` — absolute directories every working directory and every file path must resolve inside
-  (symlinks are resolved; `..` is refused). Note that roots confine the paths an agent *names*, not
-  what a command does once it runs.
+  (symlinks are resolved; `..` is refused). Roots confine the paths an agent can *name*. They do
+  not confine a command once it is running: an approved `exec` with its cwd inside a root still
+  runs as you and can read anything you can read. See "What you are agreeing to" above.
 - `envAllowlist` — environment variable names the server may set for a command. Loader and
   interpreter hooks (`LD_*`, `DYLD_*`, `PATH`, `NODE_OPTIONS`, …) are refused even if listed.
 - `maxBytes` / `maxTimeoutMs` — caps on captured output and wall-clock per command; a request that

--- a/scripts/env-bridge-exit-gate/README.md
+++ b/scripts/env-bridge-exit-gate/README.md
@@ -66,11 +66,37 @@ Full app-launch details (prod build, `WEB_APP_URL`, session/CSRF seeding) are
 in the operator's `reference_running_web_app_locally` notes.
 
 ```bash
-export PAGESPACE_GATE_HOST=http://127.0.0.1:3000
+export PAGESPACE_GATE_HOST=http://127.0.0.1:3000        # the app itself
+export PAGESPACE_GATE_UPSTREAM=$PAGESPACE_GATE_HOST      # what the capture proxy forwards to
+export PAGESPACE_GATE_PROXY_PORT=8788
+export PAGESPACE_GATE_CREDENTIAL_HOST=http://127.0.0.1:8788   # the host `env enroll` runs against
 export PAGESPACE_GATE_CLI=$PWD/packages/cli/dist/bin.js
 export PAGESPACE_GATE_APP_TZ=UTC PAGESPACE_GATE_DEPLOYMENT_MODE=onprem PAGESPACE_GATE_S3_ENDPOINT=http://127.0.0.1:9000
 bun scripts/env-bridge-exit-gate/preflight.ts
 ```
+
+`PAGESPACE_GATE_UPSTREAM` is required by `bridge-proxy.ts` at startup — without
+it the proxy exits 2 before the daemon can dial it. `PAGESPACE_GATE_CREDENTIAL_HOST`
+must be the host `env enroll` was run against: the CLI stores credentials **per
+host**, so N08/N09 against the wrong host inspect an empty profile and pass for
+the wrong reason.
+
+### Create three local envs, not one
+
+The negatives need enrollments in three different states, and none can be
+recycled from another:
+
+| env | state | used by |
+|-----|-------|---------|
+| **A** | enrolled and connected — the machine under test | steps 1–5, R1–R3, N01, N04, N05, N06–N09 |
+| **B** | created, **never enrolled** | N02 (a wrong code must reach the code comparison) |
+| **C** | created **more than ten minutes** before the run | N03 (an expired code) |
+
+`enrollLocalDriveEnv` checks `enrolledAt`/`enrollmentCodeUsedAt` *before* it
+compares the code (`drive-envs.ts:310`), so a wrong code against env A answers
+`409 used` and never reaches the branch N02 exists to test. A `mismatch`
+consumes nothing, so env B survives N02 and can be reused if you need to repeat
+it.
 
 ### The policy file
 
@@ -121,9 +147,10 @@ The code is shown **once**. Then, on the machine — through the capture proxy,
 so the same run yields the frames the later negatives need:
 
 ```bash
+# PAGESPACE_GATE_UPSTREAM and PAGESPACE_GATE_PROXY_PORT must be exported (see Environment)
 bun scripts/env-bridge-exit-gate/bridge-proxy.ts &     # 127.0.0.1:8788 -> the app
-node "$PAGESPACE_GATE_CLI" env enroll <enrollmentId> <code> --host http://127.0.0.1:8788
-node "$PAGESPACE_GATE_CLI" env token  <enrollmentId>          --host http://127.0.0.1:8788
+node "$PAGESPACE_GATE_CLI" env enroll <enrollmentId> <code> --host "$PAGESPACE_GATE_CREDENTIAL_HOST"
+node "$PAGESPACE_GATE_CLI" env token  <enrollmentId>         --host "$PAGESPACE_GATE_CREDENTIAL_HOST"
 ```
 
 Use the **same host string** for enroll, token and connect: the CLI keys its
@@ -138,7 +165,7 @@ Sprite columns NULL; after `env token`, `lastSeenAt` is stamped
 ### 2 · Connect
 
 ```bash
-node "$PAGESPACE_GATE_CLI" env connect <enrollmentId> --host http://127.0.0.1:8788
+node "$PAGESPACE_GATE_CLI" env connect <enrollmentId> --host "$PAGESPACE_GATE_CREDENTIAL_HOST"
 ```
 
 Expect env status `connected` and the `hello` capabilities persisted
@@ -180,7 +207,10 @@ Each must fail safely, and the exact denial is the evidence.
 ### Identity (`N01`–`N11`) — carried from t06, never run
 
 ```bash
-PAGESPACE_GATE_ENROLLMENT_ID=… PAGESPACE_GATE_CODE=<the spent code> PAGESPACE_GATE_TOKEN=<mcp_…> \
+PAGESPACE_GATE_ENROLLMENT_ID=<env A> PAGESPACE_GATE_CODE=<A's spent code> PAGESPACE_GATE_TOKEN=<mcp_…> \
+PAGESPACE_GATE_FRESH_ENROLLMENT_ID=<env B> \
+PAGESPACE_GATE_EXPIRED_ENROLLMENT_ID=<env C> PAGESPACE_GATE_EXPIRED_CODE=<C's code> \
+PAGESPACE_GATE_SPENT_NONCE=… PAGESPACE_GATE_SPENT_SIGNATURE=… \
   bun scripts/env-bridge-exit-gate/identity-negatives.ts
 ```
 
@@ -198,12 +228,18 @@ PAGESPACE_GATE_ENROLLMENT_ID=… PAGESPACE_GATE_CODE=<the spent code> PAGESPACE_
 | N10 | flag off: `POST /envs { substrate:'local' }` | `501` |
 | N11 | flag off: `/api/env-bridge/*` | `404` |
 
-**N03** needs an enrollment older than ten minutes: create a second local env,
-wait, and pass `PAGESPACE_GATE_EXPIRED_ENROLLMENT_ID` / `_CODE`. **N04** needs
-the `(nonce, signature)` pair `env token` already spent; the proxy records it
-(`kind:"http"` lines in the transcript) — pass it as
-`PAGESPACE_GATE_SPENT_NONCE` / `_SIGNATURE`. Both are SKIPs otherwise, and a
-SKIP is not a pass.
+**N02** uses env B (above). **N03** uses env C. **N04** needs the
+`(nonce, signature)` pair `env token` already spent; the proxy records it
+(`kind:"http"` lines in the transcript) — pass it as `PAGESPACE_GATE_SPENT_NONCE`
+/ `_SIGNATURE`. Each is a SKIP without its input, and a SKIP is not a pass.
+
+**N04 runs before N05, and the order is load-bearing.** `issueLocalEnvChallenge`
+replaces a consumed challenge and clears `challengeUsedAt`, and
+`verifyChallengeResponse` compares the nonce *before* it looks at `usedAt` — so
+if N05 fetched its challenge first, N04's replay would answer
+`401 nonce_mismatch` instead of `401 used` and the replay defence would go
+untested. N05 also leaves its nonce pending and unconsumed, which is why no
+later row asks for another challenge (it would answer `challenge_pending`).
 
 **N10/N11 need the app restarted with `LOCAL_ENVS_ENABLED` unset**, so they are
 their own pass:

--- a/scripts/env-bridge-exit-gate/README.md
+++ b/scripts/env-bridge-exit-gate/README.md
@@ -1,0 +1,302 @@
+# M1 exit gate — Local Environments zero-trust bridge
+
+The runbook and harness for **t10**, the exit gate of milestone M1 of the
+*Local Environments — zero-trust bridge* epic (`j945few5ssv75k5ad0bowbb4`,
+task `ukqmwy41zkf192hwgh6sqsxf`).
+
+**Status: this gate has NOT been run.** Everything here is written to be run;
+nothing in it has executed against real hardware. M1's code is merged
+(#2527 #2528 #2529 #2531 #2532 #2534 #2537 #2543 #2546 #2551) and every layer
+is unit-tested and mutation-checked, but no part of the chain has ever run end
+to end with the real CLI against a real app. Until the gate below is run and
+its lines recorded on the task page, M1 is code-complete and unverified.
+
+This gate also carries **t06's identity negatives**, whose own real-client
+check was never run either (it was deferred for a build slot when #2534
+merged). They are `N01`–`N11` below.
+
+## What this gate proves, and what it does not
+
+Per the founder's **[D-1]** ruling (epic page, resolved 2026-09-07), local
+execution is gated by the machine owner's `ask`/`allowlist`/`deny` policy plus
+the server policy, and is **not path-confined**. The negatives here therefore
+test **policy enforcement, replay refusal and revocation**. They do not, and
+cannot, test filesystem confinement of a running process: an approved command
+runs with the machine owner's own privileges. `P05` (the path-escape row)
+stays, and its meaning is exactly this: an agent cannot *name* a path outside a
+root. It proves nothing about what a program does after it starts.
+
+## Evidence format
+
+Every check prints one line:
+
+```
+GATE <id> <PASS|FAIL|SKIP> expected=<value> actual=<value> :: <note>
+```
+
+`expected` is the exact denial reason, status code or close code — never a
+category. A SKIP is an unfinished gate and makes the exit code non-zero; a
+skip has to be explained on the task page before the gate can be called
+passed. Copy the `GATE` lines onto the task page verbatim.
+
+## Environment (preconditions)
+
+`preflight.ts` refuses loudly when any of these is missing. Several have cost
+this repo a run before.
+
+| id | condition | why |
+|----|-----------|-----|
+| F01 | the web app answers | everything else is downstream of it |
+| F02 | `LOCAL_ENVS_ENABLED=true` in `apps/web/.env.local` | invariant 11; without it the bridge routes do not exist |
+| F03 | `ENV_BRIDGE_SIGNING_KEY` set | grants cannot be signed; the app refuses to boot with the flag on and no key |
+| F04 | the CLI under test is the **built** `packages/cli/dist/bin.js` | #2546 found `env enroll` broken in the real binary while its unit tests passed |
+| F05 | a TTY on stdin | `ask` mode refuses to start without one |
+| F06 | `TZ=UTC` on the app process **and** on Postgres | otherwise sessions revoke instantly |
+| F07 | `DEPLOYMENT_MODE=onprem` | keeps external integrations out of the run |
+| F08 | an S3 endpoint configured | page/drive creation 500s on `CredentialsProviderError` without one |
+| F09 | `pagespace env policy` reports a policy in force | no policy = deny-all, and every negative would "pass" for the wrong reason |
+
+Generate a signing key with:
+
+```bash
+node -e "const k=require('crypto').generateKeyPairSync('ed25519');console.log(k.privateKey.export({type:'pkcs8',format:'der'}).toString('base64'))"
+```
+
+Full app-launch details (prod build, `WEB_APP_URL`, session/CSRF seeding) are
+in the operator's `reference_running_web_app_locally` notes.
+
+```bash
+export PAGESPACE_GATE_HOST=http://127.0.0.1:3000
+export PAGESPACE_GATE_CLI=$PWD/packages/cli/dist/bin.js
+export PAGESPACE_GATE_APP_TZ=UTC PAGESPACE_GATE_DEPLOYMENT_MODE=onprem PAGESPACE_GATE_S3_ENDPOINT=http://127.0.0.1:9000
+bun scripts/env-bridge-exit-gate/preflight.ts
+```
+
+### The policy file
+
+Write `~/.pagespace/env-policy.json`, `chmod 600`, owned by the user running
+the daemon. A gate policy that exercises both the pre-approved and the prompted
+path:
+
+```json
+{
+  "mode": "ask",
+  "principals": ["<your PageSpace user id>"],
+  "ops": ["fs_read"],
+  "roots": ["/Users/<you>/pagespace-gate", "/workspace"],
+  "envAllowlist": ["CI"],
+  "maxBytes": 1048576,
+  "maxTimeoutMs": 120000
+}
+```
+
+`fs_read` is pre-approved so the replay/tamper injections (R1–R3) complete
+inside the grant's 60 s window without a human in the loop; `exec` is *not*, so
+step 4 exercises the prompt.
+
+> **`/workspace` is in `roots` on purpose, and it is a finding, not a
+> workaround.** The agent tool layer confines every `cwd` and every file path to
+> the Sprite root `/workspace` *before* the local host sees it
+> (`packages/lib/src/services/sandbox/sandbox-paths.ts:20`,
+> `tool-runners.ts:972-1012`), and nothing translates that to the machine's own
+> roots. Without `/workspace` in `roots` — and an actual `/workspace`
+> directory on the machine, or `spawn` fails ENOENT — every agent tool call
+> against a local env is denied `cwd_denied`. See drift **D-c** in the dry-run
+> audit on the task page.
+
+## Procedure
+
+Run in order. Steps 1–5 are the task page's; the negatives follow.
+
+### 1 · Create the env and enroll the machine
+
+As a drive **owner or admin**:
+
+```
+POST /api/drives/<driveId>/envs  { "name": "mac", "substrate": "local", "label": "<machine>" }
+  → 201 { env: { substrate: 'local', status: 'disconnected' }, enrollment: { enrollmentId, code, expiresAt } }
+```
+
+The code is shown **once**. Then, on the machine — through the capture proxy,
+so the same run yields the frames the later negatives need:
+
+```bash
+bun scripts/env-bridge-exit-gate/bridge-proxy.ts &     # 127.0.0.1:8788 -> the app
+node "$PAGESPACE_GATE_CLI" env enroll <enrollmentId> <code> --host http://127.0.0.1:8788
+node "$PAGESPACE_GATE_CLI" env token  <enrollmentId>          --host http://127.0.0.1:8788
+```
+
+Use the **same host string** for enroll, token and connect: the CLI keys its
+credential store by host.
+
+Evidence to record: the 201 body; `drive_env_local` has `machinePublicKey`,
+`enrolledAt`, `enrollmentCodeUsedAt`, `enrollmentCodeHash IS NULL`; `drive_envs`
+Sprite columns NULL; after `env token`, `lastSeenAt` is stamped
+(`consumeChallenge` writes it) and `GET /envs` reads `connected` for 90 s
+(`LOCAL_ENV_HEARTBEAT_WINDOW_MS`).
+
+### 2 · Connect
+
+```bash
+node "$PAGESPACE_GATE_CLI" env connect <enrollmentId> --host http://127.0.0.1:8788
+```
+
+Expect env status `connected` and the `hello` capabilities persisted
+(`shell:true, pty:false, fs:true, checkpoint:false`).
+
+### 3 · Bind a session
+
+From a web pane, as the env **owner**, bind a new session to the local env.
+Expect the session row to carry `envId` and **no** Sprite columns (invariant 9).
+
+### 4 · Drive the three operations
+
+Prompt the agent to read a file under an allowed root, write a file, and run a
+command that sleeps for more than 30 s. Each should produce a local prompt
+(approve it), execute on the machine, and render in the pane.
+
+Three timing facts that decide whether this step can pass at all:
+
+- The bash tool sends `sh -c <command>` with `cwd` under `/workspace`
+  (`tool-runners.ts:1010`). See the `roots` note above.
+- A grant expires **60 s** after issue (`GRANT_MAX_TTL_MS`), and that window
+  covers the prompt: an approval that lands after `exp` is refused
+  `approval_expired`. **Answer the prompt promptly.**
+- The server's correlator waits `timeoutMs + 5 s`
+  (`resolveTimeout`), and the daemon clamps `timeoutMs` to the policy's
+  `maxTimeoutMs`. With the defaults above, a >30 s command is not aborted —
+  that is the thing being proved.
+
+### 5 · Cross-reference the audit
+
+The server's `auditRequest` rows and the daemon's
+`~/.pagespace/env-audit.jsonl` must show the same `grantId`s for the three
+operations (invariant 10).
+
+## Negatives
+
+Each must fail safely, and the exact denial is the evidence.
+
+### Identity (`N01`–`N11`) — carried from t06, never run
+
+```bash
+PAGESPACE_GATE_ENROLLMENT_ID=… PAGESPACE_GATE_CODE=<the spent code> PAGESPACE_GATE_TOKEN=<mcp_…> \
+  bun scripts/env-bridge-exit-gate/identity-negatives.ts
+```
+
+| id | negative | expected |
+|----|----------|----------|
+| N01 | re-present the enrollment code | `409 used` |
+| N02 | wrong code | `401 mismatch` |
+| N03 | expired code | `410 expired` |
+| N04 | replay a spent challenge response | `401 used` |
+| N05 | signature from another key | `401 bad_signature` |
+| N06 | the `env:bridge` token at `GET /api/auth/me` | `401` |
+| N07 | the same token at mcp-ws | close `1008` |
+| N08 | `pagespace logout --key=env:<id>` | reports not logged in |
+| N09 | `pagespace keys use env:<id>` | refuses |
+| N10 | flag off: `POST /envs { substrate:'local' }` | `501` |
+| N11 | flag off: `/api/env-bridge/*` | `404` |
+
+**N03** needs an enrollment older than ten minutes: create a second local env,
+wait, and pass `PAGESPACE_GATE_EXPIRED_ENROLLMENT_ID` / `_CODE`. **N04** needs
+the `(nonce, signature)` pair `env token` already spent; the proxy records it
+(`kind:"http"` lines in the transcript) — pass it as
+`PAGESPACE_GATE_SPENT_NONCE` / `_SIGNATURE`. Both are SKIPs otherwise, and a
+SKIP is not a pass.
+
+**N10/N11 need the app restarted with `LOCAL_ENVS_ENABLED` unset**, so they are
+their own pass:
+
+```bash
+PAGESPACE_GATE_FLAG=off PAGESPACE_GATE_DRIVE_ID=… PAGESPACE_GATE_COOKIE='…' \
+  bun scripts/env-bridge-exit-gate/identity-negatives.ts
+```
+
+Enrollment is rate-limited (10/min per IP, 5 per 10 min per enrollment) and the
+token endpoints likewise; budget N01–N05 accordingly.
+
+### Frames (`R1`–`R3`) — replay and tamper
+
+Automatic, from the proxy, the moment the daemon answers the first
+`grant_exec`. Both constraints below turn a mistake into a *different denial*
+rather than a false pass, so read the reason, not just the FAIL:
+
+- Inject into the **same daemon process** that received the frame. After a
+  restart, `grantPredatesDaemon` (Codex C6) answers `predates_daemon`.
+- Inject inside the grant's 60 s window, or the answer is `expired`. The proxy
+  prints the capture age.
+
+| id | injection | expected |
+|----|-----------|----------|
+| R1 | the captured `grant_exec`, byte-for-byte | `replayed` |
+| R2 | the same frame with `grant.argsHash` altered | `args_mismatch` |
+| R3 | the same frame with `grant.grantId` altered | `bad_signature` |
+
+R2's expected value differs from the task page, which says `bad_signature`.
+That is drift in the page, not a defect: since #2527 the daemon binds the grant
+to the frame carrying it and refuses `args_mismatch` **before** verifying the
+signature. R3 exists so the signature check is still covered.
+
+### Policy, binding and revocation (`P01`–`P08`) — manual
+
+These need an agent pane and a second drive member, so they are driven by hand
+and their `GATE` lines written by the operator.
+
+| id | negative | expected | pinned by |
+|----|----------|----------|-----------|
+| P01 | no policy file (move it aside, reconnect) | `no_policy` | `policy.ts` → `decideExecution` |
+| P02 | policy `chmod 666` | `no_policy` (`writable_by_others` in the log) | `loadMachinePolicy` |
+| P03 | a principal not in `principals` drives the env | `principal_not_allowed` | `decideExecution` |
+| P04 | decline the prompt | `declined`, audited, nothing runs | `dispatcher.ts` |
+| P05 | ask the agent to read `../../etc/passwd` | `path_denied` | `confinePath` via `decideExecution` |
+| P06 | a grant carrying `LD_PRELOAD` (`sh -c env` and read the output) | no `LD_PRELOAD` in the child | `scrubEnv` + `exec-runner.ts` |
+| P07 | a non-owner member binds to a **connected** env | `bind_policy` | `decideBind` |
+| P08 | binding while the daemon is stopped | `not_connected`, Sprite host never called | `local-env-gate.ts` |
+
+**P05's expected reason differs from the task page** (`traversal`/`outside_root`):
+those are `confinePath`'s internal classifications, and `decideExecution`
+collapses them to `path_denied`, which is what reaches the wire and the audit
+log. And to say it once more: P05 proves an agent cannot *name* a path outside a
+root. It does not prove a running command is confined — per [D-1] it is not.
+
+**P07 must be run while the env is connected.** `decideBind`'s order is
+`flag_disabled → code_exec_denied → not_local → revoked → not_connected →
+bind_policy`; against a disconnected env the same attempt answers
+`not_connected` and proves nothing about the bind policy.
+
+### Revocation (`P09`–`P12`)
+
+The task page attributes all of this to `pagespace env disconnect`. It does not
+do it. `env disconnect` is **local only**: it validates the daemon's pid record
+and sends `SIGTERM` (`commands/env/disconnect.ts`). The server-side revoke —
+`revokedAt`, session revocation, the 1008 close and the signed `revoke` frame
+that makes the daemon delete its key — is `DELETE /api/drives/<driveId>/envs/<envId>`
+(`route.ts:136` → `revokeEnv` → `local-env-revoke.ts`). Run both:
+
+| id | action | expected |
+|----|--------|----------|
+| P09 | `pagespace env disconnect <enrollmentId>` | the daemon exits; children killed; **key retained**; server row unchanged |
+| P10 | `DELETE /api/drives/<driveId>/envs/<envId>` | `drive_env_local.revokedAt` stamped, sessions revoked, socket closed `1008` |
+| P11 | the daemon that was connected during P10 | logs `revoked`, deletes its key, exits non-zero |
+| P12 | `pagespace env token <enrollmentId>` after P10 | refused (`revoked`; the row is deleted with the env, so `not_found` is equally correct) |
+
+## Files
+
+| file | what it does |
+|------|--------------|
+| `report.ts` | the `GATE` line format and the exit-code tally |
+| `preflight.ts` | F01–F09, the preconditions |
+| `identity-negatives.ts` | N01–N11, over real HTTP and the built CLI |
+| `bridge-proxy.ts` | the capture/reinject proxy; R1–R3, and it records the transcript |
+| `ws-min.ts` | a dependency-free WebSocket client/server slice (the root workspace does not depend on `ws`, and `knip:check` is blocking) |
+
+## After the run
+
+Record every `GATE` line on the task page, then:
+
+- any FAIL becomes a bug task on this board **before M2 starts** (the task
+  page's own exit criterion);
+- any SKIP is explained, or the gate is not passed;
+- the epic Status line is updated to say the chain has run on real hardware —
+  and not before.

--- a/scripts/env-bridge-exit-gate/bridge-proxy.ts
+++ b/scripts/env-bridge-exit-gate/bridge-proxy.ts
@@ -1,0 +1,258 @@
+/**
+ * Capture-and-reinject for the two bridge negatives that need a real frame
+ * (Local Environments epic, M1 · t10):
+ *
+ *   R1 replay  — re-send a captured `grant_exec` byte-for-byte  → `grant_denied replayed`
+ *   R2 tamper  — alter `grant.argsHash` in that frame           → `grant_denied args_mismatch`
+ *   R3 tamper  — alter `grant.grantId` in that frame            → `grant_denied bad_signature`
+ *
+ * Neither can be faked. A replay is only a replay against the SAME daemon
+ * process holding the SAME nonce store, and a tampered grant is only
+ * interesting if the rest of it is a genuine server signature. So this is a
+ * transparent reverse proxy the daemon dials instead of the app:
+ *
+ *   pagespace env connect --host http://127.0.0.1:8788
+ *          │                                   │
+ *          │  ws /api/env-bridge/ws            │  ws → the real app
+ *          └──────────► [ this proxy ] ────────┘
+ *                          records every frame with the REAL codec
+ *                          (packages/lib/src/env-bridge/frame-codec.ts),
+ *                          then injects R1 / R2 into the DAEMON socket only.
+ *
+ * `env enroll` and `env token` are ordinary HTTP and are forwarded too, so the
+ * same run captures the challenge nonce + signature that `identity-negatives.ts`
+ * needs for N04 (replaying a spent challenge response). Use the SAME
+ * `--host http://127.0.0.1:<port>` for enroll, token and connect: the CLI keys
+ * its credential store by host, so mixing hosts loses the machine credential.
+ *
+ * WHAT EACH INJECTION PINS
+ *   R1 → `verifyGrant` in packages/lib/src/env-bridge/grant.ts:261 (`nonces.has`
+ *        ⇒ `replayed`), reached through packages/cli/src/env-bridge/dispatcher.ts.
+ *   R2 → the FRAME BINDING in the same function (grant.ts:238-241, Codex P1 /
+ *        PR #2527): the daemon recomputes `hash(canonicalizeArgs(request.args))`
+ *        from the frame and compares it to the signed `argsHash` BEFORE it
+ *        verifies the signature. So an edited `argsHash` is refused
+ *        `args_mismatch`, not `bad_signature` — the task page names the latter
+ *        and the code has said the former since #2527. See the dry-run audit on
+ *        the task page (drift D-a). `args_mismatch` is the STRONGER refusal:
+ *        it holds even against a validly signed grant for other work.
+ *   R3 → the signature check itself (grant.ts:250-256). `grantId` is inside
+ *        `encodeGrant`'s bytes but is not re-derived from the frame, so editing
+ *        it reaches the Ed25519 verification and fails there. This is the row
+ *        that actually proves the server key is checked; without it, R2 alone
+ *        would pass even on a daemon that never verified a signature.
+ *
+ * TWO CONSTRAINTS, both of which make a wrong answer instead of a wrong verdict:
+ *   - The daemon denies any grant whose `iat` predates its own start
+ *     (`grantPredatesDaemon`, Codex C6). Inject into the daemon that received
+ *     the frame — never after a restart, or R1 answers `predates_daemon`.
+ *   - A grant expires 60 s after issue (`GRANT_MAX_TTL_MS`). Injection happens
+ *     automatically the moment the daemon answers the original, and the elapsed
+ *     ms is printed; if R1 ever answers `expired`, the capture was too slow and
+ *     the run is void. Drive R1/R2 with an op that is PRE-APPROVED in the
+ *     policy `ops` so no human prompt sits inside that window.
+ *
+ * Usage:
+ *   PAGESPACE_GATE_UPSTREAM=http://127.0.0.1:3000 PAGESPACE_GATE_PROXY_PORT=8788 \
+ *   bun scripts/env-bridge-exit-gate/bridge-proxy.ts
+ * then, in another terminal, drive one `exec` from the agent pane. The proxy
+ * prints GATE R1 / GATE R2 and exits non-zero if either did not hold.
+ */
+import { createServer, request as httpRequest, type IncomingMessage, type ServerResponse } from 'node:http';
+import { appendFileSync } from 'node:fs';
+import { decodeFrame, encodeFrame, type Frame } from '@pagespace/lib/env-bridge/frame-codec';
+import { acceptUpgrade, openClient, type MinSocket } from './ws-min';
+import { expect, optional, required, summarize } from './report';
+
+const upstream = new URL(required('PAGESPACE_GATE_UPSTREAM'));
+const port = Number(optional('PAGESPACE_GATE_PROXY_PORT') ?? '8788');
+const transcript = optional('PAGESPACE_GATE_TRANSCRIPT') ?? 'env-bridge-gate-frames.jsonl';
+
+type Direction = 'server->machine' | 'machine->server';
+
+function log(entry: Record<string, unknown>): void {
+  appendFileSync(transcript, `${JSON.stringify({ at: new Date().toISOString(), ...entry })}\n`);
+}
+
+/** Plain HTTP passthrough, so enroll/token go to the real app through the same host string. */
+function proxyHttp(req: IncomingMessage, res: ServerResponse): void {
+  const chunks: Buffer[] = [];
+  req.on('data', (chunk: Buffer) => chunks.push(chunk));
+  req.on('end', () => {
+    const body = Buffer.concat(chunks);
+    // The challenge response N04 needs is in this body; recording it here is
+    // the only place it exists outside the daemon's memory.
+    if (req.url?.startsWith('/api/env-bridge/token') && req.method === 'POST') {
+      log({ kind: 'http', url: req.url, body: body.toString('utf8') });
+    }
+    const forwarded = httpRequest(
+      {
+        protocol: upstream.protocol,
+        hostname: upstream.hostname,
+        port: upstream.port,
+        method: req.method,
+        path: req.url,
+        headers: { ...req.headers, host: upstream.host },
+      },
+      (answer) => {
+        res.writeHead(answer.statusCode ?? 502, answer.headers);
+        answer.pipe(res);
+      },
+    );
+    forwarded.on('error', () => {
+      res.writeHead(502).end('upstream unreachable');
+    });
+    forwarded.end(body);
+  });
+}
+
+interface Capture {
+  /** The exact bytes that arrived from the server. */
+  readonly raw: string;
+  readonly frame: Frame;
+  readonly at: number;
+}
+
+async function main(): Promise<void> {
+  let lastGrant: Capture | null = null;
+  /** While true, machine frames are answers to an INJECTION and must not reach the app. */
+  let intercepting: ((frame: Frame) => void) | null = null;
+  let injected = 0;
+
+  const server = createServer(proxyHttp);
+
+  server.on('upgrade', (req, socket, head) => {
+    const key = req.headers['sec-websocket-key'];
+    if (!req.url?.startsWith('/api/env-bridge/ws') || typeof key !== 'string') {
+      socket.destroy();
+      return;
+    }
+    const daemonSocket = acceptUpgrade(socket, key, head);
+    const target = new URL(req.url, upstream);
+    target.protocol = upstream.protocol === 'https:' ? 'wss:' : 'ws:';
+
+    void openClient(target.toString(), { Authorization: req.headers.authorization ?? '' })
+      .then((appSocket) => wire(daemonSocket, appSocket))
+      .catch((error: unknown) => {
+        log({ kind: 'upstream_upgrade_failed', error: error instanceof Error ? error.message : String(error) });
+        daemonSocket.close(1011, 'upstream upgrade failed');
+      });
+  });
+
+  /** Relay both directions, recording every frame and injecting once the first exec round trip closes. */
+  function wire(daemonSocket: MinSocket, appSocket: MinSocket): void {
+    /** Decode with the real codec so the transcript records what the daemon will actually see. */
+    const observe = (direction: Direction, data: string): Frame | null => {
+      const verdict = decodeFrame(data, { maxFrameBytes: 1_048_576 });
+      log({ kind: 'frame', direction, ok: verdict.ok, ...(verdict.ok ? { frame: verdict.frame } : { reason: verdict.reason }) });
+      return verdict.ok ? verdict.frame : null;
+    };
+
+    appSocket.on('message', (text: string) => {
+      const frame = observe('server->machine', text);
+      if (frame?.type === 'grant_exec') lastGrant = { raw: text, frame, at: Date.now() };
+      daemonSocket.send(text);
+    });
+
+    daemonSocket.on('message', (text: string) => {
+      const frame = observe('machine->server', text);
+      const waiting = intercepting;
+      if (waiting !== null && frame !== null) {
+        // An answer to something the app never sent: swallow it, or the
+        // server's correlator would see a second reply for a grantId it has
+        // already resolved.
+        intercepting = null;
+        waiting(frame);
+        return;
+      }
+      appSocket.send(text);
+      // The original round trip is complete; inject NOW, while the grant is
+      // still inside its 60 s window and this daemon still holds its nonce.
+      if (lastGrant !== null && injected === 0 && (frame?.type === 'exec_result' || frame?.type === 'grant_denied')) {
+        injected = 1;
+        void runInjections(daemonSocket, lastGrant, (fn) => {
+          intercepting = fn;
+        }).then(() => {
+          process.exitCode = summarize('bridge-proxy injections');
+          process.stdout.write('Injections done. Ctrl-C to stop the proxy.\n');
+        });
+      }
+    });
+
+    appSocket.on('close', (code: number, reason: string) => daemonSocket.close(code === 1005 || code === 1006 ? 1000 : code, reason));
+    daemonSocket.on('close', () => appSocket.close(1000, ''));
+    appSocket.on('error', () => daemonSocket.close(1011, 'upstream error'));
+    daemonSocket.on('error', () => appSocket.close(1011, 'daemon error'));
+  }
+
+  server.listen(port, '127.0.0.1', () => {
+    process.stdout.write(`bridge proxy 127.0.0.1:${port} -> ${upstream.origin}; frames -> ${transcript}\n`);
+    process.stdout.write('Now run:  pagespace env connect <enrollmentId> --host http://127.0.0.1:' + String(port) + '\n');
+  });
+}
+
+/** Send one frame to the daemon and resolve with its answer (or a timeout marker). */
+function ask(socket: MinSocket, payload: string, arm: (fn: (frame: Frame) => void) => void): Promise<Frame | null> {
+  return new Promise((resolve) => {
+    const timer = setTimeout(() => resolve(null), 15_000);
+    arm((frame) => {
+      clearTimeout(timer);
+      resolve(frame);
+    });
+    socket.send(payload);
+  });
+}
+
+const denyReason = (frame: Frame | null): string => (frame === null ? 'no answer within 15s' : frame.type === 'grant_denied' ? frame.reason : `${frame.type} (the daemon ACTED on it)`);
+
+async function runInjections(daemonSocket: MinSocket, capture: Capture, arm: (fn: (frame: Frame) => void) => void): Promise<void> {
+  const ageMs = Date.now() - capture.at;
+  process.stdout.write(`INJECT grant captured ${String(ageMs)} ms ago (grant TTL is 60000 ms)\n`);
+
+  // R1 — the identical bytes. The nonce is spent, so `verifyGrant` refuses
+  // before any policy runs and nothing can execute.
+  const replayed = await ask(daemonSocket, capture.raw, arm);
+  expect('R1', 'replayed', denyReason(replayed), 'a captured grant_exec re-injected into the same daemon');
+
+  // R2 — `argsHash` edited. The daemon re-derives the hash from the frame's own
+  // args and compares BEFORE verifying the signature, so this is refused as a
+  // frame-binding failure. See the header: the task page says `bad_signature`;
+  // the code has said `args_mismatch` since #2527, and R3 below is what covers
+  // the signature.
+  const withBadArgsHash = mutateGrantField(capture.raw, 'argsHash');
+  if (withBadArgsHash === null) {
+    expect('R2', 'args_mismatch', 'the tampered frame did not decode', 'tampering must keep the envelope valid');
+  } else {
+    const tampered = await ask(daemonSocket, withBadArgsHash, arm);
+    expect('R2', 'args_mismatch', denyReason(tampered), 'a captured grant_exec with argsHash altered');
+  }
+
+  // R3 — `grantId` edited: signed, but nothing re-derives it, so the Ed25519
+  // check is what refuses this one.
+  const withBadGrantId = mutateGrantField(capture.raw, 'grantId');
+  if (withBadGrantId === null) {
+    expect('R3', 'bad_signature', 'the tampered frame did not decode', 'tampering must keep the envelope valid');
+  } else {
+    const tampered = await ask(daemonSocket, withBadGrantId, arm);
+    expect('R3', 'bad_signature', denyReason(tampered), 'a captured grant_exec with grantId altered');
+  }
+}
+
+/**
+ * Change ONE character of one signed grant field, keeping its length and
+ * alphabet so the strict grant parser still accepts the shape (a malformed
+ * value would be refused `malformed` and would prove nothing), and re-encode
+ * through the real codec so nothing else about the frame differs.
+ * @returns the wire string, or `null` if the result no longer decodes.
+ */
+function mutateGrantField(raw: string, field: 'argsHash' | 'grantId'): string | null {
+  const parsed: unknown = JSON.parse(raw);
+  const asFrame = parsed as { grant: Record<string, unknown> };
+  const original = String(asFrame.grant[field] ?? '');
+  const last = original.slice(-1);
+  asFrame.grant[field] = original.length > 0 ? `${original.slice(0, -1)}${last === 'a' ? 'b' : 'a'}` : 'a'.repeat(64);
+  const verdict = decodeFrame(JSON.stringify(parsed), { maxFrameBytes: 1_048_576 });
+  return verdict.ok ? encodeFrame(verdict.frame) : null;
+}
+
+void main();

--- a/scripts/env-bridge-exit-gate/identity-negatives.ts
+++ b/scripts/env-bridge-exit-gate/identity-negatives.ts
@@ -12,7 +12,8 @@
  * Each check names the file whose behaviour it pins:
  *
  *   N01 code re-presented          → 409 `used`         apps/web/src/app/api/env-bridge/enroll/route.ts (STATUS_FOR_REASON)
- *   N02 wrong code                 → 401 `mismatch`     same
+ *   N02 wrong code                 → 401 `mismatch`     same (needs an UNCONSUMED enrollment:
+ *                                                        the used/enrolled guards run first)
  *   N03 expired code               → 410 `expired`      same (needs an aged enrollment; see README)
  *   N04 signed nonce replayed      → 401 `used`         apps/web/src/app/api/env-bridge/token/route.ts POST → redeemLocalEnvChallenge
  *   N05 signature from another key → 401 `bad_signature` packages/lib/src/env-bridge/challenge.ts verifyChallengeResponse
@@ -120,8 +121,20 @@ async function main(): Promise<number> {
 
   // N02 — a wrong code of the same shape. `mismatch`, never `not_found`: the
   // route must not distinguish a bad code from a bad enrollment id.
-  const wrong = await postJson('/api/env-bridge/enroll', { enrollmentId, code: `${'0'.repeat(usedCode.length)}`, machinePublicKey: strangerPublic });
-  expect('N02', '401 mismatch', outcome(wrong), 'a wrong code for a real enrollment');
+  //
+  // This MUST use an enrollment nothing has consumed. `enrollLocalDriveEnv`
+  // checks `enrolledAt`/`enrollmentCodeUsedAt` BEFORE it compares the code
+  // (drive-envs.ts:310), so against the enrollment N01 just spent every answer
+  // is `409 used` and the code-comparison branch is never reached — the gate
+  // would look green while proving nothing. A `mismatch` consumes nothing, so
+  // this env stays available afterwards.
+  const freshEnrollmentId = optional('PAGESPACE_GATE_FRESH_ENROLLMENT_ID');
+  if (freshEnrollmentId !== null) {
+    const wrong = await postJson('/api/env-bridge/enroll', { enrollmentId: freshEnrollmentId, code: '0'.repeat(usedCode.length), machinePublicKey: strangerPublic });
+    expect('N02', '401 mismatch', outcome(wrong), 'a wrong code for an UNCONSUMED enrollment');
+  } else {
+    skip('N02', '401 mismatch', 'set PAGESPACE_GATE_FRESH_ENROLLMENT_ID to an enrolled-but-unused env — see README "N02"');
+  }
 
   // N03 — an EXPIRED code, which needs a second env created >10 minutes before
   // this runs (or its `enrollmentCodeExpiresAt` moved back in SQL). Supplied
@@ -135,8 +148,28 @@ async function main(): Promise<number> {
     skip('N03', '410 expired', 'set PAGESPACE_GATE_EXPIRED_ENROLLMENT_ID / _CODE — see README "N03"');
   }
 
-  // N05 — a challenge answered by a key the server never pinned. Run BEFORE
-  // N04 so it spends its own nonce and cannot be confused with a replay.
+  // N04 — replay, and it must come BEFORE N05 (see there). `pagespace env token`
+  // has already spent a nonce; re-POSTing the same (nonce, signature) pair must
+  // be refused as `used` while that nonce is still the stored one. The operator
+  // captures that pair by running `env token` through the proxy (see
+  // bridge-proxy.ts) or from the daemon's own audit; without it this is a SKIP
+  // rather than a fabricated pass.
+  const spentNonce = optional('PAGESPACE_GATE_SPENT_NONCE');
+  const spentSignature = optional('PAGESPACE_GATE_SPENT_SIGNATURE');
+  if (spentNonce !== null && spentSignature !== null) {
+    const replayed = await postJson('/api/env-bridge/token', { enrollmentId, nonce: spentNonce, signature: spentSignature });
+    expect('N04', '401 used', outcome(replayed), 'replaying a challenge response that already minted a token');
+  } else {
+    skip('N04', '401 used', 'set PAGESPACE_GATE_SPENT_NONCE / _SIGNATURE — see README "N04"');
+  }
+
+  // N05 — a challenge answered by a key the server never pinned. Runs LAST of
+  // the challenge rows: `issueLocalEnvChallenge` REPLACES a consumed challenge
+  // and clears `challengeUsedAt`, and `verifyChallengeResponse` compares the
+  // nonce before it looks at `usedAt` — so issuing this challenge first would
+  // turn N04's replay into `401 nonce_mismatch` instead of `401 used`. The
+  // bad-signature POST below leaves this nonce pending and unconsumed, which is
+  // why nothing after it asks for another challenge.
   const challengeForStranger = await call(`/api/env-bridge/token?enrollmentId=${encodeURIComponent(enrollmentId)}`);
   const strangerNonce = challengeForStranger.json?.nonce;
   const strangerExp = challengeForStranger.json?.expiresAt;
@@ -149,20 +182,6 @@ async function main(): Promise<number> {
     expect('N05', '401 bad_signature', outcome(forged), 'a valid signature made by a key this env never pinned');
   } else {
     failed('N05', '401 bad_signature', new Error(`challenge refused: ${outcome(challengeForStranger)}`), 'could not obtain a nonce to forge against');
-  }
-
-  // N04 — replay. `pagespace env token` has already spent a nonce; re-POSTing
-  // the same (nonce, signature) pair must be refused as `used`. The operator
-  // captures that pair by running `env token` through the proxy (see
-  // bridge-proxy.ts) or from the daemon's own audit; without it this is a SKIP
-  // rather than a fabricated pass.
-  const spentNonce = optional('PAGESPACE_GATE_SPENT_NONCE');
-  const spentSignature = optional('PAGESPACE_GATE_SPENT_SIGNATURE');
-  if (spentNonce !== null && spentSignature !== null) {
-    const replayed = await postJson('/api/env-bridge/token', { enrollmentId, nonce: spentNonce, signature: spentSignature });
-    expect('N04', '401 used', outcome(replayed), 'replaying a challenge response that already minted a token');
-  } else {
-    skip('N04', '401 used', 'set PAGESPACE_GATE_SPENT_NONCE / _SIGNATURE — see README "N04"');
   }
 
   // N06 — the bridge token is not a web session. `expectedType:'user'` at the
@@ -198,10 +217,16 @@ async function main(): Promise<number> {
 
   // N08 / N09 — the machine credential is normalized out of the auth chain at
   // the door, so neither command can ever reach it.
-  const logout = cli(['logout', `--key=env:${enrollmentId}`]);
-  expect('N08', true, /not logged in/i.test(logout.out), `logout --key=env:<id> said: ${logout.out.trim().split('\n')[0] ?? '(silent)'}`);
-  const use = cli(['keys', 'use', `env:${enrollmentId}`]);
-  expect('N09', true, use.code !== 0, `keys use env:<id> exited ${use.code}: ${use.out.trim().split('\n')[0] ?? '(silent)'}`);
+  // `--host` is not optional here. Credentials are stored PER HOST, and the
+  // runbook enrolls through the capture proxy, so without it both commands
+  // inspect an empty profile on the default host and pass merely because
+  // nothing is there — proving nothing about machine credentials being kept out
+  // of the auth chain.
+  const credentialHost = optional('PAGESPACE_GATE_CREDENTIAL_HOST') ?? host;
+  const logout = cli(['logout', `--key=env:${enrollmentId}`, `--host=${credentialHost}`]);
+  expect('N08', true, /not logged in/i.test(logout.out), `logout --key=env:<id> --host=${credentialHost} said: ${logout.out.trim().split('\n')[0] ?? '(silent)'}`);
+  const use = cli(['keys', 'use', `env:${enrollmentId}`, `--host=${credentialHost}`]);
+  expect('N09', true, use.code !== 0, `keys use env:<id> --host=${credentialHost} exited ${use.code}: ${use.out.trim().split('\n')[0] ?? '(silent)'}`);
 
   return summarize('identity-negatives (flag on)');
 }

--- a/scripts/env-bridge-exit-gate/identity-negatives.ts
+++ b/scripts/env-bridge-exit-gate/identity-negatives.ts
@@ -1,0 +1,209 @@
+/**
+ * The identity negatives of the M1 exit gate (Local Environments epic, t10) —
+ * everything provable with HTTP, the real CLI binary and a real Ed25519 key,
+ * with no daemon and no agent session.
+ *
+ * These are t10's own identity rows PLUS the ones carried over from t06, whose
+ * real-client check was never run (it was deferred for a build slot and folded
+ * into this gate). Nothing here is a synthetic probe of a pure function: every
+ * row goes over the wire to a running app, and the CLI rows shell out to the
+ * BUILT binary.
+ *
+ * Each check names the file whose behaviour it pins:
+ *
+ *   N01 code re-presented          → 409 `used`         apps/web/src/app/api/env-bridge/enroll/route.ts (STATUS_FOR_REASON)
+ *   N02 wrong code                 → 401 `mismatch`     same
+ *   N03 expired code               → 410 `expired`      same (needs an aged enrollment; see README)
+ *   N04 signed nonce replayed      → 401 `used`         apps/web/src/app/api/env-bridge/token/route.ts POST → redeemLocalEnvChallenge
+ *   N05 signature from another key → 401 `bad_signature` packages/lib/src/env-bridge/challenge.ts verifyChallengeResponse
+ *   N06 bridge token at /api/auth/me → 401              the token is a `type:'mcp'` session with only `env:bridge`
+ *   N07 bridge token at mcp-ws     → close 1008         apps/web/src/app/api/mcp-ws/route.ts (scope check)
+ *   N08 `logout --key env:<id>`    → not logged in      packages/cli/src/commands/logout.ts + credential resolver
+ *   N09 `keys use env:<id>`        → refused            packages/cli/src/commands/keys/
+ *   N10 flag off, POST /envs local → 501                apps/web/src/app/api/drives/[driveId]/envs/route.ts:109
+ *   N11 flag off, /api/env-bridge/*→ 404                enroll/route.ts:55, token/route.ts:72 and :96
+ *
+ * N10 and N11 need the app RESTARTED with `LOCAL_ENVS_ENABLED` unset, so they
+ * run in their own pass: `PAGESPACE_GATE_FLAG=off bun … identity-negatives.ts`.
+ *
+ * Usage (flag ON pass):
+ *   PAGESPACE_GATE_HOST=… PAGESPACE_GATE_CLI=… \
+ *   PAGESPACE_GATE_ENROLLMENT_ID=… PAGESPACE_GATE_CODE=… PAGESPACE_GATE_TOKEN=… \
+ *   bun scripts/env-bridge-exit-gate/identity-negatives.ts
+ */
+import { execFileSync } from 'node:child_process';
+import { createPrivateKey, generateKeyPairSync, sign as nodeSign } from 'node:crypto';
+import { expect, failed, optional, required, skip, summarize } from './report';
+
+const host = required('PAGESPACE_GATE_HOST');
+const cliBin = required('PAGESPACE_GATE_CLI');
+const flagOff = optional('PAGESPACE_GATE_FLAG') === 'off';
+
+interface Answer {
+  readonly code: number;
+  readonly json: Record<string, unknown> | null;
+}
+
+async function call(path: string, init?: RequestInit): Promise<Answer> {
+  const response = await fetch(`${host}${path}`, { redirect: 'manual', ...init });
+  const text = await response.text();
+  let json: Record<string, unknown> | null = null;
+  try {
+    const parsed: unknown = JSON.parse(text);
+    if (typeof parsed === 'object' && parsed !== null) json = parsed as Record<string, unknown>;
+  } catch {
+    json = null;
+  }
+  return { code: response.status, json };
+}
+
+const postJson = (path: string, body: unknown): Promise<Answer> =>
+  call(path, { method: 'POST', headers: { 'content-type': 'application/json' }, body: JSON.stringify(body) });
+
+/** `<status> <reason>` — the pair the task page names, so a right status with a wrong reason still fails. */
+function outcome(answer: Answer): string {
+  const reason = answer.json?.reason;
+  return `${answer.code} ${typeof reason === 'string' ? reason : '(no reason)'}`;
+}
+
+/** Run the built CLI and return its combined output plus exit code; a non-zero exit is DATA here, not a throw. */
+function cli(args: readonly string[]): { code: number; out: string } {
+  try {
+    const out = execFileSync(process.execPath, [cliBin, ...args], { encoding: 'utf8', stdio: ['ignore', 'pipe', 'pipe'] });
+    return { code: 0, out };
+  } catch (error) {
+    const e = error as { status?: number; stdout?: string; stderr?: string };
+    return { code: e.status ?? -1, out: `${e.stdout ?? ''}${e.stderr ?? ''}` };
+  }
+}
+
+async function flagOffPass(): Promise<number> {
+  const driveId = required('PAGESPACE_GATE_DRIVE_ID');
+  const cookie = required('PAGESPACE_GATE_COOKIE');
+  // N10 — a drive owner asking for a local env on a deployment that has none.
+  // 501, not 400: the request is well-formed, the deployment cannot serve it.
+  const created = await call(`/api/drives/${driveId}/envs`, {
+    method: 'POST',
+    headers: { 'content-type': 'application/json', cookie },
+    body: JSON.stringify({ name: 'gate-flag-off', substrate: 'local', label: 'gate-flag-off' }),
+  });
+  expect('N10', 501, created.code, 'POST /envs {substrate:"local"} with the flag off');
+
+  // N11 — the bridge routes do not exist at all. 404 on all three entry points;
+  // a 400 from any of them means the flag is still on somewhere.
+  const enroll = await postJson('/api/env-bridge/enroll', { enrollmentId: 'x', code: 'x', machinePublicKey: 'x' });
+  expect('N11a', 404, enroll.code, 'POST /api/env-bridge/enroll with the flag off');
+  const challenge = await call('/api/env-bridge/token?enrollmentId=x');
+  expect('N11b', 404, challenge.code, 'GET /api/env-bridge/token with the flag off');
+  const redeem = await postJson('/api/env-bridge/token', { enrollmentId: 'x', nonce: 'x', signature: 'x' });
+  expect('N11c', 404, redeem.code, 'POST /api/env-bridge/token with the flag off');
+  return summarize('identity-negatives (flag off)');
+}
+
+async function main(): Promise<number> {
+  if (flagOff) return flagOffPass();
+
+  const enrollmentId = required('PAGESPACE_GATE_ENROLLMENT_ID');
+  const usedCode = required('PAGESPACE_GATE_CODE'); // the code already spent by `pagespace env enroll`
+  const bridgeToken = required('PAGESPACE_GATE_TOKEN'); // an `mcp_…` from `pagespace env token`
+
+  // A throwaway key: enough to prove the SHAPE of a refusal without touching
+  // the enrolled key, which never leaves the credential store.
+  const stranger = generateKeyPairSync('ed25519');
+  const strangerPublic = stranger.publicKey.export({ type: 'spki', format: 'der' }).toString('base64');
+
+  // N01 — the code was spent by the real enrollment. Re-presenting it with a
+  // DIFFERENT public key is the interesting case: a second machine trying to
+  // take over an enrolled env.
+  const reused = await postJson('/api/env-bridge/enroll', { enrollmentId, code: usedCode, machinePublicKey: strangerPublic });
+  expect('N01', '409 used', outcome(reused), 're-presenting a spent enrollment code');
+
+  // N02 — a wrong code of the same shape. `mismatch`, never `not_found`: the
+  // route must not distinguish a bad code from a bad enrollment id.
+  const wrong = await postJson('/api/env-bridge/enroll', { enrollmentId, code: `${'0'.repeat(usedCode.length)}`, machinePublicKey: strangerPublic });
+  expect('N02', '401 mismatch', outcome(wrong), 'a wrong code for a real enrollment');
+
+  // N03 — an EXPIRED code, which needs a second env created >10 minutes before
+  // this runs (or its `enrollmentCodeExpiresAt` moved back in SQL). Supplied
+  // separately so the main enrollment is not held hostage to a ten-minute wait.
+  const expiredId = optional('PAGESPACE_GATE_EXPIRED_ENROLLMENT_ID');
+  const expiredCode = optional('PAGESPACE_GATE_EXPIRED_CODE');
+  if (expiredId !== null && expiredCode !== null) {
+    const expired = await postJson('/api/env-bridge/enroll', { enrollmentId: expiredId, code: expiredCode, machinePublicKey: strangerPublic });
+    expect('N03', '410 expired', outcome(expired), 'an enrollment code past its ten-minute window');
+  } else {
+    skip('N03', '410 expired', 'set PAGESPACE_GATE_EXPIRED_ENROLLMENT_ID / _CODE — see README "N03"');
+  }
+
+  // N05 — a challenge answered by a key the server never pinned. Run BEFORE
+  // N04 so it spends its own nonce and cannot be confused with a replay.
+  const challengeForStranger = await call(`/api/env-bridge/token?enrollmentId=${encodeURIComponent(enrollmentId)}`);
+  const strangerNonce = challengeForStranger.json?.nonce;
+  const strangerExp = challengeForStranger.json?.expiresAt;
+  if (typeof strangerNonce === 'string' && typeof strangerExp === 'string') {
+    // Byte-for-byte what `encodeChallenge` produces
+    // (packages/lib/src/env-bridge/challenge.ts:57) — key order included.
+    const bytes = Buffer.from(JSON.stringify({ nonce: strangerNonce, enrollmentId, exp: new Date(strangerExp).getTime() }));
+    const signature = nodeSign(null, bytes, createPrivateKey(stranger.privateKey)).toString('base64');
+    const forged = await postJson('/api/env-bridge/token', { enrollmentId, nonce: strangerNonce, signature });
+    expect('N05', '401 bad_signature', outcome(forged), 'a valid signature made by a key this env never pinned');
+  } else {
+    failed('N05', '401 bad_signature', new Error(`challenge refused: ${outcome(challengeForStranger)}`), 'could not obtain a nonce to forge against');
+  }
+
+  // N04 — replay. `pagespace env token` has already spent a nonce; re-POSTing
+  // the same (nonce, signature) pair must be refused as `used`. The operator
+  // captures that pair by running `env token` through the proxy (see
+  // bridge-proxy.ts) or from the daemon's own audit; without it this is a SKIP
+  // rather than a fabricated pass.
+  const spentNonce = optional('PAGESPACE_GATE_SPENT_NONCE');
+  const spentSignature = optional('PAGESPACE_GATE_SPENT_SIGNATURE');
+  if (spentNonce !== null && spentSignature !== null) {
+    const replayed = await postJson('/api/env-bridge/token', { enrollmentId, nonce: spentNonce, signature: spentSignature });
+    expect('N04', '401 used', outcome(replayed), 'replaying a challenge response that already minted a token');
+  } else {
+    skip('N04', '401 used', 'set PAGESPACE_GATE_SPENT_NONCE / _SIGNATURE — see README "N04"');
+  }
+
+  // N06 — the bridge token is not a web session. `expectedType:'user'` at the
+  // door refuses it whatever its scope says.
+  const me = await call('/api/auth/me', { headers: { authorization: `Bearer ${bridgeToken}` } });
+  expect('N06', 401, me.code, 'the env:bridge token presented to ordinary web auth');
+
+  // N07 — and it is not an MCP token either: `env:bridge` is deliberately
+  // outside `mcp:*`, so mcp-ws closes 1008 rather than serving tools.
+  try {
+    const { openClient } = await import('./ws-min');
+    const wsUrl = `${host.replace(/^http/, 'ws')}/api/mcp-ws`;
+    const closed = await new Promise<string>((resolve) => {
+      const timer = setTimeout(() => resolve('timeout: never closed'), 10_000);
+      void openClient(wsUrl, { Authorization: `Bearer ${bridgeToken}` })
+        .then((socket) => {
+          socket.on('close', (code: number) => {
+            clearTimeout(timer);
+            resolve(String(code));
+          });
+        })
+        .catch((error: unknown) => {
+          clearTimeout(timer);
+          // A refused UPGRADE is a different (also safe) refusal than a 1008
+          // close, and saying which one happened is the point of this row.
+          resolve(`upgrade refused: ${error instanceof Error ? error.message : String(error)}`);
+        });
+    });
+    expect('N07', '1008', closed, 'the env:bridge token presented to mcp-ws');
+  } catch (error) {
+    failed('N07', '1008', error, 'could not open a socket to mcp-ws');
+  }
+
+  // N08 / N09 — the machine credential is normalized out of the auth chain at
+  // the door, so neither command can ever reach it.
+  const logout = cli(['logout', `--key=env:${enrollmentId}`]);
+  expect('N08', true, /not logged in/i.test(logout.out), `logout --key=env:<id> said: ${logout.out.trim().split('\n')[0] ?? '(silent)'}`);
+  const use = cli(['keys', 'use', `env:${enrollmentId}`]);
+  expect('N09', true, use.code !== 0, `keys use env:<id> exited ${use.code}: ${use.out.trim().split('\n')[0] ?? '(silent)'}`);
+
+  return summarize('identity-negatives (flag on)');
+}
+
+main().then((code) => process.exit(code));

--- a/scripts/env-bridge-exit-gate/preflight.ts
+++ b/scripts/env-bridge-exit-gate/preflight.ts
@@ -1,0 +1,117 @@
+/**
+ * Exit-gate preflight (Local Environments epic, M1 · t10).
+ *
+ * The M1 exit gate needs a running app, a real Postgres, a built CLI and a
+ * terminal. Every one of the conditions below has cost this repo a wasted run
+ * before, so this refuses LOUDLY and by name rather than letting the gate fail
+ * later with a symptom three layers from its cause:
+ *
+ *   F01 the app answers at all
+ *   F02 LOCAL_ENVS_ENABLED=true              (`GET /api/env-bridge/token` with no
+ *                                             enrollmentId: 400 when the flag is on,
+ *                                             404 when the route does not exist)
+ *   F03 ENV_BRIDGE_SIGNING_KEY is loaded     (the app boots refusing to start without it
+ *                                             when the flag is on — t06 commit 5 — so F02
+ *                                             passing is the proof; recorded separately
+ *                                             because an operator who sees only F02 will
+ *                                             not know that)
+ *   F04 the CLI under test is the BUILT one  (`node packages/cli/dist/bin.js --version`,
+ *                                             never `bun run src/…`: t08 found `env enroll`
+ *                                             broken in the real binary while its unit
+ *                                             tests passed — memory `reference_cli_handlers_get_rest_args`)
+ *   F05 a TTY on stdin                       (`ask` mode refuses to start without one)
+ *   F06 TZ=UTC in this shell                 (sessions revoke instantly against a non-UTC
+ *                                             app/pg pair — memory `reference_running_web_app_locally`)
+ *   F07 DEPLOYMENT_MODE is set               (onprem for a local run; `cloud` pulls in
+ *                                             integrations this gate does not need)
+ *   F08 an S3 endpoint is configured         (page/drive creation 500s on
+ *                                             CredentialsProviderError without one, and
+ *                                             step 3 needs a drive with a pane in it)
+ *   F09 the machine policy file is loadable  (`pagespace env policy` agrees with what the
+ *                                             operator thinks is in force)
+ *
+ * F06–F08 are read from the ENVIRONMENT OF THE APP, which this script cannot
+ * see, so they are checked against the operator-supplied `PAGESPACE_GATE_*`
+ * mirrors: the point is to make the operator state them, not to prove them.
+ *
+ * Usage:  bun scripts/env-bridge-exit-gate/preflight.ts
+ */
+import { execFileSync } from 'node:child_process';
+import { expect, failed, optional, required, summarize } from './report';
+
+const host = required('PAGESPACE_GATE_HOST'); // e.g. http://127.0.0.1:3000
+const cliBin = required('PAGESPACE_GATE_CLI'); // e.g. ./packages/cli/dist/bin.js
+
+async function status(url: string, init?: RequestInit): Promise<{ code: number; body: string }> {
+  const response = await fetch(url, init);
+  return { code: response.status, body: (await response.text()).slice(0, 400) };
+}
+
+function run(args: readonly string[]): string {
+  return execFileSync(process.execPath, [cliBin, ...args], { encoding: 'utf8', stdio: ['ignore', 'pipe', 'pipe'] });
+}
+
+/** Same, but a non-zero exit is DATA: `env policy` exits 1 when the policy is deny-all. */
+function runAllowFail(args: readonly string[]): string {
+  try {
+    return run(args);
+  } catch (error) {
+    const e = error as { stdout?: string; stderr?: string };
+    return `${e.stdout ?? ''}${e.stderr ?? ''}`;
+  }
+}
+
+async function main(): Promise<number> {
+  // F01 — the app is up. Anything that answers is enough; the point is to fail
+  // here rather than inside a WebSocket handshake ten minutes later.
+  try {
+    const health = await status(`${host}/api/env-bridge/token`);
+    expect('F01', true, health.code > 0, `app answered at ${host}`);
+    // F02 — no enrollmentId: 400 means the handler ran (flag ON); 404 means the
+    // route refused before parsing (flag OFF). Pins
+    // apps/web/src/app/api/env-bridge/token/route.ts GET, lines 71-75.
+    expect('F02', 400, health.code, 'LOCAL_ENVS_ENABLED=true (404 here = the flag is off)');
+    // F03 — the app refuses to boot with the flag on and no signing key
+    // (apps/web env validation, t06 review round 1), so a live 400 above is
+    // the only proof available from outside the process.
+    expect('F03', 400, health.code, 'ENV_BRIDGE_SIGNING_KEY loaded — implied by a booted app with the flag on');
+  } catch (error) {
+    failed('F01', 'app reachable', error, `is the web app running at ${host}?`);
+    return summarize('preflight');
+  }
+
+  // F04 — the BUILT CLI, not the sources. A gate run against `bun src/bin.ts`
+  // proves nothing about what a user installs.
+  try {
+    const version = run(['--version']).trim();
+    expect('F04', true, version.length > 0 && cliBin.includes('dist'), `built CLI at ${cliBin} reports ${version}`);
+  } catch (error) {
+    failed('F04', 'built CLI runs', error, 'run `bun run --filter @pagespace/cli build` first');
+  }
+
+  // F05 — `ask` mode refuses to start without a TTY (packages/cli/src/commands/env/connect.ts).
+  expect('F05', true, process.stdin.isTTY === true, 'stdin is a TTY, so `env connect` can prompt in ask mode');
+
+  // F06 — this shell. The app's own TZ and Postgres' TZ are the operator's to confirm.
+  expect('F06', 'UTC', process.env.TZ ?? '(unset)', 'TZ=UTC in this shell; confirm the same for the app process AND Postgres');
+  expect('F06b', 'UTC', optional('PAGESPACE_GATE_APP_TZ') ?? '(unset)', 'operator-asserted TZ of the app + pg processes');
+
+  // F07 / F08 — asserted, not probed: this script is outside the app process.
+  expect('F07', 'onprem', optional('PAGESPACE_GATE_DEPLOYMENT_MODE') ?? '(unset)', 'operator-asserted DEPLOYMENT_MODE of the app');
+  expect('F08', true, optional('PAGESPACE_GATE_S3_ENDPOINT') !== null, 'operator-asserted S3 endpoint; without one, drive/page creation 500s');
+
+  // F09 — the policy the daemon will actually enforce, printed by the CLI itself.
+  try {
+    const policy = runAllowFail(['env', 'policy', '--json']);
+    const parsed: unknown = JSON.parse(policy);
+    const inForce = typeof parsed === 'object' && parsed !== null && 'policy' in parsed && (parsed as { policy: unknown }).policy !== null;
+    expect('F09', true, inForce, 'a policy file is in force (deny-all otherwise; see README "The policy file")');
+    process.stdout.write(`POLICY ${policy.replace(/\s+/g, ' ').trim()}\n`);
+  } catch (error) {
+    failed('F09', 'policy loads', error, 'run `pagespace env policy` and fix what it reports');
+  }
+
+  return summarize('preflight');
+}
+
+main().then((code) => process.exit(code));

--- a/scripts/env-bridge-exit-gate/report.ts
+++ b/scripts/env-bridge-exit-gate/report.ts
@@ -1,0 +1,93 @@
+/**
+ * The exit gate's evidence format (Local Environments epic, M1 · t10).
+ *
+ * Every check in this harness prints ONE line per gate, in a fixed shape, so a
+ * run produces evidence a reviewer can diff rather than prose someone has to
+ * believe:
+ *
+ *   GATE <id> <PASS|FAIL|SKIP> expected=<value> actual=<value> :: <note>
+ *
+ * `expected` is the exact denial reason, HTTP status or close code the task
+ * page names — never a category. A gate that cannot decide is a FAIL, not a
+ * pass with a caveat; SKIP exists only for a check whose PRECONDITION was not
+ * met (no TTY, no second drive member) and every SKIP has to be explained on
+ * the task page before the gate can be called passed.
+ *
+ * Nothing here talks to PageSpace. It is imported by `preflight.ts`,
+ * `identity-negatives.ts` and `bridge-proxy.ts`.
+ */
+
+export type GateStatus = 'PASS' | 'FAIL' | 'SKIP';
+
+export interface GateResult {
+  readonly id: string;
+  readonly status: GateStatus;
+  readonly expected: string;
+  readonly actual: string;
+  readonly note: string;
+}
+
+/** Keep a value on one line and inside a sane width; the line format is the contract. */
+function oneLine(value: unknown): string {
+  const text = typeof value === 'string' ? value : JSON.stringify(value);
+  const flat = (text ?? 'undefined').replace(/\s+/g, ' ').trim();
+  return flat.length > 300 ? `${flat.slice(0, 297)}...` : flat;
+}
+
+const results: GateResult[] = [];
+
+export function record(result: GateResult): GateResult {
+  results.push(result);
+  process.stdout.write(`GATE ${result.id} ${result.status} expected=${oneLine(result.expected)} actual=${oneLine(result.actual)} :: ${result.note}\n`);
+  return result;
+}
+
+/** The common shape: a gate passes iff `actual` equals `expected` exactly. */
+export function expect(id: string, expected: unknown, actual: unknown, note: string): GateResult {
+  const e = oneLine(expected);
+  const a = oneLine(actual);
+  return record({ id, status: e === a ? 'PASS' : 'FAIL', expected: e, actual: a, note });
+}
+
+export function skip(id: string, expected: unknown, why: string): GateResult {
+  return record({ id, status: 'SKIP', expected: oneLine(expected), actual: 'not run', note: why });
+}
+
+/** A gate whose check threw. An exception is never a pass. */
+export function failed(id: string, expected: unknown, error: unknown, note: string): GateResult {
+  const message = error instanceof Error ? error.message : String(error);
+  return record({ id, status: 'FAIL', expected: oneLine(expected), actual: `threw: ${oneLine(message)}`, note });
+}
+
+export function collected(): readonly GateResult[] {
+  return results;
+}
+
+/**
+ * Print the tally and return the process exit code: non-zero if ANYTHING is
+ * not a PASS, skips included — a skipped gate is an unfinished gate, and the
+ * exit code is what a runner (or a human in a hurry) reads.
+ */
+export function summarize(label: string): number {
+  const pass = results.filter((r) => r.status === 'PASS').length;
+  const fail = results.filter((r) => r.status === 'FAIL');
+  const skipped = results.filter((r) => r.status === 'SKIP');
+  process.stdout.write(`\nSUMMARY ${label} pass=${pass} fail=${fail.length} skip=${skipped.length}\n`);
+  for (const r of [...fail, ...skipped]) process.stdout.write(`  ${r.status} ${r.id} :: ${r.note}\n`);
+  return fail.length === 0 && skipped.length === 0 ? 0 : 1;
+}
+
+/** Read a required environment variable, or die with a message naming it. */
+export function required(name: string): string {
+  const value = process.env[name]?.trim();
+  if (!value) {
+    process.stderr.write(`${name} is required. See scripts/env-bridge-exit-gate/README.md ("Environment").\n`);
+    process.exit(2);
+  }
+  return value;
+}
+
+export function optional(name: string): string | null {
+  const value = process.env[name]?.trim();
+  return value ? value : null;
+}

--- a/scripts/env-bridge-exit-gate/ws-min.ts
+++ b/scripts/env-bridge-exit-gate/ws-min.ts
@@ -1,0 +1,230 @@
+/**
+ * A minimal, dependency-free WebSocket layer for the exit-gate harness.
+ *
+ * The harness lives in the ROOT workspace, whose only relevant dependency is
+ * `@pagespace/lib`. Importing `ws` here would be an unlisted dependency and
+ * `knip:check` (blocking in CI) would fail on it, so this implements exactly
+ * the slice the gate needs and nothing more:
+ *
+ *   - a CLIENT handshake with arbitrary headers (`Authorization: Bearer …`,
+ *     which the platform's global `WebSocket` cannot send), over `node:net`
+ *     or `node:tls`;
+ *   - a SERVER-side upgrade accept, so the capture proxy can be what the
+ *     daemon dials;
+ *   - text-frame encode/decode with the masking rules RFC 6455 requires
+ *     (client→server masked, server→client not), continuation frames
+ *     reassembled, and ping answered with pong so a long capture is not
+ *     dropped by the app's heartbeat.
+ *
+ * Binary frames are not used by the bridge (the codec is JSON text), so they
+ * are surfaced as errors rather than silently decoded — this is a test
+ * harness, and a surprise on the wire must be visible.
+ */
+import { createHash, randomBytes } from 'node:crypto';
+import { connect as netConnect, type Socket } from 'node:net';
+import { connect as tlsConnect } from 'node:tls';
+import { EventEmitter } from 'node:events';
+
+const GUID = '258EAFA5-E914-47DA-95CA-C5AB0DC85B11';
+
+const acceptValueFor = (key: string): string => createHash('sha1').update(`${key}${GUID}`).digest('base64');
+
+const OPCODE = { continuation: 0x0, text: 0x1, binary: 0x2, close: 0x8, ping: 0x9, pong: 0xa } as const;
+
+/** Encode one complete text/control frame. `mask` is required for client→server frames. */
+function encode(opcode: number, payload: Buffer, mask: boolean): Buffer {
+  const head: number[] = [0x80 | opcode];
+  const length = payload.length;
+  const lengthBytes: number[] = [];
+  if (length < 126) head.push((mask ? 0x80 : 0) | length);
+  else if (length < 65536) {
+    head.push((mask ? 0x80 : 0) | 126);
+    lengthBytes.push((length >> 8) & 0xff, length & 0xff);
+  } else {
+    head.push((mask ? 0x80 : 0) | 127);
+    for (let i = 7; i >= 0; i -= 1) lengthBytes.push(Number((BigInt(length) >> BigInt(8 * i)) & 0xffn));
+  }
+  const parts = [Buffer.from([...head, ...lengthBytes])];
+  if (mask) {
+    const key = randomBytes(4);
+    const masked = Buffer.allocUnsafe(length);
+    for (let i = 0; i < length; i += 1) masked[i] = (payload[i] as number) ^ (key[i % 4] as number);
+    parts.push(key, masked);
+  } else {
+    parts.push(payload);
+  }
+  return Buffer.concat(parts);
+}
+
+/**
+ * One end of an established WebSocket. `masked` says which side this is:
+ * a client masks what it sends, a server does not.
+ */
+export class MinSocket extends EventEmitter {
+  private buffer = Buffer.alloc(0);
+  private fragments: Buffer[] = [];
+  private fragmentOpcode = 0;
+  private closed = false;
+
+  constructor(
+    private readonly socket: Socket,
+    private readonly masked: boolean,
+  ) {
+    super();
+    socket.on('data', (chunk: Buffer) => this.ingest(chunk));
+    socket.on('close', () => this.finish(1006, 'transport closed'));
+    socket.on('error', (error: Error) => this.emit('error', error));
+  }
+
+  get isOpen(): boolean {
+    return !this.closed && !this.socket.destroyed;
+  }
+
+  send(text: string): void {
+    if (this.isOpen) this.socket.write(encode(OPCODE.text, Buffer.from(text, 'utf8'), this.masked));
+  }
+
+  close(code = 1000, reason = ''): void {
+    if (!this.isOpen) return;
+    const payload = Buffer.concat([Buffer.from([(code >> 8) & 0xff, code & 0xff]), Buffer.from(reason, 'utf8')]);
+    this.socket.write(encode(OPCODE.close, payload, this.masked));
+    this.socket.end();
+    this.finish(code, reason);
+  }
+
+  private finish(code: number, reason: string): void {
+    if (this.closed) return;
+    this.closed = true;
+    this.emit('close', code, reason);
+  }
+
+  private ingest(chunk: Buffer): void {
+    this.buffer = Buffer.concat([this.buffer, chunk]);
+    for (;;) {
+      const frame = this.take();
+      if (frame === null) return;
+      this.dispatch(frame.opcode, frame.fin, frame.payload);
+    }
+  }
+
+  /** Pull one whole frame off the buffer, or `null` when more bytes are needed. */
+  private take(): { opcode: number; fin: boolean; payload: Buffer } | null {
+    if (this.buffer.length < 2) return null;
+    const first = this.buffer[0] as number;
+    const second = this.buffer[1] as number;
+    const fin = (first & 0x80) !== 0;
+    const opcode = first & 0x0f;
+    const isMasked = (second & 0x80) !== 0;
+    let length = second & 0x7f;
+    let offset = 2;
+    if (length === 126) {
+      if (this.buffer.length < offset + 2) return null;
+      length = this.buffer.readUInt16BE(offset);
+      offset += 2;
+    } else if (length === 127) {
+      if (this.buffer.length < offset + 8) return null;
+      length = Number(this.buffer.readBigUInt64BE(offset));
+      offset += 8;
+    }
+    const maskKey = isMasked ? this.buffer.subarray(offset, offset + 4) : null;
+    if (isMasked) offset += 4;
+    if (this.buffer.length < offset + length) return null;
+    const raw = Buffer.from(this.buffer.subarray(offset, offset + length));
+    this.buffer = this.buffer.subarray(offset + length);
+    if (maskKey !== null) {
+      for (let i = 0; i < raw.length; i += 1) raw[i] = (raw[i] as number) ^ (maskKey[i % 4] as number);
+    }
+    return { opcode, fin, payload: raw };
+  }
+
+  private dispatch(opcode: number, fin: boolean, payload: Buffer): void {
+    if (opcode === OPCODE.close) {
+      const code = payload.length >= 2 ? payload.readUInt16BE(0) : 1005;
+      this.finish(code, payload.subarray(2).toString('utf8'));
+      this.socket.end();
+      return;
+    }
+    if (opcode === OPCODE.ping) {
+      if (this.isOpen) this.socket.write(encode(OPCODE.pong, payload, this.masked));
+      return;
+    }
+    if (opcode === OPCODE.pong) return;
+    if (opcode === OPCODE.binary) {
+      this.emit('error', new Error('unexpected binary frame: the bridge codec is JSON text'));
+      return;
+    }
+    if (opcode === OPCODE.text || opcode === OPCODE.continuation) {
+      if (opcode === OPCODE.text) {
+        this.fragments = [];
+        this.fragmentOpcode = OPCODE.text;
+      }
+      this.fragments.push(payload);
+      if (!fin) return;
+      const text = Buffer.concat(this.fragments).toString('utf8');
+      this.fragments = [];
+      if (this.fragmentOpcode === OPCODE.text) this.emit('message', text);
+    }
+  }
+}
+
+/** Open a client WebSocket to `url` with the given headers. Rejects on anything but a 101. */
+export function openClient(url: string, headers: Readonly<Record<string, string>> = {}): Promise<MinSocket> {
+  return new Promise((resolve, reject) => {
+    const target = new URL(url);
+    const secure = target.protocol === 'wss:';
+    const port = target.port === '' ? (secure ? 443 : 80) : Number(target.port);
+    const key = randomBytes(16).toString('base64');
+    const socket = secure
+      ? tlsConnect({ host: target.hostname, port, servername: target.hostname })
+      : netConnect({ host: target.hostname, port });
+
+    let banner = Buffer.alloc(0);
+    const onData = (chunk: Buffer): void => {
+      banner = Buffer.concat([banner, chunk]);
+      const end = banner.indexOf('\r\n\r\n');
+      if (end === -1) return;
+      const head = banner.subarray(0, end).toString('utf8');
+      socket.removeListener('data', onData);
+      const statusLine = head.split('\r\n')[0] ?? '';
+      if (!statusLine.includes(' 101 ')) {
+        socket.destroy();
+        reject(new Error(`upgrade refused: ${statusLine}`));
+        return;
+      }
+      const rest = banner.subarray(end + 4);
+      const wrapped = new MinSocket(socket, true);
+      resolve(wrapped);
+      // Bytes that arrived in the same packet as the handshake are real frames.
+      if (rest.length > 0) socket.emit('data', rest);
+    };
+    socket.on('data', onData);
+    socket.on('error', reject);
+    socket.on('connect', () => {
+      const lines = [
+        `GET ${target.pathname}${target.search} HTTP/1.1`,
+        `Host: ${target.host}`,
+        'Upgrade: websocket',
+        'Connection: Upgrade',
+        `Sec-WebSocket-Key: ${key}`,
+        'Sec-WebSocket-Version: 13',
+        ...Object.entries(headers)
+          .filter(([, value]) => value !== '')
+          .map(([name, value]) => `${name}: ${value}`),
+        '',
+        '',
+      ];
+      socket.write(lines.join('\r\n'));
+    });
+    if (secure) socket.on('secureConnect', () => socket.emit('connect'));
+  });
+}
+
+/** Complete a server-side upgrade on an already-received request and return this end of it. */
+export function acceptUpgrade(socket: Socket, secWebSocketKey: string, head: Buffer): MinSocket {
+  socket.write(
+    ['HTTP/1.1 101 Switching Protocols', 'Upgrade: websocket', 'Connection: Upgrade', `Sec-WebSocket-Accept: ${acceptValueFor(secWebSocketKey)}`, '', ''].join('\r\n'),
+  );
+  const wrapped = new MinSocket(socket, false);
+  if (head.length > 0) socket.emit('data', head);
+  return wrapped;
+}


### PR DESCRIPTION
## M1 · t10 **Phase A** — the [D-1] boundary in the docs, a runnable exit gate, and a paper audit

**Task page** `fxj2wg1fd3kwttfm6yof6anx` · epic `j945few5ssv75k5ad0bowbb4` (task `ukqmwy41zkf192hwgh6sqsxf`).

> **The exit gate has NOT been run.** t10 needs a running web app, a real Postgres, a built CLI and
> a TTY for `ask` prompts. No build slot was available (≈22 agents on the machine), so this PR is
> everything that needs none of those. Nothing here is evidence that the M1 chain works on real
> hardware, and `PR_READY` on this PR means Phase A is ready — not that the gate passed.

### 1 · The [D-1] ruling, and where it is now documented

[D-1] was resolved on 2026-09-07 as **confirmed as designed**: exec on a local environment is gated
by the owner's local `ask`/`allowlist`/`deny` policy plus the server policy, and is **not**
path-confined. A command approved with a cwd inside an allowed root runs with the machine owner's
own account privileges. Real confinement needs OS-level sandboxing, which is a milestone of its
own. No code change — the ruling binds to documentation.

`packages/cli/README.md` now opens the `pagespace env` section with **"What you are agreeing to"**
(not a footnote):

- approving a command lets it run **as you** on your machine — it can read anything you can read,
  and there is no sandbox around it;
- `roots` confine the paths an agent can **name**, not what a program does once it has started;
- the question at the prompt is not "may this touch that folder" but "may this run as me", with
  the two practical consequences (don't run as root; `principals` is your shell);
- what the daemon *does* guarantee, stated narrowly: never listens, denies by default, per-request
  signed single-use grants that expire within a minute, the local policy checked independently of
  the server, everything audited, revoke deletes the key;
- **`allowlist` allowlists operations, not executables** — `exec` in `ops` under `allowlist` means
  any command runs unprompted. Says explicitly that an executable allowlist was considered and not
  adopted, and why, so nothing implies one exists;
- deny-all restated where it belongs: a missing, unreadable, wrongly-owned or group/world-writable
  policy file denies everything.

Plus a CHANGELOG entry under `[Unreleased]`. Every pre-existing factual claim in that section was
re-verified against the code (`policy.ts`, `policy-types.ts`, `decide-execution.ts`,
`exec-runner.ts`, `secure-host.ts`, `connect.ts`, `disconnect.ts`), not copied from a summary.

### 2 · The harness — `scripts/env-bridge-exit-gate/`

Runnable, deliberately not run.

| file | what it does |
|---|---|
| `README.md` | the runbook: preconditions, the five steps, every negative, the evidence format, what to do after |
| `report.ts` | `GATE <id> PASS\|FAIL\|SKIP expected=… actual=… :: …`; a SKIP makes the exit code non-zero |
| `preflight.ts` | F01–F09: app up, `LOCAL_ENVS_ENABLED`, `ENV_BRIDGE_SIGNING_KEY`, the **built** `dist/bin.js`, a TTY, `TZ=UTC`, `DEPLOYMENT_MODE`, an S3 endpoint, a loadable policy |
| `identity-negatives.ts` | N01–N11 over real HTTP and the built CLI — **t06's negatives, which were never run either** (its real-client check was deferred for a build slot when #2534 merged) |
| `bridge-proxy.ts` | a transparent capture proxy the daemon dials instead of the app; records every frame through the real codec and auto-injects R1–R3 |
| `ws-min.ts` | a dependency-free WebSocket client/server slice — the root workspace has no `ws` and `knip:check` is blocking |

The capture helper is designed against the real codec (`packages/lib/src/env-bridge/frame-codec.ts`)
and the real dispatcher, and each check's comment names the file whose behaviour it pins. Per
[D-1] the negatives test **policy enforcement, replay refusal and revocation**; the path-escape
row stays, and its comment says precisely that it proves an agent cannot *name* a path outside a
root and nothing about a running process.

Preconditions come from the t06 and t08 PR bodies and the operator's own notes rather than being
invented — the signing-key one-liner, `TZ=UTC` on both app and Postgres, the S3 endpoint, and the
"run the built binary" rule that #2546 learned the hard way.

### 3 · Dry-run audit — six drifts, one blocking

Full table on the task page. Summary:

| id | row | status |
|---|---|---|
| **D-c** | step 4 (agent reads / writes / runs) | ❌ **blocking** |
| **D-a** | tamper `argsHash` → `bad_signature` | ❌ code answers `args_mismatch` |
| **D-b** | path escape → `traversal`/`outside_root` | ❌ wire reason is `path_denied` |
| **D-d** | `env disconnect` → `revokedAt` + key deleted + 1008 | ❌ `env disconnect` is local-only |
| **D-e** | non-owner bind → `bind_policy` | ⚠️ only against a **connected** env |
| **D-f** | ">30 s command" with a local prompt | ⚠️ the 60 s grant TTL bounds the prompt |

**D-c is the one that matters.** The bash tool sends `cwd: resolvedCwd`, defaulted to `SANDBOX_ROOT`
(`/workspace`) and forced through `resolveSandboxPath`; `readFile`/`writeFile` paths are confined
the same way (`sandbox-paths.ts:20`, `tool-runners.ts:972-1012`). `local-env-sandbox-host.ts` passes
them through unchanged, and `decideExecution` then requires them to resolve inside the machine
owner's `roots`. So **every agent tool call against a local env is denied `cwd_denied` (bash) or
`path_denied` (files)** unless the owner puts `/workspace` in `roots` *and* the directory exists.
Step 4 cannot pass as written. That is a gap in the code, not in the page: the seam was designed so
no tool runner branches on substrate, and the price is that the Sprite's path vocabulary reaches the
local host untranslated. Recommend a bug task before M2. The runbook documents the `/workspace`
workaround and labels it as one.

**D-a** is worth reading: since #2527 the daemon binds the grant to the frame carrying it and
refuses `args_mismatch` **before** verifying the signature. The page predates that. `args_mismatch`
is the stronger refusal, so the harness expects it — and adds **R3** (tamper `grantId`, signed but
not re-derived) so the signature check the page was reaching for is still covered.

I did **not** rewrite the procedure to match the code. Each difference is recorded so the founder
can decide which side is wrong.

### Verification

- No app, database, build, monorepo typecheck or full test suite was run — this worktree has no
  `node_modules` and the hard stop forbade installing one. **CI is the gate.**
- Changes are `packages/cli/README.md`, `packages/cli/CHANGELOG.md` (docs only, no source) and a new
  `scripts/env-bridge-exit-gate/` directory. `scripts/**` is a knip *entry* pattern in the root
  workspace, so the new files add no unused-file findings; the only third-party import is
  `@pagespace/lib/env-bridge/frame-codec`, which is a declared root dependency with an existing
  `packages/lib/package.json` exports entry — `ws` was deliberately avoided (undeclared at the root)
  by writing `ws-min.ts`.
- No route files, no lib exports, no `logger.child` at module load, nothing interpolated into a
  RegExp.

### What is still needed

A build slot. See the closing message on the task.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TNdjrKzfQ496xd6svkh6XL
