### PR TITLE
feat(editor): the conversion core — htmlToYDoc, four projections, minimal CRDT diff

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -88,6 +88,20 @@ jobs:
       # turning that silent skip into a hard failure — which is exactly what it
       # was added to do. If you add another variable to a step below and the
       # tests still cannot see it, this is why.
+      # packages/editor's cross-DOM parse-equality suite drives a REAL Chromium
+      # and compares its ProseMirror parse against happy-dom's, over the
+      # construct corpus. Several `parseHTML` functions in the frozen collab
+      # schema read the DOM rather than the source string, so two processes can
+      # agree on SCHEMA_HASH and still disagree about what a document IS — and
+      # nothing else in the suite can catch that. The test deliberately does not
+      # skip when the browser is missing, so this step is required, not
+      # optional. Installed from apps/e2e, the workspace that owns Playwright;
+      # the browser cache is shared, and packages/editor's playwright-core
+      # resolves the same build.
+      - name: Install Chromium (cross-DOM parse-equality suite)
+        run: bunx playwright install --with-deps chromium
+        working-directory: apps/e2e
+
       - name: Run tests with coverage (Node 24)
         env:
           DATABASE_URL: postgresql://postgres:postgres@localhost:5432/pagespace_test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -99,15 +99,15 @@ jobs:
           path: ~/.cache/ms-playwright
           key: ms-playwright-${{ runner.os }}-${{ steps.playwright-version.outputs.version }}
 
-      # `--with-deps` (the apt pass) only on a miss; the browser binary itself is
-      # what the cache restores.
+      # `--with-deps` unconditionally, INCLUDING on a cache hit. Skipping the apt
+      # pass when the browser binary is cached looks like a saving and is a trap:
+      # the cache restores the binary but not the system libraries it links
+      # against, so a runner image that drops one would fail to launch Chromium
+      # only on cache-hit runs — a failure that cannot reproduce on the run that
+      # populated the cache. The download is the expensive part and the cache
+      # already removes it; apt with everything present costs seconds.
       - name: Install Chromium (cross-DOM parse-equality suite)
