### PR TITLE
fix(dev-preview): retry a refused reconcile, bound the control-plane reads, correct the runbook

### DIFF
--- a/docs/sprites/dev-preview-runbook.md
+++ b/docs/sprites/dev-preview-runbook.md
@@ -139,55 +139,53 @@ does not know, so the spec starts a server without the allow-list first and
 records what the user actually sees, then starts one with
 `server.allowedHosts` and asserts the app renders.
 
-## 6. Before you turn it on: the sprite-edge token question
+## 6. The sprite-edge token question — ANSWERED, it does not leak
 
 The proxy authenticates to the sprite edge with the **org-scoped** Sprites
-bearer token — `preview-forward.ts` sets `authorization: Bearer <token>`
+bearer token: `preview-forward.ts` sets `authorization: Bearer <token>`
 *after* the forwardable-header allowlist, so it deliberately survives the
-filter that strips the client's own credentials
-(`preview-proxy-policy.ts`, where `authorization` is absent from
-`FORWARDABLE_REQUEST_HEADERS`). The WebSocket half does the same
-(`preview-ws-tunnel.ts`). The in-sprite relay on 8080 is a **raw TCP pipe**
-(`preview-relay.ts` — `client.pipe(upstream)` over `net`, no HTTP parsing at
-all), so nothing on our side removes that header on the way in.
+filter that strips the client's own credentials (`preview-proxy-policy.ts`,
+where `authorization` is absent from `FORWARDABLE_REQUEST_HEADERS`). The
+in-sprite relay on 8080 is a **raw TCP pipe** (`preview-relay.ts` —
+`client.pipe(upstream)` over `net`, no HTTP parsing), so nothing on our side
+removes it on the way in. The open question was whether the EDGE strips it
+before forwarding inward — if not, a previewed dev server (agent-authored or
+npm-supply-chain code) could read an org-wide credential from its own headers.
 
-The whole question is therefore whether the **sprite edge** strips it before
-forwarding inward. The spike verified the edge *accepts* the header; it never
-verified the header stops there. If it does not, a previewed dev server —
-agent-authored or npm-supply-chain code — can read an org-wide credential out
-of its own request headers.
+**Checked against a real sprite on 2026-09-07: the edge strips it.**
 
-**The check:** run a server on 5173 in a real sprite that echoes its request
-headers, reach it through the preview origin, and read what arrived. Minutes,
-one sprite, delete it after. Do not accept "the page rendered" as an answer —
-read the headers the dev server actually received.
-
-**If it leaks**, in this order — the order matters, because rotating the token
-first leaves preview forwarding up and simply hands the dev server the NEW
-credential:
+Method: create a sprite, `updateURLSettings({ auth: 'sprite' })` — the only
+mode the preview path will proxy to (`preview-access.ts:263`) and the mode
+where the edge validates the bearer — run a server on 8080 that appends every
+request header it receives to a file, then fetch the sprite URL with the
+bearer plus a canary header, and read the file back out of the sprite.
 
 ```
-# 1. Stop forwarding NOW. A secret beats [env], so this overrides the config
-#    value without waiting on a --config deploy, and only the literal string
-#    'true' enables the feature.
-fly secrets set DEV_PREVIEW_ENABLED=false -a pagespace-web
-fly secrets set DEV_PREVIEW_ENABLED=false -a pagespace-realtime
-
-# 2. Confirm it actually took in the running processes, not just in the API.
-fly ssh console -a pagespace-web      -C 'printenv DEV_PREVIEW_ENABLED'
-fly ssh console -a pagespace-realtime -C 'printenv DEV_PREVIEW_ENABLED'
-
-# 3. Only then rotate.
-fly secrets set SPRITES_API_TOKEN=<new> -a pagespace-web -a pagespace-realtime
+Host: <sprite>.sprites.app
+User-Agent: node
+Sprite-Client-Ip: …
+Via: 1.1 fly.io
+X-Canary-Header: canary-value        <-- passthrough works
+X-Forwarded-For / -Port / -Proto / -Ssl
+X-Request-Start: …
 ```
 
-Setting the secret is the fast path precisely because of the precedence rule
-in §2: it wins over `[env]`, so it takes effect on the restart the secret
-change triggers, with no deploy. Comment the `[env]` flag back out afterwards
-so the config and the running state agree, then clear the secret.
+No `Authorization`, and the token value appears nowhere. The canary is the
+control that matters: headers plainly DO reach the dev server, so the absence
+of `Authorization` is the edge removing it, not the test failing to look.
 
-The real fix is an edge change or a header-stripping hop; nothing in the
-application can repair it.
+**Two limits on that result, both deliberate:**
+
+- It covers the **HTTP** half. The WebSocket half (`preview-ws-tunnel.ts`)
+  sends the same bearer on the upgrade request, and the upgrade takes a
+  different path through the edge. That has NOT been checked — worth doing
+  before HMR is relied on, by the same method against an upgrade request.
+- It used a freshly minted org token rather than the production
+  `SPRITES_API_TOKEN`. The edge's behaviour is a property of the edge and the
+  auth mode, not of which token is presented, so this is the same question —
+  but it is not literally the production credential.
+
+The script is disposable; re-run it with the recipe above if the edge changes.
 
 ## 7. Where the smoke runs
 
@@ -217,6 +215,40 @@ ground:
    pane; it serves.
 7. Sign out in another tab → the preview stops answering on the **next**
    request, not ten minutes later.
+
+## Turning it off
+
+The kill switch is `DEV_PREVIEW_ENABLED`, and it is GLOBAL — there is no
+per-drive rollout, so it exposes the feature to every user at once and takes
+it back from every user at once. Every entry point fails closed on the next
+request: the proxy 404s, the grant mint 404s, the WebSocket upgrade is
+refused, detection stops opening watch channels, and the cron sweep no-ops.
+
+The fast path is a **secret**, not an `[env]` edit, because of the precedence
+rule in §2 — a secret beats the config value and takes effect on the restart
+it triggers, with no `--config` deploy to wait for:
+
+```
+fly secrets set DEV_PREVIEW_ENABLED=false -a pagespace-web
+fly secrets set DEV_PREVIEW_ENABLED=false -a pagespace-realtime
+
+# Confirm it took in the RUNNING processes, not just in the API.
+fly ssh console -a pagespace-web      -C 'printenv DEV_PREVIEW_ENABLED'
+fly ssh console -a pagespace-realtime -C 'printenv DEV_PREVIEW_ENABLED'
+```
+
+Only the literal string `'true'` enables the feature, so `false` — or any
+other value — is off.
+
+Afterwards, comment the `[env]` flag back out and `fly secrets unset
+DEV_PREVIEW_ENABLED` on both apps, so the config and the running state agree
+again rather than drifting apart with a secret quietly overriding the file.
+
+**If a credential is ever implicated** — §6 says the edge strips the org token
+today, but if that changes, or the WebSocket half turns out to differ — the
+order matters: switch the feature off and CONFIRM it before rotating
+`SPRITES_API_TOKEN`. Rotating first while forwarding is still up simply hands
+the previewed dev server the new credential.
 
 ## Runtime behaviour worth knowing
 

--- a/docs/sprites/dev-preview-runbook.md
+++ b/docs/sprites/dev-preview-runbook.md
@@ -46,11 +46,9 @@ Set the same apex on every app that participates. There is no default
 anywhere: an app that misses the variable keeps the feature dark, which is the
 failure mode you want.
 
