### PR TITLE
feat(android): wire Android secure storage into the platform-storage factory

### DIFF
--- a/apps/web/src/hooks/__tests__/useAuth.test.ts
+++ b/apps/web/src/hooks/__tests__/useAuth.test.ts
@@ -97,10 +97,23 @@ const {
 });
 
 // Mock dependencies with hoisted mocks
-const { mockClearNativeSession, mockGetStoredSession } = vi.hoisted(() => ({
+const { mockClearNativeSession, mockGetStoredSession, bridgeState } = vi.hoisted(() => ({
   mockClearNativeSession: vi.fn(async () => {}),
   mockGetStoredSession: vi.fn(async () => null),
+  bridgeState: { failsToLoad: false },
 }));
+
+// The capability lookup is a dynamic import inside logout's `finally`. A getter
+// that throws stands in for a chunk that will not load: the destructure at the
+// call site raises exactly as a rejected import would.
+vi.mock('@/lib/capacitor-bridge', () => ({
+  get hasNativeCapability() {
+    if (bridgeState.failsToLoad) throw new Error('Loading chunk failed');
+    return (capability: string) => capability === 'secureStore' && isNativeMock;
+  },
+}));
+
+let isNativeMock = false;
 
 // Logout has to clear the native secure store on every platform that has one.
 // Android writes to the same keychain under the same key as iOS, so this is
@@ -284,10 +297,7 @@ describe('useAuth', () => {
       // Regression: an iOS-only branch here left a revoked session in the
       // Android keychain for fetchWithAuth to keep presenting until a 401.
       mockPost.mockResolvedValue({ ok: true });
-      (window as Window & { Capacitor?: unknown }).Capacitor = {
-        isNativePlatform: () => true,
-        getPlatform: () => 'android',
-      };
+      isNativeMock = true;
 
       const { result } = renderHook(() => useAuth());
       await act(async () => {
@@ -295,7 +305,7 @@ describe('useAuth', () => {
       });
 
       expect(mockClearNativeSession).toHaveBeenCalled();
-      delete (window as Window & { Capacitor?: unknown }).Capacitor;
+      isNativeMock = false;
     });
 
     it('does not reach for a native store in a plain browser tab', async () => {
@@ -307,6 +317,25 @@ describe('useAuth', () => {
       });
 
       expect(mockClearNativeSession).not.toHaveBeenCalled();
+    });
+
+    it('finishes the logout even if the capability lookup cannot load', async () => {
+      // This runs in logout's `finally`, so anything escaping here skips the
+      // localStorage clear, the store reset and the redirect — stranding the
+      // user in a half-logged-out shell over a chunk that would not load.
+      mockPost.mockResolvedValue({ ok: true });
+      bridgeState.failsToLoad = true;
+      const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+      const { result } = renderHook(() => useAuth());
+      await act(async () => {
+        await result.current.actions.logout();
+      });
+
+      expect(mockLocalStorage.removeItem).toHaveBeenCalledWith('deviceToken');
+      expect(mockPush).toHaveBeenCalledWith('/auth/signin');
+      bridgeState.failsToLoad = false;
+      consoleError.mockRestore();
     });
 
     it('should clear deviceToken from localStorage', async () => {

--- a/apps/web/src/hooks/__tests__/useAuth.test.ts
+++ b/apps/web/src/hooks/__tests__/useAuth.test.ts
@@ -97,6 +97,22 @@ const {
 });
 
 // Mock dependencies with hoisted mocks
+const { mockClearNativeSession, mockGetStoredSession } = vi.hoisted(() => ({
+  mockClearNativeSession: vi.fn(async () => {}),
+  mockGetStoredSession: vi.fn(async () => null),
+}));
+
+// Logout has to clear the native secure store on every platform that has one.
+// Android writes to the same keychain under the same key as iOS, so this is
+// mocked at the platform-storage seam rather than at the iOS module.
+vi.mock('@/lib/auth/platform-storage', () => ({
+  getPlatformStorage: () => ({
+    platform: 'android' as const,
+    clearSession: mockClearNativeSession,
+    getStoredSession: mockGetStoredSession,
+  }),
+}));
+
 vi.mock('next/navigation', () => ({
   useRouter: () => ({
     push: mockPush,
@@ -262,6 +278,35 @@ describe('useAuth', () => {
       expect(mockAuthStore.endSession).toHaveBeenCalled();
       expect(mockPush).toHaveBeenCalledWith('/auth/signin');
       consoleError.mockRestore();
+    });
+
+    it('clears the native secure-storage session on a native shell', async () => {
+      // Regression: an iOS-only branch here left a revoked session in the
+      // Android keychain for fetchWithAuth to keep presenting until a 401.
+      mockPost.mockResolvedValue({ ok: true });
+      (window as Window & { Capacitor?: unknown }).Capacitor = {
+        isNativePlatform: () => true,
+        getPlatform: () => 'android',
+      };
+
+      const { result } = renderHook(() => useAuth());
+      await act(async () => {
+        await result.current.actions.logout();
+      });
+
+      expect(mockClearNativeSession).toHaveBeenCalled();
+      delete (window as Window & { Capacitor?: unknown }).Capacitor;
+    });
+
+    it('does not reach for a native store in a plain browser tab', async () => {
+      mockPost.mockResolvedValue({ ok: true });
+
+      const { result } = renderHook(() => useAuth());
+      await act(async () => {
+        await result.current.actions.logout();
+      });
+
+      expect(mockClearNativeSession).not.toHaveBeenCalled();
     });
 
     it('should clear deviceToken from localStorage', async () => {

--- a/apps/web/src/hooks/useAuth.ts
+++ b/apps/web/src/hooks/useAuth.ts
@@ -105,15 +105,22 @@ export function useAuth(): {
       // cover Android — which writes to the same `PageSpaceKeychain` under the
       // same key as iOS, so an iOS-only branch would leave a revoked session on
       // the device for `fetchWithAuth` to keep presenting until a 401.
+      //
+      // The capability lookup is inside the try, not before it: this runs in
+      // logout's `finally`, so anything that escapes here skips the rest of the
+      // cleanup — the localStorage token, the store reset, the redirect to
+      // sign-in. A dynamic import can reject on its own (a chunk that will not
+      // load), and no failure to *read* a capability is worth stranding a user
+      // in a half-logged-out shell.
       if (typeof window !== 'undefined') {
-        const { hasNativeCapability } = await import('@/lib/capacitor-bridge');
-        if (hasNativeCapability('secureStore')) {
-          try {
+        try {
+          const { hasNativeCapability } = await import('@/lib/capacitor-bridge');
+          if (hasNativeCapability('secureStore')) {
             const { getPlatformStorage } = await import('@/lib/auth/platform-storage');
             await getPlatformStorage().clearSession();
-          } catch (err) {
-            console.error('Failed to clear native secure-storage session', err);
           }
+        } catch (err) {
+          console.error('Failed to clear native secure-storage session', err);
         }
       }
 

--- a/apps/web/src/hooks/useAuth.ts
+++ b/apps/web/src/hooks/useAuth.ts
@@ -100,15 +100,19 @@ export function useAuth(): {
         clearSessionCache();
       }
 
-      // iOS: Clear session from Keychain
+      // Native shells: clear the secure-storage session through the platform
+      // adapter. Asking the capability, not the platform, is what makes this
+      // cover Android — which writes to the same `PageSpaceKeychain` under the
+      // same key as iOS, so an iOS-only branch would leave a revoked session on
+      // the device for `fetchWithAuth` to keep presenting until a 401.
       if (typeof window !== 'undefined') {
-        const { isCapacitorApp, getPlatform } = await import('@/lib/capacitor-bridge');
-        if (isCapacitorApp() && getPlatform() === 'ios') {
+        const { hasNativeCapability } = await import('@/lib/capacitor-bridge');
+        if (hasNativeCapability('secureStore')) {
           try {
-            const { clearStoredSession } = await import('@/lib/ios-google-auth');
-            await clearStoredSession();
+            const { getPlatformStorage } = await import('@/lib/auth/platform-storage');
+            await getPlatformStorage().clearSession();
           } catch (err) {
-            console.error('Failed to clear iOS Keychain session', err);
+            console.error('Failed to clear native secure-storage session', err);
           }
         }
       }

--- a/apps/web/src/lib/auth/platform-storage/__tests__/android-storage.test.ts
+++ b/apps/web/src/lib/auth/platform-storage/__tests__/android-storage.test.ts
@@ -72,6 +72,11 @@ describe('AndroidStorage', () => {
     keychainMock.get.mockReset();
     keychainMock.set.mockReset();
     keychainMock.remove.mockReset();
+    // The real plugin always resolves an object; default to an empty store so a
+    // test only has to say what it puts in the keychain, not that one exists.
+    keychainMock.get.mockResolvedValue({ value: null });
+    keychainMock.set.mockResolvedValue({ success: true });
+    keychainMock.remove.mockResolvedValue({ success: true });
     preferencesStore.clear();
     localStorage.clear();
     preferencesMock.get.mockClear();
@@ -133,6 +138,44 @@ describe('AndroidStorage', () => {
         key: 'pagespace_session',
         value: JSON.stringify(session),
       });
+    });
+
+    it('keeps a bearer-less refresh out of the keychain and in the legacy store', async () => {
+      // The device/refresh web branch — which is what an Android device
+      // registered by the in-WebView web flow gets — sets a session cookie and
+      // returns no sessionToken. Storing that shape would strand the device
+      // token in a blob getStoredSession rejects.
+      localStorage.setItem('deviceToken', 'old-device-token');
+      const storage = await importAndroidStorage();
+
+      await storage.storeSession({
+        sessionToken: '',
+        csrfToken: 'csrf',
+        deviceId: 'web_abc123',
+        deviceToken: 'rotated-device-token',
+      });
+
+      expect(keychainMock.set).not.toHaveBeenCalled();
+      // A rotated token must land somewhere, or the next refresh is a 401.
+      expect(localStorage.getItem('deviceToken')).toBe('rotated-device-token');
+      expect(localStorage.getItem('browser_device_id')).toBe('web_abc123');
+    });
+
+    it('still recovers the session after a bearer-less refresh', async () => {
+      localStorage.setItem('deviceToken', 'old-device-token');
+      keychainMock.get.mockResolvedValue({ value: null });
+      const storage = await importAndroidStorage();
+
+      await storage.storeSession({
+        sessionToken: '',
+        csrfToken: null,
+        deviceId: 'web_abc123',
+        deviceToken: 'rotated-device-token',
+      });
+
+      const recovered = await storage.getStoredSession();
+      expect(recovered?.deviceToken).toBe('rotated-device-token');
+      expect(await storage.getDeviceId()).toBe('web_abc123');
     });
 
     it('spends the legacy device token once the keychain holds the session', async () => {
@@ -371,6 +414,33 @@ describe('AndroidStorage', () => {
 
       expect(await storage.getDeviceId()).toBe('web_abc123');
       expect(preferencesStore.get('pagespace_device_id')).toBe('web_abc123');
+    });
+
+    it('reports the id the keychain session is bound to, not a legacy one', async () => {
+      // Both stores can hold a session at once — a keychain session plus a
+      // fresh in-WebView web sign-in. Sending the keychain's device token with
+      // the legacy id is read by the refresh route as a stolen token.
+      keychainMock.get.mockResolvedValue({
+        value: JSON.stringify({
+          sessionToken: 'session-token',
+          deviceId: 'native-device-id',
+          deviceToken: 'native-device-token',
+        }),
+      });
+      localStorage.setItem('deviceToken', 'legacy-device-token');
+      localStorage.setItem('browser_device_id', 'web_abc123');
+      const storage = await importAndroidStorage();
+
+      expect(await storage.getDeviceId()).toBe('native-device-id');
+      expect((await storage.getStoredSession())?.deviceToken).toBe('native-device-token');
+    });
+
+    it('falls back to preferences when the store cannot be read', async () => {
+      preferencesStore.set('pagespace_device_id', 'preferences-id');
+      keychainMock.get.mockRejectedValue(new Error(INIT_FAILURE));
+      const storage = await importAndroidStorage();
+
+      expect(await storage.getDeviceId()).toBe('preferences-id');
     });
 
     it('lets the live binding outrank an id already in preferences', async () => {

--- a/apps/web/src/lib/auth/platform-storage/__tests__/android-storage.test.ts
+++ b/apps/web/src/lib/auth/platform-storage/__tests__/android-storage.test.ts
@@ -135,6 +135,28 @@ describe('AndroidStorage', () => {
       });
     });
 
+    it('spends the legacy device token once the keychain holds the session', async () => {
+      // One-way migration: leaving it would keep the legacy fallback (and the
+      // legacy device-id branch) firing against a session that has moved.
+      localStorage.setItem('deviceToken', 'legacy-device-token');
+      keychainMock.set.mockResolvedValue({ success: true });
+      const storage = await importAndroidStorage();
+
+      await storage.storeSession(session);
+
+      expect(localStorage.getItem('deviceToken')).toBeNull();
+    });
+
+    it('keeps the legacy token when the keychain write fails', async () => {
+      localStorage.setItem('deviceToken', 'legacy-device-token');
+      keychainMock.set.mockRejectedValue(new Error(INIT_FAILURE));
+      const storage = await importAndroidStorage();
+
+      await expect(storage.storeSession(session)).rejects.toThrow(INIT_FAILURE);
+
+      expect(localStorage.getItem('deviceToken')).toBe('legacy-device-token');
+    });
+
     it('surfaces an EncryptedSharedPreferences init failure as an error', async () => {
       keychainMock.set.mockRejectedValue(new Error(INIT_FAILURE));
       const storage = await importAndroidStorage();
@@ -261,6 +283,21 @@ describe('AndroidStorage', () => {
       window.removeEventListener('auth:cleared', listener);
     });
 
+    it('clears the legacy device token too, so the fallback cannot resurrect it', async () => {
+      localStorage.setItem('deviceToken', 'legacy-device-token');
+      localStorage.setItem('browser_device_id', 'web_abc123');
+      keychainMock.remove.mockResolvedValue({ success: true });
+      keychainMock.get.mockResolvedValue({ value: null });
+      const storage = await importAndroidStorage();
+
+      await storage.clearSession();
+
+      expect(localStorage.getItem('deviceToken')).toBeNull();
+      expect(await storage.getStoredSession()).toBeNull();
+      // Logout ends a session, not the device's identity.
+      expect(localStorage.getItem('browser_device_id')).toBe('web_abc123');
+    });
+
     it('still completes the logout when the store rejects', async () => {
       keychainMock.remove.mockRejectedValue(new Error(INIT_FAILURE));
       vi.spyOn(console, 'error').mockImplementation(() => {});
@@ -307,14 +344,37 @@ describe('AndroidStorage', () => {
       expect(preferencesMock.set).toHaveBeenCalledTimes(1);
     });
 
-    it('adopts the id the web flow already registered for this device', async () => {
-      // Minting a fresh id beside a legacy device token bound to the old one
-      // would register a device the token does not match.
-      localStorage.setItem('browser_device_id', 'legacy-device-id');
+    it('adopts the id bound to a live legacy device token', async () => {
+      // /api/auth/device/refresh enforces strict binding — a deviceId that does
+      // not match the one the token was issued against is answered 401 as a
+      // stolen token. Every web sign-in path binds to browser_device_id.
+      localStorage.setItem('deviceToken', 'legacy-device-token');
+      localStorage.setItem('browser_device_id', 'web_abc123');
       const storage = await importAndroidStorage();
 
-      expect(await storage.getDeviceId()).toBe('legacy-device-id');
-      expect(preferencesStore.get('pagespace_device_id')).toBe('legacy-device-id');
+      expect(await storage.getDeviceId()).toBe('web_abc123');
+      expect(preferencesStore.get('pagespace_device_id')).toBe('web_abc123');
+    });
+
+    it('lets the live binding outrank an id already in preferences', async () => {
+      // A refresh attempt before sign-in mints a preferences id; reporting that
+      // one against a token bound to browser_device_id is the guaranteed 401.
+      preferencesStore.set('pagespace_device_id', 'minted-before-sign-in');
+      localStorage.setItem('deviceToken', 'legacy-device-token');
+      localStorage.setItem('browser_device_id', 'web_abc123');
+      const storage = await importAndroidStorage();
+
+      expect(await storage.getDeviceId()).toBe('web_abc123');
+      expect(preferencesStore.get('pagespace_device_id')).toBe('web_abc123');
+    });
+
+    it('ignores a legacy id with no live token behind it', async () => {
+      // No token means no binding to preserve, so the native store keeps the
+      // repo's own id format rather than inheriting a browser fingerprint.
+      localStorage.setItem('browser_device_id', 'web_abc123');
+      const storage = await importAndroidStorage();
+
+      expect(await storage.getDeviceId()).not.toBe('web_abc123');
     });
 
     it('gives concurrent callers one id and writes once', async () => {

--- a/apps/web/src/lib/auth/platform-storage/__tests__/android-storage.test.ts
+++ b/apps/web/src/lib/auth/platform-storage/__tests__/android-storage.test.ts
@@ -609,6 +609,17 @@ describe('AndroidStorage', () => {
       expect(await storage.getDeviceId()).toBe('preferences-id');
     });
 
+    it('never answers with an empty id when the legacy session names none', async () => {
+      // readLegacySession yields deviceId '' when a token was stored without an
+      // id; `??` would let that through where the contract says string | null.
+      preferencesStore.set('pagespace_device_id', 'preferences-id');
+      localStorage.setItem('deviceToken', 'legacy-device-token');
+      keychainMock.get.mockRejectedValue(new Error(INIT_FAILURE));
+      const storage = await importAndroidStorage();
+
+      expect(await storage.getDeviceId()).toBe('preferences-id');
+    });
+
     it('still reports the legacy binding when the keychain refuses', async () => {
       // A keystore that refuses is no reason to report the *wrong* id: the
       // legacy binding needs no bridge to read, and answering with the

--- a/apps/web/src/lib/auth/platform-storage/__tests__/android-storage.test.ts
+++ b/apps/web/src/lib/auth/platform-storage/__tests__/android-storage.test.ts
@@ -161,6 +161,59 @@ describe('AndroidStorage', () => {
       expect(localStorage.getItem('browser_device_id')).toBe('web_abc123');
     });
 
+    it('clears a keychain session the bearer-less refresh supersedes', async () => {
+      // getStoredSession reads the keychain first, so a stale blob left here
+      // would shadow the token just written to the legacy store.
+      keychainMock.get.mockResolvedValue({
+        value: JSON.stringify({
+          sessionToken: 'stale',
+          deviceId: 'web_abc123',
+          deviceToken: 'stale-device-token',
+        }),
+      });
+      const storage = await importAndroidStorage();
+
+      await storage.storeSession({
+        sessionToken: '',
+        csrfToken: null,
+        deviceId: 'web_abc123',
+        deviceToken: 'rotated-device-token',
+      });
+
+      expect(keychainMock.remove).toHaveBeenCalledWith({ key: 'pagespace_session' });
+    });
+
+    it('does not overwrite a browser device id that already exists', async () => {
+      // browser_device_id belongs to getOrCreateDeviceId and is what every web
+      // sign-in binds its token to; overwriting it would make a divergence
+      // permanent rather than record a missing identity.
+      localStorage.setItem('deviceToken', 'legacy-device-token');
+      localStorage.setItem('browser_device_id', 'web_abc123');
+      const storage = await importAndroidStorage();
+
+      await storage.storeSession({
+        sessionToken: '',
+        csrfToken: null,
+        deviceId: 'a-minted-cuid',
+        deviceToken: 'rotated-device-token',
+      });
+
+      expect(localStorage.getItem('browser_device_id')).toBe('web_abc123');
+    });
+
+    it('throws rather than reporting success with nothing to store', async () => {
+      const storage = await importAndroidStorage();
+
+      await expect(
+        storage.storeSession({
+          sessionToken: '',
+          csrfToken: null,
+          deviceId: 'web_abc123',
+          deviceToken: null,
+        })
+      ).rejects.toThrow(/neither a bearer token nor a device token/);
+    });
+
     it('still recovers the session after a bearer-less refresh', async () => {
       localStorage.setItem('deviceToken', 'old-device-token');
       keychainMock.get.mockResolvedValue({ value: null });
@@ -176,6 +229,28 @@ describe('AndroidStorage', () => {
       const recovered = await storage.getStoredSession();
       expect(recovered?.deviceToken).toBe('rotated-device-token');
       expect(await storage.getDeviceId()).toBe('web_abc123');
+    });
+
+    it('surfaces a failure to persist a rotated device token', async () => {
+      // The legacy store is the only home for it; swallowing the failure leaves
+      // the next refresh holding a token the server has rotated away.
+      const setItem = vi
+        .spyOn(Storage.prototype, 'setItem')
+        .mockImplementation(() => {
+          throw new Error('QuotaExceededError');
+        });
+      const storage = await importAndroidStorage();
+
+      await expect(
+        storage.storeSession({
+          sessionToken: '',
+          csrfToken: null,
+          deviceId: 'web_abc123',
+          deviceToken: 'rotated-device-token',
+        })
+      ).rejects.toThrow('QuotaExceededError');
+
+      setItem.mockRestore();
     });
 
     it('spends the legacy device token once the keychain holds the session', async () => {
@@ -450,12 +525,41 @@ describe('AndroidStorage', () => {
       vi.useRealTimers();
     });
 
-    it('falls back to preferences when the store cannot be read', async () => {
+    it('falls back to preferences when no store names a binding', async () => {
       preferencesStore.set('pagespace_device_id', 'preferences-id');
       keychainMock.get.mockRejectedValue(new Error(INIT_FAILURE));
       const storage = await importAndroidStorage();
 
       expect(await storage.getDeviceId()).toBe('preferences-id');
+    });
+
+    it('still reports the legacy binding when the keychain refuses', async () => {
+      // A keystore that refuses is no reason to report the *wrong* id: the
+      // legacy binding needs no bridge to read, and answering with the
+      // preferences id instead is the mismatch the refresh route rejects as a
+      // stolen token.
+      preferencesStore.set('pagespace_device_id', 'preferences-id');
+      localStorage.setItem('deviceToken', 'legacy-device-token');
+      localStorage.setItem('browser_device_id', 'web_abc123');
+      keychainMock.get.mockRejectedValue(new Error(INIT_FAILURE));
+      const storage = await importAndroidStorage();
+
+      expect(await storage.getDeviceId()).toBe('web_abc123');
+    });
+
+    it('still reports the legacy binding when the keychain hangs', async () => {
+      vi.useFakeTimers();
+      preferencesStore.set('pagespace_device_id', 'preferences-id');
+      localStorage.setItem('deviceToken', 'legacy-device-token');
+      localStorage.setItem('browser_device_id', 'web_abc123');
+      keychainMock.get.mockReturnValue(new Promise(() => {}));
+      const storage = await importAndroidStorage();
+
+      const pending = storage.getDeviceId();
+      await vi.advanceTimersByTimeAsync(3000);
+
+      expect(await pending).toBe('web_abc123');
+      vi.useRealTimers();
     });
 
     it('lets the live binding outrank an id already in preferences', async () => {

--- a/apps/web/src/lib/auth/platform-storage/__tests__/android-storage.test.ts
+++ b/apps/web/src/lib/auth/platform-storage/__tests__/android-storage.test.ts
@@ -487,6 +487,28 @@ describe('AndroidStorage', () => {
       expect(localStorage.getItem('browser_device_id')).toBe('web_abc123');
     });
 
+    it('forgets the revoked session id, so a later sign-in is not shadowed', async () => {
+      keychainMock.get.mockResolvedValueOnce({
+        value: JSON.stringify({
+          sessionToken: 'session-token',
+          deviceId: 'native-device-id',
+          deviceToken: 'native-device-token',
+        }),
+      });
+      const storage = await importAndroidStorage();
+      await storage.getStoredSession();
+
+      await storage.clearSession();
+
+      // A fresh web sign-in, then a keystore that refuses: the answer must come
+      // from the new binding, not the session logout just revoked.
+      localStorage.setItem('deviceToken', 'new-device-token');
+      localStorage.setItem('browser_device_id', 'web_abc123');
+      keychainMock.get.mockRejectedValue(new Error(INIT_FAILURE));
+
+      expect(await storage.getDeviceId()).toBe('web_abc123');
+    });
+
     it('still completes the logout when the store rejects', async () => {
       keychainMock.remove.mockRejectedValue(new Error(INIT_FAILURE));
       vi.spyOn(console, 'error').mockImplementation(() => {});

--- a/apps/web/src/lib/auth/platform-storage/__tests__/android-storage.test.ts
+++ b/apps/web/src/lib/auth/platform-storage/__tests__/android-storage.test.ts
@@ -390,6 +390,20 @@ describe('AndroidStorage', () => {
       expect(preferencesMock.set).toHaveBeenCalledTimes(1);
     });
 
+    it('sees a binding established after an earlier call', async () => {
+      // The instance is a module-level singleton and a passkey sign-in happens
+      // in-page, so memoizing the first answer would report a minted id against
+      // a token bound to browser_device_id until the next reload.
+      const storage = await importAndroidStorage();
+      const minted = await storage.getDeviceId();
+
+      localStorage.setItem('deviceToken', 'legacy-device-token');
+      localStorage.setItem('browser_device_id', 'web_abc123');
+
+      expect(await storage.getDeviceId()).toBe('web_abc123');
+      expect(minted).not.toBe('web_abc123');
+    });
+
     it('does not cache a failed resolution', async () => {
       preferencesMock.get.mockRejectedValueOnce(new Error('preferences unavailable'));
       const storage = await importAndroidStorage();

--- a/apps/web/src/lib/auth/platform-storage/__tests__/android-storage.test.ts
+++ b/apps/web/src/lib/auth/platform-storage/__tests__/android-storage.test.ts
@@ -211,6 +211,32 @@ describe('AndroidStorage', () => {
       setItem.mockRestore();
     });
 
+    it('does not fail a landed token write because the id write could not', async () => {
+      // Reporting failure for a refresh that actually persisted sends the
+      // caller back into the rate limiter for nothing.
+      const real = Storage.prototype.setItem;
+      const setItem = vi
+        .spyOn(Storage.prototype, 'setItem')
+        .mockImplementation(function (this: Storage, key: string, value: string) {
+          if (key === 'browser_device_id') throw new Error('QuotaExceededError');
+          real.call(this, key, value);
+        });
+      vi.spyOn(console, 'error').mockImplementation(() => {});
+      const storage = await importAndroidStorage();
+
+      await expect(
+        storage.storeSession({
+          sessionToken: '',
+          csrfToken: null,
+          deviceId: 'web_abc123',
+          deviceToken: 'rotated-device-token',
+        })
+      ).resolves.toBeUndefined();
+
+      expect(localStorage.getItem('deviceToken')).toBe('rotated-device-token');
+      setItem.mockRestore();
+    });
+
     it('does not overwrite a browser device id that already exists', async () => {
       // browser_device_id belongs to getOrCreateDeviceId and is what every web
       // sign-in binds its token to; overwriting it would make a divergence
@@ -573,6 +599,48 @@ describe('AndroidStorage', () => {
       const storage = await importAndroidStorage();
 
       expect(await storage.getDeviceId()).toBe('web_abc123');
+    });
+
+    it('answers a timed-out read the way the successful one did', async () => {
+      // refreshBearerSession reads the session, then asks for the id through a
+      // second bridge call on the same budget. If the first lands and the
+      // second times out, answering from the legacy store pairs the keychain's
+      // token with the legacy id — read as a stolen token, 401, and
+      // clearSession then destroys both credentials over a slow keystore.
+      vi.useFakeTimers();
+      localStorage.setItem('deviceToken', 'legacy-device-token');
+      localStorage.setItem('browser_device_id', 'web_abc123');
+      keychainMock.get.mockResolvedValueOnce({
+        value: JSON.stringify({
+          sessionToken: 'session-token',
+          deviceId: 'native-device-id',
+          deviceToken: 'native-device-token',
+        }),
+      });
+      const storage = await importAndroidStorage();
+
+      // Read 1 — the one auth-fetch makes for itself — succeeds.
+      expect((await storage.getStoredSession())?.deviceId).toBe('native-device-id');
+
+      // Read 2, inside getDeviceInfo, hangs.
+      keychainMock.get.mockReturnValue(new Promise(() => {}));
+      const pending = storage.getDeviceId();
+      await vi.advanceTimersByTimeAsync(3000);
+
+      expect(await pending).toBe('native-device-id');
+      vi.useRealTimers();
+    });
+
+    it('publishes a minted id where the server binding will look for it', async () => {
+      // A live token with no id recorded: minting only into preferences would
+      // leave the native and web identities permanently divergent, where
+      // WebStorage mints straight into browser_device_id.
+      localStorage.setItem('deviceToken', 'legacy-device-token');
+      const storage = await importAndroidStorage();
+
+      const id = await storage.getDeviceId();
+
+      expect(localStorage.getItem('browser_device_id')).toBe(id);
     });
 
     it('still reports the legacy binding when the keychain hangs', async () => {

--- a/apps/web/src/lib/auth/platform-storage/__tests__/android-storage.test.ts
+++ b/apps/web/src/lib/auth/platform-storage/__tests__/android-storage.test.ts
@@ -73,6 +73,7 @@ describe('AndroidStorage', () => {
     keychainMock.set.mockReset();
     keychainMock.remove.mockReset();
     preferencesStore.clear();
+    localStorage.clear();
     preferencesMock.get.mockClear();
     preferencesMock.set.mockClear();
     setPlatform('android');
@@ -177,11 +178,56 @@ describe('AndroidStorage', () => {
       expect(await storage.getStoredSession()).toBeNull();
     });
 
+    it('returns null when an optional field is the wrong shape', async () => {
+      keychainMock.get.mockResolvedValue({
+        value: JSON.stringify({
+          sessionToken: 'session-token',
+          deviceId: 'device-1',
+          deviceToken: 42,
+        }),
+      });
+      const storage = await importAndroidStorage();
+
+      expect(await storage.getStoredSession()).toBeNull();
+    });
+
     it('returns null for a corrupt payload', async () => {
       keychainMock.get.mockResolvedValue({ value: 'not json' });
       const storage = await importAndroidStorage();
 
       expect(await storage.getStoredSession()).toBeNull();
+    });
+
+    it('falls back to the device token the web sign-in flow left behind', async () => {
+      // Until native sign-in lands, Android signs in through the web flow,
+      // which writes only localStorage (useAuth.ts, PasskeyLoginButton.tsx).
+      // Ignoring it would strand a valid token and force a re-auth on the
+      // first cookie expiry.
+      localStorage.setItem('deviceToken', 'legacy-device-token');
+      localStorage.setItem('browser_device_id', 'legacy-device-id');
+      keychainMock.get.mockResolvedValue({ value: null });
+      const storage = await importAndroidStorage();
+
+      expect(await storage.getStoredSession()).toEqual({
+        sessionToken: '',
+        csrfToken: null,
+        deviceId: 'legacy-device-id',
+        deviceToken: 'legacy-device-token',
+      });
+    });
+
+    it('prefers the keychain session over the legacy one', async () => {
+      localStorage.setItem('deviceToken', 'legacy-device-token');
+      keychainMock.get.mockResolvedValue({
+        value: JSON.stringify({
+          sessionToken: 'session-token',
+          deviceId: 'device-1',
+          deviceToken: 'native-device-token',
+        }),
+      });
+      const storage = await importAndroidStorage();
+
+      expect((await storage.getStoredSession())?.deviceToken).toBe('native-device-token');
     });
 
     it('throws rather than reporting "no session" when the store is broken', async () => {
@@ -259,6 +305,38 @@ describe('AndroidStorage', () => {
 
       expect(iosId).toBe(androidId);
       expect(preferencesMock.set).toHaveBeenCalledTimes(1);
+    });
+
+    it('adopts the id the web flow already registered for this device', async () => {
+      // Minting a fresh id beside a legacy device token bound to the old one
+      // would register a device the token does not match.
+      localStorage.setItem('browser_device_id', 'legacy-device-id');
+      const storage = await importAndroidStorage();
+
+      expect(await storage.getDeviceId()).toBe('legacy-device-id');
+      expect(preferencesStore.get('pagespace_device_id')).toBe('legacy-device-id');
+    });
+
+    it('gives concurrent callers one id and writes once', async () => {
+      const storage = await importAndroidStorage();
+
+      const ids = await Promise.all([
+        storage.getDeviceId(),
+        storage.getDeviceId(),
+        storage.getDeviceId(),
+      ]);
+
+      expect(new Set(ids).size).toBe(1);
+      expect(preferencesMock.set).toHaveBeenCalledTimes(1);
+    });
+
+    it('does not cache a failed resolution', async () => {
+      preferencesMock.get.mockRejectedValueOnce(new Error('preferences unavailable'));
+      const storage = await importAndroidStorage();
+
+      await expect(storage.getDeviceId()).rejects.toThrow('preferences unavailable');
+
+      expect(await storage.getDeviceId()).toBe(preferencesStore.get('pagespace_device_id'));
     });
 
     it('reports the device id through getDeviceInfo', async () => {

--- a/apps/web/src/lib/auth/platform-storage/__tests__/android-storage.test.ts
+++ b/apps/web/src/lib/auth/platform-storage/__tests__/android-storage.test.ts
@@ -238,6 +238,15 @@ describe('AndroidStorage', () => {
       });
     });
 
+    it('falls back to the legacy session when the stored bytes are unusable', async () => {
+      // One rule for every kind of emptiness: absent, unparseable, wrong shape.
+      localStorage.setItem('deviceToken', 'legacy-device-token');
+      keychainMock.get.mockResolvedValue({ value: 'not json' });
+      const storage = await importAndroidStorage();
+
+      expect((await storage.getStoredSession())?.deviceToken).toBe('legacy-device-token');
+    });
+
     it('prefers the keychain session over the legacy one', async () => {
       localStorage.setItem('deviceToken', 'legacy-device-token');
       keychainMock.get.mockResolvedValue({
@@ -257,6 +266,14 @@ describe('AndroidStorage', () => {
       const storage = await importAndroidStorage();
 
       await expect(storage.getStoredSession()).rejects.toThrow(INIT_FAILURE);
+    });
+
+    it('reports no bearer token for a legacy cookie session', async () => {
+      localStorage.setItem('deviceToken', 'legacy-device-token');
+      keychainMock.get.mockResolvedValue({ value: null });
+      const storage = await importAndroidStorage();
+
+      expect(await storage.getSessionToken()).toBeNull();
     });
 
     it('returns just the token from getSessionToken', async () => {

--- a/apps/web/src/lib/auth/platform-storage/__tests__/android-storage.test.ts
+++ b/apps/web/src/lib/auth/platform-storage/__tests__/android-storage.test.ts
@@ -435,6 +435,21 @@ describe('AndroidStorage', () => {
       expect((await storage.getStoredSession())?.deviceToken).toBe('native-device-token');
     });
 
+    it('does not hang on a keychain read that never settles', async () => {
+      // getDeviceInfo sits inside refreshBearerSession with no timeout of its
+      // own, so a hung native call would leave the refresh pending forever.
+      vi.useFakeTimers();
+      preferencesStore.set('pagespace_device_id', 'preferences-id');
+      keychainMock.get.mockReturnValue(new Promise(() => {}));
+      const storage = await importAndroidStorage();
+
+      const pending = storage.getDeviceId();
+      await vi.advanceTimersByTimeAsync(3000);
+
+      expect(await pending).toBe('preferences-id');
+      vi.useRealTimers();
+    });
+
     it('falls back to preferences when the store cannot be read', async () => {
       preferencesStore.set('pagespace_device_id', 'preferences-id');
       keychainMock.get.mockRejectedValue(new Error(INIT_FAILURE));

--- a/apps/web/src/lib/auth/platform-storage/__tests__/android-storage.test.ts
+++ b/apps/web/src/lib/auth/platform-storage/__tests__/android-storage.test.ts
@@ -183,6 +183,34 @@ describe('AndroidStorage', () => {
       expect(keychainMock.remove).toHaveBeenCalledWith({ key: 'pagespace_session' });
     });
 
+    it('keeps the superseded session when the legacy write fails', async () => {
+      // Clearing first would destroy the old token to make room for one that
+      // never landed. A stale session the next refresh corrects beats none.
+      keychainMock.get.mockResolvedValue({
+        value: JSON.stringify({
+          sessionToken: 'stale',
+          deviceId: 'web_abc123',
+          deviceToken: 'stale-device-token',
+        }),
+      });
+      const setItem = vi.spyOn(Storage.prototype, 'setItem').mockImplementation(() => {
+        throw new Error('QuotaExceededError');
+      });
+      const storage = await importAndroidStorage();
+
+      await expect(
+        storage.storeSession({
+          sessionToken: '',
+          csrfToken: null,
+          deviceId: 'web_abc123',
+          deviceToken: 'rotated-device-token',
+        })
+      ).rejects.toThrow('QuotaExceededError');
+
+      expect(keychainMock.remove).not.toHaveBeenCalled();
+      setItem.mockRestore();
+    });
+
     it('does not overwrite a browser device id that already exists', async () => {
       // browser_device_id belongs to getOrCreateDeviceId and is what every web
       // sign-in binds its token to; overwriting it would make a divergence

--- a/apps/web/src/lib/auth/platform-storage/__tests__/android-storage.test.ts
+++ b/apps/web/src/lib/auth/platform-storage/__tests__/android-storage.test.ts
@@ -405,6 +405,21 @@ describe('AndroidStorage', () => {
       expect((await storage.getStoredSession())?.deviceToken).toBe('legacy-device-token');
     });
 
+    it('returns null when csrfToken is the wrong shape', async () => {
+      // Both wrong-shape tests used deviceToken, so dropping the csrfToken half
+      // of the guard passed everything.
+      keychainMock.get.mockResolvedValue({
+        value: JSON.stringify({
+          sessionToken: 'session-token',
+          deviceId: 'device-1',
+          csrfToken: {},
+        }),
+      });
+      const storage = await importAndroidStorage();
+
+      expect(await storage.getStoredSession()).toBeNull();
+    });
+
     it('falls back to the legacy session when an optional field is the wrong shape', async () => {
       localStorage.setItem('deviceToken', 'legacy-device-token');
       keychainMock.get.mockResolvedValue({
@@ -875,6 +890,36 @@ describe('AndroidStorage', () => {
 
       expect(await storage.getDeviceId()).toBe('web_abc123');
       expect(minted).not.toBe('web_abc123');
+    });
+
+    it('rejects rather than minting when the preferences bridge hangs', async () => {
+      // getDeviceInfo is awaited by refreshBearerSession with no timeout, so a
+      // bridge call that never settles would leave the refresh — and every
+      // request queued behind it — pending forever. Minting instead would hand
+      // the server an id the live token is not bound to.
+      vi.useFakeTimers();
+      preferencesMock.get.mockReturnValue(new Promise(() => {}));
+      const storage = await importAndroidStorage();
+
+      const pending = storage.getDeviceId();
+      const assertion = expect(pending).rejects.toThrow(/timed out/);
+      await vi.advanceTimersByTimeAsync(3000);
+      await assertion;
+
+      expect(preferencesMock.set).not.toHaveBeenCalled();
+    });
+
+    it('does not persist a device id when the preferences write hangs', async () => {
+      vi.useFakeTimers();
+      preferencesMock.set.mockReturnValue(new Promise(() => {}));
+      const storage = await importAndroidStorage();
+
+      const pending = storage.getDeviceId();
+      const assertion = expect(pending).rejects.toThrow(/timed out/);
+      await vi.advanceTimersByTimeAsync(3000);
+      await assertion;
+
+      expect(preferencesStore.get('pagespace_device_id')).toBeUndefined();
     });
 
     it('does not cache a failed resolution', async () => {

--- a/apps/web/src/lib/auth/platform-storage/__tests__/android-storage.test.ts
+++ b/apps/web/src/lib/auth/platform-storage/__tests__/android-storage.test.ts
@@ -678,6 +678,39 @@ describe('AndroidStorage', () => {
       expect(await storage.getDeviceId()).toBe('web_abc123');
     });
 
+    it('remembers the binding in force, not the one it declined to write', async () => {
+      // The bearer-less branch leaves an existing browser_device_id alone, so
+      // the session's own deviceId is not necessarily what ends up binding.
+      localStorage.setItem('browser_device_id', 'web_abc123');
+      const storage = await importAndroidStorage();
+
+      await storage.storeSession({
+        sessionToken: '',
+        csrfToken: null,
+        deviceId: 'a-minted-cuid',
+        deviceToken: 'rotated-device-token',
+      });
+
+      keychainMock.get.mockRejectedValue(new Error(INIT_FAILURE));
+      expect(await storage.getDeviceId()).toBe('web_abc123');
+    });
+
+    it('does not publish a minted id on the strength of a read that never answered', async () => {
+      // Rewriting the browser's identity to a CUID2 no server token is bound to
+      // needs better evidence than a keychain call that hung.
+      vi.useFakeTimers();
+      localStorage.setItem('deviceToken', 'legacy-device-token');
+      keychainMock.get.mockReturnValue(new Promise(() => {}));
+      const storage = await importAndroidStorage();
+
+      const pending = storage.getDeviceId();
+      await vi.advanceTimersByTimeAsync(3000);
+      await pending;
+
+      expect(localStorage.getItem('browser_device_id')).toBeNull();
+      vi.useRealTimers();
+    });
+
     it('publishes a minted id where the server binding will look for it', async () => {
       // A live token with no id recorded: minting only into preferences would
       // leave the native and web identities permanently divergent, where

--- a/apps/web/src/lib/auth/platform-storage/__tests__/android-storage.test.ts
+++ b/apps/web/src/lib/auth/platform-storage/__tests__/android-storage.test.ts
@@ -631,6 +631,31 @@ describe('AndroidStorage', () => {
       vi.useRealTimers();
     });
 
+    it('takes the id from a write that supersedes what a read last saw', async () => {
+      // The bearer-less branch removes the keychain session a read had just
+      // recorded; without updating the record, a later failed read would answer
+      // with an id belonging to a session that no longer exists.
+      keychainMock.get.mockResolvedValueOnce({
+        value: JSON.stringify({
+          sessionToken: 'session-token',
+          deviceId: 'native-device-id',
+          deviceToken: 'native-device-token',
+        }),
+      });
+      const storage = await importAndroidStorage();
+      await storage.getStoredSession();
+
+      await storage.storeSession({
+        sessionToken: '',
+        csrfToken: null,
+        deviceId: 'web_abc123',
+        deviceToken: 'rotated-device-token',
+      });
+
+      keychainMock.get.mockRejectedValue(new Error(INIT_FAILURE));
+      expect(await storage.getDeviceId()).toBe('web_abc123');
+    });
+
     it('publishes a minted id where the server binding will look for it', async () => {
       // A live token with no id recorded: minting only into preferences would
       // leave the native and web identities permanently divergent, where

--- a/apps/web/src/lib/auth/platform-storage/__tests__/android-storage.test.ts
+++ b/apps/web/src/lib/auth/platform-storage/__tests__/android-storage.test.ts
@@ -681,8 +681,18 @@ describe('AndroidStorage', () => {
     it('remembers the binding in force, not the one it declined to write', async () => {
       // The bearer-less branch leaves an existing browser_device_id alone, so
       // the session's own deviceId is not necessarily what ends up binding.
+      // A prior read seeds the record with a different id, so this fails both
+      // when the branch records the wrong value and when it records nothing.
+      keychainMock.get.mockResolvedValueOnce({
+        value: JSON.stringify({
+          sessionToken: 'session-token',
+          deviceId: 'native-device-id',
+          deviceToken: 'native-device-token',
+        }),
+      });
       localStorage.setItem('browser_device_id', 'web_abc123');
       const storage = await importAndroidStorage();
+      await storage.getStoredSession();
 
       await storage.storeSession({
         sessionToken: '',

--- a/apps/web/src/lib/auth/platform-storage/__tests__/android-storage.test.ts
+++ b/apps/web/src/lib/auth/platform-storage/__tests__/android-storage.test.ts
@@ -1,7 +1,7 @@
 /**
  * Android secure storage tests.
  *
- * Covers the four requirements of the Android storage wiring leaf:
+ * The leaf's four requirements:
  * - the factory resolves AndroidStorage on Android instead of WebStorage
  * - AndroidStorage drives the existing `PageSpaceKeychain` binding rather than
  *   a second registered plugin name
@@ -10,6 +10,20 @@
  *   instead of a silent no-op
  * - the device id round-trips through `@capacitor/preferences` under the exact
  *   key iOS uses, asserted by driving both implementations against one store
+ *
+ * Most of the file is the three contracts review found underneath those, each
+ * of which had a forced sign-out behind it:
+ * - **The legacy migration.** Until Phase B, Android signs in through the web
+ *   flow, which leaves its device token in `localStorage`. Every "the keychain
+ *   holds nothing usable" path answers with that session, and a successful
+ *   keychain write spends it.
+ * - **The bearer-less write.** `/api/auth/device/refresh` returns no
+ *   `sessionToken` for a device record stored as `platform: 'web'`, so such a
+ *   session goes to the legacy store — rotated token included — instead of
+ *   into a keychain blob the reader would reject.
+ * - **Device-id binding.** The refresh route answers a mismatched
+ *   (deviceToken, deviceId) pair 401 as a stolen token, so the id follows the
+ *   session in force, with a fallback chain for when a read fails or hangs.
  */
 
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
@@ -87,6 +101,12 @@ describe('AndroidStorage', () => {
   afterEach(() => {
     setPlatform(null);
     vi.restoreAllMocks();
+    // `restoreAllMocks` restores spies but not timers. Four tests here run on
+    // fake timers and clear them inline; if the assertion above that line
+    // fails, the restore never runs and every later test executes with a clock
+    // that does not advance — one real failure arriving as a wall of unrelated
+    // ones. Unconditional here, so a failure stays legible.
+    vi.useRealTimers();
   });
 
   describe('platform-storage factory', () => {
@@ -372,6 +392,33 @@ describe('AndroidStorage', () => {
       expect(await storage.getStoredSession()).toBeNull();
     });
 
+    it('falls back to the legacy session when the payload lacks a session token', async () => {
+      // The same "keychain holds nothing usable" rule as the unparseable case.
+      // Without it, a blob left behind by a swallowed keychain remove shadows a
+      // perfectly good legacy token — the round-2 forced sign-out.
+      localStorage.setItem('deviceToken', 'legacy-device-token');
+      keychainMock.get.mockResolvedValue({
+        value: JSON.stringify({ deviceId: 'device-1' }),
+      });
+      const storage = await importAndroidStorage();
+
+      expect((await storage.getStoredSession())?.deviceToken).toBe('legacy-device-token');
+    });
+
+    it('falls back to the legacy session when an optional field is the wrong shape', async () => {
+      localStorage.setItem('deviceToken', 'legacy-device-token');
+      keychainMock.get.mockResolvedValue({
+        value: JSON.stringify({
+          sessionToken: 'session-token',
+          deviceId: 'device-1',
+          deviceToken: 42,
+        }),
+      });
+      const storage = await importAndroidStorage();
+
+      expect((await storage.getStoredSession())?.deviceToken).toBe('legacy-device-token');
+    });
+
     it('returns null when an optional field is the wrong shape', async () => {
       keychainMock.get.mockResolvedValue({
         value: JSON.stringify({
@@ -509,6 +556,19 @@ describe('AndroidStorage', () => {
       expect(await storage.getDeviceId()).toBe('web_abc123');
     });
 
+    it('dispatches auth:refreshed when the refresh path asks it to', async () => {
+      // auth-fetch calls dispatchAuthEvent('auth:refreshed') after a successful
+      // bearer refresh; only 'auth:cleared' was ever exercised here.
+      const storage = await importAndroidStorage();
+      const listener = vi.fn();
+      window.addEventListener('auth:refreshed', listener);
+
+      storage.dispatchAuthEvent('auth:refreshed');
+
+      expect(listener).toHaveBeenCalled();
+      window.removeEventListener('auth:refreshed', listener);
+    });
+
     it('still completes the logout when the store rejects', async () => {
       keychainMock.remove.mockRejectedValue(new Error(INIT_FAILURE));
       vi.spyOn(console, 'error').mockImplementation(() => {});
@@ -609,9 +669,11 @@ describe('AndroidStorage', () => {
       expect(await storage.getDeviceId()).toBe('preferences-id');
     });
 
-    it('never answers with an empty id when the legacy session names none', async () => {
+    it('falls through to preferences when the legacy session names no id', async () => {
       // readLegacySession yields deviceId '' when a token was stored without an
-      // id; `??` would let that through where the contract says string | null.
+      // id. The `|| null` guard that keeps '' out of `boundDeviceId`'s return is
+      // NOT observable here — the caller tests truthiness, so '' and null behave
+      // alike — this pins the fall-through that is.
       preferencesStore.set('pagespace_device_id', 'preferences-id');
       localStorage.setItem('deviceToken', 'legacy-device-token');
       keychainMock.get.mockRejectedValue(new Error(INIT_FAILURE));
@@ -741,6 +803,7 @@ describe('AndroidStorage', () => {
 
       const id = await storage.getDeviceId();
 
+      expect(id).toMatch(/^[a-z][a-z0-9]+$/);
       expect(localStorage.getItem('browser_device_id')).toBe(id);
     });
 
@@ -777,7 +840,11 @@ describe('AndroidStorage', () => {
       localStorage.setItem('browser_device_id', 'web_abc123');
       const storage = await importAndroidStorage();
 
-      expect(await storage.getDeviceId()).not.toBe('web_abc123');
+      const id = await storage.getDeviceId();
+
+      expect(id).toMatch(/^[a-z][a-z0-9]+$/);
+      expect(id).not.toBe('web_abc123');
+      expect(preferencesStore.get('pagespace_device_id')).toBe(id);
     });
 
     it('gives concurrent callers one id and writes once', async () => {
@@ -816,11 +883,22 @@ describe('AndroidStorage', () => {
       expect(await storage.getDeviceId()).toBe(preferencesStore.get('pagespace_device_id'));
     });
 
+    it('reads the legacy id from the backwards-compatible alias key', async () => {
+      // `deviceId` is the older key `WebStorage.getDeviceId` still reads, so a
+      // device that predates `browser_device_id` keeps its binding.
+      localStorage.setItem('deviceToken', 'legacy-device-token');
+      localStorage.setItem('deviceId', 'web_legacy_alias');
+      const storage = await importAndroidStorage();
+
+      expect(await storage.getDeviceId()).toBe('web_legacy_alias');
+    });
+
     it('reports the device id through getDeviceInfo', async () => {
       const storage = await importAndroidStorage();
 
       const info = await storage.getDeviceInfo();
 
+      expect(info.deviceId).toMatch(/^[a-z][a-z0-9]+$/);
       expect(info.deviceId).toBe(preferencesStore.get('pagespace_device_id'));
       expect(info.userAgent).toBe(navigator.userAgent);
     });

--- a/apps/web/src/lib/auth/platform-storage/__tests__/android-storage.test.ts
+++ b/apps/web/src/lib/auth/platform-storage/__tests__/android-storage.test.ts
@@ -558,7 +558,10 @@ describe('AndroidStorage', () => {
 
     it('dispatches auth:refreshed when the refresh path asks it to', async () => {
       // auth-fetch calls dispatchAuthEvent('auth:refreshed') after a successful
-      // bearer refresh; only 'auth:cleared' was ever exercised here.
+      // bearer refresh, and every auth-fetch suite stubs that seam, so nothing
+      // asserted this argument anywhere. This covers the dispatcher only — the
+      // caller side stays uncovered, unlike 'auth:cleared', which is driven
+      // through clearSession() above.
       const storage = await importAndroidStorage();
       const listener = vi.fn();
       window.addEventListener('auth:refreshed', listener);
@@ -880,7 +883,11 @@ describe('AndroidStorage', () => {
 
       await expect(storage.getDeviceId()).rejects.toThrow('preferences unavailable');
 
-      expect(await storage.getDeviceId()).toBe(preferencesStore.get('pagespace_device_id'));
+      // Both sides would be `undefined` if the retry minted nothing, so the
+      // shape check has to run first or this passes on the failure it guards.
+      const id = await storage.getDeviceId();
+      expect(id).toMatch(/^[a-z][a-z0-9]+$/);
+      expect(preferencesStore.get('pagespace_device_id')).toBe(id);
     });
 
     it('reads the legacy id from the backwards-compatible alias key', async () => {

--- a/apps/web/src/lib/auth/platform-storage/__tests__/android-storage.test.ts
+++ b/apps/web/src/lib/auth/platform-storage/__tests__/android-storage.test.ts
@@ -1,0 +1,273 @@
+/**
+ * Android secure storage tests.
+ *
+ * Covers the four requirements of the Android storage wiring leaf:
+ * - the factory resolves AndroidStorage on Android instead of WebStorage
+ * - AndroidStorage drives the existing `PageSpaceKeychain` binding rather than
+ *   a second registered plugin name
+ * - a plugin rejection (what the Java plugin does when
+ *   EncryptedSharedPreferences failed to initialize) surfaces as an error
+ *   instead of a silent no-op
+ * - the device id round-trips through `@capacitor/preferences` under the exact
+ *   key iOS uses, asserted by driving both implementations against one store
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+
+const keychainMock = {
+  get: vi.fn(),
+  set: vi.fn(),
+  remove: vi.fn(),
+};
+
+vi.mock('@/lib/keychain-plugin', () => ({
+  PageSpaceKeychain: keychainMock,
+}));
+
+/** In-memory stand-in for @capacitor/preferences, shared by both platforms. */
+const preferencesStore = new Map<string, string>();
+const preferencesMock = {
+  get: vi.fn(async ({ key }: { key: string }) => ({
+    value: preferencesStore.get(key) ?? null,
+  })),
+  set: vi.fn(async ({ key, value }: { key: string; value: string }) => {
+    preferencesStore.set(key, value);
+  }),
+};
+
+vi.mock('@capacitor/preferences', () => ({ Preferences: preferencesMock }));
+
+interface MockCapacitor {
+  isNativePlatform: () => boolean;
+  getPlatform: () => string;
+}
+
+function setPlatform(platform: 'ios' | 'android' | null): void {
+  if (platform === null) {
+    delete (window as Window & { Capacitor?: MockCapacitor }).Capacitor;
+    return;
+  }
+  (window as Window & { Capacitor?: MockCapacitor }).Capacitor = {
+    isNativePlatform: () => true,
+    getPlatform: () => platform,
+  };
+}
+
+/**
+ * The plugin's own failure mode: `call.reject(...)` becomes a rejected promise
+ * on the JS side. This is the string the Java plugin builds when
+ * `EncryptedSharedPreferences.create()` threw during `load()`
+ * (PageSpaceSecureStoragePlugin.java:46-49, :52-58).
+ */
+const INIT_FAILURE = 'Secure storage unavailable: keystore unavailable';
+
+async function importAndroidStorage() {
+  const { AndroidStorage } = await import('../android-storage');
+  return new AndroidStorage();
+}
+
+describe('AndroidStorage', () => {
+  beforeEach(() => {
+    vi.resetModules();
+    keychainMock.get.mockReset();
+    keychainMock.set.mockReset();
+    keychainMock.remove.mockReset();
+    preferencesStore.clear();
+    preferencesMock.get.mockClear();
+    preferencesMock.set.mockClear();
+    setPlatform('android');
+  });
+
+  afterEach(() => {
+    setPlatform(null);
+    vi.restoreAllMocks();
+  });
+
+  describe('platform-storage factory', () => {
+    it('resolves AndroidStorage when running on Android', async () => {
+      const { getPlatformStorage } = await import('../index');
+
+      expect(getPlatformStorage().platform).toBe('android');
+    });
+
+    it('still resolves IOSStorage when running on iOS', async () => {
+      setPlatform('ios');
+      const { getPlatformStorage } = await import('../index');
+
+      expect(getPlatformStorage().platform).toBe('ios');
+    });
+
+    it('falls back to WebStorage in a plain browser tab', async () => {
+      setPlatform(null);
+      const { getPlatformStorage } = await import('../index');
+
+      expect(getPlatformStorage().platform).toBe('web');
+    });
+  });
+
+  describe('auth transport flags', () => {
+    it('uses Bearer tokens and does not support CSRF, matching iOS', async () => {
+      const storage = await importAndroidStorage();
+
+      expect(storage.usesBearer()).toBe(true);
+      expect(storage.supportsCSRF()).toBe(false);
+    });
+  });
+
+  describe('storeSession', () => {
+    const session = {
+      sessionToken: 'session-token',
+      csrfToken: null,
+      deviceId: 'device-1',
+      deviceToken: 'device-token',
+    };
+
+    it('writes the session through the existing PageSpaceKeychain binding', async () => {
+      keychainMock.set.mockResolvedValue({ success: true });
+      const storage = await importAndroidStorage();
+
+      await storage.storeSession(session);
+
+      expect(keychainMock.set).toHaveBeenCalledWith({
+        key: 'pagespace_session',
+        value: JSON.stringify(session),
+      });
+    });
+
+    it('surfaces an EncryptedSharedPreferences init failure as an error', async () => {
+      keychainMock.set.mockRejectedValue(new Error(INIT_FAILURE));
+      const storage = await importAndroidStorage();
+
+      await expect(storage.storeSession(session)).rejects.toThrow(INIT_FAILURE);
+    });
+  });
+
+  describe('getStoredSession', () => {
+    it('returns the parsed session', async () => {
+      keychainMock.get.mockResolvedValue({
+        value: JSON.stringify({
+          sessionToken: 'session-token',
+          deviceId: 'device-1',
+          deviceToken: 'device-token',
+        }),
+      });
+      const storage = await importAndroidStorage();
+
+      expect(await storage.getStoredSession()).toEqual({
+        sessionToken: 'session-token',
+        csrfToken: null,
+        deviceId: 'device-1',
+        deviceToken: 'device-token',
+      });
+    });
+
+    it('returns null when nothing is stored', async () => {
+      keychainMock.get.mockResolvedValue({ value: null });
+      const storage = await importAndroidStorage();
+
+      expect(await storage.getStoredSession()).toBeNull();
+    });
+
+    it('returns null for a payload missing a session token', async () => {
+      keychainMock.get.mockResolvedValue({
+        value: JSON.stringify({ deviceId: 'device-1' }),
+      });
+      const storage = await importAndroidStorage();
+
+      expect(await storage.getStoredSession()).toBeNull();
+    });
+
+    it('returns null for a corrupt payload', async () => {
+      keychainMock.get.mockResolvedValue({ value: 'not json' });
+      const storage = await importAndroidStorage();
+
+      expect(await storage.getStoredSession()).toBeNull();
+    });
+
+    it('throws rather than reporting "no session" when the store is broken', async () => {
+      keychainMock.get.mockRejectedValue(new Error(INIT_FAILURE));
+      const storage = await importAndroidStorage();
+
+      await expect(storage.getStoredSession()).rejects.toThrow(INIT_FAILURE);
+    });
+
+    it('returns just the token from getSessionToken', async () => {
+      keychainMock.get.mockResolvedValue({
+        value: JSON.stringify({ sessionToken: 'session-token', deviceId: 'device-1' }),
+      });
+      const storage = await importAndroidStorage();
+
+      expect(await storage.getSessionToken()).toBe('session-token');
+    });
+  });
+
+  describe('clearSession', () => {
+    it('removes the session and dispatches auth:cleared', async () => {
+      keychainMock.remove.mockResolvedValue({ success: true });
+      const storage = await importAndroidStorage();
+      const listener = vi.fn();
+      window.addEventListener('auth:cleared', listener);
+
+      await storage.clearSession();
+
+      expect(keychainMock.remove).toHaveBeenCalledWith({ key: 'pagespace_session' });
+      expect(listener).toHaveBeenCalled();
+      window.removeEventListener('auth:cleared', listener);
+    });
+
+    it('still completes the logout when the store rejects', async () => {
+      keychainMock.remove.mockRejectedValue(new Error(INIT_FAILURE));
+      vi.spyOn(console, 'error').mockImplementation(() => {});
+      const storage = await importAndroidStorage();
+      const listener = vi.fn();
+      window.addEventListener('auth:cleared', listener);
+
+      await expect(storage.clearSession()).resolves.toBeUndefined();
+
+      expect(listener).toHaveBeenCalled();
+      expect(console.error).toHaveBeenCalledWith(expect.stringContaining(INIT_FAILURE));
+      window.removeEventListener('auth:cleared', listener);
+    });
+  });
+
+  describe('getDeviceId', () => {
+    it('persists a generated id under pagespace_device_id', async () => {
+      const storage = await importAndroidStorage();
+
+      const id = await storage.getDeviceId();
+
+      expect(id).toMatch(/^[a-z0-9]+$/);
+      expect(preferencesStore.get('pagespace_device_id')).toBe(id);
+    });
+
+    it('reuses the stored id on a second call', async () => {
+      const storage = await importAndroidStorage();
+
+      const first = await storage.getDeviceId();
+      const second = await storage.getDeviceId();
+
+      expect(second).toBe(first);
+      expect(preferencesMock.set).toHaveBeenCalledTimes(1);
+    });
+
+    it('keeps one identity: iOS reads back the id Android wrote', async () => {
+      const android = await importAndroidStorage();
+      const { IOSStorage } = await import('../ios-storage');
+
+      const androidId = await android.getDeviceId();
+      const iosId = await new IOSStorage().getDeviceId();
+
+      expect(iosId).toBe(androidId);
+      expect(preferencesMock.set).toHaveBeenCalledTimes(1);
+    });
+
+    it('reports the device id through getDeviceInfo', async () => {
+      const storage = await importAndroidStorage();
+
+      const info = await storage.getDeviceInfo();
+
+      expect(info.deviceId).toBe(preferencesStore.get('pagespace_device_id'));
+      expect(info.userAgent).toBe(navigator.userAgent);
+    });
+  });
+});

--- a/apps/web/src/lib/auth/platform-storage/android-storage.ts
+++ b/apps/web/src/lib/auth/platform-storage/android-storage.ts
@@ -318,6 +318,12 @@ export class AndroidStorage implements PlatformStorage {
     // refresh. The device *id* stays, as it does on web and in preferences —
     // logout ends a session, not a device's identity.
     clearLegacy(LEGACY_DEVICE_TOKEN_KEY);
+    // Nothing is in force any more, so the record of what was must go too.
+    // Otherwise a sign-in that writes a new legacy binding, followed by a read
+    // the keystore refuses, would be answered with the id of the session this
+    // call just revoked. The durable identity survives in preferences, which is
+    // where the no-binding case reads from.
+    this.lastKnownDeviceId = null;
     this.dispatchAuthEvent('auth:cleared');
   }
 

--- a/apps/web/src/lib/auth/platform-storage/android-storage.ts
+++ b/apps/web/src/lib/auth/platform-storage/android-storage.ts
@@ -57,12 +57,20 @@ function readLegacy(key: string): string | null {
   }
 }
 
-/** Write a key to localStorage, ignoring an unavailable store. */
+/**
+ * Write a key to localStorage.
+ *
+ * Deliberately *not* tolerant, unlike the read and clear helpers: this is the
+ * only place a rotated device token lands, so a swallowed failure here is the
+ * silent "persisted nothing" that leaves the next refresh holding a revoked
+ * token. Reads and clears can shrug at an unavailable store because neither
+ * loses information by failing.
+ */
 function writeLegacy(key: string, value: string): void {
   try {
     localStorage.setItem(key, value);
-  } catch {
-    // Private mode or a full quota — the caller has no better option either.
+  } catch (error) {
+    throw storageError('write', error);
   }
 }
 
@@ -204,8 +212,33 @@ export class AndroidStorage implements PlatformStorage {
     // device token: the web branch returns a new one when the old is near
     // expiry, and dropping it would revoke the client on the next refresh.
     if (!session.sessionToken) {
-      if (session.deviceToken) writeLegacy(LEGACY_DEVICE_TOKEN_KEY, session.deviceToken);
-      if (session.deviceId) writeLegacy(LEGACY_DEVICE_ID_KEYS[0], session.deviceId);
+      if (!session.deviceToken) {
+        // Nothing storable in either place, and the contract above promises a
+        // throw rather than a false success — `refreshBearerSession` reports
+        // "refreshed successfully" on the line after this call.
+        throw storageError('write', 'session carries neither a bearer token nor a device token');
+      }
+
+      // Any keychain session is superseded: the server has just told us this
+      // device's record is a cookie one. Leaving it would shadow the token
+      // written below, because `getStoredSession` reads the keychain first.
+      // Best-effort, for the same reason `clearSession` is.
+      try {
+        const keychain = await this.keychain();
+        await keychain.remove({ key: SESSION_KEY });
+      } catch (error) {
+        console.error(storageError('clear', error).message);
+      }
+
+      writeLegacy(LEGACY_DEVICE_TOKEN_KEY, session.deviceToken);
+      // Only when nothing claims the key. It belongs to `getOrCreateDeviceId`
+      // in `analytics/device-fingerprint` — the browser's stable identity, and
+      // what every web sign-in binds its device token to. Overwriting it with
+      // whatever `getDeviceInfo()` happened to report would make a divergence
+      // permanent instead of recording an identity that was missing.
+      if (session.deviceId && !readLegacyDeviceId()) {
+        writeLegacy(LEGACY_DEVICE_ID_KEYS[0], session.deviceId);
+      }
       return;
     }
 
@@ -279,12 +312,20 @@ export class AndroidStorage implements PlatformStorage {
           timeoutId = setTimeout(() => resolve(null), BOUND_DEVICE_ID_TIMEOUT_MS);
         }),
       ]);
-      return session?.deviceId || null;
+      if (session?.deviceId) return session.deviceId;
     } catch {
-      return null;
+      // fall through
     } finally {
       clearTimeout(timeoutId);
     }
+
+    // A keystore that hangs or refuses is no reason to report the *wrong* id.
+    // The legacy binding lives in localStorage and needs no bridge to read, so
+    // it still answers when the native store cannot — and answering with a
+    // minted id instead is precisely the mismatch that gets a refresh rejected
+    // as a stolen token. Falling back to preferences (the caller's next step)
+    // only happens once neither store names a binding.
+    return this.readLegacySession()?.deviceId || null;
   }
 
   /**

--- a/apps/web/src/lib/auth/platform-storage/android-storage.ts
+++ b/apps/web/src/lib/auth/platform-storage/android-storage.ts
@@ -1,0 +1,161 @@
+import type { PlatformStorage, StoredSession } from './types';
+import { createId } from '@paralleldrive/cuid2';
+
+/**
+ * Key the session JSON is stored under inside the native secure store.
+ *
+ * Deliberately identical to the iOS key (`ios-google-auth.ts:129`, `:183`,
+ * `:220`) — the Android plugin registers under the *same* Capacitor name
+ * (`PageSpaceKeychain`), so the two platforms share one contract and there is
+ * no reason for the key to fork.
+ */
+const SESSION_KEY = 'pagespace_session';
+
+/**
+ * Key the device id is stored under in `@capacitor/preferences`.
+ *
+ * Must match the iOS key (`ios-storage.ts` `getDeviceId`, and
+ * `ios-google-auth.ts:94`) so a device keeps a single identity across the
+ * shared web bundle rather than minting a second one per platform module.
+ */
+const DEVICE_ID_KEY = 'pagespace_device_id';
+
+/**
+ * Wrap a native rejection in an Error that names the operation.
+ *
+ * The Android plugin rejects — it does not resolve with a failure flag — when
+ * `EncryptedSharedPreferences.create()` threw during `load()`
+ * (`PageSpaceSecureStoragePlugin.java:46-49`, surfaced by
+ * `rejectIfNotInitialized` at `:52-58`). Capacitor turns that `call.reject`
+ * into a rejected promise, so the only way for a broken keystore to become a
+ * silent no-op is for *us* to swallow it. We don't: every path below either
+ * rethrows through here or documents exactly why it cannot.
+ */
+function storageError(operation: string, cause: unknown): Error {
+  const detail = cause instanceof Error ? cause.message : String(cause);
+  return new Error(`[Android] Secure storage ${operation} failed: ${detail}`, { cause });
+}
+
+export class AndroidStorage implements PlatformStorage {
+  readonly platform = 'android' as const;
+
+  private async keychain() {
+    const { PageSpaceKeychain } = await import('@/lib/keychain-plugin');
+    return PageSpaceKeychain;
+  }
+
+  async getSessionToken(): Promise<string | null> {
+    const session = await this.getStoredSession();
+    return session?.sessionToken ?? null;
+  }
+
+  /**
+   * Read the stored session.
+   *
+   * `null` means "there is no usable session here" — nothing stored, or stored
+   * bytes we cannot parse. A *store failure* is different information and is
+   * thrown, not flattened into `null`: every consumer of this method already
+   * handles a rejection (`auth-fetch.ts:296-313` logs it and sends the request
+   * unauthenticated; `refreshBearerSession` catches it and returns
+   * `shouldLogout: false`, i.e. retry later), whereas a `null` there would be
+   * read as "device token is gone" and force the user to sign in again over
+   * what may be a transient keystore fault.
+   */
+  async getStoredSession(): Promise<StoredSession | null> {
+    let raw: string | null;
+    try {
+      const keychain = await this.keychain();
+      ({ value: raw } = await keychain.get({ key: SESSION_KEY }));
+    } catch (error) {
+      throw storageError('read', error);
+    }
+
+    if (!raw) return null;
+
+    let parsed: Partial<StoredSession>;
+    try {
+      parsed = JSON.parse(raw) as Partial<StoredSession>;
+    } catch {
+      // Corrupt payload is not a store fault — treat it as "no session".
+      return null;
+    }
+
+    if (typeof parsed.sessionToken !== 'string' || typeof parsed.deviceId !== 'string') {
+      return null;
+    }
+
+    return {
+      sessionToken: parsed.sessionToken,
+      csrfToken: parsed.csrfToken ?? null,
+      deviceId: parsed.deviceId,
+      deviceToken: parsed.deviceToken ?? null,
+    };
+  }
+
+  /**
+   * Persist the session.
+   *
+   * Always throws on failure. This is the requirement that matters most: the
+   * refresh path (`auth-fetch.ts` `refreshBearerSession`) reports
+   * `success: true` on the line after this call, so a swallowed write would
+   * hand every later request a token that was never stored and claim the
+   * refresh worked.
+   */
+  async storeSession(session: StoredSession): Promise<void> {
+    try {
+      const keychain = await this.keychain();
+      await keychain.set({ key: SESSION_KEY, value: JSON.stringify(session) });
+    } catch (error) {
+      throw storageError('write', error);
+    }
+  }
+
+  /**
+   * Clear the session.
+   *
+   * The one place a rejection is deliberately absorbed. `refreshBearerSession`
+   * calls this on a server 401 and then returns `shouldLogout: true`; a throw
+   * would escape to that method's outer catch and downgrade a definite logout
+   * to `shouldLogout: false`, leaving the user in a signed-in shell holding a
+   * token the server has already rejected. So we log, still dispatch
+   * `auth:cleared`, and let the caller complete the logout. If the store is
+   * broken there is nothing readable in it to leak anyway — the same fault
+   * makes `getStoredSession` throw rather than return the stale session.
+   */
+  async clearSession(): Promise<void> {
+    try {
+      const keychain = await this.keychain();
+      await keychain.remove({ key: SESSION_KEY });
+    } catch (error) {
+      console.error(storageError('clear', error).message);
+    }
+    this.dispatchAuthEvent('auth:cleared');
+  }
+
+  async getDeviceId(): Promise<string> {
+    const { Preferences } = await import('@capacitor/preferences');
+    const { value } = await Preferences.get({ key: DEVICE_ID_KEY });
+    if (value) return value;
+    // CUID2 for consistency across the codebase (matches iOS and web).
+    const id = createId();
+    await Preferences.set({ key: DEVICE_ID_KEY, value: id });
+    return id;
+  }
+
+  async getDeviceInfo() {
+    return { deviceId: await this.getDeviceId(), userAgent: navigator.userAgent };
+  }
+
+  usesBearer() {
+    return true;
+  }
+
+  supportsCSRF() {
+    return false;
+  }
+
+  dispatchAuthEvent(event: 'auth:cleared' | 'auth:refreshed' | 'auth:expired') {
+    window.dispatchEvent(new CustomEvent(event));
+    console.log(`[Android] Dispatched ${event}`);
+  }
+}

--- a/apps/web/src/lib/auth/platform-storage/android-storage.ts
+++ b/apps/web/src/lib/auth/platform-storage/android-storage.ts
@@ -219,9 +219,16 @@ export class AndroidStorage implements PlatformStorage {
         throw storageError('write', 'session carries neither a bearer token nor a device token');
       }
 
+      // Write before clearing, never the other way round: `writeLegacy` throws
+      // on an unusable store, and a clear that ran first would have destroyed
+      // the old token to make room for one that never landed. This order can
+      // only leave a *stale* session behind, which the next refresh corrects;
+      // the other can leave none at all.
+      writeLegacy(LEGACY_DEVICE_TOKEN_KEY, session.deviceToken);
+
       // Any keychain session is superseded: the server has just told us this
       // device's record is a cookie one. Leaving it would shadow the token
-      // written below, because `getStoredSession` reads the keychain first.
+      // written above, because `getStoredSession` reads the keychain first.
       // Best-effort, for the same reason `clearSession` is.
       try {
         const keychain = await this.keychain();
@@ -229,8 +236,6 @@ export class AndroidStorage implements PlatformStorage {
       } catch (error) {
         console.error(storageError('clear', error).message);
       }
-
-      writeLegacy(LEGACY_DEVICE_TOKEN_KEY, session.deviceToken);
       // Only when nothing claims the key. It belongs to `getOrCreateDeviceId`
       // in `analytics/device-fingerprint` — the browser's stable identity, and
       // what every web sign-in binds its device token to. Overwriting it with

--- a/apps/web/src/lib/auth/platform-storage/android-storage.ts
+++ b/apps/web/src/lib/auth/platform-storage/android-storage.ts
@@ -108,6 +108,30 @@ function storageError(operation: string, cause: unknown): Error {
   return new Error(`[Android] Secure storage ${operation} failed: ${detail}`, { cause });
 }
 
+/**
+ * Bound a native bridge call so it cannot hang a caller that has no timeout.
+ *
+ * `getDeviceInfo()` is awaited by `refreshBearerSession` with no timeout of its
+ * own, and a Capacitor call that never settles leaves that refresh — and every
+ * request queued behind `isRefreshing` — pending forever. A rejection instead
+ * lands in the refresh's outer catch as a retryable failure.
+ *
+ * Deliberately a rejection rather than a fallback value: if preferences cannot
+ * be read or written, we do not know the device's identity, and answering with
+ * a freshly minted one would hand the server an id the live token is not bound
+ * to. Nor may a timed-out `set` be treated as persisted.
+ */
+function withBridgeTimeout<T>(operation: string, call: Promise<T>): Promise<T> {
+  let timeoutId: ReturnType<typeof setTimeout> | undefined;
+  const timeout = new Promise<never>((_, reject) => {
+    timeoutId = setTimeout(
+      () => reject(storageError(operation, `timed out after ${BOUND_DEVICE_ID_TIMEOUT_MS}ms`)),
+      BOUND_DEVICE_ID_TIMEOUT_MS
+    );
+  });
+  return Promise.race([call, timeout]).finally(() => clearTimeout(timeoutId));
+}
+
 /** `undefined`, `null` and strings are all legal for an optional session field. */
 function isOptionalString(value: unknown): value is string | null | undefined {
   return value === undefined || value === null || typeof value === 'string';
@@ -432,11 +456,19 @@ export class AndroidStorage implements PlatformStorage {
     const { answered, deviceId: bound } = await this.boundDeviceId();
 
     const { Preferences } = await import('@capacitor/preferences');
-    const { value } = await Preferences.get({ key: DEVICE_ID_KEY });
+    const { value } = await withBridgeTimeout(
+      'device id read',
+      Preferences.get({ key: DEVICE_ID_KEY })
+    );
 
     if (bound) {
       // Catch preferences up rather than let it contradict the live binding.
-      if (bound !== value) await Preferences.set({ key: DEVICE_ID_KEY, value: bound });
+      if (bound !== value) {
+        await withBridgeTimeout(
+          'device id write',
+          Preferences.set({ key: DEVICE_ID_KEY, value: bound })
+        );
+      }
       return bound;
     }
 
@@ -444,7 +476,7 @@ export class AndroidStorage implements PlatformStorage {
 
     // CUID2 for consistency across the codebase (matches iOS and web).
     const id = createId();
-    await Preferences.set({ key: DEVICE_ID_KEY, value: id });
+    await withBridgeTimeout('device id write', Preferences.set({ key: DEVICE_ID_KEY, value: id }));
 
     // If a legacy device token is live but named no id, publish the minted one
     // where the *server* binding will look for it. `WebStorage.getDeviceId`

--- a/apps/web/src/lib/auth/platform-storage/android-storage.ts
+++ b/apps/web/src/lib/auth/platform-storage/android-storage.ts
@@ -57,7 +57,11 @@ function clearLegacy(key: string): void {
 
 /** The device id the legacy web flow registered, if it left one. */
 function readLegacyDeviceId(): string | null {
-  return LEGACY_DEVICE_ID_KEYS.map(readLegacy).find((value) => !!value) ?? null;
+  for (const key of LEGACY_DEVICE_ID_KEYS) {
+    const value = readLegacy(key);
+    if (value) return value;
+  }
+  return null;
 }
 
 /**
@@ -219,16 +223,21 @@ export class AndroidStorage implements PlatformStorage {
    * `getDeviceId` is a read-then-write. Two callers that both reach the read
    * before either writes each mint a CUID2, return *different* identities, and
    * leave only one of them persisted — so a refresh could register a device id
-   * that is not the one on disk. Caching the promise makes the first caller the
+   * that is not the one on disk. Sharing the promise makes the first caller the
    * only one that can create an id.
+   *
+   * Strictly *in-flight*, never a memo: it is cleared once settled. This
+   * instance is a module-level singleton, so memoizing would freeze the first
+   * answer for the life of the page — and a passkey sign-in happens in-page,
+   * establishing a device-token binding *after* an earlier call may already
+   * have minted an id. A later caller has to be able to see that binding
+   * (`resolveDeviceId`), which a memo would hide until the next reload.
    */
   private deviceIdPromise: Promise<string> | null = null;
 
   async getDeviceId(): Promise<string> {
-    this.deviceIdPromise ??= this.resolveDeviceId().catch((error: unknown) => {
-      // A failed attempt must not be cached, or every later call replays it.
+    this.deviceIdPromise ??= this.resolveDeviceId().finally(() => {
       this.deviceIdPromise = null;
-      throw error;
     });
     return this.deviceIdPromise;
   }

--- a/apps/web/src/lib/auth/platform-storage/android-storage.ts
+++ b/apps/web/src/lib/auth/platform-storage/android-storage.ts
@@ -46,6 +46,15 @@ function readLegacy(key: string): string | null {
   }
 }
 
+/** Write a key to localStorage, ignoring an unavailable store. */
+function writeLegacy(key: string, value: string): void {
+  try {
+    localStorage.setItem(key, value);
+  } catch {
+    // Private mode or a full quota — the caller has no better option either.
+  }
+}
+
 /** Drop a key from localStorage, ignoring an unavailable store. */
 function clearLegacy(key: string): void {
   try {
@@ -168,16 +177,37 @@ export class AndroidStorage implements PlatformStorage {
    * refresh worked.
    */
   async storeSession(session: StoredSession): Promise<void> {
+    // A session with no bearer token is not a native session, and the keychain
+    // is the wrong home for it. It arrives whenever the device record was
+    // registered by the in-WebView web flow — which is every Android device
+    // until Phase B, since those flows register with `platform: 'web'`. The
+    // refresh route branches on that *stored* platform and its web branch
+    // (`device/refresh/route.ts`) sets a session **cookie** and returns only
+    // `{ csrfToken, deviceToken }`. Writing that here would store a blob
+    // `getStoredSession` rejects for want of a `sessionToken`, and spending the
+    // legacy copy on top of it would destroy the only token the fallback can
+    // recover — a forced sign-out on the very refresh that succeeded.
+    //
+    // So it goes where the cookie world reads it from, exactly as
+    // `WebStorage.storeSession` puts it there. That also persists a *rotated*
+    // device token: the web branch returns a new one when the old is near
+    // expiry, and dropping it would revoke the client on the next refresh.
+    if (!session.sessionToken) {
+      if (session.deviceToken) writeLegacy(LEGACY_DEVICE_TOKEN_KEY, session.deviceToken);
+      if (session.deviceId) writeLegacy(LEGACY_DEVICE_ID_KEYS[0], session.deviceId);
+      return;
+    }
+
     try {
       const keychain = await this.keychain();
       await keychain.set({ key: SESSION_KEY, value: JSON.stringify(session) });
     } catch (error) {
       throw storageError('write', error);
     }
-    // The keychain now holds the session, so the legacy copy is spent. Dropping
-    // it here is what makes the migration one-way: `readLegacySession` stops
-    // firing, and with it `resolveDeviceId`'s legacy branch, so the device
-    // identity settles on the value already persisted to preferences.
+    // The keychain now holds a session that supersedes the legacy one, so the
+    // legacy copy is spent. Dropping it here is what makes the migration
+    // one-way: `readLegacySession` stops firing and the device identity settles
+    // on the session in the keychain.
     clearLegacy(LEGACY_DEVICE_TOKEN_KEY);
   }
 
@@ -222,6 +252,23 @@ export class AndroidStorage implements PlatformStorage {
   }
 
   /**
+   * The device id the session currently in force is bound to, if any.
+   *
+   * A store fault is not fatal here — the caller falls back to preferences —
+   * so unlike `getStoredSession` this swallows it. Losing the binding degrades
+   * a refresh; failing to answer at all would break every caller of
+   * `getDeviceInfo`.
+   */
+  private async boundDeviceId(): Promise<string | null> {
+    try {
+      const session = await this.getStoredSession();
+      return session?.deviceId || null;
+    } catch {
+      return null;
+    }
+  }
+
+  /**
    * In-flight device-id resolution, shared by concurrent callers.
    *
    * `getDeviceId` is a read-then-write. Two callers that both reach the read
@@ -247,23 +294,23 @@ export class AndroidStorage implements PlatformStorage {
   }
 
   private async resolveDeviceId(): Promise<string> {
-    const { Preferences } = await import('@capacitor/preferences');
-    const { value } = await Preferences.get({ key: DEVICE_ID_KEY });
-
-    // While a legacy device token is live, the id the web flow registered is
-    // the device's real identity and outranks anything in preferences.
+    // The identity of the session in force outranks anything in preferences.
     // `/api/auth/device/refresh` enforces strict binding: a deviceId that does
     // not match the one the token was issued against is treated as a stolen
     // token and answered 401 (`device/refresh/route.ts` via
-    // `shouldAllowDeviceRefresh`). Every web sign-in path binds the token to
-    // `getOrCreateDeviceId()` — i.e. `browser_device_id` — so reporting a
-    // preferences id minted by an earlier refresh attempt would guarantee that
-    // 401 and force a re-auth. Preferences is caught up to the live binding
-    // rather than allowed to contradict it.
-    const legacyId = readLegacy(LEGACY_DEVICE_TOKEN_KEY) ? readLegacyDeviceId() : null;
-    if (legacyId) {
-      if (legacyId !== value) await Preferences.set({ key: DEVICE_ID_KEY, value: legacyId });
-      return legacyId;
+    // `shouldAllowDeviceRefresh`), and `refreshBearerSession` sends the id from
+    // `getDeviceInfo()` rather than from the session it just read. Deriving it
+    // from that same session is what keeps the pair it sends consistent —
+    // whichever store the session came from, and however many stores hold one.
+    const bound = await this.boundDeviceId();
+
+    const { Preferences } = await import('@capacitor/preferences');
+    const { value } = await Preferences.get({ key: DEVICE_ID_KEY });
+
+    if (bound) {
+      // Catch preferences up rather than let it contradict the live binding.
+      if (bound !== value) await Preferences.set({ key: DEVICE_ID_KEY, value: bound });
+      return bound;
     }
 
     if (value) return value;

--- a/apps/web/src/lib/auth/platform-storage/android-storage.ts
+++ b/apps/web/src/lib/auth/platform-storage/android-storage.ts
@@ -156,18 +156,18 @@ export class AndroidStorage implements PlatformStorage {
       throw storageError('read', error);
     }
 
-    if (!raw) return this.readLegacySession();
+    if (!raw) return this.remember(this.readLegacySession());
 
     let parsed: Partial<StoredSession>;
     try {
       parsed = JSON.parse(raw) as Partial<StoredSession>;
     } catch {
       // Unparseable bytes are not a store fault — the store answered.
-      return this.readLegacySession();
+      return this.remember(this.readLegacySession());
     }
 
     if (typeof parsed.sessionToken !== 'string' || typeof parsed.deviceId !== 'string') {
-      return this.readLegacySession();
+      return this.remember(this.readLegacySession());
     }
 
     // The optional fields get the same treatment as the required ones. `?? null`
@@ -175,15 +175,37 @@ export class AndroidStorage implements PlatformStorage {
     // hand back something that satisfies `StoredSession` only nominally; those
     // values then travel into a refresh request body.
     if (!isOptionalString(parsed.csrfToken) || !isOptionalString(parsed.deviceToken)) {
-      return this.readLegacySession();
+      return this.remember(this.readLegacySession());
     }
 
-    return {
+    return this.remember({
       sessionToken: parsed.sessionToken,
       csrfToken: parsed.csrfToken ?? null,
       deviceId: parsed.deviceId,
       deviceToken: parsed.deviceToken ?? null,
-    };
+    });
+  }
+
+  /**
+   * The device id of the last session a read actually returned.
+   *
+   * `refreshBearerSession` reads the session itself and then asks for the
+   * device id separately, and both reads cross the same native bridge with the
+   * same 3s budget. When the first lands and the second times out, answering
+   * from the legacy store would pair the *keychain's* device token with the
+   * *legacy* id — which the refresh route reads as a stolen token, 401s, and
+   * then `clearSession` destroys both credentials over what was only a slow
+   * keystore. This remembers what the successful read said, so the second
+   * question can be answered the same way as the first.
+   *
+   * Consulted only when a live read fails, so it cannot pin a stale answer the
+   * way memoizing `deviceIdPromise` would.
+   */
+  private lastKnownDeviceId: string | null = null;
+
+  private remember(session: StoredSession | null): StoredSession | null {
+    if (session?.deviceId) this.lastKnownDeviceId = session.deviceId;
+    return session;
   }
 
   /**
@@ -241,8 +263,16 @@ export class AndroidStorage implements PlatformStorage {
       // what every web sign-in binds its device token to. Overwriting it with
       // whatever `getDeviceInfo()` happened to report would make a divergence
       // permanent instead of recording an identity that was missing.
+      // Best-effort, unlike the token above: the token has nowhere else to
+      // live, but failing this write after that one landed would report a
+      // failure for a refresh that succeeded, sending the caller back into the
+      // rate limiter.
       if (session.deviceId && !readLegacyDeviceId()) {
-        writeLegacy(LEGACY_DEVICE_ID_KEYS[0], session.deviceId);
+        try {
+          writeLegacy(LEGACY_DEVICE_ID_KEYS[0], session.deviceId);
+        } catch (error) {
+          console.error(storageError('write', error).message);
+        }
       }
       return;
     }
@@ -303,9 +333,9 @@ export class AndroidStorage implements PlatformStorage {
   /**
    * The device id the session currently in force is bound to, if any.
    *
-   * A store fault is not fatal here — the caller falls back to preferences —
-   * so unlike `getStoredSession` this swallows it. Losing the binding degrades
-   * a refresh; failing to answer at all would break every caller of
+   * A store fault is not fatal here — the fallbacks below still name a binding
+   * — so unlike `getStoredSession` this swallows it. Losing the binding
+   * degrades a refresh; failing to answer at all would break every caller of
    * `getDeviceInfo`.
    */
   private async boundDeviceId(): Promise<string | null> {
@@ -325,12 +355,13 @@ export class AndroidStorage implements PlatformStorage {
     }
 
     // A keystore that hangs or refuses is no reason to report the *wrong* id.
-    // The legacy binding lives in localStorage and needs no bridge to read, so
-    // it still answers when the native store cannot — and answering with a
-    // minted id instead is precisely the mismatch that gets a refresh rejected
-    // as a stolen token. Falling back to preferences (the caller's next step)
-    // only happens once neither store names a binding.
-    return this.readLegacySession()?.deviceId || null;
+    // What the last successful read said comes first — it is the only answer
+    // that stays consistent with a session already read through this same
+    // instance. Then the legacy binding, which lives in localStorage and needs
+    // no bridge to read. Only once neither names a binding does the caller fall
+    // through to preferences, and a minted id there is precisely the mismatch
+    // that gets a refresh rejected as a stolen token.
+    return this.lastKnownDeviceId ?? this.readLegacySession()?.deviceId ?? null;
   }
 
   /**
@@ -383,6 +414,20 @@ export class AndroidStorage implements PlatformStorage {
     // CUID2 for consistency across the codebase (matches iOS and web).
     const id = createId();
     await Preferences.set({ key: DEVICE_ID_KEY, value: id });
+
+    // If a legacy device token is live but named no id, publish the minted one
+    // where the *server* binding will look for it. `WebStorage.getDeviceId`
+    // mints straight into `browser_device_id`, so its two identities converge;
+    // minting only into preferences — which no web sign-in path reads — would
+    // leave them permanently divergent.
+    if (readLegacy(LEGACY_DEVICE_TOKEN_KEY) && !readLegacyDeviceId()) {
+      try {
+        writeLegacy(LEGACY_DEVICE_ID_KEYS[0], id);
+      } catch (error) {
+        console.error(storageError('write', error).message);
+      }
+    }
+
     return id;
   }
 

--- a/apps/web/src/lib/auth/platform-storage/android-storage.ts
+++ b/apps/web/src/lib/auth/platform-storage/android-storage.ts
@@ -349,9 +349,11 @@ export class AndroidStorage implements PlatformStorage {
    * This whole chain exists because the caller asks for the two halves of an
    * atomic pair in two separate reads: `refreshBearerSession` reads the session
    * itself and then asks for the device id through `getDeviceInfo()`. Send the
-   * id from the same read as the token — one line at `auth-fetch.ts`, recorded
-   * on Phase B's auth session gate sweep — and the record, the race and the
-   * `answered` flag all collapse. Collapse them there; do not extend them here.
+   * id from the same read as the token — `session.deviceId || info.deviceId` at
+   * both `auth-fetch.ts:645` (the request body) and `:662` (the `storeSession`
+   * call), which must move together or the id sent and the id stored diverge —
+   * and the record, the race and the `answered` flag all collapse. Recorded on
+   * Phase B's auth session gate sweep. Collapse them there, not here.
    *
    * A store fault is not fatal here — the fallbacks below still name a binding
    * — so unlike `getStoredSession` this swallows it. Losing the binding
@@ -386,7 +388,9 @@ export class AndroidStorage implements PlatformStorage {
     // the mismatch that gets a refresh rejected as a stolen token.
     return {
       answered: false,
-      deviceId: this.lastKnownDeviceId ?? this.readLegacySession()?.deviceId ?? null,
+      // `|| null`, not `??`: a legacy session names an empty `deviceId` when no
+      // id was ever recorded, and this method promises `string | null`.
+      deviceId: this.lastKnownDeviceId ?? (this.readLegacySession()?.deviceId || null),
     };
   }
 

--- a/apps/web/src/lib/auth/platform-storage/android-storage.ts
+++ b/apps/web/src/lib/auth/platform-storage/android-storage.ts
@@ -105,6 +105,11 @@ export class AndroidStorage implements PlatformStorage {
    * `shouldLogout: false`, i.e. retry later), whereas a `null` there would be
    * read as "device token is gone" and force the user to sign in again over
    * what may be a transient keystore fault.
+   *
+   * A store fault deliberately does *not* fall through to the legacy session
+   * either. A device whose keystore will not initialize cannot persist a
+   * refreshed session, so recovering a token here would only buy a session that
+   * evaporates on the next launch while hiding the fault that caused it.
    */
   async getStoredSession(): Promise<StoredSession | null> {
     let raw: string | null;

--- a/apps/web/src/lib/auth/platform-storage/android-storage.ts
+++ b/apps/web/src/lib/auth/platform-storage/android-storage.ts
@@ -274,6 +274,7 @@ export class AndroidStorage implements PlatformStorage {
           console.error(storageError('write', error).message);
         }
       }
+      this.remember(session);
       return;
     }
 
@@ -288,6 +289,9 @@ export class AndroidStorage implements PlatformStorage {
     // one-way: `readLegacySession` stops firing and the device identity settles
     // on the session in the keychain.
     clearLegacy(LEGACY_DEVICE_TOKEN_KEY);
+    // A write is as good a source of "what is in force" as a read, and a
+    // better one right after this branch supersedes what a read last saw.
+    this.remember(session);
   }
 
   /**

--- a/apps/web/src/lib/auth/platform-storage/android-storage.ts
+++ b/apps/web/src/lib/auth/platform-storage/android-storage.ts
@@ -95,14 +95,18 @@ export class AndroidStorage implements PlatformStorage {
 
   async getSessionToken(): Promise<string | null> {
     const session = await this.getStoredSession();
-    return session?.sessionToken ?? null;
+    // A legacy cookie session carries an empty `sessionToken` — there is no
+    // bearer token to hand out, and `null` says that where `''` only implies it.
+    return session?.sessionToken || null;
   }
 
   /**
    * Read the stored session.
    *
-   * `null` means "there is no usable session here" — nothing stored, or stored
-   * bytes we cannot parse. A *store failure* is different information and is
+   * Every "the keychain holds nothing usable" path — absent, unparseable, or
+   * wrong-shaped — answers with the legacy session, so there is one rule rather
+   * than a distinction between kinds of emptiness. `null` therefore means no
+   * session at all. A *store failure* is different information and is
    * thrown, not flattened into `null`: every consumer of this method already
    * handles a rejection (`auth-fetch.ts:296-313` logs it and sends the request
    * unauthenticated; `refreshBearerSession` catches it and returns
@@ -130,12 +134,12 @@ export class AndroidStorage implements PlatformStorage {
     try {
       parsed = JSON.parse(raw) as Partial<StoredSession>;
     } catch {
-      // Corrupt payload is not a store fault — treat it as "no session".
-      return null;
+      // Unparseable bytes are not a store fault — the store answered.
+      return this.readLegacySession();
     }
 
     if (typeof parsed.sessionToken !== 'string' || typeof parsed.deviceId !== 'string') {
-      return null;
+      return this.readLegacySession();
     }
 
     // The optional fields get the same treatment as the required ones. `?? null`
@@ -143,7 +147,7 @@ export class AndroidStorage implements PlatformStorage {
     // hand back something that satisfies `StoredSession` only nominally; those
     // values then travel into a refresh request body.
     if (!isOptionalString(parsed.csrfToken) || !isOptionalString(parsed.deviceToken)) {
-      return null;
+      return this.readLegacySession();
     }
 
     return {

--- a/apps/web/src/lib/auth/platform-storage/android-storage.ts
+++ b/apps/web/src/lib/auth/platform-storage/android-storage.ts
@@ -274,7 +274,10 @@ export class AndroidStorage implements PlatformStorage {
           console.error(storageError('write', error).message);
         }
       }
-      this.remember(session);
+      // The binding in force is whatever `browser_device_id` now holds: the
+      // write above declines to overwrite an existing one, so the session's own
+      // `deviceId` is not necessarily it.
+      this.lastKnownDeviceId = readLegacyDeviceId() ?? session.deviceId ?? null;
       return;
     }
 
@@ -348,16 +351,19 @@ export class AndroidStorage implements PlatformStorage {
    * degrades a refresh; failing to answer at all would break every caller of
    * `getDeviceInfo`.
    */
-  private async boundDeviceId(): Promise<string | null> {
+  private async boundDeviceId(): Promise<{ answered: boolean; deviceId: string | null }> {
+    const timeout = Symbol('timeout');
     let timeoutId: ReturnType<typeof setTimeout> | undefined;
     try {
-      const session = await Promise.race([
+      const result = await Promise.race([
         this.getStoredSession(),
-        new Promise<null>((resolve) => {
-          timeoutId = setTimeout(() => resolve(null), BOUND_DEVICE_ID_TIMEOUT_MS);
+        new Promise<typeof timeout>((resolve) => {
+          timeoutId = setTimeout(() => resolve(timeout), BOUND_DEVICE_ID_TIMEOUT_MS);
         }),
       ]);
-      if (session?.deviceId) return session.deviceId;
+      // `null` is an answer — no session anywhere — and only the sentinel means
+      // the store never got back to us.
+      if (result !== timeout) return { answered: true, deviceId: result?.deviceId || null };
     } catch {
       // fall through
     } finally {
@@ -365,13 +371,16 @@ export class AndroidStorage implements PlatformStorage {
     }
 
     // A keystore that hangs or refuses is no reason to report the *wrong* id.
-    // What the last successful read said comes first — it is the only answer
-    // that stays consistent with a session already read through this same
-    // instance. Then the legacy binding, which lives in localStorage and needs
-    // no bridge to read. Only once neither names a binding does the caller fall
-    // through to preferences, and a minted id there is precisely the mismatch
-    // that gets a refresh rejected as a stolen token.
-    return this.lastKnownDeviceId ?? this.readLegacySession()?.deviceId ?? null;
+    // What the last successful read or write said comes first — it is the only
+    // answer that stays consistent with a session already seen through this
+    // same instance. Then the legacy binding, which lives in localStorage and
+    // needs no bridge to read. Only once neither names a binding does the
+    // caller fall through to preferences, and a minted id there is precisely
+    // the mismatch that gets a refresh rejected as a stolen token.
+    return {
+      answered: false,
+      deviceId: this.lastKnownDeviceId ?? this.readLegacySession()?.deviceId ?? null,
+    };
   }
 
   /**
@@ -408,7 +417,7 @@ export class AndroidStorage implements PlatformStorage {
     // `getDeviceInfo()` rather than from the session it just read. Deriving it
     // from that same session is what keeps the pair it sends consistent —
     // whichever store the session came from, and however many stores hold one.
-    const bound = await this.boundDeviceId();
+    const { answered, deviceId: bound } = await this.boundDeviceId();
 
     const { Preferences } = await import('@capacitor/preferences');
     const { value } = await Preferences.get({ key: DEVICE_ID_KEY });
@@ -430,7 +439,10 @@ export class AndroidStorage implements PlatformStorage {
     // mints straight into `browser_device_id`, so its two identities converge;
     // minting only into preferences — which no web sign-in path reads — would
     // leave them permanently divergent.
-    if (readLegacy(LEGACY_DEVICE_TOKEN_KEY) && !readLegacyDeviceId()) {
+    // Only on the strength of a read that actually answered. Publishing after a
+    // read that never completed would make the browser's identity a CUID2 no
+    // server token is bound to, on no evidence at all.
+    if (answered && readLegacy(LEGACY_DEVICE_TOKEN_KEY) && !readLegacyDeviceId()) {
       try {
         writeLegacy(LEGACY_DEVICE_ID_KEYS[0], id);
       } catch (error) {

--- a/apps/web/src/lib/auth/platform-storage/android-storage.ts
+++ b/apps/web/src/lib/auth/platform-storage/android-storage.ts
@@ -34,6 +34,17 @@ const DEVICE_ID_KEY = 'pagespace_device_id';
  * the fallback, and the next successful refresh writes the result into the
  * keychain — a one-way migration that needs no separate step.
  */
+/**
+ * How long the device-id lookup will wait on the keychain before falling back.
+ *
+ * A native call can hang indefinitely — the hazard `getSessionTokenWithTimeout`
+ * and `useSigninRecovery` already guard against, both with the same 3s — and
+ * `getDeviceInfo` sits inside `refreshBearerSession` with no timeout of its
+ * own, so a hung read here would leave a refresh pending forever. The binding
+ * is worth waiting a moment for, never worth hanging on.
+ */
+const BOUND_DEVICE_ID_TIMEOUT_MS = 3000;
+
 const LEGACY_DEVICE_TOKEN_KEY = 'deviceToken';
 const LEGACY_DEVICE_ID_KEYS = ['browser_device_id', 'deviceId'] as const;
 
@@ -260,11 +271,19 @@ export class AndroidStorage implements PlatformStorage {
    * `getDeviceInfo`.
    */
   private async boundDeviceId(): Promise<string | null> {
+    let timeoutId: ReturnType<typeof setTimeout> | undefined;
     try {
-      const session = await this.getStoredSession();
+      const session = await Promise.race([
+        this.getStoredSession(),
+        new Promise<null>((resolve) => {
+          timeoutId = setTimeout(() => resolve(null), BOUND_DEVICE_ID_TIMEOUT_MS);
+        }),
+      ]);
       return session?.deviceId || null;
     } catch {
       return null;
+    } finally {
+      clearTimeout(timeoutId);
     }
   }
 

--- a/apps/web/src/lib/auth/platform-storage/android-storage.ts
+++ b/apps/web/src/lib/auth/platform-storage/android-storage.ts
@@ -21,6 +21,32 @@ const SESSION_KEY = 'pagespace_session';
 const DEVICE_ID_KEY = 'pagespace_device_id';
 
 /**
+ * Where the pre-native Android session lives.
+ *
+ * Until native sign-in lands, every Android sign-in runs the *web* flow inside
+ * the WebView, and that flow writes its device token to `localStorage` —
+ * `useAuth.ts` captures the `ps_device_token` cookie into `deviceToken`, and
+ * `PasskeyLoginButton` writes the same key. Android read those keys through
+ * `WebStorage` before this class existed. Reading only the keychain would leave
+ * that token stranded: `refreshBearerSession` would see no device token and
+ * return `shouldLogout: true` on the first cookie expiry, forcing a re-auth it
+ * had the credentials to avoid. So the keychain is checked first and these are
+ * the fallback, and the next successful refresh writes the result into the
+ * keychain — a one-way migration that needs no separate step.
+ */
+const LEGACY_DEVICE_TOKEN_KEY = 'deviceToken';
+const LEGACY_DEVICE_ID_KEYS = ['browser_device_id', 'deviceId'] as const;
+
+/** Read a key from localStorage, treating an unavailable store as absent. */
+function readLegacy(key: string): string | null {
+  try {
+    return localStorage.getItem(key);
+  } catch {
+    return null;
+  }
+}
+
+/**
  * Wrap a native rejection in an Error that names the operation.
  *
  * The Android plugin rejects — it does not resolve with a failure flag — when
@@ -34,6 +60,11 @@ const DEVICE_ID_KEY = 'pagespace_device_id';
 function storageError(operation: string, cause: unknown): Error {
   const detail = cause instanceof Error ? cause.message : String(cause);
   return new Error(`[Android] Secure storage ${operation} failed: ${detail}`, { cause });
+}
+
+/** `undefined`, `null` and strings are all legal for an optional session field. */
+function isOptionalString(value: unknown): value is string | null | undefined {
+  return value === undefined || value === null || typeof value === 'string';
 }
 
 export class AndroidStorage implements PlatformStorage {
@@ -70,7 +101,7 @@ export class AndroidStorage implements PlatformStorage {
       throw storageError('read', error);
     }
 
-    if (!raw) return null;
+    if (!raw) return this.readLegacySession();
 
     let parsed: Partial<StoredSession>;
     try {
@@ -81,6 +112,14 @@ export class AndroidStorage implements PlatformStorage {
     }
 
     if (typeof parsed.sessionToken !== 'string' || typeof parsed.deviceId !== 'string') {
+      return null;
+    }
+
+    // The optional fields get the same treatment as the required ones. `?? null`
+    // alone would wave through any non-null value — a number, an object — and
+    // hand back something that satisfies `StoredSession` only nominally; those
+    // values then travel into a refresh request body.
+    if (!isOptionalString(parsed.csrfToken) || !isOptionalString(parsed.deviceToken)) {
       return null;
     }
 
@@ -132,12 +171,52 @@ export class AndroidStorage implements PlatformStorage {
     this.dispatchAuthEvent('auth:cleared');
   }
 
+  /**
+   * The session the web sign-in flow left in `localStorage`, if any.
+   *
+   * Deliberately shaped exactly like `WebStorage.getStoredSession()` — an empty
+   * `sessionToken`, because a cookie session has no bearer token to hand out,
+   * and the device token that makes silent recovery work.
+   */
+  private readLegacySession(): StoredSession | null {
+    const deviceToken = readLegacy(LEGACY_DEVICE_TOKEN_KEY);
+    if (!deviceToken) return null;
+    const deviceId =
+      LEGACY_DEVICE_ID_KEYS.map(readLegacy).find((value) => !!value) ?? '';
+    return { sessionToken: '', csrfToken: null, deviceId, deviceToken };
+  }
+
+  /**
+   * In-flight device-id resolution, shared by concurrent callers.
+   *
+   * `getDeviceId` is a read-then-write. Two callers that both reach the read
+   * before either writes each mint a CUID2, return *different* identities, and
+   * leave only one of them persisted — so a refresh could register a device id
+   * that is not the one on disk. Caching the promise makes the first caller the
+   * only one that can create an id.
+   */
+  private deviceIdPromise: Promise<string> | null = null;
+
   async getDeviceId(): Promise<string> {
+    this.deviceIdPromise ??= this.resolveDeviceId().catch((error: unknown) => {
+      // A failed attempt must not be cached, or every later call replays it.
+      this.deviceIdPromise = null;
+      throw error;
+    });
+    return this.deviceIdPromise;
+  }
+
+  private async resolveDeviceId(): Promise<string> {
     const { Preferences } = await import('@capacitor/preferences');
     const { value } = await Preferences.get({ key: DEVICE_ID_KEY });
     if (value) return value;
-    // CUID2 for consistency across the codebase (matches iOS and web).
-    const id = createId();
+
+    // Adopt the id the web flow already registered for this device rather than
+    // minting a second one beside a device token that is bound to the first —
+    // the same migration reasoning as `readLegacySession`. CUID2 otherwise, for
+    // consistency across the codebase (matches iOS and web).
+    const id =
+      LEGACY_DEVICE_ID_KEYS.map(readLegacy).find((legacy) => !!legacy) ?? createId();
     await Preferences.set({ key: DEVICE_ID_KEY, value: id });
     return id;
   }

--- a/apps/web/src/lib/auth/platform-storage/android-storage.ts
+++ b/apps/web/src/lib/auth/platform-storage/android-storage.ts
@@ -346,6 +346,13 @@ export class AndroidStorage implements PlatformStorage {
   /**
    * The device id the session currently in force is bound to, if any.
    *
+   * This whole chain exists because the caller asks for the two halves of an
+   * atomic pair in two separate reads: `refreshBearerSession` reads the session
+   * itself and then asks for the device id through `getDeviceInfo()`. Send the
+   * id from the same read as the token — one line at `auth-fetch.ts`, recorded
+   * on Phase B's auth session gate sweep — and the record, the race and the
+   * `answered` flag all collapse. Collapse them there; do not extend them here.
+   *
    * A store fault is not fatal here — the fallbacks below still name a binding
    * — so unlike `getStoredSession` this swallows it. Losing the binding
    * degrades a refresh; failing to answer at all would break every caller of

--- a/apps/web/src/lib/auth/platform-storage/android-storage.ts
+++ b/apps/web/src/lib/auth/platform-storage/android-storage.ts
@@ -46,6 +46,20 @@ function readLegacy(key: string): string | null {
   }
 }
 
+/** Drop a key from localStorage, ignoring an unavailable store. */
+function clearLegacy(key: string): void {
+  try {
+    localStorage.removeItem(key);
+  } catch {
+    // A store we cannot write to holds nothing we need to clear.
+  }
+}
+
+/** The device id the legacy web flow registered, if it left one. */
+function readLegacyDeviceId(): string | null {
+  return LEGACY_DEVICE_ID_KEYS.map(readLegacy).find((value) => !!value) ?? null;
+}
+
 /**
  * Wrap a native rejection in an Error that names the operation.
  *
@@ -147,6 +161,11 @@ export class AndroidStorage implements PlatformStorage {
     } catch (error) {
       throw storageError('write', error);
     }
+    // The keychain now holds the session, so the legacy copy is spent. Dropping
+    // it here is what makes the migration one-way: `readLegacySession` stops
+    // firing, and with it `resolveDeviceId`'s legacy branch, so the device
+    // identity settles on the value already persisted to preferences.
+    clearLegacy(LEGACY_DEVICE_TOKEN_KEY);
   }
 
   /**
@@ -168,6 +187,11 @@ export class AndroidStorage implements PlatformStorage {
     } catch (error) {
       console.error(storageError('clear', error).message);
     }
+    // Clear everything `getStoredSession` can read, or the legacy fallback
+    // would hand the just-revoked device token straight back to the next
+    // refresh. The device *id* stays, as it does on web and in preferences —
+    // logout ends a session, not a device's identity.
+    clearLegacy(LEGACY_DEVICE_TOKEN_KEY);
     this.dispatchAuthEvent('auth:cleared');
   }
 
@@ -181,9 +205,7 @@ export class AndroidStorage implements PlatformStorage {
   private readLegacySession(): StoredSession | null {
     const deviceToken = readLegacy(LEGACY_DEVICE_TOKEN_KEY);
     if (!deviceToken) return null;
-    const deviceId =
-      LEGACY_DEVICE_ID_KEYS.map(readLegacy).find((value) => !!value) ?? '';
-    return { sessionToken: '', csrfToken: null, deviceId, deviceToken };
+    return { sessionToken: '', csrfToken: null, deviceId: readLegacyDeviceId() ?? '', deviceToken };
   }
 
   /**
@@ -209,14 +231,27 @@ export class AndroidStorage implements PlatformStorage {
   private async resolveDeviceId(): Promise<string> {
     const { Preferences } = await import('@capacitor/preferences');
     const { value } = await Preferences.get({ key: DEVICE_ID_KEY });
+
+    // While a legacy device token is live, the id the web flow registered is
+    // the device's real identity and outranks anything in preferences.
+    // `/api/auth/device/refresh` enforces strict binding: a deviceId that does
+    // not match the one the token was issued against is treated as a stolen
+    // token and answered 401 (`device/refresh/route.ts` via
+    // `shouldAllowDeviceRefresh`). Every web sign-in path binds the token to
+    // `getOrCreateDeviceId()` — i.e. `browser_device_id` — so reporting a
+    // preferences id minted by an earlier refresh attempt would guarantee that
+    // 401 and force a re-auth. Preferences is caught up to the live binding
+    // rather than allowed to contradict it.
+    const legacyId = readLegacy(LEGACY_DEVICE_TOKEN_KEY) ? readLegacyDeviceId() : null;
+    if (legacyId) {
+      if (legacyId !== value) await Preferences.set({ key: DEVICE_ID_KEY, value: legacyId });
+      return legacyId;
+    }
+
     if (value) return value;
 
-    // Adopt the id the web flow already registered for this device rather than
-    // minting a second one beside a device token that is bound to the first —
-    // the same migration reasoning as `readLegacySession`. CUID2 otherwise, for
-    // consistency across the codebase (matches iOS and web).
-    const id =
-      LEGACY_DEVICE_ID_KEYS.map(readLegacy).find((legacy) => !!legacy) ?? createId();
+    // CUID2 for consistency across the codebase (matches iOS and web).
+    const id = createId();
     await Preferences.set({ key: DEVICE_ID_KEY, value: id });
     return id;
   }

--- a/apps/web/src/lib/auth/platform-storage/android-storage.ts
+++ b/apps/web/src/lib/auth/platform-storage/android-storage.ts
@@ -143,9 +143,10 @@ export class AndroidStorage implements PlatformStorage {
    * what may be a transient keystore fault.
    *
    * A store fault deliberately does *not* fall through to the legacy session
-   * either. A device whose keystore will not initialize cannot persist a
-   * refreshed session, so recovering a token here would only buy a session that
-   * evaporates on the next launch while hiding the fault that caused it.
+   * either, even though a bearer-less refresh could persist without the
+   * keychain. Once a native session exists the legacy copy is spent, so the
+   * fallback would answer "nothing here" — forcing the very re-auth a
+   * transient fault should not cause, and hiding the fault that caused it.
    */
   async getStoredSession(): Promise<StoredSession | null> {
     let raw: string | null;

--- a/apps/web/src/lib/auth/platform-storage/index.ts
+++ b/apps/web/src/lib/auth/platform-storage/index.ts
@@ -1,5 +1,16 @@
 import type { PlatformStorage } from './types';
 import { hasNativeCapability, getPlatform, type Platform } from '@/lib/capacitor-bridge';
+/**
+ * These were `require()` calls so a platform's module only loaded on that
+ * platform. They are static imports now: every one of these modules already
+ * defers its platform-specific dependency (`@/lib/keychain-plugin`,
+ * `@/lib/ios-google-auth`, `@capacitor/preferences`, `window.electron`) to a
+ * dynamic import *inside* a method, so their module bodies carry nothing but
+ * `cuid2` — which `web-storage` pulls in on every platform regardless. The
+ * requires bought no code splitting and cost the factory its testability:
+ * `require` of a TypeScript module does not resolve under vitest, so nothing
+ * could assert which implementation a platform actually resolves to.
+ */
 import { AndroidStorage } from './android-storage';
 import { DesktopStorage } from './desktop-storage';
 import { IOSStorage } from './ios-storage';
@@ -25,17 +36,7 @@ const SECURE_STORAGE_FACTORIES: Record<Platform, (() => PlatformStorage) | null>
   web: null,
 };
 
-/**
- * These were `require()` calls so a platform's module only loaded on that
- * platform. They are static imports now: every one of these modules already
- * defers its platform-specific dependency (`@/lib/keychain-plugin`,
- * `@/lib/ios-google-auth`, `@capacitor/preferences`, `window.electron`) to a
- * dynamic import *inside* a method, so their module bodies carry nothing but
- * `cuid2` — which `web-storage` pulls in on every platform regardless. The
- * requires bought no code splitting and cost the factory its testability:
- * `require` of a TypeScript module does not resolve under vitest, so nothing
- * could assert which implementation a platform actually resolves to.
- */
+/** The platform's storage adapter, built once and reused. */
 export function getPlatformStorage(): PlatformStorage {
   if (instance) return instance;
 

--- a/apps/web/src/lib/auth/platform-storage/index.ts
+++ b/apps/web/src/lib/auth/platform-storage/index.ts
@@ -1,38 +1,60 @@
 import type { PlatformStorage } from './types';
-import { isCapacitorApp, getPlatform } from '@/lib/capacitor-bridge';
+import { hasNativeCapability, getPlatform, type Platform } from '@/lib/capacitor-bridge';
+import { AndroidStorage } from './android-storage';
+import { DesktopStorage } from './desktop-storage';
+import { IOSStorage } from './ios-storage';
+import { WebStorage } from './web-storage';
 
 export * from './types';
 
 let instance: PlatformStorage | null = null;
 
+/**
+ * How each platform builds its secure-storage implementation.
+ *
+ * Table-driven rather than a chain of `getPlatform() === '<os>'` tests, so
+ * adding a platform is a row here plus a flag in the capability table — the
+ * whole point of `capacitor-bridge`. `web` is `null` because a browser tab has
+ * no native store; `hasNativeCapability('secureStore')` already answers false
+ * there, and the `null` row is what makes that agreement checkable by the
+ * compiler instead of only at runtime.
+ */
+const SECURE_STORAGE_FACTORIES: Record<Platform, (() => PlatformStorage) | null> = {
+  ios: () => new IOSStorage(),
+  android: () => new AndroidStorage(),
+  web: null,
+};
+
+/**
+ * These were `require()` calls so a platform's module only loaded on that
+ * platform. They are static imports now: every one of these modules already
+ * defers its platform-specific dependency (`@/lib/keychain-plugin`,
+ * `@/lib/ios-google-auth`, `@capacitor/preferences`, `window.electron`) to a
+ * dynamic import *inside* a method, so their module bodies carry nothing but
+ * `cuid2` — which `web-storage` pulls in on every platform regardless. The
+ * requires bought no code splitting and cost the factory its testability:
+ * `require` of a TypeScript module does not resolve under vitest, so nothing
+ * could assert which implementation a platform actually resolves to.
+ */
 export function getPlatformStorage(): PlatformStorage {
   if (instance) return instance;
 
   if (typeof window !== 'undefined') {
+    const nativeStorage = hasNativeCapability('secureStore')
+      ? SECURE_STORAGE_FACTORIES[getPlatform()]
+      : null;
+
     if (window.electron?.isDesktop) {
-      // eslint-disable-next-line @typescript-eslint/no-require-imports
-      const { DesktopStorage } = require('./desktop-storage');
       instance = new DesktopStorage();
-    } else if (isCapacitorApp() && getPlatform() === 'ios') {
-      // eslint-disable-next-line @typescript-eslint/no-require-imports
-      const { IOSStorage } = require('./ios-storage');
-      instance = new IOSStorage();
+    } else if (nativeStorage) {
+      instance = nativeStorage();
     } else {
-      // eslint-disable-next-line @typescript-eslint/no-require-imports
-      const { WebStorage } = require('./web-storage');
       instance = new WebStorage();
     }
   } else {
-    // eslint-disable-next-line @typescript-eslint/no-require-imports
-    const { WebStorage } = require('./web-storage');
     instance = new WebStorage();
-  }
-
-  if (!instance) {
-    throw new Error('Failed to initialize platform storage');
   }
 
   console.log(`[PlatformStorage] ${instance.platform}`);
   return instance;
 }
-

--- a/apps/web/src/lib/auth/platform-storage/types.ts
+++ b/apps/web/src/lib/auth/platform-storage/types.ts
@@ -9,6 +9,21 @@ export interface PlatformStorage {
   readonly platform: 'web' | 'desktop' | 'ios' | 'android';
 
   getSessionToken(): Promise<string | null>;
+
+  /**
+   * The session in force, or `null` when there is none.
+   *
+   * `null` means "no usable session here" — nothing stored, or stored bytes
+   * that cannot be read back as one. A *store fault* is different information
+   * and belongs in a rejection: callers treat `null` as "the device token is
+   * gone" and force a re-auth (`refreshBearerSession` → `shouldLogout: true`),
+   * where a rejection is retryable. Flattening the two signs users out over a
+   * transient keystore failure.
+   *
+   * `AndroidStorage` honours this. `IOSStorage` does not yet — it delegates to
+   * `ios-google-auth.ts`, whose `catch { return null; }` collapses a Keychain
+   * fault into "no session"; aligning it is Phase B's auth session gate sweep.
+   */
   getStoredSession(): Promise<StoredSession | null>;
   storeSession(session: StoredSession): Promise<void>;
   clearSession(): Promise<void>;

--- a/apps/web/src/lib/capacitor-bridge.ts
+++ b/apps/web/src/lib/capacitor-bridge.ts
@@ -179,9 +179,9 @@ export function isNativeApp(): boolean {
  * `platform-storage` that cannot call `useCapacitor()`. Components should
  * prefer `useCapacitor().capabilities`.
  *
- * @public Published API of the capability bridge. The call sites that consume
- * it (secure storage, push registration, badge sync) land in later leaves of
- * the Android parity epic, so knip cannot see a consumer yet.
+ * @public Published API of the capability bridge. `platform-storage` selects
+ * its implementation through this; the remaining call sites (push
+ * registration, badge sync) land in later leaves of the Android parity epic.
  */
 export function hasNativeCapability(capability: NativeCapability): boolean {
   return PLATFORM_CAPABILITIES[getPlatform()][capability];


### PR DESCRIPTION
## What

Android parity epic, Phase A remainder: make the already-shipped `PageSpaceSecureStoragePlugin` reachable from the web bundle.

`PageSpaceSecureStoragePlugin.java` is annotated `@CapacitorPlugin(name = "PageSpaceKeychain")` and exposes the same `get`/`set`/`remove` shape as the iOS Swift plugin, but nothing ever called it. The factory's only native branch was `isCapacitorApp() && getPlatform() === 'ios'`, so an Android shell fell through to `WebStorage`.

## The leaf itself

- **New `android-storage.ts`.** `AndroidStorage implements PlatformStorage`, driving the existing `@/lib/keychain-plugin` binding — not a second `registerPlugin` name, since the Java plugin answers to `PageSpaceKeychain` already. `usesBearer()` → `true`, `supportsCSRF()` → `false`, matching iOS.
- **Init failures surface.** The Java plugin `call.reject`s when `EncryptedSharedPreferences.create()` threw during `load()` (`PageSpaceSecureStoragePlugin.java:46-49`, via `rejectIfNotInitialized` at `:52-58`), which Capacitor turns into a rejected promise. `storeSession` and `getStoredSession` propagate it. That matters most on the write: `refreshBearerSession` returns `success: true` on the line after `storeSession`, so a swallowed write would hand every later request a token that was never stored. `clearSession` is the one deliberate exception, documented in place — it runs on a 401 immediately before `shouldLogout: true`, and a throw there would downgrade a definite logout to a retry.
- **Shared device identity.** `pagespace_device_id` via `@capacitor/preferences`, the same key iOS uses (`ios-storage.ts` `getDeviceId`, `ios-google-auth.ts:94-97`). A test drives both implementations against one preferences store and asserts iOS reads back the id Android wrote.
- **The factory selects by capability**, not platform equality: `hasNativeCapability('secureStore')` gates, and a `Record<Platform, factory | null>` picks the implementation.
- **`require()` → static imports** for the four storage implementations. They bought no code splitting — each already defers its native dependency to a dynamic import *inside* a method — and cost the factory its testability, since `require` of a TS module does not resolve under vitest.

## ⚠️ One decision for you, and a cheap way to take the other branch

The leaf spec requires `usesBearer() === true` / `supportsCSRF() === false`. Until native sign-in lands (Phase B), an Android session is a **cookie** session with no bearer token, and `fetchWithAuth` attaches `X-CSRF-Token` only on its non-bearer path (`auth-fetch.ts:326`, `:398`) while the server enforces CSRF exactly when `requireCSRF && isSessionAuth && !hasBearerAuth` (`lib/auth/index.ts:606-618`) across 209 route files. So **every POST/PATCH/PUT/DELETE from the Android app would 403** in that window. GETs are unaffected (`credentials: 'include'` is unconditional), and refresh works — see below.

No user is exposed: the Android shell is unshipped (`versionCode 1`, no build since the debug APK on 2026-03-23), and Phase E is what builds an internal-testing APK. But **no APK can ship between this PR and Phase B.** I have not deviated from the spec to fix it, because the epic assigns exactly this to Phase B's *auth session gate sweep* ("should omit CSRF handling consistently with how the storage adapter reports its own capabilities"); it is written up on that task page with the mechanism and the recommended one-line close.

**If you would rather not carry that window at all:** setting `SECURE_STORAGE_FACTORIES.android = null` in `platform-storage/index.ts` holds Android on `WebStorage` until Phase B. That is a one-line change, and it would also make the entire legacy-migration section below unnecessary — roughly half of `android-storage.ts`. Your call; I have implemented the spec as written.

## What review found — 18 issues across five adversarial passes

Two bots, an independent reviewer and my own passes; several of these would have signed users out. Every one was verified against the routes and call sites before being fixed, and each fix is mutation-checked.

**Round 1 — the token this PR could strand.** Codex flagged that selecting `AndroidStorage` orphans the device token Android sign-in writes today: until Phase B, Android signs in through the *web* flow inside the WebView, which persists its token to `localStorage` (`useAuth.ts` capturing `ps_device_token`, `PasskeyLoginButton.tsx`). `getStoredSession` now falls back to that session, and `getDeviceId` adopts its binding. CodeRabbit added an unserialized read-then-write in `getDeviceId` (two callers → two identities, one persisted) and a `?? null` that waved non-strings through for `csrfToken`/`deviceToken`.

**Round 2 — the migration destroyed what it was protecting.** Android's web sign-in registers its device record with `platform: 'web'`, and `/api/auth/device/refresh` branches on that *stored* platform: its web branch sets a session **cookie** and returns only `{ csrfToken, deviceToken }`, no `sessionToken` (`route.ts:197-230`). `storeSession` wrote that as a blob `getStoredSession` rejects and then spent the legacy copy — a forced sign-out on the refresh that had just succeeded. A bearer-less session now goes where the cookie world reads it from, which also persists a **rotated** device token. Same round: `getStoredSession` and the id lookup used opposite store priorities, so a refresh could pair the keychain's token with the legacy id (read as a stolen token); and logout cleared the native store only on iOS.

**Round 3 — the fixes' own edges.** A refusing keystore answered with a *minted* id rather than the legacy binding; a hung one could leave a refresh pending forever (`getDeviceInfo` is awaited without a timeout, so `isRefreshing` would never clear); the bearer-less branch clobbered `browser_device_id`, left a superseded keychain session shadowing the token it had just written, and silently resolved when there was nothing to store. Also: clearing before writing had a window where a `QuotaExceededError` lost the only recoverable token — the order is now write-then-clear.

**Round 4 — the record added in round 3.** It could hold the id of a session no longer in force (superseded by the bearer-less branch, or revoked by logout), could return `''` against a `string | null` signature, and could not tell "no session anywhere" from "the store never answered" — so a minted id was published as the browser's identity on the strength of a read that hung.

**Round 7 — CodeRabbit on the final head.** Two Major, both real. `resolveDeviceId` awaited `Preferences.get`/`set` unbounded — the keychain read had been bounded two commits earlier and these had not, with the same consequence: `refreshBearerSession` awaits `getDeviceInfo()` without a timeout, so a bridge call that never settles leaves the refresh and everything queued behind `isRefreshing` pending forever. Both now race the same 3s budget and **reject** rather than fall back, because a minted id would be one the live token is not bound to. And the capability lookup in logout sat outside its try, inside a `finally` — a dynamic import that rejects would have skipped the localStorage clear, the store reset and the redirect, stranding a user in a half-logged-out shell. Third: the `csrfToken` half of the shape guard had no test, so dropping it passed everything.

**Round 6 — the test suite itself**, audited end to end for the first time after six rounds had grown it to 52 tests. Two real gaps: a failing fake-timer test poisoned every test after it (`restoreAllMocks` restores spies, not timers), turning one failure into a wall of unrelated ones; and the legacy fallback on the two *shape-rejection* branches had no test at all — they ran with an empty `localStorage` and asserted `toBeNull()`, so they passed whether the code fell back or not. That is the behaviour whose absence was the round-2 forced sign-out. Also uncovered: the `deviceId` backwards-compat alias and `auth:refreshed`.

**Round 5 — clean on the mechanism.** No defects; the recommendation was to stop. What it did leave: `PlatformStorage.getStoredSession` had two opposite error contracts across implementations and documented neither (`AndroidStorage` throws on a store fault, `IOSStorage` flattens it to `null` and so signs a user out over a transient Keychain failure) — the interface now states the contract and names iOS as not yet honouring it. And two tests were pinning less than their names claimed: one exercised the fault path with no legacy binding in place, so it could not have failed; another asserted a recorded value but not its presence.

## Verification

- `android-storage.test.ts` — 59 tests. `useAuth.test.ts` — 22, including two for the logout path. 201 across the nine affected suites (`auth-fetch*`, `useSigninRecovery`, `capacitor-bridge`).
- **51 mutations run, 50 caught.** Three initially survived and were fixed — no coverage for the best-effort id write, one test that asserted a recorded value but not its presence, and one probe that silently failed to apply. The 43rd is **uncatchable and is not claimed as covered**: `boundDeviceId` returning `''` instead of `null` is invisible through the public API because its single caller tests truthiness. It is fixed as a contract matter, for the Phase B change that will collapse that code.
- `eslint` on the touched files passes locally.
- **Native prerequisites verified from source**: `MainActivity.java` calls `registerPlugin(PageSpaceSecureStoragePlugin.class)` before `super.onCreate`; `androidx.security:security-crypto:1.1.0-alpha06` is on the app's `build.gradle` (an alpha, part of why the init-failure path is worth having); `capacitor-preferences` is in `capacitor.settings.gradle`.
- No repo-wide typecheck or build was run locally — many agents share this machine. CI is the gate, and the branch has `origin/master` merged in so the final run is against a current base.

**Not verified on hardware.** No Android device, and the app is not built in this worktree. The plugin's rejection shape, the device-id round trip, and every keystore-fault path are reasoned from source with the plugin modelled as a rejecting mock in tests. Phase E owns real-device verification.

## Known gaps, deliberately left

- A legacy session whose `browser_device_id` is missing yields an empty `deviceId` and therefore a minted one — `WebStorage` behaves identically (`refreshWebSession` mints through `getOrCreateDeviceId`), so it is not a regression, and the minted id is now published to that key so the two identities converge as they do on web.
- `refreshBearerSession` reads the session once itself and again inside `getDeviceInfo()`, so a write landing between the two makes them disagree. The reachable half (the second read failing) is closed by remembering what the first read said; the mutation-interleaving half cannot be closed from inside the adapter — it needs `session.deviceId || info.deviceId` in `auth-fetch.ts`, which is Phase B's file. Note it is **two** lines, not one: `:645` (the request body) and `:662` (the `storeSession` call on the success path). Changing only the first would send one id and persist another. Recorded on the Phase B task page with that correction.

## Changelog

None. Nothing is user-observable yet — Android native sign-in is Phase B, so nothing writes a session on Android for this to store.

## Scope

`platform-storage/` plus two files it forced: one comment in `capacitor-bridge.ts` (its "no consumer yet" note is now false), and the logout branch in `useAuth.ts`, which is the logout path for the store being introduced. No changes to `usePushNotifications.ts`, `useIosBadgeSync.ts`, `AndroidManifest.xml`, or the `ios-*-auth` modules — Phase D is concurrent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UAxq9Gr6fARJ2FP28QdZ9S
