### PR TITLE
Refuse presentation writes the sheet setters would silently reinterpret

### DIFF
--- a/apps/web/src/components/layout/middle-content/page-views/sheet/core/rule-presets.ts
+++ b/apps/web/src/components/layout/middle-content/page-views/sheet/core/rule-presets.ts
@@ -33,15 +33,18 @@ export const OPERATOR_LABELS: ReadonlyArray<{ value: ConditionalOperator; label:
   { value: 'isError', label: 'is an error' },
 ];
 
-/** Operators that compare against nothing — the value field is hidden for these. */
-export const VALUELESS_OPERATORS: ReadonlySet<ConditionalOperator> = new Set([
-  'isEmpty',
-  'isNotEmpty',
-  'isError',
-]);
-
-/** Operators needing a second bound. */
-export const RANGE_OPERATORS: ReadonlySet<ConditionalOperator> = new Set(['between', 'notBetween']);
+/**
+ * Re-exported, not defined here any more.
+ *
+ * The server-side write path has to refuse a `greaterThan` rule with no value
+ * for the same reason the panel hides the field for `isEmpty` — it is part of
+ * what a valid rule IS, not a rendering detail. Two copies of that answer is
+ * how the API comes to accept a rule this panel would never offer, so the
+ * definition moved to `@pagespace/lib/sheets` and both sides read it from
+ * there. Kept as re-exports so every existing importer of this module is
+ * untouched.
+ */
+export { VALUELESS_OPERATORS, RANGE_OPERATORS } from '@pagespace/lib/sheets/sheet';
 
 export type RuleKind = ConditionalRule['kind'];
 

--- a/apps/web/src/components/layout/middle-content/page-views/sheet/core/rule-presets.ts
+++ b/apps/web/src/components/layout/middle-content/page-views/sheet/core/rule-presets.ts
@@ -44,7 +44,13 @@ export const OPERATOR_LABELS: ReadonlyArray<{ value: ConditionalOperator; label:
  * there. Kept as re-exports so every existing importer of this module is
  * untouched.
  */
-export { VALUELESS_OPERATORS, RANGE_OPERATORS } from '@pagespace/lib/sheets/sheet';
+import { VALUELESS_OPERATORS, RANGE_OPERATORS } from '@pagespace/lib/sheets/sheet';
+
+// Imported AND re-exported, not `export … from`: a bare re-export forwards the
+// names without binding them in this module, and `describeRule` below reads
+// both. That distinction compiles fine in the package that defines them and
+// fails only where the module is actually type-checked.
+export { VALUELESS_OPERATORS, RANGE_OPERATORS };
 
 export type RuleKind = ConditionalRule['kind'];
 

--- a/packages/lib/src/__tests__/sheet-format-request.test.ts
+++ b/packages/lib/src/__tests__/sheet-format-request.test.ts
@@ -12,6 +12,7 @@ import {
 } from '../sheets/format-request';
 import { setColumnWidth, setRowHeight } from '../sheets/format-ops';
 import { createEmptySheet } from '../sheets/io';
+import type { SheetData } from '../sheets/types';
 import {
   MAX_CONDITIONAL_RULES,
   MAX_CONDITIONAL_TOTAL_CELLS,
@@ -63,6 +64,28 @@ const refusalOf = (ops: SheetFormatOp[], tab: SheetFormatTarget = tabWith()): st
   }
   throw new Error('Expected a SheetFormatError, but planning succeeded.');
 };
+
+describe('planFormatOps — the shape the store already has', () => {
+  it('takes a SheetData as its target without adaptation', () => {
+    // `SheetFormatTarget` says it is satisfied structurally by `SheetData`, and
+    // that claim is the whole reason the caller can hand over what it already
+    // loaded instead of building something. It was prose until now; this makes
+    // the compiler check it, and a test that only ran would not — the
+    // assignment below is the assertion, and `tsc` is what evaluates it.
+    const sheet: SheetData = {
+      ...createEmptySheet(),
+      conditionalFormats: [rule('a')],
+      regions: [region('r1')],
+    };
+    const target: SheetFormatTarget = sheet;
+
+    const result = planFormatOps([{ type: 'removeConditionalRule', id: 'a' }], target);
+    expect(result.conditionalFormats).toEqual([]);
+    // The regions it was not asked about come back untouched, which is what
+    // lets a caller write both lists from one plan.
+    expect(result.regions).toEqual([region('r1')]);
+  });
+});
 
 describe('planFormatOps — the request envelope', () => {
   it('plans nothing for an empty batch, rather than inventing work', () => {

--- a/packages/lib/src/__tests__/sheet-format-request.test.ts
+++ b/packages/lib/src/__tests__/sheet-format-request.test.ts
@@ -1235,13 +1235,12 @@ describe('planFormatOps — never something other than what was asked for', () =
     // express one, but an in-process caller building an op by hand can, and the
     // depth bound is the only thing standing between that and a hung request.
     //
-    // Fair warning about the shape of the failure: if that bound regresses this
-    // assertion HANGS rather than failing, because vitest cannot preempt a
-    // synchronous walk (measured — neutralising the depth check produces no
-    // output at all, where the depth fixtures above fail cleanly). A stalled
-    // job is a worse signal than a red one, but it is the only way to pin a
-    // non-termination property, and an unbounded walk reaching production is
-    // the thing actually worth catching.
+    // Measured: neutralising the depth check fails this in 4ms with
+    // `RangeError: Maximum call stack size exceeded`, not a hang — `canonical`
+    // recurses, so a self-reference overflows the stack long before it could
+    // loop forever. Which is the good outcome for a test, and it is why the
+    // bound has to be a bound rather than a cycle-detecting `seen` set: the
+    // same check answers depth and cycles together.
     const cyclic: Record<string, unknown> = { id: 'r1', range: 'A1:F' };
     cyclic.self = cyclic;
     expect(refusalOf([{ type: 'upsertRegion', region: cyclic }])).toContain('nested more than');

--- a/packages/lib/src/__tests__/sheet-format-request.test.ts
+++ b/packages/lib/src/__tests__/sheet-format-request.test.ts
@@ -17,9 +17,15 @@ import {
   parseConditionalRule,
   type ConditionalRule,
 } from '../sheets/conditional';
-import { MAX_REGIONS, parseRegion, type SheetRegion } from '../sheets/regions';
+import {
+  MAX_REGIONS,
+  MAX_REGION_COLUMNS,
+  MAX_REGION_TOTAL_ROWS,
+  parseRegion,
+  type SheetRegion,
+} from '../sheets/regions';
 import { PALETTE } from '../sheets/palette';
-import { MAX_ADDRESSABLE_ROW } from '../sheets/address';
+import { MAX_ADDRESSABLE_ROW, encodeColumnLabel } from '../sheets/address';
 import { MAX_CONDITIONAL_RANGES_PER_RULE } from '../sheets/conditional';
 
 const tabWith = (overrides: Partial<SheetFormatTarget> = {}): SheetFormatTarget => ({
@@ -652,6 +658,28 @@ describe('planFormatOps — nothing the parser would quietly rewrite', () => {
         },
       ])
     ).toContain("dataBar's min anchor needs a type of");
+  });
+
+  it('covers the parsers’ own caps without being told about them', () => {
+    // The claim the comparator makes is that a cap added to a parser later is
+    // refused here without this module learning it. These two are already in
+    // `regions.ts` and nothing in this module mentions either — they are caught
+    // purely because a truncated list comes back shorter than it went in.
+    // Distinct labels, or this would demonstrate the parser's de-duplication
+    // rather than its cap — the refusal would look identical and mean something
+    // else.
+    const columns = Array.from({ length: MAX_REGION_COLUMNS + 1 }, (_, i) => ({
+      column: encodeColumnLabel(i),
+      role: 'text',
+    }));
+    expect(refusalOf([{ type: 'upsertRegion', region: { ...region('r1'), columns } }])).toContain(
+      'region: "columns"'
+    );
+
+    const totalRows = Array.from({ length: MAX_REGION_TOTAL_ROWS + 1 }, (_, i) => i + 2);
+    expect(refusalOf([{ type: 'upsertRegion', region: { ...region('r1'), totalRows } }])).toContain(
+      'region: "totalRows"'
+    );
   });
 
   it('refuses a theme the palette does not have, which would render as another colour', () => {

--- a/packages/lib/src/__tests__/sheet-format-request.test.ts
+++ b/packages/lib/src/__tests__/sheet-format-request.test.ts
@@ -1762,6 +1762,38 @@ describe('planFormatOps — the dashboard this epic exists for', () => {
         tab
       ).steps
     ).toHaveLength(20);
+
+    // The two limits this module invents rather than inherits, exercised right
+    // up against their stated ceilings — because a ceiling nothing reaches in a
+    // test is a number nobody has checked. Halving either of these used to
+    // break nothing.
+    // A literal 150, not `MAX_FORMAT_OPS` — a batch sized from the constant
+    // shrinks with it, so it would pass at any ceiling and pin nothing. This is
+    // a claim about how many ops a caller may send, and it has to be written
+    // down as a number to be one.
+    expect(MAX_FORMAT_OPS).toBeGreaterThanOrEqual(150);
+    expect(
+      plan(
+        Array.from({ length: 150 }, (_, i) => ({
+          type: 'setCellFormat' as const,
+          range: `A${i + 1}`,
+          patch: { bold: true },
+        })),
+        tab
+      ).steps
+    ).toHaveLength(150);
+
+    // ~190,000 cells across 19 ops: inside the per-request budget, and past
+    // half of it.
+    expect(
+      plan(
+        Array.from({ length: 19 }, (_, i) => ({
+          type: 'clearCellFormat' as const,
+          range: `A${i * 10 + 1}:B${i * 10 + 5000}`,
+        })),
+        tab
+      ).steps
+    ).toHaveLength(19);
   });
 
   it('accepts the region the read half of this epic documents', () => {

--- a/packages/lib/src/__tests__/sheet-format-request.test.ts
+++ b/packages/lib/src/__tests__/sheet-format-request.test.ts
@@ -2027,8 +2027,13 @@ describe('planFormatOps — never something other than what was asked for', () =
     expect(refusalOf([{ type: 'clearCellFormat', range: 'Sheet1!A1:F1' }])).toContain(
       'drop the SheetName! prefix'
     );
+    // Echoes the caller's own string repaired, rather than a worked example
+    // that would change what a region range means.
     expect(refusalOf([{ type: 'clearCellFormat', range: 'A1 : F1' }])).toContain(
-      'Ranges carry no spaces'
+      'Ranges carry no spaces — write "A1:F1".'
+    );
+    expect(refusalOf([{ type: 'upsertRegion', region: { id: 'r1', range: 'A1 : F' } }])).toContain(
+      'write "A1:F".'
     );
 
     // The rule path is a separate call site; a hint added to only one of them

--- a/packages/lib/src/__tests__/sheet-format-request.test.ts
+++ b/packages/lib/src/__tests__/sheet-format-request.test.ts
@@ -26,7 +26,7 @@ import {
 } from '../sheets/regions';
 import { PALETTE } from '../sheets/palette';
 import { MAX_ADDRESSABLE_ROW, encodeColumnLabel } from '../sheets/address';
-import { MAX_CONDITIONAL_RANGES_PER_RULE } from '../sheets/conditional';
+import { MAX_CONDITIONAL_RANGES_PER_RULE, VALUELESS_OPERATORS } from '../sheets/conditional';
 
 const tabWith = (overrides: Partial<SheetFormatTarget> = {}): SheetFormatTarget => ({
   rowCount: 100,
@@ -680,6 +680,134 @@ describe('planFormatOps — nothing the parser would quietly rewrite', () => {
     expect(refusalOf([{ type: 'upsertRegion', region: { ...region('r1'), totalRows } }])).toContain(
       'region: "totalRows"'
     );
+  });
+
+  it('refuses a cell rule missing the operand its operator needs', () => {
+    // `matchesCondition` compares against nothing: a `greaterThan` with no
+    // value matches NO cell, and a `notContains` with no value matches EVERY
+    // non-error one — opposite failures, equally silent. The parser accepts
+    // both and the comparator sees nothing dropped.
+    const cell = (condition: unknown) => ({ ...rule('cf_1'), condition });
+
+    expect(
+      refusalOf([{ type: 'addConditionalRule', rule: cell({ operator: 'greaterThan' }) }])
+    ).toContain('needs a value to compare against');
+    expect(
+      refusalOf([{ type: 'addConditionalRule', rule: cell({ operator: 'notContains', value: '  ' }) }])
+    ).toContain('needs a value to compare against');
+    expect(
+      refusalOf([{ type: 'addConditionalRule', rule: cell({ operator: 'between', value: '1' }) }])
+    ).toContain('needs both bounds');
+
+    // The operators that legitimately compare against nothing still pass, and
+    // that list is the panel's own — imported, not restated.
+    for (const operator of VALUELESS_OPERATORS) {
+      expect(
+        plan([{ type: 'addConditionalRule', rule: cell({ operator }) }]).conditionalFormats
+      ).toHaveLength(1);
+    }
+    expect(
+      plan([{ type: 'addConditionalRule', rule: cell({ operator: 'between', value: '1', value2: '9' }) }])
+        .conditionalFormats
+    ).toHaveLength(1);
+  });
+
+  it('refuses a formula that does not parse', () => {
+    // The parser asks only that a formula be non-blank. The evaluator then
+    // throws while tokenizing it once per covered cell, catches, and formats
+    // none of them — checked here with the engine's own tokenizer and parser so
+    // "valid" means the same thing in both places.
+    const formula = (body: string) => ({
+      id: 'cf_1',
+      kind: 'formula',
+      ranges: ['A1:A9'],
+      formula: body,
+      format: { bold: true },
+    });
+
+    expect(refusalOf([{ type: 'addConditionalRule', rule: formula('=BROKEN(') }])).toContain(
+      'is not a formula this sheet can evaluate'
+    );
+    expect(refusalOf([{ type: 'addConditionalRule', rule: formula('=A1 >') }])).toContain(
+      'is not a formula this sheet can evaluate'
+    );
+    expect(refusalOf([{ type: 'addConditionalRule', rule: formula('=') }])).toContain(
+      'is not a formula this sheet can evaluate'
+    );
+    // With or without the leading `=`, as the evaluator reads it.
+    expect(plan([{ type: 'addConditionalRule', rule: formula('=A1>1') }]).conditionalFormats).toHaveLength(1);
+    expect(plan([{ type: 'addConditionalRule', rule: formula('SUM(A1:A9)>0') }]).conditionalFormats)
+      .toHaveLength(1);
+  });
+
+  it('refuses a scale anchor whose value the evaluator would substitute or clamp', () => {
+    const bar = (min: unknown) => ({
+      id: 'db',
+      kind: 'dataBar',
+      ranges: ['A1:A9'],
+      color: '#3b82f6',
+      min,
+    });
+
+    // `anchorValue` substitutes the data's own extreme for a missing value...
+    expect(refusalOf([{ type: 'addConditionalRule', rule: bar({ type: 'number' }) }])).toContain(
+      'of type number needs a numeric value'
+    );
+    // ...and clamps a percent that is out of range.
+    expect(
+      refusalOf([{ type: 'addConditionalRule', rule: bar({ type: 'percent', value: 150 }) }])
+    ).toContain('needs a value from 0 to 100, not 150');
+    // `min` and `max` read the data and ignore any value, so they need none.
+    expect(plan([{ type: 'addConditionalRule', rule: bar({ type: 'min' }) }]).conditionalFormats)
+      .toHaveLength(1);
+    expect(
+      plan([{ type: 'addConditionalRule', rule: bar({ type: 'percentile', value: 90 }) }])
+        .conditionalFormats
+    ).toHaveLength(1);
+  });
+
+  it('refuses a region declaration that names something outside the region', () => {
+    // `createRegionResolver` excludes cells outside the bounds before consulting
+    // either list, so these are stored faithfully and can never render.
+    // Cross-field, so the comparator cannot see them: each value is fine alone.
+    expect(
+      refusalOf([
+        {
+          type: 'upsertRegion',
+          region: { id: 'r1', range: 'A1:B10', columns: [{ column: 'Z', role: 'currency' }] },
+        },
+      ])
+    ).toContain('column "Z" is outside the region A1:B10');
+    expect(
+      refusalOf([{ type: 'upsertRegion', region: { id: 'r1', range: 'A1:B10', totalRows: [20] } }])
+    ).toContain('total row 20 is outside the region A1:B10');
+
+    // An OPEN region reaches the end of the sheet, so a total row past today's
+    // extent is a row it will grow into — which is the point of leaving the end
+    // off, and must not be refused.
+    expect(
+      plan([{ type: 'upsertRegion', region: { id: 'r1', range: 'A1:F', totalRows: [4000] } }]).regions[0]
+        .totalRows
+    ).toEqual([4000]);
+    expect(
+      plan([{ type: 'upsertRegion', region: { id: 'r1', range: 'A1:B10', totalRows: [10] } }]).regions
+    ).toHaveLength(1);
+  });
+
+  it('refuses freezeHeader while nothing acts on it', () => {
+    // Parsed and stored, with no consumer anywhere: `createRegionResolver` does
+    // not read it and the `setRegions` step only stores the region. Accepting
+    // it would be this module's own contract broken in its own output.
+    expect(
+      refusalOf([{ type: 'upsertRegion', region: { ...region('r1'), freezeHeader: true } }])
+    ).toContain('freezeHeader is not applied by anything yet');
+    expect(
+      refusalOf([{ type: 'upsertRegion', region: { ...region('r1'), freezeHeader: true } }])
+    ).toContain('setFrozen');
+    // An explicit false asks for nothing and gets nothing, which is honest.
+    expect(
+      plan([{ type: 'upsertRegion', region: { ...region('r1'), freezeHeader: false } }]).regions
+    ).toHaveLength(1);
   });
 
   it('refuses a theme the palette does not have, which would render as another colour', () => {

--- a/packages/lib/src/__tests__/sheet-format-request.test.ts
+++ b/packages/lib/src/__tests__/sheet-format-request.test.ts
@@ -1134,7 +1134,13 @@ describe('planFormatOps — nothing the parser would quietly rewrite', () => {
     // `A1e+21` — not a hang, but tens of megabytes of garbage allocated inside
     // what is supposed to be a cheap check, and every one of those entries
     // would then be stored and handed to the evaluator.
-    const started = Date.now();
+    //
+    // The assertion is the refusal itself, and deliberately nothing about how
+    // long it took. A wall-clock bound would be the only flaky line in this
+    // file, and it could not even tell the two paths apart — the bad one takes
+    // 18ms, so any threshold loose enough to survive a busy runner passes for
+    // both. What proves the work is skipped is the ORDER: the bounds check runs
+    // before `validateRanges`, and a mutation probe on that line turns red.
     expect(
       refusalOf([
         {
@@ -1146,7 +1152,6 @@ describe('planFormatOps — nothing the parser would quietly rewrite', () => {
         },
       ])
     ).toContain('is not a range this sheet can address');
-    expect(Date.now() - started).toBeLessThan(1_000);
   });
 
   it('still lets a rule written by a NEWER build be updated', () => {

--- a/packages/lib/src/__tests__/sheet-format-request.test.ts
+++ b/packages/lib/src/__tests__/sheet-format-request.test.ts
@@ -30,6 +30,7 @@ import { isSupportedFunction } from '../sheets/functions';
 import { MAX_ADDRESSABLE_ROW, encodeColumnLabel } from '../sheets/address';
 import {
   MAX_CONDITIONAL_RANGES_PER_RULE,
+  MAX_CONDITIONAL_RANGE_CELLS,
   VALUELESS_OPERATORS,
 } from '../sheets/conditional';
 
@@ -1071,6 +1072,183 @@ describe('planFormatOps — nothing the parser would quietly rewrite', () => {
           patch: { borders: { top: { style: 'thin', color: '#123456' } } },
         },
       ]).steps
+    ).toHaveLength(1);
+  });
+
+  it('refuses a formula range large enough to take the process down', () => {
+    // Not a silent no-op but a hang. `evaluation.ts` hands every Range to
+    // `expandRange`, which has no cap of any kind — two nested loops over the
+    // whole rectangle. `A1:ZZZ5000000` asks it for about ninety-one billion
+    // addresses, and the rule needs to cover only one cell to get there.
+    const formula = (body: string) => ({
+      id: 'cf_1',
+      kind: 'formula',
+      ranges: ['A1'],
+      formula: body,
+      format: { bold: true },
+    });
+
+    const message = refusalOf([
+      { type: 'addConditionalRule', rule: formula('=SUM(A1:ZZZ5000000)>0') },
+    ]);
+    expect(message).toContain('with no ceiling');
+    expect(message).toContain(MAX_CONDITIONAL_RANGE_CELLS.toLocaleString());
+
+    // A reference the sheet cannot address at all, which `parseRangeSpan`
+    // rejects before there is a count to compare.
+    expect(
+      refusalOf([{ type: 'addConditionalRule', rule: formula('=SUM(A1:ZZZZ5)>0') }])
+    ).toContain('not a range this sheet can address');
+
+    // Ranges a rule could legally cover on its own are still fine.
+    expect(
+      plan([{ type: 'addConditionalRule', rule: formula('=SUM(A1:A1000)>0') }]).conditionalFormats
+    ).toHaveLength(1);
+  });
+
+  it('refuses a call with a number of arguments the function will not take', () => {
+    // `isSupportedFunction` probes with zero arguments and treats an argument
+    // complaint as proof the name exists — which is right for that question and
+    // leaves this one open. `evaluateFunction` throws for the arity too, once
+    // per covered cell.
+    const formula = (body: string) => ({
+      id: 'cf_1',
+      kind: 'formula',
+      ranges: ['A1:A9'],
+      formula: body,
+      format: { bold: true },
+    });
+
+    expect(refusalOf([{ type: 'addConditionalRule', rule: formula('=ABS()') }])).toContain(
+      'calls ABS() with 0 argument(s)'
+    );
+    expect(refusalOf([{ type: 'addConditionalRule', rule: formula('=IFERROR(1)') }])).toContain(
+      'calls IFERROR() with 1 argument(s)'
+    );
+    for (const body of ['=ABS(A1)>0', '=IFERROR(A1, 0)>0', '=SUM(A1:A9)>0', '=ROUND(A1, 2)>0']) {
+      expect(plan([{ type: 'addConditionalRule', rule: formula(body) }]).conditionalFormats)
+        .toHaveLength(1);
+    }
+  });
+
+  it('refuses an operand the operator never reads', () => {
+    // `matchesCondition` looks at `value` only for the operators that compare
+    // against something and at `value2` only for the two range operators, so
+    // these are part of the caller's instruction stored and thrown away.
+    // Neither shape is reachable through the panel, which hides the fields it
+    // does not use.
+    const cell = (condition: unknown) => ({ ...rule('cf_1'), condition });
+
+    expect(
+      refusalOf([{ type: 'addConditionalRule', rule: cell({ operator: 'isEmpty', value: 'x' }) }])
+    ).toContain('compares against nothing, so it cannot take a value');
+    expect(
+      refusalOf([
+        { type: 'addConditionalRule', rule: cell({ operator: 'greaterThan', value: '1', value2: '9' }) },
+      ])
+    ).toContain('ignores value2');
+    expect(
+      plan([
+        { type: 'addConditionalRule', rule: cell({ operator: 'between', value: '1', value2: '9' }) },
+      ]).conditionalFormats
+    ).toHaveLength(1);
+  });
+
+  it('refuses a value on an anchor that reads the data instead', () => {
+    // The mirror of the missing-value case: `anchorValue` never looks at a
+    // value for `min`/`max`, so one supplied here is stored and silently
+    // replaced by whatever the data happens to hold.
+    expect(
+      refusalOf([
+        {
+          type: 'addConditionalRule',
+          rule: {
+            id: 'db',
+            kind: 'dataBar',
+            ranges: ['A1:A9'],
+            color: '#3b82f6',
+            min: { type: 'min', value: 50 },
+          },
+        },
+      ])
+    ).toContain("reads the data's own extreme, so it cannot take a value of 50");
+  });
+
+  it('refuses a number-format setting the kind never reads', () => {
+    // `numberFormatSchema` validates each field on its own, so the kind and the
+    // setting are never checked against each other. The toolbar drops settings
+    // that no longer apply when the kind changes; a caller has nothing dropping
+    // them. Asked of the renderers rather than a table: render twice with two
+    // different values and see whether anything moves.
+    // Cast because the point of each case is a combination the type permits
+    // and the renderer ignores.
+    const patch = (number: unknown) =>
+      ({ type: 'setCellFormat', range: 'A1', patch: { number } }) as unknown as SheetFormatOp;
+
+    expect(refusalOf([patch({ kind: 'number', dateStyle: 'long' })])).toContain(
+      'patch.number.dateStyle is not read by a "number" format'
+    );
+    expect(refusalOf([patch({ kind: 'date', currency: 'EUR' })])).toContain(
+      'patch.number.currency is not read by a "date" format'
+    );
+    // Caught beyond the two reported cases, which is the point of asking the
+    // renderer rather than listing the pairs.
+    expect(refusalOf([patch({ kind: 'text', decimals: 2 })])).toContain('is not read by a "text" format');
+
+    // Everything a kind does read still goes through, including the field the
+    // EXPORT reads but the display does not.
+    for (const number of [
+      { kind: 'date', dateStyle: 'long' },
+      { kind: 'currency', currency: 'EUR' },
+      { kind: 'currency', decimals: 0 },
+      { kind: 'percent', thousands: false },
+      { kind: 'custom', pattern: '0.00' },
+    ]) {
+      expect(plan([patch(number)]).steps).toHaveLength(1);
+    }
+  });
+
+  it('refuses column roles on a closed region with no body', () => {
+    // `A1:B1` with the default single header row is all header: the resolver
+    // treats every covered row as one and `continue`s before consulting the
+    // column map, and unlike an open region it cannot grow a body later.
+    expect(
+      refusalOf([
+        {
+          type: 'upsertRegion',
+          region: { id: 'r1', range: 'A1:B1', columns: [{ column: 'A', role: 'currency' }] },
+        },
+      ])
+    ).toContain('all of them are headers');
+
+    // A bodyless region that declares no columns is only a header strip, which
+    // is a legitimate thing to want.
+    expect(
+      plan([{ type: 'upsertRegion', region: { id: 'r1', range: 'A1:B1' } }]).regions
+    ).toHaveLength(1);
+
+    // The same range with no header rows has a body, and an OPEN region always
+    // has one to grow into.
+    expect(
+      plan([
+        {
+          type: 'upsertRegion',
+          region: {
+            id: 'r1',
+            range: 'A1:B1',
+            headerRows: 0,
+            columns: [{ column: 'A', role: 'currency' }],
+          },
+        },
+      ]).regions
+    ).toHaveLength(1);
+    expect(
+      plan([
+        {
+          type: 'upsertRegion',
+          region: { id: 'r1', range: 'A1:B', columns: [{ column: 'A', role: 'currency' }] },
+        },
+      ]).regions
     ).toHaveLength(1);
   });
 

--- a/packages/lib/src/__tests__/sheet-format-request.test.ts
+++ b/packages/lib/src/__tests__/sheet-format-request.test.ts
@@ -1577,6 +1577,65 @@ describe('planFormatOps — nothing the parser would quietly rewrite', () => {
     ).toContain("reads the data's own extreme, so it cannot take a value of 50");
   });
 
+  it('states, kind by kind, which number-format settings are read', () => {
+    // The number-format check asks the renderers rather than consulting a
+    // table, which is right — but WHICH values it renders with is a judgement,
+    // and a change to them would quietly move every one of these verdicts.
+    // Pinned here as one legible matrix, so the refusals it produces can be
+    // audited in a single place instead of inferred from eleven switch arms.
+    const fields: Record<string, unknown> = {
+      currency: 'EUR',
+      dateStyle: 'long',
+      decimals: 2,
+      thousands: false,
+      pattern: '0.00',
+    };
+
+    const readsFor = (kind: string) =>
+      Object.entries(fields)
+        .filter(([field, value]) => {
+          try {
+            planFormatOps(
+              [{ type: 'setCellFormat', range: 'A1', patch: { number: { kind, [field]: value } } }] as never,
+              tabWith()
+            );
+            return true;
+          } catch {
+            return false;
+          }
+        })
+        .map(([field]) => field);
+
+    expect({
+      auto: readsFor('auto'),
+      plain: readsFor('plain'),
+      number: readsFor('number'),
+      currency: readsFor('currency'),
+      percent: readsFor('percent'),
+      date: readsFor('date'),
+      time: readsFor('time'),
+      datetime: readsFor('datetime'),
+      scientific: readsFor('scientific'),
+      text: readsFor('text'),
+      custom: readsFor('custom'),
+    }).toEqual({
+      auto: [],
+      plain: [],
+      number: ['decimals', 'thousands'],
+      currency: ['currency', 'decimals', 'thousands'],
+      percent: ['decimals', 'thousands'],
+      date: ['dateStyle'],
+      // `time` renders hh:mm:ss and exports as a fixed code, so a dateStyle on
+      // it changes nothing — the one row most likely to look like a bug.
+      time: [],
+      datetime: ['dateStyle'],
+      // Scientific uses `toExponential`, which has no thousands separator.
+      scientific: ['decimals'],
+      text: [],
+      custom: ['pattern'],
+    });
+  });
+
   it('refuses a number-format setting the kind never reads', () => {
     // `numberFormatSchema` validates each field on its own, so the kind and the
     // setting are never checked against each other. The toolbar drops settings

--- a/packages/lib/src/__tests__/sheet-format-request.test.ts
+++ b/packages/lib/src/__tests__/sheet-format-request.test.ts
@@ -2019,6 +2019,91 @@ describe('planFormatOps — regions', () => {
   });
 });
 
+describe('planFormatOps — what each op produces', () => {
+  it('maps every op to its step, its rows and whether the tab is touched', () => {
+    // The refusals have a table; the output did not. This is the other half of
+    // the contract, and the half task 2 folds over. Two facts in it are load
+    // bearing and are stated nowhere else:
+    //
+    //   - only `setCellFormat` and `clearCellFormat` put anything in `rows`.
+    //     Everything else lives on the tab record, so a caller that touches
+    //     none of the cell ops loads no rows at all.
+    //   - five rule ops collapse to ONE `setConditionalRules` step, and three
+    //     region ops to one `setRegions`. However many ops touched a list, the
+    //     caller writes that list once.
+    const cell = (id: string) =>
+      ({
+        id,
+        kind: 'cell',
+        ranges: ['A1:A9'],
+        condition: { operator: 'greaterThan', value: '1' },
+        format: { bold: true },
+      }) as unknown as ConditionalRule;
+
+    const tab = tabWith({
+      conditionalFormats: [cell('a'), cell('b')],
+      regions: [region('r')],
+    });
+
+    const outcome = (op: SheetFormatOp) => {
+      const result = planFormatOps([op], tab);
+      return {
+        steps: result.steps.map((step) => step.type),
+        rows: [...result.rows],
+        touchesTabFields: result.touchesTabFields,
+      };
+    };
+
+    expect(outcome({ type: 'setCellFormat', range: 'B2:C3', patch: { bold: true } })).toEqual({
+      steps: ['setCellFormat'],
+      rows: [1, 2],
+      touchesTabFields: false,
+    });
+    expect(outcome({ type: 'clearCellFormat', range: 'B2' })).toEqual({
+      steps: ['clearCellFormat'],
+      rows: [1],
+      touchesTabFields: false,
+    });
+
+    // Every tab-level op: its own step, no rows, and the tab flagged.
+    const tabLevel: Array<[string, SheetFormatOp]> = [
+      ['setColumnFormat', { type: 'setColumnFormat', column: 'C', patch: { italic: true } }],
+      ['setColumnWidth', { type: 'setColumnWidth', column: 'C', width: 140 }],
+      ['setRowHeight', { type: 'setRowHeight', row: 3, height: 40 }],
+      ['setFrozen', { type: 'setFrozen', rows: 1, columns: 2 }],
+    ];
+    for (const [step, op] of tabLevel) {
+      expect(outcome(op)).toEqual({ steps: [step], rows: [], touchesTabFields: true });
+    }
+
+    // Five ways to change the rule list, one step out of all of them.
+    const ruleOps: SheetFormatOp[] = [
+      { type: 'addConditionalRule', rule: cell('c') },
+      { type: 'updateConditionalRule', id: 'a', patch: { ranges: ['B1:B4'] } },
+      { type: 'removeConditionalRule', id: 'a' },
+      { type: 'moveConditionalRule', id: 'a', direction: 1 },
+      { type: 'clearConditionalRules' },
+    ];
+    for (const op of ruleOps) {
+      expect(outcome(op)).toEqual({
+        steps: ['setConditionalRules'],
+        rows: [],
+        touchesTabFields: true,
+      });
+    }
+
+    // And three ways to change the region list, likewise.
+    const regionOps: SheetFormatOp[] = [
+      { type: 'setRegions', regions: [{ id: 'x', range: 'A1:D' }] },
+      { type: 'upsertRegion', region: region('y', 'H1:J') },
+      { type: 'removeRegion', id: 'r' },
+    ];
+    for (const op of regionOps) {
+      expect(outcome(op)).toEqual({ steps: ['setRegions'], rows: [], touchesTabFields: true });
+    }
+  });
+});
+
 describe('planFormatOps — what happens on a retry', () => {
   it('says which ops are safe to replay and which are not', () => {
     // A caller replaying a request after an I/O failure needs to know this, and

--- a/packages/lib/src/__tests__/sheet-format-request.test.ts
+++ b/packages/lib/src/__tests__/sheet-format-request.test.ts
@@ -2800,6 +2800,7 @@ describe('planFormatOps — refuses, never crashes', () => {
     const tab = tabWith({ conditionalFormats: [rule('a')], regions: [region('r1')] });
     let refusals = 0;
     let plans = 0;
+    let malformedTabs = 0;
 
     for (let seed = 0; seed < 600; seed++) {
       const rand = seeded(seed);
@@ -2821,17 +2822,40 @@ describe('planFormatOps — refuses, never crashes', () => {
           : generated;
       const op = typed as SheetFormatOp;
 
+      // The tab is generated too. It was not, until a null in
+      // `conditionalFormats` produced a TypeError twenty frames down — this
+      // test's whole purpose, missed because it only ever looked at one of the
+      // two inputs. A malformed tab is allowed to throw, but only the specific
+      // Error that names the field; anything else is the fault this catches.
+      const target: SheetFormatTarget =
+        rand() < 0.2
+          ? ({
+              rowCount: 100,
+              columnCount: 26,
+              conditionalFormats: value(rand, 2),
+              regions: value(rand, 2),
+            } as unknown as SheetFormatTarget)
+          : tab;
+
       try {
-        const result = planFormatOps([op], tab);
+        const result = planFormatOps([op], target);
         plans += 1;
         expect(Array.isArray(result.steps)).toBe(true);
         expect(result.rows).toBeInstanceOf(Set);
       } catch (error) {
-        if (!(error instanceof SheetFormatError)) {
-          throw new Error(`seed ${seed} threw ${String(error)} for ${JSON.stringify(op)}`);
+        if (error instanceof SheetFormatError) {
+          refusals += 1;
+          expect(error.message).not.toBe('');
+          continue;
         }
-        refusals += 1;
-        expect(error.message).not.toBe('');
+        if (error instanceof Error && /^planFormatOps: tab\./.test(error.message)) {
+          malformedTabs += 1;
+          continue;
+        }
+        throw new Error(
+          `seed ${seed} threw ${String(error)} for op ${JSON.stringify(op)} against ` +
+            `${JSON.stringify(target)}`
+        );
       }
     }
 
@@ -2839,5 +2863,8 @@ describe('planFormatOps — refuses, never crashes', () => {
     // door. Plans are the rarer one — most random shapes are not valid ops.
     expect(refusals).toBeGreaterThan(100);
     expect(plans).toBeGreaterThan(0);
+    // The generated tabs have to actually reach that guard, or this test has
+    // grown a second input it never exercises — the exact hole it just closed.
+    expect(malformedTabs).toBeGreaterThan(0);
   });
 });

--- a/packages/lib/src/__tests__/sheet-format-request.test.ts
+++ b/packages/lib/src/__tests__/sheet-format-request.test.ts
@@ -18,6 +18,7 @@ import {
   type ConditionalRule,
 } from '../sheets/conditional';
 import { MAX_REGIONS, parseRegion, type SheetRegion } from '../sheets/regions';
+import { PALETTE } from '../sheets/palette';
 import { MAX_ADDRESSABLE_ROW } from '../sheets/address';
 import { MAX_CONDITIONAL_RANGES_PER_RULE } from '../sheets/conditional';
 
@@ -599,6 +600,23 @@ describe('planFormatOps — nothing the parser would quietly rewrite', () => {
     expect(
       refusalOf([{ type: 'setRegions', regions: [region('r1'), { ...region('r2'), theme: 'BLUE!' }] }])
     ).toContain('regions[1]: "theme"');
+  });
+
+  it('refuses a theme the palette does not have, which would render as another colour', () => {
+    // `parseRegion` accepts any lowercase word and `hueByName` then falls back
+    // to the default at RENDER time — so this is a sanitization the comparator
+    // cannot see, and the one place the module has to know something the
+    // parsers do not. An agent that asked for a chartreuse dashboard and got
+    // slate was told the write succeeded.
+    const message = refusalOf([{ type: 'upsertRegion', region: { ...region('r1'), theme: 'chartreuse' } }]);
+    expect(message).toContain('is not a hue this build has');
+    expect(message).toContain('slate, blue');
+    // Every palette hue is still accepted, so the check cannot drift from the
+    // palette it is checking against.
+    for (const hue of PALETTE) {
+      expect(plan([{ type: 'upsertRegion', region: { ...region('r1'), theme: hue.name } }]).regions[0].theme)
+        .toBe(hue.name);
+    }
   });
 
   it('does not mistake a genuine normalization for a loss', () => {

--- a/packages/lib/src/__tests__/sheet-format-request.test.ts
+++ b/packages/lib/src/__tests__/sheet-format-request.test.ts
@@ -1908,6 +1908,77 @@ describe('planFormatOps — all or nothing', () => {
     expect(applied).toEqual([]);
   });
 
+  it('lets a batch see its own earlier ops', () => {
+    // The rules and regions are folded into one running list each, so an op can
+    // act on what an earlier op in the SAME request did. Nothing pinned this,
+    // and it is what a caller composing a batch depends on — including the
+    // subtle case at the end: the duplicate-id check reads the running list, so
+    // an id an earlier op removed is free again. Checking the STORED list
+    // instead would refuse that, and every other assertion here would still
+    // pass.
+    const cell = (id: string, value: string) => ({
+      id,
+      kind: 'cell',
+      ranges: ['A1:A9'],
+      condition: { operator: 'greaterThan', value },
+      format: { bold: true },
+    });
+
+    // An update sees the rule an earlier op added.
+    const updated = plan([
+      { type: 'addConditionalRule', rule: cell('new', '1') },
+      {
+        type: 'updateConditionalRule',
+        id: 'new',
+        patch: { condition: { operator: 'greaterThan', value: '99' } },
+      },
+    ]).conditionalFormats;
+    expect(updated).toHaveLength(1);
+    expect(updated[0]).toMatchObject({ id: 'new', condition: { value: '99' } });
+
+    // A removal sees it too, and cancels it out.
+    expect(
+      plan([
+        { type: 'addConditionalRule', rule: cell('new', '1') },
+        { type: 'removeConditionalRule', id: 'new' },
+      ]).conditionalFormats
+    ).toEqual([]);
+
+    // Regions the same way, in both directions.
+    expect(
+      plan([
+        { type: 'upsertRegion', region: region('r') },
+        { type: 'removeRegion', id: 'r' },
+      ]).regions
+    ).toEqual([]);
+    expect(
+      plan([
+        { type: 'setRegions', regions: [region('a')] },
+        { type: 'upsertRegion', region: region('b', 'H1:J') },
+      ]).regions.map((entry) => entry.id)
+    ).toEqual(['a', 'b']);
+
+    // And an id an earlier op freed can be used again...
+    expect(
+      plan([
+        { type: 'addConditionalRule', rule: cell('x', '1') },
+        { type: 'removeConditionalRule', id: 'x' },
+        { type: 'addConditionalRule', rule: cell('x', '2') },
+      ]).conditionalFormats[0]
+    ).toMatchObject({ id: 'x', condition: { value: '2' } });
+
+    // ...while one an earlier op TOOK is not. This pair is what actually pins
+    // the running list: on an empty sheet a stored-list check would accept both
+    // of these and store two rules under one id, and every other assertion in
+    // this test would still pass. A mutation probe is how that came out.
+    expect(
+      refusalOf([
+        { type: 'addConditionalRule', rule: cell('dup', '1') },
+        { type: 'addConditionalRule', rule: cell('dup', '2') },
+      ])
+    ).toContain('Op 1');
+  });
+
   it('folds a mixed batch into one plan, in request order', () => {
     const result = plan([
       { type: 'setCellFormat', range: 'A1', patch: { bold: true } },

--- a/packages/lib/src/__tests__/sheet-format-request.test.ts
+++ b/packages/lib/src/__tests__/sheet-format-request.test.ts
@@ -1215,17 +1215,36 @@ describe('planFormatOps — never something other than what was asked for', () =
     let deep: Record<string, unknown> = { end: true };
     for (let i = 0; i < 5_000; i++) deep = { next: deep };
 
-    // Refused wherever it sits, including where the identity fast path would
-    // have skipped the walk entirely. That shortcut is a performance
-    // optimisation, not a verification — accepting a value BECAUSE it was too
-    // deep to look at would turn the bound into a hole, and this module's whole
-    // claim is that what it stores has been checked.
+    // Refused wherever it sits — nested inside a list entry, where a naive
+    // comparison trips over its own recursion, and at the top level, which an
+    // identity fast path (`raw === stored`) would once have skipped entirely.
+    // That shortcut has since been removed as unobservable, but both placements
+    // stay pinned: accepting a value BECAUSE it was too deep to look at would
+    // turn the bound into a hole, and this module's whole claim is that what it
+    // stores has been checked.
     for (const region of [
       { id: 'r1', range: 'A1:F', columns: [{ column: 'B', role: 'text', extra: deep }] },
       { id: 'r1', range: 'A1:F', extra: deep },
     ]) {
       expect(refusalOf([{ type: 'upsertRegion', region }])).toContain('nested more than');
     }
+
+    // A cycle is the same guard answering a different failure. Depth escapes as
+    // a RangeError; a walk that follows a self-reference never returns, and no
+    // timeout in front of this module would make that a 400. JSON cannot
+    // express one, but an in-process caller building an op by hand can, and the
+    // depth bound is the only thing standing between that and a hung request.
+    //
+    // Fair warning about the shape of the failure: if that bound regresses this
+    // assertion HANGS rather than failing, because vitest cannot preempt a
+    // synchronous walk (measured — neutralising the depth check produces no
+    // output at all, where the depth fixtures above fail cleanly). A stalled
+    // job is a worse signal than a red one, but it is the only way to pin a
+    // non-termination property, and an unbounded walk reaching production is
+    // the thing actually worth catching.
+    const cyclic: Record<string, unknown> = { id: 'r1', range: 'A1:F' };
+    cyclic.self = cyclic;
+    expect(refusalOf([{ type: 'upsertRegion', region: cyclic }])).toContain('nested more than');
 
     // Depth is only half of it: the same field can be shallow and arbitrarily
     // WIDE, and the comparison builds and sorts a canonical array out of every

--- a/packages/lib/src/__tests__/sheet-format-request.test.ts
+++ b/packages/lib/src/__tests__/sheet-format-request.test.ts
@@ -796,6 +796,38 @@ describe('planFormatOps — nothing the parser would quietly rewrite', () => {
     ).toHaveLength(1);
   });
 
+  it('refuses a column setting the column’s own role does not use', () => {
+    // `columnRoleFormat` reads `currency` only for `role: 'currency'` and
+    // `decimals` only for the numeric roles, so `{role: 'number', currency:
+    // 'EUR'}` is stored, ignored, and looks from the outside like money that
+    // lost its symbol.
+    const withColumn = (column: unknown) => ({ id: 'r1', range: 'A1:F', columns: [column] });
+
+    expect(
+      refusalOf([
+        { type: 'upsertRegion', region: withColumn({ column: 'C', role: 'number', currency: 'EUR' }) },
+      ])
+    ).toContain('declares currency, which a "number" column does not use');
+    expect(
+      refusalOf([
+        { type: 'upsertRegion', region: withColumn({ column: 'C', role: 'date', decimals: 2 }) },
+      ])
+    ).toContain('declares decimals, which a "date" column does not use');
+
+    // The roles that DO read them still work, including the case that a naive
+    // "does removing it change anything?" check would get wrong: `USD` on a
+    // currency column matches the default, so it is redundant — not a mistake.
+    for (const column of [
+      { column: 'C', role: 'currency', currency: 'EUR' },
+      { column: 'C', role: 'currency', currency: 'USD' },
+      { column: 'C', role: 'number', decimals: 0 },
+      { column: 'C', role: 'percent', decimals: 1 },
+    ]) {
+      expect(plan([{ type: 'upsertRegion', region: withColumn(column) }]).regions[0].columns)
+        .toHaveLength(1);
+    }
+  });
+
   it('refuses freezeHeader while nothing acts on it', () => {
     // Parsed and stored, with no consumer anywhere: `createRegionResolver` does
     // not read it and the `setRegions` step only stores the region. Accepting

--- a/packages/lib/src/__tests__/sheet-format-request.test.ts
+++ b/packages/lib/src/__tests__/sheet-format-request.test.ts
@@ -1742,7 +1742,7 @@ describe('planFormatOps — never something other than what was asked for', () =
           region: { id: 'r1', range: 'A1:B1', columns: [{ column: 'A', role: 'currency' }] },
         },
       ])
-    ).toContain('every one of them is a header');
+    ).toContain('is 1 row tall and that row is a header');
 
     // A bodyless region that declares no columns is only a header strip, which
     // is a legitimate thing to want.

--- a/packages/lib/src/__tests__/sheet-format-request.test.ts
+++ b/packages/lib/src/__tests__/sheet-format-request.test.ts
@@ -2686,6 +2686,54 @@ describe('planFormatOps — everything accepted survives the parsers (#7)', () =
   });
 });
 
+describe('planFormatOps — a malformed tab is not a caller error', () => {
+  it('names the field instead of dying twenty frames deep', () => {
+    // The fuzz below covers every shape of garbage in the OPS, because those
+    // arrive as JSON from a caller and every one of them is a 400. It never
+    // covered the tab — which arrives from the store's own parser, so a
+    // non-object in one of its lists is corrupt storage or a caller that
+    // skipped the parser, not a bad request.
+    //
+    // That distinction is why these throw a plain Error rather than a
+    // `SheetFormatError`: answering 400 would blame the caller for something
+    // that is not their doing. What it must not do is surface as
+    // "null is not an object (evaluating 'rule.id')".
+    for (const [field, list] of [
+      ['conditionalFormats', [null]],
+      ['conditionalFormats', [undefined]],
+      ['conditionalFormats', ['not a rule']],
+      ['conditionalFormats', 'not an array'],
+      ['regions', [null]],
+    ] as const) {
+      let thrown: unknown;
+      try {
+        planFormatOps([{ type: 'removeConditionalRule', id: 'x' }], {
+          rowCount: 100,
+          columnCount: 26,
+          [field]: list,
+        } as unknown as SheetFormatTarget);
+      } catch (error) {
+        thrown = error;
+      }
+
+      expect(thrown).toBeInstanceOf(Error);
+      expect(thrown).not.toBeInstanceOf(SheetFormatError);
+      expect((thrown as Error).message).toContain(`tab.${field} must be an array of objects`);
+    }
+
+    // A tab whose entries are objects but poor ones is a different matter —
+    // those are the stored shapes the rest of this module already survives, and
+    // they stay the caller's ordinary business.
+    expect(
+      refusalOf([{ type: 'removeConditionalRule', id: 'x' }], {
+        rowCount: 100,
+        columnCount: 26,
+        conditionalFormats: [{ id: 'a', kind: 'cell' }] as unknown as ConditionalRule[],
+      })
+    ).toContain('No rule "x" on this sheet');
+  });
+});
+
 describe('planFormatOps — refuses, never crashes', () => {
   // The point of `SheetFormatError` is that a caller can answer 400 to it. A
   // TypeError escaping this module answers 500 instead, and a validation layer

--- a/packages/lib/src/__tests__/sheet-format-request.test.ts
+++ b/packages/lib/src/__tests__/sheet-format-request.test.ts
@@ -123,6 +123,43 @@ describe('planFormatOps — the request envelope', () => {
     expect(refusalOf([{ range: 'A1' } as unknown as SheetFormatOp])).toContain('must be an object');
   });
 
+  it('refuses a field that is not this op’s, naming the ones that are', () => {
+    // An op is a caller-specified object with a known shape, exactly like a
+    // format patch — so an unknown key gets the same answer `bolt` gets, for
+    // the same reason. A misspelled REQUIRED field already refused itself,
+    // because the field it should have been was missing. An extra one did not:
+    // `{type: 'setCellFormat', range, patch, format}` — a model reaching for the
+    // name a RULE uses — applied the bold and discarded the italic in silence.
+    expect(
+      refusalOf([
+        { type: 'setCellFormat', range: 'A1', patch: { bold: true }, format: { italic: true } } as never,
+      ])
+    ).toContain('"format" is not a field of this op');
+
+    // The message names what the op does take, which is the whole repair.
+    expect(refusalOf([{ type: 'setCellFormat', ranges: 'A1' } as never])).toContain(
+      'It takes "range" and "patch"'
+    );
+    expect(refusalOf([{ type: 'clearConditionalRules', rules: [] } as never])).toContain(
+      'It takes no fields'
+    );
+
+    // Ops are transient and versioned with the code that sends them, so unlike
+    // the stored shapes elsewhere there is no forward-compatibility case for
+    // letting a stray through — even a harmless-looking one.
+    expect(
+      refusalOf([{ type: 'setCellFormat', range: 'A1', patch: { bold: true }, requestId: 'x' } as never])
+    ).toContain('"requestId" is not a field of this op');
+
+    // And every op still accepts its own fields.
+    expect(
+      plan([
+        { type: 'setCellFormat', range: 'A1', patch: { bold: true } },
+        { type: 'moveConditionalRule', id: 'a', direction: 1 },
+      ], tabWith({ conditionalFormats: [rule('a'), rule('b')] })).steps
+    ).toHaveLength(2);
+  });
+
   it('refuses an unknown op type by name', () => {
     // Kills: a permissive default that would let a typo'd op type be planned as
     // a silent no-op — the failure mode this whole module exists to remove.

--- a/packages/lib/src/__tests__/sheet-format-request.test.ts
+++ b/packages/lib/src/__tests__/sheet-format-request.test.ts
@@ -393,6 +393,35 @@ describe('planFormatOps — conditional rules', () => {
       .toHaveLength(5);
   });
 
+  it('lets an already over-budget sheet be repaired one rule at a time', () => {
+    // A sheet can already be past the aggregate ceiling: the panel's `addRule`
+    // enforces the per-rule and rule-count caps but not this one. Refusing every
+    // write on such a sheet leaves it unrepairable — removing a rule strictly
+    // reduces the skipped render work, and would have been rejected for not
+    // fixing everything in one request.
+    const big = (id: string): ConditionalRule => ({ ...rule(id), ranges: ['A1:A400000'] });
+    const over = ['a', 'b', 'c', 'd', 'e', 'f', 'g'].map(big);
+    const tab = tabWith({ conditionalFormats: over });
+
+    expect(400_000 * 7).toBeGreaterThan(MAX_CONDITIONAL_TOTAL_CELLS);
+
+    // Still over afterwards, and still accepted, because it is lower.
+    const repaired = plan([{ type: 'removeConditionalRule', id: 'g' }], tab);
+    expect(repaired.conditionalFormats).toHaveLength(6);
+
+    // Making it worse is still refused.
+    expect(refusalOf([{ type: 'addConditionalRule', rule: big('h') }], tab)).toContain(
+      'over the sheet-wide limit'
+    );
+    // As is a swap that raises the total without adding a rule.
+    expect(
+      refusalOf(
+        [{ type: 'updateConditionalRule', id: 'g', patch: { ranges: ['A1:A490000'] } }],
+        tab
+      )
+    ).toContain('over the sheet-wide limit');
+  });
+
   it('does not charge the aggregate for ranges the evaluator would skip', () => {
     // A range past the per-range cap contributes nothing to evaluation, so
     // counting it toward the aggregate would refuse a sheet for work it was
@@ -783,6 +812,39 @@ describe('planFormatOps — nothing the parser would quietly rewrite', () => {
     expect(
       refusalOf([{ type: 'upsertRegion', region: { id: 'r1', range: 'A1:B10', totalRows: [20] } }])
     ).toContain('total row 20 is outside the region A1:B10');
+
+    // Totals are checked against the region's BODY, not its bounds. The
+    // resolver applies the header treatment and `continue`s, so a total inside
+    // the header band never reaches the total treatment — and a region starting
+    // below row 1 has rows above it that are not part of it at all. Neither is
+    // visible to a bounds-only check, and an OPEN region skipped the check
+    // entirely.
+    expect(
+      refusalOf([
+        { type: 'upsertRegion', region: { id: 'r1', range: 'A10:F', totalRows: [1] } },
+      ])
+    ).toContain('total row 1 is not in the body of A10:F');
+    expect(
+      refusalOf([
+        {
+          type: 'upsertRegion',
+          region: { id: 'r1', range: 'A1:F20', headerRows: 2, totalRows: [2] },
+        },
+      ])
+    ).toContain('its totals start at row 3');
+
+    // The first body row itself is fine, and so is a default single header row.
+    expect(
+      plan([
+        {
+          type: 'upsertRegion',
+          region: { id: 'r1', range: 'A1:F20', headerRows: 2, totalRows: [3, 20] },
+        },
+      ]).regions[0].totalRows
+    ).toEqual([3, 20]);
+    expect(
+      plan([{ type: 'upsertRegion', region: { id: 'r1', range: 'A10:F', totalRows: [11] } }]).regions
+    ).toHaveLength(1);
 
     // An OPEN region reaches the end of the sheet, so a total row past today's
     // extent is a row it will grow into — which is the point of leaving the end

--- a/packages/lib/src/__tests__/sheet-format-request.test.ts
+++ b/packages/lib/src/__tests__/sheet-format-request.test.ts
@@ -810,6 +810,126 @@ describe('planFormatOps — nothing the parser would quietly rewrite', () => {
     ).toHaveLength(1);
   });
 
+  it('refuses an unknown key NESTED inside a format', () => {
+    // The top-level key check cannot see this one, and `cellFormatSchema`
+    // strips it from the nested object just as quietly: the rule parses, the
+    // renderer ignores the misspelling and shows the default currency, and the
+    // field is gone entirely on the next load.
+    const message = refusalOf([
+      {
+        type: 'setCellFormat',
+        range: 'A1',
+        patch: { number: { kind: 'currency', curreny: 'EUR' } } as never,
+      },
+    ]);
+    expect(message).toContain('patch.number.curreny');
+
+    // And the top-level clearing behaviour has to survive the same check: a raw
+    // `undefined` is not a loss, whatever zod does with it.
+    const patch = { bold: undefined, number: { kind: 'currency' as const, currency: 'EUR' } };
+    const step = plan([{ type: 'setCellFormat', range: 'A1', patch }]).steps[0];
+    if (step.type !== 'setCellFormat') throw new Error('expected a setCellFormat step');
+    expect(step.patch).toBe(patch);
+  });
+
+  it('refuses a non-numeric operand for an operator that compares numbers', () => {
+    // A non-blank operand passes the missing-value check and still makes the
+    // rule inert: `matchesCondition` coerces it, gets null, and returns false
+    // for every cell.
+    const cell = (condition: unknown) => ({ ...rule('cf_1'), condition });
+
+    expect(
+      refusalOf([
+        { type: 'addConditionalRule', rule: cell({ operator: 'greaterThan', value: 'abc' }) },
+      ])
+    ).toContain('compares numbers, and value is "abc"');
+    expect(
+      refusalOf([
+        {
+          type: 'addConditionalRule',
+          rule: cell({ operator: 'between', value: '1', value2: 'ten' }),
+        },
+      ])
+    ).toContain('value2 is "ten"');
+
+    // `equal` and the text operators are deliberately NOT in that set — they
+    // fall back to a text comparison, so `= "done"` is a real rule.
+    for (const operator of ['equal', 'notEqual', 'contains', 'startsWith']) {
+      expect(
+        plan([{ type: 'addConditionalRule', rule: cell({ operator, value: 'done' }) }])
+          .conditionalFormats
+      ).toHaveLength(1);
+    }
+    expect(
+      plan([{ type: 'addConditionalRule', rule: cell({ operator: 'greaterThan', value: ' 10 ' }) }])
+        .conditionalFormats
+    ).toHaveLength(1);
+  });
+
+  it('refuses a formula calling a function this build does not implement', () => {
+    // Parsing proves the grammar, not the vocabulary: `FormulaParser` accepts
+    // any identifier followed by parentheses, and `evaluateFunction` then
+    // throws for a name it does not implement — once per covered cell.
+    const formula = (body: string) => ({
+      id: 'cf_1',
+      kind: 'formula',
+      ranges: ['A1:A9'],
+      formula: body,
+      format: { bold: true },
+    });
+
+    expect(refusalOf([{ type: 'addConditionalRule', rule: formula('=BROKEN()') }])).toContain(
+      'calls BROKEN(), which this sheet does not implement'
+    );
+    // Nested inside an expression, which is why the check walks the whole tree.
+    expect(
+      refusalOf([{ type: 'addConditionalRule', rule: formula('=SUM(A1:A9) + NOPE(1)') }])
+    ).toContain('calls NOPE()');
+    // Under a unary operator too, which is its own branch of the walk.
+    expect(refusalOf([{ type: 'addConditionalRule', rule: formula('=-NOPE(1)>0') }])).toContain(
+      'calls NOPE()'
+    );
+    // Real functions still pass, including nested and lazily-evaluated ones.
+    for (const body of ['=SUM(A1:A9)>0', '=IF(A1>1, 2, 3)', '=IFERROR(SUM(A1:A9), 0)']) {
+      expect(plan([{ type: 'addConditionalRule', rule: formula(body) }]).conditionalFormats)
+        .toHaveLength(1);
+    }
+  });
+
+  it('refuses a value nested past what it will verify, rather than dying on it', () => {
+    // The parsers preserve unknown fields on purpose, so a caller can attach an
+    // arbitrarily deep value to an otherwise valid region. An unbounded walk
+    // over it is a RangeError, which escapes as a 500 — the one outcome
+    // `SheetFormatError` exists to prevent.
+    //
+    let deep: Record<string, unknown> = { end: true };
+    for (let i = 0; i < 5_000; i++) deep = { next: deep };
+
+    // Refused wherever it sits, including where the identity fast path would
+    // have skipped the walk entirely. That shortcut is a performance
+    // optimisation, not a verification — accepting a value BECAUSE it was too
+    // deep to look at would turn the bound into a hole, and this module's whole
+    // claim is that what it stores has been checked.
+    for (const region of [
+      { id: 'r1', range: 'A1:F', columns: [{ column: 'B', role: 'text', extra: deep }] },
+      { id: 'r1', range: 'A1:F', extra: deep },
+    ]) {
+      expect(refusalOf([{ type: 'upsertRegion', region }])).toContain('nested more than');
+    }
+
+    // Twelve levels is far past anything these shapes reach on their own — the
+    // deepest is `borders.top.color`, at three — so nothing real is caught.
+    expect(
+      plan([
+        {
+          type: 'setCellFormat',
+          range: 'A1',
+          patch: { borders: { top: { style: 'thin', color: '#123456' } } },
+        },
+      ]).steps
+    ).toHaveLength(1);
+  });
+
   it('refuses a theme the palette does not have, which would render as another colour', () => {
     // `parseRegion` accepts any lowercase word and `hueByName` then falls back
     // to the default at RENDER time — so this is a sanitization the comparator

--- a/packages/lib/src/__tests__/sheet-format-request.test.ts
+++ b/packages/lib/src/__tests__/sheet-format-request.test.ts
@@ -1677,6 +1677,70 @@ describe('planFormatOps — the dashboard this epic exists for', () => {
   //
   // "A1:F is a table, row 1 is headers, column C is money, row 40 is a total,
   // accent blue", plus the presentation that goes with it.
+  it('accepts everything the parsers allow, at their maximum', () => {
+    // The general form of a mistake this branch made once: a bound tuned
+    // against the attack and never against real work. Every limit here belongs
+    // to the parsers, not to this module, so anything sitting exactly at one of
+    // them is by definition legitimate — and if a bound added later is too
+    // tight, or two bounds interact, this is where it shows.
+    const tab = tabWith({ rowCount: 5000, columnCount: 1000 });
+
+    // A region using every allowance `regions.ts` grants at once.
+    expect(
+      plan(
+        [
+          {
+            type: 'upsertRegion',
+            region: {
+              id: 'r',
+              range: `A1:${encodeColumnLabel(MAX_REGION_COLUMNS - 1)}4000`,
+              headerRows: 1,
+              totalRows: Array.from({ length: MAX_REGION_TOTAL_ROWS }, (_, i) => i + 2),
+              columns: Array.from({ length: MAX_REGION_COLUMNS }, (_, i) => ({
+                column: encodeColumnLabel(i),
+                role: 'number',
+                decimals: 2,
+              })),
+              theme: 'blue',
+            },
+          },
+        ],
+        tab
+      ).regions[0].columns
+    ).toHaveLength(MAX_REGION_COLUMNS);
+
+    // A rule at the per-rule range cap.
+    expect(
+      plan(
+        [
+          {
+            type: 'addConditionalRule',
+            rule: {
+              id: 'cf',
+              kind: 'cell',
+              ranges: Array.from({ length: MAX_CONDITIONAL_RANGES_PER_RULE }, (_, i) => `A${i + 1}`),
+              condition: { operator: 'greaterThan', value: '1' },
+              format: { bold: true },
+            },
+          },
+        ],
+        tab
+      ).conditionalFormats
+    ).toHaveLength(1);
+
+    // And a formatting batch of a size someone might really send.
+    expect(
+      plan(
+        Array.from({ length: 20 }, (_, i) => ({
+          type: 'setCellFormat' as const,
+          range: `A${i * 250 + 1}:E${i * 250 + 1000}`,
+          patch: { bold: true },
+        })),
+        tab
+      ).steps
+    ).toHaveLength(20);
+  });
+
   it('accepts the region the read half of this epic documents', () => {
     // #2560 is the read half, and it publishes this exact region as the shape
     // an agent gets back — the point being that it can change one field and

--- a/packages/lib/src/__tests__/sheet-format-request.test.ts
+++ b/packages/lib/src/__tests__/sheet-format-request.test.ts
@@ -1574,6 +1574,100 @@ describe('planFormatOps — regions', () => {
   });
 });
 
+describe('planFormatOps — the dashboard this epic exists for', () => {
+  // Everything else in this file is a refusal. A validator can pass every one
+  // of those and still be useless, because each new rule is a chance to refuse
+  // something legitimate — and the request that matters is the one the epic
+  // opens with: an agent asked for a budget dashboard, in one batch.
+  //
+  // "A1:F is a table, row 1 is headers, column C is money, row 40 is a total,
+  // accent blue", plus the presentation that goes with it.
+  it('plans a whole budget dashboard in one request', () => {
+    const ops: SheetFormatOp[] = [
+      { type: 'setFrozen', rows: 1, columns: null },
+      { type: 'setColumnWidth', column: 'A', width: 240 },
+      { type: 'setRowHeight', row: 1, height: 32 },
+      { type: 'setColumnFormat', column: 'C', patch: { number: { kind: 'currency', currency: 'USD' } } },
+      { type: 'setCellFormat', range: 'A1:F1', patch: { bold: true, align: 'center' } },
+      { type: 'setCellFormat', range: 'C40:F40', patch: { bold: true, borders: { top: { style: 'thin' } } } },
+      {
+        type: 'upsertRegion',
+        region: {
+          id: 'budget',
+          name: 'FY26 budget',
+          range: 'A1:F',
+          headerRows: 1,
+          totalRows: [40],
+          columns: [
+            { column: 'C', role: 'currency', currency: 'USD' },
+            { column: 'D', role: 'percent', decimals: 1 },
+            { column: 'A', role: 'text' },
+          ],
+          theme: 'blue',
+        },
+      },
+      {
+        type: 'addConditionalRule',
+        rule: {
+          id: 'over-budget',
+          kind: 'cell',
+          ranges: ['C2:C39'],
+          condition: { operator: 'greaterThan', value: '1000' },
+          format: { color: '#b91c1c', bold: true },
+        },
+      },
+      {
+        type: 'addConditionalRule',
+        rule: {
+          id: 'spend-scale',
+          kind: 'colorScale',
+          ranges: ['D2:D39'],
+          min: { type: 'min', color: '#dbeafe' },
+          max: { type: 'max', color: '#1d4ed8' },
+        },
+      },
+      {
+        type: 'addConditionalRule',
+        rule: {
+          id: 'variance-formula',
+          kind: 'formula',
+          ranges: ['E2:E39'],
+          formula: '=ABS(E2) > SUM(C2:C39) * 0.1',
+          format: { italic: true },
+        },
+      },
+    ];
+
+    const result = plan(ops, tabWith({ rowCount: 60, columnCount: 26 }));
+
+    // Every op is planned, in the order it was asked for, with the two
+    // tab-level lists folded into one step each at the end.
+    expect(result.steps.map((step) => step.type)).toEqual([
+      'setFrozen',
+      'setColumnWidth',
+      'setRowHeight',
+      'setColumnFormat',
+      'setCellFormat',
+      'setCellFormat',
+      'setConditionalRules',
+      'setRegions',
+    ]);
+
+    // Exactly the rows the per-cell ops touch — row 1 and row 40, 0-based —
+    // and nothing else. The region covers rows the plan never loads, which is
+    // the whole reason it is a region.
+    expect([...result.rows].sort((a, b) => a - b)).toEqual([0, 39]);
+    expect(result.touchesTabFields).toBe(true);
+
+    expect(result.conditionalFormats.map((rule) => rule.id)).toEqual([
+      'over-budget',
+      'spend-scale',
+      'variance-formula',
+    ]);
+    expect(result.regions[0]).toMatchObject({ id: 'budget', range: 'A1:F', theme: 'blue' });
+  });
+});
+
 describe('planFormatOps — all or nothing', () => {
   it('plans nothing when one op of ten is bad, and names its index (#5)', () => {
     // Kills: any per-op application, and any refusal that omits the index — a

--- a/packages/lib/src/__tests__/sheet-format-request.test.ts
+++ b/packages/lib/src/__tests__/sheet-format-request.test.ts
@@ -1152,3 +1152,111 @@ describe('planFormatOps — everything accepted survives the parsers (#7)', () =
     expect(checked).toBeGreaterThanOrEqual(5);
   });
 });
+
+describe('planFormatOps — refuses, never crashes', () => {
+  // The point of `SheetFormatError` is that a caller can answer 400 to it. A
+  // TypeError escaping this module answers 500 instead, and a validation layer
+  // that crashes on the input it exists to reject is worse than none: the
+  // caller learns nothing and the error looks like a server fault.
+  //
+  // Seeded rather than random so a failure is reproducible from the message
+  // alone — an intermittent fuzz failure nobody can re-run is a flake, not a
+  // finding.
+  const seeded = (seed: number) => () => {
+    seed = (seed + 0x6d2b79f5) | 0;
+    let t = Math.imul(seed ^ (seed >>> 15), 1 | seed);
+    t = (t + Math.imul(t ^ (t >>> 7), 61 | t)) ^ t;
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+  };
+
+  const OP_TYPES = [
+    'setCellFormat',
+    'clearCellFormat',
+    'setColumnFormat',
+    'setColumnWidth',
+    'setRowHeight',
+    'setFrozen',
+    'addConditionalRule',
+    'updateConditionalRule',
+    'removeConditionalRule',
+    'moveConditionalRule',
+    'clearConditionalRules',
+    'setRegions',
+    'upsertRegion',
+    'removeRegion',
+    'setCellFromat',
+    '',
+  ];
+
+  // Deliberately includes prototype-reaching keys and the shapes the parsers
+  // treat specially: a blank string, a null, a lone `-1`.
+  const SCALARS: unknown[] = [
+    0, 1, -1, 1.5, NaN, Infinity, 5_000_002, '', '  ', 'A1', 'a1:f', 'A1:', 'B2:D40', '#ff0000',
+    'red', 'bold', 'cell', 'formula', 'colorScale', 'dataBar', 'min', 'text', 'currency', true,
+    false, null, undefined, '__proto__', 'constructor',
+  ];
+  const KEYS = [
+    'id', 'kind', 'ranges', 'range', 'format', 'formula', 'condition', 'operator', 'value', 'color',
+    'min', 'mid', 'max', 'column', 'columns', 'role', 'width', 'height', 'row', 'rows', 'patch',
+    'regions', 'region', 'rule', 'direction', 'theme', 'headerRows', 'totalRows', 'bold', 'bolt',
+    'fontSize', '__proto__', 'type',
+  ];
+
+  const value = (rand: () => number, depth: number): unknown => {
+    const roll = rand();
+    if (depth > 2 || roll < 0.55) return SCALARS[Math.floor(rand() * SCALARS.length)];
+    if (roll < 0.75) {
+      return Array.from({ length: Math.floor(rand() * 4) }, () => value(rand, depth + 1));
+    }
+    const object: Record<string, unknown> = {};
+    for (let i = Math.floor(rand() * 5); i > 0; i--) {
+      object[KEYS[Math.floor(rand() * KEYS.length)]] = value(rand, depth + 1);
+    }
+    return object;
+  };
+
+  it('answers every shape of garbage with a SheetFormatError or a valid plan', () => {
+    const tab = tabWith({ conditionalFormats: [rule('a')], regions: [region('r1')] });
+    let refusals = 0;
+    let plans = 0;
+
+    for (let seed = 0; seed < 600; seed++) {
+      const rand = seeded(seed);
+      const generated = value(rand, 1);
+      // Give roughly half the cases a real op type, so the generator spends its
+      // budget inside the handlers rather than bouncing off the type check.
+      // Spread rather than assigned: half of what the generator produces is a
+      // primitive, and writing a property onto one throws in strict mode — a
+      // crash in the test, indistinguishable in the output from the crash in
+      // the module this is looking for.
+      const typed =
+        rand() < 0.5
+          ? {
+              ...(typeof generated === 'object' && generated !== null && !Array.isArray(generated)
+                ? generated
+                : {}),
+              type: OP_TYPES[Math.floor(rand() * OP_TYPES.length)],
+            }
+          : generated;
+      const op = typed as SheetFormatOp;
+
+      try {
+        const result = planFormatOps([op], tab);
+        plans += 1;
+        expect(Array.isArray(result.steps)).toBe(true);
+        expect(result.rows).toBeInstanceOf(Set);
+      } catch (error) {
+        if (!(error instanceof SheetFormatError)) {
+          throw new Error(`seed ${seed} threw ${String(error)} for ${JSON.stringify(op)}`);
+        }
+        refusals += 1;
+        expect(error.message).not.toBe('');
+      }
+    }
+
+    // Both outcomes have to occur, or the generator is only exercising one
+    // door. Plans are the rarer one — most random shapes are not valid ops.
+    expect(refusals).toBeGreaterThan(100);
+    expect(plans).toBeGreaterThan(0);
+  });
+});

--- a/packages/lib/src/__tests__/sheet-format-request.test.ts
+++ b/packages/lib/src/__tests__/sheet-format-request.test.ts
@@ -308,6 +308,12 @@ describe('planFormatOps — columns, rows and freezes', () => {
     expect(result.touchesTabFields).toBe(true);
   });
 
+  it('accepts 0 as "unfreeze", which is what setFrozen already means by it', () => {
+    expect(plan([{ type: 'setFrozen', rows: 0, columns: 0 }]).steps).toEqual([
+      { type: 'setFrozen', rows: 0, columns: 0 },
+    ]);
+  });
+
   it.each([
     ['negative', { rows: -1, columns: null }, 'whole number of 0 or more'],
     ['fractional', { rows: 1.5, columns: null }, 'whole number of 0 or more'],
@@ -454,11 +460,15 @@ describe('planFormatOps — conditional rules', () => {
     ).toContain('direction must be -1');
   });
 
-  it('clears every rule', () => {
+  it('clears every rule, and clearing none is not an error', () => {
     const tab = tabWith({ conditionalFormats: [rule('a')] });
     const result = plan([{ type: 'clearConditionalRules' }], tab);
     expect(result.conditionalFormats).toEqual([]);
     expect(result.steps).toEqual([{ type: 'setConditionalRules', rules: [] }]);
+
+    // Unlike removing an id that is not there: a clear names no target and so
+    // cannot be wrong about one.
+    expect(plan([{ type: 'clearConditionalRules' }]).conditionalFormats).toEqual([]);
   });
 
   it('refuses a resulting rule list that would come back shorter', () => {

--- a/packages/lib/src/__tests__/sheet-format-request.test.ts
+++ b/packages/lib/src/__tests__/sheet-format-request.test.ts
@@ -6,6 +6,7 @@ import {
   MAX_FORMAT_CELLS_PER_REQUEST,
   MAX_FORMAT_OPS,
   FIELDS_BY_KIND,
+  OP_FIELDS,
   SheetFormatError,
   planFormatOps,
   type SheetFormatOp,
@@ -158,6 +159,60 @@ describe('planFormatOps — the request envelope', () => {
         { type: 'moveConditionalRule', id: 'a', direction: 1 },
       ], tabWith({ conditionalFormats: [rule('a'), rule('b')] })).steps
     ).toHaveLength(2);
+  });
+
+  it('refuses every op that leaves out one of its own fields', () => {
+    // Driven off `OP_FIELDS` rather than a list written here, so an op added to
+    // the union is swept without anyone remembering to sweep it — the sample
+    // table below has to gain an entry or the first assertion fails.
+    //
+    // The property is the module's second principle applied across all fourteen
+    // ops at once: a missing required field must never plan as a no-op that
+    // reports success. One op validating its fields is easy; all of them
+    // staying that way as the union grows is the part that needs a machine.
+    const samples: Record<SheetFormatOp['type'], Record<string, unknown>> = {
+      setCellFormat: { range: 'A1', patch: { bold: true } },
+      clearCellFormat: { range: 'A1' },
+      setColumnFormat: { column: 'C', patch: { bold: true } },
+      setColumnWidth: { column: 'C', width: 120 },
+      setRowHeight: { row: 3, height: 40 },
+      setFrozen: { rows: 1, columns: 0 },
+      addConditionalRule: { rule: rule('cf_new') },
+      updateConditionalRule: { id: 'a', patch: { format: { italic: true } } },
+      removeConditionalRule: { id: 'a' },
+      moveConditionalRule: { id: 'a', direction: 1 },
+      clearConditionalRules: {},
+      setRegions: { regions: [region('r2')] },
+      upsertRegion: { region: region('r2') },
+      removeRegion: { id: 'r1' },
+    };
+    expect(Object.keys(samples).sort()).toEqual(Object.keys(OP_FIELDS).sort());
+
+    const target = tabWith({
+      conditionalFormats: [rule('a'), rule('b')],
+      regions: [region('r1')],
+    });
+
+    for (const [type, fields] of Object.entries(OP_FIELDS)) {
+      // Every sample must be valid to begin with, or an op could "pass" this
+      // sweep by being refused for some reason that has nothing to do with the
+      // field being dropped.
+      expect(() =>
+        plan([{ type, ...samples[type as SheetFormatOp['type']] } as never], target)
+      ).not.toThrow();
+
+      for (const field of fields) {
+        const op: Record<string, unknown> = {
+          type,
+          ...samples[type as SheetFormatOp['type']],
+        };
+        delete op[field];
+        const message = refusalOf([op as never], target);
+        // Naming the field is what makes the refusal repairable in one step;
+        // "invalid op" would satisfy the throw and help nobody.
+        expect(message, `${type} without ${field}`).toContain(field);
+      }
+    }
   });
 
   it('refuses an unknown op type by name', () => {

--- a/packages/lib/src/__tests__/sheet-format-request.test.ts
+++ b/packages/lib/src/__tests__/sheet-format-request.test.ts
@@ -28,7 +28,10 @@ import {
 import { PALETTE } from '../sheets/palette';
 import { isSupportedFunction } from '../sheets/functions';
 import { MAX_ADDRESSABLE_ROW, encodeColumnLabel } from '../sheets/address';
-import { MAX_CONDITIONAL_RANGES_PER_RULE, VALUELESS_OPERATORS } from '../sheets/conditional';
+import {
+  MAX_CONDITIONAL_RANGES_PER_RULE,
+  VALUELESS_OPERATORS,
+} from '../sheets/conditional';
 
 const tabWith = (overrides: Partial<SheetFormatTarget> = {}): SheetFormatTarget => ({
   rowCount: 100,
@@ -391,6 +394,30 @@ describe('planFormatOps — conditional rules', () => {
     // and not the rule count.
     expect(plan([{ type: 'addConditionalRule', rule: big('e', 15_000) }], tab).conditionalFormats)
       .toHaveLength(5);
+  });
+
+  it('bounds how much a single request can ask it to expand', () => {
+    // `validateRanges` expands every range to addresses, and the per-rule cap
+    // stops one rule at half a million cells. A batch of two hundred such rules
+    // is two hundred times that work before anything refuses — the same hole
+    // `MAX_FORMAT_CELLS_PER_REQUEST` closes on the cell path, and each op here
+    // is individually legal.
+    const ops: SheetFormatOp[] = Array.from({ length: 6 }, (_, i) => ({
+      type: 'addConditionalRule',
+      rule: { ...rule(`cf_${i}`), ranges: ['A1:A490000'] },
+    }));
+
+    expect(490_000 * 6).toBeGreaterThan(MAX_CONDITIONAL_TOTAL_CELLS);
+    const message = refusalOf(ops);
+    expect(message).toContain('cells between them');
+    // Refused on the op that crosses the line, not at the end of the batch —
+    // which is what stops the work rather than merely reporting it.
+    expect(message).toContain('Op 4');
+
+    // A request that stays under it is unaffected.
+    expect(
+      plan(ops.slice(0, 4)).conditionalFormats
+    ).toHaveLength(4);
   });
 
   it('lets an already over-budget sheet be repaired one rule at a time', () => {

--- a/packages/lib/src/__tests__/sheet-format-request.test.ts
+++ b/packages/lib/src/__tests__/sheet-format-request.test.ts
@@ -1,3 +1,4 @@
+import { readFileSync } from 'node:fs';
 import { describe, expect, it } from 'vitest';
 import {
   MAX_FORMAT_CELLS,
@@ -25,6 +26,7 @@ import {
   type SheetRegion,
 } from '../sheets/regions';
 import { PALETTE } from '../sheets/palette';
+import { isSupportedFunction } from '../sheets/functions';
 import { MAX_ADDRESSABLE_ROW, encodeColumnLabel } from '../sheets/address';
 import { MAX_CONDITIONAL_RANGES_PER_RULE, VALUELESS_OPERATORS } from '../sheets/conditional';
 
@@ -894,6 +896,27 @@ describe('planFormatOps — nothing the parser would quietly rewrite', () => {
       expect(plan([{ type: 'addConditionalRule', rule: formula(body) }]).conditionalFormats)
         .toHaveLength(1);
     }
+  });
+
+  it('recognises every function the dispatch actually implements', () => {
+    // `isSupportedFunction` probes the switch instead of listing its names, and
+    // this is the assertion that the probe is sound in the direction that
+    // matters: a FALSE negative would refuse a formula that works perfectly.
+    //
+    // The names are read out of the source rather than written here, because a
+    // list in this file is the second copy the probe exists to avoid — it would
+    // drift the first time someone adds a function, and the test would keep
+    // passing while saying nothing.
+    const source = readFileSync(new URL('../sheets/functions.ts', import.meta.url), 'utf8');
+    const names = [...new Set([...source.matchAll(/case '([A-Z0-9_.]+)'/g)].map((m) => m[1]))];
+
+    // A regex that stops matching would leave an empty list and a test that
+    // passes vacuously, which is the failure mode this whole suite is built
+    // against.
+    expect(names.length).toBeGreaterThan(40);
+
+    expect(names.filter((name) => !isSupportedFunction(name))).toEqual([]);
+    expect(isSupportedFunction('BROKEN')).toBe(false);
   });
 
   it('refuses a value nested past what it will verify, rather than dying on it', () => {

--- a/packages/lib/src/__tests__/sheet-format-request.test.ts
+++ b/packages/lib/src/__tests__/sheet-format-request.test.ts
@@ -1965,6 +1965,72 @@ describe('planFormatOps — never something other than what was asked for', () =
     expect([...plan([{ type: 'clearCellFormat', range: '  A1:F1  ' }]).rows]).toEqual([0]);
   });
 
+  it('says a condition value is text when a caller sends the number', () => {
+    // Kills: dropping `conditionValueHint`, or widening it past the two paths
+    // it can actually explain.
+    //
+    // `ConditionalCondition.value` is a string — the panel's input is text, and
+    // a date or a status name shares the field with a number. So the most
+    // ordinary rule anyone writes, "highlight cells greater than 5", arrives as
+    // `value: 5`, the parser drops it, and the comparator names
+    // `condition.value` with no remedy attached. The type IS the repair.
+    const message = refusalOf([
+      {
+        type: 'addConditionalRule',
+        rule: {
+          id: 'cf_1',
+          kind: 'cell',
+          ranges: ['A1:A9'],
+          condition: { operator: 'greaterThan', value: 5 as unknown as string },
+          format: { bold: true },
+        },
+      },
+    ]);
+    expect(message).toContain('condition.value');
+    expect(message).toContain('write "5", not 5');
+
+    // The upper bound of a `between` is the same field with the same trap.
+    expect(
+      refusalOf([
+        {
+          type: 'addConditionalRule',
+          rule: {
+            id: 'cf_1',
+            kind: 'cell',
+            ranges: ['A1:A9'],
+            condition: { operator: 'between', value: '1', value2: 9 as unknown as string },
+            format: { bold: true },
+          },
+        },
+      ])
+    ).toContain('write "9", not 9');
+
+    // And it stays silent where it cannot be sure. A sanitized path that is not
+    // a condition value gets the plain message — a hint about numbers on, say,
+    // a dropped column declaration would send the caller the wrong way.
+    const elsewhere = refusalOf([
+      { type: 'upsertRegion', region: { id: 'r1', range: 'A1:F', headerRows: 999 } },
+    ]);
+    expect(elsewhere).toContain('is not something this sheet can store');
+    expect(elsewhere).not.toContain('is text, not a number');
+
+    // Nor does it fire when the value was dropped for some reason other than
+    // being a number — here `condition` itself is not an object to read from.
+    const notANumber = refusalOf([
+      {
+        type: 'addConditionalRule',
+        rule: {
+          id: 'cf_1',
+          kind: 'cell',
+          ranges: ['A1:A9'],
+          condition: { operator: 'greaterThan', value: { n: 5 } as unknown as string },
+          format: { bold: true },
+        },
+      },
+    ]);
+    expect(notANumber).not.toContain('is text, not a number');
+  });
+
   it('still lets a rule written by a NEWER build be updated', () => {
     // The pre-parse checks are stricter than the parser, so applying them to a
     // whole merged rule — mostly the STORED one — would refuse any update to a

--- a/packages/lib/src/__tests__/sheet-format-request.test.ts
+++ b/packages/lib/src/__tests__/sheet-format-request.test.ts
@@ -1,0 +1,656 @@
+import { describe, expect, it } from 'vitest';
+import {
+  MAX_FORMAT_CELLS,
+  MAX_FORMAT_CELLS_PER_REQUEST,
+  MAX_FORMAT_OPS,
+  SheetFormatError,
+  planFormatOps,
+  type SheetFormatOp,
+  type SheetFormatPlan,
+  type SheetFormatTarget,
+} from '../sheets/format-request';
+import { setColumnWidth, setRowHeight } from '../sheets/format-ops';
+import { createEmptySheet } from '../sheets/io';
+import {
+  MAX_CONDITIONAL_RULES,
+  MAX_CONDITIONAL_TOTAL_CELLS,
+  parseConditionalRule,
+  type ConditionalRule,
+} from '../sheets/conditional';
+import { MAX_REGIONS, parseRegion, type SheetRegion } from '../sheets/regions';
+
+const tabWith = (overrides: Partial<SheetFormatTarget> = {}): SheetFormatTarget => ({
+  rowCount: 100,
+  columnCount: 26,
+  ...overrides,
+});
+
+const rule = (id: string, over = '10'): ConditionalRule => ({
+  id,
+  kind: 'cell',
+  ranges: ['A1:A9'],
+  condition: { operator: 'greaterThan', value: over },
+  format: { background: '#fee2e2' },
+});
+
+const region = (id: string, range = 'A1:F'): SheetRegion => ({ id, range });
+
+const plan = (ops: SheetFormatOp[], tab: SheetFormatTarget = tabWith()): SheetFormatPlan =>
+  planFormatOps(ops, tab);
+
+/** The refusal message, so a test can assert on what a model would be told. */
+const refusalOf = (ops: SheetFormatOp[], tab: SheetFormatTarget = tabWith()): string => {
+  try {
+    planFormatOps(ops, tab);
+  } catch (error) {
+    if (error instanceof SheetFormatError) return error.message;
+    throw error;
+  }
+  throw new Error('Expected a SheetFormatError, but planning succeeded.');
+};
+
+describe('planFormatOps — the request envelope', () => {
+  it('plans nothing for an empty batch, rather than inventing work', () => {
+    const result = plan([]);
+    expect(result.steps).toEqual([]);
+    expect(result.touchesTabFields).toBe(false);
+    expect([...result.rows]).toEqual([]);
+  });
+
+  it('refuses ops that are not an array', () => {
+    // Kills: dropping the array guard, which would make `.length` undefined and
+    // `forEach` throw a TypeError the caller would answer 500 to.
+    expect(() => planFormatOps(undefined as unknown as SheetFormatOp[], tabWith())).toThrow(
+      SheetFormatError
+    );
+  });
+
+  it('refuses a batch past MAX_FORMAT_OPS', () => {
+    const ops = Array.from({ length: MAX_FORMAT_OPS + 1 }, () => ({
+      type: 'clearCellFormat' as const,
+      range: 'A1',
+    }));
+    expect(refusalOf(ops)).toContain(`at most ${MAX_FORMAT_OPS} ops`);
+  });
+
+  it('refuses an op that is not an object with a type', () => {
+    expect(refusalOf([null as unknown as SheetFormatOp])).toContain('Op 0');
+    expect(refusalOf([{ range: 'A1' } as unknown as SheetFormatOp])).toContain('must be an object');
+  });
+
+  it('refuses an unknown op type by name', () => {
+    // Kills: a permissive default that would let a typo'd op type be planned as
+    // a silent no-op — the failure mode this whole module exists to remove.
+    expect(refusalOf([{ type: 'setCellFromat', range: 'A1' } as unknown as SheetFormatOp])).toContain(
+      'unknown op type "setCellFromat"'
+    );
+  });
+});
+
+describe('planFormatOps — ranges', () => {
+  it('resolves a range to its addresses and to the 0-based rows it touches', () => {
+    const result = plan([{ type: 'setCellFormat', range: 'B2:C3', patch: { bold: true } }]);
+    expect(result.steps).toEqual([
+      { type: 'setCellFormat', addresses: ['B2', 'C2', 'B3', 'C3'], patch: { bold: true } },
+    ]);
+    // Kills: emitting 1-based rows, which would lock and load the wrong records.
+    expect([...result.rows].sort((a, b) => a - b)).toEqual([1, 2]);
+    expect(result.touchesTabFields).toBe(false);
+  });
+
+  it('accepts a bare cell', () => {
+    expect(plan([{ type: 'clearCellFormat', range: 'a1' }]).steps).toEqual([
+      { type: 'clearCellFormat', addresses: ['A1'] },
+    ]);
+  });
+
+  it.each([
+    ['not a string', 42 as unknown as string, 'range must be a string'],
+    ['empty', '', 'not a range'],
+    ['truncated', 'A1:', 'not a range'],
+    ['three-cornered', 'A1:B2:C3', 'not a range'],
+    ['not an address', 'HELLO', 'not a range'],
+    ['row zero', 'A0:B2', 'not a range'],
+    ['past the last row', 'A5000002', 'not a range'],
+    ['past the last column', 'ZZZZ1', 'not a range'],
+  ])('refuses a range that is %s', (_label, range, expected) => {
+    // Kills: any loosening of `parseRangeSpan`. `A1:` in particular decodes to
+    // the single cell A1 if the truncation guard goes, which looks like it
+    // worked and formats one cell out of a table.
+    expect(refusalOf([{ type: 'clearCellFormat', range }])).toContain(expected);
+  });
+
+  it('refuses a range past MAX_FORMAT_CELLS and points at the better tool', () => {
+    const message = refusalOf([
+      { type: 'setCellFormat', range: `A1:A${MAX_FORMAT_CELLS + 1}`, patch: { bold: true } },
+    ]);
+    expect(message).toContain((MAX_FORMAT_CELLS + 1).toLocaleString());
+    expect(message).toContain('setColumnFormat');
+  });
+
+  it('refuses a batch whose ranges sum past the per-request budget', () => {
+    // Each op is individually legal; only the aggregate is not. Kills: deleting
+    // the per-request accumulator, which would leave the per-op cap decorative.
+    const per = 45_000;
+    const ops: SheetFormatOp[] = Array.from({ length: 5 }, () => ({
+      type: 'clearCellFormat' as const,
+      range: `A1:A${per}`,
+    }));
+    expect(per).toBeLessThan(MAX_FORMAT_CELLS);
+    expect(per * 5).toBeGreaterThan(MAX_FORMAT_CELLS_PER_REQUEST);
+    expect(refusalOf(ops)).toContain('per-request limit');
+  });
+});
+
+describe('planFormatOps — cell format patches', () => {
+  it('refuses an unknown field by name (#4)', () => {
+    // `cellFormatSchema` is a plain z.object, so `.parse({bolt: true})` returns
+    // `{}` and reports success. Kills: validating with the schema alone, which
+    // turns a typo into a successful request that formats nothing.
+    const message = refusalOf([{ type: 'setCellFormat', range: 'A1', patch: { bolt: true } as never }]);
+    expect(message).toContain('"bolt" is not a format field');
+    expect(message).toContain('bold');
+  });
+
+  it('refuses a prototype-reaching key', () => {
+    const patch = JSON.parse('{"__proto__": {"bold": true}}') as never;
+    expect(refusalOf([{ type: 'setCellFormat', range: 'A1', patch }])).toContain('not a format field');
+  });
+
+  it('refuses a patch that is not an object, and one with no fields', () => {
+    expect(refusalOf([{ type: 'setCellFormat', range: 'A1', patch: null as never }])).toContain(
+      'must be an object'
+    );
+    // A field-less patch applies cleanly and changes nothing.
+    expect(refusalOf([{ type: 'setCellFormat', range: 'A1', patch: {} }])).toContain('no fields');
+  });
+
+  it('refuses an invalid field value and names the zod path', () => {
+    expect(
+      refusalOf([{ type: 'setCellFormat', range: 'A1', patch: { color: 'red' as never } }])
+    ).toContain('color: Expected a #rrggbb color');
+    expect(
+      refusalOf([
+        { type: 'setCellFormat', range: 'A1', patch: { number: { kind: 'currency', decimals: 99 } } },
+      ])
+    ).toContain('number.decimals');
+  });
+
+  it('hands the CALLER’S object downstream so an explicit undefined still clears (#3)', () => {
+    // `setCellFormats` reads a present-but-undefined field as "clear this".
+    // Zod does not preserve one: `cellFormatSchema.parse({bold: undefined})` is
+    // `{}`. Kills: piping `result.data`, which turns every "turn bold off" in
+    // the product into a silent no-op that reports success.
+    const patch = { bold: undefined };
+    const step = plan([{ type: 'setCellFormat', range: 'A1', patch }]).steps[0];
+    if (step.type !== 'setCellFormat') throw new Error('expected a setCellFormat step');
+
+    expect(step.patch).toBe(patch);
+    expect(Object.keys(step.patch)).toEqual(['bold']);
+    expect('bold' in step.patch).toBe(true);
+  });
+});
+
+describe('planFormatOps — columns, rows and freezes', () => {
+  it('resolves a column label to a 0-based index', () => {
+    expect(plan([{ type: 'setColumnFormat', column: 'ab', patch: { bold: true } }]).steps).toEqual([
+      { type: 'setColumnFormat', columnIndex: 27, patch: { bold: true } },
+    ]);
+  });
+
+  it.each([
+    ['not a string', 3 as unknown as string, 'must be letters'],
+    ['not letters', 'C3', 'is not a column label'],
+    ['eight letters', 'AAAAAAAA', 'is not a column label'],
+    ['past ZZZ', 'ZZZZ', 'past the last addressable column'],
+  ])('refuses a column that is %s', (_label, column, expected) => {
+    expect(refusalOf([{ type: 'setColumnWidth', column, width: 100 }])).toContain(expected);
+  });
+
+  it('refuses a width outside the bounds instead of clamping it (#2)', () => {
+    // The trap: `setColumnWidth` clamps, so a test that applies the op and
+    // asserts the stored width is 24 passes under BOTH the correct
+    // implementation and the broken one. What distinguishes them is whether the
+    // clamping setter is reached at all — so nothing may be recorded here.
+    const applied: Array<number | undefined> = [];
+    const applyWidths = (ops: SheetFormatOp[]) => {
+      let sheet = createEmptySheet();
+      for (const step of planFormatOps(ops, tabWith()).steps) {
+        if (step.type !== 'setColumnWidth') continue;
+        sheet = setColumnWidth(sheet, step.columnIndex, step.width);
+        applied.push(sheet.columnWidths?.A);
+      }
+    };
+
+    expect(() => applyWidths([{ type: 'setColumnWidth', column: 'A', width: 8 }])).toThrow(
+      SheetFormatError
+    );
+    expect(applied).toEqual([]);
+
+    // And the clamp is provably a no-op for everything that does get through.
+    applyWidths([{ type: 'setColumnWidth', column: 'A', width: 240 }]);
+    expect(applied).toEqual([240]);
+  });
+
+  it('refuses a height outside the bounds instead of clamping it', () => {
+    const applied: Array<number | undefined> = [];
+    const applyHeights = (ops: SheetFormatOp[]) => {
+      let sheet = createEmptySheet();
+      for (const step of planFormatOps(ops, tabWith()).steps) {
+        if (step.type !== 'setRowHeight') continue;
+        sheet = setRowHeight(sheet, step.rowIndex, step.height);
+        applied.push(sheet.rowHeights?.['1']);
+      }
+    };
+
+    expect(() => applyHeights([{ type: 'setRowHeight', row: 1, height: 4000 }])).toThrow(
+      SheetFormatError
+    );
+    expect(applied).toEqual([]);
+  });
+
+  it.each([
+    ['not a number', 'wide' as unknown as number, 'must be a number of pixels'],
+    ['fractional', 100.5, 'whole number of pixels'],
+    ['under the minimum', 8, 'between 24 and 2000'],
+    ['over the maximum', 5000, 'between 24 and 2000'],
+  ])('refuses a width that is %s', (_label, width, expected) => {
+    expect(refusalOf([{ type: 'setColumnWidth', column: 'A', width }])).toContain(expected);
+  });
+
+  it('reads null as "clear this", not as a missing value', () => {
+    expect(plan([{ type: 'setColumnWidth', column: 'A', width: null }]).steps).toEqual([
+      { type: 'setColumnWidth', columnIndex: 0, width: undefined },
+    ]);
+    expect(plan([{ type: 'setRowHeight', row: 3, height: null }]).steps).toEqual([
+      { type: 'setRowHeight', rowIndex: 2, height: undefined },
+    ]);
+  });
+
+  it('takes rows 1-based and stores them 0-based', () => {
+    expect(plan([{ type: 'setRowHeight', row: 7, height: 40 }]).steps).toEqual([
+      { type: 'setRowHeight', rowIndex: 6, height: 40 },
+    ]);
+  });
+
+  it.each([
+    ['zero', 0],
+    ['fractional', 2.5],
+    ['not a number', 'first' as unknown as number],
+    ['past the last row', 5_000_001],
+  ])('refuses a row height addressed at %s', (_label, row) => {
+    expect(refusalOf([{ type: 'setRowHeight', row, height: 40 }])).toContain('1-based row number');
+  });
+
+  it('plans a freeze inside the sheet extent', () => {
+    const result = plan([{ type: 'setFrozen', rows: 1, columns: null }]);
+    expect(result.steps).toEqual([{ type: 'setFrozen', rows: 1, columns: undefined }]);
+    expect(result.touchesTabFields).toBe(true);
+  });
+
+  it.each([
+    ['negative', { rows: -1, columns: null }, 'whole number of 0 or more'],
+    ['fractional', { rows: 1.5, columns: null }, 'whole number of 0 or more'],
+    ['past the row extent', { rows: 500, columns: null }, 'frozen rows is 500'],
+    ['past the column extent', { rows: null, columns: 99 }, 'frozen columns is 99'],
+  ])('refuses a freeze that is %s', (_label, freeze, expected) => {
+    expect(refusalOf([{ type: 'setFrozen', ...freeze }])).toContain(expected);
+  });
+});
+
+describe('planFormatOps — conditional rules', () => {
+  it('refuses a blank custom-formula rule (#1, the PR #2540 bug verbatim)', () => {
+    // `parseConditionalRule` returns null for a formula rule whose formula is
+    // blank, so the rule was stored, reported as added, and gone on reload.
+    // Kills: accepting the caller's rule object without parsing it.
+    const blank = { id: 'cf_1', kind: 'formula', ranges: ['A1:A9'], formula: '   ', format: { bold: true } };
+    expect(parseConditionalRule(blank)).toBeNull();
+    expect(refusalOf([{ type: 'addConditionalRule', rule: blank }])).toContain(
+      'not a rule this sheet can store'
+    );
+  });
+
+  it('adds a rule as the parser stores it, and marks the tab touched', () => {
+    const result = plan([{ type: 'addConditionalRule', rule: rule('cf_1') }]);
+    expect(result.conditionalFormats).toEqual([rule('cf_1')]);
+    expect(result.steps).toEqual([{ type: 'setConditionalRules', rules: [rule('cf_1')] }]);
+    expect(result.touchesTabFields).toBe(true);
+  });
+
+  it('refuses a rule whose ranges the panel would also refuse', () => {
+    // `validateRanges` is the shared definition; reimplementing it here is how
+    // the API and the panel come to disagree about the same rule.
+    expect(
+      refusalOf([{ type: 'addConditionalRule', rule: { ...rule('cf_1'), ranges: ['A1:A600000'] } }])
+    ).toContain('is not a range this sheet can format');
+    expect(refusalOf([{ type: 'addConditionalRule', rule: { ...rule('cf_1'), ranges: [] } }])).toContain(
+      'not a rule this sheet can store'
+    );
+  });
+
+  it('refuses an add past the rule cap', () => {
+    const existing = Array.from({ length: MAX_CONDITIONAL_RULES }, (_, i) => rule(`cf_${i}`));
+    expect(
+      refusalOf([{ type: 'addConditionalRule', rule: rule('cf_new') }], tabWith({ conditionalFormats: existing }))
+    ).toContain(`maximum of ${MAX_CONDITIONAL_RULES} rules`);
+  });
+
+  it('refuses rules that individually clear every cap but sum past the aggregate (#6)', () => {
+    // `expandRangesWithinBudget` spends MAX_CONDITIONAL_TOTAL_CELLS and then
+    // BREAKS, silently: past the budget, rules simply stop being applied at
+    // render time. Kills: deleting the aggregate sum, since each rule here is
+    // legal on its own and every other cap is satisfied.
+    const big = (id: string, cells: number): ConditionalRule => ({
+      ...rule(id),
+      ranges: [`A1:A${cells}`],
+    });
+    const existing = [big('a', 495_000), big('b', 495_000), big('c', 495_000), big('d', 495_000)];
+    const tab = tabWith({ conditionalFormats: existing });
+
+    expect(495_000 * 4).toBeLessThan(MAX_CONDITIONAL_TOTAL_CELLS);
+    const message = refusalOf([{ type: 'addConditionalRule', rule: big('e', 30_000) }], tab);
+    expect(message).toContain('sheet-wide limit');
+    expect(message).toContain((495_000 * 4 + 30_000).toLocaleString());
+
+    // Just under the aggregate still goes through, so the refusal is the budget
+    // and not the rule count.
+    expect(plan([{ type: 'addConditionalRule', rule: big('e', 15_000) }], tab).conditionalFormats)
+      .toHaveLength(5);
+  });
+
+  it('does not charge the aggregate for ranges the evaluator would skip', () => {
+    // A range past the per-range cap contributes nothing to evaluation, so
+    // counting it toward the aggregate would refuse a sheet for work it was
+    // never going to do.
+    const skipped: ConditionalRule = { ...rule('skip'), ranges: ['A1:A600000', 'NOPE'] };
+    const result = plan([{ type: 'addConditionalRule', rule: rule('cf_1') }], tabWith({ conditionalFormats: [skipped] }));
+    expect(result.conditionalFormats).toHaveLength(2);
+  });
+
+  it('updates a rule in place, keeping its precedence', () => {
+    const tab = tabWith({ conditionalFormats: [rule('a'), rule('b')] });
+    const result = plan([{ type: 'updateConditionalRule', id: 'a', patch: { ranges: ['B1:B4'] } }], tab);
+    expect(result.conditionalFormats[0].ranges).toEqual(['B1:B4']);
+    expect(result.conditionalFormats[1]).toEqual(rule('b'));
+  });
+
+  it('refuses an update to an id that is not present, listing the ones that are', () => {
+    // `updateRule`-shaped code returns "no change" for an unknown id, which over
+    // the API is indistinguishable from success.
+    const tab = tabWith({ conditionalFormats: [rule('a'), rule('b')] });
+    const message = refusalOf([{ type: 'updateConditionalRule', id: 'zzz', patch: { bold: true } }], tab);
+    expect(message).toContain('No rule "zzz"');
+    expect(message).toContain('"a", "b"');
+  });
+
+  it('refuses an update whose patch is unusable', () => {
+    const tab = tabWith({ conditionalFormats: [rule('a')] });
+    expect(refusalOf([{ type: 'updateConditionalRule', id: 'a', patch: null as never }], tab)).toContain(
+      'patch must be an object'
+    );
+    expect(
+      refusalOf([{ type: 'updateConditionalRule', id: 'a', patch: { ranges: ['A1:A600000'] } }], tab)
+    ).toContain('is not a range this sheet can format');
+    // A patch that empties the format leaves a rule the parser drops on load.
+    expect(
+      refusalOf([{ type: 'updateConditionalRule', id: 'a', patch: { format: {} } }], tab)
+    ).toContain('cannot store');
+  });
+
+  it('refuses an id that is not a non-empty string', () => {
+    expect(refusalOf([{ type: 'removeConditionalRule', id: '' }])).toContain('non-empty string');
+    expect(refusalOf([{ type: 'removeConditionalRule', id: 7 as unknown as string }])).toContain(
+      'non-empty string'
+    );
+  });
+
+  it('removes a rule, and refuses to remove one that is not there', () => {
+    const tab = tabWith({ conditionalFormats: [rule('a'), rule('b')] });
+    expect(plan([{ type: 'removeConditionalRule', id: 'a' }], tab).conditionalFormats).toEqual([rule('b')]);
+    expect(refusalOf([{ type: 'removeConditionalRule', id: 'a' }])).toContain('Present rules: none');
+  });
+
+  it('moves a rule, and refuses a move with nowhere to go', () => {
+    const tab = tabWith({ conditionalFormats: [rule('a'), rule('b')] });
+    expect(
+      plan([{ type: 'moveConditionalRule', id: 'a', direction: 1 }], tab).conditionalFormats.map((r) => r.id)
+    ).toEqual(['b', 'a']);
+    // Rule order IS precedence, so a move that did not happen is not a detail.
+    expect(refusalOf([{ type: 'moveConditionalRule', id: 'a', direction: -1 }], tab)).toContain(
+      'already first'
+    );
+    expect(refusalOf([{ type: 'moveConditionalRule', id: 'b', direction: 1 }], tab)).toContain(
+      'already last'
+    );
+    expect(refusalOf([{ type: 'moveConditionalRule', id: 'zzz', direction: 1 }], tab)).toContain(
+      'No rule "zzz"'
+    );
+    expect(
+      refusalOf([{ type: 'moveConditionalRule', id: 'a', direction: 2 as unknown as 1 }], tab)
+    ).toContain('direction must be -1');
+  });
+
+  it('clears every rule', () => {
+    const tab = tabWith({ conditionalFormats: [rule('a')] });
+    const result = plan([{ type: 'clearConditionalRules' }], tab);
+    expect(result.conditionalFormats).toEqual([]);
+    expect(result.steps).toEqual([{ type: 'setConditionalRules', rules: [] }]);
+  });
+
+  it('refuses a resulting rule list that would come back shorter', () => {
+    // The round-trip detector: a tab already holding more rules than the parser
+    // will read back means any write to that list loses some of it, whatever
+    // this module's own caps say.
+    const existing = Array.from({ length: MAX_CONDITIONAL_RULES + 5 }, (_, i) => rule(`cf_${i}`));
+    const message = refusalOf(
+      [{ type: 'updateConditionalRule', id: 'cf_0', patch: { format: { bold: true } } }],
+      tabWith({ conditionalFormats: existing })
+    );
+    expect(message).toContain('would be dropped when the sheet is read back');
+    expect(message).toContain('Nothing was applied');
+  });
+});
+
+describe('planFormatOps — regions', () => {
+  it('sets a region list', () => {
+    const result = plan([{ type: 'setRegions', regions: [{ id: 'r1', range: 'a1:f' }] }]);
+    expect(result.regions).toEqual([{ id: 'r1', range: 'A1:F' }]);
+    expect(result.steps).toEqual([{ type: 'setRegions', regions: [{ id: 'r1', range: 'A1:F' }] }]);
+    expect(result.touchesTabFields).toBe(true);
+  });
+
+  it('refuses a region list that is not an array, or is past the cap', () => {
+    expect(refusalOf([{ type: 'setRegions', regions: 'A1:F' as never }])).toContain('must be an array');
+    const many = Array.from({ length: MAX_REGIONS + 1 }, (_, i) => region(`r${i}`));
+    expect(refusalOf([{ type: 'setRegions', regions: many }])).toContain(`at most ${MAX_REGIONS} regions`);
+  });
+
+  it('clears the region list with an empty array', () => {
+    const result = plan([{ type: 'setRegions', regions: [] }], tabWith({ regions: [region('r1')] }));
+    expect(result.regions).toEqual([]);
+    expect(result.steps).toEqual([{ type: 'setRegions', regions: [] }]);
+  });
+
+  it('refuses an unusable region, naming its position', () => {
+    expect(refusalOf([{ type: 'setRegions', regions: [region('r1'), { range: 'A1:F' }] }])).toContain(
+      'regions[1] is not a region'
+    );
+  });
+
+  it('refuses two regions sharing an id', () => {
+    // `parseRegions` keeps the first and drops the rest, so a duplicate id is a
+    // region lost between the write and the next read.
+    expect(refusalOf([{ type: 'setRegions', regions: [region('r1'), region('r1', 'H1:J9')] }])).toContain(
+      'Two regions share the id "r1"'
+    );
+  });
+
+  it('upserts by id: appends a new one, replaces an existing one in place', () => {
+    const tab = tabWith({ regions: [region('r1'), region('r2', 'H1:J9')] });
+    expect(plan([{ type: 'upsertRegion', region: region('r3', 'L1:M9') }], tab).regions.map((r) => r.id))
+      .toEqual(['r1', 'r2', 'r3']);
+
+    const replaced = plan([{ type: 'upsertRegion', region: region('r1', 'B2:D9') }], tab).regions;
+    expect(replaced.map((r) => r.id)).toEqual(['r1', 'r2']);
+    expect(replaced[0].range).toBe('B2:D9');
+  });
+
+  it('refuses an unusable region and an upsert past the cap', () => {
+    expect(refusalOf([{ type: 'upsertRegion', region: { id: 'r1', range: 'A1' } }])).toContain(
+      'not a region this sheet can store'
+    );
+    const full = Array.from({ length: MAX_REGIONS }, (_, i) => region(`r${i}`));
+    expect(refusalOf([{ type: 'upsertRegion', region: region('new') }], tabWith({ regions: full }))).toContain(
+      `maximum of ${MAX_REGIONS} regions`
+    );
+  });
+
+  it('removes a region, and refuses to remove one that is not there', () => {
+    const tab = tabWith({ regions: [region('r1'), region('r2')] });
+    expect(plan([{ type: 'removeRegion', id: 'r1' }], tab).regions.map((r) => r.id)).toEqual(['r2']);
+
+    const message = refusalOf([{ type: 'removeRegion', id: 'nope' }], tab);
+    expect(message).toContain('No region "nope"');
+    expect(message).toContain('"r1", "r2"');
+    expect(refusalOf([{ type: 'removeRegion', id: 'nope' }])).toContain('Present regions: none');
+  });
+
+  it('refuses a resulting region list that would come back shorter', () => {
+    const existing = Array.from({ length: MAX_REGIONS + 3 }, (_, i) => region(`r${i}`));
+    expect(
+      refusalOf([{ type: 'upsertRegion', region: region('r0', 'B2:D9') }], tabWith({ regions: existing }))
+    ).toContain('would be dropped when the sheet is read back');
+  });
+});
+
+describe('planFormatOps — all or nothing', () => {
+  it('plans nothing when one op of ten is bad, and names its index (#5)', () => {
+    // Kills: any per-op application, and any refusal that omits the index — a
+    // batch failure a model cannot locate is a batch it has to guess at.
+    const applied: string[] = [];
+    const ops: SheetFormatOp[] = Array.from({ length: 10 }, (_, i) => ({
+      type: 'setCellFormat',
+      range: `A${i + 1}`,
+      patch: i === 7 ? ({ bolt: true } as never) : { bold: true },
+    }));
+
+    try {
+      for (const step of planFormatOps(ops, tabWith()).steps) applied.push(step.type);
+      throw new Error('Expected a refusal.');
+    } catch (error) {
+      expect(error).toBeInstanceOf(SheetFormatError);
+      expect((error as SheetFormatError).message).toContain('Op 7 (setCellFormat)');
+      expect((error as SheetFormatError).opIndex).toBe(7);
+    }
+
+    expect(applied).toEqual([]);
+  });
+
+  it('folds a mixed batch into one plan, in request order', () => {
+    const result = plan([
+      { type: 'setCellFormat', range: 'A1', patch: { bold: true } },
+      { type: 'clearCellFormat', range: 'A1' },
+      { type: 'addConditionalRule', rule: rule('cf_1') },
+      { type: 'upsertRegion', region: region('r1') },
+    ]);
+
+    expect(result.steps.map((step) => step.type)).toEqual([
+      'setCellFormat',
+      'clearCellFormat',
+      'setConditionalRules',
+      'setRegions',
+    ]);
+    expect(result.touchesTabFields).toBe(true);
+  });
+});
+
+describe('planFormatOps — everything accepted survives the parsers (#7)', () => {
+  const kinds = ['cell', 'formula', 'colorScale', 'dataBar'];
+  const ranges: unknown[] = [['A1:A9'], ['A1:A9', 'C1:C9'], [], ['A1:'], 'A1:A9', ['A1:A600000']];
+  const formats: unknown[] = [{ bold: true }, { background: '#fee2e2' }, {}, { bolt: true }, 'red'];
+  const formulas: unknown[] = ['=A1>1', '', '   ', 42];
+  const colors: unknown[] = ['#ff0000', 'red', undefined];
+
+  const ruleCandidates: unknown[] = [];
+  for (const kind of kinds) {
+    for (const rangeValue of ranges) {
+      for (const format of formats) {
+        ruleCandidates.push({
+          id: 'cf_x',
+          kind,
+          ranges: rangeValue,
+          format,
+          condition: { operator: 'greaterThan', value: '10' },
+          formula: formulas[ruleCandidates.length % formulas.length],
+          color: colors[ruleCandidates.length % colors.length],
+          min: { type: 'min', color: colors[ruleCandidates.length % colors.length] },
+          max: { type: 'max', color: '#00ff00' },
+        });
+      }
+    }
+  }
+
+  it('accepts a mix of rules and refuses the rest, and every acceptance round-trips', () => {
+    let accepted = 0;
+    let refused = 0;
+
+    for (const candidate of ruleCandidates) {
+      let result: SheetFormatPlan;
+      try {
+        result = plan([{ type: 'addConditionalRule', rule: candidate }]);
+      } catch (error) {
+        expect(error).toBeInstanceOf(SheetFormatError);
+        refused += 1;
+        continue;
+      }
+
+      accepted += 1;
+      const stored = result.conditionalFormats[0];
+      // The property: nothing this validator accepts may be dropped or altered
+      // by the parser that reads it back.
+      expect(parseConditionalRule(stored)).toEqual(stored);
+    }
+
+    // A property test over a generator that accepts everything, or nothing,
+    // proves nothing — so pin that both outcomes actually occur.
+    expect(accepted).toBeGreaterThan(0);
+    expect(refused).toBeGreaterThan(0);
+  });
+
+  const regionCandidates: unknown[] = [];
+  for (const range of ['A1:F', 'A1:F200', 'A1', 'A1:', '', 'ZZZZ1:ZZZZ9', 'a1:f20']) {
+    for (const headerRows of [0, 1, 4, 999, 'two']) {
+      for (const columns of [
+        undefined,
+        [{ column: 'C', role: 'currency', currency: 'usd' }],
+        [{ column: 'C', role: 'money' }],
+        [{ column: 'C', role: 'number', decimals: 99 }],
+      ]) {
+        regionCandidates.push({ id: 'r1', range, headerRows, columns, theme: 'blue' });
+      }
+    }
+  }
+
+  it('accepts a mix of regions and refuses the rest, and every acceptance round-trips', () => {
+    let accepted = 0;
+    let refused = 0;
+
+    for (const candidate of regionCandidates) {
+      let result: SheetFormatPlan;
+      try {
+        result = plan([{ type: 'upsertRegion', region: candidate }]);
+      } catch (error) {
+        expect(error).toBeInstanceOf(SheetFormatError);
+        refused += 1;
+        continue;
+      }
+
+      accepted += 1;
+      const stored = result.regions[0];
+      expect(parseRegion(stored)).toEqual(stored);
+    }
+
+    expect(accepted).toBeGreaterThan(0);
+    expect(refused).toBeGreaterThan(0);
+  });
+});

--- a/packages/lib/src/__tests__/sheet-format-request.test.ts
+++ b/packages/lib/src/__tests__/sheet-format-request.test.ts
@@ -2008,6 +2008,64 @@ describe('planFormatOps — regions', () => {
   });
 });
 
+describe('planFormatOps — the boundaries themselves', () => {
+  // Every other test in this file establishes that a limit exists. None of them
+  // establishes that it is in the right PLACE, and a limit off by one is a
+  // limit that refuses legitimate work or admits the thing it was written to
+  // stop. Each pair is the last value in and the first value out.
+  const accepts = (ops: SheetFormatOp[], target = tabWith()) => {
+    planFormatOps(ops, target);
+    return true;
+  };
+
+  const chain = (terms: number) =>
+    ({
+      id: 'f',
+      kind: 'formula',
+      ranges: ['A1'],
+      format: { bold: true },
+      formula: `=${Array.from({ length: terms }, (_, i) => `A${(i % 90) + 1}`).join('+')}>0`,
+    }) as unknown as SheetFormatOp['type'] extends never ? never : object;
+
+  const region = (i: number) => ({ id: `r${i}`, range: 'A1:F' });
+
+  it.each([
+    ['column width', { type: 'setColumnWidth', column: 'A', width: 24 }, { type: 'setColumnWidth', column: 'A', width: 23 }],
+    ['column width upper', { type: 'setColumnWidth', column: 'A', width: 2000 }, { type: 'setColumnWidth', column: 'A', width: 2001 }],
+    ['row height', { type: 'setRowHeight', row: 1, height: 16 }, { type: 'setRowHeight', row: 1, height: 15 }],
+    ['row height upper', { type: 'setRowHeight', row: 1, height: 1000 }, { type: 'setRowHeight', row: 1, height: 1001 }],
+    ['range cells', { type: 'clearCellFormat', range: `A1:A${MAX_FORMAT_CELLS}` }, { type: 'clearCellFormat', range: `A1:A${MAX_FORMAT_CELLS + 1}` }],
+    ['frozen rows', { type: 'setFrozen', rows: 100, columns: null }, { type: 'setFrozen', rows: 101, columns: null }],
+    ['frozen columns', { type: 'setFrozen', rows: null, columns: 26 }, { type: 'setFrozen', rows: null, columns: 27 }],
+    ['font size', { type: 'setCellFormat', range: 'A1', patch: { fontSize: 6 } }, { type: 'setCellFormat', range: 'A1', patch: { fontSize: 5 } }],
+    ['decimals', { type: 'setCellFormat', range: 'A1', patch: { number: { kind: 'number', decimals: 10 } } }, { type: 'setCellFormat', range: 'A1', patch: { number: { kind: 'number', decimals: 11 } } }],
+  ])('%s: the last value in is accepted and the first out is refused', (_label, inside, outside) => {
+    expect(accepts([inside as SheetFormatOp])).toBe(true);
+    expect(() => planFormatOps([outside as SheetFormatOp], tabWith())).toThrow(SheetFormatError);
+  });
+
+  it('holds the boundaries that need a built input', () => {
+    // Regions: the cap counts the list, so 50 in and 51 out.
+    expect(
+      accepts([
+        { type: 'setRegions', regions: Array.from({ length: MAX_REGIONS }, (_, i) => region(i)) },
+      ])
+    ).toBe(true);
+    expect(
+      refusalOf([
+        { type: 'setRegions', regions: Array.from({ length: MAX_REGIONS + 1 }, (_, i) => region(i)) },
+      ])
+    ).toContain(`at most ${MAX_REGIONS} regions`);
+
+    // Formula nesting: a left-associative chain of N terms nests N levels once
+    // the comparison on top is counted, so 256 terms is the last that fits.
+    expect(accepts([{ type: 'addConditionalRule', rule: chain(256) } as SheetFormatOp])).toBe(true);
+    expect(
+      refusalOf([{ type: 'addConditionalRule', rule: chain(257) } as SheetFormatOp])
+    ).toContain(`nests more than ${MAX_FORMULA_DEPTH}`);
+  });
+});
+
 describe('planFormatOps — the dashboard this epic exists for', () => {
   // Everything else in this file is a refusal. A validator can pass every one
   // of those and still be useless, because each new rule is a chance to refuse

--- a/packages/lib/src/__tests__/sheet-format-request.test.ts
+++ b/packages/lib/src/__tests__/sheet-format-request.test.ts
@@ -1982,6 +1982,36 @@ describe('planFormatOps — never something other than what was asked for', () =
     ).toContain('is not a range this sheet can address');
   });
 
+  it('blames the region range when the range is what failed, not the id', () => {
+    // Kills: removing the range branch, so every unparseable region goes back
+    // to the catch-all.
+    //
+    // `parseRegion` fails as a whole, so the generic message lists every
+    // requirement — which told a caller holding `{id: 'r1', range: '$A$1:$F'}`
+    // that a region needs an id. It sent one. That is the same defect as
+    // blaming a legal row number for arriving quoted: the message accuses the
+    // part that was right.
+    const badRange = refusalOf([
+      { type: 'upsertRegion', region: { id: 'r1', range: '$A$1:$F' } },
+    ]);
+    expect(badRange).toContain('region range "$A$1:$F"');
+    expect(badRange).toContain('drop the $');
+    expect(badRange).not.toContain('needs an id');
+
+    // And the catch-all still answers everything it is actually for — a region
+    // whose range parses but which fails for some other reason, and one that is
+    // not an object to read a range off at all.
+    expect(refusalOf([{ type: 'upsertRegion', region: { range: 'A1:F' } }])).toContain(
+      'needs an id and a range'
+    );
+    expect(refusalOf([{ type: 'upsertRegion', region: { id: 'r1' } }])).toContain(
+      'needs an id and a range'
+    );
+    expect(refusalOf([{ type: 'upsertRegion', region: 42 as never }])).toContain(
+      'needs an id and a range'
+    );
+  });
+
   it('tells a caller writing spreadsheet notation what to change, not just that it failed', () => {
     // Kills: deleting any arm of `rangeHint`, or making it return a constant.
     //
@@ -2244,8 +2274,10 @@ describe('planFormatOps — regions', () => {
   });
 
   it('refuses an unusable region and an upsert past the cap', () => {
+    // A single cell is not a region's range, and the refusal now says which
+    // part failed rather than restating every requirement.
     expect(refusalOf([{ type: 'upsertRegion', region: { id: 'r1', range: 'A1' } }])).toContain(
-      'not a region this sheet can store'
+      'region range "A1" is not a range this sheet can address'
     );
     const full = Array.from({ length: MAX_REGIONS }, (_, i) => region(`r${i}`));
     expect(refusalOf([{ type: 'upsertRegion', region: region('new') }], tabWith({ regions: full }))).toContain(

--- a/packages/lib/src/__tests__/sheet-format-request.test.ts
+++ b/packages/lib/src/__tests__/sheet-format-request.test.ts
@@ -1,6 +1,7 @@
 import { readFileSync } from 'node:fs';
 import { describe, expect, it } from 'vitest';
 import {
+  MAX_FORMULA_DEPTH,
   MAX_FORMAT_CELLS,
   MAX_FORMAT_CELLS_PER_REQUEST,
   MAX_FORMAT_OPS,
@@ -1206,6 +1207,138 @@ describe('planFormatOps — nothing the parser would quietly rewrite', () => {
       expect(plan([{ type: 'addConditionalRule', rule: formula(body) }]).conditionalFormats)
         .toHaveLength(1);
     }
+  });
+
+  it('refuses formula work that only adds up across rules', () => {
+    // The per-rule ceiling bounds one rule and says nothing about two hundred
+    // of them. Each of these covers 10,000 cells and references 2,000 — legal
+    // alone, and the covered-cell aggregate is satisfied — while together they
+    // ask for a billion expansions in one render.
+    const heavy = (id: string) => ({
+      id,
+      kind: 'formula',
+      ranges: ['A1:A10000'],
+      formula: '=SUM(B1:B2000)>0',
+      format: { bold: true },
+    });
+    const tab = tabWith({ rowCount: 20000 });
+
+    // One alone is fine, which is what makes the sum the finding.
+    expect(
+      plan([{ type: 'addConditionalRule', rule: heavy('one') }], tab).conditionalFormats
+    ).toHaveLength(1);
+
+    expect(
+      refusalOf(
+        Array.from({ length: 50 }, (_, i) => ({
+          type: 'addConditionalRule' as const,
+          rule: heavy(`r${i}`),
+        })),
+        tab
+      )
+    ).toContain('address expansions to render once');
+
+    // And the repair exception, as for the cell aggregate: a sheet already past
+    // this can still be reduced.
+    const over = tabWith({
+      rowCount: 20000,
+      conditionalFormats: Array.from({ length: 50 }, (_, i) => heavy(`r${i}`)) as never,
+    });
+    expect(
+      plan([{ type: 'removeConditionalRule', id: 'r0' }], over).conditionalFormats
+    ).toHaveLength(49);
+  });
+
+  it('costs stored formula rules honestly, whatever they contain', () => {
+    // The work total is computed over the RESULTING list, which includes rules
+    // that were already there — and those did not come through this validator.
+    // A stored formula may not parse at all, may be blank, may reference
+    // something unaddressable, or may nest under a unary operator. None of
+    // those may throw here, and none may be counted as costing something it
+    // cannot cost: a formula that will not parse never expands anything,
+    // because it throws first.
+    const stored = (id: string, formula: string) =>
+      ({
+        id,
+        kind: 'formula',
+        ranges: ['A1:A9'],
+        formula,
+        format: { bold: true },
+      }) as unknown as ConditionalRule;
+
+    const tab = tabWith({
+      conditionalFormats: [
+        stored('unparseable', '=BROKEN('),
+        stored('blank', '   '),
+        stored('unaddressable', '=SUM(A1:ZZZZ5)>0'),
+        stored('unary', '=-SUM(A1:A9)>0'),
+      ],
+    });
+
+    // Any op that touches the rule list walks all of them.
+    const result = plan([{ type: 'removeConditionalRule', id: 'blank' }], tab);
+    expect(result.conditionalFormats.map((rule) => rule.id)).toEqual([
+      'unparseable',
+      'unaddressable',
+      'unary',
+    ]);
+  });
+
+  it('refuses a formula the recursive evaluator cannot walk', () => {
+    // The parser is iterative and so is the walk that checks a formula, but
+    // `evaluation.ts` evaluates `BinaryExpression.left` by recursion — so a long
+    // left-associative chain parses cleanly here and overflows the stack there,
+    // once per covered cell.
+    const chain = (terms: number) =>
+      `=${Array.from({ length: terms }, (_, i) => `A${(i % 90) + 1}`).join('+')}>0`;
+    const formula = (body: string) => ({
+      id: 'cf_1',
+      kind: 'formula',
+      ranges: ['A1'],
+      formula: body,
+      format: { bold: true },
+    });
+
+    const message = refusalOf([{ type: 'addConditionalRule', rule: formula(chain(5000)) }]);
+    expect(message).toContain(`nests more than ${MAX_FORMULA_DEPTH} levels deep`);
+    // The formula is quoted back abbreviated — echoing five thousand terms
+    // would make a thirty-kilobyte message out of a one-line complaint.
+    expect(message.length).toBeLessThan(300);
+
+    // A chain of a length someone might actually write still plans.
+    expect(
+      plan([{ type: 'addConditionalRule', rule: formula(chain(100)) }]).conditionalFormats
+    ).toHaveLength(1);
+  });
+
+  it('counts a range argument by the cells it really covers', () => {
+    // Probing with one extra argument models `ABS(A1:A2)` and not
+    // `LEFT(A1:A3)`, since LEFT accepts both one argument and two. The count
+    // has to be the range's real cardinality.
+    const formula = (body: string) => ({
+      id: 'cf_1',
+      kind: 'formula',
+      ranges: ['A1:A9'],
+      formula: body,
+      format: { bold: true },
+    });
+
+    expect(refusalOf([{ type: 'addConditionalRule', rule: formula('=LEFT(A1:A3)="x"') }])).toContain(
+      'arrive as 3 values'
+    );
+    expect(
+      plan([{ type: 'addConditionalRule', rule: formula('=LEFT(A1, 2)="x"') }]).conditionalFormats
+    ).toHaveLength(1);
+  });
+
+  it('refuses a region range that starts before the first cell', () => {
+    // `parseRegionRange` bounds the bottom of the sheet and not the top:
+    // `decodeCellAddress` reads `A0` as row -1, so this parses, stores, and
+    // prepares as rows -1 to -1 — a region no cell can fall inside.
+    expect(refusalOf([{ type: 'upsertRegion', region: { id: 'r', range: 'A0:B0' } }])).toContain(
+      'starts before the first cell'
+    );
+    expect(plan([{ type: 'upsertRegion', region: { id: 'r', range: 'A1:B9' } }]).regions).toHaveLength(1);
   });
 
   it('refuses a colour on a data-bar anchor, which takes its colour from the rule', () => {

--- a/packages/lib/src/__tests__/sheet-format-request.test.ts
+++ b/packages/lib/src/__tests__/sheet-format-request.test.ts
@@ -1062,4 +1062,65 @@ describe('planFormatOps — everything accepted survives the parsers (#7)', () =
     expect(accepted).toBeGreaterThanOrEqual(5);
     expect(refused).toBeGreaterThanOrEqual(regionCandidates.length / 2);
   });
+
+  // The other direction, and the one the read half of this epic depends on:
+  // #2560 hands an agent a tab's regions through `parseRegions` so it can
+  // change one field and write the list straight back. That loop only works if
+  // a value which has ALREADY been through the parser is accepted here — a
+  // parser fixed point must never trip the readback comparator, or reading a
+  // sheet and saving it unchanged becomes an error.
+  //
+  // A fixed point may still be REFUSED, and enumerating the reasons turned out
+  // to be the wrong way to say what matters — the list kept growing, because
+  // the parsers store several things they never validate:
+  //
+  //   - `readRanges` keeps `"A1:"`, a truncated range `addressesOfRange` then
+  //     formats nothing for, so `validateRanges` refuses it here (as it does in
+  //     the panel);
+  //   - `parseRegion` keeps a hue the palette lost, and the rule builders keep
+  //     an anchor `readAnchor` could not read;
+  //   - `parseCellFormat` keeps an unknown format field, which the by-name
+  //     check then refuses, so a rule written by a newer build can be edited
+  //     but not cloned.
+  //
+  // All of those are the module doing its job. The invariant is narrower and
+  // exact: a parser fixed point must never be refused for a FIDELITY reason.
+  // The comparator exists to catch what the parser would rewrite, and it cannot
+  // have anything to say about a value the parser itself produced — if it ever
+  // does, reading a sheet and saving it back unchanged becomes an error.
+  const fidelityRefusal = /would be dropped or changed on the way in/;
+
+  it('accepts anything that has already been through parseConditionalRule', () => {
+    let checked = 0;
+    for (const candidate of ruleCandidates) {
+      const parsed = parseConditionalRule(candidate);
+      if (!parsed) continue;
+
+      checked += 1;
+      try {
+        expect(plan([{ type: 'addConditionalRule', rule: parsed }]).conditionalFormats[0]).toEqual(parsed);
+      } catch (error) {
+        if (!(error instanceof SheetFormatError)) throw error;
+        expect(error.message).not.toMatch(fidelityRefusal);
+      }
+    }
+    expect(checked).toBeGreaterThanOrEqual(5);
+  });
+
+  it('accepts anything that has already been through parseRegion', () => {
+    let checked = 0;
+    for (const candidate of regionCandidates) {
+      const parsed = parseRegion(candidate);
+      if (!parsed) continue;
+
+      checked += 1;
+      try {
+        expect(plan([{ type: 'upsertRegion', region: parsed }]).regions[0]).toEqual(parsed);
+      } catch (error) {
+        if (!(error instanceof SheetFormatError)) throw error;
+        expect(error.message).not.toMatch(fidelityRefusal);
+      }
+    }
+    expect(checked).toBeGreaterThanOrEqual(5);
+  });
 });

--- a/packages/lib/src/__tests__/sheet-format-request.test.ts
+++ b/packages/lib/src/__tests__/sheet-format-request.test.ts
@@ -34,8 +34,12 @@ import { MAX_ADDRESSABLE_ROW, encodeColumnLabel } from '../sheets/address';
 import {
   MAX_CONDITIONAL_RANGES_PER_RULE,
   MAX_CONDITIONAL_RANGE_CELLS,
+  NUMERIC_OPERATORS,
+  SCALE_ANCHOR_TYPES,
+  VALUED_ANCHOR_TYPES,
   VALUELESS_OPERATORS,
   evaluateConditionalFormats,
+  matchesCondition,
 } from '../sheets/conditional';
 
 const tabWith = (overrides: Partial<SheetFormatTarget> = {}): SheetFormatTarget => ({
@@ -1405,6 +1409,59 @@ describe('planFormatOps — nothing the parser would quietly rewrite', () => {
         { type: 'addConditionalRule', rule: cell({ operator: 'between', value: '1', value2: '9' }) },
       ]).conditionalFormats
     ).toHaveLength(1);
+  });
+
+  it('derives the same anchor and operator tables the refusals rely on', () => {
+    // Two more tables that restate behaviour living somewhere else, and so can
+    // silently stop describing it. `VALUED_ANCHOR_TYPES` claims which anchors
+    // read a value; `NUMERIC_OPERATORS` claims which operators are useless
+    // without a numeric one. Both drive refusals in this module, and both are
+    // asked of the code that actually decides rather than trusted.
+    const values: Record<string, number> = { A1: 1, A2: 5, A3: 9 };
+    const context = {
+      valueAt: (address: string) => values[address] ?? '',
+      isError: () => false,
+      evaluateFormula: () => true,
+    };
+    const bar = (min: object) =>
+      ({ id: 'd', kind: 'dataBar', ranges: ['A1:A3'], color: '#3b82f6', min }) as unknown as ConditionalRule;
+    const render = (rule: ConditionalRule) =>
+      JSON.stringify(evaluateConditionalFormats([rule], context as never));
+
+    // An anchor type reads its value if changing the value changes the bars.
+    const readsValue = [...SCALE_ANCHOR_TYPES].filter(
+      (type) => render(bar({ type, value: 2 })) !== render(bar({ type, value: 8 }))
+    );
+    expect(readsValue.sort()).toEqual([...VALUED_ANCHOR_TYPES].sort());
+
+    // An operator needs a number if a non-numeric operand can never match while
+    // a numeric one sometimes does. The second half matters: without it, an
+    // operator that matches nothing either way would qualify.
+    const samples: Array<string | number> = [0, 1, 5, 9, -3, 'text', ''];
+    const operators = [
+      'greaterThan',
+      'greaterThanOrEqual',
+      'lessThan',
+      'lessThanOrEqual',
+      'equal',
+      'notEqual',
+      'between',
+      'notBetween',
+      'contains',
+      'notContains',
+      'startsWith',
+      'endsWith',
+    ] as const;
+
+    const needsNumber = operators.filter((operator) => {
+      const condition = { operator, value: 'abc', value2: 'xyz' } as never;
+      const numeric = { operator, value: '4', value2: '7' } as never;
+      return (
+        samples.every((value) => !matchesCondition(value as never, false, condition)) &&
+        samples.some((value) => matchesCondition(value as never, false, numeric))
+      );
+    });
+    expect([...needsNumber].sort()).toEqual([...NUMERIC_OPERATORS].sort());
   });
 
   it('derives the same read-what table the module encodes', () => {

--- a/packages/lib/src/__tests__/sheet-format-request.test.ts
+++ b/packages/lib/src/__tests__/sheet-format-request.test.ts
@@ -949,9 +949,11 @@ describe('planFormatOps — everything accepted survives the parsers (#7)', () =
     }
 
     // A property test over a generator that accepts everything, or nothing,
-    // proves nothing — so pin that both outcomes actually occur.
-    expect(accepted).toBeGreaterThan(0);
-    expect(refused).toBeGreaterThan(0);
+    // proves nothing — so pin that both outcomes occur in bulk. `> 0` would be
+    // satisfied by a single acceptance, which is four hand-picked examples
+    // wearing a generator's clothes.
+    expect(accepted).toBeGreaterThanOrEqual(5);
+    expect(refused).toBeGreaterThanOrEqual(ruleCandidates.length / 2);
   });
 
   const regionCandidates: unknown[] = [];
@@ -987,7 +989,7 @@ describe('planFormatOps — everything accepted survives the parsers (#7)', () =
       expect(parseRegion(stored)).toEqual(stored);
     }
 
-    expect(accepted).toBeGreaterThan(0);
-    expect(refused).toBeGreaterThan(0);
+    expect(accepted).toBeGreaterThanOrEqual(5);
+    expect(refused).toBeGreaterThanOrEqual(regionCandidates.length / 2);
   });
 });

--- a/packages/lib/src/__tests__/sheet-format-request.test.ts
+++ b/packages/lib/src/__tests__/sheet-format-request.test.ts
@@ -2008,6 +2008,80 @@ describe('planFormatOps — regions', () => {
   });
 });
 
+describe('planFormatOps — what happens on a retry', () => {
+  it('says which ops are safe to replay and which are not', () => {
+    // A caller replaying a request after an I/O failure needs to know this, and
+    // it falls straight out of "never a silent no-op": an op asking for
+    // something already true of the sheet is refused. Pinned as one table
+    // because the answer is a contract, and because discovering it from a retry
+    // storm in production is the expensive way to learn it.
+    const cell = (id: string) =>
+      ({
+        id,
+        kind: 'cell',
+        ranges: ['A1:A9'],
+        condition: { operator: 'greaterThan', value: '1' },
+        format: { bold: true },
+      }) as unknown as ConditionalRule;
+
+    // Each op paired with the tab as it looks AFTER that op already landed.
+    const replays: Array<[string, SheetFormatOp, Partial<SheetFormatTarget>]> = [
+      ['setCellFormat', { type: 'setCellFormat', range: 'A1', patch: { bold: true } }, {}],
+      ['setFrozen', { type: 'setFrozen', rows: 1, columns: null }, {}],
+      [
+        'addConditionalRule',
+        { type: 'addConditionalRule', rule: cell('a') },
+        { conditionalFormats: [cell('a')] },
+      ],
+      [
+        'updateConditionalRule',
+        { type: 'updateConditionalRule', id: 'a', patch: { format: { bold: true } } },
+        { conditionalFormats: [cell('a')] },
+      ],
+      [
+        'removeConditionalRule',
+        { type: 'removeConditionalRule', id: 'a' },
+        { conditionalFormats: [] },
+      ],
+      [
+        'moveConditionalRule',
+        { type: 'moveConditionalRule', id: 'a', direction: 1 },
+        { conditionalFormats: [cell('b'), cell('a')] },
+      ],
+      ['clearConditionalRules', { type: 'clearConditionalRules' }, { conditionalFormats: [] }],
+      ['upsertRegion', { type: 'upsertRegion', region: region('r') }, { regions: [region('r')] }],
+      ['setRegions', { type: 'setRegions', regions: [region('r')] }, { regions: [region('r')] }],
+      ['removeRegion', { type: 'removeRegion', id: 'r' }, { regions: [] }],
+    ];
+
+    const replayable = replays
+      .filter(([, op, after]) => {
+        try {
+          planFormatOps([op], tabWith(after));
+          return true;
+        } catch {
+          return false;
+        }
+      })
+      .map(([label]) => label);
+
+    expect(replayable).toEqual([
+      'setCellFormat',
+      'setFrozen',
+      'updateConditionalRule',
+      'clearConditionalRules',
+      'upsertRegion',
+      'setRegions',
+    ]);
+
+    // And the four that refuse say so in a way a retry can read as "it landed",
+    // rather than as a fault to escalate.
+    expect(
+      refusalOf([{ type: 'addConditionalRule', rule: cell('a') }], tabWith({ conditionalFormats: [cell('a')] }))
+    ).toContain('is already on this sheet');
+  });
+});
+
 describe('planFormatOps — the boundaries themselves', () => {
   // Every other test in this file establishes that a limit exists. None of them
   // establishes that it is in the right PLACE, and a limit off by one is a

--- a/packages/lib/src/__tests__/sheet-format-request.test.ts
+++ b/packages/lib/src/__tests__/sheet-format-request.test.ts
@@ -1138,6 +1138,25 @@ describe('planFormatOps — nothing the parser would quietly rewrite', () => {
       plan([{ type: 'addConditionalRule', rule: formula(['A1:A100'], '=SUM(B1:B1000)>0') }])
         .conditionalFormats
     ).toHaveLength(1);
+
+    // And the case that decided the constant: "highlight each row above the
+    // column average" is square in the row count by construction, so a bound
+    // set at the sheet-wide CELL ceiling refused it on any sheet past ~1,400
+    // rows. It is the commonest formula rule there is, and refusing it would
+    // have been a worse defect than the one being fixed.
+    for (const rows of [2000, 4000]) {
+      expect(
+        plan(
+          [
+            {
+              type: 'addConditionalRule',
+              rule: formula([`A2:A${rows}`], `=A2 > AVERAGE($B$2:$B$${rows})`),
+            },
+          ],
+          tabWith({ rowCount: 5000 })
+        ).conditionalFormats
+      ).toHaveLength(1);
+    }
   });
 
   it('refuses a range passed to a function that counts flattened values', () => {

--- a/packages/lib/src/__tests__/sheet-format-request.test.ts
+++ b/packages/lib/src/__tests__/sheet-format-request.test.ts
@@ -5,6 +5,7 @@ import {
   MAX_FORMAT_CELLS,
   MAX_FORMAT_CELLS_PER_REQUEST,
   MAX_FORMAT_OPS,
+  FIELDS_BY_KIND,
   SheetFormatError,
   planFormatOps,
   type SheetFormatOp,
@@ -34,6 +35,7 @@ import {
   MAX_CONDITIONAL_RANGES_PER_RULE,
   MAX_CONDITIONAL_RANGE_CELLS,
   VALUELESS_OPERATORS,
+  evaluateConditionalFormats,
 } from '../sheets/conditional';
 
 const tabWith = (overrides: Partial<SheetFormatTarget> = {}): SheetFormatTarget => ({
@@ -1405,7 +1407,59 @@ describe('planFormatOps — nothing the parser would quietly rewrite', () => {
     ).toHaveLength(1);
   });
 
-  it('refuses a format on a rule kind that draws from anchors', () => {
+  it('derives the same read-what table the module encodes', () => {
+    // `FIELDS_BY_KIND` is the one place this module restates something the
+    // `ConditionalRule` types already say, so it is the one place that can
+    // silently lie. This asks the evaluator instead: run each kind with each
+    // foreign field set, and see whether the output moves. A field the output
+    // ignores is one that kind does not read.
+    const values: Record<string, number> = { A1: 1, A2: 2, A3: 3 };
+    const context = {
+      valueAt: (address: string) => values[address] ?? '',
+      isError: () => false,
+      evaluateFormula: () => true,
+    };
+    const render = (rule: object) =>
+      JSON.stringify(evaluateConditionalFormats([rule as ConditionalRule], context as never));
+
+    const base: Record<string, object> = {
+      cell: {
+        id: 'c',
+        kind: 'cell',
+        ranges: ['A1:A3'],
+        condition: { operator: 'greaterThan', value: '1' },
+        format: { bold: true },
+      },
+      formula: { id: 'f', kind: 'formula', ranges: ['A1:A3'], formula: '=TRUE', format: { bold: true } },
+      colorScale: {
+        id: 's',
+        kind: 'colorScale',
+        ranges: ['A1:A3'],
+        min: { type: 'min', color: '#ffffff' },
+        max: { type: 'max', color: '#000000' },
+      },
+      dataBar: { id: 'd', kind: 'dataBar', ranges: ['A1:A3'], color: '#3b82f6' },
+    };
+    const probes: Record<string, unknown> = {
+      condition: { operator: 'lessThan', value: '0' },
+      format: { italic: true },
+      formula: '=FALSE',
+      color: '#ff0000',
+      min: { type: 'number', value: 99, color: '#ff0000' },
+      mid: { type: 'percentile', value: 50, color: '#00ff00' },
+      max: { type: 'number', value: 1, color: '#0000ff' },
+    };
+
+    for (const [kind, rule] of Object.entries(base)) {
+      const read = Object.keys(probes).filter((field) => {
+        if (field in rule) return true;
+        return render(rule) !== render({ ...rule, [field]: probes[field] });
+      });
+      expect([...read].sort()).toEqual([...FIELDS_BY_KIND[kind as ConditionalRule['kind']]].sort());
+    }
+  });
+
+  it('refuses a field belonging to a different kind of rule', () => {
     // `ConditionalColorScaleRule` and `ConditionalDataBarRule` declare no
     // format, and the evaluator agrees — evaluating either kind with and
     // without one produces byte-identical output. So a whole format is
@@ -1421,7 +1475,7 @@ describe('planFormatOps — nothing the parser would quietly rewrite', () => {
 
     expect(
       refusalOf([{ type: 'addConditionalRule', rule: scale({ format: { bold: true } }) }])
-    ).toContain('draws from its anchors, not a format');
+    ).toContain('A colorScale rule does not read format');
     expect(
       refusalOf([
         {
@@ -1429,7 +1483,7 @@ describe('planFormatOps — nothing the parser would quietly rewrite', () => {
           rule: { id: 'db', kind: 'dataBar', ranges: ['A1:A9'], color: '#3b82f6', format: { bold: true } },
         },
       ])
-    ).toContain('draws from its anchors, not a format');
+    ).toContain('A dataBar rule does not read format');
 
     // Without one it is a perfectly good rule, and the kinds that DO draw a
     // format still require it.
@@ -2194,22 +2248,41 @@ describe('planFormatOps — everything accepted survives the parsers (#7)', () =
   const formulas: unknown[] = ['=A1>1', '', '   ', 42];
   const colors: unknown[] = ['#ff0000', 'red', undefined];
 
+  // Built per kind, with only the fields that kind reads. The first version put
+  // every field on every candidate, which no caller would send and which the
+  // foreign-field refusal now rejects outright — a generator that produces
+  // nothing valid tests nothing.
   const ruleCandidates: unknown[] = [];
-  for (const kind of kinds) {
-    for (const rangeValue of ranges) {
-      for (const format of formats) {
-        ruleCandidates.push({
-          id: 'cf_x',
-          kind,
-          ranges: rangeValue,
-          format,
-          condition: { operator: 'greaterThan', value: '10' },
-          formula: formulas[ruleCandidates.length % formulas.length],
-          color: colors[ruleCandidates.length % colors.length],
-          min: { type: 'min', color: colors[ruleCandidates.length % colors.length] },
-          max: { type: 'max', color: '#00ff00' },
-        });
+  for (const rangeValue of ranges) {
+    for (const format of formats) {
+      ruleCandidates.push({
+        id: 'cf_x',
+        kind: 'cell',
+        ranges: rangeValue,
+        format,
+        condition: { operator: 'greaterThan', value: '10' },
+      });
+      for (const body of formulas) {
+        ruleCandidates.push({ id: 'cf_x', kind: 'formula', ranges: rangeValue, format, formula: body });
       }
+    }
+
+    for (const color of colors) {
+      ruleCandidates.push({
+        id: 'cf_x',
+        kind: 'colorScale',
+        ranges: rangeValue,
+        min: { type: 'min', color },
+        max: { type: 'max', color: '#00ff00' },
+      });
+      ruleCandidates.push({
+        id: 'cf_x',
+        kind: 'dataBar',
+        ranges: rangeValue,
+        color,
+        min: { type: 'min' },
+        max: { type: 'max' },
+      });
     }
   }
 

--- a/packages/lib/src/__tests__/sheet-format-request.test.ts
+++ b/packages/lib/src/__tests__/sheet-format-request.test.ts
@@ -2394,21 +2394,21 @@ describe('planFormatOps — what each op produces', () => {
 });
 
 describe('planFormatOps — what happens on a retry', () => {
+  const cell = (id: string) =>
+    ({
+      id,
+      kind: 'cell',
+      ranges: ['A1:A9'],
+      condition: { operator: 'greaterThan', value: '1' },
+      format: { bold: true },
+    }) as unknown as ConditionalRule;
+
   it('says which ops are safe to replay and which are not', () => {
     // A caller replaying a request after an I/O failure needs to know this, and
     // it falls straight out of "never a silent no-op": an op asking for
     // something already true of the sheet is refused. Pinned as one table
     // because the answer is a contract, and because discovering it from a retry
     // storm in production is the expensive way to learn it.
-    const cell = (id: string) =>
-      ({
-        id,
-        kind: 'cell',
-        ranges: ['A1:A9'],
-        condition: { operator: 'greaterThan', value: '1' },
-        format: { bold: true },
-      }) as unknown as ConditionalRule;
-
     // Each op paired with the tab as it looks AFTER that op already landed.
     const replays: Array<[string, SheetFormatOp, Partial<SheetFormatTarget>]> = [
       ['setCellFormat', { type: 'setCellFormat', range: 'A1', patch: { bold: true } }, {}],
@@ -2459,11 +2459,42 @@ describe('planFormatOps — what happens on a retry', () => {
       'setRegions',
     ]);
 
-    // And the four that refuse say so in a way a retry can read as "it landed",
+    // And the three that refuse say so in a way a retry can read as "it landed",
     // rather than as a fault to escalate.
     expect(
       refusalOf([{ type: 'addConditionalRule', rule: cell('a') }], tabWith({ conditionalFormats: [cell('a')] }))
     ).toContain('is already on this sheet');
+  });
+
+  it('moves a rule AGAIN when a landed move is replayed', () => {
+    // Kills: restoring "four ops refuse the second time" to the header, which
+    // is what the table above looks like it says and does not.
+    //
+    // That table's move case puts the rule LAST and moves it later, so it
+    // refuses — but that is the boundary refusing, not the replay being caught.
+    // A move that landed in the middle leaves nothing behind to say so, and
+    // replaying it is not refused: the rule travels one more place and the
+    // caller is told it worked. This is the one op where a blind retry after an
+    // I/O failure silently changes the sheet, so it is pinned rather than
+    // described.
+    const order = (ids: string[]) =>
+      planFormatOps(
+        [{ type: 'moveConditionalRule', id: 'd', direction: -1 }],
+        tabWith({ conditionalFormats: ids.map(cell) })
+      ).conditionalFormats.map((r) => r.id);
+
+    const landed = order(['a', 'b', 'c', 'd']);
+    expect(landed).toEqual(['a', 'b', 'd', 'c']);
+    expect(order(landed)).toEqual(['a', 'd', 'b', 'c']);
+
+    // The boundary is the only place a replay is caught, and only by accident
+    // of where the rule happened to end up.
+    expect(
+      refusalOf(
+        [{ type: 'moveConditionalRule', id: 'd', direction: -1 }],
+        tabWith({ conditionalFormats: ['d', 'a', 'b', 'c'].map(cell) })
+      )
+    ).toContain('already first');
   });
 });
 

--- a/packages/lib/src/__tests__/sheet-format-request.test.ts
+++ b/packages/lib/src/__tests__/sheet-format-request.test.ts
@@ -1897,6 +1897,44 @@ describe('planFormatOps — never something other than what was asked for', () =
     ).toContain('is not a range this sheet can address');
   });
 
+  it('tells a caller writing spreadsheet notation what to change, not just that it failed', () => {
+    // Kills: deleting any arm of `rangeHint`, or making it return a constant.
+    //
+    // These three are what a model writing A1 notation actually produces —
+    // absolute refs copied from a formula bar, a sheet qualifier copied from
+    // another tool, spaces around the colon. Every one is a single-token
+    // repair, and without the hint they all read as the same dead end, so the
+    // caller's next attempt is a guess. The refusal message IS the feedback
+    // loop; that is the whole reason this is worth a test.
+    expect(refusalOf([{ type: 'clearCellFormat', range: '$A$1:$F$1' }])).toContain(
+      'drop the $'
+    );
+    expect(refusalOf([{ type: 'clearCellFormat', range: 'Sheet1!A1:F1' }])).toContain(
+      'drop the SheetName! prefix'
+    );
+    expect(refusalOf([{ type: 'clearCellFormat', range: 'A1 : F1' }])).toContain(
+      'Ranges carry no spaces'
+    );
+
+    // The rule path is a separate call site; a hint added to only one of them
+    // is the likelier mistake than a broken hint.
+    expect(
+      refusalOf([{ type: 'addConditionalRule', rule: { ...rule('cf_1'), ranges: ['$A$1:$A$9'] } }])
+    ).toContain('drop the $');
+
+    // And a shape none of them explain gets the plain refusal rather than a
+    // wrong guess — a hint that misdiagnoses costs more than no hint.
+    const other = refusalOf([{ type: 'clearCellFormat', range: 'A1:F1:G9' }]);
+    expect(other).toContain('is not a range this sheet can address');
+    expect(other).not.toContain('drop the');
+    expect(other).not.toContain('no spaces');
+
+    // Surrounding whitespace alone is NOT a failure — `parseRangeSpan` trims,
+    // so it parses. Pinned because the hint's `.trim()` exists precisely so it
+    // does not claim credit for a case that never reaches it.
+    expect([...plan([{ type: 'clearCellFormat', range: '  A1:F1  ' }]).rows]).toEqual([0]);
+  });
+
   it('still lets a rule written by a NEWER build be updated', () => {
     // The pre-parse checks are stricter than the parser, so applying them to a
     // whole merged rule — mostly the STORED one — would refuse any update to a

--- a/packages/lib/src/__tests__/sheet-format-request.test.ts
+++ b/packages/lib/src/__tests__/sheet-format-request.test.ts
@@ -581,7 +581,20 @@ describe('planFormatOps — conditional rules', () => {
   });
 });
 
-describe('planFormatOps — nothing the parser would quietly rewrite', () => {
+// The largest group in this file, and named for the principle rather than one
+// of its halves — it began as "nothing the parser would quietly rewrite" and
+// grew past that. It covers the module's two questions, the same two its header
+// names:
+//
+//   1. Would what we store differ from what was sent? The comparator, the caps
+//      the parsers apply silently, nulls, shapes, forward compatibility.
+//   2. Would the thing we store DO what was asked? Formulas, arity, anchors,
+//      hues, column roles, number formats — all stored byte for byte and inert.
+//
+// They are interleaved rather than grouped, because each arrived with the
+// review round that found it and reordering them would cost the one thing the
+// order still records: which of these a careful reader spots, and in what order.
+describe('planFormatOps — never something other than what was asked for', () => {
   // `parseConditionalRule` and `parseRegion` are LOAD-path parsers: they
   // sanitize field by field so one bad setting cannot cost a user the rest of a
   // stored document. Reused as-is on a WRITE path that generosity is a lie —

--- a/packages/lib/src/__tests__/sheet-format-request.test.ts
+++ b/packages/lib/src/__tests__/sheet-format-request.test.ts
@@ -2031,6 +2031,17 @@ describe('planFormatOps — never something other than what was asked for', () =
     ]);
     expect(result.conditionalFormats[0]).toMatchObject({ stripes: { every: 2 } });
     expect(result.regions[0].columns).toEqual([{ column: 'C', role: 'text', tags: ['wide', 'sticky'] }]);
+
+    // The TOP-level field is the one at risk, and only this pins it. An
+    // unknown field on the OP is refused by name, and the obvious tidy-up is
+    // to make the two consistent — which would refuse this. It must not:
+    // `io.ts` reads regions off `ranges.__regions` and writes them back, so a
+    // read-modify-write of a region a newer build wrote is a path that exists
+    // today, and refusing it turns forward compatibility into a hard failure.
+    // The op envelope has no such path: it is never stored.
+    expect(
+      plan([{ type: 'setRegions', regions: [{ ...region('r1'), rowStripes: 'zebra' }] }]).regions[0]
+    ).toMatchObject({ rowStripes: 'zebra' });
   });
 });
 

--- a/packages/lib/src/__tests__/sheet-format-request.test.ts
+++ b/packages/lib/src/__tests__/sheet-format-request.test.ts
@@ -1744,6 +1744,21 @@ describe('planFormatOps — never something other than what was asked for', () =
       ])
     ).toContain('is 1 row tall and that row is a header');
 
+    // And a taller all-header region, which is the other half of that sentence.
+    expect(
+      refusalOf([
+        {
+          type: 'upsertRegion',
+          region: {
+            id: 'r1',
+            range: 'A1:B3',
+            headerRows: 3,
+            columns: [{ column: 'A', role: 'currency' }],
+          },
+        },
+      ])
+    ).toContain('is 3 rows tall and every one of them is a header');
+
     // A bodyless region that declares no columns is only a header strip, which
     // is a legitimate thing to want.
     expect(

--- a/packages/lib/src/__tests__/sheet-format-request.test.ts
+++ b/packages/lib/src/__tests__/sheet-format-request.test.ts
@@ -1154,6 +1154,47 @@ describe('planFormatOps — nothing the parser would quietly rewrite', () => {
     ).toHaveLength(1);
   });
 
+  it('refuses a format on a rule kind that draws from anchors', () => {
+    // `ConditionalColorScaleRule` and `ConditionalDataBarRule` declare no
+    // format, and the evaluator agrees — evaluating either kind with and
+    // without one produces byte-identical output. So a whole format is
+    // validated here, stored, and never drawn.
+    const scale = (extra: object) => ({
+      id: 'cs',
+      kind: 'colorScale',
+      ranges: ['A1:A9'],
+      min: { type: 'min', color: '#ffffff' },
+      max: { type: 'max', color: '#000000' },
+      ...extra,
+    });
+
+    expect(
+      refusalOf([{ type: 'addConditionalRule', rule: scale({ format: { bold: true } }) }])
+    ).toContain('draws from its anchors, not a format');
+    expect(
+      refusalOf([
+        {
+          type: 'addConditionalRule',
+          rule: { id: 'db', kind: 'dataBar', ranges: ['A1:A9'], color: '#3b82f6', format: { bold: true } },
+        },
+      ])
+    ).toContain('draws from its anchors, not a format');
+
+    // Without one it is a perfectly good rule, and the kinds that DO draw a
+    // format still require it.
+    expect(plan([{ type: 'addConditionalRule', rule: scale({}) }]).conditionalFormats).toHaveLength(1);
+
+    // And a stored stray does not make the rule uneditable: only what the
+    // caller sends is held to this.
+    const stored = { ...scale({}), format: { bold: true } } as unknown as ConditionalRule;
+    expect(
+      plan(
+        [{ type: 'updateConditionalRule', id: 'cs', patch: { ranges: ['B1:B9'] } }],
+        tabWith({ conditionalFormats: [stored] })
+      ).conditionalFormats[0].ranges
+    ).toEqual(['B1:B9']);
+  });
+
   it('refuses a value on an anchor that reads the data instead', () => {
     // The mirror of the missing-value case: `anchorValue` never looks at a
     // value for `min`/`max`, so one supplied here is stored and silently

--- a/packages/lib/src/__tests__/sheet-format-request.test.ts
+++ b/packages/lib/src/__tests__/sheet-format-request.test.ts
@@ -602,6 +602,58 @@ describe('planFormatOps — nothing the parser would quietly rewrite', () => {
     ).toContain('regions[1]: "theme"');
   });
 
+  it('refuses a scale anchor that would be stored verbatim and mean something else', () => {
+    // The comparator is blind here on purpose: `readAnchor` returns null for an
+    // anchor it cannot read, and the rule builder then keeps the caller's
+    // original through its `...value` spread. Nothing is dropped — the anchor
+    // is stored EXACTLY as written and quietly means something different.
+    //
+    // Measured against the evaluator, a colorScale whose `mid` colour is
+    // unusable produces `{}` — not a two-stop gradient, no formatting at all —
+    // while the identical rule with `#ff0000` paints every cell in range.
+    const scale = (mid: unknown) => ({
+      id: 'cs',
+      kind: 'colorScale',
+      ranges: ['A1:A9'],
+      min: { type: 'min', color: '#ffffff' },
+      mid,
+      max: { type: 'max', color: '#000000' },
+    });
+
+    expect(
+      refusalOf([{ type: 'addConditionalRule', rule: scale({ type: 'percentile', value: 50, color: 'redd' }) }])
+    ).toContain("colorScale's mid anchor needs a #rrggbb colour");
+    expect(
+      refusalOf([{ type: 'addConditionalRule', rule: scale({ type: 'midpoint', color: '#ff0000' }) }])
+    ).toContain("colorScale's mid anchor needs a type of");
+    // A valid mid still goes through, and an omitted one is a two-stop scale.
+    expect(
+      plan([{ type: 'addConditionalRule', rule: scale({ type: 'percentile', value: 50, color: '#ff0000' }) }])
+        .conditionalFormats
+    ).toHaveLength(1);
+    expect(
+      plan([{ type: 'addConditionalRule', rule: scale(undefined) }]).conditionalFormats
+    ).toHaveLength(1);
+
+    // A dataBar anchor the parser cannot read is not blank, but it is not what
+    // was asked for either: `anchorValue` falls back to the data's own extreme,
+    // so `{type: 'nubmer', value: 50}` silently becomes "the smallest value".
+    expect(
+      refusalOf([
+        {
+          type: 'addConditionalRule',
+          rule: {
+            id: 'db',
+            kind: 'dataBar',
+            ranges: ['A1:A9'],
+            color: '#3b82f6',
+            min: { type: 'nubmer', value: 50 },
+          },
+        },
+      ])
+    ).toContain("dataBar's min anchor needs a type of");
+  });
+
   it('refuses a theme the palette does not have, which would render as another colour', () => {
     // `parseRegion` accepts any lowercase word and `hueByName` then falls back
     // to the default at RENDER time — so this is a sanitization the comparator

--- a/packages/lib/src/__tests__/sheet-format-request.test.ts
+++ b/packages/lib/src/__tests__/sheet-format-request.test.ts
@@ -18,6 +18,8 @@ import {
   type ConditionalRule,
 } from '../sheets/conditional';
 import { MAX_REGIONS, parseRegion, type SheetRegion } from '../sheets/regions';
+import { MAX_ADDRESSABLE_ROW } from '../sheets/address';
+import { MAX_CONDITIONAL_RANGES_PER_RULE } from '../sheets/conditional';
 
 const tabWith = (overrides: Partial<SheetFormatTarget> = {}): SheetFormatTarget => ({
   rowCount: 100,
@@ -277,9 +279,27 @@ describe('planFormatOps — columns, rows and freezes', () => {
     ['zero', 0],
     ['fractional', 2.5],
     ['not a number', 'first' as unknown as number],
-    ['past the last row', 5_000_001],
+    ['past the last row', MAX_ADDRESSABLE_ROW + 2],
   ])('refuses a row height addressed at %s', (_label, row) => {
     expect(refusalOf([{ type: 'setRowHeight', row, height: 40 }])).toContain('1-based row number');
+  });
+
+  it('accepts a row height on the last addressable row, as the range path does', () => {
+    // `MAX_ADDRESSABLE_ROW` is a 0-based index everywhere it is compared, so a
+    // 1-based API row must be bounded by `row - 1`. Comparing `row` to it
+    // directly left the last row able to take a cell format but not a row
+    // height — a disagreement between two ops of the same request that no
+    // caller could see coming. Kills: restoring the `row > MAX_ADDRESSABLE_ROW`
+    // comparison.
+    const last = MAX_ADDRESSABLE_ROW + 1;
+    expect(plan([{ type: 'setRowHeight', row: last, height: 40 }]).steps).toEqual([
+      { type: 'setRowHeight', rowIndex: MAX_ADDRESSABLE_ROW, height: 40 },
+    ]);
+    // The range path already accepted this cell, which is what made the
+    // inconsistency observable.
+    expect(plan([{ type: 'clearCellFormat', range: `A${last}` }]).steps).toEqual([
+      { type: 'clearCellFormat', addresses: [`A${last}`] },
+    ]);
   });
 
   it('plans a freeze inside the sheet extent', () => {
@@ -324,7 +344,7 @@ describe('planFormatOps — conditional rules', () => {
       refusalOf([{ type: 'addConditionalRule', rule: { ...rule('cf_1'), ranges: ['A1:A600000'] } }])
     ).toContain('is not a range this sheet can format');
     expect(refusalOf([{ type: 'addConditionalRule', rule: { ...rule('cf_1'), ranges: [] } }])).toContain(
-      'not a rule this sheet can store'
+      'Enter at least one range'
     );
   });
 
@@ -394,7 +414,11 @@ describe('planFormatOps — conditional rules', () => {
     // A patch that empties the format leaves a rule the parser drops on load.
     expect(
       refusalOf([{ type: 'updateConditionalRule', id: 'a', patch: { format: {} } }], tab)
-    ).toContain('cannot store');
+    ).toContain('rule format has no fields');
+    // A patch is validated as a whole rule, so the kind's own requirements hold.
+    expect(
+      refusalOf([{ type: 'updateConditionalRule', id: 'a', patch: { condition: 'big' } }], tab)
+    ).toContain('not a rule this sheet can store');
   });
 
   it('refuses an id that is not a non-empty string', () => {
@@ -448,6 +472,212 @@ describe('planFormatOps — conditional rules', () => {
     );
     expect(message).toContain('would be dropped when the sheet is read back');
     expect(message).toContain('Nothing was applied');
+  });
+});
+
+describe('planFormatOps — nothing the parser would quietly rewrite', () => {
+  // `parseConditionalRule` and `parseRegion` are LOAD-path parsers: they
+  // sanitize field by field so one bad setting cannot cost a user the rest of a
+  // stored document. Reused as-is on a WRITE path that generosity is a lie —
+  // the sheet stores something other than what was asked for and reports
+  // success. Every case below was accepted before the readback comparator.
+
+  it('refuses a rule format that would lose one of its fields', () => {
+    // `parseCellFormat` keeps the bold and drops the too-small size, so the
+    // rule was stored, reported as added, and rendered without the size.
+    const message = refusalOf([
+      { type: 'addConditionalRule', rule: { ...rule('cf_1'), format: { bold: true, fontSize: 5 } } },
+    ]);
+    expect(message).toContain('rule format.fontSize');
+  });
+
+  it('refuses an unknown field inside a rule format', () => {
+    // Carried THROUGH by `parseCellFormat` rather than dropped, so nothing is
+    // lost and the comparator sees nothing wrong — it has to be named here.
+    expect(
+      refusalOf([{ type: 'addConditionalRule', rule: { ...rule('cf_1'), format: { bolt: true } } }])
+    ).toContain('"bolt" is not a format field');
+  });
+
+  it('refuses a ranges array past the per-rule cap instead of truncating it', () => {
+    // The ordering bug this exists to prevent: `parseConditionalRule` slices
+    // `ranges` to the cap FIRST, so a `validateRanges` call afterwards is handed
+    // a list that fits, pronounces it fine, and every range past the cap is gone
+    // with no refusal anywhere. Kills: moving the check after the parse.
+    const ranges = Array.from({ length: MAX_CONDITIONAL_RANGES_PER_RULE + 1 }, () => 'A1:A2');
+    expect(refusalOf([{ type: 'addConditionalRule', rule: { ...rule('cf_1'), ranges } }])).toContain(
+      `at most ${MAX_CONDITIONAL_RANGES_PER_RULE} ranges`
+    );
+  });
+
+  it('refuses a ranges array holding anything but strings', () => {
+    // `readRanges` filters non-strings and blanks out silently.
+    expect(
+      refusalOf([{ type: 'addConditionalRule', rule: { ...rule('cf_1'), ranges: ['A1:A9', 42] } }])
+    ).toContain('array of A1 ranges');
+    expect(refusalOf([{ type: 'addConditionalRule', rule: { ...rule('cf_1'), ranges: 'A1:A9' } }])).toContain(
+      'array of A1 ranges'
+    );
+    expect(refusalOf([{ type: 'addConditionalRule', rule: 'a rule' }])).toContain('rule must be an object');
+  });
+
+  it('refuses a condition value the parser would drop', () => {
+    // A numeric threshold is dropped by the parser's `typeof === "string"`
+    // check, leaving an operator with nothing to compare against.
+    expect(
+      refusalOf([
+        {
+          type: 'addConditionalRule',
+          rule: { ...rule('cf_1'), condition: { operator: 'greaterThan', value: 10 } },
+        },
+      ])
+    ).toContain('"condition.value"');
+  });
+
+  it('refuses a scale anchor whose colour the parser would drop', () => {
+    expect(
+      refusalOf([
+        {
+          type: 'addConditionalRule',
+          rule: {
+            id: 'cf_1',
+            kind: 'dataBar',
+            ranges: ['A1:A9'],
+            color: '#3b82f6',
+            min: { type: 'number', value: 0, color: 'blue' },
+          },
+        },
+      ])
+    ).toContain('"min.color"');
+  });
+
+  it('refuses a region option the parser would sanitize away', () => {
+    // `headerRows: 999` is dropped and silently becomes the default of one.
+    expect(refusalOf([{ type: 'upsertRegion', region: { ...region('r1'), headerRows: 999 } }])).toContain(
+      'region: "headerRows"'
+    );
+    // An unusable column declaration disappears from the list.
+    expect(
+      refusalOf([
+        { type: 'upsertRegion', region: { ...region('r1'), columns: [{ column: 'C', role: 'money' }] } },
+      ])
+    ).toContain('region: "columns"');
+    expect(
+      refusalOf([
+        {
+          type: 'upsertRegion',
+          region: { ...region('r1'), columns: [{ column: 'C', role: 'number', decimals: 99 }] },
+        },
+      ])
+    ).toContain('region: "columns"');
+    // A shorter list back is always a loss, whatever the surviving entries say.
+    expect(
+      refusalOf([
+        {
+          type: 'upsertRegion',
+          region: {
+            ...region('r1'),
+            columns: [
+              { column: 'C', role: 'currency' },
+              { column: 'D', role: 'money' },
+            ],
+          },
+        },
+      ])
+    ).toContain('region: "columns"');
+    // And the same check runs on every entry of a `setRegions` list.
+    expect(
+      refusalOf([{ type: 'setRegions', regions: [region('r1'), { ...region('r2'), theme: 'BLUE!' }] }])
+    ).toContain('regions[1]: "theme"');
+  });
+
+  it('does not mistake a genuine normalization for a loss', () => {
+    // The comparator has to allow exactly what the parsers are entitled to do,
+    // or every well-formed request starts being refused. Kills: comparing
+    // strings or list order strictly.
+    const result = plan([
+      {
+        type: 'upsertRegion',
+        region: {
+          id: 'r1',
+          range: 'a1:f',
+          name: '  Budget  ',
+          theme: 'Blue',
+          totalRows: [7, 3],
+          columns: [{ column: 'c', role: 'currency', currency: 'usd' }],
+        },
+      },
+    ]);
+
+    expect(result.regions[0]).toEqual({
+      id: 'r1',
+      range: 'A1:F',
+      name: 'Budget',
+      theme: 'blue',
+      totalRows: [3, 7],
+      columns: [{ column: 'C', role: 'currency', currency: 'USD' }],
+    });
+  });
+
+  it('refuses a field whose very SHAPE the parser would replace', () => {
+    // A list where a string belongs, or an object where a number belongs, is
+    // dropped whole — the comparator has to notice a type change, not only a
+    // missing key.
+    expect(refusalOf([{ type: 'upsertRegion', region: { ...region('r1'), name: ['Budget'] } }])).toContain(
+      'region: "name"'
+    );
+    expect(refusalOf([{ type: 'upsertRegion', region: { ...region('r1'), headerRows: {} } }])).toContain(
+      'region: "headerRows"'
+    );
+  });
+
+  it('carries an unknown field from a newer build through untouched', () => {
+    // Forward compatibility is the reason the parsers pass unknown fields
+    // through, and the comparator must not undo it.
+    const result = plan([
+      { type: 'addConditionalRule', rule: { ...rule('cf_1'), stripes: { every: 2 } } },
+      {
+        type: 'upsertRegion',
+        // Nested inside a list entry, which is where a naive comparison of
+        // canonical forms would trip over its own recursion.
+        region: { ...region('r1'), columns: [{ column: 'C', role: 'text', tags: ['wide', 'sticky'] }] },
+      },
+    ]);
+    expect(result.conditionalFormats[0]).toMatchObject({ stripes: { every: 2 } });
+    expect(result.regions[0].columns).toEqual([{ column: 'C', role: 'text', tags: ['wide', 'sticky'] }]);
+  });
+});
+
+describe('planFormatOps — rule identity', () => {
+  it('refuses adding a rule whose id is already on the sheet', () => {
+    // Two rules under one id: `update` and `move` reach the first by index
+    // while `remove` filters out both, so the new rule is not addressable at
+    // all. The region path already refused this.
+    const tab = tabWith({ conditionalFormats: [rule('a')] });
+    const message = refusalOf([{ type: 'addConditionalRule', rule: rule('a') }], tab);
+    expect(message).toContain('A rule "a" is already on this sheet');
+    expect(message).toContain('updateConditionalRule');
+  });
+
+  it('refuses an update that asks for nothing', () => {
+    // `id` and `kind` are pinned to the rule being edited, so a patch naming
+    // only those is applied, reports success and changes not one pixel.
+    const tab = tabWith({ conditionalFormats: [rule('a')] });
+    expect(refusalOf([{ type: 'updateConditionalRule', id: 'a', patch: {} }], tab)).toContain(
+      'patch changes nothing'
+    );
+    expect(
+      refusalOf([{ type: 'updateConditionalRule', id: 'a', patch: { id: 'b', kind: 'formula' } }], tab)
+    ).toContain('patch changes nothing');
+  });
+
+  it('keeps a rule’s identity when a patch tries to change it', () => {
+    const tab = tabWith({ conditionalFormats: [rule('a')] });
+    const result = plan(
+      [{ type: 'updateConditionalRule', id: 'a', patch: { id: 'b', format: { bold: true } } }],
+      tab
+    );
+    expect(result.conditionalFormats[0].id).toBe('a');
   });
 });
 

--- a/packages/lib/src/__tests__/sheet-format-request.test.ts
+++ b/packages/lib/src/__tests__/sheet-format-request.test.ts
@@ -1962,6 +1962,31 @@ describe('planFormatOps — the dashboard this epic exists for', () => {
     expect(
       refusalOf([{ type: 'upsertRegion', region: { ...documented, freezeHeader: true } }])
     ).toContain('freezeHeader is not applied by anything yet');
+
+    // The rest of that same sample, written back as the ops it corresponds to.
+    // The region is the interesting part, but the loop only works if the whole
+    // block round-trips: `layout.frozenRows`, `layout.columnWidths` and the one
+    // genuine `cellFormats` override.
+    expect(
+      plan([
+        { type: 'setFrozen', rows: 1, columns: null },
+        { type: 'setColumnWidth', column: 'A', width: 220 },
+        { type: 'setCellFormat', range: 'C3', patch: { italic: true } },
+      ]).steps.map((step) => step.type)
+    ).toEqual(['setFrozen', 'setColumnWidth', 'setCellFormat']);
+
+    // Rules come back from that read as `{id, kind, ranges, summary}` — a
+    // summary, not a rule — so they are deliberately NOT round-trippable, and
+    // an agent has to build a real rule to write one. Asserted so the asymmetry
+    // is recorded rather than discovered.
+    expect(
+      refusalOf([
+        {
+          type: 'addConditionalRule',
+          rule: { id: 'over', kind: 'cell', ranges: ['C2:C3'], summary: 'Cell is greater than 1000' },
+        },
+      ])
+    ).toContain('not a rule this sheet can store');
   });
 
   it('plans a whole budget dashboard in one request', () => {

--- a/packages/lib/src/__tests__/sheet-format-request.test.ts
+++ b/packages/lib/src/__tests__/sheet-format-request.test.ts
@@ -1348,6 +1348,17 @@ describe('planFormatOps — never something other than what was asked for', () =
     expect(
       plan([{ type: 'addConditionalRule', rule: formula('=LEFT(A1, 2)="x"') }]).conditionalFormats
     ).toHaveLength(1);
+
+    // A range the sheet cannot address is reported as that, not as an arity
+    // problem. It counts as one value so this check steps aside and the range
+    // check below it says what is actually wrong — with a different fallback,
+    // `=ABS(A1:ZZZZ5)` would complain about how many values ABS takes, which is
+    // true of nothing and would send an agent to fix the wrong thing.
+    for (const body of ['=ABS(A1:ZZZZ5)>0', '=SUM(A1:ZZZZ5)>0', '=ABS(A0:A5)>0']) {
+      expect(refusalOf([{ type: 'addConditionalRule', rule: formula(body) }])).toContain(
+        'is not a range this sheet can address'
+      );
+    }
   });
 
   it('refuses a region range that starts before the first cell', () => {

--- a/packages/lib/src/__tests__/sheet-format-request.test.ts
+++ b/packages/lib/src/__tests__/sheet-format-request.test.ts
@@ -1062,6 +1062,14 @@ describe('planFormatOps — nothing the parser would quietly rewrite', () => {
       expect(refusalOf([{ type: 'upsertRegion', region }])).toContain('nested more than');
     }
 
+    // Depth is only half of it: the same field can be shallow and arbitrarily
+    // WIDE, and the comparison builds and sorts a canonical array out of every
+    // list it meets.
+    const wide = Array.from({ length: 20_000 }, (_, i) => i);
+    expect(
+      refusalOf([{ type: 'upsertRegion', region: { id: 'r1', range: 'A1:F', extra: wide } }])
+    ).toContain('made of more than');
+
     // Twelve levels is far past anything these shapes reach on their own — the
     // deepest is `borders.top.color`, at three — so nothing real is caught.
     expect(
@@ -1104,6 +1112,74 @@ describe('planFormatOps — nothing the parser would quietly rewrite', () => {
     expect(
       plan([{ type: 'addConditionalRule', rule: formula('=SUM(A1:A1000)>0') }]).conditionalFormats
     ).toHaveLength(1);
+  });
+
+  it('refuses a formula whose cost is the covered cells TIMES what it references', () => {
+    // Neither per-range cap can see this one: a formula rule is evaluated once
+    // per covered cell and each evaluation expands every range it references,
+    // so 500,000 covered and 500,000 referenced clears both 500,000 checks and
+    // asks for 250 billion expansions to render once.
+    const formula = (ranges: string[], body: string) => ({
+      id: 'cf_1',
+      kind: 'formula',
+      ranges,
+      formula: body,
+      format: { bold: true },
+    });
+
+    const message = refusalOf([
+      { type: 'addConditionalRule', rule: formula(['A1:A500000'], '=SUM(B1:B500000)>0') },
+    ]);
+    expect(message).toContain('250,000,000,000 expansions');
+
+    // A rule whose product is ordinary is untouched — the bound is on the
+    // multiplication, not on either factor.
+    expect(
+      plan([{ type: 'addConditionalRule', rule: formula(['A1:A100'], '=SUM(B1:B1000)>0') }])
+        .conditionalFormats
+    ).toHaveLength(1);
+  });
+
+  it('refuses a range passed to a function that counts flattened values', () => {
+    // `evaluateFunction` flattens arguments before checking arity —
+    // `args.flatMap(flattenValue)` — so `ABS(A1:A2)` arrives as two values and
+    // throws once per covered cell, while an AST-node count sees one argument
+    // and is satisfied. Whether a function survives that is derived, not
+    // listed: if it would reject one more value than the call supplies, its
+    // arity is fixed and a range in any slot breaks it.
+    const formula = (body: string) => ({
+      id: 'cf_1',
+      kind: 'formula',
+      ranges: ['A1:A9'],
+      formula: body,
+      format: { bold: true },
+    });
+
+    expect(refusalOf([{ type: 'addConditionalRule', rule: formula('=ABS(A1:A2)>0') }])).toContain(
+      'passes a range to ABS(), which takes a fixed number of values'
+    );
+    // A variadic function takes a range happily, and a fixed-arity one takes a
+    // single cell.
+    for (const body of ['=SUM(A1:A9)>0', '=ABS(A1)>0']) {
+      expect(plan([{ type: 'addConditionalRule', rule: formula(body) }]).conditionalFormats)
+        .toHaveLength(1);
+    }
+  });
+
+  it('refuses a colour on a data-bar anchor, which takes its colour from the rule', () => {
+    const bar = (min: unknown) => ({
+      id: 'db',
+      kind: 'dataBar',
+      ranges: ['A1:A9'],
+      color: '#3b82f6',
+      min,
+    });
+
+    expect(
+      refusalOf([{ type: 'addConditionalRule', rule: bar({ type: 'min', color: '#ff0000' }) }])
+    ).toContain('takes its colour from the rule, so the anchor cannot carry one');
+    expect(plan([{ type: 'addConditionalRule', rule: bar({ type: 'min' }) }]).conditionalFormats)
+      .toHaveLength(1);
   });
 
   it('refuses a call with a number of arguments the function will not take', () => {
@@ -1582,6 +1658,41 @@ describe('planFormatOps — the dashboard this epic exists for', () => {
   //
   // "A1:F is a table, row 1 is headers, column C is money, row 40 is a total,
   // accent blue", plus the presentation that goes with it.
+  it('accepts the region the read half of this epic documents', () => {
+    // #2560 is the read half, and it publishes this exact region as the shape
+    // an agent gets back — the point being that it can change one field and
+    // write the list straight here. Copied verbatim from that PR so the two
+    // halves cannot drift apart quietly.
+    const documented: Record<string, unknown> = {
+      id: 'budget',
+      name: 'Q3 Budget',
+      range: 'A1:D',
+      headerRows: 1,
+      totalRows: [4],
+      columns: [
+        { column: 'C', role: 'currency', currency: 'USD' },
+        { column: 'D', role: 'percent' },
+      ],
+      theme: 'indigo',
+    };
+
+    expect(plan([{ type: 'upsertRegion', region: documented }]).regions[0]).toMatchObject({
+      id: 'budget',
+      range: 'A1:D',
+      theme: 'indigo',
+      totalRows: [4],
+    });
+
+    // With one exception, and it is deliberate: that sample also carries
+    // `freezeHeader: true`, which nothing reads. Refusing it is the flagged
+    // decision — see the PR discussion — and this assertion is here so that if
+    // someone makes the field work, or decides the loop matters more, the test
+    // that has to change is the one that documents the disagreement.
+    expect(
+      refusalOf([{ type: 'upsertRegion', region: { ...documented, freezeHeader: true } }])
+    ).toContain('freezeHeader is not applied by anything yet');
+  });
+
   it('plans a whole budget dashboard in one request', () => {
     const ops: SheetFormatOp[] = [
       { type: 'setFrozen', rows: 1, columns: null },

--- a/packages/lib/src/__tests__/sheet-format-request.test.ts
+++ b/packages/lib/src/__tests__/sheet-format-request.test.ts
@@ -629,12 +629,61 @@ describe('planFormatOps — nothing the parser would quietly rewrite', () => {
     });
   });
 
-  it('reads a null optional field as "not set", not as a loss', () => {
-    // JSON cannot express undefined, and every optional field the parsers read
-    // treats a null the same way it treats a missing key.
-    expect(plan([{ type: 'upsertRegion', region: { ...region('r1'), theme: null } }]).regions).toEqual([
+  it('treats an explicit null as a value the parser dropped, not as an omission', () => {
+    // A caller who means "not set" omits the key — JSON can say that — so a
+    // null that comes back as nothing is a real sanitization, and often a
+    // damaging one: the parser deletes `condition.value` and leaves a
+    // `greaterThan` rule with no threshold, which matches no cell and reads as
+    // a rule that simply does not work.
+    // Kills: canonicalizing undefined and null to the same string.
+    expect(
+      refusalOf([
+        {
+          type: 'addConditionalRule',
+          rule: { ...rule('cf_1'), condition: { operator: 'greaterThan', value: null } },
+        },
+      ])
+    ).toContain('"condition.value"');
+    expect(refusalOf([{ type: 'upsertRegion', region: { ...region('r1'), headerRows: null } }])).toContain(
+      'region: "headerRows"'
+    );
+    // An OMITTED field is still not a loss, which is the distinction that has
+    // to survive: omitting `theme` is how you say you do not want one.
+    expect(plan([{ type: 'upsertRegion', region: region('r1') }]).regions).toEqual([
       { id: 'r1', range: 'A1:F' },
     ]);
+  });
+
+  it('refuses a rule range outside the addressable sheet, before anything expands it', () => {
+    // `addressesOfRange` bounds the cell COUNT and negative coordinates, never
+    // the extent, so `A5000002` passes as one legal cell.
+    expect(
+      refusalOf([{ type: 'addConditionalRule', rule: { ...rule('cf_1'), ranges: ['A5000002'] } }])
+    ).toContain('is not a range this sheet can address');
+    expect(
+      refusalOf([{ type: 'addConditionalRule', rule: { ...rule('cf_1'), ranges: ['ZZZZ1:ZZZZ9'] } }])
+    ).toContain('is not a range this sheet can address');
+
+    // The one that matters: past 2^53 a row number loses integer precision, so
+    // `row++` inside the expansion loop stops advancing and it runs to its
+    // 500,000-address ceiling. Measured against `addressesOfRange` directly,
+    // this range yields 500,000 copies of the single malformed address
+    // `A1e+21` — not a hang, but tens of megabytes of garbage allocated inside
+    // what is supposed to be a cheap check, and every one of those entries
+    // would then be stored and handed to the evaluator.
+    const started = Date.now();
+    expect(
+      refusalOf([
+        {
+          type: 'addConditionalRule',
+          rule: {
+            ...rule('cf_1'),
+            ranges: ['A1000000000000000000000:A1000000000000000200000'],
+          },
+        },
+      ])
+    ).toContain('is not a range this sheet can address');
+    expect(Date.now() - started).toBeLessThan(1_000);
   });
 
   it('still lets a rule written by a NEWER build be updated', () => {

--- a/packages/lib/src/__tests__/sheet-format-request.test.ts
+++ b/packages/lib/src/__tests__/sheet-format-request.test.ts
@@ -1215,10 +1215,10 @@ describe('planFormatOps — nothing the parser would quietly rewrite', () => {
     });
 
     expect(refusalOf([{ type: 'addConditionalRule', rule: formula('=ABS()') }])).toContain(
-      'calls ABS() with 0 argument(s)'
+      'calls ABS() with 0 arguments'
     );
     expect(refusalOf([{ type: 'addConditionalRule', rule: formula('=IFERROR(1)') }])).toContain(
-      'calls IFERROR() with 1 argument(s)'
+      'calls IFERROR() with 1 argument'
     );
     for (const body of ['=ABS(A1)>0', '=IFERROR(A1, 0)>0', '=SUM(A1:A9)>0', '=ROUND(A1, 2)>0']) {
       expect(plan([{ type: 'addConditionalRule', rule: formula(body) }]).conditionalFormats)
@@ -1355,7 +1355,7 @@ describe('planFormatOps — nothing the parser would quietly rewrite', () => {
           region: { id: 'r1', range: 'A1:B1', columns: [{ column: 'A', role: 'currency' }] },
         },
       ])
-    ).toContain('all of them are headers');
+    ).toContain('every one of them is a header');
 
     // A bodyless region that declares no columns is only a header strip, which
     // is a legitimate thing to want.

--- a/packages/lib/src/__tests__/sheet-format-request.test.ts
+++ b/packages/lib/src/__tests__/sheet-format-request.test.ts
@@ -358,10 +358,40 @@ describe('planFormatOps — columns, rows and freezes', () => {
   it.each([
     ['zero', 0],
     ['fractional', 2.5],
-    ['not a number', 'first' as unknown as number],
     ['past the last row', MAX_ADDRESSABLE_ROW + 2],
   ])('refuses a row height addressed at %s', (_label, row) => {
     expect(refusalOf([{ type: 'setRowHeight', row, height: 40 }])).toContain('1-based row number');
+  });
+
+  it.each([
+    ['a quoted number', '3' as unknown as number],
+    ['a word', 'first' as unknown as number],
+    ['null', null as unknown as number],
+    ['missing', undefined as unknown as number],
+  ])('names the type when the row is not a number at all: %s', (_label, row) => {
+    // Kills: folding this back into the range check, which is where it lived.
+    //
+    // `row: "3"` is what a JSON round trip through a tool call produces, and
+    // the single combined check answered it with `got 3` — a rejection of the
+    // number 3, which is a legal row. The caller cannot repair that; it has to
+    // see that the QUOTES are the problem.
+    const message = refusalOf([{ type: 'setRowHeight', row, height: 40 }]);
+    expect(message).toContain('row must be a number, not');
+    expect(message).not.toContain('1-based row number');
+  });
+
+  it('shows a quoted row still quoted, so the fix is visible', () => {
+    // Kills: `String(row)` here, which renders "3" and 3 identically and puts
+    // the message straight back to blaming a legal row number.
+    expect(refusalOf([{ type: 'setRowHeight', row: '3' as unknown as number, height: 40 }])).toContain(
+      'not string; got "3".'
+    );
+    // And every other input still renders — `JSON.stringify` alone returns a
+    // non-string for `undefined`, which would print "got undefined." only by
+    // accident of interpolation.
+    expect(
+      refusalOf([{ type: 'setRowHeight', row: undefined as unknown as number, height: 40 }])
+    ).toContain('not undefined; got undefined.');
   });
 
   it('accepts a row height on the last addressable row, as the range path does', () => {

--- a/packages/lib/src/__tests__/sheet-format-request.test.ts
+++ b/packages/lib/src/__tests__/sheet-format-request.test.ts
@@ -619,6 +619,54 @@ describe('planFormatOps — nothing the parser would quietly rewrite', () => {
     });
   });
 
+  it('reads a null optional field as "not set", not as a loss', () => {
+    // JSON cannot express undefined, and every optional field the parsers read
+    // treats a null the same way it treats a missing key.
+    expect(plan([{ type: 'upsertRegion', region: { ...region('r1'), theme: null } }]).regions).toEqual([
+      { id: 'r1', range: 'A1:F' },
+    ]);
+  });
+
+  it('still lets a rule written by a NEWER build be updated', () => {
+    // The pre-parse checks are stricter than the parser, so applying them to a
+    // whole merged rule — mostly the STORED one — would refuse any update to a
+    // rule carrying a field this build does not know, which `parseCellFormat`
+    // deliberately preserves. That is the cross-version data loss the
+    // passthrough exists to prevent, arriving as a refusal instead.
+    // Kills: validating `raw` rather than the caller's `supplied` fields.
+    // Cast because `sparkle` is exactly what this build does not know about.
+    const stored = { ...rule('a'), format: { bold: true, sparkle: 3 } } as unknown as ConditionalRule;
+    const tab = tabWith({ conditionalFormats: [stored] });
+
+    const result = plan([{ type: 'updateConditionalRule', id: 'a', patch: { ranges: ['B1:B4'] } }], tab);
+    expect(result.conditionalFormats[0]).toMatchObject({
+      ranges: ['B1:B4'],
+      format: { bold: true, sparkle: 3 },
+    });
+
+    // A format the caller supplies is still held to the strict bar.
+    expect(
+      refusalOf([{ type: 'updateConditionalRule', id: 'a', patch: { format: { sparkle: 4 } } }], tab)
+    ).toContain('"sparkle" is not a format field');
+  });
+
+  it('holds only the caller’s ranges to the range caps, as the panel does', () => {
+    // `updateRule` in the panel validates `patch.ranges` and nothing else. A
+    // stored rule whose ranges the evaluator already skips must stay editable,
+    // or a sheet can reach a state where no rule on it can be fixed.
+    const stored: ConditionalRule = { ...rule('a'), ranges: ['A1:A600000'] };
+    const tab = tabWith({ conditionalFormats: [stored] });
+
+    expect(
+      plan([{ type: 'updateConditionalRule', id: 'a', patch: { format: { bold: true } } }], tab)
+        .conditionalFormats[0]
+    ).toMatchObject({ format: { bold: true } });
+
+    expect(
+      refusalOf([{ type: 'updateConditionalRule', id: 'a', patch: { ranges: ['A1:A600000'] } }], tab)
+    ).toContain('is not a range this sheet can format');
+  });
+
   it('refuses a field whose very SHAPE the parser would replace', () => {
     // A list where a string belongs, or an object where a number belongs, is
     // dropped whole — the comparator has to notice a type change, not only a

--- a/packages/lib/src/sheets/conditional.ts
+++ b/packages/lib/src/sheets/conditional.ts
@@ -693,6 +693,35 @@ const ANCHOR_TYPES = new Set(['min', 'max', 'number', 'percent', 'percentile']);
  */
 export const SCALE_ANCHOR_TYPES: ReadonlySet<string> = ANCHOR_TYPES;
 
+/**
+ * Anchor types whose `value` is the whole point. `min` and `max` read the
+ * data's own extremes and ignore any value; these three mean nothing without
+ * one, and `anchorValue` quietly substitutes an extreme when it is missing.
+ */
+export const VALUED_ANCHOR_TYPES: ReadonlySet<string> = new Set([
+  'number',
+  'percent',
+  'percentile',
+]);
+
+/**
+ * Operators that compare against nothing — the panel hides the value field for
+ * these, and every other operator needs one.
+ *
+ * Here rather than beside the panel for the reason `conditional-ops` gives at
+ * length: this is part of what a valid rule IS, and a server that writes rules
+ * has to agree with the UI that edits them. A second copy is how the API comes
+ * to accept a rule the panel would not offer.
+ */
+export const VALUELESS_OPERATORS: ReadonlySet<ConditionalOperator> = new Set([
+  'isEmpty',
+  'isNotEmpty',
+  'isError',
+]);
+
+/** Operators needing a second bound. */
+export const RANGE_OPERATORS: ReadonlySet<ConditionalOperator> = new Set(['between', 'notBetween']);
+
 const isObject = (value: unknown): value is Record<string, unknown> =>
   typeof value === 'object' && value !== null && !Array.isArray(value);
 

--- a/packages/lib/src/sheets/conditional.ts
+++ b/packages/lib/src/sheets/conditional.ts
@@ -328,6 +328,13 @@ export function rangeAnchor(range: string): { row: number; column: number } | nu
   }
 }
 
+/**
+ * The coercion `matchesCondition` applies to both sides of a numeric
+ * comparison, exported so a write path can ask "would this operand compare
+ * against anything?" with the same answer the evaluator will give.
+ */
+export const asComparableNumber = (value: SheetPrimitive): number | null => asNumber(value);
+
 const asNumber = (value: SheetPrimitive): number | null => {
   if (typeof value === 'number') return Number.isFinite(value) ? value : null;
   if (typeof value === 'boolean' || value === '') return null;
@@ -721,6 +728,25 @@ export const VALUELESS_OPERATORS: ReadonlySet<ConditionalOperator> = new Set([
 
 /** Operators needing a second bound. */
 export const RANGE_OPERATORS: ReadonlySet<ConditionalOperator> = new Set(['between', 'notBetween']);
+
+/**
+ * Operators that compare NUMBERS, and match nothing at all when their operand
+ * is not one.
+ *
+ * Taken from `matchesCondition` below and deliberately excluding `equal` /
+ * `notEqual`, which fall back to a text comparison so `= "done"` works on a
+ * status column. For everything in this set `asComparableNumber(condition.value)`
+ * returning null means the rule is false for every cell it covers — stored,
+ * valid-looking and inert.
+ */
+export const NUMERIC_OPERATORS: ReadonlySet<ConditionalOperator> = new Set([
+  'greaterThan',
+  'greaterThanOrEqual',
+  'lessThan',
+  'lessThanOrEqual',
+  'between',
+  'notBetween',
+]);
 
 const isObject = (value: unknown): value is Record<string, unknown> =>
   typeof value === 'object' && value !== null && !Array.isArray(value);

--- a/packages/lib/src/sheets/conditional.ts
+++ b/packages/lib/src/sheets/conditional.ts
@@ -680,6 +680,19 @@ const OPERATORS = new Set<ConditionalOperator>([
 
 const ANCHOR_TYPES = new Set(['min', 'max', 'number', 'percent', 'percentile']);
 
+/**
+ * The anchor types `readAnchor` accepts, exported so a write path can refuse
+ * what this one merely declines to read.
+ *
+ * An anchor whose type this set does not hold makes `readAnchor` return null —
+ * and the rule builders below then fall back to the ORIGINAL value through
+ * their `...value` spread, so the unusable anchor is stored verbatim and
+ * `anchorValue` silently substitutes the data's own minimum or maximum for it.
+ * A validator has no way to notice that by re-reading what it stored, because
+ * nothing was dropped; it has to know the list.
+ */
+export const SCALE_ANCHOR_TYPES: ReadonlySet<string> = ANCHOR_TYPES;
+
 const isObject = (value: unknown): value is Record<string, unknown> =>
   typeof value === 'object' && value !== null && !Array.isArray(value);
 

--- a/packages/lib/src/sheets/format-request.ts
+++ b/packages/lib/src/sheets/format-request.ts
@@ -574,6 +574,87 @@ const anchorProblem = (anchor: unknown, needsColor: boolean): string | null => {
 };
 
 /**
+ * Why a rule that stores faithfully would still not do what was asked, or null
+ * when there is nothing wrong with it.
+ *
+ * The second half of this module's job, and a different question from the
+ * first. `firstSanitizedPath` asks whether what we are about to store matches
+ * what was sent; these ask whether the thing we are about to store does what
+ * was asked. Every case here passes the first question perfectly — the rule is
+ * kept byte for byte — and then formats the wrong cells, or none.
+ */
+function ruleRenderProblem(rule: ConditionalRule): string | null {
+  // A condition whose operator needs an operand it does not have. The parser
+  // accepts any recognized operator on its own and the comparator sees nothing
+  // dropped, but `matchesCondition` then compares against nothing: a
+  // `greaterThan` with no value matches NO cell, and a `notContains` with no
+  // value matches EVERY non-error one. Which set of operators needs a value is
+  // the panel's answer, now shared rather than restated.
+  if (rule.kind === 'cell' && !VALUELESS_OPERATORS.has(rule.condition.operator)) {
+    const { operator, value, value2 } = rule.condition;
+    if (typeof value !== 'string' || value.trim() === '') {
+      return (
+        `A "${operator}" rule needs a value to compare against. Without one it matches nothing — or, ` +
+        'for a negative operator, everything.'
+      );
+    }
+    if (RANGE_OPERATORS.has(operator) && (typeof value2 !== 'string' || value2.trim() === '')) {
+      return `A "${operator}" rule needs both bounds: value and value2.`;
+    }
+  }
+
+  // A formula that does not parse. `parseConditionalRule` asks only that it be
+  // non-blank, and the evaluator then throws while tokenizing it once per
+  // covered cell, catches, and applies nothing — the silent render-time no-op
+  // in its purest form. Checked with the engine's own tokenizer and parser, so
+  // "valid" means the same thing here as where it runs.
+  if (rule.kind === 'formula') {
+    const body = rule.formula.trim().replace(/^=/, '');
+    let parsed = false;
+    try {
+      const tokens = tokenize(body);
+      if (tokens.length > 0) {
+        new FormulaParser(tokens).parse();
+        parsed = true;
+      }
+    } catch {
+      parsed = false;
+    }
+    if (!parsed) {
+      return (
+        `"${rule.formula}" is not a formula this sheet can evaluate. Stored as written it throws once ` +
+        'per covered cell and formats none of them.'
+      );
+    }
+  }
+
+  // Anchors, which the comparator cannot speak for — see `anchorProblem`.
+  if (rule.kind === 'colorScale') {
+    for (const [name, value] of [['min', rule.min], ['mid', rule.mid], ['max', rule.max]] as const) {
+      const problem = anchorProblem(value, true);
+      if (problem) {
+        return (
+          `The colorScale's ${name} anchor ${problem}. Stored as written it renders no colour at ` +
+          'all, on any cell in range.'
+        );
+      }
+    }
+  } else if (rule.kind === 'dataBar') {
+    for (const [name, value] of [['min', rule.min], ['max', rule.max]] as const) {
+      const problem = anchorProblem(value, false);
+      if (problem) {
+        return (
+          `The dataBar's ${name} anchor ${problem}. Stored as written it is ignored, and the bars ` +
+          `are scaled to the data's own ${name} instead.`
+        );
+      }
+    }
+  }
+
+  return null;
+}
+
+/**
  * Parse a caller-supplied rule, refusing anything the parser would quietly
  * rewrite on the way in.
  *
@@ -663,82 +744,74 @@ function validateRuleInput(
     );
   }
 
-  // A condition whose operator needs an operand it does not have. The parser
-  // accepts any recognized operator on its own and the comparator sees nothing
-  // dropped, but `matchesCondition` then compares against nothing: a
-  // `greaterThan` with no value matches NO cell, and a `notContains` with no
-  // value matches EVERY non-error one. Which set of operators needs a value is
-  // the panel's answer, now shared rather than restated.
-  if (rule.kind === 'cell' && !VALUELESS_OPERATORS.has(rule.condition.operator)) {
-    const { operator, value, value2 } = rule.condition;
-    if (typeof value !== 'string' || value.trim() === '') {
-      return refuseOp(
-        index,
-        type,
-        `A "${operator}" rule needs a value to compare against. Without one it matches nothing — or, ` +
-          'for a negative operator, everything.'
-      );
-    }
-    if (RANGE_OPERATORS.has(operator) && (typeof value2 !== 'string' || value2.trim() === '')) {
-      return refuseOp(index, type, `A "${operator}" rule needs both bounds: value and value2.`);
-    }
-  }
-
-  // A formula that does not parse. `parseConditionalRule` asks only that it be
-  // non-blank, and the evaluator then throws while tokenizing it once per
-  // covered cell, catches, and applies nothing — the silent render-time no-op
-  // in its purest form. Checked with the engine's own tokenizer and parser, so
-  // "valid" means the same thing here as where it runs.
-  if (rule.kind === 'formula') {
-    const body = rule.formula.trim().replace(/^=/, '');
-    let parsed = false;
-    try {
-      const tokens = tokenize(body);
-      if (tokens.length > 0) {
-        new FormulaParser(tokens).parse();
-        parsed = true;
-      }
-    } catch {
-      parsed = false;
-    }
-    if (!parsed) {
-      return refuseOp(
-        index,
-        type,
-        `"${rule.formula}" is not a formula this sheet can evaluate. Stored as written it throws once ` +
-          'per covered cell and formats none of them.'
-      );
-    }
-  }
-
-  // Anchors, which the comparator cannot speak for — see `anchorProblem`.
-  if (rule.kind === 'colorScale') {
-    for (const [name, value] of [['min', rule.min], ['mid', rule.mid], ['max', rule.max]] as const) {
-      const problem = anchorProblem(value, true);
-      if (problem) {
-        return refuseOp(
-          index,
-          type,
-          `The colorScale's ${name} anchor ${problem}. Stored as written it renders no colour at ` +
-            'all, on any cell in range.'
-        );
-      }
-    }
-  } else if (rule.kind === 'dataBar') {
-    for (const [name, value] of [['min', rule.min], ['max', rule.max]] as const) {
-      const problem = anchorProblem(value, false);
-      if (problem) {
-        return refuseOp(
-          index,
-          type,
-          `The dataBar's ${name} anchor ${problem}. Stored as written it is ignored, and the bars ` +
-            `are scaled to the data's own ${name} instead.`
-        );
-      }
-    }
-  }
+  const problem = ruleRenderProblem(rule);
+  if (problem) return refuseOp(index, type, problem);
 
   return rule;
+}
+
+/**
+ * The same question as {@link ruleRenderProblem}, for a region: what would be
+ * stored exactly as asked and still not do it?
+ */
+function regionRenderProblem(region: SheetRegion, label: string): string | null {
+  // A declaration that names something outside the region it belongs to.
+  // `createRegionResolver` excludes cells outside the bounds before it consults
+  // either list, so a column or total row beyond them can never render — stored
+  // faithfully, and inert. Cross-field, so the comparator cannot see it: each
+  // value survives on its own.
+  const bounds = parseRegionRange(region.range);
+  if (bounds) {
+    for (const column of region.columns ?? []) {
+      const columnIndex = decodeColumnLabel(column.column);
+      if (columnIndex < bounds.colStart || columnIndex > bounds.colEnd) {
+        return (
+          `${label}: column "${column.column}" is outside the region ${region.range}, so nothing it ` +
+          'declares can ever apply.'
+        );
+      }
+    }
+
+    // Only for a closed range: an open one ("A1:F") reaches the end of the
+    // sheet, so a total row past today's extent is a row the sheet will grow
+    // into — which is the entire point of leaving the end off.
+    if (bounds.rowEnd !== null) {
+      for (const row of region.totalRows ?? []) {
+        if (row - 1 < bounds.rowStart || row - 1 > bounds.rowEnd) {
+          return `${label}: total row ${row} is outside the region ${region.range}, so it can never render.`;
+        }
+      }
+    }
+  }
+
+  // A setting nothing acts on yet. `freezeHeader` is parsed and stored, and a
+  // repo-wide search finds no consumer: `createRegionResolver` does not read it
+  // and the `setRegions` step only stores the region. Accepting it would be the
+  // module's own contract broken in its own output — a request that succeeds
+  // and pins nothing. `setFrozen` does work today, so the refusal names it.
+  if (region.freezeHeader === true) {
+    return (
+      `${label}: freezeHeader is not applied by anything yet, so setting it would pin no rows. Use a ` +
+      'setFrozen op for now.'
+    );
+  }
+
+  // The one sanitization the comparator cannot see, because it happens at
+  // RENDER time rather than at parse time: `parseRegion` accepts any lowercase
+  // word as a theme, and `hueByName` then falls back to the default for one the
+  // palette does not have. Its own comment says why — "falling back beats
+  // refusing to render the table" — and that is right for a stored region being
+  // drawn. It is wrong for a request: an agent that asked for a blue dashboard
+  // and got slate was told the write succeeded. Refusing needs the palette,
+  // which is exactly what that comment notes `parseRegion` cannot import.
+  if (region.theme !== undefined && !PALETTE.some((hue) => hue.name === region.theme)) {
+    return (
+      `${label}: "${region.theme}" is not a hue this build has, and would render as ` +
+      `${PALETTE[0].name} without saying so. Known hues: ${PALETTE.map((hue) => hue.name).join(', ')}.`
+    );
+  }
+
+  return null;
 }
 
 /** The same contract as {@link validateRuleInput}, for a declared region. */
@@ -767,71 +840,8 @@ function validateRegionInput(raw: unknown, index: number, type: string, label: s
     );
   }
 
-  // A declaration that names something outside the region it belongs to.
-  // `createRegionResolver` excludes cells outside the bounds before it consults
-  // either list, so a column or total row beyond them can never render — stored
-  // faithfully, and inert. Cross-field, so the comparator cannot see it: each
-  // value survives on its own.
-  const bounds = parseRegionRange(region.range);
-  if (bounds) {
-    for (const column of region.columns ?? []) {
-      const columnIndex = decodeColumnLabel(column.column);
-      if (columnIndex < bounds.colStart || columnIndex > bounds.colEnd) {
-        return refuseOp(
-          index,
-          type,
-          `${label}: column "${column.column}" is outside the region ${region.range}, so nothing it ` +
-            'declares can ever apply.'
-        );
-      }
-    }
-
-    // Only for a closed range: an open one ("A1:F") reaches the end of the
-    // sheet, so a total row past today's extent is a row the sheet will grow
-    // into — which is the entire point of leaving the end off.
-    if (bounds.rowEnd !== null) {
-      for (const row of region.totalRows ?? []) {
-        if (row - 1 < bounds.rowStart || row - 1 > bounds.rowEnd) {
-          return refuseOp(
-            index,
-            type,
-            `${label}: total row ${row} is outside the region ${region.range}, so it can never render.`
-          );
-        }
-      }
-    }
-  }
-
-  // A setting nothing acts on yet. `freezeHeader` is parsed and stored, and a
-  // repo-wide search finds no consumer: `createRegionResolver` does not read it
-  // and the `setRegions` step only stores the region. Accepting it would be the
-  // module's own contract broken in its own output — a request that succeeds
-  // and pins nothing. `setFrozen` does work today, so the refusal names it.
-  if (region.freezeHeader === true) {
-    return refuseOp(
-      index,
-      type,
-      `${label}: freezeHeader is not applied by anything yet, so setting it would pin no rows. Use a ` +
-        'setFrozen op for now.'
-    );
-  }
-
-  // The one sanitization the comparator cannot see, because it happens at
-  // RENDER time rather than at parse time: `parseRegion` accepts any lowercase
-  // word as a theme, and `hueByName` then falls back to the default for one the
-  // palette does not have. Its own comment says why — "falling back beats
-  // refusing to render the table" — and that is right for a stored region being
-  // drawn. It is wrong for a request: an agent that asked for a blue dashboard
-  // and got slate was told the write succeeded. Refusing needs the palette,
-  // which is exactly what that comment notes `parseRegion` cannot import.
-  if (region.theme !== undefined && !PALETTE.some((hue) => hue.name === region.theme)) {
-    return refuseOp(
-      index,
-      type,
-      `${label}: "${region.theme}" is not a hue this build has, and would render as ` +
-        `${PALETTE[0].name} without saying so. Known hues: ${PALETTE.map((hue) => hue.name).join(', ')}.`
-    );
-  }
+  const problem = regionRenderProblem(region, label);
+  if (problem) return refuseOp(index, type, problem);
 
   return region;
 }

--- a/packages/lib/src/sheets/format-request.ts
+++ b/packages/lib/src/sheets/format-request.ts
@@ -86,12 +86,14 @@ import {
 } from './format-ops';
 import { isSupportedFunction } from './functions';
 import { PALETTE } from './palette';
+import { columnRoleFormat } from './region-format';
 import { FormulaParser, tokenize } from './parser';
 import {
   MAX_REGIONS,
   parseRegion,
   parseRegionRange,
   parseRegions,
+  type RegionColumn,
   type SheetRegion,
 } from './regions';
 import type { ASTNode, CellFormat } from './types';
@@ -903,6 +905,31 @@ function validateRuleInput(
 }
 
 /**
+ * Whether a column setting has any effect on what that column renders, asked of
+ * the deriver rather than assumed.
+ *
+ * `columnRoleFormat` reads `currency` only for `role: 'currency'` and `decimals`
+ * only for the three numeric roles, so `{role: 'number', currency: 'EUR'}` is
+ * stored, ignored, and looks from the outside like money that lost its symbol.
+ *
+ * Answered by deriving the format twice with two ARBITRARY, different values
+ * for the field: identical output means the field was not read, whatever the
+ * caller happened to send. The tempting shortcut — derive once with the
+ * caller's value and once without it — asks a different question and gets
+ * `currency: 'USD'` on a currency column wrong, because the role defaults to
+ * USD anyway, so the two derivations match and a redundant declaration is
+ * reported as an ignored one. Redundant is not a mistake.
+ */
+const columnFieldIsIgnored = (
+  column: RegionColumn,
+  field: 'currency' | 'decimals',
+  a: string | number,
+  b: string | number
+): boolean =>
+  canonical(columnRoleFormat({ ...column, [field]: a })) ===
+  canonical(columnRoleFormat({ ...column, [field]: b }));
+
+/**
  * The same question as {@link ruleRenderProblem}, for a region: what would be
  * stored exactly as asked and still not do it?
  */
@@ -933,6 +960,20 @@ function regionRenderProblem(region: SheetRegion, label: string): string | null 
           return `${label}: total row ${row} is outside the region ${region.range}, so it can never render.`;
         }
       }
+    }
+  }
+
+  for (const column of region.columns ?? []) {
+    for (const [field, a, b] of [
+      ['currency', 'AAA', 'BBB'],
+      ['decimals', 1, 2],
+    ] as const) {
+      if (column[field] === undefined) continue;
+      if (!columnFieldIsIgnored(column, field, a, b)) continue;
+      return (
+        `${label}: column ${column.column} declares ${field}, which a "${column.role}" column does ` +
+        'not use — it would be stored and never rendered.'
+      );
     }
   }
 

--- a/packages/lib/src/sheets/format-request.ts
+++ b/packages/lib/src/sheets/format-request.ts
@@ -837,7 +837,8 @@ function validateRuleInput(
   raw: unknown,
   supplied: Record<string, unknown>,
   index: number,
-  type: string
+  type: string,
+  charge: (cells: number) => void
 ): ConditionalRule {
   if (!isObject(raw)) {
     return refuseOp(index, type, 'rule must be an object.');
@@ -870,6 +871,14 @@ function validateRuleInput(
         return refuseOp(index, type, `"${range}" is not a range this sheet can address.`);
       }
     }
+
+    // Counted cheaply and charged to the request's budget BEFORE
+    // `validateRanges`, which expands every range to addresses. A per-rule cap
+    // bounds one rule at half a million cells and says nothing about a batch of
+    // two hundred of them — the same hole `MAX_FORMAT_CELLS_PER_REQUEST` closes
+    // on the cell path, and leaving it open here would make that bound the only
+    // one doing its job.
+    charge(suppliedRanges.reduce((cells, range) => cells + conditionalCellsOfRange(range), 0));
 
     // The caller's array, at its real length.
     const ranges = validateRanges(suppliedRanges);
@@ -1111,6 +1120,24 @@ export function planFormatOps(
   let rulesTouched = false;
   let regionsTouched = false;
 
+  // How many cells this request has asked us to EXPAND while checking rules,
+  // as opposed to how many the resulting sheet covers. Bounded by the same
+  // sheet-wide ceiling, because a request whose rules alone reach past it can
+  // never be the repair that ceiling makes an exception for.
+  let conditionalCellsInspected = 0;
+  const chargeInspection = (index: number, type: string) => (cells: number) => {
+    conditionalCellsInspected += cells;
+    if (conditionalCellsInspected > MAX_CONDITIONAL_TOTAL_CELLS) {
+      refuseOp(
+        index,
+        type,
+        `The rules in this request cover ${conditionalCellsInspected.toLocaleString()} cells between ` +
+          `them, past the sheet-wide limit of ${MAX_CONDITIONAL_TOTAL_CELLS.toLocaleString()} before ` +
+          'the sheet is even considered.'
+      );
+    }
+  };
+
   /** A range op's addresses, with both the per-op and per-request bounds applied. */
   const resolveRange = (range: unknown, index: number, type: string): readonly string[] => {
     if (typeof range !== 'string') {
@@ -1257,7 +1284,13 @@ export function planFormatOps(
         // The parser is the only definition of a usable rule, and on the load
         // path it drops what it cannot use. A blank custom formula is the
         // canonical case: accepted by a naive writer, gone on the next load.
-        const rule = validateRuleInput(op.rule, isObject(op.rule) ? op.rule : {}, index, op.type);
+        const rule = validateRuleInput(
+          op.rule,
+          isObject(op.rule) ? op.rule : {},
+          index,
+          op.type,
+          chargeInspection(index, op.type)
+        );
 
         if (rules.some((existing) => existing.id === rule.id)) {
           // Two rules under one id: `update` and `move` reach the first by
@@ -1309,7 +1342,8 @@ export function planFormatOps(
           { ...rules[at], ...patch, id: rules[at].id, kind: rules[at].kind },
           patch,
           index,
-          op.type
+          op.type,
+          chargeInspection(index, op.type)
         );
 
         rules = rules.map((rule, position) => (position === at ? merged : rule));

--- a/packages/lib/src/sheets/format-request.ts
+++ b/packages/lib/src/sheets/format-request.ts
@@ -724,8 +724,22 @@ const MAX_COMPARE_DEPTH = 12;
  *
  * The companion bound to the depth one, and needed for the same reason: an
  * extension field is preserved verbatim, so it can be a flat array of a million
- * entries as easily as a chain of a million objects. Ten thousand is orders of
- * magnitude past any region or rule and still cheap to walk.
+ * entries as easily as a chain of a million objects.
+ *
+ * Ten thousand is not arbitrary: a region declaring the maximum 256 columns is
+ * already about 1,300 values, so this is roughly eight times the largest
+ * legitimate input and cannot be lowered much without refusing real work.
+ *
+ * It is deliberately PER VALUE rather than per request, which makes it the one
+ * bound here that does not follow the rule the rest of this module learned the
+ * hard way — that a per-op ceiling says nothing about two hundred ops. The
+ * exception is measured rather than assumed: 50 ops each carrying a
+ * 9,000-value extension verify in 130ms, so the worst a full request can cost
+ * is about 0.6 seconds. That is three orders of magnitude below the cases the
+ * aggregate bounds exist for (a hundred million allocations, four billion
+ * expansions), and closing it would mean threading a budget through six
+ * signatures to save half a second. Written down rather than left for the next
+ * reader to rediscover.
  */
 const MAX_COMPARE_VALUES = 10_000;
 

--- a/packages/lib/src/sheets/format-request.ts
+++ b/packages/lib/src/sheets/format-request.ts
@@ -966,14 +966,28 @@ function regionRenderProblem(region: SheetRegion, label: string): string | null 
       }
     }
 
-    // Only for a closed range: an open one ("A1:F") reaches the end of the
-    // sheet, so a total row past today's extent is a row the sheet will grow
-    // into — which is the entire point of leaving the end off.
-    if (bounds.rowEnd !== null) {
-      for (const row of region.totalRows ?? []) {
-        if (row - 1 < bounds.rowStart || row - 1 > bounds.rowEnd) {
-          return `${label}: total row ${row} is outside the region ${region.range}, so it can never render.`;
-        }
+    // Totals are checked against the region's BODY, not its bounds. The
+    // resolver applies the header treatment and `continue`s, so a total row
+    // inside the header band never reaches the total treatment at all — and a
+    // region that starts below row 1 has rows above it that are simply not
+    // part of it. Both store cleanly and render as something else.
+    const headerRows = region.headerRows ?? 1;
+    const firstBodyRow = bounds.rowStart + headerRows;
+
+    for (const row of region.totalRows ?? []) {
+      if (row - 1 < firstBodyRow) {
+        return (
+          `${label}: total row ${row} is not in the body of ${region.range}. That region starts at ` +
+          `row ${bounds.rowStart + 1} and its first ${headerRows} row(s) are headers, so its totals ` +
+          `start at row ${firstBodyRow + 1}.`
+        );
+      }
+
+      // The upper bound is skipped for an open range only ("A1:F" reaches the
+      // end of the sheet), so a total row past today's extent is a row the
+      // sheet will grow into — the entire point of leaving the end off.
+      if (bounds.rowEnd !== null && row - 1 > bounds.rowEnd) {
+        return `${label}: total row ${row} is outside the region ${region.range}, so it can never render.`;
       }
     }
   }
@@ -1421,15 +1435,29 @@ export function planFormatOps(
     // the budget simply stop contributing at render time. Individually legal
     // rules can sum past it, so a write that would land there is refused while
     // there is still someone to tell.
-    let total = 0;
-    for (const rule of rules) {
-      for (const range of rule.ranges) total += conditionalCellsOfRange(range);
-    }
-    if (total > MAX_CONDITIONAL_TOTAL_CELLS) {
+    const totalCells = (list: readonly ConditionalRule[]): number => {
+      let cells = 0;
+      for (const rule of list) {
+        for (const range of rule.ranges) cells += conditionalCellsOfRange(range);
+      }
+      return cells;
+    };
+
+    const before = totalCells(tab.conditionalFormats ?? []);
+    const after = totalCells(rules);
+
+    // Over the ceiling AND worse than it was. A sheet can already be past this
+    // limit — the panel's `addRule` enforces the per-rule and rule-count caps
+    // but not the aggregate — and refusing every write on such a sheet would
+    // leave it unrepairable: removing a rule from it reduces the skipped render
+    // work and would still have been rejected for not fixing everything at
+    // once. A write that does not make matters worse is always allowed.
+    if (after > MAX_CONDITIONAL_TOTAL_CELLS && after > before) {
       refuse(
-        `Those rules cover ${total.toLocaleString()} cells in total, over the sheet-wide limit of ` +
+        `Those rules cover ${after.toLocaleString()} cells in total, over the sheet-wide limit of ` +
           `${MAX_CONDITIONAL_TOTAL_CELLS.toLocaleString()}. Rules past the limit are silently skipped when ` +
-          'the sheet renders, so narrow the ranges rather than adding more.'
+          'the sheet renders, so narrow the ranges rather than adding more. (A write that lowers the ' +
+          'total is accepted even while it is still over.)'
       );
     }
 

--- a/packages/lib/src/sheets/format-request.ts
+++ b/packages/lib/src/sheets/format-request.ts
@@ -56,6 +56,7 @@ import {
   MIN_COLUMN_WIDTH,
   MIN_ROW_HEIGHT,
 } from './format-ops';
+import { PALETTE } from './palette';
 import { MAX_REGIONS, parseRegion, parseRegions, type SheetRegion } from './regions';
 import type { CellFormat } from './types';
 
@@ -150,6 +151,13 @@ export interface SheetFormatPlan {
    * the row records, so this is exactly the set the caller must lock and load —
    * loading the whole tab to format six cells is the thing this exists to
    * avoid.
+   *
+   * A row here may lie beyond `tab.rowCount`, and deliberately is not refused:
+   * a column default and a region both cover rows that do not exist yet, so
+   * refusing the per-cell case alone would be an inconsistency dressed as a
+   * safeguard. Whether to create those rows or leave the formats unplaced is
+   * the writer's decision, not the validator's — compare against `rowCount` to
+   * find them.
    */
   rows: ReadonlySet<number>;
   /**
@@ -608,6 +616,23 @@ function validateRegionInput(raw: unknown, index: number, type: string, label: s
       type,
       `${label}: "${sanitized}" is not something this sheet can store, and would be dropped or ` +
         'changed on the way in.'
+    );
+  }
+
+  // The one sanitization the comparator cannot see, because it happens at
+  // RENDER time rather than at parse time: `parseRegion` accepts any lowercase
+  // word as a theme, and `hueByName` then falls back to the default for one the
+  // palette does not have. Its own comment says why — "falling back beats
+  // refusing to render the table" — and that is right for a stored region being
+  // drawn. It is wrong for a request: an agent that asked for a blue dashboard
+  // and got slate was told the write succeeded. Refusing needs the palette,
+  // which is exactly what that comment notes `parseRegion` cannot import.
+  if (region.theme !== undefined && !PALETTE.some((hue) => hue.name === region.theme)) {
+    return refuseOp(
+      index,
+      type,
+      `${label}: "${region.theme}" is not a hue this build has, and would render as ` +
+        `${PALETTE[0].name} without saying so. Known hues: ${PALETTE.map((hue) => hue.name).join(', ')}.`
     );
   }
 

--- a/packages/lib/src/sheets/format-request.ts
+++ b/packages/lib/src/sheets/format-request.ts
@@ -193,6 +193,9 @@ export const MAX_FORMAT_OPS = 200;
 const isObject = (value: unknown): value is Record<string, unknown> =>
   typeof value === 'object' && value !== null && !Array.isArray(value);
 
+const isStringArray = (value: unknown): value is string[] =>
+  Array.isArray(value) && value.every((entry) => typeof entry === 'string');
+
 /** Keys that would reach a prototype rather than a property once merged. */
 const FORBIDDEN_KEYS = new Set(['__proto__', 'constructor', 'prototype']);
 
@@ -518,8 +521,9 @@ function validateRuleInput(
   // cross-version data loss the passthrough exists to prevent, arriving as a
   // refusal instead. It also keeps this identical to the panel's `updateRule`,
   // which validates `patch.ranges` and nothing else.
-  if (supplied.ranges !== undefined) {
-    if (!Array.isArray(supplied.ranges) || supplied.ranges.some((entry) => typeof entry !== 'string')) {
+  const suppliedRanges = supplied.ranges;
+  if (suppliedRanges !== undefined) {
+    if (!isStringArray(suppliedRanges)) {
       return refuseOp(index, type, 'ranges must be an array of A1 ranges, such as ["B2:B20"].');
     }
     // Bounds BEFORE `validateRanges`, because `validateRanges` expands each
@@ -530,14 +534,14 @@ function validateRuleInput(
     // stops advancing at that magnitude, so the expansion loop runs to its
     // 500,000-address ceiling emitting the same malformed exponential-form
     // address every time, inside what is supposed to be a cheap check.
-    for (const range of supplied.ranges as string[]) {
+    for (const range of suppliedRanges) {
       if (!parseRangeSpan(range)) {
         return refuseOp(index, type, `"${range}" is not a range this sheet can address.`);
       }
     }
 
     // The caller's array, at its real length.
-    const ranges = validateRanges(supplied.ranges as string[]);
+    const ranges = validateRanges(suppliedRanges);
     if (!ranges.ok) return refuseOp(index, type, ranges.reason);
   }
 
@@ -828,7 +832,7 @@ export function planFormatOps(
           refuseOp(index, op.type, 'patch must be an object of rule fields.');
         }
 
-        const patch = op.patch as Record<string, unknown>;
+        const patch = op.patch;
         // `id` and `kind` are identity, not settings — matching `updateRule`,
         // which pins both so a patch cannot silently detach a rule from the row
         // being edited. Which also means a patch naming ONLY those two asks for

--- a/packages/lib/src/sheets/format-request.ts
+++ b/packages/lib/src/sheets/format-request.ts
@@ -1543,6 +1543,18 @@ function conditionValueHint(raw: Record<string, unknown>, path: string): string 
 function validateRegionInput(raw: unknown, index: number, type: string, label: string): SheetRegion {
   const region = parseRegion(raw);
   if (!region) {
+    // `parseRegion` fails as a whole, so the generic message has to list every
+    // requirement — and then tells a caller that DID send an id that a region
+    // needs one. When the range is the part that will not parse, say that
+    // instead: it is the same repair the cell-range ops get, and it is the
+    // difference between one more attempt and a guess.
+    if (isObject(raw) && typeof raw.range === 'string' && !parseRegionRange(raw.range)) {
+      return refuseOp(
+        index,
+        type,
+        `${label} range "${raw.range}" is not a range this sheet can address.${rangeHint(raw.range)}`
+      );
+    }
     return refuseOp(
       index,
       type,

--- a/packages/lib/src/sheets/format-request.ts
+++ b/packages/lib/src/sheets/format-request.ts
@@ -1,4 +1,13 @@
 /**
+ * A caller's string, short enough to put in a message.
+ *
+ * Refusals quote the thing they are refusing, which is right up until the thing
+ * is a five-thousand-term formula and the message is thirty kilobytes of it.
+ */
+const abbreviate = (value: string, limit = 60): string =>
+  value.length <= limit ? value : `${value.slice(0, limit)}…`;
+
+/**
  * What a parsed formula would do wrong at evaluation time, or null.
  *
  * Parsing proves the grammar and nothing else, so three things are checked
@@ -21,11 +30,21 @@
  * a bound.)
  */
 function formulaProblem(root: ASTNode, coveredCells: number): string | null {
-  const stack: ASTNode[] = [root];
+  const stack: Array<{ node: ASTNode; depth: number }> = [{ node: root, depth: 0 }];
   let referenced = 0;
 
   while (stack.length > 0) {
-    const node = stack.pop() as ASTNode;
+    const { node, depth } = stack.pop() as { node: ASTNode; depth: number };
+
+    // This walk is iterative, and so is the parser — but `evaluation.ts`
+    // evaluates `BinaryExpression.left` by recursion. A long left-associative
+    // chain (`=A1+A2+A3+…`, one level per term) therefore parses here and
+    // overflows the stack there, caught once per covered cell with nothing to
+    // show for it. 256 is past any formula a person would write and far short
+    // of what the evaluator's frames can take.
+    if (depth > MAX_FORMULA_DEPTH) {
+      return `nests more than ${MAX_FORMULA_DEPTH} levels deep, which the evaluator cannot walk`;
+    }
 
     switch (node.type) {
       case 'FunctionCall': {
@@ -41,22 +60,30 @@ function formulaProblem(root: ASTNode, coveredCells: number): string | null {
         }
 
         // Arity is checked against FLATTENED values, not argument nodes:
-        // `evaluateFunction` does `args.flatMap(flattenValue)` first, so
-        // `ABS(A1:A2)` arrives as two values and throws, once per covered cell.
-        // Whether a function can survive that is derivable rather than listed —
-        // if it would reject one more value than this call supplies, it has a
-        // fixed arity and a range in any slot breaks it.
-        const spreads = node.args.some(
-          (argument) => argument.type === 'Range' || argument.type === 'ExternalRange'
-        );
-        if (spreads && !isValidCall(name, node.args.length + 1)) {
+        // `evaluateFunction` does `args.flatMap(flattenValue)` first, so a range
+        // argument arrives as one value per cell it covers. Counted exactly
+        // rather than approximated — an earlier version probed with one extra
+        // argument, which models `ABS(A1:A2)` and not `LEFT(A1:A3)`, since LEFT
+        // accepts both one and two.
+        //
+        // The probe count is capped because it builds that many argument nodes,
+        // and a 500,000-cell range would build 500,000 of them for no gain: no
+        // function in the dispatch has an arity anywhere near sixteen, so
+        // anything above it is rejected or accepted for the same reason a
+        // million would be.
+        const flattened = node.args.reduce((count, argument) => {
+          if (argument.type !== 'Range' && argument.type !== 'ExternalRange') return count + 1;
+          return count + (referencedCells(argument.start.reference, argument.end.reference) ?? 1);
+        }, 0);
+
+        if (flattened !== node.args.length && !isValidCall(name, Math.min(flattened, 16))) {
           return (
-            `passes a range to ${name}(), which takes a fixed number of values — a range arrives as ` +
-            'one value per cell it covers'
+            `passes a range to ${name}(), which takes a fixed number of values — the ranges here ` +
+            `arrive as ${flattened.toLocaleString()} values`
           );
         }
 
-        for (const argument of node.args) stack.push(argument);
+        for (const argument of node.args) stack.push({ node: argument, depth: depth + 1 });
         break;
       }
 
@@ -78,11 +105,11 @@ function formulaProblem(root: ASTNode, coveredCells: number): string | null {
       }
 
       case 'UnaryExpression':
-        stack.push(node.argument);
+        stack.push({ node: node.argument, depth: depth + 1 });
         break;
 
       case 'BinaryExpression':
-        stack.push(node.left, node.right);
+        stack.push({ node: node.left, depth: depth + 1 }, { node: node.right, depth: depth + 1 });
         break;
 
       default:
@@ -394,6 +421,18 @@ export const MAX_FORMAT_OPS = 200;
  * starts being a mistake.
  */
 export const MAX_FORMULA_EXPANSION = 20_000_000;
+
+/**
+ * How deeply a conditional formula may nest.
+ *
+ * The parser is iterative and so is the walk that checks a formula here, but
+ * `evaluation.ts` evaluates `BinaryExpression.left` by recursion — so a long
+ * left-associative chain parses cleanly and then overflows the stack at render
+ * time, once per covered cell. 256 is past any formula a person would write
+ * (`=A1+A2+…` nests one level per term) and far short of what the evaluator's
+ * frames can survive.
+ */
+export const MAX_FORMULA_DEPTH = 256;
 
 const isObject = (value: unknown): value is Record<string, unknown> =>
   typeof value === 'object' && value !== null && !Array.isArray(value);
@@ -983,8 +1022,8 @@ function ruleRenderProblem(
     }
     if (!ast) {
       return (
-        `"${rule.formula}" is not a formula this sheet can evaluate. Stored as written it throws once ` +
-        'per covered cell and formats none of them.'
+        `"${abbreviate(rule.formula)}" is not a formula this sheet can evaluate. Stored as written it ` +
+        'throws once per covered cell and formats none of them.'
       );
     }
 
@@ -992,7 +1031,10 @@ function ruleRenderProblem(
     // the three things the engine will object to that a parse cannot see.
     const covered = rule.ranges.reduce((cells, range) => cells + conditionalCellsOfRange(range), 0);
     const problem = formulaProblem(ast, covered);
-    if (problem) return `"${rule.formula}" ${problem}.`;
+    // Quoted back so the caller can see which formula, but not in full: the
+    // cases refused here include a five-thousand-term chain, and echoing that
+    // makes a thirty-kilobyte error message out of a one-line complaint.
+    if (problem) return `"${abbreviate(rule.formula)}" ${problem}.`;
   }
 
   // Anchors, which the comparator cannot speak for — see `anchorProblem`.
@@ -1202,6 +1244,13 @@ function regionRenderProblem(region: SheetRegion, label: string): string | null 
   // value survives on its own.
   const bounds = parseRegionRange(region.range);
   if (bounds) {
+    // `parseRegionRange` bounds the top of the sheet and not the bottom:
+    // `decodeCellAddress` reads `A0` as row -1, so `A0:B0` parses, stores, and
+    // prepares as rows -1 to -1 — a region no cell can ever fall inside.
+    if (bounds.rowStart < 0 || bounds.colStart < 0) {
+      return `${label}: ${region.range} starts before the first cell, so no cell can be inside it.`;
+    }
+
     for (const column of region.columns ?? []) {
       const columnIndex = decodeColumnLabel(column.column);
       if (columnIndex < bounds.colStart || columnIndex > bounds.colEnd) {
@@ -1329,6 +1378,66 @@ function validateRegionInput(raw: unknown, index: number, type: string, label: s
 /** The id an op names, which must be there to name anything at all. */
 const requireId = (id: unknown, index: number, type: string): string =>
   typeof id === 'string' && id !== '' ? id : refuseOp(index, type, 'id must be a non-empty string.');
+
+/**
+ * What a rule list costs to render once, in address expansions.
+ *
+ * Only formula rules cost anything here: the other kinds walk their ranges once,
+ * while a formula is evaluated per covered cell and expands every range it
+ * references on each pass. Rules whose formula does not parse contribute
+ * nothing, which is right — they are refused on the way in, and a stored one
+ * throws rather than expanding.
+ */
+function formulaWork(rules: readonly ConditionalRule[]): number {
+  let total = 0;
+
+  for (const rule of rules) {
+    if (rule.kind !== 'formula') continue;
+
+    let ast: ASTNode | null = null;
+    try {
+      const tokens = tokenize(rule.formula.trim().replace(/^=/, ''));
+      if (tokens.length > 0) ast = new FormulaParser(tokens).parse();
+    } catch {
+      continue;
+    }
+    if (!ast) continue;
+
+    const covered = rule.ranges.reduce((cells, range) => cells + conditionalCellsOfRange(range), 0);
+    total += covered * referencedCellTotal(ast);
+  }
+
+  return total;
+}
+
+/** Cells every range in a formula refers to, added up. Iterative, as ever. */
+function referencedCellTotal(root: ASTNode): number {
+  const stack: ASTNode[] = [root];
+  let total = 0;
+
+  while (stack.length > 0) {
+    const node = stack.pop() as ASTNode;
+    switch (node.type) {
+      case 'Range':
+      case 'ExternalRange':
+        total += referencedCells(node.start.reference, node.end.reference) ?? 0;
+        break;
+      case 'FunctionCall':
+        for (const argument of node.args) stack.push(argument);
+        break;
+      case 'UnaryExpression':
+        stack.push(node.argument);
+        break;
+      case 'BinaryExpression':
+        stack.push(node.left, node.right);
+        break;
+      default:
+        break;
+    }
+  }
+
+  return total;
+}
 
 const ruleIdList = (rules: readonly ConditionalRule[]): string =>
   rules.length === 0 ? 'none' : rules.map((rule) => `"${rule.id}"`).join(', ');
@@ -1728,6 +1837,27 @@ export function planFormatOps(
 
     const before = totalCells(tab.conditionalFormats ?? []);
     const after = totalCells(rules);
+
+    // Formula work summed across the whole rule list, not just the one being
+    // written. The per-rule ceiling bounds one rule at twenty million and says
+    // nothing about two hundred of them — each legal, each covering 10,000
+    // cells and referencing 2,000, with the covered-cell aggregate satisfied
+    // and four billion expansions in one render. Same shape as every other
+    // per-op bound on this branch, and the same fix.
+    //
+    // Carries the repair exception for the same reason the cell aggregate does:
+    // a sheet can already be past this, and refusing the writes that would
+    // reduce it is how a sheet becomes unfixable.
+    const formulaWorkBefore = formulaWork(tab.conditionalFormats ?? []);
+    const formulaWorkAfter = formulaWork(rules);
+    if (formulaWorkAfter > MAX_FORMULA_EXPANSION && formulaWorkAfter > formulaWorkBefore) {
+      refuse(
+        `Those rules ask for ${formulaWorkAfter.toLocaleString()} address expansions to render once, ` +
+          `over the limit of ${MAX_FORMULA_EXPANSION.toLocaleString()}. A formula rule costs the cells ` +
+          'it covers times the cells it references, and they add up across rules. (A write that ' +
+          'lowers the total is accepted even while it is still over.)'
+      );
+    }
 
     // Over the ceiling AND worse than it was. A sheet can already be past this
     // limit — the panel's `addRule` enforces the per-rule and rule-count caps

--- a/packages/lib/src/sheets/format-request.ts
+++ b/packages/lib/src/sheets/format-request.ts
@@ -34,7 +34,10 @@ function formulaProblem(root: ASTNode, coveredCells: number): string | null {
           return `calls ${name}(), which this sheet does not implement`;
         }
         if (!isValidCall(name, node.args.length)) {
-          return `calls ${name}() with ${node.args.length} argument(s), which it does not accept`;
+          return (
+            `calls ${name}() with ${node.args.length} ` +
+            `${node.args.length === 1 ? 'argument' : 'arguments'}, which it does not accept`
+          );
         }
 
         // Arity is checked against FLATTENED values, not argument nodes:
@@ -920,7 +923,7 @@ function ruleRenderProblem(
     // stored and thrown away. Neither shape is reachable through the panel,
     // which hides the fields it does not use.
     if (VALUELESS_OPERATORS.has(operator) && (value !== undefined || value2 !== undefined)) {
-      return `A "${operator}" rule compares against nothing, so it cannot take a value.`;
+      return `"${operator}" compares against nothing, so it cannot take a value.`;
     }
     if (!RANGE_OPERATORS.has(operator) && value2 !== undefined) {
       return `Only a between/notBetween rule has a second bound; "${operator}" ignores value2.`;
@@ -934,12 +937,12 @@ function ruleRenderProblem(
     if (!VALUELESS_OPERATORS.has(operator)) {
       if (typeof value !== 'string' || value.trim() === '') {
         return (
-          `A "${operator}" rule needs a value to compare against. Without one it matches nothing — or, ` +
-          'for a negative operator, everything.'
+          `"${operator}" needs a value to compare against. Without one it matches nothing — or, for a ` +
+          'negative operator, everything.'
         );
       }
       if (RANGE_OPERATORS.has(operator) && (typeof value2 !== 'string' || value2.trim() === '')) {
-        return `A "${operator}" rule needs both bounds: value and value2.`;
+        return `"${operator}" needs both bounds: value and value2.`;
       }
 
       // Present, non-blank, and still nothing to compare against: the operand
@@ -951,8 +954,8 @@ function ruleRenderProblem(
           if (operand === undefined) continue;
           if (asComparableNumber(operand) === null) {
             return (
-              `A "${operator}" rule compares numbers, and ${field} is "${operand}". It would match no ` +
-              'cell at all.'
+              `"${operator}" compares numbers, and ${field} is "${operand}". It would match no cell ` +
+              'at all.'
             );
           }
         }
@@ -1214,8 +1217,8 @@ function regionRenderProblem(region: SheetRegion, label: string): string | null 
     // and unlike an open region it cannot grow into a body later.
     if (bounds.rowEnd !== null && firstBodyRow > bounds.rowEnd && (region.columns?.length ?? 0) > 0) {
       return (
-        `${label}: ${region.range} is ${bounds.rowEnd - bounds.rowStart + 1} row(s) tall and all of ` +
-        `them are headers, so it has no body for a column role to apply to.`
+        `${label}: ${region.range} is ${bounds.rowEnd - bounds.rowStart + 1} rows tall and every one ` +
+        'of them is a header, so it has no body for a column role to apply to.'
       );
     }
 
@@ -1223,8 +1226,9 @@ function regionRenderProblem(region: SheetRegion, label: string): string | null 
       if (row - 1 < firstBodyRow) {
         return (
           `${label}: total row ${row} is not in the body of ${region.range}. That region starts at ` +
-          `row ${bounds.rowStart + 1} and its first ${headerRows} row(s) are headers, so its totals ` +
-          `start at row ${firstBodyRow + 1}.`
+          `row ${bounds.rowStart + 1} and its first ${headerRows} ` +
+          `${headerRows === 1 ? 'row is a header' : 'rows are headers'}, so its totals start at row ` +
+          `${firstBodyRow + 1}.`
         );
       }
 

--- a/packages/lib/src/sheets/format-request.ts
+++ b/packages/lib/src/sheets/format-request.ts
@@ -256,9 +256,6 @@ const isObject = (value: unknown): value is Record<string, unknown> =>
 const isStringArray = (value: unknown): value is string[] =>
   Array.isArray(value) && value.every((entry) => typeof entry === 'string');
 
-/** Keys that would reach a prototype rather than a property once merged. */
-const FORBIDDEN_KEYS = new Set(['__proto__', 'constructor', 'prototype']);
-
 const COLUMN_ONLY = /^[A-Z]{1,7}$/;
 
 // Annotated rather than inferred: TypeScript only treats a call as
@@ -371,10 +368,14 @@ function validateCellFormatPatch(
     return refuseOp(index, type, `${label} has no fields; name at least one, such as {"bold": true}.`);
   }
 
+  // No separate prototype-key branch. `__proto__`, `constructor` and
+  // `prototype` are not format fields, so the check below already refuses them
+  // by name — a mutation probe showed the extra branch changed no outcome, and
+  // it is the fourth line on this branch to be removed for that reason. Nor is
+  // one needed for safety here: this module hands the caller's object onward
+  // untouched and never copies keys onto one of its own. `parseCellFormat`
+  // keeps its own guard because it does exactly that, key by key.
   for (const key of keys) {
-    if (FORBIDDEN_KEYS.has(key)) {
-      return refuseOp(index, type, `${label}: "${key}" is not a format field.`);
-    }
     if (!CELL_FORMAT_FIELDS.has(key)) {
       return refuseOp(
         index,

--- a/packages/lib/src/sheets/format-request.ts
+++ b/packages/lib/src/sheets/format-request.ts
@@ -1,0 +1,820 @@
+/**
+ * @module @pagespace/lib/sheets/format-request
+ * @description The refusal boundary for presentation writes that did not come
+ * from the toolbar.
+ *
+ * Every setter in `format-ops` and `conditional-ops` was written for a panel,
+ * where the UI is the validator: a slider cannot ask for a width of 8, and a
+ * colour picker cannot emit `#gggggg`. An agent calling the same setters over
+ * the API has no such fence, and the setters are *forgiving* by design — they
+ * clamp, they skip unparseable addresses, they drop fields that fail their
+ * schema. Forgiving is right for a load path, where the alternative is losing a
+ * document; it is wrong for a write path, where it turns "I did something other
+ * than what you asked" into a success response.
+ *
+ * So this module refuses instead, ahead of any mutation:
+ *
+ *  - **All-or-nothing.** One bad op refuses the batch. A partially applied
+ *    format request leaves a sheet in a state nobody asked for and no caller
+ *    can describe, and an agent cannot retry it without first working out what
+ *    landed.
+ *  - **Before I/O.** `planFormatOps` is pure and takes the tab's counters and
+ *    current rule/region lists as values, so the caller can validate, learn
+ *    exactly which rows the write touches, and only then take locks and load
+ *    them. Validating after loading would mean holding a transaction open
+ *    across work that was always going to fail.
+ *  - **Never a silent no-op.** An id that is not on the sheet, a move that is
+ *    already at the end, a patch with no fields — each of those returns
+ *    "success" from the underlying setter while changing nothing. To a person
+ *    that is a puzzling non-event; to a model it is a signal to move on, and
+ *    the missing formatting surfaces much later as a bad dashboard.
+ *
+ * Pure: no database, no I/O, no clock. The refusals are the contract, and they
+ * have to be testable without any of that.
+ */
+
+import {
+  MAX_ADDRESSABLE_COLUMN,
+  MAX_ADDRESSABLE_ROW,
+  decodeCellAddress,
+  decodeColumnLabel,
+} from './address';
+import {
+  MAX_CONDITIONAL_RANGE_CELLS,
+  MAX_CONDITIONAL_RULES,
+  MAX_CONDITIONAL_TOTAL_CELLS,
+  addressesOfRange,
+  parseConditionalRule,
+  parseConditionalRules,
+  type ConditionalRule,
+} from './conditional';
+import { validateRanges } from './conditional-ops';
+import { CELL_FORMAT_FIELDS, cellFormatSchema } from './format';
+import {
+  MAX_COLUMN_WIDTH,
+  MAX_ROW_HEIGHT,
+  MIN_COLUMN_WIDTH,
+  MIN_ROW_HEIGHT,
+} from './format-ops';
+import { MAX_REGIONS, parseRegion, parseRegions, type SheetRegion } from './regions';
+import type { CellFormat } from './types';
+
+/**
+ * A caller-supplied op that cannot be applied.
+ *
+ * Its own class so a route can answer 400 rather than 500: every one of these
+ * describes something the caller asked for, not something that went wrong on
+ * the way to doing it. The message is written to be read by whatever sent the
+ * op — an agent has to be able to fix the request from the refusal alone, which
+ * is why they name the key, the count, or the ids that do exist.
+ */
+export class SheetFormatError extends Error {
+  /** Index of the offending op in the batch, when one op is to blame. */
+  readonly opIndex?: number;
+
+  constructor(message: string, opIndex?: number) {
+    super(message);
+    this.name = 'SheetFormatError';
+    this.opIndex = opIndex;
+  }
+}
+
+/**
+ * The presentation edits a caller can request.
+ *
+ * `rule` and `region` are `unknown` deliberately. `parseConditionalRule` and
+ * `parseRegion` are the only definitions of "is this valid", and a value that
+ * satisfies `ConditionalRule` structurally can still fail them — a
+ * custom-formula rule with a blank `formula` typechecks perfectly and is
+ * dropped on the next load. Typing these fields would advertise a guarantee
+ * only the parsers can give, and every caller would then reasonably skip the
+ * parse.
+ */
+export type SheetFormatOp =
+  | { type: 'setCellFormat'; range: string; patch: CellFormat }
+  | { type: 'clearCellFormat'; range: string }
+  | { type: 'setColumnFormat'; column: string; patch: CellFormat }
+  | { type: 'setColumnWidth'; column: string; width: number | null }
+  | { type: 'setRowHeight'; row: number; height: number | null }
+  | { type: 'setFrozen'; rows: number | null; columns: number | null }
+  | { type: 'addConditionalRule'; rule: unknown }
+  | { type: 'updateConditionalRule'; id: string; patch: Record<string, unknown> }
+  | { type: 'removeConditionalRule'; id: string }
+  | { type: 'moveConditionalRule'; id: string; direction: -1 | 1 }
+  | { type: 'clearConditionalRules' }
+  | { type: 'setRegions'; regions: readonly unknown[] }
+  | { type: 'upsertRegion'; region: unknown }
+  | { type: 'removeRegion'; id: string };
+
+/**
+ * One validated edit, resolved to the arguments its `format-ops` setter takes.
+ *
+ * Kept as an ordered list rather than bucketed by kind because a
+ * `clearCellFormat` after a `setCellFormat` over the same cells means something
+ * different from the reverse, and a plan that lost that ordering would apply
+ * whichever the bucketing happened to visit last.
+ *
+ * `null` on the wire means "clear this", and `format-ops` spells the same thing
+ * `undefined`; the translation happens here so no caller has to remember it.
+ */
+export type PlannedFormatStep =
+  | { type: 'setCellFormat'; addresses: readonly string[]; patch: CellFormat }
+  | { type: 'clearCellFormat'; addresses: readonly string[] }
+  | { type: 'setColumnFormat'; columnIndex: number; patch: CellFormat }
+  | { type: 'setColumnWidth'; columnIndex: number; width: number | undefined }
+  | { type: 'setRowHeight'; rowIndex: number; height: number | undefined }
+  | { type: 'setFrozen'; rows: number | undefined; columns: number | undefined }
+  | { type: 'setConditionalRules'; rules: readonly ConditionalRule[] }
+  | { type: 'setRegions'; regions: readonly SheetRegion[] };
+
+/**
+ * What the tab looks like now. A value, not a handle: `planFormatOps` runs
+ * before the caller has taken a lock, and taking one to validate would hold a
+ * transaction open across work that frequently ends in a refusal.
+ *
+ * `SheetData` satisfies this structurally, so a caller that already has one
+ * passes it straight through.
+ */
+export interface SheetFormatTarget {
+  rowCount: number;
+  columnCount: number;
+  conditionalFormats?: readonly ConditionalRule[];
+  regions?: readonly SheetRegion[];
+}
+
+export interface SheetFormatPlan {
+  /** The edits to apply, in the order they were requested. */
+  steps: readonly PlannedFormatStep[];
+  /**
+   * Every 0-based row index the per-cell steps touch. Per-cell formats live on
+   * the row records, so this is exactly the set the caller must lock and load —
+   * loading the whole tab to format six cells is the thing this exists to
+   * avoid.
+   */
+  rows: ReadonlySet<number>;
+  /**
+   * Whether anything on the tab record itself changes — column formats and
+   * widths, row heights, freezes, rules, regions. Those live beside the tab
+   * rather than on a row, so a caller that touches none of them can skip
+   * writing it at all.
+   */
+  touchesTabFields: boolean;
+  /** The rule list as it will be after the write, already round-tripped. */
+  conditionalFormats: readonly ConditionalRule[];
+  /** The region list as it will be after the write, already round-tripped. */
+  regions: readonly SheetRegion[];
+}
+
+/**
+ * The most cells one range op may address.
+ *
+ * Formatting a whole column cell-by-cell is the request this bound exists to
+ * turn away, and turning it away is a service rather than an obstruction: a
+ * column default covers rows that do not exist yet, so the refusal points at a
+ * strictly better answer than the one being refused. 50,000 is past any
+ * hand-authored selection and well under the per-range conditional ceiling, so
+ * a range this rejects would never have been a deliberate act.
+ */
+export const MAX_FORMAT_CELLS = 50_000;
+
+/**
+ * The most cells one *request* may address across all of its range ops.
+ *
+ * The lesson `MAX_CONDITIONAL_TOTAL_CELLS` already learned, applied one layer
+ * up: a per-op ceiling bounds one op and says nothing about a batch of two
+ * hundred of them, each individually legal. Without an aggregate the per-op
+ * bound is decorative.
+ */
+export const MAX_FORMAT_CELLS_PER_REQUEST = 200_000;
+
+/** Enough for any authored batch; bounds the work of validating one. */
+export const MAX_FORMAT_OPS = 200;
+
+const isObject = (value: unknown): value is Record<string, unknown> =>
+  typeof value === 'object' && value !== null && !Array.isArray(value);
+
+/** Keys that would reach a prototype rather than a property once merged. */
+const FORBIDDEN_KEYS = new Set(['__proto__', 'constructor', 'prototype']);
+
+const COLUMN_ONLY = /^[A-Z]{1,7}$/;
+
+// Annotated rather than inferred: TypeScript only treats a call as
+// terminating control flow when the callee has an explicit `never` type, and
+// without that every refusal below would have to be followed by a `return` to
+// convince the checker that the op is not still in play.
+const refuse: (message: string, opIndex?: number) => never = (message, opIndex) => {
+  throw new SheetFormatError(message, opIndex);
+};
+
+/** `Op 3 (setColumnWidth): …` — the index is what makes a batch refusal actionable. */
+const refuseOp: (index: number, type: string, message: string) => never = (index, type, message) =>
+  refuse(`Op ${index} (${type}): ${message}`, index);
+
+interface RangeSpan {
+  rowStart: number;
+  rowEnd: number;
+  colStart: number;
+  colEnd: number;
+}
+
+/**
+ * The bounds of an A1 range, without expanding it.
+ *
+ * `addressesOfRange` is the shared expander and stays the only one — but a
+ * *count* must be available before deciding whether expanding is allowed at
+ * all, and asking the expander how big something is means building the array
+ * the bound exists to prevent. This walks the same acceptances it does,
+ * including rejecting the truncated `A1:` and the row-0 addresses
+ * `decodeCellAddress` will happily decode to -1.
+ */
+function parseRangeSpan(range: string): RangeSpan | null {
+  const normalized = range.trim().toUpperCase();
+  const [rawStart, rawEnd, ...extra] = normalized.split(':');
+  if (!rawStart || extra.length > 0) return null;
+  if (normalized.includes(':') && !rawEnd) return null;
+
+  let start: { row: number; column: number };
+  let end: { row: number; column: number };
+  try {
+    start = decodeCellAddress(rawStart);
+    end = rawEnd ? decodeCellAddress(rawEnd) : start;
+  } catch {
+    return null;
+  }
+
+  if (start.row < 0 || start.column < 0 || end.row < 0 || end.column < 0) return null;
+
+  const span: RangeSpan = {
+    rowStart: Math.min(start.row, end.row),
+    rowEnd: Math.max(start.row, end.row),
+    colStart: Math.min(start.column, end.column),
+    colEnd: Math.max(start.column, end.column),
+  };
+
+  if (span.rowEnd > MAX_ADDRESSABLE_ROW || span.colEnd > MAX_ADDRESSABLE_COLUMN) return null;
+
+  return span;
+}
+
+const cellsInSpan = (span: RangeSpan): number =>
+  (span.rowEnd - span.rowStart + 1) * (span.colEnd - span.colStart + 1);
+
+/**
+ * How many cells a range contributes to conditional evaluation.
+ *
+ * Zero for a range the evaluator would skip, which includes one past
+ * `MAX_CONDITIONAL_RANGE_CELLS` — `addressesOfRange` rejects those wholesale,
+ * so counting them toward the aggregate budget would refuse a sheet for work it
+ * was never going to do.
+ */
+function conditionalCellsOfRange(range: string): number {
+  const span = parseRangeSpan(range);
+  if (!span) return 0;
+  const cells = cellsInSpan(span);
+  return cells > MAX_CONDITIONAL_RANGE_CELLS ? 0 : cells;
+}
+
+/**
+ * Validate a cell-format patch and hand back **the caller's own object**.
+ *
+ * The return value is `patch` itself, not `cellFormatSchema`'s output, and that
+ * is the whole point of the function. `setCellFormats` treats a field present
+ * and set to `undefined` as "clear this field" — that is how a toolbar turns
+ * bold off without dropping the rest of the cell's styling. Zod does not
+ * preserve an explicitly-undefined key: `{bold: undefined}` parses to `{}`, and
+ * piping `result.data` downstream would turn every clear in the product into a
+ * silent no-op that reports success.
+ *
+ * So `safeParse` is used for its *verdict* only. And because
+ * `cellFormatSchema` is a plain `z.object`, its verdict says nothing about
+ * unknown keys — it strips them without complaint, which would make a typo like
+ * `bolt` a formatting request that quietly does nothing. Those are checked
+ * first, by hand.
+ */
+function validateCellFormatPatch(patch: unknown, index: number, type: string): CellFormat {
+  if (!isObject(patch)) {
+    return refuseOp(index, type, 'patch must be an object of format fields.');
+  }
+
+  const keys = Object.keys(patch);
+  if (keys.length === 0) {
+    // Applying this would succeed and change nothing, which is the failure mode
+    // hardest to notice from the outside.
+    return refuseOp(index, type, 'patch has no fields; name at least one, such as {"bold": true}.');
+  }
+
+  for (const key of keys) {
+    if (FORBIDDEN_KEYS.has(key)) {
+      return refuseOp(index, type, `"${key}" is not a format field.`);
+    }
+    if (!CELL_FORMAT_FIELDS.has(key)) {
+      return refuseOp(
+        index,
+        type,
+        `"${key}" is not a format field. Known fields: ${[...CELL_FORMAT_FIELDS].join(', ')}.`
+      );
+    }
+  }
+
+  const result = cellFormatSchema.safeParse(patch);
+  if (!result.success) {
+    const issue = result.error.issues[0];
+    // Rooted at `patch` unconditionally: the path is never empty here — the
+    // object and key checks above have already run — and a conditional root
+    // would be a branch no input can take.
+    return refuseOp(index, type, `${['patch', ...issue.path].join('.')}: ${issue.message}`);
+  }
+
+  // Deliberately `patch`, never `result.data`. See above.
+  return patch as CellFormat;
+}
+
+/** A column label to its 0-based index, refusing what `decodeColumnLabel` would take. */
+function validateColumn(column: unknown, index: number, type: string): number {
+  if (typeof column !== 'string') {
+    return refuseOp(index, type, 'column must be letters, such as "C".');
+  }
+
+  const normalized = column.trim().toUpperCase();
+  // `decodeColumnLabel` accepts letters of any length and returns an index no
+  // sheet can address; the length bound is what keeps `"AAAAAAAA"` a refusal
+  // rather than a number.
+  if (!COLUMN_ONLY.test(normalized)) {
+    return refuseOp(index, type, `"${column}" is not a column label; use letters, such as "C".`);
+  }
+
+  const columnIndex = decodeColumnLabel(normalized);
+  if (columnIndex > MAX_ADDRESSABLE_COLUMN) {
+    return refuseOp(index, type, `Column "${normalized}" is past the last addressable column, ZZZ.`);
+  }
+
+  return columnIndex;
+}
+
+/**
+ * A pixel measurement, refused rather than clamped when out of range.
+ *
+ * `setColumnWidth` and `setRowHeight` clamp — right for a drag handle, where
+ * the pointer is going to overshoot and the user watches it stop. Over the API
+ * it means a request for 8px reports success and produces 24px, and nothing
+ * anywhere says so. Checking here leaves the clamp in place as a provable
+ * no-op rather than removing a guard the panel still relies on.
+ */
+function validateExtent(
+  value: number | null,
+  min: number,
+  max: number,
+  field: string,
+  index: number,
+  type: string
+): number | undefined {
+  // Clearing is a real instruction, not a missing value.
+  if (value === null) return undefined;
+
+  if (typeof value !== 'number' || !Number.isFinite(value)) {
+    return refuseOp(index, type, `${field} must be a number of pixels, or null to clear it.`);
+  }
+  if (!Number.isInteger(value)) {
+    // `clamp` rounds, so a fractional request is stored as something else.
+    return refuseOp(index, type, `${field} must be a whole number of pixels; got ${value}.`);
+  }
+  if (value < min || value > max) {
+    return refuseOp(index, type, `${field} must be between ${min} and ${max} pixels; got ${value}.`);
+  }
+
+  return value;
+}
+
+/** Freeze counts are a prefix of the sheet, so they cannot exceed its extent. */
+function validateFreeze(
+  value: number | null,
+  extent: number,
+  field: string,
+  index: number,
+  type: string
+): number | undefined {
+  if (value === null) return undefined;
+
+  if (typeof value !== 'number' || !Number.isInteger(value) || value < 0) {
+    return refuseOp(index, type, `${field} must be a whole number of 0 or more, or null to clear.`);
+  }
+  if (value > extent) {
+    return refuseOp(index, type, `${field} is ${value}, but the sheet has only ${extent}.`);
+  }
+
+  return value;
+}
+
+const ruleIdList = (rules: readonly ConditionalRule[]): string =>
+  rules.length === 0 ? 'none' : rules.map((rule) => `"${rule.id}"`).join(', ');
+
+const regionIdList = (regions: readonly SheetRegion[]): string =>
+  regions.length === 0 ? 'none' : regions.map((region) => `"${region.id}"`).join(', ');
+
+/**
+ * Validate a whole format request against the tab as it stands, and describe
+ * the write it would perform.
+ *
+ * Throws `SheetFormatError` on the first op it cannot apply, before returning
+ * anything — there is no partial plan, because there is no partial write.
+ */
+export function planFormatOps(
+  ops: readonly SheetFormatOp[],
+  tab: SheetFormatTarget
+): SheetFormatPlan {
+  if (!Array.isArray(ops)) {
+    refuse('ops must be an array of format operations.');
+  }
+  if (ops.length > MAX_FORMAT_OPS) {
+    refuse(`A format request can carry at most ${MAX_FORMAT_OPS} ops; got ${ops.length}.`);
+  }
+
+  const steps: PlannedFormatStep[] = [];
+  const rows = new Set<number>();
+  let touchesTabFields = false;
+  let cellsPlanned = 0;
+
+  // Rules and regions are folded into one running list each, so a batch that
+  // adds three rules and moves one is checked against — and stored as — the
+  // list those four ops actually produce. Checking each op against the stored
+  // list instead would let a batch land past a cap that every op individually
+  // cleared.
+  let rules: ConditionalRule[] = [...(tab.conditionalFormats ?? [])];
+  let regions: SheetRegion[] = [...(tab.regions ?? [])];
+  let rulesTouched = false;
+  let regionsTouched = false;
+
+  /** A range op's addresses, with both the per-op and per-request bounds applied. */
+  const resolveRange = (range: unknown, index: number, type: string): readonly string[] => {
+    if (typeof range !== 'string') {
+      return refuseOp(index, type, 'range must be a string, such as "B2:D40".');
+    }
+
+    const span = parseRangeSpan(range);
+    if (!span) {
+      return refuseOp(index, type, `"${range}" is not a range this sheet can address.`);
+    }
+
+    const cells = cellsInSpan(span);
+    if (cells > MAX_FORMAT_CELLS) {
+      return refuseOp(
+        index,
+        type,
+        `"${range}" covers ${cells.toLocaleString()} cells, over the limit of ` +
+          `${MAX_FORMAT_CELLS.toLocaleString()}. Use setColumnFormat for a whole column, or a region ` +
+          `for a table — both cover rows that do not exist yet.`
+      );
+    }
+
+    cellsPlanned += cells;
+    if (cellsPlanned > MAX_FORMAT_CELLS_PER_REQUEST) {
+      return refuseOp(
+        index,
+        type,
+        `This request now covers ${cellsPlanned.toLocaleString()} cells, over the per-request limit ` +
+          `of ${MAX_FORMAT_CELLS_PER_REQUEST.toLocaleString()}.`
+      );
+    }
+
+    for (let row = span.rowStart; row <= span.rowEnd; row++) rows.add(row);
+
+    return addressesOfRange(range, MAX_FORMAT_CELLS);
+  };
+
+  const requireId = (id: unknown, index: number, type: string): string => {
+    if (typeof id !== 'string' || id === '') {
+      return refuseOp(index, type, 'id must be a non-empty string.');
+    }
+    return id;
+  };
+
+  ops.forEach((op, index) => {
+    // Checked through a boolean rather than an `isObject(op)` narrowing: a type
+    // predicate here would intersect the op union with `Record<string, unknown>`
+    // and every field below would arrive as `unknown`, costing a cast per field
+    // to recover what the union already says.
+    const shaped =
+      typeof op === 'object' &&
+      op !== null &&
+      !Array.isArray(op) &&
+      typeof (op as { type?: unknown }).type === 'string';
+    if (!shaped) {
+      refuse(`Op ${index}: each op must be an object with a "type".`, index);
+    }
+
+    switch (op.type) {
+      case 'setCellFormat': {
+        const addresses = resolveRange(op.range, index, op.type);
+        steps.push({
+          type: 'setCellFormat',
+          addresses,
+          patch: validateCellFormatPatch(op.patch, index, op.type),
+        });
+        break;
+      }
+
+      case 'clearCellFormat': {
+        steps.push({ type: 'clearCellFormat', addresses: resolveRange(op.range, index, op.type) });
+        break;
+      }
+
+      case 'setColumnFormat': {
+        const columnIndex = validateColumn(op.column, index, op.type);
+        steps.push({
+          type: 'setColumnFormat',
+          columnIndex,
+          patch: validateCellFormatPatch(op.patch, index, op.type),
+        });
+        touchesTabFields = true;
+        break;
+      }
+
+      case 'setColumnWidth': {
+        const columnIndex = validateColumn(op.column, index, op.type);
+        const width = validateExtent(
+          op.width,
+          MIN_COLUMN_WIDTH,
+          MAX_COLUMN_WIDTH,
+          'width',
+          index,
+          op.type
+        );
+        steps.push({ type: 'setColumnWidth', columnIndex, width });
+        touchesTabFields = true;
+        break;
+      }
+
+      case 'setRowHeight': {
+        const row = op.row;
+        // 1-based on the wire, as everywhere a row is named in A1 terms.
+        if (typeof row !== 'number' || !Number.isInteger(row) || row < 1 || row > MAX_ADDRESSABLE_ROW) {
+          refuseOp(index, op.type, `row must be a 1-based row number; got ${String(row)}.`);
+        }
+        const height = validateExtent(
+          op.height,
+          MIN_ROW_HEIGHT,
+          MAX_ROW_HEIGHT,
+          'height',
+          index,
+          op.type
+        );
+        steps.push({ type: 'setRowHeight', rowIndex: row - 1, height });
+        touchesTabFields = true;
+        break;
+      }
+
+      case 'setFrozen': {
+        const frozenRows = validateFreeze(
+          op.rows,
+          tab.rowCount,
+          'frozen rows',
+          index,
+          op.type
+        );
+        const frozenColumns = validateFreeze(
+          op.columns,
+          tab.columnCount,
+          'frozen columns',
+          index,
+          op.type
+        );
+        steps.push({ type: 'setFrozen', rows: frozenRows, columns: frozenColumns });
+        touchesTabFields = true;
+        break;
+      }
+
+      case 'addConditionalRule': {
+        const rule = parseConditionalRule(op.rule);
+        if (!rule) {
+          // The parser is the only definition of a usable rule, and it drops
+          // what it cannot use. A blank custom formula is the canonical case:
+          // accepted by a naive writer, gone on the next load.
+          refuseOp(
+            index,
+            op.type,
+            'That is not a rule this sheet can store. A rule needs an id, at least one range, and a ' +
+              'kind of cell, formula, colorScale or dataBar — a formula rule needs a non-empty formula, ' +
+              'and a cell rule a format with at least one valid field.'
+          );
+        }
+        if (rules.length >= MAX_CONDITIONAL_RULES) {
+          refuseOp(index, op.type, `This sheet already has the maximum of ${MAX_CONDITIONAL_RULES} rules.`);
+        }
+        const ranges = validateRanges(rule.ranges);
+        if (!ranges.ok) refuseOp(index, op.type, ranges.reason);
+
+        rules = [...rules, rule];
+        rulesTouched = true;
+        break;
+      }
+
+      case 'updateConditionalRule': {
+        const id = requireId(op.id, index, op.type);
+        const at = rules.findIndex((rule) => rule.id === id);
+        if (at === -1) {
+          refuseOp(index, op.type, `No rule "${id}" on this sheet. Present rules: ${ruleIdList(rules)}.`);
+        }
+        if (!isObject(op.patch)) {
+          refuseOp(index, op.type, 'patch must be an object of rule fields.');
+        }
+
+        const patch = op.patch as Record<string, unknown>;
+        // A patch that widens the ranges has to clear the same bar as a new
+        // rule, or editing is the way around a limit that adding refuses.
+        if (Array.isArray(patch.ranges)) {
+          const ranges = validateRanges(patch.ranges.filter((r): r is string => typeof r === 'string'));
+          if (!ranges.ok) refuseOp(index, op.type, ranges.reason);
+        }
+
+        // `id` and `kind` are identity, not settings — matching `updateRule`,
+        // which pins both so a patch cannot silently detach a rule from the row
+        // being edited.
+        const merged = parseConditionalRule({
+          ...rules[at],
+          ...patch,
+          id: rules[at].id,
+          kind: rules[at].kind,
+        });
+        if (!merged) {
+          refuseOp(index, op.type, `That patch leaves rule "${id}" in a state this sheet cannot store.`);
+        }
+
+        rules = rules.map((rule, position) => (position === at ? merged : rule));
+        rulesTouched = true;
+        break;
+      }
+
+      case 'removeConditionalRule': {
+        const id = requireId(op.id, index, op.type);
+        if (!rules.some((rule) => rule.id === id)) {
+          // `removeRule` returns the sheet untouched for an unknown id, which
+          // over the API is indistinguishable from having removed it.
+          refuseOp(index, op.type, `No rule "${id}" on this sheet. Present rules: ${ruleIdList(rules)}.`);
+        }
+        rules = rules.filter((rule) => rule.id !== id);
+        rulesTouched = true;
+        break;
+      }
+
+      case 'moveConditionalRule': {
+        const id = requireId(op.id, index, op.type);
+        if (op.direction !== -1 && op.direction !== 1) {
+          refuseOp(index, op.type, 'direction must be -1 (earlier) or 1 (later).');
+        }
+
+        const at = rules.findIndex((rule) => rule.id === id);
+        if (at === -1) {
+          refuseOp(index, op.type, `No rule "${id}" on this sheet. Present rules: ${ruleIdList(rules)}.`);
+        }
+
+        const target = at + op.direction;
+        if (target < 0 || target >= rules.length) {
+          // Rule order is precedence, so "already at the end" is a real answer
+          // and worth saying rather than reporting a move that did not happen.
+          refuseOp(
+            index,
+            op.type,
+            `Rule "${id}" is already ${op.direction === -1 ? 'first' : 'last'}; there is nowhere to move it.`
+          );
+        }
+
+        const next = [...rules];
+        [next[at], next[target]] = [next[target], next[at]];
+        rules = next;
+        rulesTouched = true;
+        break;
+      }
+
+      case 'clearConditionalRules': {
+        rules = [];
+        rulesTouched = true;
+        break;
+      }
+
+      case 'setRegions': {
+        if (!Array.isArray(op.regions)) {
+          refuseOp(index, op.type, 'regions must be an array.');
+        }
+        if (op.regions.length > MAX_REGIONS) {
+          refuseOp(
+            index,
+            op.type,
+            `A sheet can hold at most ${MAX_REGIONS} regions; got ${op.regions.length}.`
+          );
+        }
+
+        const next: SheetRegion[] = [];
+        const seen = new Set<string>();
+        op.regions.forEach((value: unknown, position: number) => {
+          const region = parseRegion(value);
+          if (!region) {
+            refuseOp(
+              index,
+              op.type,
+              `regions[${position}] is not a region this sheet can store. A region needs an id and a ` +
+                'range such as "A1:F" (an omitted row end means "to the end of the sheet").'
+            );
+          }
+          if (seen.has(region.id)) {
+            // `parseRegions` keeps the first and drops the rest, so a duplicate
+            // id is a region silently lost between write and read.
+            refuseOp(index, op.type, `Two regions share the id "${region.id}".`);
+          }
+          seen.add(region.id);
+          next.push(region);
+        });
+
+        regions = next;
+        regionsTouched = true;
+        break;
+      }
+
+      case 'upsertRegion': {
+        const region = parseRegion(op.region);
+        if (!region) {
+          refuseOp(
+            index,
+            op.type,
+            'That is not a region this sheet can store. A region needs an id and a range such as ' +
+              '"A1:F" (an omitted row end means "to the end of the sheet").'
+          );
+        }
+
+        const at = regions.findIndex((existing) => existing.id === region.id);
+        if (at === -1) {
+          if (regions.length >= MAX_REGIONS) {
+            refuseOp(index, op.type, `This sheet already has the maximum of ${MAX_REGIONS} regions.`);
+          }
+          regions = [...regions, region];
+        } else {
+          regions = regions.map((existing, position) => (position === at ? region : existing));
+        }
+        regionsTouched = true;
+        break;
+      }
+
+      case 'removeRegion': {
+        const id = requireId(op.id, index, op.type);
+        if (!regions.some((region) => region.id === id)) {
+          refuseOp(index, op.type, `No region "${id}" on this sheet. Present regions: ${regionIdList(regions)}.`);
+        }
+        regions = regions.filter((region) => region.id !== id);
+        regionsTouched = true;
+        break;
+      }
+
+      default:
+        refuse(`Op ${index}: unknown op type "${String(op.type)}".`, index);
+    }
+  });
+
+  if (rulesTouched) {
+    // The aggregate ceiling `MAX_CONDITIONAL_TOTAL_CELLS` is spent by
+    // `expandRangesWithinBudget` and then *broken out of*, silently: rules past
+    // the budget simply stop contributing at render time. Individually legal
+    // rules can sum past it, so a write that would land there is refused while
+    // there is still someone to tell.
+    let total = 0;
+    for (const rule of rules) {
+      for (const range of rule.ranges) total += conditionalCellsOfRange(range);
+    }
+    if (total > MAX_CONDITIONAL_TOTAL_CELLS) {
+      refuse(
+        `Those rules cover ${total.toLocaleString()} cells in total, over the sheet-wide limit of ` +
+          `${MAX_CONDITIONAL_TOTAL_CELLS.toLocaleString()}. Rules past the limit are silently skipped when ` +
+          'the sheet renders, so narrow the ranges rather than adding more.'
+      );
+    }
+
+    // Round-trip detector. The plan is only as good as what survives being
+    // stored and read back, and every cap here was written against a drop mode
+    // someone already found the hard way. Re-parsing the result catches the
+    // ones nobody has found yet — including caps added to the parsers later,
+    // which this will notice without being taught about them.
+    const stored = parseConditionalRules(rules) ?? [];
+    if (stored.length < rules.length) {
+      refuse(
+        `${rules.length - stored.length} of the resulting ${rules.length} rules would be dropped when ` +
+          'the sheet is read back. Nothing was applied.'
+      );
+    }
+
+    steps.push({ type: 'setConditionalRules', rules });
+    touchesTabFields = true;
+  }
+
+  if (regionsTouched) {
+    const stored = parseRegions(regions) ?? [];
+    if (stored.length < regions.length) {
+      refuse(
+        `${regions.length - stored.length} of the resulting ${regions.length} regions would be dropped ` +
+          'when the sheet is read back. Nothing was applied.'
+      );
+    }
+
+    steps.push({ type: 'setRegions', regions });
+    touchesTabFields = true;
+  }
+
+  return { steps, rows, touchesTabFields, conditionalFormats: rules, regions };
+}

--- a/packages/lib/src/sheets/format-request.ts
+++ b/packages/lib/src/sheets/format-request.ts
@@ -39,6 +39,18 @@
  *    checks for the cases that survive storage intact and only mean something
  *    else at RENDER time (`anchorProblem`, the palette hue).
  *
+ * A word on why this is STRICTER than the panel, since the two are meant to
+ * agree. They do agree about what a rule IS — the caps, the operators that need
+ * an operand, the fields a format may carry — and those definitions are shared
+ * rather than restated, because an API that accepts a rule the panel would not
+ * offer is a bug in one of them. That shared floor is not a ceiling. Beyond it
+ * this module refuses several things the panel allows, all of the same kind: a
+ * formula that will not parse, a hue the palette lost, an anchor with no value.
+ * A person doing any of those sees the result instantly — the cells do not
+ * change colour, and they try something else. An agent gets a success response
+ * and moves on, and the missing formatting surfaces days later as a dashboard
+ * nobody trusts. The feedback loop is the difference, so the refusals are too.
+ *
  * Pure: no database, no I/O, no clock. The refusals are the contract, and they
  * have to be testable without any of that.
  */

--- a/packages/lib/src/sheets/format-request.ts
+++ b/packages/lib/src/sheets/format-request.ts
@@ -208,6 +208,21 @@ function referencedCells(start: string, end: string): number | null {
  * and moves on, and the missing formatting surfaces days later as a dashboard
  * nobody trusts. The feedback loop is the difference, so the refusals are too.
  *
+ * One consequence of "never a silent no-op" that a caller has to know before it
+ * retries anything. Most ops are idempotent — planning `setCellFormat`,
+ * `setFrozen`, `updateConditionalRule`, `clearConditionalRules`, `setRegions` or
+ * `upsertRegion` against a tab where they already landed produces the same plan
+ * again. Four are not: `addConditionalRule`, `removeConditionalRule`,
+ * `moveConditionalRule` and `removeRegion` refuse the second time, because the
+ * second time they genuinely are being asked for something that is not true of
+ * the sheet.
+ *
+ * That is deliberate rather than an oversight, and it is not hostile to a
+ * retry: the refusal says which, so a caller replaying a request after an I/O
+ * failure can read "A rule \"x\" is already on this sheet" as "the first
+ * attempt landed" rather than as a fault. What it must not do is treat those
+ * four as safe to replay blindly.
+ *
  * Pure: no database, no I/O, no clock. The refusals are the contract, and they
  * have to be testable without any of that.
  */

--- a/packages/lib/src/sheets/format-request.ts
+++ b/packages/lib/src/sheets/format-request.ts
@@ -216,16 +216,26 @@ function referencedCells(start: string, end: string): number | null {
  * retries anything. Most ops are idempotent — planning `setCellFormat`,
  * `setFrozen`, `updateConditionalRule`, `clearConditionalRules`, `setRegions` or
  * `upsertRegion` against a tab where they already landed produces the same plan
- * again. Four are not: `addConditionalRule`, `removeConditionalRule`,
- * `moveConditionalRule` and `removeRegion` refuse the second time, because the
- * second time they genuinely are being asked for something that is not true of
- * the sheet.
+ * again. Three are not: `addConditionalRule`, `removeConditionalRule` and
+ * `removeRegion` refuse the second time, because the second time they genuinely
+ * are being asked for something that is not true of the sheet.
  *
  * That is deliberate rather than an oversight, and it is not hostile to a
  * retry: the refusal says which, so a caller replaying a request after an I/O
  * failure can read "A rule \"x\" is already on this sheet" as "the first
- * attempt landed" rather than as a fault. What it must not do is treat those
- * four as safe to replay blindly.
+ * attempt landed" rather than as a fault.
+ *
+ * `moveConditionalRule` is the one to actually worry about, and it is worse
+ * than either group. A move that landed leaves nothing behind that says so, so
+ * replaying it moves the rule ANOTHER place — silently, and reported as
+ * success. The refusal only arrives when the first move happened to reach an
+ * end ("already first", "already last"), which is a boundary accident and not
+ * a contract. Nothing here can fix that: an op that says "one place earlier"
+ * has no way to tell a fresh request from a repeat, and the position it should
+ * land on is not in the op. **A caller must not replay a move blindly.** Send
+ * the ordering it wants — `setRegions` for regions, or a move whose result is
+ * checked against a rule list read back — rather than a relative nudge it
+ * cannot make safe.
  *
  * The shape a caller is meant to use, since the ordering is the whole point:
  *

--- a/packages/lib/src/sheets/format-request.ts
+++ b/packages/lib/src/sheets/format-request.ts
@@ -527,6 +527,14 @@ function validateRuleInput(
   // `parseCellFormat` carries an unknown field THROUGH untouched — nothing is
   // lost, so nothing would be flagged, and a typo like `bolt` would be stored
   // as an inert field that formats nothing.
+  //
+  // Which is why an unknown field is refused inside a `format` and accepted at
+  // the top of a rule, an asymmetry worth stating: a format has an
+  // authoritative list of known fields to measure a typo against, and `bolt`
+  // for `bold` is a near miss an agent will really make. A rule's own shape has
+  // no such list — it is a union of four kinds the parser deliberately spreads
+  // over — so there is nothing to be confident a stray field is a mistake
+  // against. The line is drawn where the certainty is.
   if (supplied.format !== undefined) {
     validateCellFormatPatch(supplied.format, index, type, 'rule format');
   }
@@ -683,12 +691,11 @@ export function planFormatOps(
 
     switch (op.type) {
       case 'setCellFormat': {
-        const addresses = resolveRange(op.range, index, op.type);
-        steps.push({
-          type: 'setCellFormat',
-          addresses,
-          patch: validateCellFormatPatch(op.patch, index, op.type),
-        });
+        // Patch first: it is a handful of key lookups, while resolving the
+        // range expands up to `MAX_FORMAT_CELLS` addresses. A request that was
+        // always going to be refused for a typo should not pay for that.
+        const patch = validateCellFormatPatch(op.patch, index, op.type);
+        steps.push({ type: 'setCellFormat', addresses: resolveRange(op.range, index, op.type), patch });
         break;
       }
 

--- a/packages/lib/src/sheets/format-request.ts
+++ b/packages/lib/src/sheets/format-request.ts
@@ -592,6 +592,10 @@ function validateRegionInput(raw: unknown, index: number, type: string, label: s
   return region;
 }
 
+/** The id an op names, which must be there to name anything at all. */
+const requireId = (id: unknown, index: number, type: string): string =>
+  typeof id === 'string' && id !== '' ? id : refuseOp(index, type, 'id must be a non-empty string.');
+
 const ruleIdList = (rules: readonly ConditionalRule[]): string =>
   rules.length === 0 ? 'none' : rules.map((rule) => `"${rule.id}"`).join(', ');
 
@@ -666,13 +670,6 @@ export function planFormatOps(
     for (let row = span.rowStart; row <= span.rowEnd; row++) rows.add(row);
 
     return addressesOfRange(range, MAX_FORMAT_CELLS);
-  };
-
-  const requireId = (id: unknown, index: number, type: string): string => {
-    if (typeof id !== 'string' || id === '') {
-      return refuseOp(index, type, 'id must be a non-empty string.');
-    }
-    return id;
   };
 
   ops.forEach((op, index) => {
@@ -886,6 +883,10 @@ export function planFormatOps(
       }
 
       case 'clearConditionalRules': {
+        // Allowed on a sheet that already has none, unlike removing an id that
+        // is not there. The difference is what the caller asserted: a clear
+        // names no target and so cannot be wrong about one, while a remove
+        // names an id and is telling us something false about the sheet.
         rules = [];
         rulesTouched = true;
         break;

--- a/packages/lib/src/sheets/format-request.ts
+++ b/packages/lib/src/sheets/format-request.ts
@@ -1,4 +1,83 @@
 /**
+ * What a parsed formula would do wrong at evaluation time, or null.
+ *
+ * Parsing proves the grammar and nothing else, so three things are checked
+ * against the engine that will run it:
+ *
+ *  - a function name it does not implement — `evaluateFunction` throws once per
+ *    covered cell and formats none of them;
+ *  - a call with the wrong number of arguments, which fails exactly the same
+ *    way for exactly as little;
+ *  - a range large enough to take the process down. This one is not a silent
+ *    no-op but a hang: `evaluation.ts` hands every `Range` to `expandRange`,
+ *    which has no cap of any kind — it is two nested loops over the whole
+ *    rectangle. `=SUM(A1:ZZZ5000000)>0` asks it to materialise about ninety-one
+ *    billion addresses, and the rule needs to cover only one cell to get there.
+ *    Bounded by the same `MAX_CONDITIONAL_RANGE_CELLS` a rule's own ranges obey.
+ *
+ * Iterative rather than recursive: the input is a caller-supplied formula, and
+ * a walk whose depth follows it is a stack overflow escaping as a 500. (The
+ * parser would usually blow up first and be caught above, but "usually" is not
+ * a bound.)
+ */
+function formulaProblem(root: ASTNode): string | null {
+  const stack: ASTNode[] = [root];
+
+  while (stack.length > 0) {
+    const node = stack.pop() as ASTNode;
+
+    switch (node.type) {
+      case 'FunctionCall': {
+        const name = node.name.toUpperCase();
+        if (!isSupportedFunction(name)) {
+          return `calls ${name}(), which this sheet does not implement`;
+        }
+        if (!isValidCall(name, node.args.length)) {
+          return `calls ${name}() with ${node.args.length} argument(s), which it does not accept`;
+        }
+        for (const argument of node.args) stack.push(argument);
+        break;
+      }
+
+      case 'Range':
+      case 'ExternalRange': {
+        const cells = referencedCells(node.start.reference, node.end.reference);
+        if (cells === null) {
+          return `refers to ${node.start.reference}:${node.end.reference}, which is not a range this sheet can address`;
+        }
+        if (cells > MAX_CONDITIONAL_RANGE_CELLS) {
+          return (
+            `refers to ${node.start.reference}:${node.end.reference}, ${cells.toLocaleString()} cells. ` +
+            `Evaluating it expands every one of them, per covered cell, with no ceiling — the limit is ` +
+            `${MAX_CONDITIONAL_RANGE_CELLS.toLocaleString()}`
+          );
+        }
+        break;
+      }
+
+      case 'UnaryExpression':
+        stack.push(node.argument);
+        break;
+
+      case 'BinaryExpression':
+        stack.push(node.left, node.right);
+        break;
+
+      default:
+        break;
+    }
+  }
+
+  return null;
+}
+
+/** Cells in a formula's range, or null when it is not addressable. */
+function referencedCells(start: string, end: string): number | null {
+  const span = parseRangeSpan(`${start}:${end}`);
+  return span === null ? null : cellsInSpan(span);
+}
+
+/**
  * @module @pagespace/lib/sheets/format-request
  * @description The refusal boundary for presentation writes that did not come
  * from the toolbar.
@@ -91,14 +170,20 @@ import {
   type ConditionalRule,
 } from './conditional';
 import { validateRanges } from './conditional-ops';
-import { CELL_FORMAT_FIELDS, cellFormatSchema, isValidHexColor } from './format';
+import {
+  CELL_FORMAT_FIELDS,
+  applyNumberFormat,
+  cellFormatSchema,
+  isValidHexColor,
+  numberFormatToExcelCode,
+} from './format';
 import {
   MAX_COLUMN_WIDTH,
   MAX_ROW_HEIGHT,
   MIN_COLUMN_WIDTH,
   MIN_ROW_HEIGHT,
 } from './format-ops';
-import { isSupportedFunction } from './functions';
+import { isSupportedFunction, isValidCall } from './functions';
 import { PALETTE } from './palette';
 import { columnRoleFormat } from './region-format';
 import { FormulaParser, tokenize } from './parser';
@@ -110,7 +195,7 @@ import {
   type RegionColumn,
   type SheetRegion,
 } from './regions';
-import type { ASTNode, CellFormat } from './types';
+import type { ASTNode, CellFormat, NumberFormat } from './types';
 
 /**
  * A caller-supplied op that cannot be applied.
@@ -401,6 +486,28 @@ function validateCellFormatPatch(
   // caller's object against what zod made of it catches that at any depth —
   // and leaves the top-level `undefined` clearing alone, since a raw undefined
   // is never a loss.
+  // Cross-field: each number-format setting is valid on its own, and the kind
+  // decides whether it is read at all.
+  const number = (patch as { number?: NumberFormat }).number;
+  if (number && typeof number.kind === 'string') {
+    for (const [field, a, b] of [
+      ['currency', 'AAA', 'BBB'],
+      ['dateStyle', 'short', 'long'],
+      ['decimals', 1, 4],
+      ['thousands', true, false],
+      ['pattern', 'a', 'b'],
+    ] as const) {
+      if (number[field] === undefined) continue;
+      if (!ignoredNumberFormatField(number, field, a, b)) continue;
+      return refuseOp(
+        index,
+        type,
+        `${label}.number.${field} is not read by a "${number.kind}" format, so it would be stored and ` +
+          'never rendered.'
+      );
+    }
+  }
+
   const nested = sanitizedPathOrRefuse(patch, result.data, index, type, label);
   if (nested) {
     return refuseOp(
@@ -679,42 +786,15 @@ const anchorProblem = (anchor: unknown, needsColor: boolean): string | null => {
     if (anchor.type !== 'number' && (anchor.value < 0 || anchor.value > 100)) {
       return `of type ${anchor.type} needs a value from 0 to 100, not ${anchor.value}`;
     }
+  } else if (anchor.value !== undefined) {
+    // The other direction of the same mistake: `min` and `max` read the data's
+    // own extremes and `anchorValue` never looks at a value, so one supplied
+    // here is stored and silently replaced by whatever the data happens to hold.
+    return `of type ${anchor.type} reads the data's own extreme, so it cannot take a value of ${String(anchor.value)}`;
   }
 
   return null;
 };
-
-/**
- * The first function in a parsed formula that this build does not implement.
- *
- * Iterative rather than recursive: the input is a caller-supplied formula, and
- * a walk whose depth follows it is a stack overflow escaping as a 500. (The
- * parser would usually blow up first and be caught above, but "usually" is not
- * a bound.)
- */
-function firstUnsupportedFunction(root: ASTNode): string | null {
-  const stack: ASTNode[] = [root];
-
-  while (stack.length > 0) {
-    const node = stack.pop() as ASTNode;
-    switch (node.type) {
-      case 'FunctionCall':
-        if (!isSupportedFunction(node.name)) return node.name.toUpperCase();
-        for (const argument of node.args) stack.push(argument);
-        break;
-      case 'UnaryExpression':
-        stack.push(node.argument);
-        break;
-      case 'BinaryExpression':
-        stack.push(node.left, node.right);
-        break;
-      default:
-        break;
-    }
-  }
-
-  return null;
-}
 
 /**
  * Why a rule that stores faithfully would still not do what was asked, or null
@@ -733,6 +813,23 @@ function ruleRenderProblem(rule: ConditionalRule): string | null {
   // `greaterThan` with no value matches NO cell, and a `notContains` with no
   // value matches EVERY non-error one. Which set of operators needs a value is
   // the panel's answer, now shared rather than restated.
+  if (rule.kind === 'cell') {
+    const { operator, value, value2 } = rule.condition;
+
+    // An operand the operator never reads. `matchesCondition` looks at
+    // `condition.value` only for the operators that compare against something,
+    // and at `value2` only for the two range operators — so `isEmpty` with a
+    // value, or `greaterThan` with a second bound, is part of the caller's
+    // instruction stored and thrown away. Neither shape is reachable through
+    // the panel, which hides the fields it does not use.
+    if (VALUELESS_OPERATORS.has(operator) && (value !== undefined || value2 !== undefined)) {
+      return `A "${operator}" rule compares against nothing, so it cannot take a value.`;
+    }
+    if (!RANGE_OPERATORS.has(operator) && value2 !== undefined) {
+      return `Only a between/notBetween rule has a second bound; "${operator}" ignores value2.`;
+    }
+  }
+
   if (rule.kind === 'cell' && !VALUELESS_OPERATORS.has(rule.condition.operator)) {
     const { operator, value, value2 } = rule.condition;
     if (typeof value !== 'string' || value.trim() === '') {
@@ -784,17 +881,10 @@ function ruleRenderProblem(rule: ConditionalRule): string | null {
       );
     }
 
-    // Parsing proves the grammar, not the vocabulary: `FormulaParser` accepts
-    // any identifier followed by parentheses, and `evaluateFunction` then
-    // throws for a name it does not implement — once per covered cell, with the
-    // same nothing to show for it.
-    const unsupported = firstUnsupportedFunction(ast);
-    if (unsupported) {
-      return (
-        `"${rule.formula}" calls ${unsupported}(), which this sheet does not implement. Stored as ` +
-        'written it throws once per covered cell and formats none of them.'
-      );
-    }
+    // Parsing proves the grammar and nothing else — see `formulaProblem` for
+    // the three things the engine will object to that a parse cannot see.
+    const problem = formulaProblem(ast);
+    if (problem) return `"${rule.formula}" ${problem}.`;
   }
 
   // Anchors, which the comparator cannot speak for — see `anchorProblem`.
@@ -929,6 +1019,45 @@ function validateRuleInput(
 }
 
 /**
+ * A number-format setting the chosen `kind` never reads, or null.
+ *
+ * `numberFormatSchema` validates each field on its own, so
+ * `{kind: 'number', dateStyle: 'long'}` and `{kind: 'date', currency: 'EUR'}`
+ * both pass — and `applyNumberFormat` then reads neither, so part of the
+ * requested presentation is stored and has no effect. The toolbar avoids this
+ * by dropping settings that do not apply when the kind changes; a caller has
+ * nothing dropping them.
+ *
+ * Asked of the renderers rather than answered from a table of which kind reads
+ * what: render twice with two different values for the field and see whether
+ * anything moves. Both renderers are consulted, because a field the display
+ * ignores may still reach the exported workbook — `dateStyle` on a `date` kind
+ * is read by one and not the other — and a setting that changes either output
+ * is doing something.
+ *
+ * The probe values cover the shapes `applyNumberFormat` switches on: a number
+ * for the numeric kinds, an ISO timestamp for the date ones, and text.
+ */
+const PROBE_VALUES = [1234.5678, '2026-09-08T13:45:56', 'text'] as const;
+
+function ignoredNumberFormatField(
+  format: NumberFormat,
+  field: 'currency' | 'dateStyle' | 'decimals' | 'thousands' | 'pattern',
+  a: unknown,
+  b: unknown
+): boolean {
+  const render = (value: unknown): string => {
+    const candidate = { ...format, [field]: value } as NumberFormat;
+    return [
+      ...PROBE_VALUES.map((probe) => String(applyNumberFormat(probe, candidate))),
+      String(numberFormatToExcelCode(candidate)),
+    ].join('\u0000');
+  };
+
+  return render(a) === render(b);
+}
+
+/**
  * Whether a column setting has any effect on what that column renders, asked of
  * the deriver rather than assumed.
  *
@@ -982,6 +1111,17 @@ function regionRenderProblem(region: SheetRegion, label: string): string | null 
     // part of it. Both store cleanly and render as something else.
     const headerRows = region.headerRows ?? 1;
     const firstBodyRow = bounds.rowStart + headerRows;
+
+    // A closed region whose header band fills it has no body at all — the
+    // resolver treats every covered row as a header and `continue`s before it
+    // consults the column map. Column roles declared on it can never render,
+    // and unlike an open region it cannot grow into a body later.
+    if (bounds.rowEnd !== null && firstBodyRow > bounds.rowEnd && (region.columns?.length ?? 0) > 0) {
+      return (
+        `${label}: ${region.range} is ${bounds.rowEnd - bounds.rowStart + 1} row(s) tall and all of ` +
+        `them are headers, so it has no body for a column role to apply to.`
+      );
+    }
 
     for (const row of region.totalRows ?? []) {
       if (row - 1 < firstBodyRow) {

--- a/packages/lib/src/sheets/format-request.ts
+++ b/packages/lib/src/sheets/format-request.ts
@@ -71,6 +71,10 @@ function formulaProblem(root: ASTNode, coveredCells: number): string | null {
         // function in the dispatch has an arity anywhere near sixteen, so
         // anything above it is rejected or accepted for the same reason a
         // million would be.
+        // An unaddressable range counts as ONE, which makes `flattened` equal
+        // `args.length` and steps this check aside — so the Range case below
+        // reports what is actually wrong with `ABS(A1:ZZZZ5)` instead of
+        // complaining about arity for a reference that does not resolve.
         const flattened = node.args.reduce((count, argument) => {
           if (argument.type !== 'Range' && argument.type !== 'ExternalRange') return count + 1;
           return count + (referencedCells(argument.start.reference, argument.end.reference) ?? 1);

--- a/packages/lib/src/sheets/format-request.ts
+++ b/packages/lib/src/sheets/format-request.ts
@@ -1482,6 +1482,77 @@ const regionIdList = (regions: readonly SheetRegion[]): string =>
   regions.length === 0 ? 'none' : regions.map((region) => `"${region.id}"`).join(', ');
 
 /**
+ * The checks a finished rule list must pass before it is worth writing.
+ *
+ * Separate from the op loop because they are a different kind of question:
+ * every check in that loop is about one op, and every check here is about the
+ * list those ops produced. Two of them compare against the list as it WAS,
+ * because a sheet can already be past a limit and the writes that would reduce
+ * it must not be the ones refused.
+ */
+function assertRuleListIsStorable(
+  rules: readonly ConditionalRule[],
+  before: readonly ConditionalRule[]
+): void {
+  const totalCells = (list: readonly ConditionalRule[]): number => {
+    let cells = 0;
+    for (const rule of list) {
+      for (const range of rule.ranges) cells += conditionalCellsOfRange(range);
+    }
+    return cells;
+  };
+
+  // Formula work summed across the whole list, not just the rule being written.
+  // The per-rule ceiling bounds one rule and says nothing about two hundred of
+  // them, each legal, together asking for billions of expansions in one render.
+  const workBefore = formulaWork(before);
+  const workAfter = formulaWork(rules);
+  if (workAfter > MAX_FORMULA_EXPANSION && workAfter > workBefore) {
+    refuse(
+      `Those rules ask for ${workAfter.toLocaleString()} address expansions to render once, over the ` +
+        `limit of ${MAX_FORMULA_EXPANSION.toLocaleString()}. A formula rule costs the cells it covers ` +
+        'times the cells it references, and they add up across rules. (A write that lowers the total ' +
+        'is accepted even while it is still over.)'
+    );
+  }
+
+  // `expandRangesWithinBudget` spends `MAX_CONDITIONAL_TOTAL_CELLS` and then
+  // BREAKS, silently: past the budget, rules simply stop being applied at
+  // render time.
+  const cellsAfter = totalCells(rules);
+  if (cellsAfter > MAX_CONDITIONAL_TOTAL_CELLS && cellsAfter > totalCells(before)) {
+    refuse(
+      `Those rules cover ${cellsAfter.toLocaleString()} cells in total, over the sheet-wide limit of ` +
+        `${MAX_CONDITIONAL_TOTAL_CELLS.toLocaleString()}. Rules past the limit are silently skipped when ` +
+        'the sheet renders, so narrow the ranges rather than adding more. (A write that lowers the ' +
+        'total is accepted even while it is still over.)'
+    );
+  }
+
+  // The round-trip detector. Every cap here was written against a drop mode
+  // someone found the hard way; re-parsing the result catches the ones nobody
+  // has found yet, including caps added to the parsers later.
+  const stored = parseConditionalRules(rules) ?? [];
+  if (stored.length < rules.length) {
+    refuse(
+      `${rules.length - stored.length} of the resulting ${rules.length} rules would be dropped when ` +
+        'the sheet is read back. Nothing was applied.'
+    );
+  }
+}
+
+/** The same, for regions: only the round trip, since regions cost no render work. */
+function assertRegionListIsStorable(regions: readonly SheetRegion[]): void {
+  const stored = parseRegions(regions) ?? [];
+  if (stored.length < regions.length) {
+    refuse(
+      `${regions.length - stored.length} of the resulting ${regions.length} regions would be dropped ` +
+        'when the sheet is read back. Nothing was applied.'
+    );
+  }
+}
+
+/**
  * Validate a whole format request against the tab as it stands, and describe
  * the write it would perform.
  *
@@ -1858,84 +1929,13 @@ export function planFormatOps(
   });
 
   if (rulesTouched) {
-    // The aggregate ceiling `MAX_CONDITIONAL_TOTAL_CELLS` is spent by
-    // `expandRangesWithinBudget` and then *broken out of*, silently: rules past
-    // the budget simply stop contributing at render time. Individually legal
-    // rules can sum past it, so a write that would land there is refused while
-    // there is still someone to tell.
-    const totalCells = (list: readonly ConditionalRule[]): number => {
-      let cells = 0;
-      for (const rule of list) {
-        for (const range of rule.ranges) cells += conditionalCellsOfRange(range);
-      }
-      return cells;
-    };
-
-    const before = totalCells(tab.conditionalFormats ?? []);
-    const after = totalCells(rules);
-
-    // Formula work summed across the whole rule list, not just the one being
-    // written. The per-rule ceiling bounds one rule at twenty million and says
-    // nothing about two hundred of them — each legal, each covering 10,000
-    // cells and referencing 2,000, with the covered-cell aggregate satisfied
-    // and four billion expansions in one render. Same shape as every other
-    // per-op bound on this branch, and the same fix.
-    //
-    // Carries the repair exception for the same reason the cell aggregate does:
-    // a sheet can already be past this, and refusing the writes that would
-    // reduce it is how a sheet becomes unfixable.
-    const formulaWorkBefore = formulaWork(tab.conditionalFormats ?? []);
-    const formulaWorkAfter = formulaWork(rules);
-    if (formulaWorkAfter > MAX_FORMULA_EXPANSION && formulaWorkAfter > formulaWorkBefore) {
-      refuse(
-        `Those rules ask for ${formulaWorkAfter.toLocaleString()} address expansions to render once, ` +
-          `over the limit of ${MAX_FORMULA_EXPANSION.toLocaleString()}. A formula rule costs the cells ` +
-          'it covers times the cells it references, and they add up across rules. (A write that ' +
-          'lowers the total is accepted even while it is still over.)'
-      );
-    }
-
-    // Over the ceiling AND worse than it was. A sheet can already be past this
-    // limit — the panel's `addRule` enforces the per-rule and rule-count caps
-    // but not the aggregate — and refusing every write on such a sheet would
-    // leave it unrepairable: removing a rule from it reduces the skipped render
-    // work and would still have been rejected for not fixing everything at
-    // once. A write that does not make matters worse is always allowed.
-    if (after > MAX_CONDITIONAL_TOTAL_CELLS && after > before) {
-      refuse(
-        `Those rules cover ${after.toLocaleString()} cells in total, over the sheet-wide limit of ` +
-          `${MAX_CONDITIONAL_TOTAL_CELLS.toLocaleString()}. Rules past the limit are silently skipped when ` +
-          'the sheet renders, so narrow the ranges rather than adding more. (A write that lowers the ' +
-          'total is accepted even while it is still over.)'
-      );
-    }
-
-    // Round-trip detector. The plan is only as good as what survives being
-    // stored and read back, and every cap here was written against a drop mode
-    // someone already found the hard way. Re-parsing the result catches the
-    // ones nobody has found yet — including caps added to the parsers later,
-    // which this will notice without being taught about them.
-    const stored = parseConditionalRules(rules) ?? [];
-    if (stored.length < rules.length) {
-      refuse(
-        `${rules.length - stored.length} of the resulting ${rules.length} rules would be dropped when ` +
-          'the sheet is read back. Nothing was applied.'
-      );
-    }
-
+    assertRuleListIsStorable(rules, tab.conditionalFormats ?? []);
     steps.push({ type: 'setConditionalRules', rules });
     touchesTabFields = true;
   }
 
   if (regionsTouched) {
-    const stored = parseRegions(regions) ?? [];
-    if (stored.length < regions.length) {
-      refuse(
-        `${regions.length - stored.length} of the resulting ${regions.length} regions would be dropped ` +
-          'when the sheet is read back. Nothing was applied.'
-      );
-    }
-
+    assertRegionListIsStorable(regions);
     steps.push({ type: 'setRegions', regions });
     touchesTabFields = true;
   }

--- a/packages/lib/src/sheets/format-request.ts
+++ b/packages/lib/src/sheets/format-request.ts
@@ -291,27 +291,32 @@ function conditionalCellsOfRange(range: string): number {
  * `bolt` a formatting request that quietly does nothing. Those are checked
  * first, by hand.
  */
-function validateCellFormatPatch(patch: unknown, index: number, type: string): CellFormat {
+function validateCellFormatPatch(
+  patch: unknown,
+  index: number,
+  type: string,
+  label = 'patch'
+): CellFormat {
   if (!isObject(patch)) {
-    return refuseOp(index, type, 'patch must be an object of format fields.');
+    return refuseOp(index, type, `${label} must be an object of format fields.`);
   }
 
   const keys = Object.keys(patch);
   if (keys.length === 0) {
     // Applying this would succeed and change nothing, which is the failure mode
     // hardest to notice from the outside.
-    return refuseOp(index, type, 'patch has no fields; name at least one, such as {"bold": true}.');
+    return refuseOp(index, type, `${label} has no fields; name at least one, such as {"bold": true}.`);
   }
 
   for (const key of keys) {
     if (FORBIDDEN_KEYS.has(key)) {
-      return refuseOp(index, type, `"${key}" is not a format field.`);
+      return refuseOp(index, type, `${label}: "${key}" is not a format field.`);
     }
     if (!CELL_FORMAT_FIELDS.has(key)) {
       return refuseOp(
         index,
         type,
-        `"${key}" is not a format field. Known fields: ${[...CELL_FORMAT_FIELDS].join(', ')}.`
+        `${label}: "${key}" is not a format field. Known fields: ${[...CELL_FORMAT_FIELDS].join(', ')}.`
       );
     }
   }
@@ -322,7 +327,7 @@ function validateCellFormatPatch(patch: unknown, index: number, type: string): C
     // Rooted at `patch` unconditionally: the path is never empty here — the
     // object and key checks above have already run — and a conditional root
     // would be a branch no input can take.
-    return refuseOp(index, type, `${['patch', ...issue.path].join('.')}: ${issue.message}`);
+    return refuseOp(index, type, `${[label, ...issue.path].join('.')}: ${issue.message}`);
   }
 
   // Deliberately `patch`, never `result.data`. See above.
@@ -403,6 +408,163 @@ function validateFreeze(
   }
 
   return value;
+}
+
+/**
+ * A stable string for a value, with the normalizations the parsers are allowed
+ * to perform already applied: whitespace and case on strings, key order on
+ * objects, and absent-vs-undefined.
+ */
+function canonical(value: unknown): string {
+  if (typeof value === 'string') return JSON.stringify(value.trim().toLowerCase());
+  if (Array.isArray(value)) return `[${value.map(canonical).join(',')}]`;
+  if (isObject(value)) {
+    const entries = Object.keys(value)
+      .filter((key) => value[key] !== undefined)
+      .sort()
+      .map((key) => `${JSON.stringify(key)}:${canonical(value[key])}`);
+    return `{${entries.join(',')}}`;
+  }
+  return JSON.stringify(value ?? null);
+}
+
+/**
+ * The first path at which the parser altered or dropped something the caller
+ * supplied, or null when everything survived.
+ *
+ * This is the same argument as the round-trip detector, one level down.
+ * `parseConditionalRule` and `parseRegion` are LOAD-path parsers: they sanitize
+ * field by field so that one bad setting cannot cost a user the rest of a
+ * stored document. Reused as-is on the write path, that generosity becomes a
+ * lie — `format: {bold: true, fontSize: 5}` stores the bold, drops the size and
+ * reports success; `ranges` past `MAX_CONDITIONAL_RANGES_PER_RULE` is truncated
+ * to the cap and the caps that would have refused it then see a rule that fits;
+ * `headerRows: 999` silently becomes the default of one.
+ *
+ * Rather than restate every one of those rules here — a second copy of the
+ * parsers, free to drift from them — the parser stays the specification and
+ * this asks the only question that matters: is what we are about to store still
+ * what was asked for? Anything the parsers learn to sanitize later is covered
+ * without being taught.
+ *
+ * What it must NOT flag is a genuine normalization, so strings compare
+ * case- and whitespace-insensitively (a range is upper-cased, a colour
+ * lower-cased, a currency code upper-cased) and lists compare as multisets
+ * (`totalRows` comes back sorted). A shorter list is always a loss, which is
+ * what catches a truncated `ranges` array and a dropped column declaration.
+ */
+function firstSanitizedPath(raw: unknown, stored: unknown, path: string): string | null {
+  // Absent and explicitly-undefined are the same thing over the wire, and JSON
+  // cannot express the difference.
+  if (raw === undefined) return null;
+
+  if (Array.isArray(raw) || Array.isArray(stored)) {
+    if (!Array.isArray(raw) || !Array.isArray(stored)) return path;
+    const left = raw.map(canonical).sort();
+    const right = stored.map(canonical).sort();
+    // No separate length check: a list that comes back SHORTER shows up as a
+    // mismatch at the first position the parser dropped, and one that comes
+    // back longer is the parser filling something in, which is not a loss.
+    return left.every((entry, position) => entry === right[position]) ? null : path;
+  }
+
+  if (isObject(raw)) {
+    if (!isObject(stored)) return path;
+    for (const key of Object.keys(raw)) {
+      const found = firstSanitizedPath(raw[key], stored[key], path === '' ? key : `${path}.${key}`);
+      if (found) return found;
+    }
+    // A field the parser ADDS is not a loss — a default filled in is still the
+    // request being honoured.
+    return null;
+  }
+
+  return canonical(raw) === canonical(stored) ? null : path;
+}
+
+/**
+ * Parse a caller-supplied rule, refusing anything the parser would quietly
+ * rewrite on the way in.
+ *
+ * Order matters here and is the whole point: `validateRanges` runs against the
+ * caller's own `ranges`, before `parseConditionalRule` has had a chance to
+ * slice the array down to `MAX_CONDITIONAL_RANGES_PER_RULE`. Run afterwards it
+ * would be handed the truncated list, pronounce it fine, and the ranges past
+ * the cap would be gone with no refusal anywhere.
+ */
+function validateRuleInput(raw: unknown, index: number, type: string): ConditionalRule {
+  if (!isObject(raw)) {
+    return refuseOp(index, type, 'rule must be an object.');
+  }
+
+  if (raw.ranges !== undefined) {
+    if (!Array.isArray(raw.ranges) || raw.ranges.some((entry) => typeof entry !== 'string')) {
+      return refuseOp(index, type, 'ranges must be an array of A1 ranges, such as ["B2:B20"].');
+    }
+    // The caller's array, at its real length.
+    const ranges = validateRanges(raw.ranges as string[]);
+    if (!ranges.ok) return refuseOp(index, type, ranges.reason);
+  }
+
+  // Checked explicitly rather than left to the comparator below because
+  // `parseCellFormat` carries an unknown field THROUGH untouched — nothing is
+  // lost, so nothing would be flagged, and a typo like `bolt` would be stored
+  // as an inert field that formats nothing.
+  if (raw.format !== undefined) {
+    validateCellFormatPatch(raw.format, index, type, 'rule format');
+  }
+
+  const rule = parseConditionalRule(raw);
+  if (!rule) {
+    return refuseOp(
+      index,
+      type,
+      'That is not a rule this sheet can store. A rule needs an id, at least one range, and a ' +
+        'kind of cell, formula, colorScale or dataBar — a formula rule needs a non-empty formula, ' +
+        'and a cell rule a format with at least one valid field.'
+    );
+  }
+
+  const sanitized = firstSanitizedPath(raw, rule, '');
+  if (sanitized) {
+    return refuseOp(
+      index,
+      type,
+      `"${sanitized}" is not something this sheet can store, and would be dropped or changed on the ` +
+        'way in. Nothing about a stored rule may differ from what was asked for.'
+    );
+  }
+
+  return rule;
+}
+
+/** The same contract as {@link validateRuleInput}, for a declared region. */
+function validateRegionInput(raw: unknown, index: number, type: string, label: string): SheetRegion {
+  const region = parseRegion(raw);
+  if (!region) {
+    return refuseOp(
+      index,
+      type,
+      `${label} is not a region this sheet can store. A region needs an id and a range such as ` +
+        '"A1:F" (an omitted row end means "to the end of the sheet").'
+    );
+  }
+
+  const sanitized = firstSanitizedPath(raw, region, '');
+  if (sanitized) {
+    // `parseRegion` drops a bad optional setting and keeps the region, so
+    // `headerRows: 999` becomes the default of one and an unusable column
+    // declaration disappears — in both cases the sheet stores something the
+    // caller did not ask for and hears that it worked.
+    return refuseOp(
+      index,
+      type,
+      `${label}: "${sanitized}" is not something this sheet can store, and would be dropped or ` +
+        'changed on the way in.'
+    );
+  }
+
+  return region;
 }
 
 const ruleIdList = (rules: readonly ConditionalRule[]): string =>
@@ -546,8 +708,12 @@ export function planFormatOps(
 
       case 'setRowHeight': {
         const row = op.row;
-        // 1-based on the wire, as everywhere a row is named in A1 terms.
-        if (typeof row !== 'number' || !Number.isInteger(row) || row < 1 || row > MAX_ADDRESSABLE_ROW) {
+        // 1-based on the wire, as everywhere a row is named in A1 terms — so
+        // the bound is `row - 1`, since `MAX_ADDRESSABLE_ROW` is a 0-based
+        // index everywhere it is compared. Comparing `row` to it directly left
+        // the last addressable row able to take a cell format but not a row
+        // height, which is the kind of disagreement no caller can see coming.
+        if (typeof row !== 'number' || !Number.isInteger(row) || row < 1 || row - 1 > MAX_ADDRESSABLE_ROW) {
           refuseOp(index, op.type, `row must be a 1-based row number; got ${String(row)}.`);
         }
         const height = validateExtent(
@@ -584,24 +750,25 @@ export function planFormatOps(
       }
 
       case 'addConditionalRule': {
-        const rule = parseConditionalRule(op.rule);
-        if (!rule) {
-          // The parser is the only definition of a usable rule, and it drops
-          // what it cannot use. A blank custom formula is the canonical case:
-          // accepted by a naive writer, gone on the next load.
-          refuseOp(
-            index,
-            op.type,
-            'That is not a rule this sheet can store. A rule needs an id, at least one range, and a ' +
-              'kind of cell, formula, colorScale or dataBar — a formula rule needs a non-empty formula, ' +
-              'and a cell rule a format with at least one valid field.'
-          );
-        }
+        // The parser is the only definition of a usable rule, and on the load
+        // path it drops what it cannot use. A blank custom formula is the
+        // canonical case: accepted by a naive writer, gone on the next load.
+        const rule = validateRuleInput(op.rule, index, op.type);
+
         if (rules.length >= MAX_CONDITIONAL_RULES) {
           refuseOp(index, op.type, `This sheet already has the maximum of ${MAX_CONDITIONAL_RULES} rules.`);
         }
-        const ranges = validateRanges(rule.ranges);
-        if (!ranges.ok) refuseOp(index, op.type, ranges.reason);
+        if (rules.some((existing) => existing.id === rule.id)) {
+          // Two rules under one id: `update` and `move` reach the first by
+          // `findIndex` while `remove` filters out both, so the new rule is no
+          // longer addressable at all. `upsertRegion` refuses the same thing.
+          refuseOp(
+            index,
+            op.type,
+            `A rule "${rule.id}" is already on this sheet. Use updateConditionalRule to change it, ` +
+              'or give the new rule its own id.'
+          );
+        }
 
         rules = [...rules, rule];
         rulesTouched = true;
@@ -619,25 +786,29 @@ export function planFormatOps(
         }
 
         const patch = op.patch as Record<string, unknown>;
-        // A patch that widens the ranges has to clear the same bar as a new
-        // rule, or editing is the way around a limit that adding refuses.
-        if (Array.isArray(patch.ranges)) {
-          const ranges = validateRanges(patch.ranges.filter((r): r is string => typeof r === 'string'));
-          if (!ranges.ok) refuseOp(index, op.type, ranges.reason);
-        }
-
         // `id` and `kind` are identity, not settings — matching `updateRule`,
         // which pins both so a patch cannot silently detach a rule from the row
-        // being edited.
-        const merged = parseConditionalRule({
-          ...rules[at],
-          ...patch,
-          id: rules[at].id,
-          kind: rules[at].kind,
-        });
-        if (!merged) {
-          refuseOp(index, op.type, `That patch leaves rule "${id}" in a state this sheet cannot store.`);
+        // being edited. Which also means a patch naming ONLY those two asks for
+        // nothing: it would be applied, report success and change not one
+        // pixel.
+        const mutable = Object.keys(patch).filter((key) => key !== 'id' && key !== 'kind');
+        if (mutable.length === 0) {
+          refuseOp(
+            index,
+            op.type,
+            'patch changes nothing; id and kind are a rule’s identity and cannot be patched. Name a ' +
+              'field such as ranges, format, formula or condition.'
+          );
         }
+
+        // Validated as a whole rule, so a patch that widens the ranges clears
+        // exactly the same bar a new rule does — otherwise editing is the way
+        // around a limit that adding refuses.
+        const merged = validateRuleInput(
+          { ...rules[at], ...patch, id: rules[at].id, kind: rules[at].kind },
+          index,
+          op.type
+        );
 
         rules = rules.map((rule, position) => (position === at ? merged : rule));
         rulesTouched = true;
@@ -706,15 +877,7 @@ export function planFormatOps(
         const next: SheetRegion[] = [];
         const seen = new Set<string>();
         op.regions.forEach((value: unknown, position: number) => {
-          const region = parseRegion(value);
-          if (!region) {
-            refuseOp(
-              index,
-              op.type,
-              `regions[${position}] is not a region this sheet can store. A region needs an id and a ` +
-                'range such as "A1:F" (an omitted row end means "to the end of the sheet").'
-            );
-          }
+          const region = validateRegionInput(value, index, op.type, `regions[${position}]`);
           if (seen.has(region.id)) {
             // `parseRegions` keeps the first and drops the rest, so a duplicate
             // id is a region silently lost between write and read.
@@ -730,15 +893,7 @@ export function planFormatOps(
       }
 
       case 'upsertRegion': {
-        const region = parseRegion(op.region);
-        if (!region) {
-          refuseOp(
-            index,
-            op.type,
-            'That is not a region this sheet can store. A region needs an id and a range such as ' +
-              '"A1:F" (an omitted row end means "to the end of the sheet").'
-          );
-        }
+        const region = validateRegionInput(op.region, index, op.type, 'region');
 
         const at = regions.findIndex((existing) => existing.id === region.id);
         if (at === -1) {

--- a/packages/lib/src/sheets/format-request.ts
+++ b/packages/lib/src/sheets/format-request.ts
@@ -820,7 +820,7 @@ function ruleRenderProblem(
   // Read from what the CALLER sent, not the merged rule, so a stored stray does
   // not make every later update to that rule impossible.
   if ((rule.kind === 'colorScale' || rule.kind === 'dataBar') && supplied.format !== undefined) {
-    return `a ${rule.kind} rule draws from its anchors, not a format, so the format would never be drawn`;
+    return `A ${rule.kind} rule draws from its anchors, not a format, so the format would never be drawn.`;
   }
 
   // A condition whose operator needs an operand it does not have. The parser
@@ -832,55 +832,53 @@ function ruleRenderProblem(
   if (rule.kind === 'cell') {
     const { operator, value, value2 } = rule.condition;
 
-    // An operand the operator never reads. `matchesCondition` looks at
-    // `condition.value` only for the operators that compare against something,
-    // and at `value2` only for the two range operators — so `isEmpty` with a
-    // value, or `greaterThan` with a second bound, is part of the caller's
-    // instruction stored and thrown away. Neither shape is reachable through
-    // the panel, which hides the fields it does not use.
+    // An operand the operator never reads. `matchesCondition` looks at `value`
+    // only for the operators that compare against something, and at `value2`
+    // only for the two range operators — so `isEmpty` with a value, or
+    // `greaterThan` with a second bound, is part of the caller's instruction
+    // stored and thrown away. Neither shape is reachable through the panel,
+    // which hides the fields it does not use.
     if (VALUELESS_OPERATORS.has(operator) && (value !== undefined || value2 !== undefined)) {
       return `A "${operator}" rule compares against nothing, so it cannot take a value.`;
     }
     if (!RANGE_OPERATORS.has(operator) && value2 !== undefined) {
       return `Only a between/notBetween rule has a second bound; "${operator}" ignores value2.`;
     }
-  }
 
-  if (rule.kind === 'cell' && !VALUELESS_OPERATORS.has(rule.condition.operator)) {
-    const { operator, value, value2 } = rule.condition;
-    if (typeof value !== 'string' || value.trim() === '') {
-      return (
-        `A "${operator}" rule needs a value to compare against. Without one it matches nothing — or, ` +
-        'for a negative operator, everything.'
-      );
-    }
-    if (RANGE_OPERATORS.has(operator) && (typeof value2 !== 'string' || value2.trim() === '')) {
-      return `A "${operator}" rule needs both bounds: value and value2.`;
-    }
+    // And the mirror: an operand the operator needs and does not have. The
+    // parser accepts any recognized operator on its own and the comparator sees
+    // nothing dropped, but `matchesCondition` then compares against nothing —
+    // a `greaterThan` with no value matches NO cell, and a `notContains` with
+    // no value matches EVERY non-error one.
+    if (!VALUELESS_OPERATORS.has(operator)) {
+      if (typeof value !== 'string' || value.trim() === '') {
+        return (
+          `A "${operator}" rule needs a value to compare against. Without one it matches nothing — or, ` +
+          'for a negative operator, everything.'
+        );
+      }
+      if (RANGE_OPERATORS.has(operator) && (typeof value2 !== 'string' || value2.trim() === '')) {
+        return `A "${operator}" rule needs both bounds: value and value2.`;
+      }
 
-    // Present but not a number, for an operator that only compares numbers.
-    // `matchesCondition` coerces the operand and returns false for every cell
-    // once that yields null — the same inert rule as a missing value, reached a
-    // different way. `equal`/`notEqual` are absent from the set on purpose:
-    // they fall back to a text comparison, so `= "done"` is a real rule.
-    if (NUMERIC_OPERATORS.has(operator)) {
-      for (const [field, operand] of [['value', value], ['value2', value2]] as const) {
-        if (operand === undefined) continue;
-        if (asComparableNumber(operand) === null) {
-          return (
-            `A "${operator}" rule compares numbers, and ${field} is "${operand}". It would match no ` +
-            'cell at all.'
-          );
+      // Present, non-blank, and still nothing to compare against: the operand
+      // is coerced and returns null, so the rule is false for every cell it
+      // covers. `equal`/`notEqual` are absent from the set on purpose — they
+      // fall back to a text comparison, so `= "done"` is a real rule.
+      if (NUMERIC_OPERATORS.has(operator)) {
+        for (const [field, operand] of [['value', value], ['value2', value2]] as const) {
+          if (operand === undefined) continue;
+          if (asComparableNumber(operand) === null) {
+            return (
+              `A "${operator}" rule compares numbers, and ${field} is "${operand}". It would match no ` +
+              'cell at all.'
+            );
+          }
         }
       }
     }
   }
 
-  // A formula that does not parse. `parseConditionalRule` asks only that it be
-  // non-blank, and the evaluator then throws while tokenizing it once per
-  // covered cell, catches, and applies nothing — the silent render-time no-op
-  // in its purest form. Checked with the engine's own tokenizer and parser, so
-  // "valid" means the same thing here as where it runs.
   if (rule.kind === 'formula') {
     const body = rule.formula.trim().replace(/^=/, '');
     let ast: ASTNode | null = null;

--- a/packages/lib/src/sheets/format-request.ts
+++ b/packages/lib/src/sheets/format-request.ts
@@ -43,13 +43,14 @@ import {
   MAX_CONDITIONAL_RANGE_CELLS,
   MAX_CONDITIONAL_RULES,
   MAX_CONDITIONAL_TOTAL_CELLS,
+  SCALE_ANCHOR_TYPES,
   addressesOfRange,
   parseConditionalRule,
   parseConditionalRules,
   type ConditionalRule,
 } from './conditional';
 import { validateRanges } from './conditional-ops';
-import { CELL_FORMAT_FIELDS, cellFormatSchema } from './format';
+import { CELL_FORMAT_FIELDS, cellFormatSchema, isValidHexColor } from './format';
 import {
   MAX_COLUMN_WIDTH,
   MAX_ROW_HEIGHT,
@@ -501,6 +502,33 @@ function firstSanitizedPath(raw: unknown, stored: unknown, path: string): string
 }
 
 /**
+ * Why a scale anchor is unusable, in words, or null when it is fine.
+ *
+ * The one class of damage the readback comparator is blind to, because nothing
+ * is dropped: when `readAnchor` cannot read an anchor it returns null, and the
+ * rule builders then keep the caller's original through their `...value`
+ * spread. The anchor is stored EXACTLY as written — and quietly means something
+ * else. `anchorValue` substitutes the data's own minimum or maximum for an
+ * unreadable type, and a `colorScale` whose `mid` has no usable colour renders
+ * nothing at all: `mixColors` returns null for both halves of the gradient, so
+ * every cell in range comes back unpainted. Measured, not assumed — swapping
+ * that one `mid.color` for a valid hex takes the same rule from zero formatted
+ * cells to every cell painted.
+ */
+const anchorProblem = (anchor: unknown, needsColor: boolean): string | null => {
+  if (anchor === undefined) return null;
+
+  if (!isObject(anchor) || typeof anchor.type !== 'string' || !SCALE_ANCHOR_TYPES.has(anchor.type)) {
+    return `needs a type of ${[...SCALE_ANCHOR_TYPES].join(', ')}`;
+  }
+  if (needsColor && !isValidHexColor(anchor.color)) {
+    return 'needs a #rrggbb colour';
+  }
+
+  return null;
+};
+
+/**
  * Parse a caller-supplied rule, refusing anything the parser would quietly
  * rewrite on the way in.
  *
@@ -588,6 +616,33 @@ function validateRuleInput(
       `"${sanitized}" is not something this sheet can store, and would be dropped or changed on the ` +
         'way in. Nothing about a stored rule may differ from what was asked for.'
     );
+  }
+
+  // Anchors, which the comparator cannot speak for — see `anchorProblem`.
+  if (rule.kind === 'colorScale') {
+    for (const [name, value] of [['min', rule.min], ['mid', rule.mid], ['max', rule.max]] as const) {
+      const problem = anchorProblem(value, true);
+      if (problem) {
+        return refuseOp(
+          index,
+          type,
+          `The colorScale's ${name} anchor ${problem}. Stored as written it renders no colour at ` +
+            'all, on any cell in range.'
+        );
+      }
+    }
+  } else if (rule.kind === 'dataBar') {
+    for (const [name, value] of [['min', rule.min], ['max', rule.max]] as const) {
+      const problem = anchorProblem(value, false);
+      if (problem) {
+        return refuseOp(
+          index,
+          type,
+          `The dataBar's ${name} anchor ${problem}. Stored as written it is ignored, and the bars ` +
+            `are scaled to the data's own ${name} instead.`
+        );
+      }
+    }
   }
 
   return rule;

--- a/packages/lib/src/sheets/format-request.ts
+++ b/packages/lib/src/sheets/format-request.ts
@@ -28,6 +28,16 @@
  *    "success" from the underlying setter while changing nothing. To a person
  *    that is a puzzling non-event; to a model it is a signal to move on, and
  *    the missing formatting surfaces much later as a bad dashboard.
+ *  - **Never something OTHER than what was asked for.** The hardest of the
+ *    four, because it does not look like a failure from anywhere. The stored
+ *    parsers sanitize field by field — a too-small font size vanishes from a
+ *    format that keeps its bold, a `ranges` array is truncated to its cap, a
+ *    `headerRows` of 999 becomes the default of one — and the write reports
+ *    success either way. Three mechanisms cover it: `validateRanges` on the
+ *    caller's own array before the parser can shorten it, `firstSanitizedPath`
+ *    comparing what would be stored against what was sent, and a handful of
+ *    checks for the cases that survive storage intact and only mean something
+ *    else at RENDER time (`anchorProblem`, the palette hue).
  *
  * Pure: no database, no I/O, no clock. The refusals are the contract, and they
  * have to be testable without any of that.
@@ -43,7 +53,10 @@ import {
   MAX_CONDITIONAL_RANGE_CELLS,
   MAX_CONDITIONAL_RULES,
   MAX_CONDITIONAL_TOTAL_CELLS,
+  RANGE_OPERATORS,
   SCALE_ANCHOR_TYPES,
+  VALUED_ANCHOR_TYPES,
+  VALUELESS_OPERATORS,
   addressesOfRange,
   parseConditionalRule,
   parseConditionalRules,
@@ -58,7 +71,14 @@ import {
   MIN_ROW_HEIGHT,
 } from './format-ops';
 import { PALETTE } from './palette';
-import { MAX_REGIONS, parseRegion, parseRegions, type SheetRegion } from './regions';
+import { FormulaParser, tokenize } from './parser';
+import {
+  MAX_REGIONS,
+  parseRegion,
+  parseRegionRange,
+  parseRegions,
+  type SheetRegion,
+} from './regions';
 import type { CellFormat } from './types';
 
 /**
@@ -525,6 +545,19 @@ const anchorProblem = (anchor: unknown, needsColor: boolean): string | null => {
     return 'needs a #rrggbb colour';
   }
 
+  // `min` and `max` read the data's own extremes and ignore any value. The
+  // other three ARE their value — and `anchorValue` quietly substitutes an
+  // extreme for a missing one and clamps an out-of-range percent, so both are
+  // stored intact and mean something else.
+  if (VALUED_ANCHOR_TYPES.has(anchor.type)) {
+    if (typeof anchor.value !== 'number' || !Number.isFinite(anchor.value)) {
+      return `of type ${anchor.type} needs a numeric value`;
+    }
+    if (anchor.type !== 'number' && (anchor.value < 0 || anchor.value > 100)) {
+      return `of type ${anchor.type} needs a value from 0 to 100, not ${anchor.value}`;
+    }
+  }
+
   return null;
 };
 
@@ -618,6 +651,54 @@ function validateRuleInput(
     );
   }
 
+  // A condition whose operator needs an operand it does not have. The parser
+  // accepts any recognized operator on its own and the comparator sees nothing
+  // dropped, but `matchesCondition` then compares against nothing: a
+  // `greaterThan` with no value matches NO cell, and a `notContains` with no
+  // value matches EVERY non-error one. Which set of operators needs a value is
+  // the panel's answer, now shared rather than restated.
+  if (rule.kind === 'cell' && !VALUELESS_OPERATORS.has(rule.condition.operator)) {
+    const { operator, value, value2 } = rule.condition;
+    if (typeof value !== 'string' || value.trim() === '') {
+      return refuseOp(
+        index,
+        type,
+        `A "${operator}" rule needs a value to compare against. Without one it matches nothing — or, ` +
+          'for a negative operator, everything.'
+      );
+    }
+    if (RANGE_OPERATORS.has(operator) && (typeof value2 !== 'string' || value2.trim() === '')) {
+      return refuseOp(index, type, `A "${operator}" rule needs both bounds: value and value2.`);
+    }
+  }
+
+  // A formula that does not parse. `parseConditionalRule` asks only that it be
+  // non-blank, and the evaluator then throws while tokenizing it once per
+  // covered cell, catches, and applies nothing — the silent render-time no-op
+  // in its purest form. Checked with the engine's own tokenizer and parser, so
+  // "valid" means the same thing here as where it runs.
+  if (rule.kind === 'formula') {
+    const body = rule.formula.trim().replace(/^=/, '');
+    let parsed = false;
+    try {
+      const tokens = tokenize(body);
+      if (tokens.length > 0) {
+        new FormulaParser(tokens).parse();
+        parsed = true;
+      }
+    } catch {
+      parsed = false;
+    }
+    if (!parsed) {
+      return refuseOp(
+        index,
+        type,
+        `"${rule.formula}" is not a formula this sheet can evaluate. Stored as written it throws once ` +
+          'per covered cell and formats none of them.'
+      );
+    }
+  }
+
   // Anchors, which the comparator cannot speak for — see `anchorProblem`.
   if (rule.kind === 'colorScale') {
     for (const [name, value] of [['min', rule.min], ['mid', rule.mid], ['max', rule.max]] as const) {
@@ -671,6 +752,55 @@ function validateRegionInput(raw: unknown, index: number, type: string, label: s
       type,
       `${label}: "${sanitized}" is not something this sheet can store, and would be dropped or ` +
         'changed on the way in.'
+    );
+  }
+
+  // A declaration that names something outside the region it belongs to.
+  // `createRegionResolver` excludes cells outside the bounds before it consults
+  // either list, so a column or total row beyond them can never render — stored
+  // faithfully, and inert. Cross-field, so the comparator cannot see it: each
+  // value survives on its own.
+  const bounds = parseRegionRange(region.range);
+  if (bounds) {
+    for (const column of region.columns ?? []) {
+      const columnIndex = decodeColumnLabel(column.column);
+      if (columnIndex < bounds.colStart || columnIndex > bounds.colEnd) {
+        return refuseOp(
+          index,
+          type,
+          `${label}: column "${column.column}" is outside the region ${region.range}, so nothing it ` +
+            'declares can ever apply.'
+        );
+      }
+    }
+
+    // Only for a closed range: an open one ("A1:F") reaches the end of the
+    // sheet, so a total row past today's extent is a row the sheet will grow
+    // into — which is the entire point of leaving the end off.
+    if (bounds.rowEnd !== null) {
+      for (const row of region.totalRows ?? []) {
+        if (row - 1 < bounds.rowStart || row - 1 > bounds.rowEnd) {
+          return refuseOp(
+            index,
+            type,
+            `${label}: total row ${row} is outside the region ${region.range}, so it can never render.`
+          );
+        }
+      }
+    }
+  }
+
+  // A setting nothing acts on yet. `freezeHeader` is parsed and stored, and a
+  // repo-wide search finds no consumer: `createRegionResolver` does not read it
+  // and the `setRegions` step only stores the region. Accepting it would be the
+  // module's own contract broken in its own output — a request that succeeds
+  // and pins nothing. `setFrozen` does work today, so the refusal names it.
+  if (region.freezeHeader === true) {
+    return refuseOp(
+      index,
+      type,
+      `${label}: freezeHeader is not applied by anything yet, so setting it would pin no rows. Use a ` +
+        'setFrozen op for now.'
     );
   }
 

--- a/packages/lib/src/sheets/format-request.ts
+++ b/packages/lib/src/sheets/format-request.ts
@@ -668,6 +668,15 @@ function validateFreeze(
  * `SheetFormatError` exists to prevent. Twelve is far past anything the rule
  * and region shapes reach on their own; the deepest is `borders.top.color`, at
  * three.
+ *
+ * Which is also why no test pins this number, or `MAX_COMPARE_VALUES` — halving
+ * either breaks nothing, because there is no legitimate input anywhere near
+ * them to break. That is the honest state of a bound set purely to stop an
+ * attack: the justification lives in this comment, because there is nothing
+ * real to measure it against. The bounds a caller CAN reach are a different
+ * matter, and each is exercised right up against its ceiling by a test —
+ * halving `MAX_FORMAT_OPS`, `MAX_FORMAT_CELLS`, `MAX_FORMAT_CELLS_PER_REQUEST`
+ * or `MAX_FORMULA_EXPANSION` does break something.
  */
 const MAX_COMPARE_DEPTH = 12;
 

--- a/packages/lib/src/sheets/format-request.ts
+++ b/packages/lib/src/sheets/format-request.ts
@@ -1603,6 +1603,28 @@ export function planFormatOps(
     refuse(`A format request can carry at most ${MAX_FORMAT_OPS} ops; got ${ops.length}.`);
   }
 
+  // The tab is trusted differently from the ops, and the difference is worth
+  // being explicit about. Ops arrive as JSON from a caller, so every shape of
+  // garbage in them is a `SheetFormatError` — a 400 the caller can act on. The
+  // tab arrives from the store's own parser, so a non-object sitting in one of
+  // its lists is not a bad request but corrupt storage or a caller that skipped
+  // the parser, and calling that a 400 would blame the wrong party.
+  //
+  // It still must not surface as `null is not an object (evaluating 'rule.id')`
+  // twenty frames deep. Checked here, where the message can name the field.
+  for (const [field, list] of [
+    ['conditionalFormats', tab.conditionalFormats],
+    ['regions', tab.regions],
+  ] as const) {
+    if (list === undefined) continue;
+    if (!Array.isArray(list) || list.some((entry) => !isObject(entry))) {
+      throw new Error(
+        `planFormatOps: tab.${field} must be an array of objects from the store's parser. ` +
+          'This is not a caller error — the tab itself is malformed.'
+      );
+    }
+  }
+
   const steps: PlannedFormatStep[] = [];
   const rows = new Set<number>();
   let touchesTabFields = false;

--- a/packages/lib/src/sheets/format-request.ts
+++ b/packages/lib/src/sheets/format-request.ts
@@ -20,8 +20,9 @@
  * parser would usually blow up first and be caught above, but "usually" is not
  * a bound.)
  */
-function formulaProblem(root: ASTNode): string | null {
+function formulaProblem(root: ASTNode, coveredCells: number): string | null {
   const stack: ASTNode[] = [root];
+  let referenced = 0;
 
   while (stack.length > 0) {
     const node = stack.pop() as ASTNode;
@@ -35,6 +36,23 @@ function formulaProblem(root: ASTNode): string | null {
         if (!isValidCall(name, node.args.length)) {
           return `calls ${name}() with ${node.args.length} argument(s), which it does not accept`;
         }
+
+        // Arity is checked against FLATTENED values, not argument nodes:
+        // `evaluateFunction` does `args.flatMap(flattenValue)` first, so
+        // `ABS(A1:A2)` arrives as two values and throws, once per covered cell.
+        // Whether a function can survive that is derivable rather than listed —
+        // if it would reject one more value than this call supplies, it has a
+        // fixed arity and a range in any slot breaks it.
+        const spreads = node.args.some(
+          (argument) => argument.type === 'Range' || argument.type === 'ExternalRange'
+        );
+        if (spreads && !isValidCall(name, node.args.length + 1)) {
+          return (
+            `passes a range to ${name}(), which takes a fixed number of values — a range arrives as ` +
+            'one value per cell it covers'
+          );
+        }
+
         for (const argument of node.args) stack.push(argument);
         break;
       }
@@ -52,6 +70,7 @@ function formulaProblem(root: ASTNode): string | null {
             `${MAX_CONDITIONAL_RANGE_CELLS.toLocaleString()}`
           );
         }
+        referenced += cells;
         break;
       }
 
@@ -66,6 +85,21 @@ function formulaProblem(root: ASTNode): string | null {
       default:
         break;
     }
+  }
+
+  // The multiplication, which neither cap above can see. A formula rule is
+  // evaluated ONCE PER COVERED CELL, and each evaluation expands every range it
+  // references — so a rule covering 500,000 cells whose formula sums 500,000
+  // more asks for 250 billion address materialisations while clearing both
+  // 500,000-cell checks. Bounded by the same ceiling that bounds conditional
+  // work generally, because that is what this is: work.
+  const work = coveredCells * referenced;
+  if (work > MAX_CONDITIONAL_TOTAL_CELLS) {
+    return (
+      `covers ${coveredCells.toLocaleString()} cells and references ${referenced.toLocaleString()} ` +
+      `per cell, which is ${work.toLocaleString()} expansions to render once — the limit is ` +
+      `${MAX_CONDITIONAL_TOTAL_CELLS.toLocaleString()}`
+    );
   }
 
   return null;
@@ -612,6 +646,16 @@ function validateFreeze(
 const MAX_COMPARE_DEPTH = 12;
 
 /**
+ * How many values the comparison will look at in total, across the whole shape.
+ *
+ * The companion bound to the depth one, and needed for the same reason: an
+ * extension field is preserved verbatim, so it can be a flat array of a million
+ * entries as easily as a chain of a million objects. Ten thousand is orders of
+ * magnitude past any region or rule and still cheap to walk.
+ */
+const MAX_COMPARE_VALUES = 10_000;
+
+/**
  * Whether a value nests deeper than the comparison will follow.
  *
  * Checked BEFORE comparing rather than guarded during it, which is what lets
@@ -619,12 +663,19 @@ const MAX_COMPARE_DEPTH = 12;
  * depth. Iterative, with its own stack: a recursive depth probe on a
  * caller-supplied value is the very stack overflow it exists to prevent.
  */
-function nestsTooDeep(value: unknown): boolean {
+function tooLargeToVerify(value: unknown): string | null {
   const stack: Array<{ value: unknown; depth: number }> = [{ value, depth: 0 }];
+  let seen = 0;
 
   while (stack.length > 0) {
     const current = stack.pop() as { value: unknown; depth: number };
-    if (current.depth > MAX_COMPARE_DEPTH) return true;
+    if (current.depth > MAX_COMPARE_DEPTH) return `nested more than ${MAX_COMPARE_DEPTH} levels deep`;
+
+    // Depth is only half of it. A shallow value can be arbitrarily WIDE, and
+    // the comparison does more than walk it — `firstSanitizedPath` builds and
+    // sorts two canonical arrays out of every list it meets. A million-element
+    // extension array is bounded by neither the depth cap nor anything else.
+    if (++seen > MAX_COMPARE_VALUES) return `made of more than ${MAX_COMPARE_VALUES.toLocaleString()} values`;
 
     if (Array.isArray(current.value)) {
       for (const entry of current.value) stack.push({ value: entry, depth: current.depth + 1 });
@@ -635,7 +686,7 @@ function nestsTooDeep(value: unknown): boolean {
     }
   }
 
-  return false;
+  return null;
 }
 
 /**
@@ -739,12 +790,13 @@ function sanitizedPathOrRefuse(
   type: string,
   label: string
 ): string | null {
-  if (nestsTooDeep(raw)) {
+  const tooLarge = tooLargeToVerify(raw);
+  if (tooLarge) {
     return refuseOp(
       index,
       type,
-      `${label} is nested more than ${MAX_COMPARE_DEPTH} levels deep, which is past what this sheet ` +
-        'will check for silent changes. Flatten it.'
+      `${label} is ${tooLarge}, which is past what this sheet will check for silent changes. ` +
+        'Simplify it.'
     );
   }
 
@@ -773,6 +825,12 @@ const anchorProblem = (anchor: unknown, needsColor: boolean): string | null => {
   }
   if (needsColor && !isValidHexColor(anchor.color)) {
     return 'needs a #rrggbb colour';
+  }
+  if (!needsColor && anchor.color !== undefined) {
+    // The other direction: a data bar takes its colour from `rule.color`, and
+    // the evaluator reads only `type` and `value` off these anchors. A colour
+    // here is validated, stored, and never drawn.
+    return 'takes its colour from the rule, so the anchor cannot carry one';
   }
 
   // `min` and `max` read the data's own extremes and ignore any value. The
@@ -897,7 +955,8 @@ function ruleRenderProblem(
 
     // Parsing proves the grammar and nothing else — see `formulaProblem` for
     // the three things the engine will object to that a parse cannot see.
-    const problem = formulaProblem(ast);
+    const covered = rule.ranges.reduce((cells, range) => cells + conditionalCellsOfRange(range), 0);
+    const problem = formulaProblem(ast, covered);
     if (problem) return `"${rule.formula}" ${problem}.`;
   }
 

--- a/packages/lib/src/sheets/format-request.ts
+++ b/packages/lib/src/sheets/format-request.ts
@@ -547,6 +547,32 @@ interface RangeSpan {
 }
 
 /**
+ * What is probably wrong with a range that would not parse.
+ *
+ * "Not a range this sheet can address" is true of everything here and useful
+ * for nothing: the three shapes below are what a model writing spreadsheet
+ * notation actually produces, each is a one-token repair, and without the hint
+ * the caller spends a round trip guessing. The module already answers this way
+ * elsewhere — the too-large range names `setColumnFormat`, the unknown hue
+ * lists the hues.
+ *
+ * Only a suffix: the range is quoted by the caller, and a shape none of these
+ * match still gets the plain refusal rather than a wrong guess.
+ */
+function rangeHint(range: string): string {
+  if (range.includes('$')) {
+    return ' Ranges here are plain A1 notation — drop the $ (A1:F1, not $A$1:$F$1).';
+  }
+  if (range.includes('!')) {
+    return ' A range names cells on this tab only — drop the SheetName! prefix.';
+  }
+  if (/\s/.test(range.trim())) {
+    return ' Ranges carry no spaces — write A1:F1.';
+  }
+  return '';
+}
+
+/**
  * The bounds of an A1 range, without expanding it.
  *
  * `addressesOfRange` is the shared expander and stays the only one — but a
@@ -1232,7 +1258,11 @@ function validateRuleInput(
     // address every time, inside what is supposed to be a cheap check.
     for (const range of suppliedRanges) {
       if (!parseRangeSpan(range)) {
-        return refuseOp(index, type, `"${range}" is not a range this sheet can address.`);
+        return refuseOp(
+          index,
+          type,
+          `"${range}" is not a range this sheet can address.${rangeHint(range)}`
+        );
       }
     }
 
@@ -1723,7 +1753,11 @@ export function planFormatOps(
 
     const span = parseRangeSpan(range);
     if (!span) {
-      return refuseOp(index, type, `"${range}" is not a range this sheet can address.`);
+      return refuseOp(
+        index,
+        type,
+        `"${range}" is not a range this sheet can address.${rangeHint(range)}`
+      );
     }
 
     const cells = cellsInSpan(span);

--- a/packages/lib/src/sheets/format-request.ts
+++ b/packages/lib/src/sheets/format-request.ts
@@ -94,11 +94,11 @@ function formulaProblem(root: ASTNode, coveredCells: number): string | null {
   // 500,000-cell checks. Bounded by the same ceiling that bounds conditional
   // work generally, because that is what this is: work.
   const work = coveredCells * referenced;
-  if (work > MAX_CONDITIONAL_TOTAL_CELLS) {
+  if (work > MAX_FORMULA_EXPANSION) {
     return (
       `covers ${coveredCells.toLocaleString()} cells and references ${referenced.toLocaleString()} ` +
       `per cell, which is ${work.toLocaleString()} expansions to render once — the limit is ` +
-      `${MAX_CONDITIONAL_TOTAL_CELLS.toLocaleString()}`
+      `${MAX_FORMULA_EXPANSION.toLocaleString()}`
     );
   }
 
@@ -368,6 +368,29 @@ export const MAX_FORMAT_CELLS_PER_REQUEST = 200_000;
 
 /** Enough for any authored batch; bounds the work of validating one. */
 export const MAX_FORMAT_OPS = 200;
+
+/**
+ * The most address materialisations one formula rule may cost to render once.
+ *
+ * A formula rule is evaluated per covered cell and each evaluation expands
+ * every range it references, so its cost is the product of the two — a factor
+ * neither the per-range nor the per-sheet cell cap can see.
+ *
+ * Its own constant rather than a reuse of `MAX_CONDITIONAL_TOTAL_CELLS`, which
+ * was the first attempt and was wrong by being far too tight. That ceiling
+ * counts CELLS; this counts work, and at two million it refused the commonest
+ * formula rule there is — "highlight each row above the column average" — on
+ * any sheet past about 1,400 rows, because such a rule is square in the row
+ * count by construction.
+ *
+ * Twenty million keeps that rule legal to roughly 4,500 rows, which is past the
+ * sheets people actually build, and still refuses the case this bound exists
+ * for by four orders of magnitude. Measured rather than guessed: `expandRange`
+ * produces about 24 million addresses a second, so this is the better part of a
+ * second of pure materialisation — the point where a rule stops being slow and
+ * starts being a mistake.
+ */
+export const MAX_FORMULA_EXPANSION = 20_000_000;
 
 const isObject = (value: unknown): value is Record<string, unknown> =>
   typeof value === 'object' && value !== null && !Array.isArray(value);

--- a/packages/lib/src/sheets/format-request.ts
+++ b/packages/lib/src/sheets/format-request.ts
@@ -994,16 +994,22 @@ const anchorProblem = (anchor: unknown, needsColor: boolean): string | null => {
   if (anchor === undefined) return null;
 
   if (!isObject(anchor) || typeof anchor.type !== 'string' || !SCALE_ANCHOR_TYPES.has(anchor.type)) {
-    return `needs a type of ${[...SCALE_ANCHOR_TYPES].join(', ')}`;
+    return (
+      `needs a type of ${[...SCALE_ANCHOR_TYPES].join(', ')} — stored as written it is ignored, and ` +
+      "the scale falls back to the data's own extreme"
+    );
   }
   if (needsColor && !isValidHexColor(anchor.color)) {
-    return 'needs a #rrggbb colour';
+    return 'needs a #rrggbb colour — without one the whole scale renders no colour, on any cell in range';
   }
   if (!needsColor && anchor.color !== undefined) {
     // The other direction: a data bar takes its colour from `rule.color`, and
     // the evaluator reads only `type` and `value` off these anchors. A colour
-    // here is validated, stored, and never drawn.
-    return 'takes its colour from the rule, so the anchor cannot carry one';
+    // here is validated, stored, and never drawn — but the anchor itself still
+    // works, so this must NOT inherit the "the bars are scaled to the data's
+    // own extreme instead" consequence the other problems carry. It is not
+    // true here, and a false consequence sends a caller to fix the wrong thing.
+    return 'takes its colour from the rule, so the anchor cannot carry one — that colour is stored and never drawn';
   }
 
   // `min` and `max` read the data's own extremes and ignore any value. The
@@ -1012,10 +1018,10 @@ const anchorProblem = (anchor: unknown, needsColor: boolean): string | null => {
   // stored intact and mean something else.
   if (VALUED_ANCHOR_TYPES.has(anchor.type)) {
     if (typeof anchor.value !== 'number' || !Number.isFinite(anchor.value)) {
-      return `of type ${anchor.type} needs a numeric value`;
+      return `of type ${anchor.type} needs a numeric value — without one the data's own extreme is used`;
     }
     if (anchor.type !== 'number' && (anchor.value < 0 || anchor.value > 100)) {
-      return `of type ${anchor.type} needs a value from 0 to 100, not ${anchor.value}`;
+      return `of type ${anchor.type} needs a value from 0 to 100, not ${anchor.value}, which is clamped`;
     }
   } else if (anchor.value !== undefined) {
     // The other direction of the same mistake: `min` and `max` read the data's
@@ -1163,20 +1169,17 @@ function ruleRenderProblem(
     for (const [name, value] of [['min', rule.min], ['mid', rule.mid], ['max', rule.max]] as const) {
       const problem = anchorProblem(value, true);
       if (problem) {
-        return (
-          `The colorScale's ${name} anchor ${problem}. Stored as written it renders no colour at ` +
-          'all, on any cell in range.'
-        );
+        return `The colorScale's ${name} anchor ${problem}.`;
       }
     }
   } else if (rule.kind === 'dataBar') {
     for (const [name, value] of [['min', rule.min], ['max', rule.max]] as const) {
       const problem = anchorProblem(value, false);
       if (problem) {
-        return (
-          `The dataBar's ${name} anchor ${problem}. Stored as written it is ignored, and the bars ` +
-          `are scaled to the data's own ${name} instead.`
-        );
+        // The consequence lives with the problem, because they differ: an
+        // unreadable anchor makes the bars scale to the data's own extreme,
+        // while a stray colour changes nothing about the bars at all.
+        return `The dataBar's ${name} anchor ${problem}.`;
       }
     }
   }
@@ -1394,10 +1397,12 @@ function regionRenderProblem(region: SheetRegion, label: string): string | null 
     // resolver treats every covered row as a header and `continue`s before it
     // consults the column map. Column roles declared on it can never render,
     // and unlike an open region it cannot grow into a body later.
+    const height = bounds.rowEnd === null ? 0 : bounds.rowEnd - bounds.rowStart + 1;
     if (bounds.rowEnd !== null && firstBodyRow > bounds.rowEnd && (region.columns?.length ?? 0) > 0) {
       return (
-        `${label}: ${region.range} is ${bounds.rowEnd - bounds.rowStart + 1} rows tall and every one ` +
-        'of them is a header, so it has no body for a column role to apply to.'
+        `${label}: ${region.range} is ${height} ${height === 1 ? 'row' : 'rows'} tall and ` +
+        `${height === 1 ? 'that row is a header' : 'every one of them is a header'}, so it has no body ` +
+        'for a column role to apply to.'
       );
     }
 

--- a/packages/lib/src/sheets/format-request.ts
+++ b/packages/lib/src/sheets/format-request.ts
@@ -33,11 +33,25 @@
  *    parsers sanitize field by field — a too-small font size vanishes from a
  *    format that keeps its bold, a `ranges` array is truncated to its cap, a
  *    `headerRows` of 999 becomes the default of one — and the write reports
- *    success either way. Three mechanisms cover it: `validateRanges` on the
- *    caller's own array before the parser can shorten it, `firstSanitizedPath`
- *    comparing what would be stored against what was sent, and a handful of
- *    checks for the cases that survive storage intact and only mean something
- *    else at RENDER time (`anchorProblem`, the palette hue).
+ *    success either way. It splits into two questions, and they need different
+ *    machinery:
+ *
+ *    1. *Would what we store differ from what was sent?* `firstSanitizedPath`
+ *       compares the two and names the first field that would not survive, so
+ *       a cap the parsers learn later is covered without this module being
+ *       told. `validateRanges` runs ahead of it on the caller's own array,
+ *       because a check applied after the parser has already truncated that
+ *       array is handed one that fits.
+ *    2. *Would the thing we store do what was asked?* `ruleRenderProblem` and
+ *       `regionRenderProblem`. Everything here is kept byte for byte — a
+ *       formula that will not parse, a function that does not exist, an
+ *       operand that compares against nothing, an anchor with no value, a hue
+ *       the palette lost — so the comparison above has nothing to say about
+ *       any of it, and only knowledge of what the renderer does can catch it.
+ *
+ *    Both are bounded by `nestsTooDeep`, because the value being checked is
+ *    caller-supplied and a walk that follows it is a crash rather than a
+ *    refusal.
  *
  * A word on why this is STRICTER than the panel, since the two are meant to
  * agree. They do agree about what a rule IS — the caps, the operators that need

--- a/packages/lib/src/sheets/format-request.ts
+++ b/packages/lib/src/sheets/format-request.ts
@@ -454,8 +454,11 @@ function canonical(value: unknown): string {
  * what catches a truncated `ranges` array and a dropped column declaration.
  */
 function firstSanitizedPath(raw: unknown, stored: unknown, path: string): string | null {
-  // Absent and explicitly-undefined are the same thing over the wire, and JSON
-  // cannot express the difference.
+  // Absent and explicitly-undefined are the same thing over the wire, since
+  // JSON cannot express undefined. An explicit `null` needs no guard of its
+  // own: `canonical` maps both it and a missing field to the same string, so a
+  // nulled optional field compares equal to the one the parser dropped, which
+  // is what "not set" means for every optional field these parsers read.
   if (raw === undefined) return null;
 
   if (Array.isArray(raw) || Array.isArray(stored)) {
@@ -492,17 +495,31 @@ function firstSanitizedPath(raw: unknown, stored: unknown, path: string): string
  * would be handed the truncated list, pronounce it fine, and the ranges past
  * the cap would be gone with no refusal anywhere.
  */
-function validateRuleInput(raw: unknown, index: number, type: string): ConditionalRule {
+function validateRuleInput(
+  raw: unknown,
+  supplied: Record<string, unknown>,
+  index: number,
+  type: string
+): ConditionalRule {
   if (!isObject(raw)) {
     return refuseOp(index, type, 'rule must be an object.');
   }
 
-  if (raw.ranges !== undefined) {
-    if (!Array.isArray(raw.ranges) || raw.ranges.some((entry) => typeof entry !== 'string')) {
+  // Both checks below are STRICTER than the parser, so they may only be applied
+  // to fields this request actually carries. `raw` is the whole rule, which for
+  // an update is mostly the stored one — and a stored rule is a fixed point of
+  // the parser, not of these. Holding it to them would refuse an unrelated
+  // update to any rule a newer build wrote (`parseCellFormat` preserves an
+  // unknown field, and the key check would then reject it) — the same
+  // cross-version data loss the passthrough exists to prevent, arriving as a
+  // refusal instead. It also keeps this identical to the panel's `updateRule`,
+  // which validates `patch.ranges` and nothing else.
+  if (supplied.ranges !== undefined) {
+    if (!Array.isArray(supplied.ranges) || supplied.ranges.some((entry) => typeof entry !== 'string')) {
       return refuseOp(index, type, 'ranges must be an array of A1 ranges, such as ["B2:B20"].');
     }
     // The caller's array, at its real length.
-    const ranges = validateRanges(raw.ranges as string[]);
+    const ranges = validateRanges(supplied.ranges as string[]);
     if (!ranges.ok) return refuseOp(index, type, ranges.reason);
   }
 
@@ -510,8 +527,8 @@ function validateRuleInput(raw: unknown, index: number, type: string): Condition
   // `parseCellFormat` carries an unknown field THROUGH untouched — nothing is
   // lost, so nothing would be flagged, and a typo like `bolt` would be stored
   // as an inert field that formats nothing.
-  if (raw.format !== undefined) {
-    validateCellFormatPatch(raw.format, index, type, 'rule format');
+  if (supplied.format !== undefined) {
+    validateCellFormatPatch(supplied.format, index, type, 'rule format');
   }
 
   const rule = parseConditionalRule(raw);
@@ -750,14 +767,18 @@ export function planFormatOps(
       }
 
       case 'addConditionalRule': {
-        // The parser is the only definition of a usable rule, and on the load
-        // path it drops what it cannot use. A blank custom formula is the
-        // canonical case: accepted by a naive writer, gone on the next load.
-        const rule = validateRuleInput(op.rule, index, op.type);
-
+        // Counted before the rule is validated: `validateRanges` expands every
+        // range to addresses, and there is no reason to pay for that on a sheet
+        // that cannot take another rule whatever the rule says.
         if (rules.length >= MAX_CONDITIONAL_RULES) {
           refuseOp(index, op.type, `This sheet already has the maximum of ${MAX_CONDITIONAL_RULES} rules.`);
         }
+
+        // The parser is the only definition of a usable rule, and on the load
+        // path it drops what it cannot use. A blank custom formula is the
+        // canonical case: accepted by a naive writer, gone on the next load.
+        const rule = validateRuleInput(op.rule, isObject(op.rule) ? op.rule : {}, index, op.type);
+
         if (rules.some((existing) => existing.id === rule.id)) {
           // Two rules under one id: `update` and `move` reach the first by
           // `findIndex` while `remove` filters out both, so the new rule is no
@@ -806,6 +827,7 @@ export function planFormatOps(
         // around a limit that adding refuses.
         const merged = validateRuleInput(
           { ...rules[at], ...patch, id: rules[at].id, kind: rules[at].kind },
+          patch,
           index,
           op.type
         );

--- a/packages/lib/src/sheets/format-request.ts
+++ b/packages/lib/src/sheets/format-request.ts
@@ -1863,7 +1863,20 @@ export function planFormatOps(
         // index everywhere it is compared. Comparing `row` to it directly left
         // the last addressable row able to take a cell format but not a row
         // height, which is the kind of disagreement no caller can see coming.
-        if (typeof row !== 'number' || !Number.isInteger(row) || row < 1 || row - 1 > MAX_ADDRESSABLE_ROW) {
+        // Split from the range check on purpose. A quoted row — `row: "3"` is
+        // what JSON round-tripping through a tool call produces — used to
+        // refuse with `got 3`, which reads as a rejection of the number 3, a
+        // perfectly legal row. The quoting IS the defect, so name the type.
+        // `String(JSON.stringify(...))` renders every input, `undefined`
+        // included, and shows a string with its quotes still on.
+        if (typeof row !== 'number') {
+          refuseOp(
+            index,
+            op.type,
+            `row must be a number, not ${typeof row}; got ${String(JSON.stringify(row))}.`
+          );
+        }
+        if (!Number.isInteger(row) || row < 1 || row - 1 > MAX_ADDRESSABLE_ROW) {
           refuseOp(index, op.type, `row must be a 1-based row number; got ${String(row)}.`);
         }
         const height = validateExtent(

--- a/packages/lib/src/sheets/format-request.ts
+++ b/packages/lib/src/sheets/format-request.ts
@@ -223,6 +223,20 @@ function referencedCells(start: string, end: string): number | null {
  * attempt landed" rather than as a fault. What it must not do is treat those
  * four as safe to replay blindly.
  *
+ * What the layers above import, and why each is public rather than internal:
+ *
+ *  - `planFormatOps`, `SheetFormatOp`, `SheetFormatPlan`, `PlannedFormatStep`,
+ *    `SheetFormatTarget` — the call and its shapes.
+ *  - `SheetFormatError` — so a route can answer 400 to it by type rather than
+ *    by guessing from a message.
+ *  - `MAX_FORMAT_CELLS`, `MAX_FORMAT_CELLS_PER_REQUEST`, `MAX_FORMAT_OPS`,
+ *    `MAX_FORMULA_EXPANSION`, `MAX_FORMULA_DEPTH` — a tool describing this
+ *    surface to a model should tell it the limits up front rather than let it
+ *    discover them one refusal at a time.
+ *  - `FIELDS_BY_KIND` — which fields each rule kind reads. A tool building a
+ *    per-kind schema needs exactly this, and it is the only copy of that answer
+ *    that a test checks against the evaluator.
+ *
  * Pure: no database, no I/O, no clock. The refusals are the contract, and they
  * have to be testable without any of that.
  */

--- a/packages/lib/src/sheets/format-request.ts
+++ b/packages/lib/src/sheets/format-request.ts
@@ -806,7 +806,23 @@ const anchorProblem = (anchor: unknown, needsColor: boolean): string | null => {
  * was asked. Every case here passes the first question perfectly — the rule is
  * kept byte for byte — and then formats the wrong cells, or none.
  */
-function ruleRenderProblem(rule: ConditionalRule): string | null {
+function ruleRenderProblem(
+  rule: ConditionalRule,
+  supplied: Record<string, unknown>
+): string | null {
+  // A format on a rule kind that has none. `ConditionalColorScaleRule` and
+  // `ConditionalDataBarRule` do not declare one, and the evaluator agrees: the
+  // colorScale branch contributes a background from the gradient and the
+  // dataBar branch contributes a bar, and neither reads `rule.format`.
+  // Verified by evaluating both kinds with and without one — byte-identical
+  // output. So a whole format is validated, stored, and never drawn.
+  //
+  // Read from what the CALLER sent, not the merged rule, so a stored stray does
+  // not make every later update to that rule impossible.
+  if ((rule.kind === 'colorScale' || rule.kind === 'dataBar') && supplied.format !== undefined) {
+    return `a ${rule.kind} rule draws from its anchors, not a format, so the format would never be drawn`;
+  }
+
   // A condition whose operator needs an operand it does not have. The parser
   // accepts any recognized operator on its own and the comparator sees nothing
   // dropped, but `matchesCondition` then compares against nothing: a
@@ -1012,7 +1028,7 @@ function validateRuleInput(
     );
   }
 
-  const problem = ruleRenderProblem(rule);
+  const problem = ruleRenderProblem(rule, supplied);
   if (problem) return refuseOp(index, type, problem);
 
   return rule;

--- a/packages/lib/src/sheets/format-request.ts
+++ b/packages/lib/src/sheets/format-request.ts
@@ -572,7 +572,12 @@ function rangeHint(range: string): string {
     return ' A range names cells on this tab only — drop the SheetName! prefix.';
   }
   if (/\s/.test(range.trim())) {
-    return ' Ranges carry no spaces — write A1:F1.';
+    // The caller's own string with the spaces taken out, not a worked example:
+    // `A1:F1` would be a fine repair for a cell range and a silent change of
+    // meaning for a region, where `A1:F` runs to the end of the sheet and
+    // `A1:F1` is one row. If what is left is wrong for some further reason,
+    // the next refusal names that reason — one repair at a time.
+    return ` Ranges carry no spaces — write "${range.replace(/\s+/g, '')}".`;
   }
   return '';
 }

--- a/packages/lib/src/sheets/format-request.ts
+++ b/packages/lib/src/sheets/format-request.ts
@@ -416,6 +416,12 @@ function validateFreeze(
  * objects, and absent-vs-undefined.
  */
 function canonical(value: unknown): string {
+  // Distinct from `null` on purpose. A caller who means "not set" omits the
+  // key — JSON can say that — so an explicit null that comes back as nothing is
+  // a real sanitization, and often a damaging one: `condition.value: null` is
+  // dropped and leaves a `greaterThan` rule with no threshold, which matches no
+  // cell and looks like a rule that simply does not work.
+  if (value === undefined) return '<absent>';
   if (typeof value === 'string') return JSON.stringify(value.trim().toLowerCase());
   if (Array.isArray(value)) return `[${value.map(canonical).join(',')}]`;
   if (isObject(value)) {
@@ -425,7 +431,7 @@ function canonical(value: unknown): string {
       .map((key) => `${JSON.stringify(key)}:${canonical(value[key])}`);
     return `{${entries.join(',')}}`;
   }
-  return JSON.stringify(value ?? null);
+  return JSON.stringify(value);
 }
 
 /**
@@ -455,10 +461,8 @@ function canonical(value: unknown): string {
  */
 function firstSanitizedPath(raw: unknown, stored: unknown, path: string): string | null {
   // Absent and explicitly-undefined are the same thing over the wire, since
-  // JSON cannot express undefined. An explicit `null` needs no guard of its
-  // own: `canonical` maps both it and a missing field to the same string, so a
-  // nulled optional field compares equal to the one the parser dropped, which
-  // is what "not set" means for every optional field these parsers read.
+  // JSON cannot express undefined. An explicit `null` is NOT the same thing and
+  // deliberately falls through to the comparison below — see `canonical`.
   if (raw === undefined) return null;
 
   if (Array.isArray(raw) || Array.isArray(stored)) {
@@ -518,6 +522,20 @@ function validateRuleInput(
     if (!Array.isArray(supplied.ranges) || supplied.ranges.some((entry) => typeof entry !== 'string')) {
       return refuseOp(index, type, 'ranges must be an array of A1 ranges, such as ["B2:B20"].');
     }
+    // Bounds BEFORE `validateRanges`, because `validateRanges` expands each
+    // range and `addressesOfRange` bounds only the cell COUNT and negative
+    // coordinates — never the addressable extent. So `A5000002` sails through
+    // as one legal cell, and a row number large enough to lose float precision
+    // (`A1000000000000000000000`) is worse than merely out of range: `row++`
+    // stops advancing at that magnitude, so the expansion loop runs to its
+    // 500,000-address ceiling emitting the same malformed exponential-form
+    // address every time, inside what is supposed to be a cheap check.
+    for (const range of supplied.ranges as string[]) {
+      if (!parseRangeSpan(range)) {
+        return refuseOp(index, type, `"${range}" is not a range this sheet can address.`);
+      }
+    }
+
     // The caller's array, at its real length.
     const ranges = validateRanges(supplied.ranges as string[]);
     if (!ranges.ok) return refuseOp(index, type, ranges.reason);

--- a/packages/lib/src/sheets/format-request.ts
+++ b/packages/lib/src/sheets/format-request.ts
@@ -1312,7 +1312,7 @@ function validateRuleInput(
       index,
       type,
       `"${sanitized}" is not something this sheet can store, and would be dropped or changed on the ` +
-        'way in. Nothing about a stored rule may differ from what was asked for.'
+        `way in. Nothing about a stored rule may differ from what was asked for.${conditionValueHint(raw, sanitized)}`
     );
   }
 
@@ -1497,6 +1497,41 @@ function regionRenderProblem(region: SheetRegion, label: string): string | null 
   }
 
   return null;
+}
+
+/**
+ * The one sanitized path worth explaining, because it is the one a caller will
+ * actually hit.
+ *
+ * `ConditionalCondition.value` is a STRING — the panel's input is text, and a
+ * date or a status name has to fit in the same field as a number. So
+ * "highlight cells greater than 5", the most ordinary rule there is, is
+ * naturally written `{ operator: 'greaterThan', value: 5 }`, the parser drops
+ * the number, and the comparator refuses with a path and no remedy. Naming the
+ * type is the whole repair, and quoting the caller's own number shows it.
+ *
+ * Deliberately not a coercion. Storing "5" for 5 would be this module doing
+ * the one thing it exists to prevent — writing something other than what was
+ * asked for — and it is the same call as refusing rather than clamping a width.
+ */
+function conditionValueHint(raw: Record<string, unknown>, path: string): string {
+  // The path names the field, so it selects the field. A path this cannot
+  // explain yields no key, reads nothing, and falls out at the number check
+  // below — one exit rather than a second guard that could never fire on its
+  // own. Slicing the prefix off instead would make the choice of paths above
+  // decorative, true only by the accident that no other path's tail happens to
+  // be a condition key.
+  const key = path === 'condition.value' ? 'value' : path === 'condition.value2' ? 'value2' : '';
+
+  // Read without a guard on purpose. `raw` is already an object — the check at
+  // the top of `validateRuleInput` saw to that — and a path spelled
+  // `condition.value` exists only because the comparator walked a condition
+  // object to build it, so a guard here would have a side that cannot run.
+  // `Object()` never throws, which keeps that true even if the comparator's
+  // path vocabulary ever changes.
+  const value = (Object(raw.condition) as Record<string, unknown>)[key];
+  if (typeof value !== 'number') return '';
+  return ` A condition's value is text, not a number — write "${value}", not ${value}.`;
 }
 
 /** The same contract as {@link validateRuleInput}, for a declared region. */

--- a/packages/lib/src/sheets/format-request.ts
+++ b/packages/lib/src/sheets/format-request.ts
@@ -501,8 +501,13 @@ export const MAX_FORMULA_DEPTH = 256;
  * Ops are transient and versioned with the code that sends them, so unlike the
  * stored shapes elsewhere in this module there is no forward-compatibility
  * argument for letting an unrecognised key through.
+ *
+ * Exported so a test can enumerate the ops rather than restate them: a new op
+ * added to the union has to be added here too, and that is what makes the
+ * "every op refuses its own field missing" sweep cover it without being
+ * taught.
  */
-const OP_FIELDS: Record<SheetFormatOp['type'], readonly string[]> = {
+export const OP_FIELDS: Record<SheetFormatOp['type'], readonly string[]> = {
   setCellFormat: ['range', 'patch'],
   clearCellFormat: ['range'],
   setColumnFormat: ['column', 'patch'],

--- a/packages/lib/src/sheets/format-request.ts
+++ b/packages/lib/src/sheets/format-request.ts
@@ -65,11 +65,13 @@ import {
   MAX_CONDITIONAL_RANGE_CELLS,
   MAX_CONDITIONAL_RULES,
   MAX_CONDITIONAL_TOTAL_CELLS,
+  NUMERIC_OPERATORS,
   RANGE_OPERATORS,
   SCALE_ANCHOR_TYPES,
   VALUED_ANCHOR_TYPES,
   VALUELESS_OPERATORS,
   addressesOfRange,
+  asComparableNumber,
   parseConditionalRule,
   parseConditionalRules,
   type ConditionalRule,
@@ -82,6 +84,7 @@ import {
   MIN_COLUMN_WIDTH,
   MIN_ROW_HEIGHT,
 } from './format-ops';
+import { isSupportedFunction } from './functions';
 import { PALETTE } from './palette';
 import { FormulaParser, tokenize } from './parser';
 import {
@@ -91,7 +94,7 @@ import {
   parseRegions,
   type SheetRegion,
 } from './regions';
-import type { CellFormat } from './types';
+import type { ASTNode, CellFormat } from './types';
 
 /**
  * A caller-supplied op that cannot be applied.
@@ -374,6 +377,23 @@ function validateCellFormatPatch(
     return refuseOp(index, type, `${[label, ...issue.path].join('.')}: ${issue.message}`);
   }
 
+  // The key check above only sees the TOP level, and `cellFormatSchema` strips
+  // unknown keys from a NESTED object just as quietly: `{number: {kind:
+  // 'currency', curreny: 'EUR'}}` parses successfully, renders as the default
+  // currency, and loses the misspelled field on the next load. Comparing the
+  // caller's object against what zod made of it catches that at any depth —
+  // and leaves the top-level `undefined` clearing alone, since a raw undefined
+  // is never a loss.
+  const nested = sanitizedPathOrRefuse(patch, result.data, index, type, label);
+  if (nested) {
+    return refuseOp(
+      index,
+      type,
+      `${label}.${nested} is not something this sheet can store. It would be dropped, and the field ` +
+        'it belongs to rendered as if you had never set it.'
+    );
+  }
+
   // Deliberately `patch`, never `result.data`. See above.
   return patch as CellFormat;
 }
@@ -455,6 +475,46 @@ function validateFreeze(
 }
 
 /**
+ * How deep a caller-supplied value may nest before this module stops trying to
+ * verify it.
+ *
+ * The parsers preserve unknown fields ON PURPOSE, so a request can carry an
+ * arbitrarily nested value attached to an otherwise valid rule. Walking that
+ * without a bound is a `RangeError` — which escapes as a 500, the one outcome
+ * `SheetFormatError` exists to prevent. Twelve is far past anything the rule
+ * and region shapes reach on their own; the deepest is `borders.top.color`, at
+ * three.
+ */
+const MAX_COMPARE_DEPTH = 12;
+
+/**
+ * Whether a value nests deeper than the comparison will follow.
+ *
+ * Checked BEFORE comparing rather than guarded during it, which is what lets
+ * the comparison itself stay a plain recursive walk with nothing to say about
+ * depth. Iterative, with its own stack: a recursive depth probe on a
+ * caller-supplied value is the very stack overflow it exists to prevent.
+ */
+function nestsTooDeep(value: unknown): boolean {
+  const stack: Array<{ value: unknown; depth: number }> = [{ value, depth: 0 }];
+
+  while (stack.length > 0) {
+    const current = stack.pop() as { value: unknown; depth: number };
+    if (current.depth > MAX_COMPARE_DEPTH) return true;
+
+    if (Array.isArray(current.value)) {
+      for (const entry of current.value) stack.push({ value: entry, depth: current.depth + 1 });
+    } else if (isObject(current.value)) {
+      for (const key of Object.keys(current.value)) {
+        stack.push({ value: current.value[key], depth: current.depth + 1 });
+      }
+    }
+  }
+
+  return false;
+}
+
+/**
  * A stable string for a value, with the normalizations the parsers are allowed
  * to perform already applied: whitespace and case on strings, key order on
  * objects, and absent-vs-undefined.
@@ -504,10 +564,18 @@ function canonical(value: unknown): string {
  * what catches a truncated `ranges` array and a dropped column declaration.
  */
 function firstSanitizedPath(raw: unknown, stored: unknown, path: string): string | null {
-  // Absent and explicitly-undefined are the same thing over the wire, since
-  // JSON cannot express undefined. An explicit `null` is NOT the same thing and
-  // deliberately falls through to the comparison below — see `canonical`.
-  if (raw === undefined) return null;
+  // Absent and explicitly-undefined need no case of their own. The object walk
+  // below visits the keys of RAW only, so a key the parser added is never
+  // reached, and a key the caller set to `undefined` against a parser that
+  // dropped it compares `<absent>` to `<absent>` at the bottom. An explicit
+  // `null` is NOT the same thing and deliberately falls through to that same
+  // comparison; see `canonical`.
+  //
+  // An identity fast path (`raw === stored`) used to sit here, on the grounds
+  // that the parsers preserve an unknown field by passing the same reference
+  // through. It was removed: `nestsTooDeep` already bounds the walk, so it
+  // optimised a bounded operation, and no test could tell whether it was there
+  // — an object cannot be sanitized into itself, so it never changed an answer.
 
   if (Array.isArray(raw) || Array.isArray(stored)) {
     if (!Array.isArray(raw) || !Array.isArray(stored)) return path;
@@ -531,6 +599,32 @@ function firstSanitizedPath(raw: unknown, stored: unknown, path: string): string
   }
 
   return canonical(raw) === canonical(stored) ? null : path;
+}
+
+/**
+ * `firstSanitizedPath`, with the depth bound applied first.
+ *
+ * Every caller wants the same thing from a value nested past what this module
+ * will verify: refuse it. Silently accepting what could not be checked would
+ * make the bound a hole rather than a limit.
+ */
+function sanitizedPathOrRefuse(
+  raw: unknown,
+  stored: unknown,
+  index: number,
+  type: string,
+  label: string
+): string | null {
+  if (nestsTooDeep(raw)) {
+    return refuseOp(
+      index,
+      type,
+      `${label} is nested more than ${MAX_COMPARE_DEPTH} levels deep, which is past what this sheet ` +
+        'will check for silent changes. Flatten it.'
+    );
+  }
+
+  return firstSanitizedPath(raw, stored, '');
 }
 
 /**
@@ -574,6 +668,38 @@ const anchorProblem = (anchor: unknown, needsColor: boolean): string | null => {
 };
 
 /**
+ * The first function in a parsed formula that this build does not implement.
+ *
+ * Iterative rather than recursive: the input is a caller-supplied formula, and
+ * a walk whose depth follows it is a stack overflow escaping as a 500. (The
+ * parser would usually blow up first and be caught above, but "usually" is not
+ * a bound.)
+ */
+function firstUnsupportedFunction(root: ASTNode): string | null {
+  const stack: ASTNode[] = [root];
+
+  while (stack.length > 0) {
+    const node = stack.pop() as ASTNode;
+    switch (node.type) {
+      case 'FunctionCall':
+        if (!isSupportedFunction(node.name)) return node.name.toUpperCase();
+        for (const argument of node.args) stack.push(argument);
+        break;
+      case 'UnaryExpression':
+        stack.push(node.argument);
+        break;
+      case 'BinaryExpression':
+        stack.push(node.left, node.right);
+        break;
+      default:
+        break;
+    }
+  }
+
+  return null;
+}
+
+/**
  * Why a rule that stores faithfully would still not do what was asked, or null
  * when there is nothing wrong with it.
  *
@@ -601,6 +727,23 @@ function ruleRenderProblem(rule: ConditionalRule): string | null {
     if (RANGE_OPERATORS.has(operator) && (typeof value2 !== 'string' || value2.trim() === '')) {
       return `A "${operator}" rule needs both bounds: value and value2.`;
     }
+
+    // Present but not a number, for an operator that only compares numbers.
+    // `matchesCondition` coerces the operand and returns false for every cell
+    // once that yields null — the same inert rule as a missing value, reached a
+    // different way. `equal`/`notEqual` are absent from the set on purpose:
+    // they fall back to a text comparison, so `= "done"` is a real rule.
+    if (NUMERIC_OPERATORS.has(operator)) {
+      for (const [field, operand] of [['value', value], ['value2', value2]] as const) {
+        if (operand === undefined) continue;
+        if (asComparableNumber(operand) === null) {
+          return (
+            `A "${operator}" rule compares numbers, and ${field} is "${operand}". It would match no ` +
+            'cell at all.'
+          );
+        }
+      }
+    }
   }
 
   // A formula that does not parse. `parseConditionalRule` asks only that it be
@@ -610,20 +753,29 @@ function ruleRenderProblem(rule: ConditionalRule): string | null {
   // "valid" means the same thing here as where it runs.
   if (rule.kind === 'formula') {
     const body = rule.formula.trim().replace(/^=/, '');
-    let parsed = false;
+    let ast: ASTNode | null = null;
     try {
       const tokens = tokenize(body);
-      if (tokens.length > 0) {
-        new FormulaParser(tokens).parse();
-        parsed = true;
-      }
+      if (tokens.length > 0) ast = new FormulaParser(tokens).parse();
     } catch {
-      parsed = false;
+      ast = null;
     }
-    if (!parsed) {
+    if (!ast) {
       return (
         `"${rule.formula}" is not a formula this sheet can evaluate. Stored as written it throws once ` +
         'per covered cell and formats none of them.'
+      );
+    }
+
+    // Parsing proves the grammar, not the vocabulary: `FormulaParser` accepts
+    // any identifier followed by parentheses, and `evaluateFunction` then
+    // throws for a name it does not implement — once per covered cell, with the
+    // same nothing to show for it.
+    const unsupported = firstUnsupportedFunction(ast);
+    if (unsupported) {
+      return (
+        `"${rule.formula}" calls ${unsupported}(), which this sheet does not implement. Stored as ` +
+        'written it throws once per covered cell and formats none of them.'
       );
     }
   }
@@ -734,7 +886,7 @@ function validateRuleInput(
     );
   }
 
-  const sanitized = firstSanitizedPath(raw, rule, '');
+  const sanitized = sanitizedPathOrRefuse(raw, rule, index, type, 'This rule');
   if (sanitized) {
     return refuseOp(
       index,
@@ -826,7 +978,7 @@ function validateRegionInput(raw: unknown, index: number, type: string, label: s
     );
   }
 
-  const sanitized = firstSanitizedPath(raw, region, '');
+  const sanitized = sanitizedPathOrRefuse(raw, region, index, type, label);
   if (sanitized) {
     // `parseRegion` drops a bad optional setting and keeps the region, so
     // `headerRows: 999` becomes the default of one and an unusable column

--- a/packages/lib/src/sheets/format-request.ts
+++ b/packages/lib/src/sheets/format-request.ts
@@ -259,6 +259,11 @@ function referencedCells(start: string, end: string): number | null {
  *  - `FIELDS_BY_KIND` — which fields each rule kind reads. A tool building a
  *    per-kind schema needs exactly this, and it is the only copy of that answer
  *    that a test checks against the evaluator.
+ *  - `OP_FIELDS` — which fields each op takes, for the same reason one level
+ *    up: a tool describing the ops has the answer here rather than restating
+ *    it, and the test sweep that checks every op refuses a missing field
+ *    enumerates this instead of a list of its own, so a new op cannot join the
+ *    union without being swept.
  *
  * Pure: no database, no I/O, no clock. The refusals are the contract, and they
  * have to be testable without any of that.

--- a/packages/lib/src/sheets/format-request.ts
+++ b/packages/lib/src/sheets/format-request.ts
@@ -943,6 +943,25 @@ const anchorProblem = (anchor: unknown, needsColor: boolean): string | null => {
 };
 
 /**
+ * Which fields each kind of rule actually reads.
+ *
+ * A mirror of the four `ConditionalRule` members, and the one place in this
+ * module that restates something the types already say — kept honest by a test
+ * that derives the same table from the evaluator itself, running each kind with
+ * each foreign field and comparing the output. If a kind starts reading a new
+ * field, that test fails rather than this table silently lying.
+ */
+export const FIELDS_BY_KIND: Record<ConditionalRule['kind'], readonly string[]> = {
+  cell: ['condition', 'format'],
+  formula: ['formula', 'format'],
+  colorScale: ['min', 'mid', 'max'],
+  dataBar: ['color', 'min', 'max'],
+};
+
+/** Every field that belongs to some kind, and so may be foreign to another. */
+const KIND_FIELDS: readonly string[] = [...new Set(Object.values(FIELDS_BY_KIND).flat())];
+
+/**
  * Why a rule that stores faithfully would still not do what was asked, or null
  * when there is nothing wrong with it.
  *
@@ -956,17 +975,20 @@ function ruleRenderProblem(
   rule: ConditionalRule,
   supplied: Record<string, unknown>
 ): string | null {
-  // A format on a rule kind that has none. `ConditionalColorScaleRule` and
-  // `ConditionalDataBarRule` do not declare one, and the evaluator agrees: the
-  // colorScale branch contributes a background from the gradient and the
-  // dataBar branch contributes a bar, and neither reads `rule.format`.
-  // Verified by evaluating both kinds with and without one — byte-identical
-  // output. So a whole format is validated, stored, and never drawn.
+  // A field belonging to a different kind of rule. Each kind reads its own
+  // handful and the parser carries the rest through untouched, so `format` on a
+  // colorScale, `condition` on a formula rule or `color` on anything but a data
+  // bar is validated, stored, and never read. Verified against the evaluator
+  // rather than inferred from the interfaces — the test derives this same table
+  // by running every kind with every foreign field and comparing output, so it
+  // cannot drift from what actually reads what.
   //
   // Read from what the CALLER sent, not the merged rule, so a stored stray does
   // not make every later update to that rule impossible.
-  if ((rule.kind === 'colorScale' || rule.kind === 'dataBar') && supplied.format !== undefined) {
-    return `A ${rule.kind} rule draws from its anchors, not a format, so the format would never be drawn.`;
+  for (const field of KIND_FIELDS) {
+    if (supplied[field] === undefined) continue;
+    if (FIELDS_BY_KIND[rule.kind].includes(field)) continue;
+    return `A ${rule.kind} rule does not read ${field}, so it would be stored and never used.`;
   }
 
   // A condition whose operator needs an operand it does not have. The parser

--- a/packages/lib/src/sheets/format-request.ts
+++ b/packages/lib/src/sheets/format-request.ts
@@ -227,6 +227,25 @@ function referencedCells(start: string, end: string): number | null {
  * attempt landed" rather than as a fault. What it must not do is treat those
  * four as safe to replay blindly.
  *
+ * The shape a caller is meant to use, since the ordering is the whole point:
+ *
+ *     const plan = planFormatOps(ops, tab);          // throws before any I/O
+ *
+ *     await tx(async () => {
+ *       const rows = await loadRows(tabId, plan.rows);   // exactly these
+ *       let sheet = materialise(tab, rows);
+ *       for (const step of plan.steps) sheet = apply(sheet, step);
+ *       await saveRows(tabId, plan.rows, sheet);
+ *       if (plan.touchesTabFields) await saveTab(tabId, sheet);
+ *     });
+ *
+ * `planFormatOps` runs OUTSIDE the transaction and before the load, which is
+ * what makes `plan.rows` worth having: the set is known before a lock is taken,
+ * so a request that formats six cells locks six rows rather than a tab. A plan
+ * that returns has already refused everything it is going to refuse, so the
+ * loop over `steps` needs no error handling of its own — see the note above on
+ * which ops survive being replayed if the transaction fails.
+ *
  * What the layers above import, and why each is public rather than internal:
  *
  *  - `planFormatOps`, `SheetFormatOp`, `SheetFormatPlan`, `PlannedFormatStep`,

--- a/packages/lib/src/sheets/format-request.ts
+++ b/packages/lib/src/sheets/format-request.ts
@@ -486,6 +486,39 @@ export const MAX_FORMULA_EXPANSION = 20_000_000;
  */
 export const MAX_FORMULA_DEPTH = 256;
 
+/**
+ * The fields each op carries, beside its `type`.
+ *
+ * An op is a caller-specified object with a known shape, exactly like a
+ * `CellFormat` patch — so an unknown key on one gets the same answer a `bolt`
+ * gets in a patch, and for the same reason. A misspelled REQUIRED field already
+ * refuses itself (the field it should have been is missing), but a field that
+ * is simply extra was being dropped in silence, and the shape that matters is
+ * `{type: 'setCellFormat', range, patch, format}` — a model reaching for the
+ * name a rule uses. That applied the bold and discarded the italic without a
+ * word.
+ *
+ * Ops are transient and versioned with the code that sends them, so unlike the
+ * stored shapes elsewhere in this module there is no forward-compatibility
+ * argument for letting an unrecognised key through.
+ */
+const OP_FIELDS: Record<SheetFormatOp['type'], readonly string[]> = {
+  setCellFormat: ['range', 'patch'],
+  clearCellFormat: ['range'],
+  setColumnFormat: ['column', 'patch'],
+  setColumnWidth: ['column', 'width'],
+  setRowHeight: ['row', 'height'],
+  setFrozen: ['rows', 'columns'],
+  addConditionalRule: ['rule'],
+  updateConditionalRule: ['id', 'patch'],
+  removeConditionalRule: ['id'],
+  moveConditionalRule: ['id', 'direction'],
+  clearConditionalRules: [],
+  setRegions: ['regions'],
+  upsertRegion: ['region'],
+  removeRegion: ['id'],
+};
+
 const isObject = (value: unknown): value is Record<string, unknown> =>
   typeof value === 'object' && value !== null && !Array.isArray(value);
 
@@ -1726,6 +1759,21 @@ export function planFormatOps(
       typeof (op as { type?: unknown }).type === 'string';
     if (!shaped) {
       refuse(`Op ${index}: each op must be an object with a "type".`, index);
+    }
+
+    // Checked before the switch so every op gets it, and after `shaped` so
+    // `op.type` is known to be a string.
+    const allowed: readonly string[] | undefined = OP_FIELDS[op.type as SheetFormatOp['type']];
+    if (allowed !== undefined) {
+      const names = allowed.map((field) => `"${field}"`).join(' and ');
+      for (const key of Object.keys(op)) {
+        if (key === 'type' || allowed.includes(key)) continue;
+        refuseOp(
+          index,
+          op.type,
+          `"${key}" is not a field of this op. It takes ${allowed.length === 0 ? 'no fields' : names}.`
+        );
+      }
     }
 
     switch (op.type) {

--- a/packages/lib/src/sheets/format.ts
+++ b/packages/lib/src/sheets/format.ts
@@ -112,6 +112,19 @@ const FIELD_SCHEMAS = new Map<string, z.ZodType>([
 ]);
 
 /**
+ * The field names a `CellFormat` may carry, derived from the schemas above so
+ * there is only ever one list.
+ *
+ * Exported for the write path: `cellFormatSchema` is a plain `z.object`, so it
+ * *strips* an unknown key and reports success — which makes a typo like `bolt`
+ * a request that validates and formats nothing. A caller that wants to refuse
+ * one instead has to check the keys itself, and it must check against this list
+ * rather than a hand-copied one, or adding a field here would silently start
+ * being rejected there.
+ */
+export const CELL_FORMAT_FIELDS: ReadonlySet<string> = new Set(FIELD_SCHEMAS.keys());
+
+/**
  * Keys never carried through, whatever a stored document says. Passing these
  * on would let a crafted sheet reach `Object.prototype` through the spreads in
  * `resolveCellFormat` and `setCellFormats`.

--- a/packages/lib/src/sheets/functions.ts
+++ b/packages/lib/src/sheets/functions.ts
@@ -93,6 +93,40 @@ export function formatDisplayValue(value: SheetPrimitive): string {
 /**
  * Evaluate a function call
  */
+/**
+ * Thrown for a function name this build does not implement.
+ *
+ * A type rather than a message, because a caller needs to tell "I do not know
+ * this function" apart from "I know it and you called it wrong", and matching
+ * on prose is how that distinction rots. Still an `Error` with the same text,
+ * so every existing catch behaves exactly as before.
+ */
+export class UnsupportedFunctionError extends Error {
+  constructor(readonly functionName: string) {
+    super(`Unsupported function ${functionName}`);
+    this.name = 'UnsupportedFunctionError';
+  }
+}
+
+/**
+ * Whether this build implements a function, asked of the dispatch itself.
+ *
+ * The alternative is a list of names beside the switch, which is a second copy
+ * free to drift the first time someone adds a function and forgets it — the
+ * exact failure the switch would then hide. Probing costs one call of a pure
+ * function with no arguments: a name that is implemented either returns
+ * something or complains about its arguments, and only an unimplemented one
+ * raises `UnsupportedFunctionError`.
+ */
+export function isSupportedFunction(name: string): boolean {
+  try {
+    evaluateFunction(name, [], () => '');
+    return true;
+  } catch (error) {
+    return !(error instanceof UnsupportedFunctionError);
+  }
+}
+
 export function evaluateFunction(
   name: string,
   args: ASTNode[],
@@ -462,6 +496,6 @@ export function evaluateFunction(
       return Math.floor(Math.random() * (top - bottom + 1)) + bottom;
     }
     default:
-      throw new Error(`Unsupported function ${upperName}`);
+      throw new UnsupportedFunctionError(upperName);
   }
 }

--- a/packages/lib/src/sheets/functions.ts
+++ b/packages/lib/src/sheets/functions.ts
@@ -101,6 +101,13 @@ export function formatDisplayValue(value: SheetPrimitive): string {
  * on prose is how that distinction rots. Still an `Error` with the same text,
  * so every existing catch behaves exactly as before.
  */
+export class FunctionArityError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'FunctionArityError';
+  }
+}
+
 export class UnsupportedFunctionError extends Error {
   constructor(readonly functionName: string) {
     super(`Unsupported function ${functionName}`);
@@ -127,6 +134,28 @@ export function isSupportedFunction(name: string): boolean {
   }
 }
 
+/**
+ * Whether a call of `argCount` arguments is one this build can evaluate.
+ *
+ * The same probe, one question further on, and it needs `FunctionArityError` to
+ * exist for the same reason `isSupportedFunction` needs its own type: the
+ * arguments are stand-ins, so a function that dislikes their VALUES will throw
+ * too, and only a typed error separates "you gave me the wrong number of
+ * arguments" from "I cannot work with a 1 there". Anything but the two typed
+ * errors means the shape of the call was fine.
+ */
+export function isValidCall(name: string, argCount: number): boolean {
+  const argument: ASTNode = { type: 'NumberLiteral', value: 1 };
+  const args = Array.from({ length: argCount }, () => argument);
+
+  try {
+    evaluateFunction(name, args, () => 1);
+    return true;
+  } catch (error) {
+    return !(error instanceof UnsupportedFunctionError) && !(error instanceof FunctionArityError);
+  }
+}
+
 export function evaluateFunction(
   name: string,
   args: ASTNode[],
@@ -138,7 +167,7 @@ export function evaluateFunction(
   switch (upperName) {
     case 'IFERROR': {
       if (args.length < 2) {
-        throw new Error('IFERROR expects at least two arguments');
+        throw new FunctionArityError('IFERROR expects at least two arguments');
       }
       try {
         return flattenValue(evaluateNode(args[0]))[0];
@@ -202,13 +231,13 @@ export function evaluateFunction(
     }
     case 'ABS': {
       if (values.length !== 1) {
-        throw new Error('ABS expects exactly one argument');
+        throw new FunctionArityError('ABS expects exactly one argument');
       }
       return Math.abs(coerceNumber(values[0]));
     }
     case 'ROUND': {
       if (values.length === 0) {
-        throw new Error('ROUND expects at least one argument');
+        throw new FunctionArityError('ROUND expects at least one argument');
       }
       const value = coerceNumber(values[0]);
       const precision = values.length > 1 ? coerceNumber(values[1]) : 0;
@@ -217,7 +246,7 @@ export function evaluateFunction(
     }
     case 'FLOOR': {
       if (values.length === 0) {
-        throw new Error('FLOOR expects at least one argument');
+        throw new FunctionArityError('FLOOR expects at least one argument');
       }
       const value = coerceNumber(values[0]);
       const significance = values.length > 1 ? Math.abs(coerceNumber(values[1])) : 1;
@@ -228,7 +257,7 @@ export function evaluateFunction(
     }
     case 'CEILING': {
       if (values.length === 0) {
-        throw new Error('CEILING expects at least one argument');
+        throw new FunctionArityError('CEILING expects at least one argument');
       }
       const value = coerceNumber(values[0]);
       const significance = values.length > 1 ? Math.abs(coerceNumber(values[1])) : 1;
@@ -239,7 +268,7 @@ export function evaluateFunction(
     }
     case 'IF': {
       if (args.length < 2) {
-        throw new Error('IF expects at least two arguments');
+        throw new FunctionArityError('IF expects at least two arguments');
       }
       const conditionValue = flattenValue(evaluateNode(args[0]))[0];
       const condition = toBoolean(conditionValue);
@@ -258,31 +287,31 @@ export function evaluateFunction(
     // String functions
     case 'UPPER': {
       if (values.length !== 1) {
-        throw new Error('UPPER expects exactly one argument');
+        throw new FunctionArityError('UPPER expects exactly one argument');
       }
       return String(values[0]).toUpperCase();
     }
     case 'LOWER': {
       if (values.length !== 1) {
-        throw new Error('LOWER expects exactly one argument');
+        throw new FunctionArityError('LOWER expects exactly one argument');
       }
       return String(values[0]).toLowerCase();
     }
     case 'TRIM': {
       if (values.length !== 1) {
-        throw new Error('TRIM expects exactly one argument');
+        throw new FunctionArityError('TRIM expects exactly one argument');
       }
       return String(values[0]).trim();
     }
     case 'LEN': {
       if (values.length !== 1) {
-        throw new Error('LEN expects exactly one argument');
+        throw new FunctionArityError('LEN expects exactly one argument');
       }
       return String(values[0]).length;
     }
     case 'LEFT': {
       if (values.length < 1 || values.length > 2) {
-        throw new Error('LEFT expects one or two arguments');
+        throw new FunctionArityError('LEFT expects one or two arguments');
       }
       const text = String(values[0]);
       const numChars = values.length > 1 ? coerceNumber(values[1]) : 1;
@@ -290,7 +319,7 @@ export function evaluateFunction(
     }
     case 'RIGHT': {
       if (values.length < 1 || values.length > 2) {
-        throw new Error('RIGHT expects one or two arguments');
+        throw new FunctionArityError('RIGHT expects one or two arguments');
       }
       const text = String(values[0]);
       const numChars = values.length > 1 ? coerceNumber(values[1]) : 1;
@@ -299,7 +328,7 @@ export function evaluateFunction(
     }
     case 'MID': {
       if (values.length !== 3) {
-        throw new Error('MID expects exactly three arguments');
+        throw new FunctionArityError('MID expects exactly three arguments');
       }
       const text = String(values[0]);
       const startNum = Math.max(1, Math.floor(coerceNumber(values[1])));
@@ -308,7 +337,7 @@ export function evaluateFunction(
     }
     case 'SUBSTITUTE': {
       if (values.length < 3 || values.length > 4) {
-        throw new Error('SUBSTITUTE expects three or four arguments');
+        throw new FunctionArityError('SUBSTITUTE expects three or four arguments');
       }
       const text = String(values[0]);
       const oldText = String(values[1]);
@@ -328,7 +357,7 @@ export function evaluateFunction(
     }
     case 'REPT': {
       if (values.length !== 2) {
-        throw new Error('REPT expects exactly two arguments');
+        throw new FunctionArityError('REPT expects exactly two arguments');
       }
       const text = String(values[0]);
       const times = Math.max(0, Math.floor(coerceNumber(values[1])));
@@ -339,7 +368,7 @@ export function evaluateFunction(
     }
     case 'FIND': {
       if (values.length < 2 || values.length > 3) {
-        throw new Error('FIND expects two or three arguments');
+        throw new FunctionArityError('FIND expects two or three arguments');
       }
       const findText = String(values[0]);
       const withinText = String(values[1]);
@@ -352,7 +381,7 @@ export function evaluateFunction(
     }
     case 'SEARCH': {
       if (values.length < 2 || values.length > 3) {
-        throw new Error('SEARCH expects two or three arguments');
+        throw new FunctionArityError('SEARCH expects two or three arguments');
       }
       const findText = String(values[0]).toLowerCase();
       const withinText = String(values[1]).toLowerCase();
@@ -373,7 +402,7 @@ export function evaluateFunction(
     }
     case 'YEAR': {
       if (values.length !== 1) {
-        throw new Error('YEAR expects exactly one argument');
+        throw new FunctionArityError('YEAR expects exactly one argument');
       }
       const date = new Date(String(values[0]));
       if (isNaN(date.getTime())) {
@@ -383,7 +412,7 @@ export function evaluateFunction(
     }
     case 'MONTH': {
       if (values.length !== 1) {
-        throw new Error('MONTH expects exactly one argument');
+        throw new FunctionArityError('MONTH expects exactly one argument');
       }
       const date = new Date(String(values[0]));
       if (isNaN(date.getTime())) {
@@ -393,7 +422,7 @@ export function evaluateFunction(
     }
     case 'DAY': {
       if (values.length !== 1) {
-        throw new Error('DAY expects exactly one argument');
+        throw new FunctionArityError('DAY expects exactly one argument');
       }
       const date = new Date(String(values[0]));
       if (isNaN(date.getTime())) {
@@ -404,44 +433,44 @@ export function evaluateFunction(
     // Logical functions
     case 'AND': {
       if (values.length === 0) {
-        throw new Error('AND expects at least one argument');
+        throw new FunctionArityError('AND expects at least one argument');
       }
       return values.every((v) => toBoolean(v));
     }
     case 'OR': {
       if (values.length === 0) {
-        throw new Error('OR expects at least one argument');
+        throw new FunctionArityError('OR expects at least one argument');
       }
       return values.some((v) => toBoolean(v));
     }
     case 'NOT': {
       if (values.length !== 1) {
-        throw new Error('NOT expects exactly one argument');
+        throw new FunctionArityError('NOT expects exactly one argument');
       }
       return !toBoolean(values[0]);
     }
     case 'ISBLANK': {
       if (values.length !== 1) {
-        throw new Error('ISBLANK expects exactly one argument');
+        throw new FunctionArityError('ISBLANK expects exactly one argument');
       }
       return values[0] === '' || values[0] === null || values[0] === undefined;
     }
     case 'ISNUMBER': {
       if (values.length !== 1) {
-        throw new Error('ISNUMBER expects exactly one argument');
+        throw new FunctionArityError('ISNUMBER expects exactly one argument');
       }
       return typeof values[0] === 'number' && Number.isFinite(values[0]);
     }
     case 'ISTEXT': {
       if (values.length !== 1) {
-        throw new Error('ISTEXT expects exactly one argument');
+        throw new FunctionArityError('ISTEXT expects exactly one argument');
       }
       return typeof values[0] === 'string' && values[0] !== '';
     }
     // Math functions
     case 'SQRT': {
       if (values.length !== 1) {
-        throw new Error('SQRT expects exactly one argument');
+        throw new FunctionArityError('SQRT expects exactly one argument');
       }
       const num = coerceNumber(values[0]);
       if (num < 0) {
@@ -452,13 +481,13 @@ export function evaluateFunction(
     case 'POWER':
     case 'POW': {
       if (values.length !== 2) {
-        throw new Error('POWER expects exactly two arguments');
+        throw new FunctionArityError('POWER expects exactly two arguments');
       }
       return Math.pow(coerceNumber(values[0]), coerceNumber(values[1]));
     }
     case 'MOD': {
       if (values.length !== 2) {
-        throw new Error('MOD expects exactly two arguments');
+        throw new FunctionArityError('MOD expects exactly two arguments');
       }
       const divisor = coerceNumber(values[1]);
       if (divisor === 0) {
@@ -468,13 +497,13 @@ export function evaluateFunction(
     }
     case 'INT': {
       if (values.length !== 1) {
-        throw new Error('INT expects exactly one argument');
+        throw new FunctionArityError('INT expects exactly one argument');
       }
       return Math.floor(coerceNumber(values[0]));
     }
     case 'SIGN': {
       if (values.length !== 1) {
-        throw new Error('SIGN expects exactly one argument');
+        throw new FunctionArityError('SIGN expects exactly one argument');
       }
       return Math.sign(coerceNumber(values[0]));
     }
@@ -486,7 +515,7 @@ export function evaluateFunction(
     }
     case 'RANDBETWEEN': {
       if (values.length !== 2) {
-        throw new Error('RANDBETWEEN expects exactly two arguments');
+        throw new FunctionArityError('RANDBETWEEN expects exactly two arguments');
       }
       const bottom = Math.floor(coerceNumber(values[0]));
       const top = Math.floor(coerceNumber(values[1]));

--- a/packages/lib/src/sheets/sheet.ts
+++ b/packages/lib/src/sheets/sheet.ts
@@ -14,6 +14,7 @@ export * from './parser';
 export * from './functions';
 export * from './format';
 export * from './format-ops';
+export * from './format-request';
 export * from './conditional';
 export * from './conditional-ops';
 export * from './palette';

--- a/packages/lib/vitest.config.ts
+++ b/packages/lib/vitest.config.ts
@@ -84,6 +84,7 @@ export default defineConfig({
         'src/sheets/conditional-ops.ts': { lines: 100, branches: 100, functions: 100, statements: 100 },
         'src/sheets/palette.ts': { lines: 100, branches: 100, functions: 100, statements: 100 },
         'src/sheets/regions.ts': { lines: 100, branches: 100, functions: 100, statements: 100 },
+        'src/sheets/format-request.ts': { lines: 100, branches: 100, functions: 100, statements: 100 },
         'src/sheets/region-format.ts': { lines: 100, branches: 100, functions: 100, statements: 100 },
       },
     },


### PR DESCRIPTION
Task 1 of 5 in the sheet-agent-regions epic — the WRITE half of the agent surface. Base is `pu/sheet-agent-regions`, the integration branch carrying the region model. ([#2560](https://github.com/2witstudios/PageSpace/pull/2560) is the read half and shares this base; no file overlap.)

> **Two things want a human decision before this merges** — both are one line either way, both are argued in full below and in their threads:
> 1. **`freezeHeader` is refused** because nothing reads it. But [#2560](https://github.com/2witstudios/PageSpace/pull/2560)'s documented read output *includes* it, so the read-then-write-back loop this epic is built on hits the refusal. Delete the refusal and accept the no-op, or derive a `setFrozen` step from the region — the second needs precedence rules I have no standing to invent.
> 2. **The evaluator has no limits**, and four of the eight review rounds produced a P1 that is really the same finding. This PR bounds what it can predict at the write door; the durable fix belongs where the work happens. Not attempted here.
>
> Everything else is done and verified. This is a long description because the reasoning is the deliverable — the refusals are only as good as the arguments for them.

## Why

Six PRs in, sheets have a full presentation model — cell formats, column defaults, widths, row heights, frozen panes, conditional formatting, and now regions — and all of it is reachable only from the React toolbar. Everything above this PR (`applyFormatOps` in the store, the `format_sheet` tool) needs a validator first, because the setters those layers call were written for a panel where the UI *is* the validator: a drag handle cannot ask for an 8px column, and a colour picker cannot emit `#gggggg`.

The setters — and the parsers beneath them — are forgiving by design. They clamp, they skip unparseable addresses, they drop fields that fail their schema, they truncate lists to a cap. That is right on a load path, where the alternative is losing a document. On a write path it turns "I did something other than what you asked" into a success response.

## What

`packages/lib/src/sheets/format-request.ts` — pure, no database, no I/O, no clock.

- `SheetFormatError` — a caller-supplied op that cannot be applied, so a route answers 400 rather than 500.
- `SheetFormatOp` — the full 14-member op union. `rule` and `region` are `unknown` on purpose: `parseConditionalRule` and `parseRegion` are the only definitions of valid, and a value satisfying the TS type can still fail them.
- `planFormatOps(ops, tab)` — validates everything before any caller does I/O and returns `{ steps, rows, touchesTabFields, conditionalFormats, regions }`. `rows` is the 0-based set the per-cell ops touch, so the caller locks and loads exactly those rows instead of the whole tab. `steps` stays one ordered list rather than buckets, because a `clearCellFormat` after a `setCellFormat` over the same cells means something different from the reverse.

All-or-nothing: one bad op refuses the batch, naming its index. A partially applied format request leaves a sheet in a state nobody asked for, and an agent cannot retry without first working out what landed.

## The refusal matrix

| Refusal | What it prevents |
|---|---|
| Unknown key in a `CellFormat` patch, named | `cellFormatSchema` is a plain `z.object`: `.parse({bolt: true})` strips the key and reports success. Checked against a new `CELL_FORMAT_FIELDS` set derived from the field schemas, so the two lists cannot drift. |
| **The caller's object travels downstream, never `result.data`** | `setCellFormats` reads a present-but-undefined field as "clear this field". Zod does not preserve one, so `safeParse` is used for its verdict only. Piping `result.data` would turn every "turn bold off" into a silent no-op. |
| Width outside 24..2000, height outside 16..1000 — refused, not clamped | The setters clamp. Over the API that means a request for 8px reports success and produces 24px. Checking here leaves the clamp as a provable no-op rather than removing a guard the panel relies on. |
| Unparseable range; a range over `MAX_FORMAT_CELLS` (50,000), counted as `rowSpan * colSpan` before expanding | Points at `setColumnFormat` or a region, both of which cover rows that do not exist yet. |
| A batch summing past `MAX_FORMAT_CELLS_PER_REQUEST` (200,000) | A per-op ceiling bounds one op and says nothing about two hundred legal ones. |
| A batch of rules asking the validator to expand past `MAX_CONDITIONAL_TOTAL_CELLS` while checking | The same hole on the rule path, which I only spotted by re-reading the sentence above. `validateRanges` expands every range; the per-rule cap stops one rule at 500,000 cells and nothing stopped two hundred of them — ~100M string allocations before any refusal. Ranges are now counted cheaply and charged to a per-request budget *before* expansion, refusing on the op that crosses the line rather than at the end of the batch. |
| Column label not `^[A-Z]{1,7}$` or past `MAX_ADDRESSABLE_COLUMN` | `decodeColumnLabel` accepts letters of any length and returns an index no sheet can address. |
| Frozen rows/columns negative, non-integer, or past the extent | — |
| Rule failing `parseConditionalRule` | The exact bug #2540 shipped: a blank custom formula was stored, reported as added, and gone on the next load. |
| Rule range and count caps via `validateRanges` and the shared constants | Reused, not reimplemented — they moved into lib precisely so the server and the panel refuse identically. |
| **Aggregate `MAX_CONDITIONAL_TOTAL_CELLS` (2,000,000)** | The fifth cap. `expandRangesWithinBudget` spends this budget and then `break`s, silently: individually legal rules that sum past it stop applying at render time. |
| Region failing `parseRegion`; `MAX_REGIONS`; duplicate ids (rules and regions alike) | `parseRegions` keeps the first duplicate and drops the rest; two rules under one id leaves the newer unaddressable, since update/move reach the first by index while remove filters out both. |
| An id that is not on the sheet, a move already at the end, a patch naming only `id`/`kind` | All are "success, nothing changed" from the underlying setters, which over the API is indistinguishable from having worked. |
| **Anything the load-path parsers would quietly rewrite** | See below. |
| **Round-trip drop detector** | The resulting rule and region lists are re-parsed; anything coming back shorter refuses the batch. |

## What the parsers would quietly rewrite

Two rounds of Codex review found seven issues, and the largest group shares one shape: `parseConditionalRule` and `parseRegion` are LOAD-path parsers, and reusing them as write-path validators inherits their generosity. Before the fix, all of these were accepted and reported as success:

- `format: {bold: true, fontSize: 5}` stored the bold and dropped the size.
- `ranges` past `MAX_CONDITIONAL_RANGES_PER_RULE` was sliced to the cap **by the parser** before `validateRanges` saw it — so the check that exists to refuse exactly that was handed a list that fits and pronounced it fine.
- `headerRows: 999` was dropped and silently became the default of one; an unusable column declaration disappeared from the list.
- a numeric `condition.value`, and an explicit `condition.value: null`, were dropped — leaving a `greaterThan` rule with no threshold, which matches no cell and reads as simply broken.

The fix is deliberately not a hand-written strict validator — that is a second copy of the parsers' rules, free to drift from the thing it mirrors. The parser stays the specification, and `firstSanitizedPath` asks the only question that matters: **is what we are about to store still what was asked for?** Anything the parsers learn to sanitize later is covered without being taught, which is the same argument the round-trip detector makes one level up.

It allows exactly what a parser is entitled to do — case and whitespace on strings, set ordering on lists, since `totalRows` comes back sorted — and refuses everything else with the field named. Unknown fields from a newer build still travel through untouched, so forward compatibility survives. An explicit `null` is **not** treated as an omission: a caller who means "not set" omits the key, and JSON says that perfectly well.

Two checks stay explicit in front of it, because a comparator cannot see them: `validateRanges` runs against the caller's own array before the parser can truncate it, and an unknown key in a rule's format is carried THROUGH rather than dropped, so only a by-name check can catch the typo. Both apply to **the fields the request actually carries** — the whole rule for an add, the patch for an update — because they are stricter than the parser and a stored rule is a fixed point of the parser, not of them. Applying them to a whole merged rule would refuse any update to a rule a newer build wrote: the same cross-version data loss the passthrough exists to prevent, arriving as a refusal instead.

### And what survives storage but means something else

Following that same argument — with three rounds of Codex review pushing on it — turned up a second family the comparator is **structurally** blind to. Here nothing is dropped: the value is stored byte-for-byte as written, and only means something different when the sheet is drawn. Each was measured against the evaluator or verified by search, not reasoned about:

| Accepted before | What actually happened |
|---|---|
| `colorScale` with an unusable `mid` colour | **Paints nothing at all.** `mixColors` returns null for *both* halves of the gradient, so the whole rule is inert. Measured: `{}` versus every cell painted for the identical rule with `#ff0000`. |
| A formula that does not parse (`=BROKEN(`) | The evaluator throws while tokenizing, once per covered cell, catches, and formats none of them. Now validated with the engine's own `tokenize` and `FormulaParser`, so "valid" means the same thing here as where it runs. |
| A cell rule missing its operand | Two **opposite** silent failures: `greaterThan` with no value matches *no* cell, `notContains` with no value matches *every* non-error one. |
| A scale anchor without its value | `anchorValue` substitutes the data's own extreme for a missing one and clamps an out-of-range percent, so `{type:'number'}` becomes "the smallest value". |
| A region declaring a column or total row outside its **body** | `createRegionResolver` excludes cells beyond the bounds before consulting either list — and applies the header treatment and `continue`s, so a total row inside the header band never reaches the total treatment either. **Cross-field**, which is exactly what a readback comparison cannot see: every value is fine on its own. |
| A region naming a hue the palette lost | Renders as slate. `region-format`'s own comment flags this as something "`parseRegion` cannot check without importing the palette" — this module can. |
| A formula calling a function that does not exist (`=BROKEN()`) | Parses fine — `FormulaParser` validates grammar, not vocabulary — then `evaluateFunction` throws once per covered cell. The AST is now walked for calls, and asking whether a function exists probes the 46-case dispatch itself rather than keeping a list beside it. (The spreadsheets skill already tells agents "any other name … fails with `Unsupported function NAME`" and counts the same 46 names, so this refuses at write time what the product already documents at render time.) |
| A formula range with no ceiling (`=SUM(A1:ZZZ5000000)`) | **Not a wrong answer — the process.** See the section below. Bounded by the same `MAX_CONDITIONAL_RANGE_CELLS` the rule's own ranges obey. |
| A call with the wrong number of arguments (`=ABS()`, `=IFERROR(1)`) | Names a real function, passes the vocabulary check, throws once per covered cell. `functions.ts` now raises a typed `FunctionArityError` from its 32 arity guards (same messages), so the dispatch can be *asked* rather than copied. |
| A number-format setting its kind never reads (`{kind: 'number', dateStyle: 'long'}`) | Each field validates on its own; the kind decides whether it is read. Asked of `applyNumberFormat` *and* `numberFormatToExcelCode`, since a field the display ignores can still reach the exported workbook. Catches more than the reported pair. |
| An operand the operator never reads (`isEmpty` with a value, `greaterThan` with `value2`) | Stored and discarded. Neither shape is reachable through the panel, which hides the fields it does not use. |
| A `format` on a `colorScale` or `dataBar` rule | Neither interface declares one and neither evaluator branch reads it — verified by evaluating both kinds with and without a format for byte-identical output. The format is validated field by field, stored, and never drawn, with the validation itself as the false signal. Found by hunting the pattern rather than waiting for it. |
| A `value` on a `min`/`max` anchor | Those read the data's own extreme; a supplied 50 is stored and silently replaced. The mirror of the missing-value case, which I had implemented in only one direction. |
| Column roles on a closed region whose header band fills it | The resolver treats every covered row as a header and `continue`s before consulting the column map — and unlike an open region it cannot grow a body later. |
| A non-numeric operand for a numeric comparison (`greaterThan` with `"abc"`) | `matchesCondition` coerces it to null and returns false for every cell — the same inert rule as a missing value, reached a different way. `equal`/`notEqual` are excluded, since they fall back to a text comparison. |
| An unknown key **nested** inside a format (`{number: {kind, curreny}}`) | `cellFormatSchema` strips it from the nested object as quietly as from the top level: renders as the default currency, gone on the next load. |
| A column setting the column's role never reads (`{role: 'number', currency: 'EUR'}`) | `columnRoleFormat` reads `currency` only for `role: 'currency'`, so this is stored, ignored, and looks like money that lost its symbol. Answered by asking the deriver — render the format with two different values for the field and see whether the output moves — rather than restating which role reads what. |
| `freezeHeader: true` | Nothing reads it — **and this one needs a decision, see below.** Parsed, stored, and no consumer exists anywhere, so the request succeeds and pins no rows. Refused with a pointer to `setFrozen`, which works today — see the thread for why refusing rather than deriving, and what it would take to flip. |

One finding in this family was not a wrong answer but a **crash**: the readback comparison descended a caller-supplied nested value until V8 raised a `RangeError`, which escapes as a 500 — the one outcome `SheetFormatError` exists to prevent. Bounded at twelve levels, as a pre-check rather than a guard inside the walk, so the comparison stays a plain recursive walk and the bound is enforced iteratively where it cannot overflow itself. A too-deep value is refused wherever it sits, including where an identity shortcut would have skipped looking: accepting something *because* it was too deep to check would turn the bound into a hole.

Three of these needed something only the engine knows, and in each case the answer is taken from the engine rather than copied into this module: `conditional.ts` exports `SCALE_ANCHOR_TYPES` and `VALUED_ANCHOR_TYPES`; `functions.ts` gains an `isSupportedFunction` that probes its 46-case dispatch instead of listing it; and which column settings a role reads is answered by rendering the format twice and seeing whether the output moves. Every one of those lists would otherwise have been a second copy, free to drift the first time someone extended the first.

One went further: `VALUELESS_OPERATORS` and `RANGE_OPERATORS` already existed, in `apps/web/.../rule-presets.ts`, where `packages/lib` cannot reach them. A server that writes rules has to agree with the UI that edits them about what a valid rule *is* — that is the whole reason `conditional-ops.ts` lives in lib — so both sets moved to `@pagespace/lib/sheets` and the panel re-exports them. Every existing importer is untouched, and it is the only change outside `packages/lib`.

## Four P1s, one root cause — worth reading before the next sheets PR

Eight review rounds produced four P1 findings, and they are the same finding wearing different clothes:

| | The formula the caller sends | What the evaluator then does |
|---|---|---|
| 1 | `=SUM(A1:ZZZ5000000)` | expands ~91 billion addresses — `expandRange` has no cap |
| 2 | covers 500k cells, references 500k | re-expands per covered cell: 250 billion |
| 3 | 200 rules each legal on its own | four billion, because the ceiling was per-rule |
| 4 | a 5,000-term `A1+A2+…` chain | overflows the stack, once per covered cell |

Every one is "the evaluator will do unbounded work, so the write path must predict it and refuse." This PR does that, and does it with measurements rather than guesses. But it is worth being explicit that **this is the wrong end of the problem to be solving.**

`expandRange` is two nested loops with no ceiling; `evaluateNode` recurses on `BinaryExpression.left` with no depth limit; nothing bounds how much work a render may cost in total. A validator can only refuse the shapes it has been taught to predict, and each new formula capability reopens the hole — as this branch demonstrated four times in four rounds. The durable fix is limits in the evaluator, where the work actually happens and where a stored sheet written by any other path is also protected.

Recorded here rather than attempted: capping `expandRange` changes evaluation semantics repo-wide and belongs in its own change with its own tests. The same goes for the maximum-arity guards discussed in the threads.

## A refusal that had become a trap

Worth calling out separately, because it is the one place the module's own doctrine had inverted. The aggregate `MAX_CONDITIONAL_TOTAL_CELLS` check refused any write whose resulting total was over the ceiling — **including a write that lowered it**. Sheets past that ceiling are reachable: the panel's `addRule` enforces the per-rule and rule-count caps but not the aggregate. So on such a sheet every write was refused, including the removals that would have fixed it, and the only writer that could repair it was the one refusing to.

It now refuses only when the result is over the ceiling *and* higher than it was. A write that does not make matters worse is always allowed, and the message says so — an agent that reads "over the limit" and stops has been told the wrong thing.

The alternative Codex offered — enforce the aggregate in every writer, including the panel — would make the panel refuse edits on sheets that already exist. That is a product decision this PR has no standing to make, so it is flagged in the thread rather than chosen silently.

## One refusal that needs someone else's decision

`freezeHeader` is refused because nothing reads it: `createRegionResolver` does not, and the `setRegions` step only stores the region, so accepting it is a request that succeeds and pins no rows.

The complication, found late: **[#2560](https://github.com/2witstudios/PageSpace/pull/2560) documents its read output with a sample region containing `"freezeHeader": true`.** The half of this epic built for an agent to read a region and write it straight back advertises the field this half refuses.

I have left the refusal in, and it is accurate: the field pins no rows whatever wrote it. But I first argued it was also nearly free, on the grounds that nothing writes regions except this validator — and that is wrong. `io.ts` reads regions out of the sheet document's own bag (`ranges.__regions`) and writes them back, so a region can reach a tab from a stored or imported document carrying `freezeHeader` without ever passing through here. On such a sheet this refusal blocks re-writing that region until the field is removed. No UI writes regions, so those are the only two paths — but "nobody can have one yet" was doing work in my argument and it is not true.

The alternative (derive a `setFrozen` step from the region) needs decisions this PR has no standing to make: precedence against an explicit `setFrozen` in the same batch, which region wins when two declare it, and whether removing the region should unfreeze. One line either way once someone picks.

## Found on the way: an uncapped path this PR does not own

Review flagged that a conditional formula could reference `A1:ZZZ5000000`, which this PR now refuses. Chasing it turned up something larger, so it is recorded here rather than fixed quietly.

`expandRange` has no cap of any kind — two nested loops over the whole rectangle, one string per cell. Measured on bounded inputs: `A1:J100000` yields 1,000,000 addresses in 42ms, about 24M/s. At that rate the ~91 billion addresses of `A1:ZZZ5000000` is roughly an hour of CPU, and it would exhaust memory long before finishing.

`evaluation.ts` calls it in **four** places, two of them on the ordinary cell path (`collectDependencies` and `evaluateNode`). So `=SUM(A1:ZZZ5000000)` typed into a plain cell reaches the same loop. That predates this branch and is not specific to conditional formatting.

This PR closes the door it owns — a formula arriving through the write path is bounded by `MAX_CONDITIONAL_RANGE_CELLS`. Capping `expandRange` itself would change evaluation semantics repo-wide and wants its own change and its own tests, so it is flagged rather than folded in here.

## The refusal message is the caller's only feedback loop

An agent cannot inspect this module; it sees one string and gets one chance to repair the op. So I probed what task 3 will actually send, rather than what the tests already assert, and fixed three messages that were true but unusable:

- **Ranges.** `$A$1:$F$1`, `Sheet1!A1:F1` and `A1 : F1` — absolute refs off a formula bar, a qualifier copied from another tool, spaces around the colon — all collapsed into `"…" is not a range this sheet can address`. Each is a one-token repair, so the message now names the token. Suffix only: a shape it cannot explain keeps the plain refusal rather than a wrong guess.
- **Rows.** `{ row: "3" }`, which is what a JSON round trip through a tool call produces, refused with `row must be a 1-based row number; got 3`. Three *is* a 1-based row number — the message accused the one thing that was right and hid the quoting, which was the actual defect. The type check now stands on its own and names the type.
- **Condition values.** `ConditionalCondition.value` is a string, so the most ordinary rule there is — "highlight cells greater than 5" — arrives as `value: 5`, gets dropped by the parser, and refused with a path and no remedy. It now says the value is text and quotes the number back. Deliberately not a coercion: storing `"5"` for `5` is this module doing the one thing it exists to prevent, and it is the same call as refusing rather than clamping an out-of-range width.

- **Regions.** `parseRegion` fails as a whole, so its refusal listed every requirement — telling a caller holding `{id: 'r1', range: '$A$1:$F'}` that a region needs an id. It sent one. When the range is the part that will not parse, the refusal now says so and carries the same hint. The catch-all keeps the cases it is actually for: no id, a range that parses but fails elsewhere, and a region that is not an object at all.

The same probing found a stray `format` beside `patch` on `setCellFormat` being accepted with the italic silently discarded, which is why ops now refuse a field that is not theirs.

Two of these hints repair one thing at a time on purpose, and the spaces hint echoes the caller's own string with the spaces removed rather than a worked example — `A1:F1` is a fine repair for a cell range and a silent change of meaning for a region, where `A1:F` runs to the end of the sheet.

Probing all fourteen ops with each required field omitted found **nothing wrong**: every one refuses, names the field and gives a shape. That is now a sweep driven off `OP_FIELDS` (exported for it, and public through the `sheets/sheet` barrel like `FIELDS_BY_KIND`), with the sample table asserted against its keys — so a fifteenth op cannot join the union without being swept, and each sample is checked valid first, or an op could pass by being refused for an unrelated reason.

Worth noting what this did **not** change. An unknown field *inside* a region is still carried through, while an unknown field *on the op* is refused. That asymmetry is deliberate: `io.ts` reads regions back out of `ranges.__regions` and writes them again, so read-modify-write of a region a newer build wrote is a path that exists today and refusing an unknown field would turn forward compatibility into a hard failure. The op envelope is never stored and has no such path. Only the nested case was pinned by a test, so a tidy-up making the two "consistent" would have passed; it is pinned now.

## A retry hazard task 3 has to know about

The module documents which ops are safe to replay after an I/O failure, and that documentation was wrong in the direction that costs data. It claimed four ops "refuse the second time", so a caller could read the refusal as "the first attempt landed". Three do. `moveConditionalRule` does not: a move that landed leaves nothing behind saying so, so replaying it moves the rule **another place** and reports success.

The retry table in the tests looked like it proved otherwise — its move case puts the rule last and moves it later, so what refuses is the boundary, not the replay. Probed directly: `a,b,c,d` with `move d earlier` gives `a,b,d,c`, and replaying the identical op gives `a,d,b,c`.

Nothing in this module can fix it. An op meaning "one place earlier" cannot tell a fresh request from a repeat, and the position it should land on is not in the op — that is a property of the op union the task specified, not of this validator. So the header now says so plainly, the general case is pinned by a test rather than implied by a boundary, and the guidance for a tool built on this is: **do not replay a move blindly** — send the ordering you want, or re-read the rule list and check the result.

If `format_sheet` wants a safely retryable reorder, the op it needs is an absolute one (`setConditionalRuleOrder(ids)`, the way `setRegions` works) rather than a relative nudge. Not invented here, for the same reason as the gap below: the union was enumerated in the task.

## One gap worth naming for task 3

The op union is the one the task specified, and it has no `clearColumnFormat` to match `clearCellFormat`. Clearing a column default is still possible — `setColumnFormat` with each field explicitly `undefined` empties the entry, since `isEmptyFormat` then drops it — but it is awkward to express and an agent is unlikely to find it. Left alone rather than invented here, because the union was enumerated in the task; flagging it in case the `format_sheet` tool wants the op.

## Tests

`packages/lib/src/__tests__/sheet-format-request.test.ts` — 145 tests, and a 100% per-glob coverage threshold for the file in `packages/lib/vitest.config.ts`, met on all four metrics.

Green tests are weak evidence here, so every claim is mutation-checked: break the source line (by line index, not string-replace — twin lines make first-occurrence replace test the wrong branch), confirm the suite goes red, restore.

**The guard sweep, stated precisely.** It neutralises each guard in turn and runs the suite. There are 133: 99 written `if (…) {` and 34 brace-less early returns (`if (…) return null;`). 130 go red. Three do not, and they are named here rather than rounded away:

- `canonical`'s `undefined` and array branches. `firstSanitizedPath` handles arrays itself before either side reaches `canonical`, and where a nested array is reached both sides pass through the same function, so the normalisation difference cancels. Kept because `canonical` is a general-purpose serialiser — without the `undefined` branch it stops returning a string at all — and because neither is *subsumed* by another check, which was the bar for the five lines this branch did delete.
- `if (rule.kind !== 'formula') continue` in the formula-budget loop. Chased down rather than assumed: `parseConditionalRule` really does preserve a stray `formula` on a cell rule, so without the guard that rule gets tokenized and charged. It still cannot change an answer, because the aggregate test is `workAfter > MAX && workAfter > workBefore` — the repair exception — and a stored rule's cost is counted on both sides. So the doctrine already covers the correctness; the guard only saves the tokenizing.

An earlier revision of this section said "all 92 go red" and "every guard is mutation-covered". That was measured over the braced guards only; the brace-less ones had never been swept. The count and the claim are corrected above.

It was 77 of 78 first time round. The survivor was a prototype-key branch subsumed by the unknown-key check beside it, and it was removed rather than kept — worth stating plainly in case that reads as dropping a safety guard. It is not: this module hands the caller's object onward untouched and never copies keys onto an object of its own, so there is no assignment for a prototype key to reach. `parseCellFormat` keeps its guard, where it builds a new object key by key and the guard is load-bearing.

Alongside the sweep, ~75 targeted probes across the branch, all but four killed. The three greens were acted on rather than explained away:

- the array length check in the comparator changed nothing (the positional comparison already catches a shorter list) → **line deleted**;
- an explicit null guard changed nothing (`canonical` mapped null and a missing field alike) → **line deleted**, and then Codex showed the *behaviour* was wrong too, so `canonical` now distinguishes them;
- the third was an early probe superseded by those two.

Two of the required cases exist specifically because the obvious test passes under both the correct and the broken implementation:

- **width 8** — asserting the stored value is 24 passes either way, since the setter clamps. The test applies the plan through the real `setColumnWidth` and asserts nothing was recorded, and proves in the same body that the recorder does record (a "was not called" assertion is vacuous otherwise).
- **`{ bold: undefined }`** — asserting on a round-tripped result hides the trap. The test asserts `step.patch` is identically (`toBe`) the caller's object and still carries the `bold` key.

**One test is not a refusal.** After nine rounds of adding them, a validator can pass every negative test and still be useless — each new rule is a chance to refuse something legitimate. So one test plans the request this epic opens with, as an agent would send it in a single batch: *"A1:F is a table, row 1 is headers, column C is money, row 40 is a total, accent blue"*, plus a freeze, a column width, a row height, a currency column default, two cell formats, a colour scale and a formula rule calling `ABS` and `SUM`. It passed first time. It also pins the two properties a caller depends on — steps come back in request order, and `rows` holds exactly the two rows the per-cell ops touch, not the sixty the region covers.

There is also a seeded fuzz — 600 generated op shapes, built from the scalars and keys the parsers treat specially — asserting that every outcome is either a well-formed plan or a `SheetFormatError`. A `TypeError` escaping this module would answer 500 where a 400 belongs, and a validation layer that crashes on the input it exists to reject is worse than none. Seeded so a failure is reproducible from its message, and verified to actually catch one: disabling a single guard produces `seed 13 threw TypeError: Cannot convert undefined or null to object for {"type":"setCellFormat"}`.

Four property tests over ~186 generated rule and ~140 generated region candidates, in both directions:

- everything the validator **accepts** must survive `parseConditionalRule` / `parseRegion` unchanged, with floors on both outcomes (measured 12 accepted / 174 refused for rules, 18 / 122 for regions) so a generator that accepts almost nothing cannot pass vacuously;
- everything the **parsers produce** must survive `planFormatOps` — the loop #2560 depends on, where an agent reads regions, changes one field and writes the list straight back. This one found four boundaries on its first run. Enumerating them in the assertion was the wrong shape, because the list kept growing; the invariant is that a parser fixed point may be refused for a VALIDITY reason but never for a FIDELITY one. The comparator can have nothing to say about a value the parser itself produced.

A caveat worth stating for whoever wires the read path to this one: a region that already carries a *render-time* problem — a hue this build's palette no longer has, a total row sitting in its header band, a `currency` on a non-currency column — will be **refused on write-back**, by design. The invariant only guarantees that a parser fixed point is never refused for a fidelity reason. In practice that only bites regions written by the panel or an older build, and the refusal names the field and what to change, so it is a fix-this rather than a dead end.

One consequence is stated rather than left latent: a rule carrying a format field a newer build wrote can be **edited but not cloned**, since the by-name check holds a caller-supplied format to this build's list. Refusing costs a copy-this-format flow across versions and names the field; accepting would let `bolt` for `bold` format nothing, forever, silently.

## What it costs

A fair question after this many checks, answered with a measurement rather than a shrug. `planFormatOps` on a typical dashboard request — a freeze, a width, a column default, a cell format, a region and two rules — is **0.084ms**. A single op covering the maximum 50,000 cells is **1.4ms**, and that is almost entirely materialising the 50,000 addresses the caller needs anyway.

Two things keep it there. Cell counts are arithmetic on range corners, never expansion — `rowSpan * colSpan` is computed before anything is allocated, so the ops that get refused for being too large are the cheapest to refuse. And the probes that ask the engine questions (`isSupportedFunction`, `isValidCall`, the number-format and column-role checks) run once per *declaration*, not per cell.

## Verification

- `bun run --filter @pagespace/lib test -- sheet-format-request` → 145 passed (exit 0 captured before any pipe)
- `bun run --filter @pagespace/lib test:coverage -- sheet-format-request` → the new glob meets 100% on lines, branches, functions and statements
- `bun run --filter @pagespace/lib typecheck` → 0 errors

Also run: `bun run --filter @pagespace/lib lint` → exit 0.

**Note on CI:** `test.yml` filters `pull_request` on the **base** branch (`[main, master, develop, pu/flash-sandbox, pu/panes-agent]`), so a PR based on `pu/sheet-agent-regions` gets no automatic run — the only status GitHub shows here is CodeRabbit reporting that it skipped. The full suite has therefore been dispatched manually against this branch via `workflow_dispatch` several times as the work landed. On `8de85ff83` — which carries every refusal in this PR, the typed errors added to `functions.ts`, and the one change in `apps/web` — **Lint & TypeScript Check and E2E are green**, which is what confirms the monorepo typecheck, the `packages/lib` build (a different gate from `tsc --noEmit`) and `knip` all pass with these changes. The Unit Tests job on that commit was still running at the time of writing; an earlier dispatch had all three green.

**Where CI stands, precisely.** On `25d48dca9` — carrying every refusal in this PR, both typed errors added to `functions.ts`, and the one `apps/web` change — **Lint & TypeScript Check and E2E are green**. That is the job that runs the monorepo typecheck, the `packages/lib` build (a different gate from `tsc --noEmit`) and `knip`, so those three are confirmed.

As of the latest dispatch, on `8f921e487`: **Lint & TypeScript Check and E2E are green.** That first job is the one carrying the monorepo typecheck, the `packages/lib` build (a different gate from `tsc --noEmit`) and the **knip** unused-code gate — so every export added on this branch, including the ones that only tests consume, is confirmed clean. Four commits sit past that SHA; three are tests and documentation, and the fourth is the malformed-tab guard, which throws a plain `Error` and is covered locally.

The Unit Tests job is the slow one — full runs of this suite are currently taking about 30 minutes end to end, on every branch. An earlier dispatch of this branch had all three jobs green; later dispatches have been re-cut as commits landed, and the current one is still going.

(I twice read that slowness as a hang and cancelled a run for it. The second time was wrong: the sibling run I had cited as evidence went on to finish successfully at 30 minutes, which means the run I cancelled at 23 minutes was probably minutes from returning. Recorded because the CI history on this PR shows several cancellations and they deserve an honest explanation rather than the tidier one I first gave.)

One later dispatch failed a single test — `preview-ws-tunnel > answers 502 when the upstream cannot be reached at all`, `Test timed out in 5000ms` at 5310ms, with 12,390 of 12,397 passing. That test opens a socket, closes it to obtain a dead port, and waits for the OS to refuse a connection; it is timing-dependent by construction, sits in the sandbox preview subsystem, contains no reference to sheets, and is not in this diff. It passed on the dispatch before and is re-run on the final one.

**Note on knip:** `bun run knip:check` reports 5 issues, all in files this PR does not touch (`env-bridge/index.ts`, `app-hosting/build-wiring.ts`, `drive-envs/env-contract.ts`, last modified by unrelated commits). Pre-existing on the base branch, or the worktree-phantom effect knip has shown here before — either way not introduced here, and flagged so it is not a surprise when this epic reaches master.

## Also touched

- `format.ts` — exports `CELL_FORMAT_FIELDS`, derived from the existing `FIELD_SCHEMAS` map so there is one list of format fields, not two.
- `conditional.ts` — exports `SCALE_ANCHOR_TYPES`, `VALUED_ANCHOR_TYPES`, `NUMERIC_OPERATORS`, `asComparableNumber`, and now houses `VALUELESS_OPERATORS` / `RANGE_OPERATORS`.
- `functions.ts` — `UnsupportedFunctionError` and `FunctionArityError` (types, so "unknown function", "wrong number of arguments" and "I can't work with that value" stay distinguishable without matching on prose), plus `isSupportedFunction` and `isValidCall`, which probe the 46-case dispatch instead of duplicating it. The 32 arity guards keep their exact messages, so the three existing tests asserting them are untouched.
- `vitest.config.ts` — the 100% per-glob threshold for the new file, beside the existing `regions.ts` entry.
- `apps/web/.../core/rule-presets.ts` — re-exports those two sets instead of defining them. The only change outside `packages/lib`.
- `sheet.ts` — barrel export.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NXiBa4MAQsSHXF9aZApZEo





