### PR TITLE
Android Phase D: push permission, registration, and badge sync generalization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ All notable user-facing changes to PageSpace are documented here. Format follows
 
 ### Added
 
+- **Android app: it can now ask for notification permission and register for push (not yet
+  distributed)** — the server has been able to send an Android push since the FCM sender landed, but
+  no Android build could receive one: the app declared no notification permission and the shared
+  registration code was gated to iOS. Android now declares `POST_NOTIFICATIONS`, asks for it at
+  runtime, and registers its FCM token the same way iOS does. If you say no, that is remembered —
+  the prompt does not come back on every launch, and turning notifications on in system settings
+  picks up where it left off. The app icon can also carry an unread badge on Android now, where the
+  launcher supports one (many do not, and those simply show nothing). **Nobody can see any of this
+  yet:** there is still no Android release build and no distribution, and none of it has been run on
+  a real device — this is the client half of the loop being closed, not a shipped feature.
+
 - **Android app: a failed load now offers a Retry instead of a dead end (not yet distributed)** —
   the Android shell had no bundled error screen, so launching without connectivity left the WebView
   on Chrome's own error page with nothing to do. It now falls back to a PageSpace screen with a

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,8 +12,8 @@ All notable user-facing changes to PageSpace are documented here. Format follows
   no Android build could receive one: the app declared no notification permission and the shared
   registration code was gated to iOS. Android now declares `POST_NOTIFICATIONS`, asks for it at
   runtime, and registers its FCM token the same way iOS does. If you say no, that is remembered —
-  the prompt does not come back on every launch, and turning notifications on in system settings
-  picks up where it left off. The app icon can also carry an unread badge on Android now, where the
+  the prompt does not come back on every launch — and if you later turn notifications on in system
+  settings, the next time you open the app it picks up where it left off. The app icon can also carry an unread badge on Android now, where the
   launcher supports one (many do not, and those simply show nothing). **Nobody can see any of this
   yet:** there is still no Android release build and no distribution, and none of it has been run on
   a real device — this is the client half of the loop being closed, not a shipped feature.

--- a/apps/android/README.md
+++ b/apps/android/README.md
@@ -336,10 +336,26 @@ comparing the platform to `'ios'`. On registration the FCM token POSTs to
 **A refusal is remembered.** The hook writes a `push_permission_denied` record to `localStorage`
 and declines to call `requestPermissions()` again while it stands, so the dialog does not return on
 every cold start. This is not redundant with the OS state: after one refusal Android reports
-`'prompt-with-rationale'` from `checkPermissions()` and would still allow the ask. The record is
-dropped as soon as `checkPermissions()` reads `granted` — which is what happens when the user turns
-notifications on from system settings — and an explicitly user-initiated retry can pass
-`requestPermission({ ignoreRecordedDenial: true })` to ask anyway.
+`'prompt-with-rationale'` from `checkPermissions()` and would still allow the ask.
+
+The record is a cache of the OS's answer, never a second source of truth. The permission-check
+effect drops it whenever `checkPermissions()` reports a state that is not holding a refusal —
+`granted` (the user turned notifications on from system settings) or `prompt` (the OS has forgotten
+the refusal and would ask again, which is where **Android 11+ lands after auto-revoking permissions
+for an app that went unused**). `denied` and `prompt-with-rationale` both keep it. There is
+therefore no manual override to re-ask: the way back is the OS's own state, so the record can never
+outlive the refusal it stands for. While it does stand, `hasPreviouslyDenied` is the signal a
+settings surface should use to say "enable notifications in system settings" rather than offer a
+button that would do nothing.
+
+**Not covered here: how the notification is drawn.** This work makes a push *deliverable*; what the
+tray renders is separate and unverified. The manifest declares no
+`com.google.firebase.messaging.default_notification_icon` or `default_notification_channel_id`
+meta-data, so both the small icon and the channel fall to Firebase's defaults inside
+`CommonNotificationBuilder.getOrCreateChannel` / `createNotificationInfo` (the plugin calls both —
+`PushNotificationsPlugin.java:274-286`). Whether that produces a usable icon and a sensibly-named
+channel on a real device is a device-verification question, and adding a monochrome notification
+icon is its own asset task.
 
 **Badges.** `@capawesome/capacitor-badge` is now an Android dependency and `useNativeBadgeSync`
 (formerly `useIosBadgeSync`) projects the unread count on both platforms. The Android badge is a

--- a/apps/android/README.md
+++ b/apps/android/README.md
@@ -359,6 +359,14 @@ meta-data, so both the small icon and the channel fall to Firebase's defaults in
 channel on a real device is a device-verification question, and adding a monochrome notification
 icon is its own asset task.
 
+One thing that will look like a bug during verification and is not: a push arriving while the app is
+in the **foreground** does nothing visible. The hook dispatches a `push:received` window event and
+nothing in the app listens for it — deliberately, on both platforms, because the foreground already
+has a better channel (the realtime socket drives `useNotificationStore`, which is what moves the
+in-app unread count and the badge). Tapping a notification *is* wired: `PushActionHandler` listens
+for `push:action` with no platform gate and routes on `data.type` / `data.pageId` / `data.driveId`,
+all of which the sender populates and FCM delivers as strings.
+
 **Badges.** `@capawesome/capacitor-badge` is now an Android dependency and `useNativeBadgeSync`
 (formerly `useIosBadgeSync`) projects the unread count on both platforms. The Android badge is a
 launcher feature: launchers that do not implement one reject or ignore the write, which the hook

--- a/apps/android/README.md
+++ b/apps/android/README.md
@@ -365,10 +365,13 @@ launcher feature: launchers that do not implement one reject or ignore the write
 logs and otherwise treats as a no-op. The iOS-only authorization gate inside it is conditional, not
 removed — see the comment there for the one-shot option cap it defends against.
 
-Adding that dependency means `capacitor.settings.gradle` and `app/capacitor.build.gradle` are stale
-until someone runs `bun run --filter '@pagespace/android' sync` (`cap sync android`); both files are
-generated, and until they are regenerated the Badge plugin is not compiled into the APK and
-`Badge.set()` rejects at runtime (silently, per the above). Do that before the first build.
+Adding that dependency leaves the generated `capacitor.settings.gradle` and
+`app/capacitor.build.gradle` stale in the repo — neither lists the badge plugin yet, and until they
+do it is not compiled into the APK and `Badge.set()` rejects at runtime (silently, per the above).
+No separate step is needed to fix that: `cap sync android` regenerates both, and it is already the
+second half of `build:full`, so the documented device-verification path
+(`bun run --cwd apps/android build:full`) picks it up. The stale files only bite someone who builds
+Gradle directly without syncing first.
 
 **Not verified on a device.** Nothing here has been exercised on real hardware — there is no
 release build yet. The permission dialog, the FCM token round trip and badge behaviour across

--- a/apps/android/README.md
+++ b/apps/android/README.md
@@ -339,7 +339,9 @@ every cold start. This is not redundant with the OS state: after one refusal And
 `'prompt-with-rationale'` from `checkPermissions()` and would still allow the ask.
 
 The record is a cache of the OS's answer, never a second source of truth. The permission-check
-effect drops it whenever `checkPermissions()` reports a state that is not holding a refusal —
+effect runs once per mount, so the sync below happens on the next launch rather than the moment a
+setting changes; it drops the record whenever `checkPermissions()` reports a state that is not
+holding a refusal —
 `granted` (the user turned notifications on from system settings) or `prompt` (the OS has forgotten
 the refusal and would ask again, which is where **Android 11+ lands after auto-revoking permissions
 for an app that went unused**). `denied` and `prompt-with-rationale` both keep it. There is

--- a/apps/android/README.md
+++ b/apps/android/README.md
@@ -340,8 +340,11 @@ every cold start. This is not redundant with the OS state: after one refusal And
 
 The record is a cache of the OS's answer, never a second source of truth. The permission-check
 effect runs once per mount, so the sync below happens on the next launch rather than the moment a
-setting changes; it drops the record whenever `checkPermissions()` reports a state that is not
-holding a refusal —
+setting changes; it makes the record agree with the OS in both directions. It writes one when
+`checkPermissions()` reports `denied` or `prompt-with-rationale` — the OS can be holding a refusal
+this client never saw it collect, which is exactly the state of a user who refused on a build
+predating the record, or one whose storage write failed — and it drops one whenever the OS reports a
+state that is not holding a refusal —
 `granted` (the user turned notifications on from system settings) or `prompt` (the OS has forgotten
 the refusal and would ask again, which is where **Android 11+ lands after auto-revoking permissions
 for an app that went unused**). `denied` and `prompt-with-rationale` both keep it. There is

--- a/apps/android/README.md
+++ b/apps/android/README.md
@@ -3,9 +3,9 @@
 Capacitor wrapper around the web app, mirroring `apps/ios`.
 
 > **Scope of this file today:** why the Capacitor config diverges from the iOS one, what deep
-> links ship and what is deferred, and the server-side push requirements. Client-side setup — the
-> runtime permission prompt, token registration, build and signing — belongs to the Android client
-> work and is not documented here yet.
+> links ship and what is deferred, the server-side push requirements, and the client-side push
+> permission and registration path. Build and signing belong to the release work and are not
+> documented here yet.
 
 ## Why this config is not a copy of the iOS one
 
@@ -317,3 +317,41 @@ Once the secret is set, three sends confirm the whole path:
 
 Only a token-specific verdict from FCM deactivates a device. Credential, project, quota, outage
 and malformed-message rejections never count against a phone, however many times they occur.
+
+## Client-side push: permission and registration
+
+`POST_NOTIFICATIONS` is declared in `AndroidManifest.xml`. It has to be: on API 33+ (targetSdk is
+36) it is a dangerous permission that starts out ungranted, and an *undeclared* dangerous
+permission cannot be requested at all — the request resolves denied with no dialog shown. On API 32
+and below the OS ignores the declaration, and `@capacitor/push-notifications` resolves
+`requestPermissions()` as granted without asking.
+
+The runtime request and the token round trip live in the shared web layer, in
+`apps/web/src/hooks/usePushNotifications.ts` and `apps/web/src/components/PushNotificationManager.tsx`
+— the same code iOS runs. What changed for Android is only the gate: the hook now asks
+`useCapacitor().capabilities.push` (the table in `apps/web/src/lib/capacitor-bridge.ts`) instead of
+comparing the platform to `'ios'`. On registration the FCM token POSTs to
+`/api/notifications/push-tokens` with `platform: 'android'`, which that route has always accepted.
+
+**A refusal is remembered.** The hook writes a `push_permission_denied` record to `localStorage`
+and declines to call `requestPermissions()` again while it stands, so the dialog does not return on
+every cold start. This is not redundant with the OS state: after one refusal Android reports
+`'prompt-with-rationale'` from `checkPermissions()` and would still allow the ask. The record is
+dropped as soon as `checkPermissions()` reads `granted` — which is what happens when the user turns
+notifications on from system settings — and an explicitly user-initiated retry can pass
+`requestPermission({ ignoreRecordedDenial: true })` to ask anyway.
+
+**Badges.** `@capawesome/capacitor-badge` is now an Android dependency and `useNativeBadgeSync`
+(formerly `useIosBadgeSync`) projects the unread count on both platforms. The Android badge is a
+launcher feature: launchers that do not implement one reject or ignore the write, which the hook
+logs and otherwise treats as a no-op. The iOS-only authorization gate inside it is conditional, not
+removed — see the comment there for the one-shot option cap it defends against.
+
+Adding that dependency means `capacitor.settings.gradle` and `app/capacitor.build.gradle` are stale
+until someone runs `bun run --filter '@pagespace/android' sync` (`cap sync android`); both files are
+generated, and until they are regenerated the Badge plugin is not compiled into the APK and
+`Badge.set()` rejects at runtime (silently, per the above). Do that before the first build.
+
+**Not verified on a device.** Nothing here has been exercised on real hardware — there is no
+release build yet. The permission dialog, the FCM token round trip and badge behaviour across
+launchers are all the device-verification task's to confirm.

--- a/apps/android/android/app/src/main/AndroidManifest.xml
+++ b/apps/android/android/app/src/main/AndroidManifest.xml
@@ -103,4 +103,24 @@
     <!-- Permissions -->
 
     <uses-permission android:name="android.permission.INTERNET" />