-**Not `fly secrets set`.** `fly.toml [env]` OVERRIDES a secret of the same
-name, so a value set both places is silently shadowed — the same trap the
-sandbox gate flags carry a warning about in `fly.web.toml`. Neither of these
-is a secret. They live in `[env]`, and `DEV_PREVIEW_APEX` is already there for
-all three apps as of `PageSpace-Deploy` #27:
+Neither value is a secret, so both live in `[env]`, where they are reviewable
+and travel with the deploy. `DEV_PREVIEW_APEX` is already there for all three
+apps as of `PageSpace-Deploy` #27:
 
 ```toml
 # fly/fly.proxy.toml, fly/fly.web.toml, fly/fly.realtime.toml
@@ -59,13 +57,31 @@ all three apps as of `PageSpace-Deploy` #27:
   # DEV_PREVIEW_ENABLED = "true"   # web + realtime only; uncomment to go live
 ```
 
+**Precedence, because the tree gets this backwards.** `fly.web.toml` and
+`fly.realtime.toml` both carry a comment claiming `[env]` overrides a
+same-named secret. It is the other way round —
+[Fly's configuration reference](https://fly.io/docs/reference/configuration/):
+*"Secrets take precedence over env variables with the same name."* Nobody has
+noticed because `CODE_EXECUTION_ENABLED` and `SANDBOX_CONTAINMENT_VERIFIED`
+are set BOTH ways on `pagespace-web` with the same value, so the two readings
+agree by accident. So: do not also `fly secrets set` either preview variable —
+a secret would win and silently mask the value in the config the reviews see.
+
 `[env]` changes only take effect on a **`--config` deploy** (`deploy-fly.sh`);
 an image-only CI deploy preserves the running config, so a deploy that "went
-green" is not evidence the variable landed. Check the running process:
+green" is not evidence the variable landed. Check the running processes —
+**all three**, because a partial rollout passes any single-app check while the
+origin the browser is sent to is not the origin a server will accept:
 
 ```
-fly ssh console -a pagespace-proxy -C 'printenv DEV_PREVIEW_APEX'
+for app in pagespace-proxy pagespace-web pagespace-realtime; do
+  echo "== $app"
+  fly ssh console -a "$app" -C 'printenv DEV_PREVIEW_APEX DEV_PREVIEW_ENABLED' || true
+done
 ```
+
+`pagespace-proxy` should report the apex and no flag; web and realtime should
+report both once you are live.
 
 The apex alone is inert — `isDevPreviewConfigured()` requires the flag too —
 so shipping the apex is a no-op for users and can go out well ahead of the
@@ -146,9 +162,32 @@ headers, reach it through the preview origin, and read what arrived. Minutes,
 one sprite, delete it after. Do not accept "the page rendered" as an answer —
 read the headers the dev server actually received.
 
-**If it leaks:** unset `DEV_PREVIEW_ENABLED` immediately and rotate
-`SPRITES_API_TOKEN`. The fix is an edge change or a header-stripping hop;
-nothing in the application can repair it.
+**If it leaks**, in this order — the order matters, because rotating the token
+first leaves preview forwarding up and simply hands the dev server the NEW
+credential:
+
+```
+# 1. Stop forwarding NOW. A secret beats [env], so this overrides the config
+#    value without waiting on a --config deploy, and only the literal string
+#    'true' enables the feature.
+fly secrets set DEV_PREVIEW_ENABLED=false -a pagespace-web
+fly secrets set DEV_PREVIEW_ENABLED=false -a pagespace-realtime
+
+# 2. Confirm it actually took in the running processes, not just in the API.
+fly ssh console -a pagespace-web      -C 'printenv DEV_PREVIEW_ENABLED'
+fly ssh console -a pagespace-realtime -C 'printenv DEV_PREVIEW_ENABLED'
+
+# 3. Only then rotate.
+fly secrets set SPRITES_API_TOKEN=<new> -a pagespace-web -a pagespace-realtime
+```
+
+Setting the secret is the fast path precisely because of the precedence rule
+in §2: it wins over `[env]`, so it takes effect on the restart the secret
+change triggers, with no deploy. Comment the `[env]` flag back out afterwards
+so the config and the running state agree, then clear the secret.
+
+The real fix is an edge change or a header-stripping hop; nothing in the
+application can repair it.
 
 ## 7. Where the smoke runs
 
@@ -179,19 +218,29 @@ ground:
 7. Sign out in another tab → the preview stops answering on the **next**
    request, not ten minutes later.
 
-## Known gaps, open on purpose
+## Runtime behaviour worth knowing
 
-- **A deferred reconcile is never retried.** If the holder's advisory lock is
-  unavailable when a `port_opened` frame arrives, the detector logs
-  `deferred` and drops it. The cron sweep cannot recover it — its WHERE clause
-  requires `stoppedByUserAt IS NOT NULL AND relayServiceName IS NOT NULL`, so
-  a preview that never started is invisible to it — and a dev server that
-  binds once emits no further frames. The user sees no preview and no error.
-- **The advisory lock has no time bound.** `services.get/list/remove` and
-  `getSprite` carry no timeout, and `services.create/start/stop` bound only
-  the log-stream drain, not the HTTP call. The advisory pool is `max: 10` and
-  shared with every other advisory-lock consumer, so hung Sprites calls
-  degrade more than the preview.
+- **A refused reconcile is retried, three times across ~21s.** If the holder's
+  advisory lock is unavailable when a `port_opened` frame arrives, the
+  detector no longer drops it — dropping it meant a running dev server got no
+  preview and no error, because a quiet server emits no further frames, the
+  backstop sweep only sees rows that are switched OFF and still name a relay,
+  and a healthy watcher is never recycled. The retry is cancelled when the
+  connection drops (the next `port_list` reconciles instead), when a newer
+  frame reconciles ahead of it, and when the detected port itself closes. Past
+  the budget it gives up with a `warn` rather than retrying forever.
+- **Control-plane READS are bounded at 15s.** `services.list` and
+  `services.get` stop waiting rather than pinning an advisory-lock connection
+  from a pool of ten that every lock consumer shares.
+- **Control-plane MUTATIONS are deliberately NOT bounded.** `services.create`,
+  `start`, `stop` and `remove` still wait indefinitely. Abandoning the wait
+  would release the lock while the mutation is in flight, letting the next
+  holder plan against a sprite about to change under it — the exact
+  interleaving the lock exists to prevent — and the Sprites SDK exposes no
+  `AbortSignal`, so there is no way to end the call rather than the wait. A
+  hung mutation still holds its connection. That is the remaining gap.
+- **`getSprite` is likewise unbounded**, for the same reason: it is reached
+  through the same SDK surface.
 
-Both are tracked as follow-up work. Neither is a security issue, and the
-kill switch covers both.
+The kill switch covers all of it: unset the flag and every entry point fails
+closed on the next request.

--- a/docs/sprites/dev-preview-runbook.md
+++ b/docs/sprites/dev-preview-runbook.md
@@ -2,12 +2,11 @@
 
 The dev-server preview ships **dark**. Every layer fails closed on a missing
 variable, so a half-configured deployment shows nothing rather than something
-wrong. This is the list of what has to be true, in order, and what is still
-undecided.
+wrong. This is the list of what has to be true, in order.
 
-Preview apex: **`pagespace.io`** — chosen because it shares no registrable
-domain with `pagespace.ai`. A dev server's own JavaScript running on
-`preview.pagespace.ai` could set `Domain=.pagespace.ai` cookies and toss
+Preview apex: **`pagespace.io`** — registered, on our own DNS, and chosen
+because it shares no registrable domain with `pagespace.ai`. A dev server's
+own JavaScript running on `preview.pagespace.ai` could set `Domain=.pagespace.ai` cookies and toss
 cookies at the dashboard; a separate registrable domain makes that
 impossible rather than merely discouraged.
 
@@ -26,7 +25,20 @@ never falls through to the auth redirect and never picks up the app's security
 headers — `X-Frame-Options: DENY` would break the pane, and the preview
 response carries its own `frame-ancestors`.
 
-Merge that PR and deploy `pagespace-proxy`.
+Verified with a real Caddy binary, not by reading: `caddy validate` passes,
+and `caddy adapt` resolves the matcher to `*.preview.pagespace.io` when the
+apex is set and to the unmatchable `*.preview.` when it is not. Both preview
+routes land ahead of every host-less catch-all, and every block that sets
+`X-Frame-Options: DENY` is host-matched to `pagespace.ai`, so a preview
+response cannot pick one up.
+
+One marginal collision to know about: the `/api/cron/*`, `/api/memory/cron`
+and `/api/pulse/cron` 403 block is host-less, so a previewed dev server
+serving one of those exact paths gets a 403 from the edge rather than its own
+response.
+
+Merge that PR and deploy `pagespace-proxy`, `pagespace-web` and
+`pagespace-realtime` — with `--config`, or the `[env]` values do not land.
 
 ## 2. Environment
 
@@ -34,11 +46,30 @@ Set the same apex on every app that participates. There is no default
 anywhere: an app that misses the variable keeps the feature dark, which is the
 failure mode you want.
 
+**Not `fly secrets set`.** `fly.toml [env]` OVERRIDES a secret of the same
+name, so a value set both places is silently shadowed — the same trap the
+sandbox gate flags carry a warning about in `fly.web.toml`. Neither of these
+is a secret. They live in `[env]`, and `DEV_PREVIEW_APEX` is already there for
+all three apps as of `PageSpace-Deploy` #27:
+
+```toml
+# fly/fly.proxy.toml, fly/fly.web.toml, fly/fly.realtime.toml
+[env]
+  DEV_PREVIEW_APEX = "pagespace.io"
+  # DEV_PREVIEW_ENABLED = "true"   # web + realtime only; uncomment to go live
 ```
-fly secrets set --app pagespace-proxy    DEV_PREVIEW_APEX=pagespace.io
-fly secrets set --app pagespace-web      DEV_PREVIEW_APEX=pagespace.io DEV_PREVIEW_ENABLED=true
-fly secrets set --app pagespace-realtime DEV_PREVIEW_APEX=pagespace.io DEV_PREVIEW_ENABLED=true
+
+`[env]` changes only take effect on a **`--config` deploy** (`deploy-fly.sh`);
+an image-only CI deploy preserves the running config, so a deploy that "went
+green" is not evidence the variable landed. Check the running process:
+
 ```
+fly ssh console -a pagespace-proxy -C 'printenv DEV_PREVIEW_APEX'
+```
+
+The apex alone is inert — `isDevPreviewConfigured()` requires the flag too —
+so shipping the apex is a no-op for users and can go out well ahead of the
+flag.
 
 `SANDBOX_SESSION_SECRET` must already be set on web and realtime: the preview
 cookie's signing key is derived from it, and rotating it invalidates every
@@ -92,38 +123,75 @@ does not know, so the spec starts a server without the allow-list first and
 records what the user actually sees, then starts one with
 `server.allowedHosts` and asserts the app renders.
 
-### Verify this against a real sprite before the flag goes on
+## 6. Before you turn it on: the sprite-edge token question
 
-The proxy authenticates to the sprite edge with the **org-scoped Sprites
-bearer token** (`preview-forward.ts`, and the WebSocket tunnel does the same),
-and the in-sprite relay is a byte-for-byte TCP pipe — it copies whatever
-arrives on 8080 straight to the dev server. So the whole question is whether
-the sprite edge STRIPS that `Authorization` header before proxying inward. The
-spike verified the edge *accepts* the header; it did not verify that the
-header stops there.
+The proxy authenticates to the sprite edge with the **org-scoped** Sprites
+bearer token — `preview-forward.ts` sets `authorization: Bearer <token>`
+*after* the forwardable-header allowlist, so it deliberately survives the
+filter that strips the client's own credentials
+(`preview-proxy-policy.ts`, where `authorization` is absent from
+`FORWARDABLE_REQUEST_HEADERS`). The WebSocket half does the same
+(`preview-ws-tunnel.ts`). The in-sprite relay on 8080 is a **raw TCP pipe**
+(`preview-relay.ts` — `client.pipe(upstream)` over `net`, no HTTP parsing at
+all), so nothing on our side removes that header on the way in.
 
-If it does not stop there, a previewed dev server — which is agent-authored or
-npm-supply-chain code — can read an org-wide credential out of its own request
-headers. That is worth one direct check against a real sprite (curl through
-the preview origin to a server that echoes its request headers) before this is
-enabled anywhere, and it is cheap. Nothing in the application can fix it if the
-answer is bad; the mitigation would be an edge change or a header-stripping hop.
+The whole question is therefore whether the **sprite edge** strips it before
+forwarding inward. The spike verified the edge *accepts* the header; it never
+verified the header stops there. If it does not, a previewed dev server —
+agent-authored or npm-supply-chain code — can read an org-wide credential out
+of its own request headers.
 
-## What is NOT ready — the smoke has no target yet
+**The check:** run a server on 5173 in a real sprite that echoes its request
+headers, reach it through the preview origin, and read what arrived. Minutes,
+one sprite, delete it after. Do not accept "the page rendered" as an answer —
+read the headers the dev server actually received.
 
-**Staging cannot run it as configured**, and this is the open item:
+**If it leaks:** unset `DEV_PREVIEW_ENABLED` immediately and rotate
+`SPRITES_API_TOKEN`. The fix is an edge change or a header-stripping hop;
+nothing in the application can repair it.
 
-- `fly/fly.web.staging.toml` deliberately leaves `CODE_EXECUTION_ENABLED` and
-  `SANDBOX_CONTAINMENT_VERIFIED` unset, with the reason written into the file:
-  "no sandbox egress review has been done for a staging network path". No
-  sandbox means no dev server means nothing to preview.
-- There is **no staging realtime app**. Detection *is* the realtime tier's
-  `ports/watch` channel, and the HMR half of the proxy is its upgrade handler.
-  Without it the preview never appears.
-- There is **no staging proxy**, so whether staging fronts through
-  `pagespace-proxy` or gets its own is an open decision, and it determines
-  where the wildcard record points.
+## 7. Where the smoke runs
 
-Three decisions, then the smoke has somewhere to run. Until it passes,
-production stays dark: nothing in this document should be applied to
-`pagespace-web` before a real browser has loaded a real dev server somewhere.
+**Production** — and that is not a compromise, it is the only place with
+sandboxes. `CODE_EXECUTION_ENABLED` and `SANDBOX_CONTAINMENT_VERIFIED` are
+both `"true"` on `fly.web.toml` and `fly.realtime.toml`. An earlier draft of
+this document said staging had to host it; staging deliberately leaves those
+flags unset (`fly.web.staging.toml`: "no sandbox egress review has been done
+for a staging network path"), has no realtime app and no proxy, so it cannot
+run this at all. Standing one up is real work and buys nothing the flag does
+not already buy: unsetting `DEV_PREVIEW_ENABLED` takes the whole feature back
+out on the next request.
+
+**Do the first pass by hand.** `21-dev-preview.spec.ts` needs `E2E_SANDBOX=1`
+*and* `DATABASE_URL`, because it calls `seedUser` — pointing it at production
+writes a test user into the production database. Run the spec only against a
+database you are willing to seed. The manual walkthrough covers the same
+ground:
+
+1. Open an agent session; start a real Vite dev server on 5173.
+2. The affordance appears **on its own** naming `:5173` — no page action.
+3. Preview → the app renders through `https://ws-<id>.preview.pagespace.io/`.
+4. Edit a source file → the frame hot-updates **without a reload**.
+5. Confirm the `allowedHosts` failure first, then that `server.allowedHosts`
+   fixes it — so we know what a user hits, not just that it can work.
+6. Bind something on **9000** → detected but *not* shared; approve in the
+   pane; it serves.
+7. Sign out in another tab → the preview stops answering on the **next**
+   request, not ten minutes later.
+
+## Known gaps, open on purpose
+
+- **A deferred reconcile is never retried.** If the holder's advisory lock is
+  unavailable when a `port_opened` frame arrives, the detector logs
+  `deferred` and drops it. The cron sweep cannot recover it — its WHERE clause
+  requires `stoppedByUserAt IS NOT NULL AND relayServiceName IS NOT NULL`, so
+  a preview that never started is invisible to it — and a dev server that
+  binds once emits no further frames. The user sees no preview and no error.
+- **The advisory lock has no time bound.** `services.get/list/remove` and
+  `getSprite` carry no timeout, and `services.create/start/stop` bound only
+  the log-stream drain, not the HTTP call. The advisory pool is `max: 10` and
+  shared with every other advisory-lock consumer, so hung Sprites calls
+  degrade more than the preview.
+
+Both are tracked as follow-up work. Neither is a security issue, and the
+kill switch covers both.

--- a/packages/lib/src/services/sandbox/preview/__tests__/dev-preview-detection.test.ts
+++ b/packages/lib/src/services/sandbox/preview/__tests__/dev-preview-detection.test.ts
@@ -385,6 +385,61 @@ describe('createDevPreviewDetector — a deferred reconcile is retried', () => {
     });
   });
 