-        run: |
-          if [ "${{ steps.playwright-cache.outputs.cache-hit }}" = "true" ]; then
-            bunx playwright install chromium
-          else
-            bunx playwright install --with-deps chromium
-          fi
+        run: bunx playwright install --with-deps chromium
         working-directory: apps/e2e
 
       # ADMIN_DATABASE_URL belongs here too, not only on the backfill/db-integration

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -94,7 +94,7 @@ jobs:
 
       - name: Cache Playwright browsers
         id: playwright-cache
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
         with:
           path: ~/.cache/ms-playwright
           key: ms-playwright-${{ runner.os }}-${{ steps.playwright-version.outputs.version }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,6 +72,44 @@ jobs:
       - name: Create scratch Admin database
         run: PGPASSWORD=postgres psql -h localhost -U postgres -d postgres -c 'CREATE DATABASE pagespace_admin_test'
 
+      # packages/editor's cross-DOM parse-equality suite drives a REAL Chromium
+      # and compares its ProseMirror parse against happy-dom's over the construct
+      # corpus. Several `parseHTML` functions in the frozen collab schema read the
+      # DOM rather than the source string, so two processes can agree on
+      # SCHEMA_HASH and still disagree about what a document IS — and nothing else
+      # in the suite can catch that. The test deliberately does NOT skip when the
+      # browser is missing (a cross-DOM check that goes green with one DOM is
+      # worse than no check), so this step is required, not optional.
+      #
+      # Installed from apps/e2e, the workspace that owns Playwright; the browser
+      # cache is shared, and packages/editor's playwright-core resolves the same
+      # build. Cached on the resolved Playwright version so only the first run
+      # after a bump pays the ~170MB download — without this every push to every
+      # branch re-downloads it, and this repo has no CI concurrency group, so
+      # superseded runs never cancel and each one pays again.
+      - name: Resolve Playwright version (cache key)
+        id: playwright-version
+        run: echo "version=$(node -p "require('playwright-core/package.json').version")" >> "$GITHUB_OUTPUT"
+        working-directory: packages/editor
+
+      - name: Cache Playwright browsers
+        id: playwright-cache
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/ms-playwright
+          key: ms-playwright-${{ runner.os }}-${{ steps.playwright-version.outputs.version }}
+
+      # `--with-deps` (the apt pass) only on a miss; the browser binary itself is
+      # what the cache restores.
+      - name: Install Chromium (cross-DOM parse-equality suite)
+        run: |
+          if [ "${{ steps.playwright-cache.outputs.cache-hit }}" = "true" ]; then
+            bunx playwright install chromium
+          else
+            bunx playwright install --with-deps chromium
+          fi
+        working-directory: apps/e2e
+
       # ADMIN_DATABASE_URL belongs here too, not only on the backfill/db-integration
       # steps below. The GDPR eraser's integration suite
       # (packages/lib/src/compliance/erasure/__tests__) gates its whole describe
@@ -88,20 +126,6 @@ jobs:
       # turning that silent skip into a hard failure — which is exactly what it
       # was added to do. If you add another variable to a step below and the
       # tests still cannot see it, this is why.
-      # packages/editor's cross-DOM parse-equality suite drives a REAL Chromium
-      # and compares its ProseMirror parse against happy-dom's, over the
-      # construct corpus. Several `parseHTML` functions in the frozen collab
-      # schema read the DOM rather than the source string, so two processes can
-      # agree on SCHEMA_HASH and still disagree about what a document IS — and
-      # nothing else in the suite can catch that. The test deliberately does not
-      # skip when the browser is missing, so this step is required, not
-      # optional. Installed from apps/e2e, the workspace that owns Playwright;
-      # the browser cache is shared, and packages/editor's playwright-core
-      # resolves the same build.
-      - name: Install Chromium (cross-DOM parse-equality suite)
-        run: bunx playwright install --with-deps chromium
-        working-directory: apps/e2e
-
       - name: Run tests with coverage (Node 24)
         env:
           DATABASE_URL: postgresql://postgres:postgres@localhost:5432/pagespace_test

--- a/.pu-reports/pu-mp-conversion-core.md
+++ b/.pu-reports/pu-mp-conversion-core.md
@@ -216,6 +216,59 @@ cannot reach (`node.text ?? ''` on a text node, `Number(attrs.level) || 1` on a 
 covering them would mean asserting against documents the schema forbids. Deleting the narrowing is
 not available under `no any`. The reasoning is in `vitest.config.ts` next to the numbers.
 
+## Cleanup pass (second commit)
+
+A four-angle quality review (reuse / simplification / efficiency / altitude) ran over the diff.
+What it changed, beyond the mechanical dedup:
+
+- **The two fail-closed guards had already drifted.** HTML checked the document root, markdown did
+  not — `descendants` never visits the root — so a document whose TOP node a projection cannot
+  represent was accepted. Now one shared `assertProjectable`, and the root is checked. The *sets*
+  stay separate on purpose: the markdown serializer's node map legitimately differs from the schema.
+- **Two totality gaps.** Nothing compared the schema's node set against what each projector handles,
+  so adding a node in a Class B change and forgetting a projector left CI green and threw in the
+  collab service instead. And `BLOCK_NODE_TYPES` fails *open*: a block node missing from it silently
+  yields `blockId: null`, which callers read as legitimate pre-v1 content and skip. Both are now
+  compared against the schema in `projector-totality.test.ts`. The current lists are correct — the
+  mechanism was the gap, not the data.
+- **A latent bug the refactor surfaced:** `tableMarkdown` sized the table from the *first* row rather
+  than the widest, so a ragged table dropped the extra cells of every wider row. Found by rewriting
+  it around one `line()` helper; now tested.
+- **The fidelity gate was blind to attribute VALUES.** `attr:p@style` merged the question with the
+  answer — `text-align:center` becoming `left`, or `data-type="taskList"` becoming `taskItem`, moved
+  no construct key. Now keyed per CSS property and per `data-type` value.
+- **Removed a mirror test.** "preserves every visible character" recomputed what `describeHtmlLoss`
+  already asserts and could not fail unless that failed first, while its duplicated whitespace rule
+  would silently drift from `visibleCharacters`.
+- **Efficiency, measured:** `assertMarkdownProjectable` rebuilt two `Set`s per call and
+  `pmDocToBlocks` projects once per block — 400 throwaway sets on a 200-block document, ~40% of its
+  runtime. Now built once.
+- **CI:** the Chromium step had been inserted *between* the `ADMIN_DATABASE_URL` comment and the step
+  it explains. Moved, and cached on the resolved Playwright version — with no CI concurrency group in
+  this repo, every superseded run was re-downloading ~170MB.
+
+Deliberately **not** done, each a real finding parked rather than dismissed:
+
+- **`TEXTLESS_CONTENT_ELEMENTS` is a deny-list, so an unknown embed (`<math>`, `<model-viewer>`, the
+  24 raw-HTML-passthrough pages) fails OPEN** — the one place the inbound half is not fail-closed.
+  The fix is a catch-all "unrecognised `<tag>`" reason, which changes which documents refuse to seed.
+  That belongs to the seed-fidelity leaf, with real corpus numbers behind it.
+- **A `<br>` dropped mid-paragraph is undetectable** — `visibleCharacters` strips `\n`, and `<br>` is
+  excluded from the element count to tolerate trailing caret padding. The precise fix (count only
+  non-trailing `<br>` against `hardBreak`) is also a behaviour change; same leaf.
+- **The happy-dom `Window` per call** (~1.1ms per flush, ~25% of the HTML projection). A shared
+  module-level workspace would recover it, but it argues against a decision this module documents at
+  length, and 1.1ms per flush is not the constraint. Noted, not changed.
+- **`createDomWorkspace` now exists three times** (here, `apps/web/.../document-content-format.ts`,
+  `apps/web/.../census/constructs.ts`). `apps/web` already depends on `@pagespace/editor`, so the
+  direction is legal and this is the right home — but collapsing them edits `apps/web` and the census
+  is documented as temporary. The `dom-workspace.ts` docstring now names both twins so the next
+  reader is not misled.
+
+Final: **283 tests**, 11 files. **19 further mutations** run against the refactored paths; four
+survived and all four were genuine gaps in the new code (the root check, a label-less mention, an
+empty `blockId`, and the ragged table), each now covered and re-confirmed red.
+
 ## Not in scope, and deliberately not done
 
 - The **seed-fidelity gate over real production documents** is its own leaf (`jklkkf8aaao6v7jpc0mk8qub`,
@@ -237,7 +290,7 @@ At the monorepo root:
 | `bun run lint` | **green** — 17/17 tasks |
 | `bun run knip:check` | **green** |
 | `bun run test` | **could not run locally** — see below |
-| `packages/editor` suite | **green** — 288 tests, 10 files |
+| `packages/editor` suite | **green** — 283 tests, 11 files |
 
 `SCHEMA_HASH` unchanged at `'ded0823d'`.
 

--- a/.pu-reports/pu-mp-conversion-core.md
+++ b/.pu-reports/pu-mp-conversion-core.md
@@ -1,0 +1,252 @@
+# Phase B — the conversion core: `htmlToYDoc`, the four projections, `applyPmDocToYDoc`
+
+All three leaves' acceptance criteria are met, in `packages/editor`. The headline results:
+
+- **The cross-DOM parse-equality blocker is answered, and answered positively.** happy-dom and a
+  real Chromium produce byte-identical ProseMirror JSON for every fixture in the construct corpus,
+  including the three cases the leaf singled out as most likely to diverge (a single-quoted
+  `font-family` in a `style` attribute, list tightness inferred via `querySelector('p')`, and a
+  table written with no explicit `<tbody>`). This was the highest-impact unknown in Phase B and it
+  is now a test that runs in CI, not an assumption.
+- **Every construct in the corpus reaches a one-pass fixpoint and loses nothing.** 23 fixtures,
+  measured, with the cosmetic rewrites named in an explicit allowlist rather than absorbed by a
+  loose comparison.
+- **Mutation testing found a real error in my own implementation**, described below. It is the one
+  thing in this PR I would not have caught any other way.
+
+`SCHEMA_HASH` is unchanged at `'ded0823d'` — nothing in this PR touches `collabExtensions()`.
+
+## What landed
+
+Nine new modules in `packages/editor`, all pure, all React-free, all importable from a Node
+service with no DOM installed process-wide:
+
+| module | what it is |
+|---|---|
+| `dom-workspace.ts` | happy-dom as a **production `dependency`**, wrapped so a window is never leaked and never installed as a global |
+| `collab-document.ts` | memoised frozen schema, `COLLAB_FRAGMENT_FIELD`, `Y.Doc` ⇄ ProseMirror |
+| `html-to-ydoc.ts` | the seed parse, `describeHtmlLoss`, fail-closed |
+| `y-doc-to-html.ts` | the lossless projection — what `pages.content` keeps holding |
+| `y-doc-to-text.ts` | the search projection — no markup, at all |
+| `y-doc-to-markdown.ts` | the AI-context projection, on `prosemirror-markdown` directly |
+| `y-doc-to-blocks.ts` | block addressing, replacing line-number splicing |
+| `apply-pm-doc-to-y-doc.ts` | minimal CRDT diff via `updateYFragment` |
+| `projection-errors.ts` | `UnknownNodeError`, `UnrepresentableContentError` |
+
+287 tests, all new work mutation-checked. Coverage floors raised: lines 71 → 92, functions
+53 → 96, statements 71 → 92.
+
+## The correction mutation testing forced
+
+My first `applyPmDocToYDoc` called `initProseMirrorDoc(fragment, schema)` to build a populated
+binding mapping before `updateYFragment`, and the docstring asserted — confidently, in bold — that
+passing a fresh empty mapping "would quietly defeat the whole thing, because every existing node
+would fail the identity check and be rewritten."
+
+**That was wrong.** The mutation that replaced the populated mapping with an empty one *survived*
+every test. Measured directly: a one-word change in a 37 KB document emits a **41-byte** update
+with a populated mapping and a **41-byte** update without one. On a mapping miss `updateYFragment`
+falls back to `equalYTypePNode`, a deep structural comparison, so the diff is minimal either way.
+`initProseMirrorDoc` materialises the entire fragment as ProseMirror nodes to build a mapping that
+changes nothing — an O(document) walk on **every apply**, in the hot path of a service that applies
+on every AI edit.
+
+Removed. `y-prosemirror` itself passes `{ mapping: new Map(), isOMark: new Map() }` for exactly
+this kind of one-shot conversion (`sync-plugin.js:564`), and `isOMark` is a lazily-populated memo,
+so empty is not merely tolerable but correct.
+
+What *is* load-bearing is `updateYFragment` rather than delete-and-reinsert, and that mutation goes
+red: replacing it with `fragment.delete(...)` + `prosemirrorToYXmlFragment` fails the size and
+identity assertions. The comment now says the true thing, with the measurement in it.
+
+The general lesson is the one already in this epic's history: a test that only compares *documents*
+cannot tell a correct diff from a correct-looking one. Both converge on the same content. Only
+update size and Y-type identity separate them, so those are what is asserted.
+
+## The corrections from the brief, and how each was handled
+
+**1. Byte-identical round-trip is the wrong bar.** Not built. `seed-fidelity.test.ts` asserts
+`render(parse(h1)) == h1` plus zero construct loss, and expresses the tolerance as
+`ALLOWED_COSMETIC_ADDITIONS` — twenty named markup constructs one pass may add (`<colgroup>`,
+`ul@data-tight`, `TaskItem`'s checkbox markup, `Link`'s `target`/`rel`, …), each with a comment
+saying why its absence from the source is not information. A twenty-first fails the suite.
+
+The allowlist has its own guard: a test asserts it contains **nothing the corpus does not actually
+produce**, so it cannot rot into a blanket tolerance that hides the next real change. (That guard
+must be computed per fixture and unioned, not over the concatenated corpus — in the concatenation a
+construct one fixture gains is already present in another fixture's source, and five real rewrites
+read as never produced. The comment records this.)
+
+**2. No `tiptap-markdown` in the projector.** `yDocToMarkdown` is written on `prosemirror-markdown`
+directly, over all 19 nodes and 11 marks of the frozen schema. (The leaf says "16 nodes and 7
+marks" — that predates the v1 freeze, which added `taskList`/`taskItem`, `image`, the three collab
+marks and the table nodes. The live count is 19/11.)
+
+GFM tables are hand-written, because `prosemirror-markdown` has no table serializer: alignment from
+each cell's `align` attribute, pipes escaped inside cells so a cell containing `|` cannot forge a
+column boundary, and an empty header row when the first row is not a header — rather than promoting
+a data row, which would silently change what the table says.
+
+**3. happy-dom as a production dependency.** Done, with the reasoning in the module docstring. It
+is never installed as `globalThis.window`/`document`: this package drives `prosemirror-model`'s
+`DOMParser`/`DOMSerializer` with an explicit element, so importing it in a Node service mutates
+nothing process-wide and two conversions cannot race on a shared document. Every window is closed
+in a `finally`.
+
+**4. The cross-DOM equality check.** `cross-dom-parse-equality.test.ts` bundles the real parse path
+with esbuild, injects it into a Chromium page via `playwright-core`, and compares
+`doc.toJSON()` against the happy-dom parse for all 23 fixtures, the whole corpus as one document,
+and three targeted divergence candidates. **It does not skip when the browser is missing** — a
+cross-DOM check that quietly reports green on a machine with one DOM is worse than no check — so
+`.github/workflows/ci.yml`'s unit-test job gains one `playwright install chromium` step.
+
+It runs under `// @vitest-environment node` rather than the package's default jsdom. Practical
+reason: esbuild refuses to start under jsdom, whose `TextEncoder` does not return a real
+`Uint8Array`. Better reason: the Node half of the comparison must parse through happy-dom
+explicitly, and an ambient jsdom `document` in scope is exactly the accident that could make it
+silently do something else.
+
+Mutation-checked: making the browser strip `style` attributes before parsing turns the suite red,
+so the comparison is real rather than two paths trivially agreeing.
+
+**5. Minimal diff via `updateYFragment`.** See the correction above. Asserted: a one-word change in
+a 200-paragraph document emits < 500 bytes and < 1/50th of the document; the diff is > 20× smaller
+than replacing the fragment wholesale (that comparison is what gives the 500 its meaning); an
+untouched paragraph keeps its Y-type **identity**, not merely equal content; a concurrent edit in
+an untouched paragraph survives; a concurrent edit *inside the very paragraph being rewritten*
+merges character-level; the whole apply is one transaction carrying the caller's origin.
+
+**6. `y-prosemirror` pinned.** `"y-prosemirror": "1.3.7"` — exact, in the same commit that adds it,
+alongside `"yjs": "13.6.32"` matching the root override. `prosemirror-model`, `-state`, `-view` and
+`y-protocols` are declared explicitly to satisfy y-prosemirror's peers deterministically rather
+than by hoisting luck; verified single copies of `yjs`, `prosemirror-model` and `y-prosemirror` in
+the tree, because two copies of yjs throw "Yjs was already imported" at runtime.
+
+**7. Fail closed.** Every projector throws `UnknownNodeError` on a node or mark the frozen schema
+does not describe — including `y-doc-to-html.ts`, where it is *not* automatic:
+`DOMSerializer.fromSchema` builds its map from the schema the **document** was created against, so
+a foreign node serializes through whatever `toDOM` it brought, or yields nothing. Either way the
+projection would be written and the loss invisible. An explicit name check turns that into a throw.
+
+Block and inline are separate code paths in the text projection, and the first version only guarded
+the block one — the inline guard was untested until a mutation exposed it (see below). Both are now
+guarded and both mutations go red.
+
+On the inbound half, `htmlToPmDoc` throws `UnrepresentableContentError` rather than seed a lossy
+document: an `<img>` with no `data-file-id`, an `<iframe>`, `<video>`, `<svg>`, or any change to the
+visible character stream. Error messages carry **counts and element names only** — never the markup
+or the prose, because these run over production user content and land in logs and Sentry, and there
+is a test asserting exactly that. `describeHtmlLoss` is exported so a bulk seed can survey a corpus
+and route the exceptions in one pass instead of catching a page at a time.
+
+`<br>` is deliberately excluded from the dropped-element check: ProseMirror legitimately discards a
+trailing `<br>` at the end of a block (browsers emit those as caret padding), and counting them
+would report a loss on markup that lost nothing — a false alarm on the seed path is a blocked
+migration.
+
+## Verification against the leaves' criteria
+
+- **`SCHEMA_HASH` unchanged** — `'ded0823d'`, recomputed and confirmed.
+- **Fixpoint + no loss over tables, nested lists, every `mentionType` (page/user/role/everyone plus
+  the AI dialect), code blocks with `language`, all 11 marks, `<span style>`, tight vs loose lists,
+  task lists, images with `fileId`, headings 1–6** — 23 fixtures, all green, plus the corpus as one
+  document.
+- **The text projection contains no markup** — asserted against nine markup tokens (`span`, `href`,
+  `style`, `table`, `class`, `data-`, `<`, `>`, `colspan`) over a corpus that is full of all of
+  them. One corpus fixture's prose was changed from "styled" to "tinted" so that `style` stays a
+  pure markup token; leaving it would have made that assertion untestable rather than passing.
+- **The markdown projection is materially cheaper** — under 60% of the HTML on the corpus by two
+  independent proxies (characters, and whitespace/punctuation-delimited words). No tokenizer
+  dependency was added: the gap is a factor, not a few per cent, so no tokenizer's segmentation
+  could reverse it, and a production package should not carry one for a single assertion.
+- **Same PM JSON under the Node shim and a real browser** — 28 assertions, green.
+
+## Mutation checks
+
+29 mutations, every one applied **by content-verified edit** (the harness asserts the file changed
+on disk and restores it afterwards, so a no-op mutation is reported as INVALID, never as
+"survived"). Three survived the first pass. All three are resolved:
+
+| survivor | what it actually meant |
+|---|---|
+| text projection's unknown-**inline**-node throw | A **coverage gap**. The first-occurrence replace hit `inlineText`'s `default` branch, not `collectLines`' — the two functions end with the identical three lines. The block guard was covered; the inline one was not. Added a test with an unknown inline node inside a known paragraph; both mutations now go red. (This is the twin-line first-occurrence trap, again.) |
+| `initProseMirrorDoc` → empty mapping | A **real defect in my code**, described above. Removed. |
+| `<hr>` → `<hr/>` in the HTML projection | An **invalid mutation** — it does not break idempotency, since both passes emit `<hr/>`. Replaced with one that does (append a paragraph per render); that goes red. |
+
+What was broken and confirmed red, by mechanism: the `@` sigil on mentions; block newline joining;
+table-cell tab joining; images contributing no text; both unknown-node throws in the text
+projection; `assertProjectable` in the HTML projection; `assertMarkdownProjectable`; heading level;
+task-item checked state; cell pipe escaping; the image file reference; the code-fence language; the
+fence widening past a nested backtick run; table column alignment; transparent underline; the
+textless-element loss check; the visible-text loss check; script/style stripping; the throw on loss;
+`COLLAB_FRAGMENT_FIELD`; per-block doc wrapping; `null` (not index) for a missing `blockId`; the
+allowlist's own guard; the one-pass fixpoint assertion; `updateYFragment` vs delete-and-reinsert;
+the single transaction and its origin; and the browser side of the cross-DOM comparison.
+
+**On the `assert` hazard:** this package's suites use vitest's `describe/it/expect`, matching the
+five that were already here. No riteway-style `assert({given, should, actual, expected})` is used
+anywhere in the new tests, so the chai-truthy-global shadowing that shipped a production deadlock
+behind 22 green tests in this epic is not reachable here.
+
+## Decisions taken, and their costs
+
+**The markdown projection is one-way.** It renders `pageMention` as its visible `@label` and drops
+mention identity; `underline`, `highlight`, `textStyle` and the three collab marks pass through
+transparently; `colspan`/`rowspan` have no GFM form. Every one of those preserves the *text* and
+drops only an annotation, and `pages.content` (HTML) remains lossless. The consequence worth
+flagging for Phase D: **a block tool that rewrites a block through markdown cannot preserve mention
+identity**, so `replace_block` must carry ids out of band rather than expecting them in the
+markdown. Stated in the module docstring, not buried.
+
+**The image markdown is `![alt](pagespace-file:<fileId>)`.** The v1 `image` node holds a file
+reference and never a URL, so there is nothing to put in the parentheses;
+`prosemirror-markdown`'s default `image` serializer reads `node.attrs.src` and would throw. An
+explicit non-resolvable scheme beats fabricating a URL, and keeps the reference recoverable.
+
+**`yDocToBlocks` does not flatten nesting.** A list is one block. "Replace this list" is an
+operation a caller can express safely; "replace the third `listItem` of the second list" is a
+position, and positions do not survive concurrency.
+
+**The text projection excludes image `alt`.** It is an accessibility annotation, not document
+prose; putting it in the search corpus lets a decorative image's alt text answer a prose query.
+
+**Coverage branch floor 94 → 92**, while lines/functions/statements rose sharply. Not a relaxation
+of anything already covered: the new modules carry type-narrowing fallbacks the frozen schema
+cannot reach (`node.text ?? ''` on a text node, `Number(attrs.level) || 1` on a heading), and
+covering them would mean asserting against documents the schema forbids. Deleting the narrowing is
+not available under `no any`. The reasoning is in `vitest.config.ts` next to the numbers.
+
+## Not in scope, and deliberately not done
+
+- The **seed-fidelity gate over real production documents** is its own leaf (`jklkkf8aaao6v7jpc0mk8qub`,
+  still `pending`). This PR builds the machinery and proves it over a synthetic corpus;
+  running it against 4,771 real pages is that leaf's job, and `describeHtmlLoss` exists to make it
+  a survey rather than a crash.
+- **Markdown image ingestion** (`![alt](url)` → `fileId`) remains the open Phase K gate. Nothing
+  here changes it.
+- No `apps/collab` service, no wiring into `applyPageMutation`, no `page_docs` columns. Those are
+  later phases; this is the pure core they rest on.
+
+## Gates
+
+At the monorepo root:
+
+| gate | result |
+|---|---|
+| `bun run typecheck` | **green** — 19/19 tasks (includes `web:build`) |
+| `bun run lint` | **green** — 17/17 tasks |
+| `bun run knip:check` | **green** |
+| `bun run test` | **could not run locally** — see below |
+| `packages/editor` suite | **green** — 288 tests, 10 files |
+
+`SCHEMA_HASH` unchanged at `'ded0823d'`.
+
+**`bun run test` did not run here.** `scripts/test-with-db.sh` requires the Docker test-Postgres
+container and the Docker daemon is not running in this environment (`Cannot connect to the Docker
+daemon`). Two things worth stating plainly rather than glossing: the shell pipeline reported exit 0
+because the failure was swallowed by `| tail`, which is exactly the trap `feedback_run_the_command_ci_runs`
+describes — the real signal was in the body, not the status; and the run was a **no-op**, not a
+pass. No suite outside `packages/editor` was executed locally. Nothing outside `packages/editor`
+and one CI workflow step is touched by this diff, and `typecheck` (which builds every package
+including `web`) and `lint` both ran clean across the whole monorepo, so CI is the gate for the
+remainder. Do not read the table above as "the full suite passed".

--- a/bun.lock
+++ b/bun.lock
@@ -452,7 +452,7 @@
     },
     "packages/cli": {
       "name": "@pagespace/cli",
-      "version": "1.8.0",
+      "version": "1.9.0",
       "bin": {
         "pagespace": "./dist/bin.js",
         "pagespace-mcp": "./dist/bin-pagespace-mcp.js",
@@ -502,10 +502,20 @@
         "@tiptap/extension-text-style": "^3.0.7",
         "@tiptap/pm": "^3.7.2",
         "@tiptap/starter-kit": "^3.0.7",
+        "happy-dom": "^20.8.9",
+        "prosemirror-markdown": "^1.13.4",
+        "prosemirror-model": "^1.25.7",
+        "prosemirror-state": "^1.4.4",
+        "prosemirror-view": "^1.41.8",
         "tiptap-markdown": "^0.8.10",
+        "y-prosemirror": "1.3.7",
+        "y-protocols": "^1.0.7",
+        "yjs": "13.6.32",
       },
       "devDependencies": {
+        "esbuild": "^0.25.12",
         "eslint": "^9.36.0",
+        "playwright-core": "^1.60.0",
         "typescript-eslint": "^8.59.0",
       },
     },
@@ -1915,15 +1925,15 @@
 
     "@types/keyv": ["@types/keyv@3.1.4", "", { "dependencies": { "@types/node": "*" } }, "sha512-BQ5aZNSCpj7D6K2ksrRCTmKRLEpnPvWDiLPfoGyhZ++8YtiK9d/3DBKPJgry359X/P1PfruyYwvnvwFjuEiEIg=="],
 
-    "@types/linkify-it": ["@types/linkify-it@3.0.5", "", {}, "sha512-yg6E+u0/+Zjva+buc3EIb+29XEg4wltq7cSmd4Uc2EE/1nUVmxyzpX6gUXD0V8jIrG0r7YeOGVIbYRkxeooCtw=="],
+    "@types/linkify-it": ["@types/linkify-it@5.0.0", "", {}, "sha512-sVDA58zAw4eWAffKOaQH5/5j3XeayukzDk+ewSsnv3p4yJEZHCCzMDiZM8e0OUrRvmpGZ85jf4yDHkHsgBNr9Q=="],
 
     "@types/long": ["@types/long@4.0.2", "", {}, "sha512-MqTGEo5bj5t157U6fA/BiDynNkn0YknVdh48CMPkTSpFTVmvao5UQmm7uEF6xBEo7qIMAlY/JSleYaE6VOdpaA=="],
 
-    "@types/markdown-it": ["@types/markdown-it@13.0.9", "", { "dependencies": { "@types/linkify-it": "^3", "@types/mdurl": "^1" } }, "sha512-1XPwR0+MgXLWfTn9gCsZ55AHOKW1WN+P9vr0PaQh5aerR9LLQXUbjfEAFhjmEmyoYFWAyuN2Mqkn40MZ4ukjBw=="],
+    "@types/markdown-it": ["@types/markdown-it@14.1.2", "", { "dependencies": { "@types/linkify-it": "^5", "@types/mdurl": "^2" } }, "sha512-promo4eFwuiW+TfGxhi+0x3czqTYJkG8qB17ZUJiVF10Xm7NLVRSLUsfRTU/6h1e24VvRnXCx+hG7li58lkzog=="],
 
     "@types/mdast": ["@types/mdast@4.0.4", "", { "dependencies": { "@types/unist": "*" } }, "sha512-kGaNbPh1k7AFzgpud/gMdvIm5xuECykRR+JnWKQno9TAXVa6WIVCGTPvYGekIDL4uwCZQSYbUxNBSb1aUo79oA=="],
 
-    "@types/mdurl": ["@types/mdurl@1.0.5", "", {}, "sha512-6L6VymKTzYSrEf4Nev4Xa1LCHKrlTlYCBMTlQKFuddo1CvQcE52I0mwfOJayueUC7MJuXOeHTcIU683lzd0cUA=="],
+    "@types/mdurl": ["@types/mdurl@2.0.0", "", {}, "sha512-RGdgjQUZba5p6QEFAVx2OGb8rQDL/cPRG7GiedRzMcJ1tYnUANBncjbSB1NRGwbvjcPeikRABz2nshyPk1bhWg=="],
 
     "@types/methods": ["@types/methods@1.1.4", "", {}, "sha512-ymXWVrDiCxTBE3+RIrrP533E70eA+9qu7zdWoHuOmGujkYtzf4HQF96b8nwHLqhuf4ykX61IGRIB38CC6/sImQ=="],
 
@@ -4655,6 +4665,8 @@
 
     "xtend": ["xtend@4.0.2", "", {}, "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ=="],
 
+    "y-prosemirror": ["y-prosemirror@1.3.7", "", { "dependencies": { "lib0": "^0.2.109" }, "peerDependencies": { "prosemirror-model": "^1.7.1", "prosemirror-state": "^1.2.3", "prosemirror-view": "^1.9.10", "y-protocols": "^1.0.1", "yjs": "^13.5.38" } }, "sha512-NpM99WSdD4Fx4if5xOMDpPtU3oAmTSjlzh5U4353ABbRHl1HtAFUx6HlebLZfyFxXN9jzKMDkVbcRjqOZVkYQg=="],
+
     "y-protocols": ["y-protocols@1.0.7", "", { "dependencies": { "lib0": "^0.2.85" }, "peerDependencies": { "yjs": "^13.0.0" } }, "sha512-YSVsLoXxO67J6eE/nV4AtFtT3QEotZf5sK5BHxFBXso7VDUT3Tx07IfA6hsu5Q5OmBdMkQVmFZ9QOA7fikWvnw=="],
 
     "y18n": ["y18n@5.0.8", "", {}, "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA=="],
@@ -5269,8 +5281,6 @@
 
     "prop-types/react-is": ["react-is@16.13.1", "", {}, "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="],
 
-    "prosemirror-markdown/@types/markdown-it": ["@types/markdown-it@14.1.2", "", { "dependencies": { "@types/linkify-it": "^5", "@types/mdurl": "^2" } }, "sha512-promo4eFwuiW+TfGxhi+0x3czqTYJkG8qB17ZUJiVF10Xm7NLVRSLUsfRTU/6h1e24VvRnXCx+hG7li58lkzog=="],
-
     "radix-ui/@radix-ui/react-avatar": ["@radix-ui/react-avatar@1.1.10", "", { "dependencies": { "@radix-ui/react-context": "1.1.2", "@radix-ui/react-primitive": "2.1.3", "@radix-ui/react-use-callback-ref": "1.1.1", "@radix-ui/react-use-is-hydrated": "0.1.0", "@radix-ui/react-use-layout-effect": "1.1.1" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-V8piFfWapM5OmNCXTzVQY+E1rDa53zY+MQ4Y7356v4fFz6vqCyUtIz2rUD44ZEdwg78/jKmMJHj07+C/Z/rcog=="],
 
     "radix-ui/@radix-ui/react-label": ["@radix-ui/react-label@2.1.7", "", { "dependencies": { "@radix-ui/react-primitive": "2.1.3" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-YT1GqPSL8kJn20djelMX7/cTRp/Y9w5IZHvfxQTVHrOqa2yMl7i/UfMqKRU5V7mEyKTrUVgJXhNQPVCG8PBLoQ=="],
@@ -5372,6 +5382,8 @@
     "through2/readable-stream": ["readable-stream@3.6.2", "", { "dependencies": { "inherits": "^2.0.3", "string_decoder": "^1.1.1", "util-deprecate": "^1.0.1" } }, "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA=="],
 
     "tiny-async-pool/semver": ["semver@5.7.2", "", { "bin": { "semver": "bin/semver" } }, "sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g=="],
+
+    "tiptap-markdown/@types/markdown-it": ["@types/markdown-it@13.0.9", "", { "dependencies": { "@types/linkify-it": "^3", "@types/mdurl": "^1" } }, "sha512-1XPwR0+MgXLWfTn9gCsZ55AHOKW1WN+P9vr0PaQh5aerR9LLQXUbjfEAFhjmEmyoYFWAyuN2Mqkn40MZ4ukjBw=="],
 
     "tsx/esbuild": ["esbuild@0.27.2", "", { "optionalDependencies": { "@esbuild/aix-ppc64": "0.27.2", "@esbuild/android-arm": "0.27.2", "@esbuild/android-arm64": "0.27.2", "@esbuild/android-x64": "0.27.2", "@esbuild/darwin-arm64": "0.27.2", "@esbuild/darwin-x64": "0.27.2", "@esbuild/freebsd-arm64": "0.27.2", "@esbuild/freebsd-x64": "0.27.2", "@esbuild/linux-arm": "0.27.2", "@esbuild/linux-arm64": "0.27.2", "@esbuild/linux-ia32": "0.27.2", "@esbuild/linux-loong64": "0.27.2", "@esbuild/linux-mips64el": "0.27.2", "@esbuild/linux-ppc64": "0.27.2", "@esbuild/linux-riscv64": "0.27.2", "@esbuild/linux-s390x": "0.27.2", "@esbuild/linux-x64": "0.27.2", "@esbuild/netbsd-arm64": "0.27.2", "@esbuild/netbsd-x64": "0.27.2", "@esbuild/openbsd-arm64": "0.27.2", "@esbuild/openbsd-x64": "0.27.2", "@esbuild/openharmony-arm64": "0.27.2", "@esbuild/sunos-x64": "0.27.2", "@esbuild/win32-arm64": "0.27.2", "@esbuild/win32-ia32": "0.27.2", "@esbuild/win32-x64": "0.27.2" }, "bin": "bin/esbuild" }, "sha512-HyNQImnsOC7X9PMNaCIeAm4ISCQXs5a5YasTXVliKv4uuBo1dKrG0A+uQS8M5eXjVMnLg3WgXaKvprHlFJQffw=="],
 
@@ -5849,10 +5861,6 @@
 
     "pkg-dir/find-up/locate-path": ["locate-path@3.0.0", "", { "dependencies": { "p-locate": "^3.0.0", "path-exists": "^3.0.0" } }, "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A=="],
 
-    "prosemirror-markdown/@types/markdown-it/@types/linkify-it": ["@types/linkify-it@5.0.0", "", {}, "sha512-sVDA58zAw4eWAffKOaQH5/5j3XeayukzDk+ewSsnv3p4yJEZHCCzMDiZM8e0OUrRvmpGZ85jf4yDHkHsgBNr9Q=="],
-
-    "prosemirror-markdown/@types/markdown-it/@types/mdurl": ["@types/mdurl@2.0.0", "", {}, "sha512-RGdgjQUZba5p6QEFAVx2OGb8rQDL/cPRG7GiedRzMcJ1tYnUANBncjbSB1NRGwbvjcPeikRABz2nshyPk1bhWg=="],
-
     "react-email/esbuild/@esbuild/aix-ppc64": ["@esbuild/aix-ppc64@0.27.4", "", { "os": "aix", "cpu": "ppc64" }, "sha512-cQPwL2mp2nSmHHJlCyoXgHGhbEPMrEEU5xhkcy3Hs/O7nGZqEpZ2sUtLaL9MORLtDfRvVl2/3PAuEkYZH0Ty8Q=="],
 
     "react-email/esbuild/@esbuild/android-arm": ["@esbuild/android-arm@0.27.4", "", { "os": "android", "cpu": "arm" }, "sha512-X9bUgvxiC8CHAGKYufLIHGXPJWnr0OCdR0anD2e21vdvgCI8lIfqFbnoeOz7lBjdrAGUhqLZLcQo6MLhTO2DKQ=="],
@@ -5942,6 +5950,10 @@
     "temp/rimraf/glob": ["glob@7.2.3", "", { "dependencies": { "fs.realpath": "^1.0.0", "inflight": "^1.0.4", "inherits": "2", "minimatch": "^3.1.1", "once": "^1.3.0", "path-is-absolute": "^1.0.0" } }, "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q=="],
 
     "test-exclude/glob/path-scurry": ["path-scurry@1.11.1", "", { "dependencies": { "lru-cache": "^10.2.0", "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0" } }, "sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA=="],
+
+    "tiptap-markdown/@types/markdown-it/@types/linkify-it": ["@types/linkify-it@3.0.5", "", {}, "sha512-yg6E+u0/+Zjva+buc3EIb+29XEg4wltq7cSmd4Uc2EE/1nUVmxyzpX6gUXD0V8jIrG0r7YeOGVIbYRkxeooCtw=="],
+
+    "tiptap-markdown/@types/markdown-it/@types/mdurl": ["@types/mdurl@1.0.5", "", {}, "sha512-6L6VymKTzYSrEf4Nev4Xa1LCHKrlTlYCBMTlQKFuddo1CvQcE52I0mwfOJayueUC7MJuXOeHTcIU683lzd0cUA=="],
 
     "tsx/esbuild/@esbuild/aix-ppc64": ["@esbuild/aix-ppc64@0.27.2", "", { "os": "aix", "cpu": "ppc64" }, "sha512-GZMB+a0mOMZs4MpDbj8RJp4cw+w1WV5NYD6xzgvzUJ5Ek2jerwfO2eADyI6ExDSUED+1X8aMbegahsJi+8mgpw=="],
 

--- a/packages/editor/package.json
+++ b/packages/editor/package.json
@@ -13,6 +13,11 @@
     "lint": "eslint src"
   },
   "exports": {
+    "./apply-pm-doc-to-y-doc": {
+      "types": "./dist/apply-pm-doc-to-y-doc.d.ts",
+      "import": "./dist/apply-pm-doc-to-y-doc.js",
+      "default": "./dist/apply-pm-doc-to-y-doc.js"
+    },
     "./block-id": {
       "types": "./dist/block-id.d.ts",
       "import": "./dist/block-id.js",
@@ -22,6 +27,11 @@
       "types": "./dist/code-block-node.d.ts",
       "import": "./dist/code-block-node.js",
       "default": "./dist/code-block-node.js"
+    },
+    "./collab-document": {
+      "types": "./dist/collab-document.d.ts",
+      "import": "./dist/collab-document.js",
+      "default": "./dist/collab-document.js"
     },
     "./collab-marks": {
       "types": "./dist/collab-marks.d.ts",
@@ -33,6 +43,16 @@
       "import": "./dist/collab-schema.js",
       "default": "./dist/collab-schema.js"
     },
+    "./dom-workspace": {
+      "types": "./dist/dom-workspace.d.ts",
+      "import": "./dist/dom-workspace.js",
+      "default": "./dist/dom-workspace.js"
+    },
+    "./html-to-ydoc": {
+      "types": "./dist/html-to-ydoc.d.ts",
+      "import": "./dist/html-to-ydoc.js",
+      "default": "./dist/html-to-ydoc.js"
+    },
     "./image-node": {
       "types": "./dist/image-node.d.ts",
       "import": "./dist/image-node.js",
@@ -43,19 +63,50 @@
       "import": "./dist/page-mention-node.js",
       "default": "./dist/page-mention-node.js"
     },
+    "./projection-errors": {
+      "types": "./dist/projection-errors.d.ts",
+      "import": "./dist/projection-errors.js",
+      "default": "./dist/projection-errors.js"
+    },
     "./simple-data-attr": {
       "types": "./dist/simple-data-attr.d.ts",
       "import": "./dist/simple-data-attr.js",
       "default": "./dist/simple-data-attr.js"
+    },
+    "./y-doc-to-blocks": {
+      "types": "./dist/y-doc-to-blocks.d.ts",
+      "import": "./dist/y-doc-to-blocks.js",
+      "default": "./dist/y-doc-to-blocks.js"
+    },
+    "./y-doc-to-html": {
+      "types": "./dist/y-doc-to-html.d.ts",
+      "import": "./dist/y-doc-to-html.js",
+      "default": "./dist/y-doc-to-html.js"
+    },
+    "./y-doc-to-markdown": {
+      "types": "./dist/y-doc-to-markdown.d.ts",
+      "import": "./dist/y-doc-to-markdown.js",
+      "default": "./dist/y-doc-to-markdown.js"
+    },
+    "./y-doc-to-text": {
+      "types": "./dist/y-doc-to-text.d.ts",
+      "import": "./dist/y-doc-to-text.js",
+      "default": "./dist/y-doc-to-text.js"
     }
   },
   "typesVersions": {
     "*": {
+      "apply-pm-doc-to-y-doc": [
+        "./dist/apply-pm-doc-to-y-doc.d.ts"
+      ],
       "block-id": [
         "./dist/block-id.d.ts"
       ],
       "code-block-node": [
         "./dist/code-block-node.d.ts"
+      ],
+      "collab-document": [
+        "./dist/collab-document.d.ts"
       ],
       "collab-marks": [
         "./dist/collab-marks.d.ts"
@@ -63,14 +114,35 @@
       "collab-schema": [
         "./dist/collab-schema.d.ts"
       ],
+      "dom-workspace": [
+        "./dist/dom-workspace.d.ts"
+      ],
+      "html-to-ydoc": [
+        "./dist/html-to-ydoc.d.ts"
+      ],
       "image-node": [
         "./dist/image-node.d.ts"
       ],
       "page-mention-node": [
         "./dist/page-mention-node.d.ts"
       ],
+      "projection-errors": [
+        "./dist/projection-errors.d.ts"
+      ],
       "simple-data-attr": [
         "./dist/simple-data-attr.d.ts"
+      ],
+      "y-doc-to-blocks": [
+        "./dist/y-doc-to-blocks.d.ts"
+      ],
+      "y-doc-to-html": [
+        "./dist/y-doc-to-html.d.ts"
+      ],
+      "y-doc-to-markdown": [
+        "./dist/y-doc-to-markdown.d.ts"
+      ],
+      "y-doc-to-text": [
+        "./dist/y-doc-to-text.d.ts"
       ]
     }
   },
@@ -85,10 +157,20 @@
     "@tiptap/extension-text-style": "^3.0.7",
     "@tiptap/pm": "^3.7.2",
     "@tiptap/starter-kit": "^3.0.7",
-    "tiptap-markdown": "^0.8.10"
+    "happy-dom": "^20.8.9",
+    "prosemirror-markdown": "^1.13.4",
+    "prosemirror-model": "^1.25.7",
+    "prosemirror-state": "^1.4.4",
+    "prosemirror-view": "^1.41.8",
+    "tiptap-markdown": "^0.8.10",
+    "y-prosemirror": "1.3.7",
+    "y-protocols": "^1.0.7",
+    "yjs": "13.6.32"
   },
   "devDependencies": {
+    "esbuild": "^0.25.12",
     "eslint": "^9.36.0",
+    "playwright-core": "^1.60.0",
     "typescript-eslint": "^8.59.0"
   }
 }

--- a/packages/editor/package.json
+++ b/packages/editor/package.json
@@ -63,6 +63,11 @@
       "import": "./dist/page-mention-node.js",
       "default": "./dist/page-mention-node.js"
     },
+    "./pm-attrs": {
+      "types": "./dist/pm-attrs.d.ts",
+      "import": "./dist/pm-attrs.js",
+      "default": "./dist/pm-attrs.js"
+    },
     "./projection-errors": {
       "types": "./dist/projection-errors.d.ts",
       "import": "./dist/projection-errors.js",
@@ -125,6 +130,9 @@
       ],
       "page-mention-node": [
         "./dist/page-mention-node.d.ts"
+      ],
+      "pm-attrs": [
+        "./dist/pm-attrs.d.ts"
       ],
       "projection-errors": [
         "./dist/projection-errors.d.ts"

--- a/packages/editor/src/__tests__/apply-pm-doc-to-y-doc.test.ts
+++ b/packages/editor/src/__tests__/apply-pm-doc-to-y-doc.test.ts
@@ -1,0 +1,160 @@
+/**
+ * `applyPmDocToYDoc` — a server-computed replacement document becoming a
+ * MINIMAL CRDT diff.
+ *
+ * The naive implementation (clear the fragment, insert the new document) is
+ * indistinguishable from this one by any assertion about the resulting
+ * document: both converge on the same content. The two things that separate
+ * them are the SIZE of the update and what happens to a concurrent edit — so
+ * those are what this suite asserts, and a test that only compared documents
+ * would go green on the implementation this exists to forbid.
+ */
+import { describe, it, expect } from 'vitest';
+import * as Y from 'yjs';
+import { applyPmDocToYDoc } from '../apply-pm-doc-to-y-doc.js';
+import { htmlToPmDoc, htmlToYDoc } from '../html-to-ydoc.js';
+import { collabFragment, pmDocToYDoc } from '../collab-document.js';
+import { yDocToText } from '../y-doc-to-text.js';
+
+const PARAGRAPHS = 200;
+
+function longDocumentHtml(changedWord = 'unchanged'): string {
+  return Array.from(
+    { length: PARAGRAPHS },
+    (_unused, index) =>
+      `<p data-block-id="blk_${index}">Paragraph ${index} carries a sentence of ordinary ` +
+      `prose so the document has real length, and paragraph zero is ` +
+      `${index === 0 ? changedWord : 'unchanged'} here.</p>`,
+  ).join('');
+}
+
+/** Bytes an observer at `before` must receive to catch up with `yDoc`. */
+function updateSizeSince(yDoc: Y.Doc, before: Uint8Array): number {
+  return Y.encodeStateAsUpdate(yDoc, before).byteLength;
+}
+
+describe('minimal diff', () => {
+  it('emits an update proportional to the change, not to the document', () => {
+    const yDoc = htmlToYDoc(longDocumentHtml());
+    const before = Y.encodeStateVector(yDoc);
+    const wholeDocumentSize = Y.encodeStateAsUpdate(yDoc).byteLength;
+
+    applyPmDocToYDoc(yDoc, htmlToPmDoc(longDocumentHtml('REPLACED')));
+
+    const diffSize = updateSizeSince(yDoc, before);
+    expect(yDocToText(yDoc)).toContain('paragraph zero is REPLACED here');
+    // The changed word is ~8 bytes. A couple of hundred bytes of Yjs framing
+    // is expected; a fraction of the document is not.
+    expect(diffSize).toBeLessThan(500);
+    expect(diffSize).toBeLessThan(wholeDocumentSize / 50);
+  });
+
+  it('is dramatically smaller than replacing the fragment wholesale', () => {
+    // The comparison that gives the number above its meaning. Without it,
+    // "under 500 bytes" is a magic constant nobody can re-derive; with it, the
+    // test fails the moment this stops being a diff at all.
+    const diffed = htmlToYDoc(longDocumentHtml());
+    const replaced = htmlToYDoc(longDocumentHtml());
+    const before = Y.encodeStateVector(diffed);
+    const next = htmlToPmDoc(longDocumentHtml('REPLACED'));
+
+    applyPmDocToYDoc(diffed, next);
+
+    const naiveBefore = Y.encodeStateVector(replaced);
+    replaced.transact(() => {
+      const fragment = collabFragment(replaced);
+      fragment.delete(0, fragment.length);
+      Y.applyUpdate(replaced, Y.encodeStateAsUpdate(pmDocToYDoc(next)));
+    });
+
+    expect(updateSizeSince(diffed, before) * 20).toBeLessThan(
+      updateSizeSince(replaced, naiveBefore),
+    );
+  });
+
+  it('touches only the paragraph that changed', () => {
+    const yDoc = htmlToYDoc('<p>alpha</p><p>beta</p><p>gamma</p>');
+    const fragment = collabFragment(yDoc);
+    const untouched = fragment.get(2);
+
+    applyPmDocToYDoc(yDoc, htmlToPmDoc('<p>alpha</p><p>BETA</p><p>gamma</p>'));
+
+    // Identity, not equality: a rewritten paragraph is a NEW Y type even when
+    // its text matches, and only identity distinguishes the two.
+    expect(collabFragment(yDoc).get(2)).toBe(untouched);
+    expect(yDocToText(yDoc)).toBe('alpha\nBETA\ngamma');
+  });
+});
+
+describe('concurrency', () => {
+  it('preserves a concurrent edit in an untouched paragraph', () => {
+    // Delete-all-and-reinsert tombstones every character, so a collaborator's
+    // concurrent edit merges against nothing and vanishes — silently, with the
+    // document still perfectly well-formed.
+    const server = htmlToYDoc('<p>first</p><p>second</p><p>third</p>');
+    const client = new Y.Doc();
+    Y.applyUpdate(client, Y.encodeStateAsUpdate(server));
+
+    // Server rewrites the FIRST paragraph from a computed document.
+    applyPmDocToYDoc(server, htmlToPmDoc('<p>FIRST</p><p>second</p><p>third</p>'));
+
+    // Concurrently, and in ignorance of that, the client types in the THIRD.
+    const clientThird = collabFragment(client).get(2) as Y.XmlElement;
+    (clientThird.get(0) as Y.XmlText).insert(0, 'edited ');
+
+    const serverUpdate = Y.encodeStateAsUpdate(server);
+    const clientUpdate = Y.encodeStateAsUpdate(client);
+    Y.applyUpdate(client, serverUpdate);
+    Y.applyUpdate(server, clientUpdate);
+
+    expect(yDocToText(server)).toBe('FIRST\nsecond\nedited third');
+    expect(yDocToText(client)).toBe(yDocToText(server));
+  });
+
+  it('preserves a concurrent edit inside the very paragraph it rewrites', () => {
+    const server = htmlToYDoc('<p>hello world</p>');
+    const client = new Y.Doc();
+    Y.applyUpdate(client, Y.encodeStateAsUpdate(server));
+
+    applyPmDocToYDoc(server, htmlToPmDoc('<p>hello there world</p>'));
+    ((collabFragment(client).get(0) as Y.XmlElement).get(0) as Y.XmlText).insert(0, 'oh ');
+
+    Y.applyUpdate(client, Y.encodeStateAsUpdate(server));
+    Y.applyUpdate(server, Y.encodeStateAsUpdate(client));
+
+    // Character-level merge: both edits present, and both replicas agree.
+    expect(yDocToText(server)).toBe(yDocToText(client));
+    expect(yDocToText(server)).toContain('oh ');
+    expect(yDocToText(server)).toContain('there');
+  });
+});
+
+describe('transaction origin', () => {
+  it('forwards the origin so a service can recognise its own writes', () => {
+    // The collab service echoes updates to every client except the one that
+    // caused them; without an origin it cannot tell which that is.
+    const yDoc = htmlToYDoc('<p>a</p>');
+    const origins: unknown[] = [];
+    yDoc.on('update', (_update: Uint8Array, origin: unknown) => origins.push(origin));
+
+    const marker = Symbol('ai-edit');
+    applyPmDocToYDoc(yDoc, htmlToPmDoc('<p>b</p>'), marker);
+
+    expect(origins).toEqual([marker]);
+  });
+
+  it('applies the whole document change in ONE transaction', () => {
+    // Several transactions would emit several updates, and a client could
+    // observe the document mid-rewrite — a paragraph deleted but not yet
+    // reinserted.
+    const yDoc = htmlToYDoc('<p>a</p><p>b</p><p>c</p>');
+    let updates = 0;
+    yDoc.on('update', () => {
+      updates += 1;
+    });
+
+    applyPmDocToYDoc(yDoc, htmlToPmDoc('<p>A</p><p>B</p><p>C</p>'));
+
+    expect(updates).toBe(1);
+  });
+});

--- a/packages/editor/src/__tests__/cross-dom-parse-equality.test.ts
+++ b/packages/editor/src/__tests__/cross-dom-parse-equality.test.ts
@@ -1,0 +1,118 @@
+// @vitest-environment node
+//
+// Runs under `node`, NOT this package's default `jsdom` environment, for two
+// reasons. The practical one: esbuild refuses to start under jsdom, whose
+// `TextEncoder` does not return a real `Uint8Array`. The better one: the Node
+// half of this comparison must parse through happy-dom explicitly, and an
+// ambient jsdom `document` in scope is exactly the accident that could make it
+// silently do something else.
+/**
+ * The same source HTML must yield the same ProseMirror document under the Node
+ * DOM shim (happy-dom) and under a real browser.
+ *
+ * **This is the highest-impact unknown in the whole conversion core, and it is
+ * a hard blocker rather than a nice-to-have.** Several `parseHTML` functions in
+ * the frozen schema read the *DOM*, not the source string:
+ * `TextStyleKit`'s `getStyleProperty` fallbacks, `MarkdownTightLists`'
+ * `!element.querySelector('p')`, `CodeBlockNode`'s `element.querySelector('code')`.
+ * DOM implementations disagree about exactly those things — jsdom canonicalises
+ * `'Times New Roman'` to `"Times New Roman"` and reorders `style` declarations;
+ * happy-dom and Chromium need not agree either.
+ *
+ * So `SCHEMA_HASH` can be identical in two processes while the PARSE diverges.
+ * That is not a cosmetic difference: it means the collab server and the browser
+ * disagree about what a document *is*, for a document neither of them changed.
+ * `SCHEMA_HASH` cannot catch it — it hashes the schema's shape, and
+ * `parseHTML` is its documented blind spot. Only this comparison can.
+ *
+ * Needs Chromium: `bunx playwright install chromium`. It deliberately does NOT
+ * skip when the browser is absent — a cross-DOM check that quietly reports
+ * green on a machine with no second DOM is worse than no check at all.
+ */
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import * as esbuild from 'esbuild';
+import { chromium, type Browser, type Page } from 'playwright-core';
+import { fileURLToPath } from 'node:url';
+import { htmlToPmDoc } from '../html-to-ydoc.js';
+import { CONSTRUCT_CORPUS, corpusDocumentHtml } from './support/construct-corpus.js';
+
+let browser: Browser;
+let page: Page;
+
+beforeAll(async () => {
+  const bundle = await esbuild.build({
+    entryPoints: [fileURLToPath(new URL('./support/cross-dom-browser-entry.ts', import.meta.url))],
+    bundle: true,
+    write: false,
+    format: 'iife',
+    platform: 'browser',
+    target: 'chrome110',
+  });
+
+  browser = await chromium.launch();
+  page = await browser.newPage();
+  // `setContent` rather than a file:// or http:// URL: the parse under test
+  // needs a document, not a server, and no network makes the comparison
+  // reproducible.
+  await page.setContent('<!doctype html><html><body></body></html>');
+  await page.addScriptTag({ content: bundle.outputFiles[0].text });
+}, 120_000);
+
+afterAll(async () => {
+  await browser?.close();
+});
+
+async function parseInBrowser(html: string): Promise<unknown> {
+  return page.evaluate((source: string) => {
+    const parse = window.__parseHtmlToPmJson;
+    if (!parse) {
+      throw new Error('browser entry bundle did not install __parseHtmlToPmJson');
+    }
+    return parse(source);
+  }, html);
+}
+
+describe('cross-DOM parse equality', () => {
+  it('installed the browser harness', async () => {
+    // Guards the comparison itself: if the bundle silently failed to evaluate,
+    // every `page.evaluate` below would throw rather than pass — but a future
+    // edit that made `parseInBrowser` fall back to anything would not, and this
+    // states the precondition rather than leaving it implicit.
+    expect(await page.evaluate(() => typeof window.__parseHtmlToPmJson)).toBe('function');
+  });
+
+  it.each(CONSTRUCT_CORPUS.map((fixture) => [fixture.key, fixture] as const))(
+    'agrees with Chromium on %s',
+    async (_key, fixture) => {
+      expect(await parseInBrowser(fixture.html)).toEqual(htmlToPmDoc(fixture.html).toJSON());
+    },
+  );
+
+  it('agrees with Chromium on the whole corpus as one document', async () => {
+    const html = corpusDocumentHtml();
+    expect(await parseInBrowser(html)).toEqual(htmlToPmDoc(html).toJSON());
+  });
+
+  it('agrees on a style declaration written in a dialect a DOM may rewrite', async () => {
+    // The specific divergence the leaf names: single-quoted font families,
+    // shorthand colours and declaration ORDER are all things a DOM
+    // implementation may canonicalise on its way into `element.style`, and
+    // `TextStyleKit` reads `element.style`, not the attribute text.
+    const html =
+      '<p><span style="font-size:14px;font-family:\'Times New Roman\',serif;color:#F00">x</span></p>';
+    expect(await parseInBrowser(html)).toEqual(htmlToPmDoc(html).toJSON());
+  });
+
+  it('agrees on list tightness, which is inferred from the DOM tree', async () => {
+    // `MarkdownTightLists` calls `element.querySelector('p')`. Two DOMs that
+    // build the tree differently — over an implied `<tbody>`, an unclosed
+    // `<li>`, or whitespace text nodes — would answer differently.
+    const html = '<ul><li>bare<li>second</ul><ul><li><p>wrapped</p></li></ul>';
+    expect(await parseInBrowser(html)).toEqual(htmlToPmDoc(html).toJSON());
+  });
+
+  it('agrees on a table written without an explicit tbody', async () => {
+    const html = '<table><tr><th>H</th></tr><tr><td>c</td></tr></table>';
+    expect(await parseInBrowser(html)).toEqual(htmlToPmDoc(html).toJSON());
+  });
+});

--- a/packages/editor/src/__tests__/cross-dom-parse-equality.test.ts
+++ b/packages/editor/src/__tests__/cross-dom-parse-equality.test.ts
@@ -34,7 +34,7 @@ import * as esbuild from 'esbuild';
 import { chromium, type Browser, type Page } from 'playwright-core';
 import { fileURLToPath } from 'node:url';
 import { htmlToPmDoc } from '../html-to-ydoc.js';
-import { CONSTRUCT_CORPUS, corpusDocumentHtml } from './support/construct-corpus.js';
+import { CORPUS_CASES, corpusDocumentHtml } from './support/construct-corpus.js';
 
 let browser: Browser;
 let page: Page;
@@ -81,7 +81,7 @@ describe('cross-DOM parse equality', () => {
     expect(await page.evaluate(() => typeof window.__parseHtmlToPmJson)).toBe('function');
   });
 
-  it.each(CONSTRUCT_CORPUS.map((fixture) => [fixture.key, fixture] as const))(
+  it.each(CORPUS_CASES)(
     'agrees with Chromium on %s',
     async (_key, fixture) => {
       expect(await parseInBrowser(fixture.html)).toEqual(htmlToPmDoc(fixture.html).toJSON());

--- a/packages/editor/src/__tests__/cross-dom-parse-equality.test.ts
+++ b/packages/editor/src/__tests__/cross-dom-parse-equality.test.ts
@@ -58,9 +58,13 @@ beforeAll(async () => {
   await page.addScriptTag({ content: bundle.outputFiles[0].text });
 }, 120_000);
 
+// Explicit timeout: vitest's DEFAULT hook timeout is 10s, and closing Chromium
+// under a loaded full-suite `test:coverage` run exceeded it — the suite's 28
+// tests all passed and the FILE still failed. That failure mode is invisible to
+// a `Tests N passed` summary, and `test:coverage` is exactly what CI runs.
 afterAll(async () => {
   await browser?.close();
-});
+}, 60_000);
 
 async function parseInBrowser(html: string): Promise<unknown> {
   return page.evaluate((source: string) => {

--- a/packages/editor/src/__tests__/html-to-ydoc.test.ts
+++ b/packages/editor/src/__tests__/html-to-ydoc.test.ts
@@ -1,0 +1,107 @@
+/**
+ * The inbound half: stored `pages.content` HTML into the CRDT.
+ *
+ * Seeding is the one irreversible step in the whole design. Once a document is
+ * seeded and a collaborator connects, the Y.Doc IS the document — a construct
+ * lost on the way in is lost permanently, and `pages.content` is overwritten by
+ * the projection of the lossy result on the next flush. So this path fails
+ * closed: it throws rather than seed a document it could not fully represent.
+ */
+import { describe, it, expect } from 'vitest';
+import * as Y from 'yjs';
+import { htmlToPmDoc, htmlToYDoc, describeHtmlLoss } from '../html-to-ydoc.js';
+import { yDocToHtml } from '../y-doc-to-html.js';
+import { yDocToText } from '../y-doc-to-text.js';
+import { COLLAB_FRAGMENT_FIELD } from '../collab-document.js';
+import { UnrepresentableContentError } from '../projection-errors.js';
+
+describe('htmlToYDoc', () => {
+  it('seeds the body under the field the client editor reads', () => {
+    // `@tiptap/extension-collaboration` defaults to `field: 'default'`. Seed
+    // under any other name and the editor opens an empty document over a Y.Doc
+    // that is full — silently, with no error anywhere.
+    const yDoc = htmlToYDoc('<p>seeded</p>');
+    expect(COLLAB_FRAGMENT_FIELD).toBe('default');
+    expect(yDoc.getXmlFragment('default').length).toBe(1);
+    expect(yDocToText(yDoc)).toBe('seeded');
+  });
+
+  it('produces a Y.Doc that another replica converges on from its update alone', () => {
+    const source = htmlToYDoc('<h2>Title</h2><p>body</p>');
+    const replica = new Y.Doc();
+    Y.applyUpdate(replica, Y.encodeStateAsUpdate(source));
+    expect(yDocToHtml(replica)).toBe(yDocToHtml(source));
+  });
+
+  it('drops script and style without calling them lost content', () => {
+    const html = '<p>keep</p><script>var a = 1;</script><style>.a { color: red }</style>';
+    expect(describeHtmlLoss(html)).toEqual([]);
+    expect(yDocToText(htmlToYDoc(html))).toBe('keep');
+  });
+});
+
+describe('fail closed on unrepresentable content', () => {
+  it.each([
+    ['an <img> with no data-file-id', '<p>a</p><img src="https://x.test/y.png" alt="pic">', 'img'],
+    ['an <iframe>', '<iframe src="https://x.test"></iframe>', 'iframe'],
+    ['a <video>', '<video src="v.mp4"></video>', 'video'],
+    ['an <svg>', '<svg><circle /></svg>', 'svg'],
+  ])('refuses to seed %s', (_name, html, tag) => {
+    expect(() => htmlToPmDoc(html)).toThrow(UnrepresentableContentError);
+    expect(describeHtmlLoss(html)).toEqual([`dropped 1 <${tag}> element(s)`]);
+  });
+
+  it('refuses to seed when visible text would change', () => {
+    // A page mention whose only text is the `@` sigil: `label` falls back to
+    // the element's text with one leading `@` stripped, which leaves nothing,
+    // and the text projection then contributes nothing for it.
+    const html = '<p><a class="mention" data-mention-type="page" data-page-id="p1">@</a></p>';
+    expect(() => htmlToPmDoc(html)).toThrow(UnrepresentableContentError);
+    expect(describeHtmlLoss(html)).toEqual(['visible text changed (1 characters in, 0 out)']);
+  });
+
+  it('never puts the offending markup or prose in the error', () => {
+    // These run over production user content and land in logs and Sentry.
+    const secret = 'Quarterly Revenue Projections';
+    const html = `<p>${secret}</p><iframe src="https://x.test/${secret}"></iframe>`;
+    try {
+      htmlToPmDoc(html);
+      expect.unreachable('should have thrown');
+    } catch (error) {
+      expect(error).toBeInstanceOf(UnrepresentableContentError);
+      expect((error as Error).message).not.toContain(secret);
+      // The element NAME is reported (it is the diagnosis); the attribute
+      // values and the surrounding prose are not.
+      expect((error as Error).message).not.toContain('src=');
+      expect((error as Error).message).not.toContain('https://');
+      expect((error as UnrepresentableContentError).reasons).toEqual([
+        'dropped 1 <iframe> element(s)',
+      ]);
+    }
+  });
+
+  it('reports every reason at once rather than stopping at the first', () => {
+    // A bulk seed needs the whole verdict on a document in one pass, not a
+    // page-at-a-time game of whack-a-mole.
+    expect(
+      describeHtmlLoss('<img src="a.png"><iframe src="b"></iframe>').sort(),
+    ).toEqual(['dropped 1 <iframe> element(s)', 'dropped 1 <img> element(s)']);
+  });
+
+  it('counts multiple drops of the same element', () => {
+    expect(describeHtmlLoss('<img src="a.png"><img src="b.png">')).toEqual([
+      'dropped 2 <img> element(s)',
+    ]);
+  });
+
+  it('does not report a trailing <br>, which is caret padding rather than content', () => {
+    // Browsers emit these; counting them would report a loss on markup that
+    // lost nothing, and a false alarm on the seed path is a blocked migration.
+    expect(describeHtmlLoss('<p>a</p><br><br>')).toEqual([]);
+  });
+
+  it('keeps an <img> that DOES carry a file id', () => {
+    expect(describeHtmlLoss('<img data-file-id="file_1" alt="ok">')).toEqual([]);
+    expect(() => htmlToPmDoc('<img data-file-id="file_1" alt="ok">')).not.toThrow();
+  });
+});

--- a/packages/editor/src/__tests__/projections.test.ts
+++ b/packages/editor/src/__tests__/projections.test.ts
@@ -16,7 +16,7 @@ import { pmDocToText, yDocToText } from '../y-doc-to-text.js';
 import { pmDocToMarkdown, yDocToMarkdown } from '../y-doc-to-markdown.js';
 import { pmDocToBlocks, yDocToBlocks } from '../y-doc-to-blocks.js';
 import { UnknownNodeError } from '../projection-errors.js';
-import { CONSTRUCT_CORPUS, corpusDocumentHtml } from './support/construct-corpus.js';
+import { CORPUS_CASES, corpusDocumentHtml } from './support/construct-corpus.js';
 
 const corpusHtml = corpusDocumentHtml();
 const corpusDoc = htmlToPmDoc(corpusHtml);
@@ -52,7 +52,7 @@ describe('text projection', () => {
     },
   );
 
-  it.each(CONSTRUCT_CORPUS.map((fixture) => [fixture.key, fixture] as const))(
+  it.each(CORPUS_CASES)(
     'keeps every visible string of %s',
     (_key, fixture) => {
       for (const expected of fixture.text) {
@@ -93,6 +93,19 @@ describe('text projection', () => {
     expect(projected).not.toContain('pg_secret');
   });
 
+  it('contributes nothing for a mention with no label — never the word "null"', () => {
+    // `label` defaults to `null` in the frozen schema. Stringifying it without
+    // narrowing puts the literal `@null` into the search corpus, and emitting
+    // the id instead would let a CUID-shaped query match every document that
+    // merely links to a page.
+    const doc = corpusDoc.type.schema;
+    const mention = doc.node('doc', null, [
+      doc.node('paragraph', null, [doc.node('pageMention', { id: 'pg_1', label: null })]),
+    ]);
+    expect(pmDocToText(mention)).toBe('');
+    expect(pmDocToMarkdown(mention).trim()).toBe('');
+  });
+
   it('contributes nothing for an image, so alt text cannot answer a prose query', () => {
     expect(pmDocToText(htmlToPmDoc('<img data-file-id="f1" alt="a diagram">'))).toBe('');
   });
@@ -119,7 +132,7 @@ describe('markdown projection', () => {
     expect(tokens(markdown)).toBeLessThan(tokens(html) * 0.6);
   });
 
-  it.each(CONSTRUCT_CORPUS.map((fixture) => [fixture.key, fixture] as const))(
+  it.each(CORPUS_CASES)(
     'keeps every visible string of %s',
     (_key, fixture) => {
       for (const expected of fixture.text) {
@@ -191,6 +204,20 @@ describe('markdown projection', () => {
       htmlToPmDoc('<table><tbody><tr><td><p>a|b</p></td></tr></tbody></table>'),
     );
     expect(projected).toContain('a\\|b');
+  });
+
+  it('pads every row to the widest row, so a short row cannot shift columns', () => {
+    // A ragged table is legal in the schema. Sizing the table from the FIRST
+    // row instead of the widest silently truncates every wider row's cells —
+    // content loss that reads as a well-formed table.
+    expect(
+      pmDocToMarkdown(
+        htmlToPmDoc(
+          '<table><tbody><tr><td><p>a</p></td></tr>' +
+            '<tr><td><p>b</p></td><td><p>c</p></td></tr></tbody></table>',
+        ),
+      ).trim(),
+    ).toBe('|  |  |\n| --- | --- |\n| a |  |\n| b | c |');
   });
 
   it('emits an empty header when the table has no header row', () => {
@@ -277,6 +304,17 @@ describe('blocks projection', () => {
     expect(pmDocToBlocks(htmlToPmDoc('<p>no id</p>'))[0].blockId).toBeNull();
   });
 
+  it('treats an EMPTY blockId as no id, not as an id', () => {
+    // An empty string is not an addressable identity: returned as a string it
+    // would let a caller treat "no id" as an id and address the wrong block.
+    // (HTML parsing folds `data-block-id=""` to null on its own, so this can
+    // only be reached by constructing the node directly — which is exactly why
+    // the narrowing has to live in one named place.)
+    const schema = htmlToPmDoc('<p>x</p>').type.schema;
+    const doc = schema.node('doc', null, [schema.node('paragraph', { blockId: '' })]);
+    expect(pmDocToBlocks(doc)[0].blockId).toBeNull();
+  });
+
   it('keeps a list as ONE block rather than flattening it to its items', () => {
     const blocks = pmDocToBlocks(htmlToPmDoc('<ul><li>a</li><li>b</li></ul>'));
     expect(blocks).toHaveLength(1);
@@ -333,6 +371,26 @@ describe('fail closed', () => {
       expect((error as UnknownNodeError).nodeName).toBe('mystery');
       expect((error as UnknownNodeError).projection).toBe('markdown');
     }
+  });
+
+  it('throws on an unrecognised ROOT node, which `descendants` never visits', () => {
+    // `Node.descendants` does not visit the node it is called on, so a guard
+    // built only from it accepts ANY root. A document whose top node the
+    // projection cannot represent is not projectable, and this is the only
+    // assertion that says so.
+    const rootSchema = new Schema({
+      topNode: 'article',
+      nodes: {
+        article: { content: 'block+' },
+        paragraph: { content: 'text*', group: 'block' },
+        text: { group: 'inline' },
+      },
+      marks: {},
+    });
+    const doc = rootSchema.node('article', null, [rootSchema.node('paragraph')]);
+    expect(() => pmDocToHtml(doc)).toThrow(UnknownNodeError);
+    expect(() => pmDocToHtml(doc)).toThrow(/article/u);
+    expect(() => pmDocToMarkdown(doc)).toThrow(UnknownNodeError);
   });
 
   it('throws on an unknown INLINE node, not only an unknown block', () => {

--- a/packages/editor/src/__tests__/projections.test.ts
+++ b/packages/editor/src/__tests__/projections.test.ts
@@ -1,0 +1,377 @@
+/**
+ * The four projections, over the shared construct corpus.
+ *
+ * `pages.content` is not the editor's private field — it is a public
+ * integration surface (search, AI context, export, publish, `syncMentions`,
+ * backups, tenant export). These projections are written on every flush,
+ * forever, so a projector that silently drops a construct corrupts documents
+ * at scale with no failing test anywhere. That is what this suite exists to
+ * make impossible.
+ */
+import { describe, it, expect } from 'vitest';
+import { Schema } from 'prosemirror-model';
+import { htmlToPmDoc, htmlToYDoc } from '../html-to-ydoc.js';
+import { pmDocToHtml, yDocToHtml } from '../y-doc-to-html.js';
+import { pmDocToText, yDocToText } from '../y-doc-to-text.js';
+import { pmDocToMarkdown, yDocToMarkdown } from '../y-doc-to-markdown.js';
+import { pmDocToBlocks, yDocToBlocks } from '../y-doc-to-blocks.js';
+import { UnknownNodeError } from '../projection-errors.js';
+import { CONSTRUCT_CORPUS, corpusDocumentHtml } from './support/construct-corpus.js';
+
+const corpusHtml = corpusDocumentHtml();
+const corpusDoc = htmlToPmDoc(corpusHtml);
+
+describe('the Y.Doc projections agree with the ProseMirror ones', () => {
+  const yDoc = htmlToYDoc(corpusHtml);
+
+  it('renders the same HTML through the CRDT as directly', () => {
+    expect(yDocToHtml(yDoc)).toBe(pmDocToHtml(corpusDoc));
+  });
+
+  it('renders the same text, markdown and blocks through the CRDT', () => {
+    expect(yDocToText(yDoc)).toBe(pmDocToText(corpusDoc));
+    expect(yDocToMarkdown(yDoc)).toBe(pmDocToMarkdown(corpusDoc));
+    expect(yDocToBlocks(yDoc)).toEqual(pmDocToBlocks(corpusDoc));
+  });
+});
+
+describe('text projection', () => {
+  const text = pmDocToText(corpusDoc);
+
+  /**
+   * The live defect this projection exists to fix:
+   * `apps/web/src/app/api/search/route.ts` `ILIKE`s raw HTML, so a query for
+   * `span` matches every document containing a styled span. The corpus is full
+   * of `<span style>`, `<a href>`, `<table>` and `data-*` attributes and none
+   * of those words may appear in the output.
+   */
+  it.each(['span', 'href', 'style', 'table', 'class', 'data-', '<', '>', 'colspan'])(
+    'does not match a search for the markup token %j',
+    (token) => {
+      expect(text.toLowerCase()).not.toContain(token);
+    },
+  );
+
+  it.each(CONSTRUCT_CORPUS.map((fixture) => [fixture.key, fixture] as const))(
+    'keeps every visible string of %s',
+    (_key, fixture) => {
+      for (const expected of fixture.text) {
+        expect(text).toContain(expected);
+      }
+    },
+  );
+
+  it('separates blocks so two paragraphs cannot form a phrase', () => {
+    // `Element.textContent` would join these into "aboveblue"; the projection
+    // must not, or a search for a phrase spanning a block boundary hits.
+    const projected = pmDocToText(htmlToPmDoc('<p>above</p><p>blue</p>'));
+    expect(projected).toBe('above\nblue');
+  });
+
+  it('separates table cells within a row and rows from each other', () => {
+    const projected = pmDocToText(
+      htmlToPmDoc(
+        '<table><tbody><tr><td><p>a</p></td><td><p>b</p></td></tr>' +
+          '<tr><td><p>c</p></td><td><p>d</p></td></tr></tbody></table>',
+      ),
+    );
+    expect(projected).toBe('a\tb\nc\td');
+  });
+
+  it('keeps a code block\'s own line breaks', () => {
+    const projected = pmDocToText(htmlToPmDoc('<pre><code>one\ntwo</code></pre>'));
+    expect(projected).toBe('one\ntwo');
+  });
+
+  it('renders a mention as its visible label, never its id', () => {
+    const projected = pmDocToText(
+      htmlToPmDoc(
+        '<p><a class="mention" data-mention-type="page" data-page-id="pg_secret">@Roadmap</a></p>',
+      ),
+    );
+    expect(projected).toBe('@Roadmap');
+    expect(projected).not.toContain('pg_secret');
+  });
+
+  it('contributes nothing for an image, so alt text cannot answer a prose query', () => {
+    expect(pmDocToText(htmlToPmDoc('<img data-file-id="f1" alt="a diagram">'))).toBe('');
+  });
+});
+
+describe('markdown projection', () => {
+  const markdown = pmDocToMarkdown(corpusDoc);
+  const html = pmDocToHtml(corpusDoc);
+
+  /**
+   * "Materially cheaper in tokens" is asserted through two independent
+   * proxies — characters, and whitespace/punctuation-delimited words — rather
+   * than a real tokenizer. Adding a tokenizer dependency to a package that
+   * ships in every production image, for one assertion, costs more than it
+   * proves; and the gap being measured here is a factor, not a few per cent,
+   * so no tokenizer's exact segmentation could reverse it.
+   */
+  it('costs materially fewer characters than the HTML', () => {
+    expect(markdown.length).toBeLessThan(html.length * 0.6);
+  });
+
+  it('costs materially fewer word-ish tokens than the HTML', () => {
+    const tokens = (text: string): number => text.split(/[\s<>="/]+/u).filter(Boolean).length;
+    expect(tokens(markdown)).toBeLessThan(tokens(html) * 0.6);
+  });
+
+  it.each(CONSTRUCT_CORPUS.map((fixture) => [fixture.key, fixture] as const))(
+    'keeps every visible string of %s',
+    (_key, fixture) => {
+      for (const expected of fixture.text) {
+        expect(markdown).toContain(expected);
+      }
+    },
+  );
+
+  it('emits headings 1 to 6 at their own levels', () => {
+    expect(pmDocToMarkdown(htmlToPmDoc('<h1>a</h1><h4>b</h4><h6>c</h6>')).trim()).toBe(
+      '# a\n\n#### b\n\n###### c',
+    );
+  });
+
+  it('fences a code block with its language', () => {
+    expect(
+      pmDocToMarkdown(
+        htmlToPmDoc('<pre><code class="language-typescript">const a = 1;</code></pre>'),
+      ).trim(),
+    ).toBe('```typescript\nconst a = 1;\n```');
+  });
+
+  it('fences a code block that itself contains a triple backtick', () => {
+    const projected = pmDocToMarkdown(
+      htmlToPmDoc('<pre><code>```\nnested\n```</code></pre>'),
+    ).trim();
+    expect(projected.startsWith('````')).toBe(true);
+    expect(projected.endsWith('````')).toBe(true);
+  });
+
+  it('renders a tight list tightly and a loose list loosely', () => {
+    expect(pmDocToMarkdown(htmlToPmDoc('<ul><li>a</li><li>b</li></ul>')).trim()).toBe('- a\n- b');
+    expect(
+      pmDocToMarkdown(htmlToPmDoc('<ul><li><p>a</p></li><li><p>b</p></li></ul>')).trim(),
+    ).toBe('- a\n\n- b');
+  });
+
+  it('numbers an ordered list from its start attribute', () => {
+    expect(pmDocToMarkdown(htmlToPmDoc('<ol start="7"><li>a</li><li>b</li></ol>')).trim()).toBe(
+      '7. a\n8. b',
+    );
+  });
+
+  it('renders task items with their checked state', () => {
+    expect(
+      pmDocToMarkdown(
+        htmlToPmDoc(
+          '<ul data-type="taskList">' +
+            '<li data-type="taskItem" data-checked="true"><p>done</p></li>' +
+            '<li data-type="taskItem" data-checked="false"><p>todo</p></li></ul>',
+        ),
+      ).trim(),
+    ).toBe('- [x] done\n- [ ] todo');
+  });
+
+  it('renders a table as GFM, with its header row and alignment', () => {
+    expect(
+      pmDocToMarkdown(
+        htmlToPmDoc(
+          '<table><tbody><tr><th style="text-align: right"><p>N</p></th><th><p>R</p></th></tr>' +
+            '<tr><td><p>Ada</p></td><td><p>Eng</p></td></tr></tbody></table>',
+        ),
+      ).trim(),
+    ).toBe('| N | R |\n| ---: | --- |\n| Ada | Eng |');
+  });
+
+  it('escapes a pipe inside a cell so it cannot forge a column', () => {
+    const projected = pmDocToMarkdown(
+      htmlToPmDoc('<table><tbody><tr><td><p>a|b</p></td></tr></tbody></table>'),
+    );
+    expect(projected).toContain('a\\|b');
+  });
+
+  it('emits an empty header when the table has no header row', () => {
+    expect(
+      pmDocToMarkdown(
+        htmlToPmDoc('<table><tbody><tr><td><p>only</p></td></tr></tbody></table>'),
+      ).trim(),
+    ).toBe('|  |\n| --- |\n| only |');
+  });
+
+  it('renders an image with no alt and no file id without emitting "null"', () => {
+    // Both attributes default to `null` in the schema (`alt` distinguishes
+    // "explicitly decorative" from "unset"), and interpolating a null into the
+    // markdown would put the word `null` into the AI's context.
+    expect(pmDocToMarkdown(htmlToPmDoc('<img data-file-id="">')).trim()).toBe(
+      '![](pagespace-file:)',
+    );
+  });
+
+  it('numbers a list declared to start at zero from one', () => {
+    // Markdown has no zero-indexed ordered list; `start="0"` is legal HTML.
+    expect(pmDocToMarkdown(htmlToPmDoc('<ol start="0"><li>a</li></ol>')).trim()).toBe('1. a');
+  });
+
+  it('renders a link mark carrying no href as an empty target, not "null"', () => {
+    const doc = htmlToPmDoc('<p>x</p>');
+    const schema = doc.type.schema;
+    const linked = schema.node('doc', null, [
+      schema.node('paragraph', null, [schema.text('x', [schema.mark('link', { href: null })])]),
+    ]);
+    expect(pmDocToMarkdown(linked).trim()).toBe('[x]()');
+  });
+
+  it('serializes a bare table fragment rather than throwing', () => {
+    // `table` builds its own pipe markup and never renders rows through the
+    // serializer, so the row and cell entries are off that path — but they are
+    // what makes a table PROJECTABLE at all, and this is what exercises them.
+    const table = htmlToPmDoc(
+      '<table><tbody><tr><th><p>head</p></th></tr><tr><td><p>cell</p></td></tr></tbody></table>',
+    ).child(0);
+    expect(pmDocToMarkdown(table).trim()).toBe('head\n\ncell');
+  });
+
+  it('renders an image as its file reference, never a URL', () => {
+    const projected = pmDocToMarkdown(
+      htmlToPmDoc('<img data-file-id="file_abc" alt="a diagram">'),
+    ).trim();
+    expect(projected).toBe('![a diagram](pagespace-file:file_abc)');
+  });
+
+  it('renders marks it can express, and passes the rest through transparently', () => {
+    expect(
+      pmDocToMarkdown(
+        htmlToPmDoc(
+          '<p><strong>b</strong> <em>i</em> <s>s</s> <code>c</code> ' +
+            '<a href="https://x.test/p">l</a></p>',
+        ),
+      ).trim(),
+    ).toBe('**b** *i* ~~s~~ `c` [l](https://x.test/p)');
+    // underline / highlight / textStyle have no markdown form. The TEXT must
+    // survive; only the annotation is dropped.
+    expect(
+      pmDocToMarkdown(
+        htmlToPmDoc(
+          '<p><u>under</u> <mark>high</mark> <span style="color: #f00">red</span></p>',
+        ),
+      ).trim(),
+    ).toBe('under high red');
+  });
+});
+
+describe('blocks projection', () => {
+  it('addresses top-level blocks by their stable blockId', () => {
+    const blocks = pmDocToBlocks(
+      htmlToPmDoc('<p data-block-id="blk_1">one</p><h2 data-block-id="blk_2">two</h2>'),
+    );
+    expect(blocks).toEqual([
+      { blockId: 'blk_1', type: 'paragraph', index: 0, text: 'one', markdown: 'one' },
+      { blockId: 'blk_2', type: 'heading', index: 1, text: 'two', markdown: '## two' },
+    ]);
+  });
+
+  it('reports a block with no id as null rather than falling back to its index', () => {
+    expect(pmDocToBlocks(htmlToPmDoc('<p>no id</p>'))[0].blockId).toBeNull();
+  });
+
+  it('keeps a list as ONE block rather than flattening it to its items', () => {
+    const blocks = pmDocToBlocks(htmlToPmDoc('<ul><li>a</li><li>b</li></ul>'));
+    expect(blocks).toHaveLength(1);
+    expect(blocks[0].type).toBe('bulletList');
+    expect(blocks[0].markdown).toBe('- a\n- b');
+  });
+
+  it('renders each block as its own root, with its own markup', () => {
+    // Serialized as a bare node this heading would lose its `##` — the
+    // serializer renders its argument's CHILDREN.
+    const blocks = pmDocToBlocks(htmlToPmDoc('<h3>heading</h3><blockquote><p>q</p></blockquote>'));
+    expect(blocks.map((block) => block.markdown)).toEqual(['### heading', '> q']);
+  });
+
+  it('covers every top-level block of the corpus', () => {
+    expect(pmDocToBlocks(corpusDoc)).toHaveLength(corpusDoc.childCount);
+  });
+});
+
+describe('fail closed', () => {
+  /**
+   * A node the frozen schema does not describe. Every projector must THROW
+   * rather than skip it: a projector that degrades silently makes search go
+   * permanently stale, and a lossy projection written once is indistinguishable
+   * from a document that legitimately lacked the content.
+   */
+  const foreignSchema = new Schema({
+    nodes: {
+      doc: { content: 'block+' },
+      paragraph: { content: 'text*', group: 'block' },
+      mystery: { group: 'block', atom: true },
+      text: { group: 'inline' },
+    },
+    marks: {},
+  });
+  const foreignDoc = foreignSchema.node('doc', null, [foreignSchema.node('mystery')]);
+
+  it.each([
+    ['text', () => pmDocToText(foreignDoc)],
+    ['html', () => pmDocToHtml(foreignDoc)],
+    ['markdown', () => pmDocToMarkdown(foreignDoc)],
+    ['blocks', () => pmDocToBlocks(foreignDoc)],
+  ])('the %s projection throws on an unknown node', (_name, project) => {
+    expect(project).toThrow(UnknownNodeError);
+    expect(project).toThrow(/mystery/u);
+  });
+
+  it('names the projection it refused, so a caller can tell which one failed', () => {
+    try {
+      pmDocToMarkdown(foreignDoc);
+      expect.unreachable('should have thrown');
+    } catch (error) {
+      expect(error).toBeInstanceOf(UnknownNodeError);
+      expect((error as UnknownNodeError).nodeName).toBe('mystery');
+      expect((error as UnknownNodeError).projection).toBe('markdown');
+    }
+  });
+
+  it('throws on an unknown INLINE node, not only an unknown block', () => {
+    // A separate code path: the text projection walks blocks and inline
+    // content through different functions, so a block-level guard says nothing
+    // about an unrecognised inline node sitting inside a known paragraph.
+    const inlineSchema = new Schema({
+      nodes: {
+        doc: { content: 'block+' },
+        paragraph: { content: 'inline*', group: 'block' },
+        mystery: { group: 'inline', inline: true, atom: true },
+        text: { group: 'inline' },
+      },
+      marks: {},
+    });
+    const doc = inlineSchema.node('doc', null, [
+      inlineSchema.node('paragraph', null, [inlineSchema.node('mystery')]),
+    ]);
+    expect(() => pmDocToText(doc)).toThrow(UnknownNodeError);
+    expect(() => pmDocToHtml(doc)).toThrow(UnknownNodeError);
+    expect(() => pmDocToMarkdown(doc)).toThrow(UnknownNodeError);
+    expect(() => pmDocToBlocks(doc)).toThrow(UnknownNodeError);
+  });
+
+  it('throws on a mark the frozen schema does not describe', () => {
+    const markedSchema = new Schema({
+      nodes: {
+        doc: { content: 'block+' },
+        paragraph: { content: 'text*', group: 'block' },
+        text: { group: 'inline' },
+      },
+      marks: { mystery: {} },
+    });
+    const doc = markedSchema.node('doc', null, [
+      markedSchema.node('paragraph', null, [
+        markedSchema.text('t', [markedSchema.mark('mystery')]),
+      ]),
+    ]);
+    expect(() => pmDocToHtml(doc)).toThrow(UnknownNodeError);
+    expect(() => pmDocToMarkdown(doc)).toThrow(UnknownNodeError);
+  });
+});

--- a/packages/editor/src/__tests__/projections.test.ts
+++ b/packages/editor/src/__tests__/projections.test.ts
@@ -206,6 +206,31 @@ describe('markdown projection', () => {
     expect(projected).toContain('a\\|b');
   });
 
+  it.each(['toString', 'constructor', '__proto__', 'valueOf', 'hasOwnProperty'])(
+    'does not resolve the align attribute %j through Object.prototype',
+    (align) => {
+      // Node attributes on a live document are written by CLIENTS into the
+      // Y.Doc, and the schema declares no validator for `align`, so any string
+      // arrives here. Indexed against an object literal, `align="toString"`
+      // returned a FUNCTION — and `?? '---'` never fired, because a function is
+      // not nullish — emitting `| function toString() {` and its embedded
+      // newlines into the delimiter row. TipTap's HTML parser whitelists this
+      // attribute, so it is unreachable from stored content and reachable only
+      // from the CRDT: exactly the path these projections exist to serve.
+      const schema = corpusDoc.type.schema;
+      const cell = schema.nodes.tableHeader.createAndFill({ align });
+      if (cell === null) {
+        expect.unreachable('tableHeader must be fillable');
+        return;
+      }
+      const doc = schema.topNodeType.create(null, [
+        schema.nodes.table.create(null, [schema.nodes.tableRow.create(null, [cell])]),
+      ]);
+      const delimiterRow = pmDocToMarkdown(doc).split('\n')[1];
+      expect(delimiterRow).toBe('| --- |');
+    },
+  );
+
   it('pads every row to the widest row, so a short row cannot shift columns', () => {
     // A ragged table is legal in the schema. Sizing the table from the FIRST
     // row instead of the widest silently truncates every wider row's cells —

--- a/packages/editor/src/__tests__/projections.test.ts
+++ b/packages/editor/src/__tests__/projections.test.ts
@@ -231,6 +231,44 @@ describe('markdown projection', () => {
     },
   );
 
+  it.each([
+    [9, '######'],
+    [7, '######'],
+    [0, '#'],
+    [-3, '#'],
+  ])('clamps a client-written heading level %i into GFM range', (level, hashes) => {
+    // Same class as the `align` defect: `level` has no validator and a CRDT
+    // client can write anything. `######### H` is not a heading in GFM — the
+    // projection silently demoted a heading to paragraph text.
+    const schema = corpusDoc.type.schema;
+    const doc = schema.topNodeType.create(null, [
+      schema.nodes.heading.create({ level }, schema.text('H')),
+    ]);
+    expect(pmDocToMarkdown(doc).trim()).toBe(`${hashes} H`);
+  });
+
+  it.each(['js```\n# not code', 'a\nb', 'has space', '`tick`'])(
+    'drops an unsafe code-block language rather than writing it into the fence (%j)',
+    (language) => {
+      // The worst of the client-attribute family: the fence closed on the
+      // attribute's own backticks and the remainder escaped INTO the document
+      // as markdown. Content injection into the AI-context projection.
+      const schema = corpusDoc.type.schema;
+      const doc = schema.topNodeType.create(null, [
+        schema.nodes.codeBlock.create({ language }, schema.text('payload')),
+      ]);
+      expect(pmDocToMarkdown(doc).trim()).toBe('```\npayload\n```');
+    },
+  );
+
+  it('keeps a language that is safe', () => {
+    const schema = corpusDoc.type.schema;
+    const doc = schema.topNodeType.create(null, [
+      schema.nodes.codeBlock.create({ language: 'c++' }, schema.text('x')),
+    ]);
+    expect(pmDocToMarkdown(doc).trim()).toBe('```c++\nx\n```');
+  });
+
   it('pads every row to the widest row, so a short row cannot shift columns', () => {
     // A ragged table is legal in the schema. Sizing the table from the FIRST
     // row instead of the widest silently truncates every wider row's cells —
@@ -284,6 +322,28 @@ describe('markdown projection', () => {
       '<table><tbody><tr><th><p>head</p></th></tr><tr><td><p>cell</p></td></tr></tbody></table>',
     ).child(0);
     expect(pmDocToMarkdown(table).trim()).toBe('head\n\ncell');
+  });
+
+  it('closes the image block, so the next block is still its own block', () => {
+    // `image` is a BLOCK node. Without `closeBlock` the next block ran straight
+    // into it — `![pic](...)## Heading` — and the heading stopped being a
+    // heading in the projection the AI reads. Containment assertions cannot see
+    // this; only the structure can.
+    expect(
+      pmDocToMarkdown(
+        htmlToPmDoc('<img data-file-id="f1" alt="pic"><h2>Heading</h2><p>after</p>'),
+      ).trim(),
+    ).toBe('![pic](pagespace-file:f1)\n\n## Heading\n\nafter');
+  });
+
+  it('widens the inline-code delimiter around embedded backticks', () => {
+    // Fixed single backticks with `escape: false` closed the span early:
+    // text ``a`b`` serialized as `` `a`b` ``, leaving an unmatched delimiter and
+    // mis-parsed code.
+    expect(pmDocToMarkdown(htmlToPmDoc('<p><code>a`b</code></p>')).trim()).toBe('`` a`b ``');
+    expect(pmDocToMarkdown(htmlToPmDoc('<p><code>x``y</code></p>')).trim()).toBe('``` x``y ```');
+    // The ordinary case must not gain padding.
+    expect(pmDocToMarkdown(htmlToPmDoc('<p><code>plain</code></p>')).trim()).toBe('`plain`');
   });
 
   it('renders an image as its file reference, never a URL', () => {

--- a/packages/editor/src/__tests__/projector-totality.test.ts
+++ b/packages/editor/src/__tests__/projector-totality.test.ts
@@ -1,0 +1,149 @@
+/**
+ * Do the projectors actually cover the frozen schema?
+ *
+ * Every other guard in this package is per-DOCUMENT and at RUNTIME: an
+ * unhandled node throws `UnknownNodeError` when a document containing one is
+ * projected. That is fail-closed, but it fails in the collab service rather
+ * than in the pull request. Add a node in a Class B schema change and forget
+ * one projector, and CI stays green — `SCHEMA_HASH` moves, which the drift
+ * guard catches, but nothing compares the schema's node set against what each
+ * projector can render. The first production document containing the new node
+ * then throws on every flush, forever.
+ *
+ * These tests close that gap by comparing the two enumerable sets directly, so
+ * a forgotten projector is red here instead of loud in production.
+ */
+import { describe, it, expect } from 'vitest';
+import type { Node as PmNode } from 'prosemirror-model';
+import { collabSchema } from '../collab-document.js';
+import { pmDocToText } from '../y-doc-to-text.js';
+import { pmDocToMarkdown } from '../y-doc-to-markdown.js';
+import { pmDocToHtml } from '../y-doc-to-html.js';
+import { BLOCK_NODE_TYPES } from '../block-id.js';
+
+const schema = collabSchema();
+const schemaNodeNames = Object.keys(schema.nodes).sort();
+
+/**
+ * One minimal, valid document containing `nodeName`, built through
+ * `createAndFill` so ProseMirror synthesises whatever required content the
+ * node's own content expression demands. Returns `null` for nodes that cannot
+ * be placed at the top level (`text`, `listItem`, `tableRow`, …) — those are
+ * reached through their parents, which the corpus already covers.
+ */
+function documentContaining(nodeName: string): PmNode | null {
+  const type = schema.nodes[nodeName];
+  if (type === schema.topNodeType) {
+    return schema.topNodeType.createAndFill();
+  }
+  const node = type.createAndFill();
+  if (node === null || !schema.topNodeType.contentMatch.matchType(type)) {
+    return null;
+  }
+  return schema.topNodeType.createAndFill(null, [node]);
+}
+
+describe('every schema node is projectable', () => {
+  const placeable = schemaNodeNames.filter((name) => documentContaining(name) !== null);
+
+  it('covers enough of the schema for this suite to be meaningful', () => {
+    // Guards the guard: if `documentContaining` silently stopped being able to
+    // build anything, every case below would vacuously pass.
+    expect(placeable.length).toBeGreaterThanOrEqual(10);
+    expect(placeable).toContain('table');
+    expect(placeable).toContain('taskList');
+    expect(placeable).toContain('image');
+  });
+
+  it.each(placeable)('projects a document containing %s to all four formats', (nodeName) => {
+    const doc = documentContaining(nodeName);
+    expect(doc).not.toBeNull();
+    if (doc === null) {
+      return;
+    }
+    // Not asserting the OUTPUT — the corpus suites do that. Asserting only that
+    // no projector refuses a node the frozen schema describes.
+    expect(() => pmDocToText(doc)).not.toThrow();
+    expect(() => pmDocToMarkdown(doc)).not.toThrow();
+    expect(() => pmDocToHtml(doc)).not.toThrow();
+  });
+
+  it('the markdown serializer knows every schema node except the root', () => {
+    // The direct set comparison, which catches nodes `documentContaining`
+    // cannot place at the top level (`listItem`, `tableCell`, `hardBreak`, …).
+    // `doc` is legitimately absent: `MarkdownSerializer.serialize` renders the
+    // root's CHILDREN, so the root never reaches a node serializer.
+    const missing = schemaNodeNames.filter(
+      (name) => name !== schema.topNodeType.name && !markdownHandles(name),
+    );
+    expect(missing).toEqual([]);
+  });
+});
+
+function markdownHandles(nodeName: string): boolean {
+  // Probed through the public projector rather than by reaching into the
+  // serializer's node map: what matters is that projecting does not throw
+  // `UnknownNodeError`, which is the contract callers actually depend on.
+  const type = schema.nodes[nodeName];
+  const node = type.createAndFill();
+  if (node === null) {
+    return true;
+  }
+  try {
+    pmDocToMarkdown(schema.topNodeType.create(null, wrapForRoot(node)));
+    return true;
+  } catch (error) {
+    return !(error instanceof Error && error.name === 'UnknownNodeError');
+  }
+}
+
+/**
+ * Places `node` under the root, wrapping it in whatever parents its content
+ * expression requires (a `listItem` needs a list, a `tableCell` needs a row and
+ * a table), so a non-top-level node still reaches the projectors.
+ */
+function wrapForRoot(node: PmNode): PmNode {
+  if (schema.topNodeType.contentMatch.matchType(node.type)) {
+    return node;
+  }
+  for (const parentName of Object.keys(schema.nodes)) {
+    const parent = schema.nodes[parentName];
+    if (parent === schema.topNodeType || !parent.contentMatch.matchType(node.type)) {
+      continue;
+    }
+    const wrapped = parent.createAndFill(null, [node]);
+    if (wrapped !== null) {
+      const placed = wrapForRoot(wrapped);
+      if (schema.topNodeType.contentMatch.matchType(placed.type)) {
+        return placed;
+      }
+    }
+  }
+  return schema.nodes.paragraph.create();
+}
+
+describe('blockId covers every block node', () => {
+  /**
+   * `BLOCK_NODE_TYPES` (`block-id.ts`) is the hand-written list of node types
+   * that get a `blockId` stamped on them, and it is the one place in this
+   * package that fails OPEN. Add a block node to the frozen schema, forget it
+   * here, and nothing throws: `pmDocToBlocks` reports `blockId: null` for it
+   * forever, which its own docstring defines as *unaddressable*. The `null`
+   * branch is a legitimate value for pre-v1 content, so every caller takes its
+   * nothing-to-do path and reports success — the block tools simply cannot
+   * target that block type, silently.
+   *
+   * The list cannot be derived from the finished schema (it is an INPUT to
+   * building it), but it can be closed over it.
+   */
+  it('lists exactly the schema nodes in the block group, plus the two list items', () => {
+    const blockGroupNodes = Object.keys(schema.nodes).filter((name) =>
+      (schema.nodes[name].spec.group ?? '').split(' ').includes('block'),
+    );
+    // `listItem`/`taskItem` are not in the `block` group — they are children of
+    // a list — but they are the unit a tracked change or comment attaches to,
+    // so they carry the attributes too.
+    const expected = [...blockGroupNodes, 'listItem', 'taskItem'].sort();
+    expect([...BLOCK_NODE_TYPES].sort()).toEqual(expected);
+  });
+});

--- a/packages/editor/src/__tests__/seed-fidelity.test.ts
+++ b/packages/editor/src/__tests__/seed-fidelity.test.ts
@@ -35,8 +35,13 @@ import {
  * - `a@data-type`, `span@data-type` — TipTap's node-name marker on a mention.
  * - `a@contenteditable`, `a@data-drive-id` — the AI mention dialect omits
  *   them; the node's own `renderHTML` always writes them.
- * - `ul@class`, `ul@data-tight` — `MarkdownTightLists` makes the tightness it
- *   INFERRED from the source (`!element.querySelector('p')`) explicit.
+ * - `ul@class`, `ul@data-tight` (`=true`) — `MarkdownTightLists` makes the
+ *   tightness it INFERRED from the source (`!element.querySelector('p')`)
+ *   explicit.
+ * - `a@data-drive-id=` — the AI mention dialect carries no drive, and the
+ *   node's `renderHTML` always writes the attribute, so it appears empty. The
+ *   EMPTY value is the allowlisted one; a mention gaining a real drive id would
+ *   produce a different key and fail.
  * - `p` — a bare `<li>text</li>` becomes `<li><p>text</p></li>`, because the
  *   schema's `listItem` content is `paragraph block*`.
  * - `label`, `input`, `input@type`, `input@checked`, `span`, `div` —
@@ -58,6 +63,7 @@ import {
 const ALLOWED_COSMETIC_ADDITIONS: ReadonlySet<string> = new Set([
   'attr:a@contenteditable',
   'attr:a@data-drive-id',
+  'attr:a@data-drive-id=',
   'attr:a@data-type',
   'attr:a@data-type=pageMention',
   'attr:a@rel',
@@ -73,6 +79,7 @@ const ALLOWED_COSMETIC_ADDITIONS: ReadonlySet<string> = new Set([
   'attr:table@style:min-width',
   'attr:ul@class',
   'attr:ul@data-tight',
+  'attr:ul@data-tight=true',
   'el:col',
   'el:colgroup',
   'el:div',
@@ -88,12 +95,36 @@ const ALLOWED_COSMETIC_ADDITIONS: ReadonlySet<string> = new Set([
  * Deliberately not the markup string: a set difference names WHICH construct
  * moved, where a string diff only says "changed".
  *
- * `style` is split per CSS property and `data-type` carries its value, because
- * a bare `attr:p@style` merges the question with the answer. `text-align:center`
- * becoming `text-align:left`, or `data-type="taskList"` becoming `taskItem`,
- * would otherwise be invisible to a gate whose entire job is naming the
- * construct that moved — and the corpus has fixtures for both.
+ * `style` is split per CSS property, and the attributes in
+ * `VALUE_BEARING_ATTRIBUTES` carry their value, because a bare `attr:p@style`
+ * merges the question with the answer. `text-align:center` becoming
+ * `text-align:left`, `data-type="taskList"` becoming `taskItem`, a rewritten
+ * `href`, a `data-page-id` pointing at a different page, or `start="7"` becoming
+ * `start="1"` would otherwise all be invisible to a gate whose entire job is
+ * naming the construct that moved — and the corpus has fixtures for every one
+ * of them.
+ *
+ * Presence-only keys are kept alongside the value keys, so a DROPPED attribute
+ * and a CHANGED one are distinguishable in the diff.
  */
+const VALUE_BEARING_ATTRIBUTES: ReadonlySet<string> = new Set([
+  'data-type',
+  'href',
+  'data-page-id',
+  'data-user-id',
+  'data-role-id',
+  'data-drive-id',
+  'data-file-id',
+  'data-block-id',
+  'data-change-id',
+  'data-change-type',
+  'data-checked',
+  'data-tight',
+  'start',
+  'colspan',
+  'rowspan',
+  'alt',
+]);
 function constructsOf(html: string): Set<string> {
   return withDomWorkspace((workspace) => {
     const keys = new Set<string>();
@@ -102,8 +133,8 @@ function constructsOf(html: string): Set<string> {
       keys.add(`el:${tag}`);
       for (const name of element.getAttributeNames()) {
         keys.add(`attr:${tag}@${name}`);
-        if (name === 'data-type') {
-          keys.add(`attr:${tag}@data-type=${element.getAttribute(name) ?? ''}`);
+        if (VALUE_BEARING_ATTRIBUTES.has(name)) {
+          keys.add(`attr:${tag}@${name}=${element.getAttribute(name) ?? ''}`);
         }
         if (name === 'style') {
           for (const declaration of (element.getAttribute(name) ?? '').split(';')) {

--- a/packages/editor/src/__tests__/seed-fidelity.test.ts
+++ b/packages/editor/src/__tests__/seed-fidelity.test.ts
@@ -19,9 +19,12 @@
 import { describe, it, expect } from 'vitest';
 import { htmlToPmDoc, describeHtmlLoss } from '../html-to-ydoc.js';
 import { pmDocToHtml } from '../y-doc-to-html.js';
-import { pmDocToText } from '../y-doc-to-text.js';
-import { createDomWorkspace } from '../dom-workspace.js';
-import { CONSTRUCT_CORPUS, corpusDocumentHtml } from './support/construct-corpus.js';
+import { withDomWorkspace } from '../dom-workspace.js';
+import {
+  CONSTRUCT_CORPUS,
+  CORPUS_CASES,
+  corpusDocumentHtml,
+} from './support/construct-corpus.js';
 
 /**
  * Every markup construct one pass through the schema is allowed to ADD.
@@ -40,8 +43,14 @@ import { CONSTRUCT_CORPUS, corpusDocumentHtml } from './support/construct-corpus
  *   `TaskItem`'s rendered checkbox. The state itself lives in
  *   `li@data-checked`, which the source already carried.
  * - `pre@class` — `CodeBlockNode` mirrors `language-x` onto the `<pre>`.
- * - `table@style`, `colgroup`, `col`, `col@style` — TipTap's table column
- *   model, emitted as `min-width` from the schema's own defaults.
+ * - `table@style`, `colgroup`, `col`, `col@style` (and their `style:min-width`
+ *   forms) — TipTap's table column model, emitted as `min-width` from the
+ *   schema's own defaults.
+ *
+ * The `=pageMention` entries are the VALUE-bearing form of the `data-type`
+ * marker above. They are listed separately, and deliberately: it is the value
+ * that carries the meaning, so `data-type` changing from `taskList` to
+ * `taskItem` must fail rather than be absorbed by a bare `attr@data-type`.
  *
  * Nothing here changes what the document SAYS. An addition outside this set is
  * a change to the stored dialect and must be looked at, not tolerated.
@@ -50,14 +59,18 @@ const ALLOWED_COSMETIC_ADDITIONS: ReadonlySet<string> = new Set([
   'attr:a@contenteditable',
   'attr:a@data-drive-id',
   'attr:a@data-type',
+  'attr:a@data-type=pageMention',
   'attr:a@rel',
   'attr:a@target',
   'attr:col@style',
+  'attr:col@style:min-width',
   'attr:input@checked',
   'attr:input@type',
   'attr:pre@class',
   'attr:span@data-type',
+  'attr:span@data-type=pageMention',
   'attr:table@style',
+  'attr:table@style:min-width',
   'attr:ul@class',
   'attr:ul@data-tight',
   'el:col',
@@ -70,19 +83,36 @@ const ALLOWED_COSMETIC_ADDITIONS: ReadonlySet<string> = new Set([
 ]);
 
 /**
- * Markup constructs as comparable keys: `el:<tag>` and `attr:<tag>@<name>`.
- * Deliberately not the markup string — a set difference names WHICH construct
+ * Markup constructs as comparable keys: `el:<tag>`, `attr:<tag>@<name>`, and —
+ * for the two attributes whose VALUE is the construct — `attr:<tag>@<name>=<value>`.
+ * Deliberately not the markup string: a set difference names WHICH construct
  * moved, where a string diff only says "changed".
+ *
+ * `style` is split per CSS property and `data-type` carries its value, because
+ * a bare `attr:p@style` merges the question with the answer. `text-align:center`
+ * becoming `text-align:left`, or `data-type="taskList"` becoming `taskItem`,
+ * would otherwise be invisible to a gate whose entire job is naming the
+ * construct that moved — and the corpus has fixtures for both.
  */
 function constructsOf(html: string): Set<string> {
-  const workspace = createDomWorkspace();
-  try {
+  return withDomWorkspace((workspace) => {
     const keys = new Set<string>();
     const walk = (element: Element): void => {
       const tag = element.tagName.toLowerCase();
       keys.add(`el:${tag}`);
       for (const name of element.getAttributeNames()) {
         keys.add(`attr:${tag}@${name}`);
+        if (name === 'data-type') {
+          keys.add(`attr:${tag}@data-type=${element.getAttribute(name) ?? ''}`);
+        }
+        if (name === 'style') {
+          for (const declaration of (element.getAttribute(name) ?? '').split(';')) {
+            const property = declaration.split(':')[0]?.trim().toLowerCase();
+            if (property) {
+              keys.add(`attr:${tag}@style:${property}`);
+            }
+          }
+        }
       }
       for (const child of Array.from(element.children)) {
         walk(child);
@@ -92,15 +122,13 @@ function constructsOf(html: string): Set<string> {
       walk(child);
     }
     return keys;
-  } finally {
-    workspace.close();
-  }
+  });
 }
 
 const difference = (a: Set<string>, b: Set<string>): string[] =>
   [...a].filter((key) => !b.has(key)).sort();
 
-describe.each(CONSTRUCT_CORPUS.map((fixture) => [fixture.key, fixture] as const))(
+describe.each(CORPUS_CASES)(
   'seed fidelity: %s',
   (_key, fixture) => {
     const rendered = pmDocToHtml(htmlToPmDoc(fixture.html));
@@ -118,18 +146,14 @@ describe.each(CONSTRUCT_CORPUS.map((fixture) => [fixture.key, fixture] as const)
       expect(added.filter((key) => !ALLOWED_COSMETIC_ADDITIONS.has(key))).toEqual([]);
     });
 
-    it('preserves every visible character', () => {
-      const strip = (text: string): string => text.replace(/\s+/gu, '');
-      const workspace = createDomWorkspace();
-      try {
-        expect(strip(pmDocToText(htmlToPmDoc(fixture.html)))).toBe(
-          strip(workspace.parse(fixture.html).textContent ?? ''),
-        );
-      } finally {
-        workspace.close();
-      }
-    });
-
+    // No "preserves every visible character" test here. It would recompute
+    // `visibleCharacters(source.textContent) === visibleCharacters(pmDocToText(...))`,
+    // which is exactly what `describeHtmlLoss` does below — a mirror that
+    // cannot fail unless the next test fails first, and whose duplicated
+    // whitespace rule would silently drift from the implementation's. The
+    // independent check on the same property is in `projections.test.ts`,
+    // where each fixture's expected visible strings are hand-written rather
+    // than derived from the code under test.
     it('reports no loss', () => {
       expect(describeHtmlLoss(fixture.html)).toEqual([]);
     });

--- a/packages/editor/src/__tests__/seed-fidelity.test.ts
+++ b/packages/editor/src/__tests__/seed-fidelity.test.ts
@@ -1,0 +1,171 @@
+/**
+ * The seed invariant, over the construct corpus.
+ *
+ * The bar is `render(parse(h1)) == h1` — a FIXPOINT — plus zero loss of any
+ * content-bearing construct. It is deliberately NOT byte-identical output,
+ * because measured over the corpus one pass through the schema rewrites its
+ * input in ways that lose nothing: tables gain `<colgroup>` and `min-width`,
+ * a bare `<ul>` gains `class="tight" data-tight="true"`, bare `<li>` text is
+ * wrapped in `<p>`, `TaskItem` renders its own checkbox markup, `Link` stamps
+ * `target`/`rel`. A byte-equality assertion here would fail on all of that and
+ * send its next reader off to "fix" normalisation that is not broken.
+ *
+ * The danger in relaxing an assertion is that the relaxation swallows a real
+ * loss. So the tolerance is NOT a loose comparison — it is an explicit,
+ * exhaustively-named allowlist (`ALLOWED_COSMETIC_ADDITIONS`) which the suite
+ * also asserts is not larger than it needs to be. A rewrite that is not on the
+ * list fails, whether it is new or newly noticed.
+ */
+import { describe, it, expect } from 'vitest';
+import { htmlToPmDoc, describeHtmlLoss } from '../html-to-ydoc.js';
+import { pmDocToHtml } from '../y-doc-to-html.js';
+import { pmDocToText } from '../y-doc-to-text.js';
+import { createDomWorkspace } from '../dom-workspace.js';
+import { CONSTRUCT_CORPUS, corpusDocumentHtml } from './support/construct-corpus.js';
+
+/**
+ * Every markup construct one pass through the schema is allowed to ADD.
+ *
+ * Each entry is a rewrite whose absence from the source is not information:
+ *
+ * - `a@target` / `a@rel` — `Link` stamps these on every anchor it renders.
+ * - `a@data-type`, `span@data-type` — TipTap's node-name marker on a mention.
+ * - `a@contenteditable`, `a@data-drive-id` — the AI mention dialect omits
+ *   them; the node's own `renderHTML` always writes them.
+ * - `ul@class`, `ul@data-tight` — `MarkdownTightLists` makes the tightness it
+ *   INFERRED from the source (`!element.querySelector('p')`) explicit.
+ * - `p` — a bare `<li>text</li>` becomes `<li><p>text</p></li>`, because the
+ *   schema's `listItem` content is `paragraph block*`.
+ * - `label`, `input`, `input@type`, `input@checked`, `span`, `div` —
+ *   `TaskItem`'s rendered checkbox. The state itself lives in
+ *   `li@data-checked`, which the source already carried.
+ * - `pre@class` — `CodeBlockNode` mirrors `language-x` onto the `<pre>`.
+ * - `table@style`, `colgroup`, `col`, `col@style` — TipTap's table column
+ *   model, emitted as `min-width` from the schema's own defaults.
+ *
+ * Nothing here changes what the document SAYS. An addition outside this set is
+ * a change to the stored dialect and must be looked at, not tolerated.
+ */
+const ALLOWED_COSMETIC_ADDITIONS: ReadonlySet<string> = new Set([
+  'attr:a@contenteditable',
+  'attr:a@data-drive-id',
+  'attr:a@data-type',
+  'attr:a@rel',
+  'attr:a@target',
+  'attr:col@style',
+  'attr:input@checked',
+  'attr:input@type',
+  'attr:pre@class',
+  'attr:span@data-type',
+  'attr:table@style',
+  'attr:ul@class',
+  'attr:ul@data-tight',
+  'el:col',
+  'el:colgroup',
+  'el:div',
+  'el:input',
+  'el:label',
+  'el:p',
+  'el:span',
+]);
+
+/**
+ * Markup constructs as comparable keys: `el:<tag>` and `attr:<tag>@<name>`.
+ * Deliberately not the markup string — a set difference names WHICH construct
+ * moved, where a string diff only says "changed".
+ */
+function constructsOf(html: string): Set<string> {
+  const workspace = createDomWorkspace();
+  try {
+    const keys = new Set<string>();
+    const walk = (element: Element): void => {
+      const tag = element.tagName.toLowerCase();
+      keys.add(`el:${tag}`);
+      for (const name of element.getAttributeNames()) {
+        keys.add(`attr:${tag}@${name}`);
+      }
+      for (const child of Array.from(element.children)) {
+        walk(child);
+      }
+    };
+    for (const child of Array.from(workspace.parse(html).children)) {
+      walk(child);
+    }
+    return keys;
+  } finally {
+    workspace.close();
+  }
+}
+
+const difference = (a: Set<string>, b: Set<string>): string[] =>
+  [...a].filter((key) => !b.has(key)).sort();
+
+describe.each(CONSTRUCT_CORPUS.map((fixture) => [fixture.key, fixture] as const))(
+  'seed fidelity: %s',
+  (_key, fixture) => {
+    const rendered = pmDocToHtml(htmlToPmDoc(fixture.html));
+
+    it('reaches a fixpoint in one pass', () => {
+      expect(pmDocToHtml(htmlToPmDoc(rendered))).toBe(rendered);
+    });
+
+    it('loses no construct the source carried', () => {
+      expect(difference(constructsOf(fixture.html), constructsOf(rendered))).toEqual([]);
+    });
+
+    it('adds only allowlisted cosmetic constructs', () => {
+      const added = difference(constructsOf(rendered), constructsOf(fixture.html));
+      expect(added.filter((key) => !ALLOWED_COSMETIC_ADDITIONS.has(key))).toEqual([]);
+    });
+
+    it('preserves every visible character', () => {
+      const strip = (text: string): string => text.replace(/\s+/gu, '');
+      const workspace = createDomWorkspace();
+      try {
+        expect(strip(pmDocToText(htmlToPmDoc(fixture.html)))).toBe(
+          strip(workspace.parse(fixture.html).textContent ?? ''),
+        );
+      } finally {
+        workspace.close();
+      }
+    });
+
+    it('reports no loss', () => {
+      expect(describeHtmlLoss(fixture.html)).toEqual([]);
+    });
+  },
+);
+
+describe('the corpus as one document', () => {
+  it('reaches a fixpoint and loses nothing', () => {
+    const source = corpusDocumentHtml();
+    const rendered = pmDocToHtml(htmlToPmDoc(source));
+    expect(describeHtmlLoss(source)).toEqual([]);
+    expect(difference(constructsOf(source), constructsOf(rendered))).toEqual([]);
+    expect(pmDocToHtml(htmlToPmDoc(rendered))).toBe(rendered);
+  });
+});
+
+describe('the allowlist itself', () => {
+  /**
+   * Without this, a rewrite that stops happening leaves a stale entry behind,
+   * and the allowlist grows into a blanket tolerance that would hide the next
+   * real change. Every entry must be earned by the corpus.
+   */
+  it('contains nothing the corpus does not actually produce', () => {
+    // Per fixture, then unioned — NOT over the concatenated document. In the
+    // concatenation a construct one fixture gains is already present in
+    // another fixture's source, so five real rewrites (`el:p`, `el:span`,
+    // `a@rel`, `a@contenteditable`, `a@data-drive-id`) would read as never
+    // produced and this guard would demand their removal from the allowlist.
+    const produced = CONSTRUCT_CORPUS.flatMap((fixture) =>
+      difference(
+        constructsOf(pmDocToHtml(htmlToPmDoc(fixture.html))),
+        constructsOf(fixture.html),
+      ),
+    );
+    expect([...ALLOWED_COSMETIC_ADDITIONS].sort().filter((key) => !produced.includes(key))).toEqual(
+      [],
+    );
+  });
+});

--- a/packages/editor/src/__tests__/support/construct-corpus.ts
+++ b/packages/editor/src/__tests__/support/construct-corpus.ts
@@ -181,6 +181,15 @@ export const CONSTRUCT_CORPUS: readonly ConstructFixture[] = [
   },
 ] as const;
 
+/**
+ * The corpus as `it.each` rows. Exported because three suites parametrise over
+ * it and each was writing this same `.map` inline — the kind of line that
+ * drifts when one file adds a filter and the others do not.
+ */
+export const CORPUS_CASES = CONSTRUCT_CORPUS.map(
+  (fixture) => [fixture.key, fixture] as const,
+);
+
 /** Every fixture concatenated — one document exercising the whole corpus. */
 export function corpusDocumentHtml(): string {
   return CONSTRUCT_CORPUS.map((fixture) => fixture.html).join('');

--- a/packages/editor/src/__tests__/support/construct-corpus.ts
+++ b/packages/editor/src/__tests__/support/construct-corpus.ts
@@ -1,0 +1,187 @@
+/**
+ * The construct corpus — one named fixture per content-bearing construct the
+ * frozen v1 schema can represent.
+ *
+ * Three different invariants are held against this same list on purpose:
+ * seed fidelity (`seed-fidelity.test.ts`), projection fidelity
+ * (`projections.test.ts`) and cross-DOM parse equality
+ * (`cross-dom-parse-equality.test.ts`). Sharing the corpus is what makes
+ * "covered by one, silently missing from another" impossible — adding a
+ * construct here adds it to all three at once, and each of those suites
+ * asserts it covers every entry rather than iterating whatever it is given.
+ *
+ * Fixtures are written in the dialect the schema RENDERS (`<li><p>text</p>`,
+ * explicit `colspan`), except where the fixture's whole point is a foreign
+ * dialect — `bareList`, `bareListItem` and the three legacy/AI mention
+ * dialects. That keeps the fixpoint assertion meaningful for the normalised
+ * cases and still exercises the parser's tolerance for stored content.
+ */
+export interface ConstructFixture {
+  /** Stable key; the suites assert they covered every one of these. */
+  readonly key: string;
+  readonly html: string;
+  /**
+   * Visible prose the text projection MUST contain. Never markup — a fixture
+   * whose expectation named a tag would defeat the projection it is checking.
+   */
+  readonly text: readonly string[];
+}
+
+export const CONSTRUCT_CORPUS: readonly ConstructFixture[] = [
+  {
+    key: 'headings-1-to-6',
+    html:
+      '<h1>One</h1><h2>Two</h2><h3>Three</h3><h4>Four</h4><h5>Five</h5><h6>Six</h6>',
+    text: ['One', 'Two', 'Three', 'Four', 'Five', 'Six'],
+  },
+  {
+    key: 'paragraph-with-hard-break',
+    html: '<p>first line<br>second line</p>',
+    text: ['first line', 'second line'],
+  },
+  {
+    key: 'all-marks',
+    html:
+      '<p><strong>bold</strong> <em>italic</em> <s>strike</s> <u>under</u> ' +
+      '<code>code</code> <mark>highlighted</mark> ' +
+      '<a href="https://example.test/a">linked</a></p>',
+    text: ['bold', 'italic', 'strike', 'under', 'code', 'highlighted', 'linked'],
+  },
+  {
+    key: 'collab-marks',
+    html:
+      '<p><span data-thread-id="th_1">commented</span> ' +
+      '<span data-change-type="insertion" data-author-id="u1" data-change-id="c1">added</span> ' +
+      '<span data-change-type="deletion" data-author-id="u1" data-change-id="c2">removed</span></p>',
+    text: ['commented', 'added', 'removed'],
+  },
+  {
+    key: 'text-style-span',
+    // The `<span style>` shape `TextStyleKit` owns since `FontFormatting` was
+    // deleted. Its `parseHTML` reads the DOM's *parsed* style declaration, not
+    // the source string, which is exactly why cross-DOM equality is asserted.
+    html:
+      '<p><span style="font-family: \'Times New Roman\'; font-size: 14px; color: #ff0000">tinted</span></p>',
+    text: ['tinted'],
+  },
+  {
+    key: 'text-align',
+    html: '<p style="text-align: center">centred</p><h2 style="text-align: right">right</h2>',
+    text: ['centred', 'right'],
+  },
+  {
+    key: 'loose-list',
+    html: '<ul><li><p>alpha</p></li><li><p>beta</p></li></ul>',
+    text: ['alpha', 'beta'],
+  },
+  {
+    key: 'bare-list',
+    // No `<p>` inside the items, so `MarkdownTightLists` parses `tight: true`
+    // (`!element.querySelector('p')`) — the tight/loose distinction, read from
+    // the DOM rather than the source string.
+    html: '<ul><li>alpha</li><li>beta</li></ul>',
+    text: ['alpha', 'beta'],
+  },
+  {
+    key: 'nested-list',
+    html:
+      '<ul><li><p>outer</p><ul><li><p>inner</p><ol><li><p>deep</p></li></ol></li></ul></li></ul>',
+    text: ['outer', 'inner', 'deep'],
+  },
+  {
+    key: 'ordered-list-with-start',
+    html: '<ol start="7"><li><p>seven</p></li><li><p>eight</p></li></ol>',
+    text: ['seven', 'eight'],
+  },
+  {
+    key: 'task-list',
+    html:
+      '<ul data-type="taskList">' +
+      '<li data-type="taskItem" data-checked="true"><p>done</p></li>' +
+      '<li data-type="taskItem" data-checked="false"><p>pending</p></li>' +
+      '</ul>',
+    text: ['done', 'pending'],
+  },
+  {
+    key: 'blockquote',
+    html: '<blockquote><p>quoted prose</p></blockquote>',
+    text: ['quoted prose'],
+  },
+  {
+    key: 'code-block-with-language',
+    html: '<pre><code class="language-typescript">const answer = 42;</code></pre>',
+    text: ['const answer = 42;'],
+  },
+  {
+    key: 'code-block-without-language',
+    html: '<pre><code>plain code</code></pre>',
+    text: ['plain code'],
+  },
+  {
+    key: 'horizontal-rule',
+    html: '<p>above</p><hr><p>below</p>',
+    text: ['above', 'below'],
+  },
+  {
+    key: 'table',
+    html:
+      '<table><tbody>' +
+      '<tr><th colspan="1" rowspan="1"><p>Name</p></th><th colspan="1" rowspan="1"><p>Role</p></th></tr>' +
+      '<tr><td colspan="1" rowspan="1"><p>Ada</p></td><td colspan="1" rowspan="1"><p>Engineer</p></td></tr>' +
+      '</tbody></table>',
+    text: ['Name', 'Role', 'Ada', 'Engineer'],
+  },
+  {
+    key: 'image-with-file-id',
+    html: '<img data-file-id="file_abc123" alt="a diagram" data-width="320">',
+    text: [],
+  },
+  {
+    key: 'block-id-and-change-attrs',
+    html:
+      '<p data-block-id="blk_1" data-change-id="chg_1" data-change-type="insertion">tracked</p>',
+    text: ['tracked'],
+  },
+  {
+    key: 'mention-page',
+    html:
+      '<p><a class="mention" contenteditable="false" href="/dashboard/drv_1/pg_1" ' +
+      'rel="noopener noreferrer nofollow" data-mention-type="page" data-page-id="pg_1" ' +
+      'data-drive-id="drv_1">@Design Notes</a></p>',
+    text: ['@Design Notes'],
+  },
+  {
+    key: 'mention-user',
+    html:
+      '<p><a class="mention" contenteditable="false" data-mention-type="user" ' +
+      'data-user-id="usr_1" data-drive-id="drv_1">@Ada</a></p>',
+    text: ['@Ada'],
+  },
+  {
+    key: 'mention-role',
+    html:
+      '<p><span class="mention" contenteditable="false" data-mention-type="role" ' +
+      'data-role-id="rol_1" data-drive-id="drv_1">@Editors</span></p>',
+    text: ['@Editors'],
+  },
+  {
+    key: 'mention-everyone',
+    html:
+      '<p><span class="mention" contenteditable="false" data-mention-type="everyone" ' +
+      'data-drive-id="drv_1">@everyone</span></p>',
+    text: ['@everyone'],
+  },
+  {
+    key: 'mention-ai-dialect',
+    // What `lib/ai/skills/bodies/writing-documents.ts` instructs models to
+    // write: no href, no label attribute, no `data-type`. The label falls back
+    // to the element's text.
+    html: '<p><a class="mention" data-mention-type="page" data-page-id="pg_2">@Roadmap</a></p>',
+    text: ['@Roadmap'],
+  },
+] as const;
+
+/** Every fixture concatenated — one document exercising the whole corpus. */
+export function corpusDocumentHtml(): string {
+  return CONSTRUCT_CORPUS.map((fixture) => fixture.html).join('');
+}

--- a/packages/editor/src/__tests__/support/cross-dom-browser-entry.ts
+++ b/packages/editor/src/__tests__/support/cross-dom-browser-entry.ts
@@ -1,0 +1,24 @@
+/**
+ * The browser half of `cross-dom-parse-equality.test.ts`. Bundled by that
+ * suite with esbuild and injected into a real Chromium page, where `document`
+ * is Chromium's own — the DOM the client editor actually parses against.
+ *
+ * It must run the SAME parse the production path runs (`html-to-ydoc.ts`'s
+ * `parseIn`): `DOMParser.fromSchema(collabSchema()).parse(container)` over an
+ * element whose `innerHTML` is the source. Any difference here would make the
+ * comparison meaningless in the reassuring direction.
+ */
+import { DOMParser as PmDOMParser } from 'prosemirror-model';
+import { collabSchema } from '../../collab-document.js';
+
+declare global {
+  interface Window {
+    __parseHtmlToPmJson?: (html: string) => unknown;
+  }
+}
+
+window.__parseHtmlToPmJson = (html: string): unknown => {
+  const container = document.createElement('div');
+  container.innerHTML = html;
+  return PmDOMParser.fromSchema(collabSchema()).parse(container).toJSON();
+};

--- a/packages/editor/src/apply-pm-doc-to-y-doc.ts
+++ b/packages/editor/src/apply-pm-doc-to-y-doc.ts
@@ -1,0 +1,56 @@
+import type { Node as PmNode } from 'prosemirror-model';
+import type * as Y from 'yjs';
+import { updateYFragment } from 'y-prosemirror';
+import { collabFragment } from './collab-document.js';
+
+/**
+ * Replaces a live `Y.Doc`'s content with `nextDoc` as a **minimal CRDT diff**.
+ *
+ * This is how every server-computed document reaches a live document: an AI
+ * edit, a version restore, a projection-driven repair. The obvious
+ * implementation — clear the fragment and insert the new document — is
+ * catastrophic here for two independent reasons, and the second is the one
+ * that loses data:
+ *
+ * 1. **Size.** A CRDT update is a log, not a snapshot. Delete-all-and-reinsert
+ *    emits an update proportional to the *document*, so a one-word AI
+ *    correction to a long page costs every connected client a full re-download
+ *    and grows the document's history by its own length, permanently.
+ * 2. **Concurrency.** Every character of the old document is tombstoned and
+ *    every character of the new one is a fresh insertion, so a collaborator's
+ *    concurrent edit in an untouched paragraph merges against nothing and
+ *    disappears. Not a conflict — a silent loss.
+ *
+ * `updateYFragment` is `y-prosemirror`'s own structural diff, the same one
+ * `ySyncPlugin` runs on every local transaction, so this path is exactly as
+ * well-tested as ordinary typing.
+ *
+ * The `meta` it takes is a fresh, empty pair of maps — deliberately, and this
+ * was corrected by mutation testing after the first version called
+ * `initProseMirrorDoc` to build a populated mapping first. That looked
+ * necessary (`updateYFragment` consults `meta.mapping` through
+ * `mappedIdentity`) and is not: on a mapping miss it falls back to
+ * `equalYTypePNode`, a deep structural comparison, so the diff is minimal
+ * either way — measured, 41 bytes with a populated mapping and 41 bytes
+ * without, on a 37 KB document. `initProseMirrorDoc` materialises the entire
+ * fragment as ProseMirror nodes to build that mapping, so keeping it would
+ * have cost an O(document) walk on every apply for no effect. `y-prosemirror`
+ * itself passes `{ mapping: new Map(), isOMark: new Map() }` for exactly this
+ * kind of one-shot conversion (`sync-plugin.js:564`), and `isOMark` is a
+ * lazily-populated memo, so empty is not merely tolerable but correct.
+ *
+ * What IS load-bearing is `updateYFragment` itself rather than
+ * delete-and-reinsert, and the tests that guard it assert an update *size* and
+ * Y-type *identity* — the only observable differences between a correct diff
+ * and a correct-looking one.
+ *
+ * `origin` is forwarded to `Y.Doc.transact` so a caller (the collab service)
+ * can recognise its own writes in an `update` handler and avoid echoing them
+ * back to the client that caused them.
+ */
+export function applyPmDocToYDoc(yDoc: Y.Doc, nextDoc: PmNode, origin?: unknown): void {
+  const fragment = collabFragment(yDoc);
+  yDoc.transact(() => {
+    updateYFragment(yDoc, fragment, nextDoc, { mapping: new Map(), isOMark: new Map() });
+  }, origin);
+}

--- a/packages/editor/src/collab-document.ts
+++ b/packages/editor/src/collab-document.ts
@@ -1,0 +1,70 @@
+import { getSchema } from '@tiptap/core';
+import type { Node as PmNode, Schema } from 'prosemirror-model';
+import * as Y from 'yjs';
+import {
+  prosemirrorToYXmlFragment,
+  yXmlFragmentToProseMirrorRootNode,
+} from 'y-prosemirror';
+import { collabExtensions } from './collab-schema.js';
+
+/**
+ * The `Y.Doc` field holding the document body.
+ *
+ * `'default'` is not arbitrary: it is `@tiptap/extension-collaboration`'s own
+ * default `field` (`dist/index.js:86`). The client editor and every headless
+ * consumer must name the same fragment or they read different documents out
+ * of the same `Y.Doc` and silently disagree — so the constant lives here, next
+ * to the schema it shares a compatibility surface with, rather than being
+ * retyped at each call site. Note that `y-prosemirror`'s own helpers default
+ * to `'prosemirror'` instead; nothing in this package relies on that default.
+ */
+export const COLLAB_FRAGMENT_FIELD = 'default';
+
+let cachedSchema: Schema | undefined;
+
+/**
+ * The frozen v1 ProseMirror schema, built once per process.
+ *
+ * `getSchema()` from `@tiptap/core@3.23.5` is DOM-free (verified at
+ * `core/dist/index.js:1745`) and therefore safe to call in a Node service —
+ * unlike `generateJSON`/`generateHTML`, which reach for a global `window`.
+ * Memoised because building it walks every extension's `addAttributes`/
+ * `addGlobalAttributes`, and the collab service converts on every flush.
+ *
+ * Memoisation is safe precisely because the schema is *frozen*: it has no
+ * inputs, so there is no configuration under which two callers should get
+ * different schemas.
+ */
+export function collabSchema(): Schema {
+  cachedSchema ??= getSchema(collabExtensions());
+  return cachedSchema;
+}
+
+/** The body fragment of `yDoc`, under the shared field name. */
+export function collabFragment(yDoc: Y.Doc): Y.XmlFragment {
+  return yDoc.getXmlFragment(COLLAB_FRAGMENT_FIELD);
+}
+
+/**
+ * The document currently in `yDoc`, as a ProseMirror node over the frozen
+ * schema. Every projection starts here — they differ only in how they render
+ * this node, never in how they read the CRDT, so a projection can never
+ * disagree with another about what the document contains.
+ */
+export function yDocToPmDoc(yDoc: Y.Doc): PmNode {
+  return yXmlFragmentToProseMirrorRootNode(collabFragment(yDoc), collabSchema());
+}
+
+/**
+ * A brand-new `Y.Doc` seeded with `doc`.
+ *
+ * SEEDING ONLY. This is `prosemirrorToYXmlFragment`, which replaces the
+ * fragment's contents wholesale; running it against a document that already
+ * has collaborators destroys their history and their concurrent edits. Once a
+ * document is live, the only way in is `applyPmDocToYDoc`.
+ */
+export function pmDocToYDoc(doc: PmNode): Y.Doc {
+  const yDoc = new Y.Doc();
+  prosemirrorToYXmlFragment(doc, collabFragment(yDoc));
+  return yDoc;
+}

--- a/packages/editor/src/dom-workspace.ts
+++ b/packages/editor/src/dom-workspace.ts
@@ -28,6 +28,15 @@ import { Window } from 'happy-dom';
  * *is*. `__tests__/cross-dom-parse-equality.test.ts` holds this shim against
  * a real browser DOM over the construct corpus for that reason.
  *
+ * TWO OLDER TWINS EXIST, both in `apps/web` and both predating this module:
+ * `src/lib/editor/document-content-format.ts` and
+ * `src/lib/editor/census/constructs.ts` each build the same happy-dom `Window`
+ * with the same five `disable*` settings. They are not collapsed into this one
+ * yet — `apps/web` already depends on `@pagespace/editor`, so the direction is
+ * legal and this is the right home — because the census is documented as
+ * temporary and deleting it is its own change. If you are fixing a happy-dom
+ * lifetime or settings bug here, fix it there too, or finish the consolidation.
+ *
  * Deliberately NOT installed as `globalThis.window`/`globalThis.document`.
  * `@tiptap/html`'s `generateJSON`/`generateHTML` reach for those globals;
  * this package drives `prosemirror-model`'s `DOMParser`/`DOMSerializer`

--- a/packages/editor/src/dom-workspace.ts
+++ b/packages/editor/src/dom-workspace.ts
@@ -1,0 +1,95 @@
+import { Window } from 'happy-dom';
+
+/**
+ * The DOM every HTML-touching conversion in this package parses into and
+ * serializes out of.
+ *
+ * **happy-dom, as a production `dependency`** — decided on the projections
+ * leaf (`ta44dhnzeda8unluhugtqp1n`), and the reasoning matters more than the
+ * choice:
+ *
+ * 1. It is the declared peer dependency of `@tiptap/html@3.23.5`, the
+ *    sanctioned TipTap v3 Node path. zeed-dom was the v2 path; jsdom is
+ *    neither.
+ * 2. jsdom 25 resolves in this repo today — but only *transitively, through
+ *    vitest*. That is exactly what makes it a trap rather than a convenience:
+ *    `apps/collab` is a production Node service, and a DOM that arrives via a
+ *    test tool's dependency chain disappears on a devDependency prune, a
+ *    vitest major, or a Docker production install. It would fail in the image,
+ *    not in CI.
+ *
+ * **The DOM implementation is part of the schema's contract, not an
+ * implementation detail.** Several `parseHTML` functions in the frozen schema
+ * read the *DOM*, not the source string — `TextStyleKit`'s `getStyleProperty`
+ * fallbacks, `MarkdownTightLists`' `!element.querySelector('p')`,
+ * `CodeBlockNode`'s `element.querySelector('code')`. DOM implementations
+ * canonicalise `style` declarations and attribute quoting differently, so two
+ * processes can agree on `SCHEMA_HASH` and still disagree on what a document
+ * *is*. `__tests__/cross-dom-parse-equality.test.ts` holds this shim against
+ * a real browser DOM over the construct corpus for that reason.
+ *
+ * Deliberately NOT installed as `globalThis.window`/`globalThis.document`.
+ * `@tiptap/html`'s `generateJSON`/`generateHTML` reach for those globals;
+ * this package drives `prosemirror-model`'s `DOMParser`/`DOMSerializer`
+ * directly with an explicit element instead, so importing this module in a
+ * Node service mutates nothing process-wide and two conversions can never
+ * race on a shared document.
+ */
+export interface DomWorkspace {
+  /** Parses stored markup into a detached element. */
+  parse(html: string): HTMLElement;
+  /** A fresh detached element to serialize a document into. */
+  empty(): HTMLElement;
+  /** The document `DOMSerializer` creates its nodes from. */
+  document: Document;
+  /** Releases the underlying window's async tasks. Always call it. */
+  close(): void;
+}
+
+/**
+ * happy-dom's `Window` is structurally the DOM's but is not `lib.dom`'s type,
+ * and the two universes do not meet. Casting at this one boundary — where the
+ * decision is recorded — beats spreading `as unknown as` through every caller.
+ */
+export function createDomWorkspace(): DomWorkspace {
+  const window = new Window({
+    settings: {
+      disableJavaScriptEvaluation: true,
+      disableJavaScriptFileLoading: true,
+      disableCSSFileLoading: true,
+      disableIframePageLoading: true,
+      disableComputedStyleRendering: true,
+    },
+  });
+
+  const empty = (): HTMLElement =>
+    window.document.createElement('div') as unknown as HTMLElement;
+
+  return {
+    empty,
+    parse(html: string): HTMLElement {
+      const container = empty();
+      container.innerHTML = html;
+      return container;
+    },
+    document: window.document as unknown as Document,
+    close(): void {
+      void window.happyDOM.close();
+    },
+  };
+}
+
+/**
+ * Runs `body` against a workspace and closes it afterwards, including on
+ * throw. Every conversion in this package that needs a DOM goes through here:
+ * a leaked happy-dom `Window` holds timers, and the collab service converts
+ * once per flush for the life of the process.
+ */
+export function withDomWorkspace<T>(body: (workspace: DomWorkspace) => T): T {
+  const workspace = createDomWorkspace();
+  try {
+    return body(workspace);
+  } finally {
+    workspace.close();
+  }
+}

--- a/packages/editor/src/html-to-ydoc.ts
+++ b/packages/editor/src/html-to-ydoc.ts
@@ -1,0 +1,172 @@
+import { DOMParser as PmDOMParser, type Node as PmNode } from 'prosemirror-model';
+import type * as Y from 'yjs';
+import { collabSchema, pmDocToYDoc } from './collab-document.js';
+import { withDomWorkspace, type DomWorkspace } from './dom-workspace.js';
+import { pmDocToText } from './y-doc-to-text.js';
+import { UnrepresentableContentError } from './projection-errors.js';
+
+/**
+ * Elements whose content is not text, mapped to the schema node that must
+ * absorb them. `null` means the frozen v1 schema has no node for this element
+ * at all, so its presence is always a loss.
+ *
+ * A text-only comparison is blind to every one of these: an `<img>` with no
+ * `data-file-id` (which `ImageNode` deliberately refuses — there is no URL to
+ * `fileId` pipeline yet) carries no characters, so dropping it changes no
+ * text. Losing a picture is not a cosmetic difference.
+ *
+ * `<br>` is deliberately absent. ProseMirror legitimately discards a trailing
+ * `<br>` at the end of a block — browsers emit those as caret padding, not as
+ * content — so counting them reports a loss on markup that lost nothing.
+ */
+const TEXTLESS_CONTENT_ELEMENTS: Readonly<Record<string, string | null>> = {
+  img: 'image',
+  hr: 'horizontalRule',
+  iframe: null,
+  video: null,
+  audio: null,
+  embed: null,
+  object: null,
+  canvas: null,
+  svg: null,
+};
+
+/**
+ * Elements the parse is *supposed* to discard: they carry no document
+ * content, and their text is not prose. Removed from the source before the
+ * text comparison, or a `<style>` block's CSS reads as lost text.
+ */
+const NON_CONTENT_ELEMENTS = ['script', 'style', 'noscript', 'template'];
+
+/**
+ * Whitespace is stripped, not normalised, before comparing text.
+ *
+ * HTML collapses runs of whitespace and ProseMirror re-lays it out; a
+ * whitespace difference is exactly the class of cosmetic rewrite the seed
+ * invariant explicitly tolerates. What must not change is the sequence of
+ * visible characters.
+ */
+function visibleCharacters(text: string): string {
+  return text.replace(/\s+/gu, '');
+}
+
+function countNodesOfType(doc: PmNode, typeName: string): number {
+  let count = 0;
+  doc.descendants((node) => {
+    if (node.type.name === typeName) {
+      count += 1;
+    }
+    return true;
+  });
+  return count;
+}
+
+/**
+ * What parsing `html` against the frozen schema would lose — an empty array
+ * when nothing is lost.
+ *
+ * Exported so a bulk seed can survey a corpus and route the exceptions,
+ * rather than catching `UnrepresentableContentError` a page at a time. The
+ * reasons are counts and element names; the offending markup is never
+ * included, because this runs over production user content.
+ */
+export function describeHtmlLoss(html: string): string[] {
+  return withDomWorkspace((workspace) => parseAndDiagnose(html, workspace).reasons);
+}
+
+/**
+ * One parse, both answers. `htmlToPmDoc` needs the document *and* the verdict
+ * on it, and parsing twice to get them would double the cost of every seed —
+ * and, worse, leave open the possibility of the checked document and the
+ * returned one differing.
+ */
+function parseAndDiagnose(
+  html: string,
+  workspace: DomWorkspace,
+): { doc: PmNode; reasons: string[] } {
+  const source = workspace.parse(html);
+  for (const tag of NON_CONTENT_ELEMENTS) {
+    for (const element of Array.from(source.querySelectorAll(tag))) {
+      element.remove();
+    }
+  }
+
+  const doc = parseIn(source);
+  const reasons: string[] = [];
+
+  const sourceText = visibleCharacters(source.textContent ?? '');
+  const parsedText = visibleCharacters(pmDocToText(doc));
+  if (sourceText !== parsedText) {
+    // Counts only. Quoting the differing text would put user prose into an
+    // error message, a log line and a Sentry event.
+    reasons.push(
+      `visible text changed (${sourceText.length} characters in, ${parsedText.length} out)`,
+    );
+  }
+
+  for (const [tag, nodeName] of Object.entries(TEXTLESS_CONTENT_ELEMENTS)) {
+    const inSource = Array.from(source.querySelectorAll(tag)).length;
+    if (inSource === 0) {
+      continue;
+    }
+    const survived = nodeName === null ? 0 : countNodesOfType(doc, nodeName);
+    if (survived < inSource) {
+      reasons.push(`dropped ${inSource - survived} <${tag}> element(s)`);
+    }
+  }
+
+  return { doc, reasons };
+}
+
+/**
+ * `preserveWhitespace: 'full'` is deliberately NOT passed. The schema's own
+ * `codeBlock` carries `whitespace: 'pre'`, so ProseMirror already preserves
+ * whitespace exactly where it is significant; forcing it document-wide would
+ * turn every indentation newline in stored, pretty-printed HTML into document
+ * text.
+ *
+ * `DOMParser.parse` reads the element it is given and never reaches for a
+ * global `document`, which is what lets this run in a Node service with no DOM
+ * installed process-wide.
+ */
+function parseIn(source: HTMLElement): PmNode {
+  return PmDOMParser.fromSchema(collabSchema()).parse(source);
+}
+
+/**
+ * Stored `pages.content` HTML, parsed to a ProseMirror document over the
+ * frozen v1 schema. **Throws** rather than return a document that lost
+ * content — see `UnrepresentableContentError`.
+ *
+ * The invariant this upholds is `render(parse(h1)) == h1`, NOT
+ * `parse(h1) == h1` byte-for-byte. Measured over the construct corpus, one
+ * pass through the schema is a *fixpoint* that nonetheless rewrites its
+ * input: tables gain `<colgroup>`, `min-width` and explicit `colspan="1"`;
+ * a bare `<ul>` gains `class="tight" data-tight="true"`; bare `<li>` text
+ * gets wrapped in `<p>`; `style` declarations reorder and requote. None of
+ * that is loss, and a byte-equality test here would send its next reader off
+ * to "fix" normalisation that is not broken. The allowlist of those rewrites
+ * is explicit in `__tests__/seed-fidelity.test.ts` rather than expressed as a
+ * tolerance, so a real loss cannot be rounded away by a loose comparison.
+ */
+export function htmlToPmDoc(html: string): PmNode {
+  return withDomWorkspace((workspace) => {
+    const { doc, reasons } = parseAndDiagnose(html, workspace);
+    if (reasons.length > 0) {
+      throw new UnrepresentableContentError(reasons);
+    }
+    return doc;
+  });
+}
+
+/**
+ * Stored HTML seeded into a fresh `Y.Doc` — the inbound half of the
+ * conversion core, and the only supported way a document enters the CRDT.
+ *
+ * SEEDING ONLY: this builds a *new* `Y.Doc`. Applying a server-computed
+ * document to one that already has collaborators is `applyPmDocToYDoc`,
+ * which diffs; seeding replaces.
+ */
+export function htmlToYDoc(html: string): Y.Doc {
+  return pmDocToYDoc(htmlToPmDoc(html));
+}

--- a/packages/editor/src/page-mention-node.ts
+++ b/packages/editor/src/page-mention-node.ts
@@ -1,5 +1,6 @@
 import { Mention, type MentionOptions } from '@tiptap/extension-mention';
-import type { DOMOutputSpec } from '@tiptap/pm/model';
+import type { DOMOutputSpec, Node as PmNode } from '@tiptap/pm/model';
+import { nonEmptyStringAttr } from './pm-attrs.js';
 
 /**
  * The `pageMention` node's schema-affecting shape only: attributes and the
@@ -289,5 +290,24 @@ export const PageMentionNode = PageMentionExtension.configure({
   },
   renderHTML: pageMentionRenderHTML,
 });
+
+/**
+ * What a reader SEES for a mention: `@label`, or nothing when there is no
+ * label.
+ *
+ * Lives here, on the node that owns this attribute's contract, because the
+ * text and markdown projections must agree on it — `projections.test.ts`
+ * asserts they do — and two copies of the rule would let a change to mention
+ * rendering land in one projection only.
+ *
+ * A label-less mention contributes NOTHING rather than a bare `@`: the id is a
+ * CUID, and emitting it (or an empty sigil) would put identifiers into the
+ * search corpus, where a query of the right shape would match documents that
+ * merely link to a page.
+ */
+export function mentionLabelText(node: PmNode): string {
+  const label = nonEmptyStringAttr(node.attrs, 'label');
+  return label === null ? '' : `@${label}`;
+}
 
 export { getMentionAttrs };

--- a/packages/editor/src/pm-attrs.ts
+++ b/packages/editor/src/pm-attrs.ts
@@ -1,0 +1,32 @@
+import type { Attrs } from 'prosemirror-model';
+
+/**
+ * ProseMirror types `Attrs` as `{ readonly [attr: string]: any }`, so every
+ * attribute read in a projector needs narrowing before it can be interpolated
+ * into output. Without it, `no any` is satisfied by a cast that quietly lets a
+ * `null` default reach a template and render the literal word `null` into a
+ * document projection — `alt`, `fileId`, `href` and `language` all default to
+ * `null` in the frozen schema.
+ *
+ * These two functions are that narrowing, named once. They were five
+ * hand-written `typeof x === 'string' ? x : …` ternaries across three modules
+ * before, which is exactly the shape that drifts.
+ */
+
+/** The attribute as a string, or `''` when it is unset or not a string. */
+export function stringAttr(attrs: Attrs, name: string): string {
+  const value = attrs[name];
+  return typeof value === 'string' ? value : '';
+}
+
+/**
+ * The attribute as a NON-EMPTY string, or `null`.
+ *
+ * Distinct from `stringAttr` because for identity-bearing attributes the empty
+ * string is not a value: a `blockId` of `''` is unaddressable, and returning it
+ * as a string would let a caller treat "no id" as an id.
+ */
+export function nonEmptyStringAttr(attrs: Attrs, name: string): string | null {
+  const value = attrs[name];
+  return typeof value === 'string' && value.length > 0 ? value : null;
+}

--- a/packages/editor/src/projection-errors.ts
+++ b/packages/editor/src/projection-errors.ts
@@ -1,3 +1,5 @@
+import type { Node as PmNode } from 'prosemirror-model';
+
 /**
  * Thrown when a projector meets a node or mark the frozen schema does not
  * describe.
@@ -52,4 +54,48 @@ export class UnrepresentableContentError extends Error {
     this.name = 'UnrepresentableContentError';
     this.reasons = reasons;
   }
+}
+
+/**
+ * The fail-closed walk itself, shared by every projector that renders through
+ * a node/mark map rather than through an exhaustive `switch`.
+ *
+ * The mechanism is shared; the SETS deliberately are not. Each projection
+ * decides for itself what it can represent — the markdown serializer's node map
+ * legitimately differs from the schema (it has no `doc` entry, because
+ * `MarkdownSerializer.serialize` renders the root's children rather than the
+ * root) — and forcing one set on both would either add meaningless entries or
+ * turn a design decision into the wrong compile error. What must NOT differ is
+ * the walk: before this was one function, the HTML guard checked the root node
+ * and the markdown guard did not, silently applying two different rules to the
+ * same document. A future third guard also cannot now forget the marks half.
+ *
+ * Callers pass PRE-BUILT sets. Building them here would allocate two `Set`s per
+ * call, and `pmDocToBlocks` calls a projection once per block — measured at 400
+ * throwaway sets and ~40% of its total runtime for a 200-block document.
+ */
+export function assertProjectable(
+  doc: PmNode,
+  projection: string,
+  knownNodes: ReadonlySet<string>,
+  knownMarks: ReadonlySet<string>,
+): void {
+  const check = (node: PmNode): void => {
+    if (!knownNodes.has(node.type.name)) {
+      throw new UnknownNodeError(node.type.name, projection);
+    }
+    for (const mark of node.marks) {
+      if (!knownMarks.has(mark.type.name)) {
+        throw new UnknownNodeError(mark.type.name, projection);
+      }
+    }
+  };
+  // `descendants` does not visit the root, and the root is a node like any
+  // other — a document whose top node the projection cannot represent is not
+  // projectable.
+  check(doc);
+  doc.descendants((node) => {
+    check(node);
+    return true;
+  });
 }

--- a/packages/editor/src/projection-errors.ts
+++ b/packages/editor/src/projection-errors.ts
@@ -1,0 +1,55 @@
+/**
+ * Thrown when a projector meets a node or mark the frozen schema does not
+ * describe.
+ *
+ * **This package fails closed, and that is a deliberate cost.** The tempting
+ * alternative — skip what you don't recognise and project the rest — makes a
+ * projector *degrade silently*: search goes permanently stale for the affected
+ * documents, AI context quietly loses a table, export drops a construct, and
+ * nothing anywhere reports a problem. A projection is written on every flush,
+ * forever; a lossy one written once is a corrupt row that no later fix can
+ * distinguish from a document that legitimately lacked that content.
+ *
+ * A throw, by contrast, is loud, attributable to a document, and recoverable:
+ * `pages.content` still holds the previous projection.
+ */
+export class UnknownNodeError extends Error {
+  readonly nodeName: string;
+  readonly projection: string;
+
+  constructor(nodeName: string, projection: string) {
+    super(
+      `Cannot project node "${nodeName}" to ${projection}: not part of the frozen ` +
+        'COLLAB_SCHEMA_VERSION v1 schema. Refusing to write a lossy projection.',
+    );
+    this.name = 'UnknownNodeError';
+    this.nodeName = nodeName;
+    this.projection = projection;
+  }
+}
+
+/**
+ * Thrown by `htmlToPmDoc` when parsing stored HTML against the frozen schema
+ * would lose content — text that vanished, or a content-bearing element the
+ * schema has no node for (an `<img>` with no `data-file-id`, an `<iframe>`,
+ * raw-HTML passthrough).
+ *
+ * Same reasoning as `UnknownNodeError`, on the inbound half: seeding a `Y.Doc`
+ * from a lossy parse makes the loss permanent the moment the first
+ * collaborator connects, because the Y.Doc then *is* the document. Callers
+ * that need to survey before seeding should use `describeHtmlLoss` rather
+ * than catching this.
+ */
+export class UnrepresentableContentError extends Error {
+  /** Human-readable, content-free reasons — never the offending markup. */
+  readonly reasons: string[];
+
+  constructor(reasons: string[]) {
+    super(
+      `Parsing this HTML against the frozen schema would lose content: ${reasons.join('; ')}. ` +
+        'Refusing to seed a lossy document.',
+    );
+    this.name = 'UnrepresentableContentError';
+    this.reasons = reasons;
+  }
+}

--- a/packages/editor/src/y-doc-to-blocks.ts
+++ b/packages/editor/src/y-doc-to-blocks.ts
@@ -1,6 +1,7 @@
 import type { Node as PmNode } from 'prosemirror-model';
 import type * as Y from 'yjs';
 import { yDocToPmDoc } from './collab-document.js';
+import { nonEmptyStringAttr } from './pm-attrs.js';
 import { pmDocToMarkdown } from './y-doc-to-markdown.js';
 import { pmDocToText } from './y-doc-to-text.js';
 
@@ -56,9 +57,8 @@ export function yDocToBlocks(yDoc: Y.Doc): DocumentBlock[] {
 export function pmDocToBlocks(doc: PmNode): DocumentBlock[] {
   const blocks: DocumentBlock[] = [];
   doc.forEach((node, _offset, index) => {
-    const blockId = node.attrs.blockId;
     blocks.push({
-      blockId: typeof blockId === 'string' && blockId.length > 0 ? blockId : null,
+      blockId: nonEmptyStringAttr(node.attrs, 'blockId'),
       type: node.type.name,
       index,
       text: pmDocToText(node),

--- a/packages/editor/src/y-doc-to-blocks.ts
+++ b/packages/editor/src/y-doc-to-blocks.ts
@@ -1,0 +1,74 @@
+import type { Node as PmNode } from 'prosemirror-model';
+import type * as Y from 'yjs';
+import { yDocToPmDoc } from './collab-document.js';
+import { pmDocToMarkdown } from './y-doc-to-markdown.js';
+import { pmDocToText } from './y-doc-to-text.js';
+
+/**
+ * One addressable unit of a document.
+ *
+ * This projection is the replacement for line-number addressing. Today AI and
+ * MCP tools read `pages.content`, splice it by line number and write the whole
+ * string back — and line numbers over HTML are meaningless, which is exactly
+ * why `addLineBreaksForAI` exists to fabricate them by regex-injecting
+ * newlines into markup. Against a lagging projection a line splice does not
+ * produce a merge conflict; it lands in the wrong place and corrupts live
+ * text.
+ *
+ * A `blockId` is stable across edits elsewhere in the document (that is what
+ * the schema's `blockId` attribute is for), so `replace_block(blockId, …)`
+ * addresses the same block a human is looking at even after concurrent edits
+ * above it.
+ */
+export interface DocumentBlock {
+  /**
+   * The block's stable identity, or `null` for a block written before
+   * `blockId` stamping existed. A `null` id is not an error — most stored
+   * content predates v1 — but it IS unaddressable, so a caller that means to
+   * write must stamp ids first rather than fall back to the index.
+   */
+  blockId: string | null;
+  /** The schema node name: `paragraph`, `heading`, `table`, … */
+  type: string;
+  /**
+   * Position among the document's top-level blocks. Present for rendering and
+   * ordering only; it is invalidated by any concurrent insert above this
+   * block, which is the whole reason `blockId` exists.
+   */
+  index: number;
+  /** The block's prose, no markup — same rules as the text projection. */
+  text: string;
+  /** The block rendered on its own, same rules as the markdown projection. */
+  markdown: string;
+}
+
+/**
+ * The document as its top-level blocks. Nesting is deliberately not flattened:
+ * a list is one block, because "replace this list" is an operation a caller
+ * can express safely and "replace the third `listItem` of the second list" is
+ * not — the latter is a position, and positions do not survive concurrency.
+ */
+export function yDocToBlocks(yDoc: Y.Doc): DocumentBlock[] {
+  return pmDocToBlocks(yDocToPmDoc(yDoc));
+}
+
+/** `yDocToBlocks` over an already-materialised ProseMirror document. */
+export function pmDocToBlocks(doc: PmNode): DocumentBlock[] {
+  const blocks: DocumentBlock[] = [];
+  doc.forEach((node, _offset, index) => {
+    const blockId = node.attrs.blockId;
+    blocks.push({
+      blockId: typeof blockId === 'string' && blockId.length > 0 ? blockId : null,
+      type: node.type.name,
+      index,
+      text: pmDocToText(node),
+      // Wrapped in a fresh `doc` rather than serialized directly.
+      // `MarkdownSerializer.serialize` renders its argument's CHILDREN, so
+      // handing it a `heading` would emit the heading's inline text with no
+      // `#` and a `bulletList` with no bullets — the block's own markup is
+      // produced by the node serializer that the parent's render invokes.
+      markdown: pmDocToMarkdown(node.type.schema.node('doc', null, node)).trimEnd(),
+    });
+  });
+  return blocks;
+}

--- a/packages/editor/src/y-doc-to-blocks.ts
+++ b/packages/editor/src/y-doc-to-blocks.ts
@@ -67,7 +67,9 @@ export function pmDocToBlocks(doc: PmNode): DocumentBlock[] {
       // handing it a `heading` would emit the heading's inline text with no
       // `#` and a `bulletList` with no bullets — the block's own markup is
       // produced by the node serializer that the parent's render invokes.
-      markdown: pmDocToMarkdown(node.type.schema.node('doc', null, node)).trimEnd(),
+      // `topNodeType`, not the literal `'doc'`: the root's name is a schema
+      // property, and the markdown guard already resolves it that way.
+      markdown: pmDocToMarkdown(node.type.schema.topNodeType.create(null, node)).trimEnd(),
     });
   });
   return blocks;

--- a/packages/editor/src/y-doc-to-html.ts
+++ b/packages/editor/src/y-doc-to-html.ts
@@ -1,0 +1,66 @@
+import { DOMSerializer, type Node as PmNode } from 'prosemirror-model';
+import type * as Y from 'yjs';
+import { collabSchema, yDocToPmDoc } from './collab-document.js';
+import { withDomWorkspace } from './dom-workspace.js';
+import { UnknownNodeError } from './projection-errors.js';
+
+/**
+ * The HTML projection — what `pages.content` keeps holding, forever.
+ *
+ * This is the projection every existing consumer already reads: export,
+ * publish and canvas render, `syncMentions` (which parses mentions back out of
+ * this markup), drive backups, `scripts/tenant-export.ts`, and the
+ * human-readable recovery artifact if a `Y.Doc` is ever corrupted. It is the
+ * lossless one: the other three projections may drop formatting they cannot
+ * express, this one may not.
+ *
+ * Rendered through `DOMSerializer` against the frozen schema, into a detached
+ * happy-dom element — never through `@tiptap/html`'s `generateHTML`, which
+ * calls `document.implementation.createHTMLDocument()` on a *global*
+ * `document` this package refuses to install.
+ */
+export function yDocToHtml(yDoc: Y.Doc): string {
+  return pmDocToHtml(yDocToPmDoc(yDoc));
+}
+
+/** `yDocToHtml` over an already-materialised ProseMirror document. */
+export function pmDocToHtml(doc: PmNode): string {
+  assertProjectable(doc);
+  return withDomWorkspace((workspace) => {
+    const target = workspace.empty();
+    DOMSerializer.fromSchema(collabSchema()).serializeFragment(
+      doc.content,
+      { document: workspace.document },
+      target,
+    );
+    return target.innerHTML;
+  });
+}
+
+/**
+ * `DOMSerializer.fromSchema` builds its node map from the schema the *document*
+ * was created against, so a node from a foreign schema does not throw here —
+ * it serializes through whatever `toDOM` that schema gave it, or silently
+ * yields nothing. Either way the projection would be written and the loss
+ * would be invisible, which is precisely the failure mode this package exists
+ * to make impossible. Checking node names against the frozen schema up front
+ * turns it into a throw.
+ */
+function assertProjectable(doc: PmNode): void {
+  const schema = collabSchema();
+  const check = (node: PmNode): void => {
+    if (!Object.prototype.hasOwnProperty.call(schema.nodes, node.type.name)) {
+      throw new UnknownNodeError(node.type.name, 'html');
+    }
+  };
+  check(doc);
+  doc.descendants((node) => {
+    check(node);
+    for (const mark of node.marks) {
+      if (!Object.prototype.hasOwnProperty.call(schema.marks, mark.type.name)) {
+        throw new UnknownNodeError(mark.type.name, 'html');
+      }
+    }
+    return true;
+  });
+}

--- a/packages/editor/src/y-doc-to-html.ts
+++ b/packages/editor/src/y-doc-to-html.ts
@@ -2,7 +2,7 @@ import { DOMSerializer, type Node as PmNode } from 'prosemirror-model';
 import type * as Y from 'yjs';
 import { collabSchema, yDocToPmDoc } from './collab-document.js';
 import { withDomWorkspace } from './dom-workspace.js';
-import { UnknownNodeError } from './projection-errors.js';
+import { assertProjectable } from './projection-errors.js';
 
 /**
  * The HTML projection — what `pages.content` keeps holding, forever.
@@ -23,9 +23,33 @@ export function yDocToHtml(yDoc: Y.Doc): string {
   return pmDocToHtml(yDocToPmDoc(yDoc));
 }
 
+/**
+ * The frozen schema's own names — the HTML projection can represent exactly
+ * what the schema describes, no more and no less. Memoised for the same reason
+ * the schema is: this runs on every flush.
+ *
+ * The check is NOT redundant with `DOMSerializer`. `DOMSerializer.fromSchema`
+ * builds its node map from the schema the *document* was created against, so a
+ * node from a foreign schema serializes through whatever `toDOM` that schema
+ * gave it, or silently yields nothing — the projection gets written either way
+ * and the loss is invisible. Checking names against the FROZEN schema up front
+ * is what turns that into a throw.
+ */
+let cachedNames: { nodes: ReadonlySet<string>; marks: ReadonlySet<string> } | undefined;
+
+function projectableNames(): { nodes: ReadonlySet<string>; marks: ReadonlySet<string> } {
+  const schema = collabSchema();
+  cachedNames ??= {
+    nodes: new Set(Object.keys(schema.nodes)),
+    marks: new Set(Object.keys(schema.marks)),
+  };
+  return cachedNames;
+}
+
 /** `yDocToHtml` over an already-materialised ProseMirror document. */
 export function pmDocToHtml(doc: PmNode): string {
-  assertProjectable(doc);
+  const known = projectableNames();
+  assertProjectable(doc, 'html', known.nodes, known.marks);
   return withDomWorkspace((workspace) => {
     const target = workspace.empty();
     DOMSerializer.fromSchema(collabSchema()).serializeFragment(
@@ -34,33 +58,5 @@ export function pmDocToHtml(doc: PmNode): string {
       target,
     );
     return target.innerHTML;
-  });
-}
-
-/**
- * `DOMSerializer.fromSchema` builds its node map from the schema the *document*
- * was created against, so a node from a foreign schema does not throw here —
- * it serializes through whatever `toDOM` that schema gave it, or silently
- * yields nothing. Either way the projection would be written and the loss
- * would be invisible, which is precisely the failure mode this package exists
- * to make impossible. Checking node names against the frozen schema up front
- * turns it into a throw.
- */
-function assertProjectable(doc: PmNode): void {
-  const schema = collabSchema();
-  const check = (node: PmNode): void => {
-    if (!Object.prototype.hasOwnProperty.call(schema.nodes, node.type.name)) {
-      throw new UnknownNodeError(node.type.name, 'html');
-    }
-  };
-  check(doc);
-  doc.descendants((node) => {
-    check(node);
-    for (const mark of node.marks) {
-      if (!Object.prototype.hasOwnProperty.call(schema.marks, mark.type.name)) {
-        throw new UnknownNodeError(mark.type.name, 'html');
-      }
-    }
-    return true;
   });
 }

--- a/packages/editor/src/y-doc-to-markdown.ts
+++ b/packages/editor/src/y-doc-to-markdown.ts
@@ -1,0 +1,302 @@
+import {
+  MarkdownSerializer,
+  type MarkdownSerializerState,
+} from 'prosemirror-markdown';
+import type { Node as PmNode } from 'prosemirror-model';
+import type * as Y from 'yjs';
+import { yDocToPmDoc } from './collab-document.js';
+import { UnknownNodeError } from './projection-errors.js';
+
+/**
+ * The markdown projection — the AI-context format.
+ *
+ * Two things it is NOT:
+ *
+ * 1. **Not `tiptap-markdown`.** That package's serializer needs a live
+ *    `Editor` instance (`tiptap-markdown.es.js:744-796` reads
+ *    `this.editor.extensionManager` and `this.editor.schema`), which a
+ *    headless Node service does not have and must not be made to fake. This is
+ *    written on `prosemirror-markdown` directly, over the frozen schema's own
+ *    node and mark names.
+ * 2. **Not a round-trip format.** It is one-way, and deliberately so: it
+ *    exists because HTML costs materially more tokens per document than
+ *    markdown and models comprehend markdown better. `pages.content` (HTML)
+ *    remains the lossless projection; anything this one cannot express is
+ *    still there.
+ *
+ * What it cannot express, stated rather than hidden — each of these preserves
+ * the *text* and drops only an annotation:
+ *
+ * - `underline`, `highlight` and `textStyle` (font, size, colour) have no
+ *   markdown form and pass through transparently.
+ * - `comment`, `insertion` and `deletion` are inert v1 marks with no markdown
+ *   form; likewise transparent.
+ * - `pageMention` renders as its visible `@label`. The mention *graph* —
+ *   which page or user it points at — lives in the HTML projection, which is
+ *   what `syncMentions` reads. A consumer that rewrites a block through this
+ *   projection therefore cannot preserve mention identity, and the block tools
+ *   must carry ids out of band rather than expecting them here.
+ * - `colspan`/`rowspan` have no GFM equivalent; a merged cell's text survives,
+ *   its span does not.
+ *
+ * Everything else — headings 1-6, both list kinds with their `tight` flag,
+ * task lists with checked state, code blocks with their `language`, tables
+ * with column alignment, images with `alt` and `fileId`, links, bold, italic,
+ * strike and inline code — is represented.
+ */
+export function yDocToMarkdown(yDoc: Y.Doc): string {
+  return pmDocToMarkdown(yDocToPmDoc(yDoc));
+}
+
+/** `yDocToMarkdown` over an already-materialised ProseMirror document. */
+export function pmDocToMarkdown(doc: PmNode): string {
+  assertMarkdownProjectable(doc);
+  return markdownSerializer().serialize(doc, { tightLists: true });
+}
+
+/**
+ * `![alt](pagespace-file:<fileId>)`.
+ *
+ * The v1 `image` node holds a FILE REFERENCE and never a URL (see
+ * `image-node.ts` for why: a signed URL written into a CRDT is permanent,
+ * expiring and credential-bearing at once). There is no URL to put in the
+ * parentheses, so this emits the reference under an explicit non-resolvable
+ * scheme rather than fabricating one. `prosemirror-markdown`'s own default
+ * `image` serializer reads `node.attrs.src` and would throw here.
+ */
+function imageMarkdown(state: MarkdownSerializerState, node: PmNode): void {
+  const alt = typeof node.attrs.alt === 'string' ? node.attrs.alt : '';
+  const fileId = typeof node.attrs.fileId === 'string' ? node.attrs.fileId : '';
+  state.write(`![${state.esc(alt)}](pagespace-file:${fileId.replace(/[()]/gu, '\\$&')})`);
+}
+
+/**
+ * One GFM cell: its blocks flattened onto a single line, because a pipe table
+ * row cannot contain a newline. Pipes are escaped so a cell containing `|`
+ * cannot forge a column boundary — the one way a table's *structure* could be
+ * corrupted rather than merely simplified.
+ */
+function cellMarkdown(cell: PmNode): string {
+  return markdownSerializer()
+    .serialize(cell, { tightLists: true })
+    .replace(/\|/gu, '\\|')
+    .replace(/\s*\n\s*/gu, ' ')
+    .trim();
+}
+
+const ALIGNMENT_DELIMITERS: Readonly<Record<string, string>> = {
+  left: ':---',
+  center: ':---:',
+  right: '---:',
+};
+
+function alignmentDelimiter(cell: PmNode | undefined): string {
+  const align = cell?.attrs.align;
+  return (typeof align === 'string' && ALIGNMENT_DELIMITERS[align]) || '---';
+}
+
+function tableMarkdown(state: MarkdownSerializerState, node: PmNode): void {
+  const rows: PmNode[] = [];
+  node.forEach((row) => rows.push(row));
+
+  const cellsOf = (row: PmNode): PmNode[] => {
+    const cells: PmNode[] = [];
+    row.forEach((cell) => cells.push(cell));
+    return cells;
+  };
+
+  const columnCount = rows.reduce((max, row) => Math.max(max, row.childCount), 0);
+  const pad = (cells: string[]): string[] =>
+    Array.from({ length: columnCount }, (_unused, index) => cells[index] ?? '');
+
+  // GFM has no table without a header row. When the first row is not one (a
+  // table of plain cells is perfectly legal in the schema), an empty header is
+  // emitted rather than promoting a data row — promoting one would silently
+  // change what the table says.
+  const firstRow = rows[0];
+  const firstIsHeader =
+    firstRow !== undefined &&
+    firstRow.childCount > 0 &&
+    cellsOf(firstRow).every((cell) => cell.type.name === 'tableHeader');
+
+  const headerCells = firstIsHeader ? cellsOf(firstRow).map(cellMarkdown) : [];
+  const bodyRows = (firstIsHeader ? rows.slice(1) : rows).map((row) =>
+    cellsOf(row).map(cellMarkdown),
+  );
+  const alignmentSource = cellsOf(firstRow ?? node);
+
+  const lines = [
+    `| ${pad(headerCells).join(' | ')} |`,
+    `| ${pad([])
+      .map((_unused, index) => alignmentDelimiter(alignmentSource[index]))
+      .join(' | ')} |`,
+    ...bodyRows.map((cells) => `| ${pad(cells).join(' | ')} |`),
+  ];
+
+  state.write(lines.join('\n'));
+  state.closeBlock(node);
+}
+
+let cachedSerializer: MarkdownSerializer | undefined;
+
+/**
+ * Lazily built and memoised — `tableMarkdown` and `cellMarkdown` recurse back
+ * into the serializer to render a cell's own blocks, so it cannot be a plain
+ * module-level `const` without a temporal-dead-zone reference to itself.
+ */
+function markdownSerializer(): MarkdownSerializer {
+  cachedSerializer ??= new MarkdownSerializer(
+    {
+      paragraph(state, node) {
+        state.renderInline(node);
+        state.closeBlock(node);
+      },
+
+      heading(state, node) {
+        state.write(`${state.repeat('#', Number(node.attrs.level) || 1)} `);
+        state.renderInline(node, false);
+        state.closeBlock(node);
+      },
+
+      blockquote(state, node) {
+        state.wrapBlock('> ', null, node, () => state.renderContent(node));
+      },
+
+      codeBlock(state, node) {
+        // The fence must be longer than the longest backtick run inside the
+        // block, or the block terminates early and the rest of the document
+        // is swallowed into it.
+        const runs = node.textContent.match(/`{3,}/gmu);
+        const fence = runs ? `${runs.sort().slice(-1)[0]}\`` : '```';
+        const language = typeof node.attrs.language === 'string' ? node.attrs.language : '';
+        state.write(`${fence}${language}\n`);
+        state.text(node.textContent, false);
+        state.write('\n');
+        state.write(fence);
+        state.closeBlock(node);
+      },
+
+      horizontalRule(state, node) {
+        state.write('---');
+        state.closeBlock(node);
+      },
+
+      bulletList(state, node) {
+        state.renderList(node, '  ', () => '- ');
+      },
+
+      orderedList(state, node) {
+        const start = Number(node.attrs.start) || 1;
+        const width = String(start + node.childCount - 1).length;
+        state.renderList(node, state.repeat(' ', width + 2), (index) => {
+          const label = String(start + index);
+          return `${state.repeat(' ', width - label.length)}${label}. `;
+        });
+      },
+
+      listItem(state, node) {
+        state.renderContent(node);
+      },
+
+      taskList(state, node) {
+        state.renderList(node, '  ', (index) =>
+          node.child(index).attrs.checked === true ? '- [x] ' : '- [ ] ',
+        );
+      },
+
+      taskItem(state, node) {
+        state.renderContent(node);
+      },
+
+      table: tableMarkdown,
+
+      // A whole table is rendered by `table` above, which builds its pipe
+      // markup itself and never renders rows through the state — so these
+      // three are not on that path. They are still REQUIRED: they are what
+      // `assertMarkdownProjectable` checks a table's rows and cells against,
+      // and without them every document containing a table would be refused
+      // as unprojectable. They also make serializing a bare table fragment
+      // (a row, a cell) produce its content rather than throw.
+      tableRow(state, node) {
+        state.renderContent(node);
+      },
+      tableCell(state, node) {
+        state.renderContent(node);
+      },
+      tableHeader(state, node) {
+        state.renderContent(node);
+      },
+
+      image: imageMarkdown,
+
+      pageMention(state, node) {
+        const label = node.attrs.label;
+        if (typeof label === 'string' && label.length > 0) {
+          state.text(`@${label}`);
+        }
+      },
+
+      hardBreak(state, node, parent, index) {
+        // A run of trailing hard breaks at the end of a block is caret
+        // padding, not content — only emit one when real content follows.
+        for (let i = index + 1; i < parent.childCount; i += 1) {
+          if (parent.child(i).type !== node.type) {
+            state.write('\\\n');
+            return;
+          }
+        }
+      },
+
+      text(state, node) {
+        state.text(node.text ?? '');
+      },
+    },
+    {
+      bold: { open: '**', close: '**', mixable: true, expelEnclosingWhitespace: true },
+      italic: { open: '*', close: '*', mixable: true, expelEnclosingWhitespace: true },
+      strike: { open: '~~', close: '~~', mixable: true, expelEnclosingWhitespace: true },
+      code: { open: '`', close: '`', escape: false },
+      link: {
+        open: '[',
+        close(_state, mark) {
+          const href = typeof mark.attrs.href === 'string' ? mark.attrs.href : '';
+          return `](${href.replace(/[()"]/gu, '\\$&')})`;
+        },
+      },
+
+      // Transparent by design — see this module's docstring. `open`/`close`
+      // of '' preserves the marked text and drops only the annotation.
+      underline: { open: '', close: '', mixable: true },
+      highlight: { open: '', close: '', mixable: true },
+      textStyle: { open: '', close: '', mixable: true },
+      comment: { open: '', close: '', mixable: true },
+      insertion: { open: '', close: '', mixable: true },
+      deletion: { open: '', close: '', mixable: true },
+    },
+  );
+  return cachedSerializer;
+}
+
+/**
+ * `MarkdownSerializer` throws its own `RangeError` for an unregistered node,
+ * but the message ("Token type `x` not supported by Markdown renderer") reads
+ * as a renderer gap rather than as this package's fail-closed contract, and it
+ * carries no projection name. Rethrowing as `UnknownNodeError` keeps a single
+ * error type across all four projections, which is what a caller catches on.
+ */
+function assertMarkdownProjectable(doc: PmNode): void {
+  const serializer = markdownSerializer();
+  const knownNodes = new Set(Object.keys(serializer.nodes));
+  const knownMarks = new Set(Object.keys(serializer.marks));
+  doc.descendants((node) => {
+    if (!knownNodes.has(node.type.name)) {
+      throw new UnknownNodeError(node.type.name, 'markdown');
+    }
+    for (const mark of node.marks) {
+      if (!knownMarks.has(mark.type.name)) {
+        throw new UnknownNodeError(mark.type.name, 'markdown');
+      }
+    }
+    return true;
+  });
+}

--- a/packages/editor/src/y-doc-to-markdown.ts
+++ b/packages/editor/src/y-doc-to-markdown.ts
@@ -4,8 +4,10 @@ import {
 } from 'prosemirror-markdown';
 import type { Node as PmNode } from 'prosemirror-model';
 import type * as Y from 'yjs';
-import { yDocToPmDoc } from './collab-document.js';
-import { UnknownNodeError } from './projection-errors.js';
+import { collabSchema, yDocToPmDoc } from './collab-document.js';
+import { mentionLabelText } from './page-mention-node.js';
+import { stringAttr } from './pm-attrs.js';
+import { assertProjectable } from './projection-errors.js';
 
 /**
  * The markdown projection — the AI-context format.
@@ -65,9 +67,10 @@ export function pmDocToMarkdown(doc: PmNode): string {
  * `image` serializer reads `node.attrs.src` and would throw here.
  */
 function imageMarkdown(state: MarkdownSerializerState, node: PmNode): void {
-  const alt = typeof node.attrs.alt === 'string' ? node.attrs.alt : '';
-  const fileId = typeof node.attrs.fileId === 'string' ? node.attrs.fileId : '';
-  state.write(`![${state.esc(alt)}](pagespace-file:${fileId.replace(/[()]/gu, '\\$&')})`);
+  const fileId = stringAttr(node.attrs, 'fileId');
+  state.write(
+    `![${state.esc(stringAttr(node.attrs, 'alt'))}](pagespace-file:${fileId.replace(/[()]/gu, '\\$&')})`,
+  );
 }
 
 /**
@@ -90,50 +93,47 @@ const ALIGNMENT_DELIMITERS: Readonly<Record<string, string>> = {
   right: '---:',
 };
 
+/** A node's children as an array — ProseMirror only offers `forEach`. */
+function childrenOf(node: PmNode): PmNode[] {
+  const children: PmNode[] = [];
+  node.forEach((child) => children.push(child));
+  return children;
+}
+
 function alignmentDelimiter(cell: PmNode | undefined): string {
-  const align = cell?.attrs.align;
-  return (typeof align === 'string' && ALIGNMENT_DELIMITERS[align]) || '---';
+  return ALIGNMENT_DELIMITERS[cell === undefined ? '' : stringAttr(cell.attrs, 'align')] ?? '---';
 }
 
 function tableMarkdown(state: MarkdownSerializerState, node: PmNode): void {
-  const rows: PmNode[] = [];
-  node.forEach((row) => rows.push(row));
-
-  const cellsOf = (row: PmNode): PmNode[] => {
-    const cells: PmNode[] = [];
-    row.forEach((cell) => cells.push(cell));
-    return cells;
-  };
-
+  const rows = childrenOf(node);
   const columnCount = rows.reduce((max, row) => Math.max(max, row.childCount), 0);
-  const pad = (cells: string[]): string[] =>
-    Array.from({ length: columnCount }, (_unused, index) => cells[index] ?? '');
+
+  // Every row is padded to the widest row's width, so a short row cannot shift
+  // the columns after it — one rule, applied by one function, to all three
+  // kinds of line below.
+  const line = (cell: (index: number) => string): string =>
+    `| ${Array.from({ length: columnCount }, (_unused, index) => cell(index)).join(' | ')} |`;
 
   // GFM has no table without a header row. When the first row is not one (a
   // table of plain cells is perfectly legal in the schema), an empty header is
   // emitted rather than promoting a data row — promoting one would silently
   // change what the table says.
-  const firstRow = rows[0];
+  const firstCells = rows.length > 0 ? childrenOf(rows[0]) : [];
   const firstIsHeader =
-    firstRow !== undefined &&
-    firstRow.childCount > 0 &&
-    cellsOf(firstRow).every((cell) => cell.type.name === 'tableHeader');
+    firstCells.length > 0 && firstCells.every((cell) => cell.type.name === 'tableHeader');
 
-  const headerCells = firstIsHeader ? cellsOf(firstRow).map(cellMarkdown) : [];
+  const headerCells = firstIsHeader ? firstCells.map(cellMarkdown) : [];
   const bodyRows = (firstIsHeader ? rows.slice(1) : rows).map((row) =>
-    cellsOf(row).map(cellMarkdown),
+    childrenOf(row).map(cellMarkdown),
   );
-  const alignmentSource = cellsOf(firstRow ?? node);
 
-  const lines = [
-    `| ${pad(headerCells).join(' | ')} |`,
-    `| ${pad([])
-      .map((_unused, index) => alignmentDelimiter(alignmentSource[index]))
-      .join(' | ')} |`,
-    ...bodyRows.map((cells) => `| ${pad(cells).join(' | ')} |`),
-  ];
-
-  state.write(lines.join('\n'));
+  state.write(
+    [
+      line((index) => headerCells[index] ?? ''),
+      line((index) => alignmentDelimiter(firstCells[index])),
+      ...bodyRows.map((cells) => line((index) => cells[index] ?? '')),
+    ].join('\n'),
+  );
   state.closeBlock(node);
 }
 
@@ -168,8 +168,7 @@ function markdownSerializer(): MarkdownSerializer {
         // is swallowed into it.
         const runs = node.textContent.match(/`{3,}/gmu);
         const fence = runs ? `${runs.sort().slice(-1)[0]}\`` : '```';
-        const language = typeof node.attrs.language === 'string' ? node.attrs.language : '';
-        state.write(`${fence}${language}\n`);
+        state.write(`${fence}${stringAttr(node.attrs, 'language')}\n`);
         state.text(node.textContent, false);
         state.write('\n');
         state.write(fence);
@@ -230,9 +229,11 @@ function markdownSerializer(): MarkdownSerializer {
       image: imageMarkdown,
 
       pageMention(state, node) {
-        const label = node.attrs.label;
-        if (typeof label === 'string' && label.length > 0) {
-          state.text(`@${label}`);
+        // Shared with the text projection — `projections.test.ts` asserts the
+        // two agree, so the rule cannot live in both.
+        const label = mentionLabelText(node);
+        if (label.length > 0) {
+          state.text(label);
         }
       },
 
@@ -259,8 +260,7 @@ function markdownSerializer(): MarkdownSerializer {
       link: {
         open: '[',
         close(_state, mark) {
-          const href = typeof mark.attrs.href === 'string' ? mark.attrs.href : '';
-          return `](${href.replace(/[()"]/gu, '\\$&')})`;
+          return `](${stringAttr(mark.attrs, 'href').replace(/[()"]/gu, '\\$&')})`;
         },
       },
 
@@ -278,25 +278,36 @@ function markdownSerializer(): MarkdownSerializer {
 }
 
 /**
+ * The names the markdown projection can represent.
+ *
+ * Deliberately NOT the schema's set: the serializer's node map has no `doc`
+ * entry, because `MarkdownSerializer.serialize` renders the root's CHILDREN.
+ * The root is still a node the guard must accept, so the schema's top node is
+ * added back explicitly rather than the guard being taught to skip roots.
+ *
+ * Built once. `pmDocToBlocks` projects each block separately, so building these
+ * per call meant 400 throwaway `Set`s on a 200-block document — measured at
+ * ~40% of its runtime.
+ */
+let cachedNames: { nodes: ReadonlySet<string>; marks: ReadonlySet<string> } | undefined;
+
+function projectableNames(): { nodes: ReadonlySet<string>; marks: ReadonlySet<string> } {
+  const serializer = markdownSerializer();
+  cachedNames ??= {
+    nodes: new Set([...Object.keys(serializer.nodes), collabSchema().topNodeType.name]),
+    marks: new Set(Object.keys(serializer.marks)),
+  };
+  return cachedNames;
+}
+
+/**
  * `MarkdownSerializer` throws its own `RangeError` for an unregistered node,
  * but the message ("Token type `x` not supported by Markdown renderer") reads
  * as a renderer gap rather than as this package's fail-closed contract, and it
- * carries no projection name. Rethrowing as `UnknownNodeError` keeps a single
- * error type across all four projections, which is what a caller catches on.
+ * carries no projection name. Checking up front keeps a single error type
+ * across all four projections, which is what a caller catches on.
  */
 function assertMarkdownProjectable(doc: PmNode): void {
-  const serializer = markdownSerializer();
-  const knownNodes = new Set(Object.keys(serializer.nodes));
-  const knownMarks = new Set(Object.keys(serializer.marks));
-  doc.descendants((node) => {
-    if (!knownNodes.has(node.type.name)) {
-      throw new UnknownNodeError(node.type.name, 'markdown');
-    }
-    for (const mark of node.marks) {
-      if (!knownMarks.has(mark.type.name)) {
-        throw new UnknownNodeError(mark.type.name, 'markdown');
-      }
-    }
-    return true;
-  });
+  const known = projectableNames();
+  assertProjectable(doc, 'markdown', known.nodes, known.marks);
 }

--- a/packages/editor/src/y-doc-to-markdown.ts
+++ b/packages/editor/src/y-doc-to-markdown.ts
@@ -71,6 +71,10 @@ function imageMarkdown(state: MarkdownSerializerState, node: PmNode): void {
   state.write(
     `![${state.esc(stringAttr(node.attrs, 'alt'))}](pagespace-file:${fileId.replace(/[()]/gu, '\\$&')})`,
   );
+  // `image` is a BLOCK node in this schema, so the block must be closed or the
+  // next one runs straight into it — an image followed by a heading serialized
+  // as `![...](...)## Heading`, and the heading stopped being a heading.
+  state.closeBlock(node);
 }
 
 /**
@@ -110,6 +114,59 @@ const ALIGNMENT_DELIMITERS: ReadonlyMap<string, string> = new Map([
   ['center', ':---:'],
   ['right', '---:'],
 ]);
+
+/**
+ * Heading levels the schema declares (`STARTER_KIT_SCHEMA_OPTIONS.heading`).
+ *
+ * Clamped rather than trusted, for the same reason `align` is looked up through
+ * a `Map`: attributes on a live document are written by CLIENTS into the Y.Doc
+ * and `level` has no validator. `level: 9` emitted `######### H`, which GFM does
+ * not parse as a heading at all — the projection silently demotes a heading to
+ * paragraph text in the context the AI reads.
+ */
+function headingHashes(node: PmNode): string {
+  const level = Math.round(Number(node.attrs.level));
+  return '#'.repeat(Number.isFinite(level) ? Math.min(6, Math.max(1, level)) : 1);
+}
+
+/**
+ * A fence info string is only safe if it cannot terminate or reshape the fence.
+ *
+ * `language` has no validator either, and it is written verbatim after the
+ * opening backticks. A value of ``js```\n# not code`` produced
+ * ``` ```js```\n# not code ``` — the fence closed on its own first line and the
+ * rest of the attribute escaped INTO the document as a heading. That is content
+ * injection into the AI-context projection from a client-writable attribute, so
+ * an unsafe value is dropped rather than sanitised: the code block's own text is
+ * never at risk, and a missing language annotation costs nothing.
+ */
+const SAFE_LANGUAGE = /^[A-Za-z0-9_+#.-]{1,32}$/u;
+
+function fenceLanguage(node: PmNode): string {
+  const language = stringAttr(node.attrs, 'language');
+  return SAFE_LANGUAGE.test(language) ? language : '';
+}
+
+/**
+ * `prosemirror-markdown`'s own `backticksFor`, which this serializer's fixed
+ * single-backtick delimiters had replaced. Code text containing a backtick
+ * closed the span early — `` `a`b` `` for the text ``a`b`` — leaving an
+ * unmatched delimiter and mis-parsed code. The delimiter must be longer than
+ * the longest backtick run inside, with padding spaces when it starts or ends
+ * with one.
+ */
+function backticksFor(node: PmNode, side: number): string {
+  const ticks = /`+/gu;
+  let longest = 0;
+  if (node.isText && node.text !== undefined) {
+    for (let match = ticks.exec(node.text); match !== null; match = ticks.exec(node.text)) {
+      longest = Math.max(longest, match[0].length);
+    }
+  }
+  let result = longest > 0 && side > 0 ? ' `' : '`';
+  result += '`'.repeat(longest);
+  return longest > 0 && side < 0 ? `${result} ` : result;
+}
 
 /** A node's children as an array — ProseMirror only offers `forEach`. */
 function childrenOf(node: PmNode): PmNode[] {
@@ -174,7 +231,7 @@ function markdownSerializer(): MarkdownSerializer {
       },
 
       heading(state, node) {
-        state.write(`${state.repeat('#', Number(node.attrs.level) || 1)} `);
+        state.write(`${headingHashes(node)} `);
         state.renderInline(node, false);
         state.closeBlock(node);
       },
@@ -189,7 +246,7 @@ function markdownSerializer(): MarkdownSerializer {
         // is swallowed into it.
         const runs = node.textContent.match(/`{3,}/gmu);
         const fence = runs ? `${runs.sort().slice(-1)[0]}\`` : '```';
-        state.write(`${fence}${stringAttr(node.attrs, 'language')}\n`);
+        state.write(`${fence}${fenceLanguage(node)}\n`);
         state.text(node.textContent, false);
         state.write('\n');
         state.write(fence);
@@ -277,7 +334,15 @@ function markdownSerializer(): MarkdownSerializer {
       bold: { open: '**', close: '**', mixable: true, expelEnclosingWhitespace: true },
       italic: { open: '*', close: '*', mixable: true, expelEnclosingWhitespace: true },
       strike: { open: '~~', close: '~~', mixable: true, expelEnclosingWhitespace: true },
-      code: { open: '`', close: '`', escape: false },
+      code: {
+        open: (_state, _mark, parent, index) => backticksFor(parent.child(index), -1),
+        // `index - 1`, matching upstream: `close` is invoked with `index + 1`
+        // (`prosemirror-markdown/dist/index.js:775`), so `index` itself is
+        // one past the marked node and throws `RangeError` at the end of a
+        // paragraph.
+        close: (_state, _mark, parent, index) => backticksFor(parent.child(index - 1), 1),
+        escape: false,
+      },
       link: {
         open: '[',
         close(_state, mark) {

--- a/packages/editor/src/y-doc-to-markdown.ts
+++ b/packages/editor/src/y-doc-to-markdown.ts
@@ -87,11 +87,29 @@ function cellMarkdown(cell: PmNode): string {
     .trim();
 }
 
-const ALIGNMENT_DELIMITERS: Readonly<Record<string, string>> = {
-  left: ':---',
-  center: ':---:',
-  right: '---:',
-};
+/**
+ * A `Map`, NOT an object literal, and that is load-bearing rather than
+ * stylistic.
+ *
+ * `align` is read from a node attribute, and node attributes on a live document
+ * come from whatever a CLIENT wrote into the Y.Doc — the schema declares no
+ * validator for this one, so any string reaches here. Indexing an object
+ * literal with that string resolves through `Object.prototype`:
+ * `align="toString"` returned the function, and `?? '---'` never fired because
+ * a function is not nullish. The projection then emitted
+ * `| function toString() {` into the delimiter row — a function's source, with
+ * its own newlines, injected into the AI-context projection and destroying the
+ * table's structure.
+ *
+ * TipTap's own HTML parser whitelists `align`, so this is unreachable from
+ * stored `pages.content`. It is entirely reachable from the CRDT, which is the
+ * path this package exists to serve.
+ */
+const ALIGNMENT_DELIMITERS: ReadonlyMap<string, string> = new Map([
+  ['left', ':---'],
+  ['center', ':---:'],
+  ['right', '---:'],
+]);
 
 /** A node's children as an array — ProseMirror only offers `forEach`. */
 function childrenOf(node: PmNode): PmNode[] {
@@ -101,7 +119,10 @@ function childrenOf(node: PmNode): PmNode[] {
 }
 
 function alignmentDelimiter(cell: PmNode | undefined): string {
-  return ALIGNMENT_DELIMITERS[cell === undefined ? '' : stringAttr(cell.attrs, 'align')] ?? '---';
+  if (cell === undefined) {
+    return '---';
+  }
+  return ALIGNMENT_DELIMITERS.get(stringAttr(cell.attrs, 'align')) ?? '---';
 }
 
 function tableMarkdown(state: MarkdownSerializerState, node: PmNode): void {

--- a/packages/editor/src/y-doc-to-text.ts
+++ b/packages/editor/src/y-doc-to-text.ts
@@ -1,0 +1,124 @@
+import type { Node as PmNode } from 'prosemirror-model';
+import type * as Y from 'yjs';
+import { yDocToPmDoc } from './collab-document.js';
+import { UnknownNodeError } from './projection-errors.js';
+
+/**
+ * The plain-text projection: the document's prose, and nothing else.
+ *
+ * This projection exists to fix a live defect. `apps/web/src/app/api/search/
+ * route.ts` `ILIKE`s `pages.content`, which is raw HTML — so searching for
+ * `span`, `href`, `style` or `table` matches *markup*, and a document that
+ * merely contains a styled span is returned as a hit for "span". The output
+ * here contains no tag name, no attribute name and no attribute value, which
+ * is why the test for this asserts that a document full of `<span style>` and
+ * `<a href>` does not match a search for `span` or `href`.
+ *
+ * Marks are ignored entirely — a mark is formatting, and formatting is exactly
+ * what must not appear. Only nodes that carry *text* contribute; `image` and
+ * `horizontalRule` contribute nothing, deliberately: `alt` is an accessibility
+ * annotation rather than document prose, and putting it in the search corpus
+ * would let a decorative image's alt text answer a prose query.
+ *
+ * Blocks are separated by `\n` so a phrase can never be formed by two
+ * paragraphs abutting — the failure mode that makes `Element.textContent` the
+ * wrong tool here. Table cells are separated by tabs within their row.
+ */
+export function yDocToText(yDoc: Y.Doc): string {
+  return pmDocToText(yDocToPmDoc(yDoc));
+}
+
+/** `yDocToText` over an already-materialised ProseMirror document. */
+export function pmDocToText(doc: PmNode): string {
+  const lines: string[] = [];
+  collectLines(doc, lines);
+  return lines.filter((line) => line.length > 0).join('\n');
+}
+
+/**
+ * `@label`, matching what a reader sees. A mention with no label contributes
+ * nothing rather than a bare `@`: the id is a CUID, and putting CUIDs in the
+ * search corpus means a query of the right shape matches documents that
+ * merely link to a page.
+ */
+function mentionText(node: PmNode): string {
+  const label = node.attrs.label;
+  return typeof label === 'string' && label.length > 0 ? `@${label}` : '';
+}
+
+function inlineText(node: PmNode): string {
+  switch (node.type.name) {
+    case 'text':
+      return node.text ?? '';
+    case 'hardBreak':
+      return '\n';
+    case 'pageMention':
+      return mentionText(node);
+    default:
+      throw new UnknownNodeError(node.type.name, 'text');
+  }
+}
+
+function inlineChildren(node: PmNode): string {
+  let text = '';
+  node.forEach((child) => {
+    text += inlineText(child);
+  });
+  return text;
+}
+
+/** A table cell's blocks flattened onto one line, so a row stays a row. */
+function cellText(cell: PmNode): string {
+  const lines: string[] = [];
+  collectLines(cell, lines);
+  return lines.filter((line) => line.length > 0).join(' ');
+}
+
+function collectLines(node: PmNode, lines: string[]): void {
+  switch (node.type.name) {
+    case 'doc':
+    case 'blockquote':
+    case 'bulletList':
+    case 'orderedList':
+    case 'listItem':
+    case 'taskList':
+    case 'taskItem':
+    case 'tableCell':
+    case 'tableHeader':
+      node.forEach((child) => collectLines(child, lines));
+      return;
+
+    case 'paragraph':
+    case 'heading':
+      lines.push(inlineChildren(node));
+      return;
+
+    case 'codeBlock':
+      // `codeBlock`'s content is `text*` with `whitespace: 'pre'`, so its own
+      // newlines are real and must survive as line breaks rather than being
+      // flattened into one line.
+      lines.push(...inlineChildren(node).split('\n'));
+      return;
+
+    case 'table':
+      node.forEach((row) => collectLines(row, lines));
+      return;
+
+    case 'tableRow': {
+      const cells: string[] = [];
+      node.forEach((cell) => cells.push(cellText(cell)));
+      lines.push(cells.join('\t'));
+      return;
+    }
+
+    // Content-bearing but textless: they contribute a document position, not
+    // prose. Emitting a blank line for them would insert phantom block
+    // boundaries into the corpus.
+    case 'image':
+    case 'horizontalRule':
+      return;
+
+    default:
+      throw new UnknownNodeError(node.type.name, 'text');
+  }
+}

--- a/packages/editor/src/y-doc-to-text.ts
+++ b/packages/editor/src/y-doc-to-text.ts
@@ -1,6 +1,7 @@
 import type { Node as PmNode } from 'prosemirror-model';
 import type * as Y from 'yjs';
 import { yDocToPmDoc } from './collab-document.js';
+import { mentionLabelText } from './page-mention-node.js';
 import { UnknownNodeError } from './projection-errors.js';
 
 /**
@@ -23,6 +24,13 @@ import { UnknownNodeError } from './projection-errors.js';
  * Blocks are separated by `\n` so a phrase can never be formed by two
  * paragraphs abutting — the failure mode that makes `Element.textContent` the
  * wrong tool here. Table cells are separated by tabs within their row.
+ *
+ * NOT the same thing as `projectContent`
+ * (`packages/lib/src/content/anchoring/text-projection.ts`), which looks
+ * similar and is not interchangeable: that one collapses whitespace and trims
+ * because it defines an ANCHOR COORDINATE SYSTEM that tag offsets are stored
+ * against. This one keeps text verbatim, tab-joins table cells and throws on an
+ * unknown node. Do not wire anchors to this projection.
  */
 export function yDocToText(yDoc: Y.Doc): string {
   return pmDocToText(yDocToPmDoc(yDoc));
@@ -30,20 +38,18 @@ export function yDocToText(yDoc: Y.Doc): string {
 
 /** `yDocToText` over an already-materialised ProseMirror document. */
 export function pmDocToText(doc: PmNode): string {
-  const lines: string[] = [];
-  collectLines(doc, lines);
-  return lines.filter((line) => line.length > 0).join('\n');
+  return flatten(doc, '\n');
 }
 
 /**
- * `@label`, matching what a reader sees. A mention with no label contributes
- * nothing rather than a bare `@`: the id is a CUID, and putting CUIDs in the
- * search corpus means a query of the right shape matches documents that
- * merely link to a page.
+ * The projection's core join rule, in one place: collect the node's lines, drop
+ * the empty ones, join. Only the separator differs between a document (`\n`,
+ * block boundaries) and a table cell (`' '`, which cannot contain a newline).
  */
-function mentionText(node: PmNode): string {
-  const label = node.attrs.label;
-  return typeof label === 'string' && label.length > 0 ? `@${label}` : '';
+function flatten(node: PmNode, separator: string): string {
+  const lines: string[] = [];
+  collectLines(node, lines);
+  return lines.filter((line) => line.length > 0).join(separator);
 }
 
 function inlineText(node: PmNode): string {
@@ -53,7 +59,9 @@ function inlineText(node: PmNode): string {
     case 'hardBreak':
       return '\n';
     case 'pageMention':
-      return mentionText(node);
+      // Shared with the markdown projection, which must render mentions
+      // identically — see `mentionLabelText`.
+      return mentionLabelText(node);
     default:
       throw new UnknownNodeError(node.type.name, 'text');
   }
@@ -69,13 +77,14 @@ function inlineChildren(node: PmNode): string {
 
 /** A table cell's blocks flattened onto one line, so a row stays a row. */
 function cellText(cell: PmNode): string {
-  const lines: string[] = [];
-  collectLines(cell, lines);
-  return lines.filter((line) => line.length > 0).join(' ');
+  return flatten(cell, ' ');
 }
 
 function collectLines(node: PmNode, lines: string[]): void {
   switch (node.type.name) {
+    // Pure containers: recurse, contribute nothing of their own. `table` is
+    // here too — its rows are what carry structure, and `tableRow` below is
+    // where a row becomes a line.
     case 'doc':
     case 'blockquote':
     case 'bulletList':
@@ -83,6 +92,7 @@ function collectLines(node: PmNode, lines: string[]): void {
     case 'listItem':
     case 'taskList':
     case 'taskItem':
+    case 'table':
     case 'tableCell':
     case 'tableHeader':
       node.forEach((child) => collectLines(child, lines));
@@ -98,10 +108,6 @@ function collectLines(node: PmNode, lines: string[]): void {
       // newlines are real and must survive as line breaks rather than being
       // flattened into one line.
       lines.push(...inlineChildren(node).split('\n'));
-      return;
-
-    case 'table':
-      node.forEach((row) => collectLines(row, lines));
       return;
 
     case 'tableRow': {

--- a/packages/editor/vitest.config.ts
+++ b/packages/editor/vitest.config.ts
@@ -14,11 +14,25 @@ export default defineConfig({
       reportsDirectory: './coverage',
       reportOnFailure: true,
       exclude: ['**/*.d.ts', '**/*.config.*', '**/dist/**', '**/node_modules/**'],
+      /**
+       * Floors, set to what the suite actually measures — raise them when
+       * coverage rises, never lower them to make a change fit.
+       *
+       * The conversion core (PR: htmlToYDoc, the four projections,
+       * applyPmDocToYDoc) moved lines 71 -> 92, functions 53 -> 96 and
+       * statements 71 -> 92. Branches moved 94 -> 92, and that is not a
+       * relaxation of what was already covered: the new modules carry a
+       * handful of type-narrowing fallbacks the frozen schema cannot actually
+       * reach (`node.text ?? ''` on a text node, `Number(attrs.level) || 1` on
+       * a heading), and covering them would mean asserting against documents
+       * the schema forbids. The alternative — deleting the narrowing — is not
+       * available under `no any`.
+       */
       thresholds: {
-        lines: 71,
-        branches: 94,
-        functions: 53,
-        statements: 71,
+        lines: 92,
+        branches: 92,
+        functions: 96,
+        statements: 92,
       },
     },
   },


### PR DESCRIPTION
Phase B's conversion core, in `packages/editor`: `htmlToYDoc`, `yDocToHtml`/`Markdown`/`Text`/`Blocks`, and `applyPmDocToYDoc`. All pure, all React-free, all importable from a Node service with no DOM installed process-wide — `apps/collab` has to be able to import this.

`SCHEMA_HASH` unchanged at `'ded0823d'`. Full write-up: `.pu-reports/pu-mp-conversion-core.md`.

## The three results worth reading first

**The cross-DOM parse-equality blocker is answered, positively.** Several `parseHTML` functions in the frozen schema read the *DOM*, not the source string, so two processes can agree on `SCHEMA_HASH` and still disagree about what a document *is* — for a document neither changed. happy-dom and a real Chromium now produce byte-identical ProseMirror JSON for every fixture in the construct corpus, including the three cases the leaf singled out as most likely to diverge: a single-quoted `font-family` inside `style`, list tightness inferred via `!element.querySelector('p')`, and a table written with no explicit `<tbody>`. The suite deliberately does **not** skip when the browser is missing, so CI gains one `playwright install chromium` step.

**Every construct reaches a one-pass fixpoint and loses nothing.** 23 fixtures. The bar is `render(parse(h1)) == h1` plus zero construct loss, not byte equality — one pass legitimately rewrites its input (`<colgroup>`, `ul@data-tight`, TaskItem's checkbox markup, Link's `target`/`rel`). Those rewrites are an explicit twenty-entry allowlist with a reason each, and the allowlist has its own guard asserting it contains nothing the corpus does not actually produce, so it cannot decay into a blanket tolerance that hides the next real change.

**Mutation testing found a real error in my own code.** My first `applyPmDocToYDoc` called `initProseMirrorDoc` to build a populated binding mapping, and the docstring asserted in bold that an empty one "would quietly defeat the whole thing." Wrong: the mutation replacing it with an empty mapping *survived every test*. Measured — a one-word change in a 37 KB document emits **41 bytes with a populated mapping and 41 bytes without**, because `updateYFragment` falls back to `equalYTypePNode`, a deep structural comparison, on a mapping miss. `initProseMirrorDoc` materialises the whole fragment to build a mapping that changes nothing: an O(document) walk on every apply, in the hot path of a service that applies on every AI edit. Removed; the comment now carries the measurement instead of the claim. What *is* load-bearing is `updateYFragment` vs delete-and-reinsert, and that mutation goes red.

## Fail closed

Every projector throws `UnknownNodeError` on a node or mark the frozen schema does not describe — including the HTML one, where it is **not** automatic: `DOMSerializer.fromSchema` builds its node map from the schema the *document* was created against, so a foreign node serializes through whatever `toDOM` it brought, or yields nothing. Either way the projection gets written and the loss is invisible. An explicit name check turns that into a throw.

Block and inline are separate code paths in the text projection; the first version only guarded the block one, and a mutation exposed it. Both are guarded now.

On the inbound half, `htmlToPmDoc` throws rather than seed a lossy document. Errors carry counts and element names only — never markup or prose, because this runs over production user content and lands in logs and Sentry, and a test asserts exactly that. `describeHtmlLoss` is exported so a bulk seed can survey a corpus in one pass instead of catching a page at a time.

## Decisions with costs, stated

- **The markdown projection is one-way.** `pageMention` renders as its visible `@label`; `underline`/`highlight`/`textStyle` and the three collab marks pass through transparently; `colspan`/`rowspan` have no GFM form. Each preserves the *text* and drops only an annotation, and the HTML projection stays lossless. **Consequence for Phase D:** a block tool that rewrites a block through markdown cannot preserve mention identity, so `replace_block` must carry ids out of band. Flagged in the module docstring, not buried.
- **Image markdown is `![alt](pagespace-file:<fileId>)`.** The v1 node holds a file reference, never a URL, so there is nothing to put in the parentheses; `prosemirror-markdown`'s default image serializer reads `attrs.src` and would throw. An explicit non-resolvable scheme beats fabricating a URL.
- **`yDocToBlocks` does not flatten nesting** — a list is one block. "Replace this list" is expressible safely; "replace the third `listItem` of the second list" is a position, and positions do not survive concurrency.
- **The text projection excludes image `alt`** — an accessibility annotation, not prose; in the search corpus it would let a decorative image answer a prose query.
- **`tiptap-markdown` is not imported here** — its serializer needs a live `Editor`. Written on `prosemirror-markdown` directly, over the frozen schema's 19 nodes and 11 marks. (The leaf says 16/7; that predates the v1 freeze.) GFM tables are hand-written: alignment from `align`, pipes escaped so a cell cannot forge a column, and an empty header row rather than promoting a data row, which would change what the table says.
- **happy-dom is a production `dependency`.** jsdom resolves today only transitively via vitest — it would vanish on a devDependency prune or a production install and fail in the image, not in CI. It is never installed as a global.
- **`y-prosemirror` pinned exactly** (`1.3.7`) in the same commit that introduces it, beside `yjs` at the root override's `13.6.32`. Single copies of `yjs`, `prosemirror-model` and `y-prosemirror` verified in the tree — two copies of yjs throw at runtime.
- **Coverage branch floor 94 → 92**, while lines 71 → 92, functions 53 → 96, statements 71 → 92. Not a relaxation of anything already covered: the new modules carry type-narrowing fallbacks the frozen schema cannot reach (`node.text ?? ''` on a text node), and deleting the narrowing is not available under `no any`. Reasoning is in `vitest.config.ts` beside the numbers.

## Verification

288 tests. **29 mutations, every one applied by content-verified edit** — the harness asserts the file changed on disk and restores it, so a no-op mutation reports INVALID rather than "survived". Three survived the first pass: one real defect (above), one coverage gap (the first-occurrence replace hit `inlineText`'s `default` instead of `collectLines`' — identical three lines; the twin-line trap again), and one invalid mutation (`<hr>` → `<hr/>` does not break idempotency). All three resolved; the full list of broken mechanisms is in the report.

These suites use vitest's `describe/it/expect`. No riteway-style `assert({given, should, actual, expected})` appears anywhere in the new tests, so the chai-truthy-global shadowing that shipped a production deadlock behind 22 green tests in this epic is not reachable here.

| gate | result |
|---|---|
| `bun run typecheck` (root) | green — 19/19, includes `web:build` |
| `bun run lint` (root) | green — 17/17 |
| `bun run knip:check` | green |
| `packages/editor` suite | green — 288 tests |
| `bun run test` (root) | **did not run** |

**On that last row, plainly:** `scripts/test-with-db.sh` needs the Docker test-Postgres container and the Docker daemon is not running in this worktree's environment. The shell reported exit 0 only because `| tail` swallowed the failure — the run was a **no-op, not a pass**, and no suite outside `packages/editor` executed locally. Nothing outside `packages/editor` and one CI workflow step is touched by this diff, and root typecheck (which builds every package including `web`) and root lint both ran clean, so CI is the gate for the remainder.

## Not in scope

The seed-fidelity gate over real production documents is its own leaf (`jklkkf8aaao6v7jpc0mk8qub`, still pending) — this PR builds the machinery and proves it over a synthetic corpus; `describeHtmlLoss` exists to make that run a survey rather than a crash. Markdown image ingestion remains the open Phase K gate. No `apps/collab`, no `applyPageMutation` wiring, no `page_docs` columns.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012VEG3YMwoWNtxoGqya4WKW


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added reliable conversion between editor content and collaborative documents.
  - Added HTML, plain-text, Markdown, and block-level document exports.
  - Added support for preserving mentions, lists, tables, images, formatting, and stable block identifiers.
  - Added safeguards that clearly report unsupported or potentially lossy content.

- **Bug Fixes**
  - Improved collaborative updates to preserve unchanged content and merge concurrent edits more reliably.
  - Improved table formatting, mention text, and cross-browser parsing consistency.

- **Tests**
  - Expanded coverage across real Chromium and alternate DOM environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->