+
+    <!--
+        Notification delivery. Declaring this is what makes a runtime request
+        possible at all: on API 33+ (targetSdk is 36) POST_NOTIFICATIONS is a
+        dangerous permission that starts out not granted, and an undeclared
+        dangerous permission cannot be requested — the request resolves denied
+        without ever showing a dialog, so every FCM message would be dropped
+        silently.
+
+        The runtime request itself is issued by @capacitor/push-notifications'
+        requestPermissions(), driven from usePushNotifications.ts. On API 32 and
+        below that plugin resolves "granted" without asking, because
+        notifications were not permission-gated then; maxSdkVersion is therefore
+        deliberately absent — the OS ignores the declaration on those levels.
+
+        This grants the ability to POST a notification, not to receive data.
+        A data-only FCM message still reaches MessagingService while the
+        permission is denied; only the visible notification is suppressed.
+    -->
+    <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
 </manifest>

--- a/apps/android/package.json
+++ b/apps/android/package.json
@@ -14,6 +14,7 @@
     "run": "bun x cap run android"
   },
   "dependencies": {
+    "@capawesome/capacitor-badge": "^7.0.0",
     "@capacitor/app": "^7.0.3",
     "@capacitor/browser": "^7.0.3",
     "@capacitor/core": "^7.4.5",

--- a/apps/ios/README.md
+++ b/apps/ios/README.md
@@ -34,7 +34,7 @@ This is a **remote-loading** app. The WebView loads the live site directly:
 Push is driven from the web layer (`apps/web/src/hooks/usePushNotifications.ts`), device tokens
 POST to `/api/notifications/push-tokens`, and the server sends via
 `packages/lib/src/notifications/push-notifications.ts` (ES256 JWT over HTTP/2 to APNs). The app
-icon badge is projected from the unread count (`useIosBadgeSync.ts` + `deriveBadgeCount`).
+icon badge is projected from the unread count (`useNativeBadgeSync.ts` + `deriveBadgeCount`).
 
 ### Server-side push requirements (production `pagespace-web`)
 

--- a/apps/web/src/components/PushNotificationManager.tsx
+++ b/apps/web/src/components/PushNotificationManager.tsx
@@ -29,7 +29,13 @@ export function PushNotificationManager() {
     } else if (permissionStatus === 'granted' && !isRegistered) {
       void registerToken();
     }
-    // 'denied': burn the attempt, do nothing — user must enable in iOS Settings.
+    // Every other state burns the attempt and does nothing:
+    // - 'denied': the OS will not ask again; the user must enable notifications
+    //   in system settings.
+    // - 'prompt-with-rationale' (Android only): the OS would still allow the
+    //   ask, but the user has already refused once. Re-prompting here is exactly
+    //   the every-launch nag the hook's recorded-denial guard exists to stop,
+    //   and requestPermission() would decline it anyway.
   }, [isNative, isSupported, permissionStatus, isRegistered, requestPermission, registerToken]);
 
   return null;