+  it('a retry that has already FIRED is still superseded by the newer frame it queued behind', async () => {
+    // Firing is not running. The timer callback drops its canceller and
+    // appends to the chain, so between those two points a newer frame can
+    // reconcile — and without a generation check the stale retry then runs
+    // LAST and re-points the relay back to the port the newer frame left.
+    const h = harness({ lockBusyTimes: 0 });
+    await h.detector.onFrame({ type: 'port_list', ports: [] });
+    h.setBusy(1);
+    await h.detector.onFrame({ type: 'port_opened', port: 5173, address: '10.0.0.1', pid: 383 });
+
+    // The ORDER is the whole point: the newer frame is queued FIRST and is
+    // still in flight, and the timer fires while it is — so the retry lands
+    // BEHIND it on the chain and would otherwise get the last word.
+    const newer = h.detector.onFrame({ type: 'port_opened', port: 3000, address: '10.0.0.1', pid: 384 });
+    const armed = h.timers.filter((t) => !t.cancelled);
+    armed[armed.length - 1]?.run();
+    await newer;
+    for (let i = 0; i < 8; i += 1) await new Promise((r) => setTimeout(r, 0));
+
+    assert({
+      given: 'a fired-but-queued retry for 5173 and a newer frame that took 3000',
+      should: 'leave the relay on 3000 — the stale retry must not re-point it',
+      actual: h.calls.filter((c) => c.startsWith('create:')),
+      expected: ['create:3000'],
+    });
+    assert({
+      given: 'the superseded retry',
+      should: 'say so rather than silently doing nothing',
+      actual: h.logs.some((l) => l.startsWith('info:dev-preview: deferred retry superseded')),
+      expected: true,
+    });
+  });
+
+  it('a retry whose OWN port closes is cancelled — a relay to a server that has gone is worse than none', async () => {
+    const h = harness({ lockBusyTimes: 0 });
+    await h.detector.onFrame({ type: 'port_list', ports: [] });
+    h.setBusy(1);
+    await h.detector.onFrame({ type: 'port_opened', port: 5173, address: '10.0.0.1', pid: 383 });
+    await h.detector.onFrame({ type: 'port_closed', port: 5173 });
+
+    assert({
+      given: 'the detected port closing before the retry fires',
+      should: 'cancel it — the planner takes detected.port without checking it still listens',
+      actual: h.timers.filter((t) => !t.cancelled).length,
+      expected: 0,
+    });
+    await h.fire();
+    assert({
+      given: 'the cancelled retry',
+      should: 'never create a relay for the closed port',
+      actual: h.calls.filter((c) => c.startsWith('create:')),
+      expected: [],
+    });
+  });
+
   it('a NEW frame supersedes the pending retry, and a dropped connection cancels it', async () => {
     const superseded = harness({ lockBusyTimes: 0 });
     await superseded.detector.onFrame({ type: 'port_list', ports: [] });

--- a/packages/lib/src/services/sandbox/preview/__tests__/dev-preview-detection.test.ts
+++ b/packages/lib/src/services/sandbox/preview/__tests__/dev-preview-detection.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect } from 'vitest';
 import { assert } from '../../__tests__/riteway';
 import type { SandboxServiceInfo, SandboxServicesApi } from '../../sandbox-host';
-import { createDevPreviewDetector, type DevPreviewDetectorDeps } from '../dev-preview-detection';
+import { createDevPreviewDetector, DEFERRED_RETRY_DELAYS_MS, type DevPreviewDetectorDeps } from '../dev-preview-detection';
 import type { DevPreviewRecord, DevPreviewStore } from '../dev-preview-store';
 import type { DevPreviewRowIntent } from '../dev-preview-core';
 import { buildPreviewRelaySpec, PREVIEW_RELAY_SERVICE_NAME } from '../preview-relay';
@@ -23,6 +23,8 @@ function harness(overrides: {
   failCreate?: boolean;
   /** What the PLANNER sees, when the stored row has already moved on (the stop/detection race). */
   readsAheadOfWrites?: DevPreviewRecord | null;
+  /** Refuse the holder's lock this many times, then acquire. */
+  lockBusyTimes?: number;
 } = {}) {
   let relay: SandboxServiceInfo | null = overrides.relay ?? null;
   let row: DevPreviewRecord | null = overrides.row ?? null;
@@ -85,8 +87,43 @@ function harness(overrides: {
     },
     probeRuntime: async () => { probes += 1; return overrides.runtime ?? 'node'; },
   };
+  // A scripted lock: contention is a FACT here, not a timing hope.
+  let busyLeft = overrides.lockBusyTimes ?? 0;
+  if (overrides.lockBusyTimes !== undefined) {
+    deps.lock = async (_holder, run) => {
+      if (busyLeft > 0) { busyLeft -= 1; calls.push('lock-busy'); return { outcome: 'busy' }; }
+      calls.push('lock-acquired');
+      return { outcome: 'acquired', result: await run() };
+    };
+  }
+  /** Refuse the NEXT `n` lock acquisitions — lets a test settle first, then contend. */
+  const setBusy = (n: number) => { busyLeft = n; };
+  // Timers as data: every armed retry is captured and fired by hand, so the
+  // test asserts the SCHEDULE, not a wall clock.
+  const timers: { ms: number; run: () => void; cancelled: boolean }[] = [];
+  deps.schedule = (run, ms) => {
+    const entry = { ms, run, cancelled: false };
+    timers.push(entry);
+    return () => { entry.cancelled = true; };
+  };
   const detector = createDevPreviewDetector(deps);
-  return { detector, calls, logs, probes: () => probes, relay: () => relay, row: () => row };
+  /**
+   * Fire the newest armed, uncancelled timer and let its work settle. It must
+   * NOT go through `onFrame` — a frame cancels the pending retry, which is
+   * exactly the thing under test.
+   */
+  const fired = new Set<{ ms: number }>();
+  const fire = async (): Promise<boolean> => {
+    const next = [...timers].reverse().find((t) => !t.cancelled && !fired.has(t));
+    if (next === undefined) return false;
+    fired.add(next);
+    next.run();
+    // The retry queues onto the detector's internal chain; drain the macrotask
+    // queue so every awaited store/service call has settled.
+    for (let i = 0; i < 8; i += 1) await new Promise((r) => setTimeout(r, 0));
+    return true;
+  };
+  return { detector, calls, logs, probes: () => probes, relay: () => relay, row: () => row, timers, fire, setBusy };
 }
 
 describe('createDevPreviewDetector — port_opened', () => {
@@ -281,5 +318,117 @@ describe('createDevPreviewDetector — discipline', () => {
 
     await h.detector.onFrame({ type: 'port_list', ports: [{ port: 5173, pid: 11 }] });
     assert({ given: 'the snapshot arriving', should: 'start the relay for real', actual: h.calls, expected: [`upsert:5173:${PREVIEW_RELAY_SERVICE_NAME}`, 'create:5173'] });
+  });
+});
+
+describe('createDevPreviewDetector — a deferred reconcile is retried', () => {
+  it('a frame refused by the lock is RE-ATTEMPTED, and the retry starts the relay', async () => {
+    // The gap this closes: a dev server binds once and then sits quiet, so
+    // there is no second frame; the backstop sweep only ever sees rows that
+    // are switched OFF and still name a relay, so a preview that never
+    // started is invisible to it; a healthy watcher is never recycled, so no
+    // reconnect snapshot arrives; and the status read plans nothing. Drop the
+    // frame and the user's running dev server simply never gets a preview,
+    // with no error anywhere.
+    const h = harness({ lockBusyTimes: 0 });
+    await h.detector.onFrame({ type: 'port_list', ports: [] });
+    h.setBusy(1);
+    await h.detector.onFrame({ type: 'port_opened', port: 5173, address: '10.0.0.1', pid: 383 });
+
+    assert({
+      given: 'a port_opened whose reconcile the lock refused',
+      should: 'have started NOTHING yet, and armed exactly one retry',
+      actual: [h.calls.filter((c) => c.startsWith('create')).length, h.timers.filter((t) => !t.cancelled).length],
+      expected: [0, 1],
+    });
+    assert({
+      given: 'the first retry',
+      should: 'be armed at the first delay in the schedule',
+      actual: h.timers[0]?.ms,
+      expected: DEFERRED_RETRY_DELAYS_MS[0],
+    });
+
+    assert({ given: 'the armed retry firing', should: 'have run', actual: await h.fire(), expected: true });
+    assert({
+      given: 'a lock that is now free',
+      should: 'create the relay for the port the dropped frame carried',
+      actual: h.calls.filter((c) => c.startsWith('create:')),
+      expected: ['create:5173'],
+    });
+  });
+
+  it('gives up after a BOUNDED number of attempts rather than retrying forever', async () => {
+    const h = harness({ lockBusyTimes: 0 });
+    await h.detector.onFrame({ type: 'port_list', ports: [] });
+    h.setBusy(99);
+    await h.detector.onFrame({ type: 'port_opened', port: 5173, address: '10.0.0.1', pid: 383 });
+
+    let fires = 0;
+    while (await h.fire()) fires += 1;
+    assert({
+      given: 'a lock that never frees',
+      should: 'retry exactly as many times as the schedule has delays, then stop',
+      actual: fires,
+      expected: DEFERRED_RETRY_DELAYS_MS.length,
+    });
+    assert({
+      given: 'the exhausted schedule',
+      should: 'say so rather than failing silently',
+      actual: h.logs.some((l) => l.startsWith('warn:dev-preview: giving up on a deferred reconcile')),
+      expected: true,
+    });
+    assert({
+      given: 'every attempt refused',
+      should: 'never have touched the sprite',
+      actual: h.calls.filter((c) => c.startsWith('create') || c.startsWith('start')),
+      expected: [],
+    });
+  });
+
+  it('a NEW frame supersedes the pending retry, and a dropped connection cancels it', async () => {
+    const superseded = harness({ lockBusyTimes: 0 });
+    await superseded.detector.onFrame({ type: 'port_list', ports: [] });
+    superseded.setBusy(1);
+    await superseded.detector.onFrame({ type: 'port_opened', port: 5173, address: '10.0.0.1', pid: 383 });
+    await superseded.detector.onFrame({ type: 'port_opened', port: 3000, address: '10.0.0.1', pid: 384 });
+    assert({
+      given: 'a newer frame that RECONCILES arriving before the retry fires',
+      should: 'leave no armed retry — the successful reconcile supersedes it',
+      actual: superseded.timers.filter((t) => !t.cancelled).length,
+      expected: 0,
+    });
+
+    // The counterweight, and the reason `onFrame` does NOT cancel blindly: a
+    // frame that reconciles NOTHING must leave the pending retry alone, or an
+    // unrelated port closing would silently reintroduce the dropped-frame bug.
+    const unrelated = harness({ lockBusyTimes: 0 });
+    await unrelated.detector.onFrame({ type: 'port_list', ports: [] });
+    unrelated.setBusy(1);
+    await unrelated.detector.onFrame({ type: 'port_opened', port: 5173, address: '10.0.0.1', pid: 383 });
+    await unrelated.detector.onFrame({ type: 'port_closed', port: 4321 });
+    assert({
+      given: 'an unrelated port_closed while a retry is pending',
+      should: 'leave the retry armed',
+      actual: unrelated.timers.filter((t) => !t.cancelled).length,
+      expected: 1,
+    });
+    assert({
+      given: 'that still-armed retry firing',
+      should: 'start the relay the dropped frame was for',
+      actual: (await unrelated.fire()) && unrelated.calls.filter((c) => c.startsWith('create:')).length === 1,
+      expected: true,
+    });
+
+    const dropped = harness({ lockBusyTimes: 0 });
+    await dropped.detector.onFrame({ type: 'port_list', ports: [] });
+    dropped.setBusy(1);
+    await dropped.detector.onFrame({ type: 'port_opened', port: 5173, address: '10.0.0.1', pid: 383 });
+    dropped.detector.invalidateSnapshot();
+    assert({
+      given: 'the watch connection dropping',
+      should: 'cancel the retry — the next connection reconciles from a real snapshot',
+      actual: dropped.timers.filter((t) => !t.cancelled).length,
+      expected: 0,
+    });
   });
 });

--- a/packages/lib/src/services/sandbox/preview/dev-preview-detection.ts
+++ b/packages/lib/src/services/sandbox/preview/dev-preview-detection.ts
@@ -145,6 +145,16 @@ export function createDevPreviewDetector(deps: DevPreviewDetectorDeps): DevPrevi
   let chain: Promise<void> = Promise.resolve();
   /** Cancels the pending deferred-reconcile retry, or `null` when none is armed. */
   let cancelRetry: (() => void) | null = null;
+  /**
+   * Bumped by every cancel. A fired retry captures the generation it was armed
+   * in and re-checks it once it reaches the front of the chain, because
+   * `cancelRetry` is already `null` by then — firing is not running, and
+   * between the two a newer frame can reconcile and be superseded by the very
+   * work it was supposed to replace.
+   */
+  let retryGeneration = 0;
+  /** The port the pending retry would act on, so a close of THAT port can cancel it. */
+  let pendingRetryPort: number | null = null;
 
   const context = () => ({ holderKind: holder.kind, holderId: holder.id, spriteInstanceId: handle.spriteInstanceId });
 
@@ -191,10 +201,23 @@ export function createDevPreviewDetector(deps: DevPreviewDetectorDeps): DevPrevi
       log.warn('dev-preview: giving up on a deferred reconcile', { ...context(), attempts: DEFERRED_RETRY_DELAYS_MS.length });
       return;
     }