--- a/apps/web/src/components/__tests__/PushNotificationManager.test.tsx
+++ b/apps/web/src/components/__tests__/PushNotificationManager.test.tsx
@@ -22,6 +22,7 @@ const defaultPushState = {
   isRegistered: false,
   isLoading: false,
   error: null,
+  hasPreviouslyDenied: false,
   requestPermission: vi.fn().mockResolvedValue(true),
   registerToken: vi.fn().mockResolvedValue(true),
   unregisterToken: vi.fn().mockResolvedValue(undefined),
@@ -108,6 +109,23 @@ describe('PushNotificationManager', () => {
     mockUsePushNotifications.mockReturnValue({
       ...defaultPushState,
       permissionStatus: 'denied',
+      requestPermission,
+      registerToken,
+    });
+
+    render(<PushNotificationManager />);
+
+    expect(requestPermission).not.toHaveBeenCalled();
+    expect(registerToken).not.toHaveBeenCalled();
+  });
+
+  it("regression: Android's 'prompt-with-rationale' does not re-prompt — the OS would still allow the dialog, so only this branch stops the every-launch nag", async () => {
+    const requestPermission = vi.fn().mockResolvedValue(false);
+    const registerToken = vi.fn().mockResolvedValue(false);
+    mockUsePushNotifications.mockReturnValue({
+      ...defaultPushState,
+      permissionStatus: 'prompt-with-rationale',
+      hasPreviouslyDenied: true,
       requestPermission,
       registerToken,
     });

--- a/apps/web/src/components/layout/Layout.tsx
+++ b/apps/web/src/components/layout/Layout.tsx
@@ -5,7 +5,7 @@ import { useSocket } from "@/hooks/useSocket";
 import { useAccessRevocation } from "@/hooks/useAccessRevocation";
 import { useNotificationToasts } from "@/hooks/useNotificationToasts";
 import { useDesktopNotifications } from "@/hooks/useDesktopNotifications";
-import { useIosBadgeSync } from "@/hooks/useIosBadgeSync";
+import { useNativeBadgeSync } from "@/hooks/useNativeBadgeSync";
 import TopBar from "@/components/layout/main-header";
 import MemoizedSidebar from "@/components/layout/left-sidebar/MemoizedSidebar";
 import CenterPanel from "@/components/layout/middle-content/CenterPanel";
@@ -153,8 +153,8 @@ function Layout({ children }: LayoutProps) {
   // Show native OS notifications for new notifications when the desktop app is unfocused
   useDesktopNotifications();
 
-  // Keep the native iOS app-icon badge in sync with the unread count (reactive SSOT projection)
-  useIosBadgeSync();
+  // Keep the native app-icon badge in sync with the unread count (reactive SSOT projection)
+  useNativeBadgeSync();
 
   // Monitor performance
   usePerformanceMonitor();

--- a/apps/web/src/components/layout/__tests__/Layout.voice-reveal.test.tsx
+++ b/apps/web/src/components/layout/__tests__/Layout.voice-reveal.test.tsx
@@ -30,7 +30,7 @@ vi.mock('@/hooks/useSocket', () => ({ useSocket: () => undefined }));
 vi.mock('@/hooks/useAccessRevocation', () => ({ useAccessRevocation: () => undefined }));
 vi.mock('@/hooks/useNotificationToasts', () => ({ useNotificationToasts: () => undefined }));
 vi.mock('@/hooks/useDesktopNotifications', () => ({ useDesktopNotifications: () => undefined }));
-vi.mock('@/hooks/useIosBadgeSync', () => ({ useIosBadgeSync: () => undefined }));
+vi.mock('@/hooks/useNativeBadgeSync', () => ({ useNativeBadgeSync: () => undefined }));
 vi.mock('@/hooks/usePerformanceMonitor', () => ({ usePerformanceMonitor: () => undefined }));
 vi.mock('@/hooks/useIOSKeyboardInit', () => ({ useIOSKeyboardInit: () => undefined }));
 vi.mock('@/hooks/useMobileKeyboard', () => ({ dismissKeyboard: () => {} }));

--- a/apps/web/src/components/layout/__tests__/Layout.voice-session.test.tsx
+++ b/apps/web/src/components/layout/__tests__/Layout.voice-session.test.tsx
@@ -67,7 +67,7 @@ vi.mock('@/hooks/useNotificationToasts', () => ({
 vi.mock('@/hooks/useDesktopNotifications', () => ({
   useDesktopNotifications: () => undefined,
 }));
-vi.mock('@/hooks/useIosBadgeSync', () => ({ useIosBadgeSync: () => undefined }));
+vi.mock('@/hooks/useNativeBadgeSync', () => ({ useNativeBadgeSync: () => undefined }));
 vi.mock('@/hooks/usePerformanceMonitor', () => ({
   usePerformanceMonitor: () => undefined,
 }));

--- a/apps/web/src/hooks/__tests__/useCapacitor.test.ts
+++ b/apps/web/src/hooks/__tests__/useCapacitor.test.ts
@@ -280,7 +280,7 @@ describe('useCapacitor', () => {
       });
     });
 
-    it('exposes the Android capability set, badge still unsupported', async () => {
+    it('exposes the Android capability set', async () => {
       (window as Window & { Capacitor?: MockCapacitor }).Capacitor = {
         isNativePlatform: vi.fn(() => true),
         getPlatform: vi.fn(() => 'android'),
@@ -296,7 +296,7 @@ describe('useCapacitor', () => {
         secureStore: true,
         nativeAuth: true,
         push: true,
-        badge: false,
+        badge: true,
       });
     });
 

--- a/apps/web/src/hooks/__tests__/useNativeBadgeSync.test.tsx
+++ b/apps/web/src/hooks/__tests__/useNativeBadgeSync.test.tsx
@@ -13,17 +13,41 @@ type MockCapacitorState = {
   isIOS: boolean;
   isAndroid: boolean;
   isIPad: boolean;
+  capabilities: { secureStore: boolean; nativeAuth: boolean; push: boolean; badge: boolean };
   isReady: boolean;
 };
 
-let mockCapacitorState: MockCapacitorState = {
+const IOS_STATE: MockCapacitorState = {
   isNative: true,
   platform: 'ios',
   isIOS: true,
   isAndroid: false,
   isIPad: false,
+  capabilities: { secureStore: true, nativeAuth: true, push: true, badge: true },
   isReady: true,
 };
+
+const ANDROID_STATE: MockCapacitorState = {
+  isNative: true,
+  platform: 'android',
+  isIOS: false,
+  isAndroid: true,
+  isIPad: false,
+  capabilities: { secureStore: true, nativeAuth: true, push: true, badge: true },
+  isReady: true,
+};
+
+const WEB_STATE: MockCapacitorState = {
+  isNative: false,
+  platform: 'web',
+  isIOS: false,
+  isAndroid: false,
+  isIPad: false,
+  capabilities: { secureStore: false, nativeAuth: false, push: false, badge: false },
+  isReady: true,
+};
+
+let mockCapacitorState: MockCapacitorState = IOS_STATE;
 
 vi.mock('@/hooks/useCapacitor', () => ({
   useCapacitor: () => mockCapacitorState,
@@ -46,7 +70,7 @@ vi.mock('@capawesome/capacitor-badge', () => ({
   Badge: { set: mockBadgeSet, checkPermissions: mockCheckPermissions },
 }));
 
-import { useIosBadgeSync } from '../useIosBadgeSync';
+import { useNativeBadgeSync } from '../useNativeBadgeSync';
 import { useNotificationStore } from '@/stores/useNotificationStore';
 
 /** Drive useAppStateRecovery's web visibilitychange resume path. */
@@ -63,20 +87,13 @@ const backgroundThenResume = async () => {
   });
 };
 
-describe('useIosBadgeSync', () => {
+describe('useNativeBadgeSync', () => {
   beforeEach(() => {
     vi.resetAllMocks();
     mockBadgeSet.mockResolvedValue(undefined);
     mockCheckPermissions.mockResolvedValue({ display: 'granted' });
     mockFetchNotifications.mockResolvedValue(undefined);
-    mockCapacitorState = {
-      isNative: true,
-      platform: 'ios',
-      isIOS: true,
-      isAndroid: false,
-      isIPad: false,
-      isReady: true,
-    };
+    mockCapacitorState = IOS_STATE;
     useNotificationStore.setState({
       notifications: [],
       unreadCount: 0,
@@ -89,11 +106,11 @@ describe('useIosBadgeSync', () => {
     vi.restoreAllMocks();
   });
 
-  it('never calls Badge.set when not on iOS', async () => {
-    mockCapacitorState = { ...mockCapacitorState, isNative: false, platform: 'web', isIOS: false };
+  it('never calls Badge.set on a platform without the badge capability', async () => {
+    mockCapacitorState = WEB_STATE;
     useNotificationStore.setState({ unreadCount: 3 });
 
-    renderHook(() => useIosBadgeSync());
+    renderHook(() => useNativeBadgeSync());
     await act(async () => {
       await Promise.resolve();
     });
@@ -102,7 +119,7 @@ describe('useIosBadgeSync', () => {
   });
 
   it('projects count 0 on mount when iOS and unreadCount is 0', async () => {
-    renderHook(() => useIosBadgeSync());
+    renderHook(() => useNativeBadgeSync());
 
     await waitFor(() => expect(mockBadgeSet).toHaveBeenCalledWith({ count: 0 }));
   });
@@ -111,7 +128,7 @@ describe('useIosBadgeSync', () => {
     mockCheckPermissions.mockResolvedValue({ display: 'prompt' });
     useNotificationStore.setState({ unreadCount: 3 });
 
-    renderHook(() => useIosBadgeSync());
+    renderHook(() => useNativeBadgeSync());
     await waitFor(() => expect(mockCheckPermissions).toHaveBeenCalled());
     await act(async () => {
       await Promise.resolve();
@@ -124,7 +141,7 @@ describe('useIosBadgeSync', () => {
     mockCheckPermissions.mockResolvedValue({ display: 'denied' });
     useNotificationStore.setState({ unreadCount: 3 });
 
-    renderHook(() => useIosBadgeSync());
+    renderHook(() => useNativeBadgeSync());
     await waitFor(() => expect(mockCheckPermissions).toHaveBeenCalled());
     await act(async () => {
       await Promise.resolve();
@@ -137,7 +154,7 @@ describe('useIosBadgeSync', () => {
     mockCheckPermissions.mockResolvedValue({ display: 'granted' });
     useNotificationStore.setState({ unreadCount: 3 });
 
-    renderHook(() => useIosBadgeSync());
+    renderHook(() => useNativeBadgeSync());
 
     await waitFor(() => expect(mockBadgeSet).toHaveBeenCalledWith({ count: 3 }));
   });
@@ -149,7 +166,7 @@ describe('useIosBadgeSync', () => {
     // possibly-nonzero native badge left over from a prior session.
     useNotificationStore.setState({ unreadCount: 0, hasHydrated: false });
 
-    renderHook(() => useIosBadgeSync());
+    renderHook(() => useNativeBadgeSync());
     await act(async () => {
       await Promise.resolve();
     });
@@ -162,7 +179,7 @@ describe('useIosBadgeSync', () => {
     // is the whole point of this feature (it's how the badge clears), so a
     // hydrated 0 must always reach Badge.set, unlike an unhydrated 0.
     useNotificationStore.setState({ unreadCount: 0, hasHydrated: false });
-    renderHook(() => useIosBadgeSync());
+    renderHook(() => useNativeBadgeSync());
     await act(async () => {
       await Promise.resolve();
     });
@@ -177,7 +194,7 @@ describe('useIosBadgeSync', () => {
 
   it('regression: projects the real count once hydration completes after a cold launch', async () => {
     useNotificationStore.setState({ unreadCount: 0, hasHydrated: false });
-    renderHook(() => useIosBadgeSync());
+    renderHook(() => useNativeBadgeSync());
     await act(async () => {
       await Promise.resolve();
     });
@@ -194,14 +211,14 @@ describe('useIosBadgeSync', () => {
   it('projects unreadCount 3 on mount', async () => {
     useNotificationStore.setState({ unreadCount: 3 });
 
-    renderHook(() => useIosBadgeSync());
+    renderHook(() => useNativeBadgeSync());
 
     await waitFor(() => expect(mockBadgeSet).toHaveBeenCalledWith({ count: 3 }));
   });
 
   it('re-projects when the count changes from 3 to 0', async () => {
     useNotificationStore.setState({ unreadCount: 3 });
-    renderHook(() => useIosBadgeSync());
+    renderHook(() => useNativeBadgeSync());
     await waitFor(() => expect(mockBadgeSet).toHaveBeenCalledWith({ count: 3 }));
 
     act(() => {
@@ -213,7 +230,7 @@ describe('useIosBadgeSync', () => {
 
   it('on app resume, refreshes the store from the server and re-projects the refreshed count', async () => {
     useNotificationStore.setState({ unreadCount: 1 });
-    renderHook(() => useIosBadgeSync());
+    renderHook(() => useNativeBadgeSync());
     await waitFor(() => expect(mockBadgeSet).toHaveBeenCalledWith({ count: 1 }));
 
     mockFetchNotifications.mockImplementation(async () => {
@@ -231,16 +248,76 @@ describe('useIosBadgeSync', () => {
     mockBadgeSet.mockRejectedValueOnce(new Error('not supported on this device'));
     useNotificationStore.setState({ unreadCount: 2 });
 
-    expect(() => renderHook(() => useIosBadgeSync())).not.toThrow();
+    expect(() => renderHook(() => useNativeBadgeSync())).not.toThrow();
     await waitFor(() => expect(mockBadgeSet).toHaveBeenCalledWith({ count: 2 }));
     await waitFor(() => expect(consoleError).toHaveBeenCalled());
 
     consoleError.mockRestore();
   });
 
+  it('projects on Android, whose capability row now has badge: true', async () => {
+    mockCapacitorState = ANDROID_STATE;
+    useNotificationStore.setState({ unreadCount: 3 });
+
+    renderHook(() => useNativeBadgeSync());
+
+    await waitFor(() => expect(mockBadgeSet).toHaveBeenCalledWith({ count: 3 }));
+  });
+
+  it('regression: does NOT run the iOS authorization gate on Android — the hazard it guards is iOS-only, and the Android plugin declares no backing permission', async () => {
+    mockCapacitorState = ANDROID_STATE;
+    // Even a non-granted read must not suppress the Android badge.
+    mockCheckPermissions.mockResolvedValue({ display: 'denied' });
+    useNotificationStore.setState({ unreadCount: 2 });
+
+    renderHook(() => useNativeBadgeSync());
+
+    await waitFor(() => expect(mockBadgeSet).toHaveBeenCalledWith({ count: 2 }));
+    expect(mockCheckPermissions).not.toHaveBeenCalled();
+  });
+
+  it('regression: still gates on iOS — the conditional must narrow the gate to iOS, not remove it', async () => {
+    mockCapacitorState = IOS_STATE;
+    mockCheckPermissions.mockResolvedValue({ display: 'prompt' });
+    useNotificationStore.setState({ unreadCount: 2 });
+
+    renderHook(() => useNativeBadgeSync());
+
+    await waitFor(() => expect(mockCheckPermissions).toHaveBeenCalled());
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    expect(mockBadgeSet).not.toHaveBeenCalled();
+  });
+
+  it('on Android, a launcher that rejects the write fails silently — logged, never thrown', async () => {
+    mockCapacitorState = ANDROID_STATE;
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {});
+    mockBadgeSet.mockRejectedValue(new Error('Badge is not supported on this launcher'));
+    useNotificationStore.setState({ unreadCount: 4 });
+
+    expect(() => renderHook(() => useNativeBadgeSync())).not.toThrow();
+
+    await waitFor(() => expect(consoleError).toHaveBeenCalled());
+    consoleError.mockRestore();
+  });
+
+  it('regression: does not project before the store has hydrated on Android either', async () => {
+    mockCapacitorState = ANDROID_STATE;
+    useNotificationStore.setState({ unreadCount: 0, hasHydrated: false });
+
+    renderHook(() => useNativeBadgeSync());
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    expect(mockBadgeSet).not.toHaveBeenCalled();
+  });
+
   it('stops projecting after unmount', async () => {
     useNotificationStore.setState({ unreadCount: 1 });
-    const { unmount } = renderHook(() => useIosBadgeSync());
+    const { unmount } = renderHook(() => useNativeBadgeSync());
     await waitFor(() => expect(mockBadgeSet).toHaveBeenCalledWith({ count: 1 }));
 
     unmount();

--- a/apps/web/src/hooks/__tests__/usePushNotifications.test.tsx
+++ b/apps/web/src/hooks/__tests__/usePushNotifications.test.tsx
@@ -309,22 +309,36 @@ describe('usePushNotifications', () => {
     expect(mockRegister).not.toHaveBeenCalled();
   });
 
-  it('an explicitly user-initiated retry can override the recorded refusal', async () => {
+  it("regression: the record is dropped when the OS reports 'prompt' again — Android auto-resets permissions for an unused app, and a record that outlived the refusal would lock the user out forever", async () => {
     localStorage.setItem(DENIAL_KEY, 'android');
-    mockCheckPermissions.mockResolvedValue({ receive: 'prompt-with-rationale' });
+    mockCheckPermissions.mockResolvedValue({ receive: 'prompt' });
 
     const { result } = renderHook(() => usePushNotifications());
-    await waitFor(() => expect(result.current.isSupported).toBe(true));
 
+    await waitFor(() => expect(result.current.permissionStatus).toBe('prompt'));
+    expect(localStorage.getItem(DENIAL_KEY)).toBeNull();
+    expect(result.current.hasPreviouslyDenied).toBe(false);
+
+    // ...and the guard is open again, so the OS can be asked.
     let granted: boolean | undefined;
     await act(async () => {
-      granted = await result.current.requestPermission({ ignoreRecordedDenial: true });
+      granted = await result.current.requestPermission();
     });
 
     expect(granted).toBe(true);
     expect(mockRequestPermissions).toHaveBeenCalledTimes(1);
     expect(mockRegister).toHaveBeenCalledTimes(1);
-    expect(localStorage.getItem(DENIAL_KEY)).toBeNull();
+  });
+
+  it("regression: 'prompt-with-rationale' does NOT drop the record — the refusal still stands there", async () => {
+    localStorage.setItem(DENIAL_KEY, 'android');
+    mockCheckPermissions.mockResolvedValue({ receive: 'prompt-with-rationale' });
+
+    const { result } = renderHook(() => usePushNotifications());
+
+    await waitFor(() => expect(result.current.permissionStatus).toBe('prompt-with-rationale'));
+    expect(localStorage.getItem(DENIAL_KEY)).toBe('android');
+    expect(result.current.hasPreviouslyDenied).toBe(true);
   });
 
   it('drops the recorded refusal when the OS reports the permission granted (enabled from system settings)', async () => {

--- a/apps/web/src/hooks/__tests__/usePushNotifications.test.tsx
+++ b/apps/web/src/hooks/__tests__/usePushNotifications.test.tsx
@@ -176,6 +176,51 @@ describe('usePushNotifications', () => {
     );
   });
 
+  it('regression: a rotated FCM token reaches the server — registration is tracked per token, not as a one-shot boolean', async () => {
+    const { result } = renderHook(() => usePushNotifications());
+    await waitFor(() => expect(result.current.isSupported).toBe(true));
+
+    const onRegistration = listeners.registration as (token: { value: string }) => void;
+    await act(async () => {
+      onRegistration({ value: 'fcm-token-original' });
+      await Promise.resolve();
+    });
+    await waitFor(() => expect(mockPost).toHaveBeenCalledTimes(1));
+
+    // FCM rotates the token while the hook stays mounted.
+    await act(async () => {
+      onRegistration({ value: 'fcm-token-rotated' });
+      await Promise.resolve();
+    });
+
+    await waitFor(() => expect(mockPost).toHaveBeenCalledTimes(2));
+    expect(mockPost).toHaveBeenLastCalledWith('/api/notifications/push-tokens', {
+      token: 'fcm-token-rotated',
+      platform: 'android',
+      deviceId: 'device-abc',
+      deviceName: 'Pixel 8',
+    });
+  });
+
+  it('re-emitting the SAME token does not POST again', async () => {
+    const { result } = renderHook(() => usePushNotifications());
+    await waitFor(() => expect(result.current.isSupported).toBe(true));
+
+    const onRegistration = listeners.registration as (token: { value: string }) => void;
+    await act(async () => {
+      onRegistration({ value: 'fcm-token-same' });
+      await Promise.resolve();
+    });
+    await waitFor(() => expect(mockPost).toHaveBeenCalledTimes(1));
+
+    await act(async () => {
+      onRegistration({ value: 'fcm-token-same' });
+      await Promise.resolve();
+    });
+
+    expect(mockPost).toHaveBeenCalledTimes(1);
+  });
+
   it('records the refusal when the user denies, and does not register', async () => {
     mockRequestPermissions.mockResolvedValue({ receive: 'denied' });
 

--- a/apps/web/src/hooks/__tests__/usePushNotifications.test.tsx
+++ b/apps/web/src/hooks/__tests__/usePushNotifications.test.tsx
@@ -1,0 +1,261 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { renderHook, act, waitFor } from '@testing-library/react';
+
+const {
+  mockAddListener,
+  mockRegister,
+  mockCheckPermissions,
+  mockRequestPermissions,
+  mockPost,
+  mockDel,
+} = vi.hoisted(() => ({
+  mockAddListener: vi.fn(),
+  mockRegister: vi.fn(),
+  mockCheckPermissions: vi.fn(),
+  mockRequestPermissions: vi.fn(),
+  mockPost: vi.fn(),
+  mockDel: vi.fn(),
+}));
+
+vi.mock('@capacitor/push-notifications', () => ({
+  PushNotifications: {
+    addListener: mockAddListener,
+    register: mockRegister,
+    checkPermissions: mockCheckPermissions,
+    requestPermissions: mockRequestPermissions,
+  },
+}));
+
+vi.mock('@/lib/auth/auth-fetch', () => ({ post: mockPost, del: mockDel }));
+
+vi.mock('@/lib/analytics', () => ({
+  getOrCreateDeviceId: () => 'device-abc',
+  getDeviceName: () => 'Pixel 8',
+}));
+
+vi.mock('@/hooks/useAuth', () => ({
+  useAuth: () => ({ isAuthenticated: true, user: { id: 'user-1' } }),
+}));
+
+type MockCapacitorState = {
+  isNative: boolean;
+  platform: 'ios' | 'android' | 'web';
+  isIOS: boolean;
+  isAndroid: boolean;
+  isIPad: boolean;
+  capabilities: { secureStore: boolean; nativeAuth: boolean; push: boolean; badge: boolean };
+  isReady: boolean;
+};
+
+const ANDROID_STATE: MockCapacitorState = {
+  isNative: true,
+  platform: 'android',
+  isIOS: false,
+  isAndroid: true,
+  isIPad: false,
+  capabilities: { secureStore: true, nativeAuth: true, push: true, badge: true },
+  isReady: true,
+};
+
+const WEB_STATE: MockCapacitorState = {
+  isNative: false,
+  platform: 'web',
+  isIOS: false,
+  isAndroid: false,
+  isIPad: false,
+  capabilities: { secureStore: false, nativeAuth: false, push: false, badge: false },
+  isReady: true,
+};
+
+let mockCapacitorState: MockCapacitorState = ANDROID_STATE;
+
+vi.mock('@/hooks/useCapacitor', () => ({
+  useCapacitor: () => mockCapacitorState,
+}));
+
+import { usePushNotifications } from '../usePushNotifications';
+
+/** The key usePushNotifications persists a refusal under. */
+const DENIAL_KEY = 'push_permission_denied';
+
+/**
+ * Handlers captured from PushNotifications.addListener, keyed by event name.
+ * Held as `unknown` because the four handlers take four different payloads;
+ * each test narrows the one it fires.
+ */
+let listeners: Record<string, unknown>;
+
+describe('usePushNotifications', () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+    localStorage.clear();
+    listeners = {};
+    mockCapacitorState = ANDROID_STATE;
+    mockAddListener.mockImplementation(async (event: string, handler: unknown) => {
+      listeners[event] = handler;
+      return { remove: vi.fn() };
+    });
+    mockCheckPermissions.mockResolvedValue({ receive: 'prompt' });
+    mockRequestPermissions.mockResolvedValue({ receive: 'granted' });
+    mockRegister.mockResolvedValue(undefined);
+    mockPost.mockResolvedValue({ success: true, tokenId: 't1' });
+    mockDel.mockResolvedValue(undefined);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('reports supported on Android — the gate is the push capability, not a platform equality check', async () => {
+    const { result } = renderHook(() => usePushNotifications());
+
+    await waitFor(() => expect(result.current.isSupported).toBe(true));
+  });
+
+  it('reports unsupported, and attaches no listeners, on a platform without the push capability', async () => {
+    mockCapacitorState = WEB_STATE;
+
+    const { result } = renderHook(() => usePushNotifications());
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    expect(result.current.isSupported).toBe(false);
+    expect(mockAddListener).not.toHaveBeenCalled();
+  });
+
+  it('regression: attaches all four listeners BEFORE reporting supported, so nothing downstream can register into a missing registration listener', async () => {
+    let releaseListeners: () => void = () => {};
+    const attached = new Promise<void>((resolve) => {
+      releaseListeners = resolve;
+    });
+    mockAddListener.mockImplementation(async (event: string, handler: unknown) => {
+      listeners[event] = handler;
+      await attached;
+      return { remove: vi.fn() };
+    });
+
+    const { result } = renderHook(() => usePushNotifications());
+
+    await waitFor(() => expect(mockAddListener).toHaveBeenCalledTimes(4));
+    // All four addListener calls are in flight and none has resolved yet — if
+    // isSupported were set first, a consumer could call register() here.
+    expect(result.current.isSupported).toBe(false);
+
+    await act(async () => {
+      releaseListeners();
+      await Promise.resolve();
+    });
+
+    await waitFor(() => expect(result.current.isSupported).toBe(true));
+    expect(Object.keys(listeners).sort()).toEqual([
+      'pushNotificationActionPerformed',
+      'pushNotificationReceived',
+      'registration',
+      'registrationError',
+    ]);
+  });
+
+  it('posts the FCM token to the push-token endpoint with platform "android"', async () => {
+    const { result } = renderHook(() => usePushNotifications());
+    await waitFor(() => expect(result.current.isSupported).toBe(true));
+
+    const onRegistration = listeners.registration as (token: { value: string }) => void;
+    await act(async () => {
+      onRegistration({ value: 'fcm-token-0123456789abcdef' });
+      await Promise.resolve();
+    });
+
+    await waitFor(() =>
+      expect(mockPost).toHaveBeenCalledWith('/api/notifications/push-tokens', {
+        token: 'fcm-token-0123456789abcdef',
+        platform: 'android',
+        deviceId: 'device-abc',
+        deviceName: 'Pixel 8',
+      })
+    );
+  });
+
+  it('records the refusal when the user denies, and does not register', async () => {
+    mockRequestPermissions.mockResolvedValue({ receive: 'denied' });
+
+    const { result } = renderHook(() => usePushNotifications());
+    await waitFor(() => expect(result.current.isSupported).toBe(true));
+
+    let granted: boolean | undefined;
+    await act(async () => {
+      granted = await result.current.requestPermission();
+    });
+
+    expect(granted).toBe(false);
+    expect(localStorage.getItem(DENIAL_KEY)).toBe('android');
+    expect(mockRegister).not.toHaveBeenCalled();
+    await waitFor(() => expect(result.current.hasPreviouslyDenied).toBe(true));
+  });
+
+  it('regression: a recorded refusal survives a relaunch — the next mount never re-asks the OS', async () => {
+    // Android reports 'prompt-with-rationale' on the launch after a refusal,
+    // and the OS would still allow the dialog, so nothing native stops a
+    // re-prompt here; only the recorded denial does.
+    localStorage.setItem(DENIAL_KEY, 'android');
+    mockCheckPermissions.mockResolvedValue({ receive: 'prompt-with-rationale' });
+
+    const { result } = renderHook(() => usePushNotifications());
+    await waitFor(() => expect(result.current.isSupported).toBe(true));
+    await waitFor(() => expect(result.current.hasPreviouslyDenied).toBe(true));
+
+    let granted: boolean | undefined;
+    await act(async () => {
+      granted = await result.current.requestPermission();
+    });
+
+    expect(granted).toBe(false);
+    expect(mockRequestPermissions).not.toHaveBeenCalled();
+    expect(mockRegister).not.toHaveBeenCalled();
+  });
+
+  it('an explicitly user-initiated retry can override the recorded refusal', async () => {
+    localStorage.setItem(DENIAL_KEY, 'android');
+    mockCheckPermissions.mockResolvedValue({ receive: 'prompt-with-rationale' });
+
+    const { result } = renderHook(() => usePushNotifications());
+    await waitFor(() => expect(result.current.isSupported).toBe(true));
+
+    let granted: boolean | undefined;
+    await act(async () => {
+      granted = await result.current.requestPermission({ ignoreRecordedDenial: true });
+    });
+
+    expect(granted).toBe(true);
+    expect(mockRequestPermissions).toHaveBeenCalledTimes(1);
+    expect(mockRegister).toHaveBeenCalledTimes(1);
+    expect(localStorage.getItem(DENIAL_KEY)).toBeNull();
+  });
+
+  it('drops the recorded refusal when the OS reports the permission granted (enabled from system settings)', async () => {
+    localStorage.setItem(DENIAL_KEY, 'android');
+    mockCheckPermissions.mockResolvedValue({ receive: 'granted' });
+
+    const { result } = renderHook(() => usePushNotifications());
+
+    await waitFor(() => expect(result.current.permissionStatus).toBe('granted'));
+    expect(localStorage.getItem(DENIAL_KEY)).toBeNull();
+    expect(result.current.hasPreviouslyDenied).toBe(false);
+  });
+
+  it('registerToken() with a recorded refusal falls through to requestPermission and stays blocked', async () => {
+    localStorage.setItem(DENIAL_KEY, 'android');
+    mockCheckPermissions.mockResolvedValue({ receive: 'prompt-with-rationale' });
+
+    const { result } = renderHook(() => usePushNotifications());
+    await waitFor(() => expect(result.current.isSupported).toBe(true));
+
+    let registered: boolean | undefined;
+    await act(async () => {
+      registered = await result.current.registerToken();
+    });
+
+    expect(registered).toBe(false);
+    expect(mockRegister).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/src/hooks/__tests__/usePushNotifications.test.tsx
+++ b/apps/web/src/hooks/__tests__/usePushNotifications.test.tsx
@@ -221,6 +221,56 @@ describe('usePushNotifications', () => {
     expect(mockPost).toHaveBeenCalledTimes(1);
   });
 
+  it('regression: two registration events with the same token before the first POST resolves send only one request', async () => {
+    let releasePost: (value: unknown) => void = () => {};
+    mockPost.mockImplementation(
+      () => new Promise((resolve) => { releasePost = resolve; })
+    );
+
+    const { result } = renderHook(() => usePushNotifications());
+    await waitFor(() => expect(result.current.isSupported).toBe(true));
+
+    const onRegistration = listeners.registration as (token: { value: string }) => void;
+    await act(async () => {
+      onRegistration({ value: 'fcm-token-dup' });
+      onRegistration({ value: 'fcm-token-dup' });
+      await Promise.resolve();
+    });
+
+    expect(mockPost).toHaveBeenCalledTimes(1);
+
+    await act(async () => {
+      releasePost({ success: true, tokenId: 't1' });
+      await Promise.resolve();
+    });
+
+    expect(mockPost).toHaveBeenCalledTimes(1);
+  });
+
+  it('a failed registration does not lock the same token out of a retry', async () => {
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {});
+    mockPost.mockRejectedValueOnce(new Error('network down'));
+
+    const { result } = renderHook(() => usePushNotifications());
+    await waitFor(() => expect(result.current.isSupported).toBe(true));
+
+    const onRegistration = listeners.registration as (token: { value: string }) => void;
+    await act(async () => {
+      onRegistration({ value: 'fcm-token-retry' });
+      await Promise.resolve();
+    });
+    await waitFor(() => expect(result.current.error).toBe('network down'));
+
+    mockPost.mockResolvedValue({ success: true, tokenId: 't1' });
+    await act(async () => {
+      onRegistration({ value: 'fcm-token-retry' });
+      await Promise.resolve();
+    });
+
+    await waitFor(() => expect(mockPost).toHaveBeenCalledTimes(2));
+    consoleError.mockRestore();
+  });
+
   it('records the refusal when the user denies, and does not register', async () => {
     mockRequestPermissions.mockResolvedValue({ receive: 'denied' });
 

--- a/apps/web/src/hooks/__tests__/usePushNotifications.test.tsx
+++ b/apps/web/src/hooks/__tests__/usePushNotifications.test.tsx
@@ -78,6 +78,7 @@ import { usePushNotifications } from '../usePushNotifications';
 /** The key usePushNotifications persists a refusal under. */
 const DENIAL_KEY = 'push_permission_denied';
 
+
 /**
  * Handlers captured from PushNotifications.addListener, keyed by event name.
  * Held as `unknown` because the four handlers take four different payloads;
@@ -370,25 +371,48 @@ describe('usePushNotifications', () => {
   it('the in-memory flag still blocks when storage is unavailable, so a failed write cannot reopen the guard', async () => {
     // recordDenial swallows a failed write by design; hasPreviouslyDenied is the
     // half of the answer that does not depend on storage surviving.
+    //
+    // The whole localStorage object is replaced rather than spied on: whether
+    // jsdom routes these methods through Storage.prototype is an implementation
+    // detail, and if a spy on the prototype missed, the write would succeed and
+    // this test would pass vacuously — closing the guard for the ordinary
+    // reason instead of the in-memory one. Replacing the object cannot miss,
+    // and the setItem assertion below fails loudly if it somehow did.
     mockCheckPermissions.mockResolvedValue({ receive: 'denied' });
-    const setItem = vi.spyOn(Storage.prototype, 'setItem').mockImplementation(() => {
+    const setItem = vi.fn(() => {
       throw new Error('QuotaExceededError');
     });
-    const getItem = vi.spyOn(Storage.prototype, 'getItem').mockReturnValue(null);
-
-    const { result } = renderHook(() => usePushNotifications());
-    await waitFor(() => expect(result.current.hasPreviouslyDenied).toBe(true));
-
-    let granted: boolean | undefined;
-    await act(async () => {
-      granted = await result.current.requestPermission();
+    const brokenStorage = {
+      getItem: vi.fn((_key: string): string | null => null),
+      setItem,
+      removeItem: vi.fn((_key: string): void => {}),
+      clear: vi.fn(),
+      key: vi.fn((_index: number): string | null => null),
+      length: 0,
+    };
+    const realStorage = Object.getOwnPropertyDescriptor(window, 'localStorage');
+    Object.defineProperty(window, 'localStorage', {
+      configurable: true,
+      value: brokenStorage,
     });
 
-    expect(granted).toBe(false);
-    expect(mockRequestPermissions).not.toHaveBeenCalled();
+    try {
+      const { result } = renderHook(() => usePushNotifications());
+      await waitFor(() => expect(result.current.hasPreviouslyDenied).toBe(true));
 
-    setItem.mockRestore();
-    getItem.mockRestore();
+      expect(setItem).toHaveBeenCalledWith(DENIAL_KEY, 'android');
+      expect(brokenStorage.getItem(DENIAL_KEY)).toBeNull();
+
+      let granted: boolean | undefined;
+      await act(async () => {
+        granted = await result.current.requestPermission();
+      });
+
+      expect(granted).toBe(false);
+      expect(mockRequestPermissions).not.toHaveBeenCalled();
+    } finally {
+      if (realStorage) Object.defineProperty(window, 'localStorage', realStorage);
+    }
   });
 
   it("regression: 'prompt-with-rationale' does NOT drop the record — the refusal still stands there", async () => {

--- a/apps/web/src/hooks/__tests__/usePushNotifications.test.tsx
+++ b/apps/web/src/hooks/__tests__/usePushNotifications.test.tsx
@@ -330,6 +330,67 @@ describe('usePushNotifications', () => {
     expect(mockRegister).toHaveBeenCalledTimes(1);
   });
 
+  it("regression: an OS refusal with NO local record still blocks — a user who refused on a build predating the record has exactly this state", async () => {
+    // No DENIAL_KEY at all, but the OS is holding a refusal this client never
+    // saw it collect. Before the OS->record direction was mirrored, the guard
+    // reopened and hasPreviouslyDenied claimed the user had never said no.
+    expect(localStorage.getItem(DENIAL_KEY)).toBeNull();
+    mockCheckPermissions.mockResolvedValue({ receive: 'prompt-with-rationale' });
+
+    const { result } = renderHook(() => usePushNotifications());
+    await waitFor(() => expect(result.current.hasPreviouslyDenied).toBe(true));
+    expect(localStorage.getItem(DENIAL_KEY)).toBe('android');
+
+    let granted: boolean | undefined;
+    await act(async () => {
+      granted = await result.current.requestPermission();
+    });
+
+    expect(granted).toBe(false);
+    expect(mockRequestPermissions).not.toHaveBeenCalled();
+  });
+
+  it("regression: an OS 'denied' with no local record does the same", async () => {
+    expect(localStorage.getItem(DENIAL_KEY)).toBeNull();
+    mockCheckPermissions.mockResolvedValue({ receive: 'denied' });
+
+    const { result } = renderHook(() => usePushNotifications());
+    await waitFor(() => expect(result.current.hasPreviouslyDenied).toBe(true));
+    expect(localStorage.getItem(DENIAL_KEY)).toBe('android');
+
+    let granted: boolean | undefined;
+    await act(async () => {
+      granted = await result.current.requestPermission();
+    });
+
+    expect(granted).toBe(false);
+    expect(mockRequestPermissions).not.toHaveBeenCalled();
+  });
+
+  it('the in-memory flag still blocks when storage is unavailable, so a failed write cannot reopen the guard', async () => {
+    // recordDenial swallows a failed write by design; hasPreviouslyDenied is the
+    // half of the answer that does not depend on storage surviving.
+    mockCheckPermissions.mockResolvedValue({ receive: 'denied' });
+    const setItem = vi.spyOn(Storage.prototype, 'setItem').mockImplementation(() => {
+      throw new Error('QuotaExceededError');
+    });
+    const getItem = vi.spyOn(Storage.prototype, 'getItem').mockReturnValue(null);
+
+    const { result } = renderHook(() => usePushNotifications());
+    await waitFor(() => expect(result.current.hasPreviouslyDenied).toBe(true));
+
+    let granted: boolean | undefined;
+    await act(async () => {
+      granted = await result.current.requestPermission();
+    });
+
+    expect(granted).toBe(false);
+    expect(mockRequestPermissions).not.toHaveBeenCalled();
+
+    setItem.mockRestore();
+    getItem.mockRestore();
+  });
+
   it("regression: 'prompt-with-rationale' does NOT drop the record — the refusal still stands there", async () => {
     localStorage.setItem(DENIAL_KEY, 'android');
     mockCheckPermissions.mockResolvedValue({ receive: 'prompt-with-rationale' });

--- a/apps/web/src/hooks/useNativeBadgeSync.ts
+++ b/apps/web/src/hooks/useNativeBadgeSync.ts
@@ -5,10 +5,23 @@ import { useCapacitor } from './useCapacitor';
 import { useAppStateRecovery } from './useAppStateRecovery';
 import { useNotificationStore } from '@/stores/useNotificationStore';
 import { deriveBadgeCount } from '@pagespace/lib/notifications/derive-badge-count';
+import type { Platform } from '@/lib/capacitor-bridge';
 
-async function projectNativeBadge(unreadCount: number): Promise<void> {
+async function projectNativeBadge(unreadCount: number, platform: Platform): Promise<void> {
   try {
     const { Badge } = await import('@capawesome/capacitor-badge');
+    // The permission gate below is iOS-only, and deliberately so. It is not a
+    // general "check before you write" precaution; it defends against an
+    // iOS-specific one-shot authorization cap, described below, that Android has
+    // no analogue of. Android's badge is a launcher feature, and the plugin
+    // declares its permission with no backing Android permission string
+    // (`@CapacitorPlugin(name = "Badge", permissions = @Permission(strings = {},
+    // alias = "display"))` in BadgePlugin.java), which Capacitor's
+    // Bridge.getPermissionStates() answers as GRANTED unconditionally — so
+    // running the gate there would be a native round trip that can only ever
+    // return 'granted'. Keeping it conditional says which platform the hazard
+    // belongs to instead of implying Android has one too.
+    //
     // Badge.set() internally calls UNUserNotificationCenter.requestAuthorization(
     // options: .badge) before writing the count (see @capawesome/capacitor-badge's
     // ios/Plugin/Badge.swift). iOS shows the permission prompt only once per
@@ -21,18 +34,24 @@ async function projectNativeBadge(unreadCount: number): Promise<void> {
     // itself be the first-ever authorization request — by the time badge
     // permission reads as granted, the push flow's broader request already
     // decided the option set.
-    const permissions = await Badge.checkPermissions();
-    if (permissions.display !== 'granted') return;
+    if (platform === 'ios') {
+      const permissions = await Badge.checkPermissions();
+      if (permissions.display !== 'granted') return;
+    }
     await Badge.set({ count: deriveBadgeCount(unreadCount) });
   } catch (error) {
     // Best-effort only — never let a missing/broken native plugin crash the app.
-    console.error('[useIosBadgeSync] Failed to project native badge:', error);
+    // This is also the whole of Android's failure handling: launcher badge
+    // support is optional there and many launchers reject or ignore the write,
+    // so a rejection must stay a console line and never reach the user.
+    console.error('[useNativeBadgeSync] Failed to project native badge:', error);
   }
 }
 
 /**
- * Projects `unreadCount` (the single source of truth) onto the native iOS
- * app-icon badge. Reactive: re-projects on every store change and re-syncs
+ * Projects `unreadCount` (the single source of truth) onto the native app-icon
+ * badge, on every platform whose `badge` capability is true. Reactive:
+ * re-projects on every store change and re-syncs
  * from the server on app resume, instead of relying on the lossy APNs
  * silent push to teach the client the truth (which is why the badge used to
  * get stuck).
@@ -47,23 +66,26 @@ async function projectNativeBadge(unreadCount: number): Promise<void> {
  * stays a second, best-effort writer to the same native badge — an
  * unrelated silent push could have overwritten it correctly-but-stale value
  * while the app was backgrounded, even if unreadCount itself hasn't changed.
+ * Re-syncing on resume matters on Android for the plainer reason too: the count
+ * can have moved on the server while the app was away.
  */
-export function useIosBadgeSync(): void {
-  const { isIOS, isReady } = useCapacitor();
+export function useNativeBadgeSync(): void {
+  const { capabilities, platform, isReady } = useCapacitor();
+  const canBadge = capabilities.badge;
   const unreadCount = useNotificationStore((state) => state.unreadCount);
   const hasHydrated = useNotificationStore((state) => state.hasHydrated);
 
   useEffect(() => {
-    if (!isReady || !isIOS || !hasHydrated) return;
-    void projectNativeBadge(unreadCount);
-  }, [isReady, isIOS, hasHydrated, unreadCount]);
+    if (!isReady || !canBadge || !hasHydrated) return;
+    void projectNativeBadge(unreadCount, platform);
+  }, [isReady, canBadge, platform, hasHydrated, unreadCount]);
 
   useAppStateRecovery({
     onResume: async () => {
       await useNotificationStore.getState().fetchNotifications();
-      await projectNativeBadge(useNotificationStore.getState().unreadCount);
+      await projectNativeBadge(useNotificationStore.getState().unreadCount, platform);
     },
-    enabled: () => isIOS,
+    enabled: () => canBadge,
     minBackgroundTime: 0,
   });
 }

--- a/apps/web/src/hooks/useNativeBadgeSync.ts
+++ b/apps/web/src/hooks/useNativeBadgeSync.ts
@@ -66,8 +66,9 @@ async function projectNativeBadge(unreadCount: number, platform: Platform): Prom
  * stays a second, best-effort writer to the same native badge — an
  * unrelated silent push could have overwritten it correctly-but-stale value
  * while the app was backgrounded, even if unreadCount itself hasn't changed.
- * Re-syncing on resume matters on Android for the plainer reason too: the count
- * can have moved on the server while the app was away.
+ * That second writer is the APNs `badge` field specifically, so the race is
+ * iOS's; on Android the resume re-sync earns its place for the plainer reason
+ * that the count can have moved on the server while the app was away.
  */
 export function useNativeBadgeSync(): void {
   const { capabilities, platform, isReady } = useCapacitor();

--- a/apps/web/src/hooks/usePushNotifications.ts
+++ b/apps/web/src/hooks/usePushNotifications.ts
@@ -5,8 +5,62 @@ import { useCapacitor } from './useCapacitor';
 import { useAuth } from './useAuth';
 import { post, del } from '@/lib/auth/auth-fetch';
 import { getOrCreateDeviceId, getDeviceName } from '@/lib/analytics';
+import type { Platform } from '@/lib/capacitor-bridge';
 
-type PermissionStatus = 'prompt' | 'granted' | 'denied' | 'unknown';
+/**
+ * `PermissionState` from `@capacitor/core`, plus the pre-native-answer state.
+ *
+ * All four native values are listed deliberately. Android reports
+ * `'prompt-with-rationale'` from `checkPermissions()` once the user has refused
+ * the POST_NOTIFICATIONS dialog at least once and the OS would still allow
+ * another ask (Capacitor caches that in SharedPreferences from the request
+ * result, so it survives a relaunch — see Bridge.validatePermissions/
+ * getPermissionStates in @capacitor/android), and `'denied'` once the OS has
+ * stopped allowing the ask at all. Omitting it and casting would have typed a
+ * value the native layer really does return as one it cannot.
+ */
+type PermissionStatus = 'prompt' | 'prompt-with-rationale' | 'granted' | 'denied' | 'unknown';
+
+/**
+ * Where a refusal is remembered across launches.
+ *
+ * The native permission state already survives a relaunch on both platforms,
+ * but it says different things on each — iOS reports 'denied', Android reports
+ * 'prompt-with-rationale' until the OS gives up and only then 'denied' — so
+ * "has this user already said no?" is not one native value to compare against.
+ * This record answers it directly, in one place, on every platform.
+ */
+const DENIAL_STORAGE_KEY = 'push_permission_denied';
+
+/** Read the recorded refusal. Storage can throw (Safari private mode); never let that break registration. */
+function hasRecordedDenial(): boolean {
+  if (typeof window === 'undefined') return false;
+  try {
+    return localStorage.getItem(DENIAL_STORAGE_KEY) !== null;
+  } catch {
+    return false;
+  }
+}
+
+/** Remember that the user refused, so the next launch does not ask again. */
+function recordDenial(platform: Platform): void {
+  if (typeof window === 'undefined') return;
+  try {
+    localStorage.setItem(DENIAL_STORAGE_KEY, platform);
+  } catch {
+    // Storage unavailable: the native permission state is still the backstop.
+  }
+}
+
+/** Forget the refusal — the user granted permission, possibly from system settings. */
+function clearRecordedDenial(): void {
+  if (typeof window === 'undefined') return;
+  try {
+    localStorage.removeItem(DENIAL_STORAGE_KEY);
+  } catch {
+    // Nothing to do; a stale record only costs an un-asked prompt.
+  }
+}
 
 interface PushNotificationState {
   isSupported: boolean;
@@ -14,10 +68,22 @@ interface PushNotificationState {
   isRegistered: boolean;
   isLoading: boolean;
   error: string | null;
+  /**
+   * Whether this device has already refused the permission.
+   *
+   * Exposed so a settings surface can offer "enable notifications in system
+   * settings" instead of a button that silently does nothing.
+   */
+  hasPreviouslyDenied: boolean;
 }
 
 interface PushNotificationActions {
-  requestPermission: () => Promise<boolean>;
+  /**
+   * @param options.ignoreRecordedDenial - ask again even though the user
+   * already refused. For an explicitly user-initiated retry only; the
+   * automatic path must never pass it, or the prompt returns every launch.
+   */
+  requestPermission: (options?: { ignoreRecordedDenial?: boolean }) => Promise<boolean>;
   registerToken: () => Promise<boolean>;
   unregisterToken: () => Promise<void>;
 }
@@ -35,8 +101,9 @@ interface ActionPerformed {
 }
 
 export function usePushNotifications(): PushNotificationState & PushNotificationActions {
-  const { isNative, platform, isReady } = useCapacitor();
+  const { capabilities, platform, isReady } = useCapacitor();
   const { isAuthenticated, user } = useAuth();
+  const canPush = capabilities.push;
 
   const [state, setState] = useState<PushNotificationState>({
     isSupported: false,
@@ -44,6 +111,9 @@ export function usePushNotifications(): PushNotificationState & PushNotification
     isRegistered: false,
     isLoading: false,
     error: null,
+    // Read inside the effect below rather than here: this initial state is also
+    // what the server renders, and localStorage does not exist there.
+    hasPreviouslyDenied: false,
   });
 
   const tokenRef = useRef<string | null>(null);
@@ -56,15 +126,20 @@ export function usePushNotifications(): PushNotificationState & PushNotification
   // isSupported unlocks the permission-check effect and, from consumers like
   // PushNotificationManager, an immediate registerToken()/register() call —
   // if that raced ahead of the 'registration' listener being attached, the
-  // APNs token event could fire with no listener present to catch it.
+  // device-token event (APNs on iOS, FCM on Android) could fire with no
+  // listener present to catch it.
   // Registering listeners first guarantees they exist by the time anything
   // downstream can trigger a native registration.
   useEffect(() => {
     if (!isReady) return;
 
     const checkSupport = async () => {
-      // Only supported on iOS for now
-      if (isNative && platform === 'ios') {
+      // Capability, not platform: both native shells ship
+      // @capacitor/push-notifications (APNs on iOS, FCM on Android), so the
+      // question this asks is "can this platform receive a push?", answered by
+      // the single table in capacitor-bridge.ts rather than by an equality
+      // check that has to be found and edited per platform.
+      if (canPush) {
         try {
           const { PushNotifications } = await import('@capacitor/push-notifications');
           pushNotificationsRef.current = PushNotifications;
@@ -113,7 +188,11 @@ export function usePushNotifications(): PushNotificationState & PushNotification
             () => actionListener.remove(),
           );
 
-          setState(prev => ({ ...prev, isSupported: true }));
+          setState(prev => ({
+            ...prev,
+            isSupported: true,
+            hasPreviouslyDenied: hasRecordedDenial(),
+          }));
         } catch {
           setState(prev => ({ ...prev, isSupported: false }));
         }
@@ -128,7 +207,7 @@ export function usePushNotifications(): PushNotificationState & PushNotification
       listenersRef.current.forEach(remove => remove());
       listenersRef.current = [];
     };
-  }, [isNative, platform, isReady]);
+  }, [canPush, isReady]);
 
   // Check permission status
   useEffect(() => {
@@ -140,9 +219,13 @@ export function usePushNotifications(): PushNotificationState & PushNotification
 
       try {
         const result = await PushNotifications.checkPermissions();
+        // The user may have granted it from system settings since the refusal.
+        // Drop the record so the auto-registration path is unblocked again.
+        if (result.receive === 'granted') clearRecordedDenial();
         setState(prev => ({
           ...prev,
-          permissionStatus: result.receive as PermissionStatus,
+          permissionStatus: result.receive,
+          hasPreviouslyDenied: result.receive === 'granted' ? false : prev.hasPreviouslyDenied,
         }));
       } catch (error) {
         console.error('[PushNotifications] Error checking permissions:', error);
@@ -191,8 +274,20 @@ export function usePushNotifications(): PushNotificationState & PushNotification
   registerTokenWithServerRef.current = registerTokenWithServer;
 
   // Request permission and register for push notifications
-  const requestPermission = useCallback(async (): Promise<boolean> => {
+  const requestPermission = useCallback(async (
+    options?: { ignoreRecordedDenial?: boolean }
+  ): Promise<boolean> => {
     if (!state.isSupported || !pushNotificationsRef.current) {
+      return false;
+    }
+
+    // A refusal is final until the user revisits it. Without this the automatic
+    // registration path in PushNotificationManager would call straight back
+    // into requestPermissions() on every cold start — on Android the OS still
+    // allows that ask while it reports 'prompt-with-rationale', so the dialog
+    // really would reappear each launch.
+    if (!options?.ignoreRecordedDenial && hasRecordedDenial()) {
+      setState(prev => ({ ...prev, hasPreviouslyDenied: true, isLoading: false }));
       return false;
     }
 
@@ -204,16 +299,19 @@ export function usePushNotifications(): PushNotificationState & PushNotification
       const permResult = await PushNotifications.requestPermissions();
 
       if (permResult.receive === 'granted') {
-        setState(prev => ({ ...prev, permissionStatus: 'granted' }));
+        clearRecordedDenial();
+        setState(prev => ({ ...prev, permissionStatus: 'granted', hasPreviouslyDenied: false }));
 
-        // Register with APNs
+        // Register with the platform push service (APNs on iOS, FCM on Android)
         await PushNotifications.register();
 
         return true;
       } else {
+        recordDenial(platform);
         setState(prev => ({
           ...prev,
-          permissionStatus: permResult.receive as PermissionStatus,
+          permissionStatus: permResult.receive,
+          hasPreviouslyDenied: true,
           isLoading: false,
         }));
         return false;
@@ -227,7 +325,7 @@ export function usePushNotifications(): PushNotificationState & PushNotification
       }));
       return false;
     }
-  }, [state.isSupported]);
+  }, [state.isSupported, platform]);
 
   // Manually register token (if already have permission)
   const registerToken = useCallback(async (): Promise<boolean> => {

--- a/apps/web/src/hooks/usePushNotifications.ts
+++ b/apps/web/src/hooks/usePushNotifications.ts
@@ -117,7 +117,15 @@ export function usePushNotifications(): PushNotificationState & PushNotification
   });
 
   const tokenRef = useRef<string | null>(null);
-  const hasRegisteredRef = useRef(false);
+  // The token the server was last told about, not a boolean "have we registered
+  // once?". FCM rotates a registration token on its own (app data cleared, a
+  // restore onto a new device, a periodic refresh), and Capacitor re-emits
+  // 'registration' with the new value while this hook stays mounted. A boolean
+  // would make that second event a no-op and leave the server holding a token
+  // that no longer routes anywhere — push delivery would stop until the next
+  // cold start. Comparing the value instead lets a *different* token through
+  // while still collapsing a repeat of the same one.
+  const registeredTokenRef = useRef<string | null>(null);
   const pushNotificationsRef = useRef<typeof import('@capacitor/push-notifications').PushNotifications | null>(null);
   const registerTokenWithServerRef = useRef<(token: string) => Promise<void>>(async () => { });
   const listenersRef = useRef<(() => void)[]>([]);
@@ -237,7 +245,7 @@ export function usePushNotifications(): PushNotificationState & PushNotification
 
   // Register token with server
   const registerTokenWithServer = useCallback(async (token: string) => {
-    if (!isAuthenticated || hasRegisteredRef.current) return;
+    if (!isAuthenticated || registeredTokenRef.current === token) return;
 
     setState(prev => ({ ...prev, isLoading: true, error: null }));
 
@@ -252,7 +260,7 @@ export function usePushNotifications(): PushNotificationState & PushNotification
         deviceName,
       });
 
-      hasRegisteredRef.current = true;
+      registeredTokenRef.current = token;
       setState(prev => ({
         ...prev,
         isRegistered: true,
@@ -359,7 +367,7 @@ export function usePushNotifications(): PushNotificationState & PushNotification
     try {
       await del('/api/notifications/push-tokens', { token: tokenRef.current });
       tokenRef.current = null;
-      hasRegisteredRef.current = false;
+      registeredTokenRef.current = null;
       setState(prev => ({ ...prev, isRegistered: false }));
       console.log('[PushNotifications] Token unregistered');
     } catch (error) {
@@ -374,7 +382,7 @@ export function usePushNotifications(): PushNotificationState & PushNotification
       state.isSupported &&
       state.permissionStatus === 'granted' &&
       !state.isRegistered &&
-      !hasRegisteredRef.current &&
+      registeredTokenRef.current !== tokenRef.current &&
       tokenRef.current
     ) {
       registerTokenWithServer(tokenRef.current);
@@ -390,7 +398,7 @@ export function usePushNotifications(): PushNotificationState & PushNotification
 
   // Reset registration state when user changes
   useEffect(() => {
-    hasRegisteredRef.current = false;
+    registeredTokenRef.current = null;
     setState(prev => ({ ...prev, isRegistered: false }));
   }, [user?.id]);
 

--- a/apps/web/src/hooks/usePushNotifications.ts
+++ b/apps/web/src/hooks/usePushNotifications.ts
@@ -29,6 +29,10 @@ type PermissionStatus = 'prompt' | 'prompt-with-rationale' | 'granted' | 'denied
  * 'prompt-with-rationale' until the OS gives up and only then 'denied' — so
  * "has this user already said no?" is not one native value to compare against.
  * This record answers it directly, in one place, on every platform.
+ *
+ * It is a cache of the OS's answer, never a second source of truth: the
+ * permission-check effect clears it the moment the OS stops holding a refusal,
+ * so it can never outlive the refusal it stands for.
  */
 const DENIAL_STORAGE_KEY = 'push_permission_denied';
 
@@ -78,12 +82,7 @@ interface PushNotificationState {
 }
 
 interface PushNotificationActions {
-  /**
-   * @param options.ignoreRecordedDenial - ask again even though the user
-   * already refused. For an explicitly user-initiated retry only; the
-   * automatic path must never pass it, or the prompt returns every launch.
-   */
-  requestPermission: (options?: { ignoreRecordedDenial?: boolean }) => Promise<boolean>;
+  requestPermission: () => Promise<boolean>;
   registerToken: () => Promise<boolean>;
   unregisterToken: () => Promise<void>;
 }
@@ -231,13 +230,22 @@ export function usePushNotifications(): PushNotificationState & PushNotification
 
       try {
         const result = await PushNotifications.checkPermissions();
-        // The user may have granted it from system settings since the refusal.
-        // Drop the record so the auto-registration path is unblocked again.
-        if (result.receive === 'granted') clearRecordedDenial();
+        // Keep the record in step with the OS, which is the real authority on
+        // whether this user has refused. Two states mean it is no longer
+        // holding a refusal against them:
+        //   'granted' — turned on from system settings since.
+        //   'prompt'  — the OS has forgotten the refusal and would ask again.
+        //               Android 11+ auto-revokes and RESETS permissions for an
+        //               app that goes unused, landing exactly here; without
+        //               this the record would outlive the refusal it stands for
+        //               and the user could never be asked again.
+        // 'denied' and 'prompt-with-rationale' both mean the refusal stands.
+        const osHasNoRefusal = result.receive === 'granted' || result.receive === 'prompt';
+        if (osHasNoRefusal) clearRecordedDenial();
         setState(prev => ({
           ...prev,
           permissionStatus: result.receive,
-          hasPreviouslyDenied: result.receive === 'granted' ? false : prev.hasPreviouslyDenied,
+          hasPreviouslyDenied: osHasNoRefusal ? false : prev.hasPreviouslyDenied,
         }));
       } catch (error) {
         console.error('[PushNotifications] Error checking permissions:', error);
@@ -294,19 +302,19 @@ export function usePushNotifications(): PushNotificationState & PushNotification
   registerTokenWithServerRef.current = registerTokenWithServer;
 
   // Request permission and register for push notifications
-  const requestPermission = useCallback(async (
-    options?: { ignoreRecordedDenial?: boolean }
-  ): Promise<boolean> => {
+  const requestPermission = useCallback(async (): Promise<boolean> => {
     if (!state.isSupported || !pushNotificationsRef.current) {
       return false;
     }
 
-    // A refusal is final until the user revisits it. Without this the automatic
-    // registration path in PushNotificationManager would call straight back
-    // into requestPermissions() on every cold start — on Android the OS still
-    // allows that ask while it reports 'prompt-with-rationale', so the dialog
-    // really would reappear each launch.
-    if (!options?.ignoreRecordedDenial && hasRecordedDenial()) {
+    // A refusal stands until the OS itself stops holding it — at which point
+    // the permission-check effect above clears the record and this guard opens
+    // again. Without it the automatic registration path in
+    // PushNotificationManager would call straight back into
+    // requestPermissions() on every cold start: on Android the OS still allows
+    // that ask while it reports 'prompt-with-rationale', so the dialog really
+    // would reappear each launch.
+    if (hasRecordedDenial()) {
       setState(prev => ({ ...prev, hasPreviouslyDenied: true, isLoading: false }));
       return false;
     }

--- a/apps/web/src/hooks/usePushNotifications.ts
+++ b/apps/web/src/hooks/usePushNotifications.ts
@@ -31,8 +31,10 @@ type PermissionStatus = 'prompt' | 'prompt-with-rationale' | 'granted' | 'denied
  * This record answers it directly, in one place, on every platform.
  *
  * It is a cache of the OS's answer, never a second source of truth: the
- * permission-check effect clears it the moment the OS stops holding a refusal,
- * so it can never outlive the refusal it stands for.
+ * permission-check effect makes it agree with the OS in both directions on
+ * every launch — dropped the moment the OS stops holding a refusal, written
+ * when the OS is holding one this client never saw it collect — so it can
+ * neither outlive the refusal it stands for nor miss one.
  */
 const DENIAL_STORAGE_KEY = 'push_permission_denied';
 
@@ -52,7 +54,9 @@ function recordDenial(platform: Platform): void {
   try {
     localStorage.setItem(DENIAL_STORAGE_KEY, platform);
   } catch {
-    // Storage unavailable: the native permission state is still the backstop.
+    // Swallowed by design. Two things still hold the refusal: `hasPreviouslyDenied`
+    // in state for the rest of this session, and the OS itself on the next launch,
+    // which the permission-check effect reads back.
   }
 }
 

--- a/apps/web/src/hooks/usePushNotifications.ts
+++ b/apps/web/src/hooks/usePushNotifications.ts
@@ -240,6 +240,12 @@ export function usePushNotifications(): PushNotificationState & PushNotification
         //               this the record would outlive the refusal it stands for
         //               and the user could never be asked again.
         // 'denied' and 'prompt-with-rationale' both mean the refusal stands.
+        //
+        // Clearing BEFORE the setState below is what makes the ordering safe:
+        // PushNotificationManager waits for permissionStatus to leave 'unknown'
+        // before it calls requestPermission(), and this setState is the only
+        // thing that moves it — so the record is always already in step by the
+        // time requestPermission() reads it. Do not reorder these two.
         const osHasNoRefusal = result.receive === 'granted' || result.receive === 'prompt';
         if (osHasNoRefusal) clearRecordedDenial();
         setState(prev => ({

--- a/apps/web/src/hooks/usePushNotifications.ts
+++ b/apps/web/src/hooks/usePushNotifications.ts
@@ -230,28 +230,35 @@ export function usePushNotifications(): PushNotificationState & PushNotification
 
       try {
         const result = await PushNotifications.checkPermissions();
-        // Keep the record in step with the OS, which is the real authority on
-        // whether this user has refused. Two states mean it is no longer
-        // holding a refusal against them:
-        //   'granted' — turned on from system settings since.
+        // Mirror the OS in BOTH directions. It is the real authority on whether
+        // this user has refused, and the record is only a cache of its answer,
+        // so every launch makes the cache agree with it:
+        //   'granted' — turned on from system settings since. Clear.
         //   'prompt'  — the OS has forgotten the refusal and would ask again.
         //               Android 11+ auto-revokes and RESETS permissions for an
         //               app that goes unused, landing exactly here; without
         //               this the record would outlive the refusal it stands for
-        //               and the user could never be asked again.
-        // 'denied' and 'prompt-with-rationale' both mean the refusal stands.
+        //               and the user could never be asked again. Clear.
+        //   'denied' / 'prompt-with-rationale' — the refusal stands. Write it,
+        //               because the OS can be holding one this client never saw
+        //               it collect: a user who refused on a build that predates
+        //               this record has exactly that state, and so does one
+        //               whose localStorage write failed. Without this the guard
+        //               would reopen and `hasPreviouslyDenied` would claim the
+        //               user had never said no.
         //
-        // Clearing BEFORE the setState below is what makes the ordering safe:
+        // Syncing BEFORE the setState below is what makes the ordering safe:
         // PushNotificationManager waits for permissionStatus to leave 'unknown'
         // before it calls requestPermission(), and this setState is the only
         // thing that moves it — so the record is always already in step by the
         // time requestPermission() reads it. Do not reorder these two.
         const osHasNoRefusal = result.receive === 'granted' || result.receive === 'prompt';
         if (osHasNoRefusal) clearRecordedDenial();
+        else recordDenial(platform);
         setState(prev => ({
           ...prev,
           permissionStatus: result.receive,
-          hasPreviouslyDenied: osHasNoRefusal ? false : prev.hasPreviouslyDenied,
+          hasPreviouslyDenied: !osHasNoRefusal,
         }));
       } catch (error) {
         console.error('[PushNotifications] Error checking permissions:', error);
@@ -259,7 +266,7 @@ export function usePushNotifications(): PushNotificationState & PushNotification
     };
 
     checkPermission();
-  }, [state.isSupported]);
+  }, [state.isSupported, platform]);
 
   // Register token with server
   const registerTokenWithServer = useCallback(async (token: string) => {
@@ -320,7 +327,11 @@ export function usePushNotifications(): PushNotificationState & PushNotification
     // requestPermissions() on every cold start: on Android the OS still allows
     // that ask while it reports 'prompt-with-rationale', so the dialog really
     // would reappear each launch.
-    if (hasRecordedDenial()) {
+    //
+    // `state.hasPreviouslyDenied` is the in-memory half of the same answer, and
+    // it is what holds when storage is unavailable — every writer of the record
+    // sets it too, but `recordDenial` swallows a failed write by design.
+    if (hasRecordedDenial() || state.hasPreviouslyDenied) {
       setState(prev => ({ ...prev, hasPreviouslyDenied: true, isLoading: false }));
       return false;
     }
@@ -359,7 +370,7 @@ export function usePushNotifications(): PushNotificationState & PushNotification
       }));
       return false;
     }
-  }, [state.isSupported, platform]);
+  }, [state.isSupported, state.hasPreviouslyDenied, platform]);
 
   // Manually register token (if already have permission)
   const registerToken = useCallback(async (): Promise<boolean> => {

--- a/apps/web/src/hooks/usePushNotifications.ts
+++ b/apps/web/src/hooks/usePushNotifications.ts
@@ -126,6 +126,10 @@ export function usePushNotifications(): PushNotificationState & PushNotification
   // cold start. Comparing the value instead lets a *different* token through
   // while still collapsing a repeat of the same one.
   const registeredTokenRef = useRef<string | null>(null);
+  // Tokens whose POST is in flight. registeredTokenRef is only written after the
+  // request resolves, so it cannot suppress a duplicate 'registration' event
+  // that arrives while the first request is still open.
+  const inFlightTokensRef = useRef(new Set<string>());
   const pushNotificationsRef = useRef<typeof import('@capacitor/push-notifications').PushNotifications | null>(null);
   const registerTokenWithServerRef = useRef<(token: string) => Promise<void>>(async () => { });
   const listenersRef = useRef<(() => void)[]>([]);
@@ -245,8 +249,13 @@ export function usePushNotifications(): PushNotificationState & PushNotification
 
   // Register token with server
   const registerTokenWithServer = useCallback(async (token: string) => {
-    if (!isAuthenticated || registeredTokenRef.current === token) return;
+    if (
+      !isAuthenticated ||
+      registeredTokenRef.current === token ||
+      inFlightTokensRef.current.has(token)
+    ) return;
 
+    inFlightTokensRef.current.add(token);
     setState(prev => ({ ...prev, isLoading: true, error: null }));
 
     try {
@@ -275,6 +284,9 @@ export function usePushNotifications(): PushNotificationState & PushNotification
         error: error instanceof Error ? error.message : 'Failed to register token',
         isLoading: false,
       }));
+    } finally {
+      // Cleared on failure too, so a retry of the same token is not locked out.
+      inFlightTokensRef.current.delete(token);
     }
   }, [isAuthenticated, platform]);
 

--- a/apps/web/src/lib/__tests__/capacitor-bridge.test.ts
+++ b/apps/web/src/lib/__tests__/capacitor-bridge.test.ts
@@ -489,7 +489,7 @@ describe('capacitor-bridge', () => {
     // exhaustively so a wrong flag anywhere fails a named test.
     const TRUTH_TABLE = {
       ios: { secureStore: true, nativeAuth: true, push: true, badge: true },
-      android: { secureStore: true, nativeAuth: true, push: true, badge: false },
+      android: { secureStore: true, nativeAuth: true, push: true, badge: true },
       web: { secureStore: false, nativeAuth: false, push: false, badge: false },
     } as const;
 
@@ -584,7 +584,7 @@ describe('capacitor-bridge', () => {
       });
     });
 
-    it('returns the full Android capability set with badge unsupported', async () => {
+    it('returns the full Android capability set', async () => {
       setupCapacitorMock(true, 'android');
       vi.resetModules();
       capacitorBridge = await import('../capacitor-bridge');
@@ -593,7 +593,7 @@ describe('capacitor-bridge', () => {
         secureStore: true,
         nativeAuth: true,
         push: true,
-        badge: false,
+        badge: true,
       });
     });
 
@@ -609,7 +609,7 @@ describe('capacitor-bridge', () => {
     });
 
     it('returns a frozen table entry callers cannot corrupt', async () => {
-      setupCapacitorMock(true, 'android');
+      removeCapacitorMock();
       vi.resetModules();
       capacitorBridge = await import('../capacitor-bridge');
 
@@ -699,18 +699,19 @@ describe('capacitor-bridge', () => {
   describe('capability consumers', () => {
     it('needs no call-site change when a platform gains a capability', async () => {
       // Consumers ask hasNativeCapability('badge'); they never name a platform.
-      // Adding badge support to Android is a one-line table edit, and this
-      // simulated consumer picks it up unchanged.
+      // Android gaining badge support was exactly this: a one-line table edit
+      // that useNativeBadgeSync picked up unchanged. The unsupported side is a
+      // browser tab, which is where a consumer must still skip.
       const consumer = (
         bridge: typeof import('../capacitor-bridge')
       ): string => (bridge.hasNativeCapability('badge') ? 'sync' : 'skip');
 
-      setupCapacitorMock(true, 'android');
+      removeCapacitorMock();
       vi.resetModules();
       capacitorBridge = await import('../capacitor-bridge');
       expect(consumer(capacitorBridge)).toBe('skip');
 
-      setupCapacitorMock(true, 'ios');
+      setupCapacitorMock(true, 'android');
       vi.resetModules();
       capacitorBridge = await import('../capacitor-bridge');
       expect(consumer(capacitorBridge)).toBe('sync');

--- a/apps/web/src/lib/capacitor-bridge.ts
+++ b/apps/web/src/lib/capacitor-bridge.ts
@@ -55,13 +55,17 @@ const PLATFORM_CAPABILITIES: Record<
   }),
   // PageSpaceSecureStoragePlugin (registered in MainActivity.java as
   // "PageSpaceKeychain"), @capgo/capacitor-social-login (Google only),
-  // Firebase Messaging via the Gradle build. The badge plugin is not yet in
-  // apps/android/package.json.
+  // Firebase Messaging via the Gradle build, @capawesome/capacitor-badge.
+  //
+  // `badge: true` states that the plugin is a declared dependency and the shared
+  // code path is wired, not that every device will show a count: the Android
+  // badge is drawn by the launcher, and launchers that do not implement one
+  // ignore or reject the write. useNativeBadgeSync treats that as a no-op.
   android: Object.freeze({
     secureStore: true,
     nativeAuth: true,
     push: true,
-    badge: false,
+    badge: true,
   }),
   // A plain browser tab has none of these.
   web: Object.freeze({

--- a/bun.lock
+++ b/bun.lock
@@ -98,6 +98,7 @@
         "@capacitor/push-notifications": "^7.0.0",
         "@capacitor/splash-screen": "^7.0.3",
         "@capacitor/status-bar": "^7.0.3",
+        "@capawesome/capacitor-badge": "^7.0.0",
         "@capgo/capacitor-social-login": "^7.20.0",
       },
       "devDependencies": {

--- a/knip.json
+++ b/knip.json
@@ -564,6 +564,7 @@
     },
     "apps/android": {
       "ignoreDependencies": [
+        "@capawesome/capacitor-badge",
         "@capacitor/app",
         "@capacitor/browser",
         "@capacitor/preferences",


### PR DESCRIPTION
## Android Parity Epic — Phase D remainder

Two epic tasks, one PR: **Push permission and registration** (`mtspubavafmchf1i0mz1l1fm`) and
**Badge sync generalization** (`yl0r7hnp8m4nsar7iry7rqpm`).

Phase D's server half already shipped in #2501 (+#2505, #2506) — the FCM sender exists and is not
touched here. The phone half never landed, so today the server can send an Android push and no
Android device can receive one. This closes that loop.

### Push permission and registration

| Before | After |
|---|---|
| `AndroidManifest.xml` declares only `INTERNET`, targeting SDK 36 | also declares `POST_NOTIFICATIONS` |
| `usePushNotifications.ts:67` gates on `isNative && platform === 'ios'` | gates on `useCapacitor().capabilities.push` |
| a refusal is not recorded anywhere | recorded in `localStorage`, and blocks the next ask |

- **Manifest.** `POST_NOTIFICATIONS` has to be declared for the runtime request to be possible at
  all: on API 33+ it is a dangerous permission that starts ungranted, and an *undeclared* dangerous
  permission cannot be requested — the request resolves denied with no dialog shown. `targetSdk 36`
  / `minSdk 23` read from `apps/android/android/variables.gradle:2-4`. Phase C's comment blocks
  (including `READ BEFORE MAKING IT LIVE`) are untouched; the permission is appended to the existing
  `<!-- Permissions -->` block with its own comment.
- **Capability gate, not a platform equality.** `usePushNotifications.ts` now asks
  `capabilities.push` from the bridge PR #2500 landed, so the capability table stays the one place
  that knows what a platform can do. `apps/android/package.json` already carried
  `@capacitor/push-notifications`, and `capacitor.settings.gradle:19` already wires it into Gradle.
- **Token registration** needed no change beyond opening the gate: `registerTokenWithServer` posts
  the hook's own `platform`, and `apps/web/src/app/api/notifications/push-tokens/route.ts:46`
  already accepts `'android'`.
- **A refusal is remembered.** `push_permission_denied` in `localStorage`; `requestPermission()`
  declines to call the native `requestPermissions()` while it stands. This is *not* redundant with
  the OS state — after one refusal Android reports `'prompt-with-rationale'`
  (`Bridge.validatePermissions` writes it to SharedPreferences, `Bridge.getPermissionStates` reads
  it back, both in `@capacitor/android`) and the OS would still allow the dialog.
- **The record is a cache of the OS's answer, never a second source of truth**, and the
  permission-check effect mirrors it in both directions on every launch. It **drops** the record on
  `granted` (turned on from system settings) or `prompt` — which is where **Android 11+ lands after
  auto-revoking permissions for an app that went unused**; without that case the record would
  outlive the refusal it stands for and the user could never be asked again on that install. It
  **writes** one on `denied` / `prompt-with-rationale`, because the OS can be holding a refusal this
  client never saw it collect: that is the state of every user who refused on a build predating the
  record — on iOS, where push already ships, the entire installed base of deniers — and of anyone
  whose storage write failed. The guard also falls back to the in-memory `hasPreviouslyDenied` so a
  failed write cannot reopen it in-session. That OS sync is the whole recovery path, which is why
  there is no manual override; `hasPreviouslyDenied` is what a settings surface should read to say
  "enable notifications in system settings".
- **`PermissionStatus` gains `'prompt-with-rationale'`.** `PermissionState` in `@capacitor/core` is
  `'prompt' | 'prompt-with-rationale' | 'granted' | 'denied'`; the old `as PermissionStatus` cast
  typed a value the native layer really returns as one it could not.
- **Listener ordering is untouched.** Only the condition around the block moved. A regression test
  now pins it: all four `addListener` promises are held open, `isSupported` is asserted false, and
  only then released.

### Badge sync

- `useIosBadgeSync` → `useNativeBadgeSync`, gated on `capabilities.badge`; Android's row flips to
  `true`; `@capawesome/capacitor-badge` added to `apps/android/package.json` (it was already in
  `apps/ios/package.json`), lockfile regenerated with `bun install --lockfile-only`.
- **The iOS permission gate is made conditional, not deleted.** It defends against iOS permanently
  capping the authorization option set to whatever the first-ever request asked for. Android has no
  analogue — and concretely, the plugin declares `@CapacitorPlugin(name = "Badge", permissions =
  @Permission(strings = {}, alias = "display"))` (`BadgePlugin.java:11`), which Capacitor's
  `Bridge.getPermissionStates()` answers `GRANTED` unconditionally, so running the gate there could
  only ever be a wasted round trip. Two regression tests pin both halves: Android projects with
  `checkPermissions` never called, iOS still suppresses on a non-granted read.
- **Launcher rejections fail silently.** Android badges are launcher-dependent; a rejection lands in
  the existing `try/catch` — logged, never surfaced. Test added.

### Display side is deliberately untouched

This makes a push *deliverable*; what the tray actually draws is separate and unverified. The
manifest declares no `com.google.firebase.messaging.default_notification_icon` or
`default_notification_channel_id` meta-data, so the small icon and the channel both fall to
Firebase's defaults inside `CommonNotificationBuilder.getOrCreateChannel` / `createNotificationInfo`
(the plugin calls both — `PushNotificationsPlugin.java:274-286`). Whether that yields a usable icon
and a sensibly-named channel on a real device is a device-verification question, and a monochrome
notification icon is its own asset task. Written up in `apps/android/README.md`.

### Verification — what was and was not done

- **Not run on a device, and no build.** Every behavioural claim above is read off sources (cited by
  file and line where it matters) or is stated as unverified. No push was received; that is the
  epic's own Device verification task.
- **Manifest validated as XML** with `xmllint --noout` — `apps/android` has no lint, typecheck or
  test script, so nothing in CI parses it.
- **Tests were not executed locally.** This worktree has no `node_modules` and the standing
  instruction is no builds while ~20 agents run; CI is the gate. Test coverage added:
  `usePushNotifications.test.tsx` (new, 17 cases), plus new Android/iOS cases in
  `useNativeBadgeSync.test.tsx` (18) and `PushNotificationManager.test.tsx` (10).

### Review feedback addressed

Both bot findings were real defects in the registration path this PR activates, both fixed with
regression tests, both replied to in-thread:

1. **Rotated FCM token never reached the server** (Codex, P2). `hasRegisteredRef` was a one-shot
   boolean, so the second `registration` event carrying a new token returned at the guard and the
   server kept a token that no longer routes — delivery would stop until a cold start. Now tracks
   the registered token by value. (Server-side was already fine: `registerPushToken` deactivates
   other tokens for the same `deviceId`+`platform`, `push-notifications.ts:908-919`.)
2. **Duplicate in-flight registration** (CodeRabbit). `registeredTokenRef` is written only after
   `post()` resolves, so two events with the same token before it settled both POSTed. Guarded on an
   in-flight set, cleared in `finally` so a failed registration is still retryable.
3. **An OS-held refusal the client never saw** (CodeRabbit) — see the bullet above. The denial record
   was synced from the OS in one direction only, so `hasPreviouslyDenied` could assert the opposite
   of the OS. Not reachable as a re-prompt today (`PushNotificationManager` only calls
   `requestPermission()` on exactly `'prompt'`), but the signal itself was wrong, which is the
   field's entire purpose. **Left open for reviewer verification** rather than self-resolved.

Self-review during convergence also found and fixed the auto-reset lockout described above (the
record outliving an OS permission reset), and removed a `requestPermission({ ignoreRecordedDenial })`
escape hatch that no caller could reach once the OS sync became the recovery path.
- Three existing suites asserted `android.badge === false` as the truth table
  (`capacitor-bridge.test.ts`, `useCapacitor.test.ts`); those expectations are updated, and the
  "capability consumers" test now uses a browser tab as its unsupported side.

### Follow-ups, not blockers

- The generated `capacitor.settings.gradle` / `app/capacitor.build.gradle` are stale for the new
  dependency, so the badge plugin is not compiled into an APK until `cap sync android` regenerates
  them. That needs no separate step — `cap sync android` is the second half of `build:full`, which
  is the build command the epic's Device verification task already specifies
  (`bun run --cwd apps/android build:full`). It only bites someone invoking Gradle directly without
  syncing. Noted in `apps/android/README.md`.
- `FCM_SERVICE_ACCOUNT_JSON` is a Fly secret Jono provisions and may not exist yet. The sender
  already fails closed without it — no blocker here.

### Changelog

Added under Unreleased, and deliberately narrow: Android can now *ask* and *register*, the refusal
sticks, and the badge may show where the launcher supports one — with no claim that any phone has
received a push, since there is still no build and no distribution.

Closes two epic tasks under `yqkxh0e9wdt730dqdro8xf6o` (Phase D container `jes25rq0nurv8yxe9nojl5xs`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KvrjK8KTEtaCjz2MU3pNAw