+    // Captured AFTER the cancel above, which is what bumps the counter.
+    const generation = retryGeneration;
+    pendingRetryPort = detected?.port ?? null;
     cancelRetry = schedule(() => {
+      // Fired, but not yet run: everything from here is queued behind whatever
+      // is already on the chain, and `cancelRetry` no longer refers to it.
       cancelRetry = null;
       const next = chain
         .then(async () => {
+          // The generation is the ONLY thing that can stop a fired retry. A
+          // newer frame that reconciled while this sat in the queue has
+          // already cancelled — running now would re-point the relay back to
+          // the port the newer frame moved away from.
+          if (generation !== retryGeneration) {
+            log.info('dev-preview: deferred retry superseded', { ...context(), attempt: attempt + 1 });
+            return;
+          }
           const applied = await reconcile(detected, attempt + 1);
           log.info('dev-preview: deferred reconcile retried', { ...context(), attempt: attempt + 1, applied: applied.action });
         })
@@ -206,6 +229,10 @@ export function createDevPreviewDetector(deps: DevPreviewDetectorDeps): DevPrevi
   }
 
   function cancelDeferredRetry(): void {
+    // Unconditional: a retry that has FIRED has already dropped its canceller,
+    // and the bump is the only thing that still reaches it.
+    retryGeneration += 1;
+    pendingRetryPort = null;
     if (cancelRetry === null) return;
     cancelRetry();
     cancelRetry = null;
@@ -273,6 +300,16 @@ export function createDevPreviewDetector(deps: DevPreviewDetectorDeps): DevPrevi
     if (frame.type === 'port_closed') {
       // Best-effort on the wire (spike §5, §9): bookkeeping only, never a teardown.
       listeners.delete(frame.port);
+      // ...except for a pending retry FOR THIS PORT, which is now known to be
+      // for a server that has gone. The planner takes `detected.port` without
+      // requiring it to still be listening, so letting that retry run would
+      // create a relay and a row pointing at nothing. A close of any OTHER
+      // port still leaves the retry alone — that distinction is the whole
+      // reason `onFrame` does not cancel blindly.
+      if (pendingRetryPort === frame.port) {
+        log.info('dev-preview: deferred retry cancelled, its port closed', { ...context(), port: frame.port });
+        cancelDeferredRetry();
+      }
       return;
     }
 

--- a/packages/lib/src/services/sandbox/preview/dev-preview-detection.ts
+++ b/packages/lib/src/services/sandbox/preview/dev-preview-detection.ts
@@ -68,6 +68,12 @@ export interface DevPreviewDetectorDeps {
    * Postgres; the realtime binding supplies the real advisory lock.
    */
   lock?: DevPreviewLock;
+  /**
+   * Test seam for {@link DEFERRED_RETRY_DELAYS_MS}; production uses
+   * `setTimeout`. Returns its own canceller so the detector never has to know
+   * what a timer handle is.
+   */
+  schedule?: (run: () => void, ms: number) => () => void;
 }
 
 export interface DevPreviewDetector {
@@ -97,12 +103,36 @@ export interface DevPreviewDetector {
   invalidateSnapshot(): void;
 }
 
+/**
+ * How long to wait before re-attempting a reconcile the holder's lock refused.
+ *
+ * A deferred frame USED TO BE DROPPED, and the claim that "the next frame or
+ * the backstop sweep converges" was simply false in the one case that matters:
+ * a dev server binds once and then sits quiet, so there is no next frame; the
+ * sweep's candidate query requires `stoppedByUserAt IS NOT NULL AND
+ * relayServiceName IS NOT NULL`, so a preview that never STARTED is invisible
+ * to it; a healthy watcher is never recycled, so no reconnect snapshot
+ * arrives; and the status read plans nothing. The user's dev server was
+ * running, the preview never appeared, and nothing ever tried again.
+ *
+ * Three attempts across ~21s, well past the lock's own ~350ms budget — the
+ * contention this covers is another tier mid-reconcile, or a degraded lock
+ * pool, both of which resolve in seconds or not at all. Bounded on purpose: a
+ * preview that cannot start is not worth an unbounded timer, and every other
+ * path (a new frame, a reconnect, a user click) still converges it.
+ */
+export const DEFERRED_RETRY_DELAYS_MS = [1_000, 5_000, 15_000] as const;
+
 type Detected = Extract<DevServerClassification, { kind: 'dev-server' }>;
 
 export function createDevPreviewDetector(deps: DevPreviewDetectorDeps): DevPreviewDetector {
   const { holder, handle, store, now, log } = deps;
   const probe = deps.probeRuntime ?? probeRelayRuntime;
   const lock = deps.lock ?? unlocked;
+  const schedule = deps.schedule ?? ((run: () => void, ms: number) => {
+    const handle = setTimeout(run, ms);
+    return () => { clearTimeout(handle); };
+  });
   const listeners = new Map<number, ListeningPort>();
   /** True once a `port_list` has been applied and no invalidation has landed since. */
   let snapshotKnown = false;
@@ -113,6 +143,8 @@ export function createDevPreviewDetector(deps: DevPreviewDetectorDeps): DevPrevi
   let epoch = 0;
   let runtime: PreviewRelayRuntime | undefined;
   let chain: Promise<void> = Promise.resolve();
+  /** Cancels the pending deferred-reconcile retry, or `null` when none is armed. */
+  let cancelRetry: (() => void) | null = null;
 
   const context = () => ({ holderKind: holder.kind, holderId: holder.id, spriteInstanceId: handle.spriteInstanceId });
 
@@ -126,13 +158,57 @@ export function createDevPreviewDetector(deps: DevPreviewDetectorDeps): DevPrevi
    * A bounded retry rather than a bare try-lock, because frames are not
    * guaranteed to recur — a `port_opened` for a server that then sits quiet is
    * often the last frame for minutes, so dropping one can mean the preview
-   * silently never appears. Past the budget the frame is DEFERRED, which the
-   * next frame or the backstop sweep converges.
+   * silently never appears. Past the budget the frame is DEFERRED and a
+   * bounded retry is armed ({@link DEFERRED_RETRY_DELAYS_MS}) — nothing else
+   * would converge it, which is what made dropping it a silent failure.
    */
-  async function reconcile(detected: Detected | null): Promise<AppliedDevServerServicePlan> {
+  async function reconcile(detected: Detected | null, attempt = 0): Promise<AppliedDevServerServicePlan> {
     const outcome = await lock(holder, () => reconcileLocked(detected));
-    if (outcome.outcome === 'acquired') return outcome.result;
+    if (outcome.outcome === 'acquired') {
+      cancelDeferredRetry();
+      return outcome.result;
+    }
+    armDeferredRetry(detected, attempt);
     return { action: 'deferred', reason: 'reconcile-in-progress' };
+  }
+
+  /**
+   * Re-attempt a refused reconcile. Cancelled by anything that supersedes it:
+   * a new frame (which reconciles with fresher facts), and
+   * `invalidateSnapshot` (the connection died, so this retry's premise is
+   * gone and the next connection's `port_list` reconciles anyway).
+   *
+   * The retry re-reads the relay and the row inside the lock, and plans
+   * against `snapshotKnown` as it is AT THAT MOMENT — so a retry that fires
+   * after the snapshot went unknown refuses with `slot-unknown` rather than
+   * starting a relay blind. It carries the classification forward only
+   * because a quiet dev server will not re-announce itself.
+   */
+  function armDeferredRetry(detected: Detected | null, attempt: number): void {
+    cancelDeferredRetry();
+    const delay = DEFERRED_RETRY_DELAYS_MS[attempt];
+    if (delay === undefined) {
+      log.warn('dev-preview: giving up on a deferred reconcile', { ...context(), attempts: DEFERRED_RETRY_DELAYS_MS.length });
+      return;
+    }
+    cancelRetry = schedule(() => {
+      cancelRetry = null;
+      const next = chain
+        .then(async () => {
+          const applied = await reconcile(detected, attempt + 1);
+          log.info('dev-preview: deferred reconcile retried', { ...context(), attempt: attempt + 1, applied: applied.action });
+        })
+        .catch((error: unknown) => {
+          log.error('dev-preview: deferred retry failed', error instanceof Error ? error : new Error(String(error)), context());
+        });
+      chain = next;
+    }, delay);
+  }
+
+  function cancelDeferredRetry(): void {
+    if (cancelRetry === null) return;
+    cancelRetry();
+    cancelRetry = null;
   }
 
   async function reconcileLocked(detected: Detected | null): Promise<AppliedDevServerServicePlan> {
@@ -210,6 +286,13 @@ export function createDevPreviewDetector(deps: DevPreviewDetectorDeps): DevPrevi
 
   return {
     onFrame(frame) {
+      // NOTE: deliberately NOT cancelling the pending retry here. A frame
+      // that actually reconciles supersedes it anyway — `armDeferredRetry`
+      // cancels before re-arming, and an acquired lock cancels outright — so
+      // a cancel here would be redundant for those, and WRONG for the frames
+      // that reconcile nothing: a `port_closed` for an unrelated port, or an
+      // `ignored` classification, would throw away a legitimate pending retry
+      // and reintroduce exactly the dropped-frame bug this exists to fix.
       // The epoch is captured at ARRIVAL, not at apply time: that is what
       // makes a frame belong to the connection it came from.
       const frameEpoch = epoch;
@@ -223,6 +306,10 @@ export function createDevPreviewDetector(deps: DevPreviewDetectorDeps): DevPrevi
     invalidateSnapshot() {
       snapshotKnown = false;
       epoch += 1;
+      // The connection this retry belonged to is gone. The next one opens
+      // with a `port_list`, which reconciles from a real snapshot; retrying
+      // against a dead connection's premise would only refuse.
+      cancelDeferredRetry();
     },
   };
 }

--- a/packages/lib/src/services/sandbox/sandbox-client/__tests__/sprite-sandbox-host.test.ts
+++ b/packages/lib/src/services/sandbox/sandbox-client/__tests__/sprite-sandbox-host.test.ts
@@ -1,7 +1,7 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi } from 'vitest';
 import { EventEmitter } from 'node:events';
 import { createSpriteSandboxHost, normalizeSpritePowerState } from '../sprite-sandbox-host';
-import { SandboxSpriteReplacedError, SandboxStreamOpenTimeoutError } from '../../sandbox-host';
+import { SandboxControlPlaneTimeoutError, SandboxSpriteReplacedError, SandboxStreamOpenTimeoutError } from '../../sandbox-host';
 import {
   createSpritesSandboxClient,
   spawnWithSelfHealingCwd,
@@ -974,5 +974,54 @@ describe('createSpriteSandboxHost', () => {
       ]);
       expect(nested).toEqual([{ type: 'port_closed', port: 3000 }]);
     });
+  });
+});
+
+describe('control-plane reads are time-bounded', () => {
+  async function handleWith(over: Partial<SpriteInstanceLike>) {
+    const { sdk } = makeSdk({ getSprite: async () => fakeSprite(over) });
+    const client = createSpritesSandboxClient({ sdk });
+    const host = createSpriteSandboxHost({ sdk, client });
+    return host.provision({ name: 'k', substrate: { kind: 'sprite' }, options });
+  }
+
+  it('given a listServices that never settles, should stop WAITING rather than pin its caller forever', async () => {
+    // These reads run inside the dev-preview advisory lock, over a pool of 10
+    // that every advisory-lock consumer shares. A hung read held that
+    // connection indefinitely, and ten of them starve every other holder —
+    // whose reconciles then defer. The SDK exposes no AbortSignal, so the
+    // request itself keeps running; abandoning the WAIT is the bound that is
+    // actually available, and it is free for a read because nothing was
+    // mutated.
+    const handle = await handleWith({ listServices: () => new Promise<never>(() => {}) });
+    vi.useFakeTimers();
+    try {
+      const settled = handle.services.get('anything').then(
+        () => 'resolved',
+        (error: unknown) => (error instanceof SandboxControlPlaneTimeoutError ? `timeout:${error.operation}` : `other:${String(error)}`),
+      );
+      await vi.advanceTimersByTimeAsync(15_000);
+      expect(await settled).toBe('timeout:services.get');
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('given a deleteService that never settles, should leave the MUTATION unbounded on purpose', async () => {
+    // Abandoning the wait on a mutation would release the advisory lock while
+    // the delete is still in flight, letting the next holder plan against a
+    // sprite about to change under it — the exact interleaving the lock
+    // exists to prevent. Bounding it honestly needs cancellation the SDK does
+    // not offer, so it stays pending rather than lying about being over.
+    const handle = await handleWith({ deleteService: () => new Promise<never>(() => {}) });
+    vi.useFakeTimers();
+    try {
+      let settled = false;
+      void handle.services.remove('preview-relay').then(() => { settled = true; }, () => { settled = true; });
+      await vi.advanceTimersByTimeAsync(120_000);
+      expect(settled).toBe(false);
+    } finally {
+      vi.useRealTimers();
+    }
   });
 });

--- a/packages/lib/src/services/sandbox/sandbox-client/sprite-sandbox-host.ts
+++ b/packages/lib/src/services/sandbox/sandbox-client/sprite-sandbox-host.ts
@@ -18,6 +18,7 @@
 
 import {
   SandboxSpriteReplacedError,
+  SandboxControlPlaneTimeoutError,
   SandboxStreamOpenTimeoutError,
   type SandboxHandle,
   type SandboxHost,
@@ -171,6 +172,34 @@ export function normalizeSpritePowerState(status: string | undefined): SandboxPo
   return 'unknown';
 }
 
+/**
+ * How long to wait on a control-plane READ before giving up on the wait.
+ * Generous: this is a hang guard, not a latency budget, and a read that has
+ * not answered in fifteen seconds is not about to.
+ */
+const CONTROL_PLANE_READ_TIMEOUT_MS = 15_000;
+
+/**
+ * Bound the WAIT on a read. See {@link SandboxControlPlaneTimeoutError} for
+ * why mutations are pointedly excluded.
+ */
+async function boundedRead<T>(operation: string, run: () => Promise<T>): Promise<T> {
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  try {
+    return await Promise.race([
+      run(),
+      new Promise<never>((_resolve, reject) => {
+        timer = setTimeout(
+          () => { reject(new SandboxControlPlaneTimeoutError(operation, CONTROL_PLANE_READ_TIMEOUT_MS)); },
+          CONTROL_PLANE_READ_TIMEOUT_MS,
+        );
+      }),
+    ]);
+  } finally {
+    if (timer !== undefined) clearTimeout(timer);
+  }
+}
+
 function wrapSpriteServices(getSprite: () => Promise<SpriteInstanceLike>): SandboxServicesApi {
   return {
     async create({ name, command, args, httpPort }) {
@@ -187,17 +216,21 @@ function wrapSpriteServices(getSprite: () => Promise<SpriteInstanceLike>): Sandb
       );
     },
     async list() {
-      const sprite = await getSprite();
-      return (await sprite.listServices()).map(normalizeSpriteService);
+      return boundedRead('services.list', async () => {
+        const sprite = await getSprite();
+        return (await sprite.listServices()).map(normalizeSpriteService);
+      });
     },
     async get(name) {
       // Derived from list rather than the SDK's getService: the SDK rejects a
       // miss with an untyped `Error('Service not found: …')` that message-match
       // classification would have to fish out — an absent row from the listing
       // is the same answer without the fragility.
-      const sprite = await getSprite();
-      const record = (await sprite.listServices()).find((s) => s.name === name);
-      return record !== undefined ? normalizeSpriteService(record) : null;
+      return boundedRead('services.get', async () => {
+        const sprite = await getSprite();
+        const record = (await sprite.listServices()).find((s) => s.name === name);
+        return record !== undefined ? normalizeSpriteService(record) : null;
+      });
     },
     async start(name) {
       const sprite = await getSprite();

--- a/packages/lib/src/services/sandbox/sandbox-host.ts
+++ b/packages/lib/src/services/sandbox/sandbox-host.ts
@@ -222,6 +222,32 @@ export class SandboxStreamOpenTimeoutError extends Error {
 }
 
 /**
+ * A control-plane READ did not answer in time — listing a sandbox's services,
+ * or resolving the sandbox itself.
+ *
+ * Only reads raise this, and that asymmetry is the whole design. These calls
+ * run inside a per-holder advisory lock (`dev-preview-lock.ts`), and the SDK
+ * exposes no `AbortSignal`, so the best available bound is to stop WAITING —
+ * the request itself keeps running until the runtime drops it. For a read
+ * that is free: nothing was mutated, so abandoning the wait costs only the
+ * work already done, and it releases a Postgres connection from a pool of 10
+ * that every advisory-lock consumer shares.
+ *
+ * A MUTATION is deliberately NOT bounded this way. Abandoning the wait there
+ * would release the lock while the create/start/stop is still in flight,
+ * letting the next holder plan against a sprite that is about to change under
+ * it — exactly the interleaving the lock exists to prevent. A hung mutation
+ * still pins its connection; bounding it honestly needs cancellation the SDK
+ * does not offer.
+ */
+export class SandboxControlPlaneTimeoutError extends Error {
+  constructor(public readonly operation: string, public readonly timeoutMs: number) {
+    super(`Sandbox control-plane read '${operation}' did not answer within ${timeoutMs}ms`);
+    this.name = 'SandboxControlPlaneTimeoutError';
+  }
+}
+
+/**
  * A port lifecycle notification observed on a machine's interactive stream —
  * a process inside the sandbox bound (or released) a TCP port. Data only:
  * whether that port is a dev server, whether it should be exposed, and what to


### PR DESCRIPTION
Closes the two gaps deliberately left open on #2550, and corrects the rollout runbook now that the target is known.

## A deferred reconcile was dropped, and nothing converged it

The detector's docblock claimed "the next frame or the backstop sweep converges" a deferred frame. Neither does — verified end to end:

- a dev server binds once and then sits quiet, so there **is** no next frame;
- the sweep's candidate query requires `stoppedByUserAt IS NOT NULL AND relayServiceName IS NOT NULL`, so a preview that never *started* is structurally invisible to it — and it plans with `listenersKnown: false` anyway, which can only ever produce `stop-relay`;
- `read()` re-arms a watcher only when one is **missing**, so a healthy watcher yields no reconnect snapshot;
- `gatherDevPreviewStatus` is strictly read-only.

Net effect: dev server running, the holder's lock busy for ~350 ms, preview never appears, **no error anywhere**, and nothing ever tries again.

The detector now arms a bounded retry — `DEFERRED_RETRY_DELAYS_MS`, three attempts across ~21 s — carrying the classification forward, because a quiet server will not re-announce itself. The retry re-plans against `snapshotKnown` *as it is when it fires*, so one that lands after the snapshot went unknown refuses with `slot-unknown` rather than starting a relay blind.

`onFrame` deliberately does **not** cancel the pending retry. Mutation testing caught that the first version's cancel there was not merely redundant (`armDeferredRetry` cancels before re-arming; an acquired lock cancels outright) but actively wrong for frames that reconcile nothing: an unrelated `port_closed` would have thrown away a legitimate retry and reintroduced the very bug. There is a test for that now, and it fails if the cancel comes back.

## A hung control-plane read pinned its advisory-lock connection forever

`services.list` / `services.get` now bound the **wait** at 15 s.

The plan called for an `AbortSignal`. The Sprites SDK exposes none on any service method, so the honest available bound is to stop waiting — which is free for a read, since nothing was mutated, and it releases a connection from a pool of `max: 10` that **every** advisory-lock consumer shares. Ten hung reads degrade `wakePublishedAppSerialized` and machine-storage reconcile too, not just this feature.

**Mutations stay unbounded, deliberately, with a test asserting it.** Abandoning the wait on a create/start/stop/remove releases the lock while the mutation is still in flight, letting the next holder plan against a sprite about to change under it — exactly the interleaving the lock exists to prevent. Same reasoning that rejected wrapping the lock body in `Promise.race`; it still holds. Bounding a mutation honestly needs cancellation the SDK does not offer.

## Runbook corrections

- **`fly secrets set` was wrong.** `fly.toml [env]` overrides a same-named secret, so those instructions would be silently shadowed once PageSpace-Deploy [#27](https://github.com/2witstudios/PageSpace-Deploy/pull/27) puts `DEV_PREVIEW_APEX` in `[env]`. Also records that `[env]` only lands on a `--config` deploy, so a green deploy is not evidence the variable took.
- **Production, not staging, is where the smoke runs.** Staging has no sandboxes, no realtime app and no proxy; prod already carries `CODE_EXECUTION_ENABLED=true`. The earlier "three staging decisions" were a dead end.
- **The e2e spec seeds a user**, so it needs a database you are willing to seed — the first pass should be the manual walkthrough.
- Records the sprite-edge token question and the two known gaps above.

## Verification

Mutation-checked red, each independently: dropping the retry, re-adding the blind `onFrame` cancel, dropping the `invalidateSnapshot` cancel, and removing the read bound.

lib sandbox 1311/1311 across 58 files · realtime 1266/1266 · `tsc --noEmit` clean on lib, web and realtime.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01P8A8KLYCoViP7ouH5QzbnB

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Development previews now retry temporarily blocked reconciliation attempts, with bounded retries and automatic cancellation when no longer needed.
  - Sandbox service reads now fail with a clear timeout error if the control plane does not respond within 15 seconds.

- **Documentation**
  - Updated preview environment guidance with configuration, routing, deployment, validation, token-exposure checks, production browser testing, and known operational gaps.
  - Removed the former staging-readiness checklist.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->