### PR TITLE
feat(web): create a local environment and show its one-time enrollment code (M3 · UI)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,22 @@ All notable user-facing changes to PageSpace are documented here. Format follows
 
 ### Added
 
+- **Local Environments: create one from the app, get your enrollment code, and get a new one if
+  you lose it (opt-in)** — a local Environment (your own computer, reached through the bridge) is
+  now a choice in the ordinary "New environment" step rather than something only an API call could
+  make. On a deployment with `LOCAL_ENVS_ENABLED`, a drive owner or admin picks **This computer**,
+  names the machine, and is shown the one-time enrollment code beside the exact two commands to run
+  on it — `pagespace env enroll …` then `pagespace env connect …`, with this deployment's address
+  filled in — plus when the code expires and, in plain words, what enrolling agrees to: everything
+  runs as you, with no sandbox, and in `ask` mode one approval covers every later command of that
+  kind for that session. Closing that step used to be a dead end: the code was shown once and
+  could never be recovered, so the Environment had to be deleted and made again. Now the row reads
+  **Awaiting enrollment** and its menu offers **Show a new code**, which replaces the previous one;
+  the server refuses, for good, once a machine has enrolled, so a lost code can never let a second
+  machine take over an enrolled Environment. Local Environments show a laptop and the machine's
+  name in the sidebar and in the "where should it run?" list, so a computer is never mistaken for a
+  cloud sandbox. Creating a cloud Environment is unchanged. Still off by default.
+
 - **Android app: it can now ask for notification permission and register for push (not yet
   distributed)** — the server has been able to send an Android push since the FCM sender landed, but
   no Android build could receive one: the app declared no notification permission and the shared

--- a/apps/web/src/app/api/ai/page-agents/multi-drive/route.ts
+++ b/apps/web/src/app/api/ai/page-agents/multi-drive/route.ts
@@ -8,6 +8,7 @@ import { pages, drives } from '@pagespace/db/schema/core';
 import { users } from '@pagespace/db/schema/auth';
 import { driveMembers, driveRoles } from '@pagespace/db/schema/members';
 import { isCodeExecutionEnabled } from '@pagespace/lib/services/sandbox/can-run-code';
+import { isLocalEnvsEnabled } from '@pagespace/lib/services/drive-envs/local-envs-enabled';
 import { loggers } from '@pagespace/lib/logging/logger-config';
 import { auditRequest } from '@pagespace/lib/audit/audit-log';
 import { computeSandboxEligibilityByDrive, resolveEditableDriveIds } from './sandbox-eligibility-by-drive';
@@ -130,7 +131,10 @@ export async function GET(request: Request) {
       agents: AgentSummary[];
       /** Whether THIS REQUESTER can use the sandbox in this drive (payer tier + actor edit access + kill switch). */
       sandboxEligible: boolean;
+      /** The deployment's `LOCAL_ENVS_ENABLED` — how the create step learns whether to offer "This computer". */
+      localEnvsEnabled: boolean;
     }[] = [];
+    const localEnvsEnabled = isLocalEnvsEnabled();
     const allAccessibleAgents: AgentSummary[] = [];
 
     // Get agents from each accessible drive (filtered by MCP scope)
@@ -212,6 +216,7 @@ export async function GET(request: Request) {
           agentCount: accessibleAgentsInDrive.length,
           agents: accessibleAgentsInDrive,
           sandboxEligible: sandboxEligibleByDrive.get(drive.id) ?? false,
+          localEnvsEnabled,
         });
       }
     }

--- a/apps/web/src/app/api/drives/[driveId]/envs/[envId]/enrollment-code/route.ts
+++ b/apps/web/src/app/api/drives/[driveId]/envs/[envId]/enrollment-code/route.ts
@@ -1,0 +1,102 @@
+/**
+ * A fresh one-time enrollment code — `POST /api/drives/[driveId]/envs/[envId]/enrollment-code`.
+ *
+ * The create response carries a local env's code exactly once. Before this
+ * route existed, closing that dialog, losing the clipboard, or letting the ten
+ * minutes run out left the env PERMANENTLY unenrollable — a row that could only
+ * be deleted and made again (Local Environments epic, M3). Re-issue is the
+ * load-bearing fix: it replaces the code for an env whose machine has NOT yet
+ * enrolled, and refuses, typed, for one that has.
+ *
+ * Its own sub-route and a POST, like `rebuild`: this is an ACT on the env, not
+ * an edit to its attributes. Owner/admin, exactly the bar every other env write
+ * meets, and only on a deployment that opted into local envs.
+ *
+ * POST → 201 { enrollment: { enrollmentId, code, expiresAt } }
+ *
+ * Refusals a client will meet: `409 not_local` (a Sprite env has no code),
+ * `409 already_enrolled` (a machine already pinned its key — this is FINAL,
+ * because re-opening an enrolled env to a second key would be a takeover),
+ * `410 revoked`. The `already_enrolled` answer is decided by the store's
+ * compare-and-set, not by a read here.
+ */
+
+import { NextResponse } from 'next/server';
+import {
+  authenticateRequestWithOptions,
+  isAuthError,
+  checkMCPDriveScope,
+  isPrincipalDriveOwnerOrAdmin,
+} from '@/lib/auth';
+import { isLocalEnvsEnabled } from '@pagespace/lib/services/drive-envs/local-envs-enabled';
+import { auditRequest } from '@pagespace/lib/audit/audit-log';
+import { loggers } from '@pagespace/lib/logging/logger-config';
+import { reissueEnvEnrollmentCode, resolveEnvInDrive } from '@/lib/drive-envs/drive-envs-runtime';
+
+const AUTH_OPTIONS_WRITE = { allow: ['session', 'mcp'] as const, requireCSRF: true };
+
+export async function POST(request: Request, context: { params: Promise<{ driveId: string; envId: string }> }) {
+  try {
+    const { driveId, envId } = await context.params;
+    const auth = await authenticateRequestWithOptions(request, AUTH_OPTIONS_WRITE);
+    if (isAuthError(auth)) return auth.error;
+
+    const scopeError = checkMCPDriveScope(auth, driveId);
+    if (scopeError) return scopeError;
+
+    if (!(await isPrincipalDriveOwnerOrAdmin(auth, driveId))) {
+      auditRequest(request, {
+        eventType: 'authz.access.denied',
+        userId: auth.userId,
+        resourceType: 'drive',
+        resourceId: driveId,
+        details: { route: 'drive-envs', operation: 'reissue-enrollment-code', envId },
+      });
+      return NextResponse.json({ error: 'Only drive owners and admins can issue enrollment codes' }, { status: 403 });
+    }
+
+    // The same opt-in the create path enforces: with local envs off there is
+    // nothing to enrol and no code to mint.
+    if (!isLocalEnvsEnabled()) {
+      return NextResponse.json({ error: 'Local environments are not enabled on this deployment' }, { status: 501 });
+    }
+
+    const env = await resolveEnvInDrive(envId, driveId);
+    if (!env) return NextResponse.json({ error: 'Environment not found' }, { status: 404 });
+    if (env.substrate !== 'local') {
+      return NextResponse.json({ error: 'Only a local environment has an enrollment code', reason: 'not_local' }, { status: 409 });
+    }
+
+    const result = await reissueEnvEnrollmentCode({ envId });
+    if (!result.ok) {
+      if (result.reason === 'not_found') return NextResponse.json({ error: 'Environment not found' }, { status: 404 });
+      if (result.reason === 'revoked') {
+        return NextResponse.json({ error: 'This environment’s machine was revoked; delete the environment and create a new one', reason: result.reason }, { status: 410 });
+      }
+      return NextResponse.json({ error: 'A machine has already enrolled in this environment', reason: result.reason }, { status: 409 });
+    }
+
+    auditRequest(request, {
+      eventType: 'data.write',
+      userId: auth.userId,
+      resourceType: 'drive',
+      resourceId: driveId,
+      details: { route: 'drive-envs', operation: 'reissue-enrollment-code', envId, enrollmentId: result.enrollment.enrollmentId },
+    });
+
+    // The code rides the response ONCE — the server keeps only its hash.
+    return NextResponse.json(
+      {
+        enrollment: {
+          enrollmentId: result.enrollment.enrollmentId,
+          code: result.enrollment.code,
+          expiresAt: result.enrollment.expiresAt.toISOString(),
+        },
+      },
+      { status: 201 },
+    );
+  } catch (error) {
+    loggers.api.error('Failed to re-issue drive environment enrollment code', error instanceof Error ? error : new Error(String(error)));
+    return NextResponse.json({ error: 'Failed to issue an enrollment code' }, { status: 500 });
+  }
+}

--- a/apps/web/src/app/api/drives/[driveId]/envs/__tests__/routes.test.ts
+++ b/apps/web/src/app/api/drives/[driveId]/envs/__tests__/routes.test.ts
@@ -28,6 +28,7 @@ vi.mock('@/lib/drive-envs/drive-envs-runtime', () => ({
   deleteEnv: vi.fn(),
   revokeEnv: vi.fn(),
   rebuildEnv: vi.fn(),
+  reissueEnvEnrollmentCode: vi.fn(),
   resolveEnvInDrive: vi.fn(),
   toDriveEnvDTO: vi.fn((row: { id: string; driveId: string; name: string }) => ({
     id: row.id,
@@ -41,6 +42,7 @@ vi.mock('@/lib/drive-envs/drive-envs-runtime', () => ({
 import { GET as listEnvs, POST as createEnv } from '../route';
 import { GET as readEnv, PATCH as patchEnv, DELETE as deleteEnvRoute } from '../[envId]/route';
 import { POST as rebuildEnvRoute } from '../[envId]/rebuild/route';
+import { POST as reissueCodeRoute } from '../[envId]/enrollment-code/route';
 import { isPrincipalDriveMember, isPrincipalDriveOwnerOrAdmin, authenticateRequestWithOptions } from '@/lib/auth';
 import { isLocalEnvsEnabled } from '@pagespace/lib/services/drive-envs/local-envs-enabled';
 import {
@@ -48,6 +50,7 @@ import {
   deleteEnv,
   listEnvsInDrive,
   rebuildEnv,
+  reissueEnvEnrollmentCode,
   renameEnv,
   resolveEnvInDrive,
   revokeEnv,
@@ -382,5 +385,79 @@ describe('DELETE /envs/[envId] on a LOCAL env — revoke first (Codex C4), then 
     const response = await del();
     expect(response.status).toBe(409);
     expect(revokeEnv).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('POST /envs/[envId]/enrollment-code — a fresh one-time code for a machine that has not enrolled (M3)', () => {
+  const localRow = { ...envRow, name: 'mac', substrate: 'local' };
+  const codeReq = () => req(`http://localhost/api/drives/${DRIVE_ID}/envs/${ENV_ID}/enrollment-code`, { method: 'POST' });
+  const expiresAt = new Date('2026-09-07T10:10:00.000Z');
+
+  beforeEach(() => {
+    vi.mocked(isLocalEnvsEnabled).mockReturnValue(true);
+    vi.mocked(resolveEnvInDrive).mockResolvedValue(localRow as never);
+  });
+
+  it('given a plain member, should refuse — the same bar as every other env write', async () => {
+    vi.mocked(isPrincipalDriveOwnerOrAdmin).mockResolvedValue(false);
+    const response = await reissueCodeRoute(codeReq(), envParams);
+    expect(response.status).toBe(403);
+    expect(reissueEnvEnrollmentCode).not.toHaveBeenCalled();
+  });
+
+  it('given LOCAL_ENVS_ENABLED is off, should answer 501 and mint nothing', async () => {
+    vi.mocked(isLocalEnvsEnabled).mockReturnValue(false);
+    const response = await reissueCodeRoute(codeReq(), envParams);
+    expect(response.status).toBe(501);
+    expect(reissueEnvEnrollmentCode).not.toHaveBeenCalled();
+  });
+
+  it('given an env that is not in this drive, should answer 404 without minting', async () => {
+    vi.mocked(resolveEnvInDrive).mockResolvedValue(null);
+    const response = await reissueCodeRoute(codeReq(), envParams);
+    expect(response.status).toBe(404);
+    expect(reissueEnvEnrollmentCode).not.toHaveBeenCalled();
+  });
+
+  it('given a Sprite env, should answer 409 not_local — there is no code to re-issue', async () => {
+    vi.mocked(resolveEnvInDrive).mockResolvedValue({ ...envRow, substrate: 'sprite' } as never);
+    const response = await reissueCodeRoute(codeReq(), envParams);
+    expect(response.status).toBe(409);
+    expect((await response.json()).reason).toBe('not_local');
+    expect(reissueEnvEnrollmentCode).not.toHaveBeenCalled();
+  });
+
+  it('given an admin and a pending local env, should answer 201 with the new code ONCE (expiry as ISO) and audit the write', async () => {
+    vi.mocked(reissueEnvEnrollmentCode).mockResolvedValue({ ok: true, enrollment: { enrollmentId: 'enr_1', code: 'ABCDEFGHJKMNPQRSTVWX', expiresAt } });
+    const response = await reissueCodeRoute(codeReq(), envParams);
+    expect(response.status).toBe(201);
+    expect(reissueEnvEnrollmentCode).toHaveBeenCalledWith({ envId: ENV_ID });
+    expect(await response.json()).toEqual({ enrollment: { enrollmentId: 'enr_1', code: 'ABCDEFGHJKMNPQRSTVWX', expiresAt: expiresAt.toISOString() } });
+    expect(auditRequest).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ eventType: 'data.write', details: expect.objectContaining({ operation: 'reissue-enrollment-code', envId: ENV_ID }) }),
+    );
+  });
+
+  it('given a machine ALREADY enrolled, should answer 409 already_enrolled — final, never a new code', async () => {
+    vi.mocked(reissueEnvEnrollmentCode).mockResolvedValue({ ok: false, reason: 'already_enrolled' });
+    const response = await reissueCodeRoute(codeReq(), envParams);
+    expect(response.status).toBe(409);
+    const body = (await response.json()) as { reason: string; enrollment?: unknown };
+    expect(body.reason).toBe('already_enrolled');
+    expect(body.enrollment).toBeUndefined();
+  });
+
+  it('given a revoked enrollment, should answer 410 revoked', async () => {
+    vi.mocked(reissueEnvEnrollmentCode).mockResolvedValue({ ok: false, reason: 'revoked' });
+    const response = await reissueCodeRoute(codeReq(), envParams);
+    expect(response.status).toBe(410);
+    expect((await response.json()).reason).toBe('revoked');
+  });
+
+  it('given the sibling row is gone (owner erased), should answer 404', async () => {
+    vi.mocked(reissueEnvEnrollmentCode).mockResolvedValue({ ok: false, reason: 'not_found' });
+    const response = await reissueCodeRoute(codeReq(), envParams);
+    expect(response.status).toBe(404);
   });
 });

--- a/apps/web/src/app/api/drives/[driveId]/envs/route.ts
+++ b/apps/web/src/app/api/drives/[driveId]/envs/route.ts
@@ -156,7 +156,7 @@ export async function POST(request: Request, context: { params: Promise<{ driveI
     if (local && result.enrollment) {
       return NextResponse.json(
         {
-          env: toDriveEnvDTO(result.env, { label: local.label, status: 'disconnected' }),
+          env: toDriveEnvDTO(result.env, { label: local.label, status: 'disconnected', enrolled: false }),
           enrollment: { enrollmentId: result.enrollment.enrollmentId, code: result.enrollment.code, expiresAt: result.enrollment.expiresAt.toISOString() },
         },
         { status: 201 },

--- a/apps/web/src/components/agents/LocalEnvEnrollment.tsx
+++ b/apps/web/src/components/agents/LocalEnvEnrollment.tsx
@@ -1,0 +1,143 @@
+'use client';
+
+/**
+ * The one-time enrollment handoff for a LOCAL environment (Local Environments
+ * epic, [D-3]): the code, the exact commands to run on the machine, when the
+ * code stops working, and — in the words the founder approved for the CLI
+ * README — what the person is agreeing to.
+ *
+ * Shared by the two places a code is ever shown: the spawn palette right after
+ * a local create, and the sidebar row's "Show a new code" (a server re-issue
+ * for an env whose machine has not enrolled). The code is rendered from the
+ * response that carried it and from nothing else; there is no endpoint that
+ * returns an existing code, only one that replaces it.
+ */
+
+import { useState } from 'react';
+import { Check, Copy } from 'lucide-react';
+import { toast } from 'sonner';
+
+/** What a local create or a re-issue hands back ONCE (`localEnvEnrollmentIssueSchema`). */
+export interface LocalEnvEnrollmentIssue {
+  enrollmentId: string;
+  code: string;
+  /** ISO-8601. */
+  expiresAt: string;
+}
+
+/** The full boundary statement, as merged in #2555 — linked rather than pasted into a dialog. */
+const CLI_BOUNDARY_DOCS_URL = 'https://github.com/2witstudios/PageSpace/blob/master/packages/cli/README.md#what-you-are-agreeing-to';
+
+/**
+ * The two commands, in the order and with the flags `packages/cli/README.md`
+ * documents. `--host` is given explicitly on both: the daemon resolves its host
+ * per command (`--host`, else `PAGESPACE_API_URL`, else the default), and a
+ * self-hosted or preview deployment is not the default.
+ */
+function enrollmentCommands({ host, enrollmentId, code }: { host: string; enrollmentId: string; code: string }): string {
+  return `pagespace env enroll ${enrollmentId} ${code} --host ${host}\npagespace env connect ${enrollmentId} --host ${host}`;
+}
+
+/** Where this app is served from — the host the machine must dial. Never a hardcoded string. */
+function useAppOrigin(): string {
+  const [origin] = useState(() => (typeof window === 'undefined' ? '' : window.location.origin));
+  return origin;
+}
+
+function CopyButton({ text, label }: { text: string; label: string }) {
+  const [copied, setCopied] = useState(false);
+  return (
+    <button
+      type="button"
+      aria-label={label}
+      title={label}
+      className="inline-flex shrink-0 items-center gap-1 rounded-md border border-input px-2 py-1 text-xs hover:bg-accent"
+      onClick={async () => {
+        try {
+          await navigator.clipboard.writeText(text);
+          setCopied(true);
+          setTimeout(() => setCopied(false), 2000);
+        } catch {
+          toast.error('Could not copy', { description: 'Select the text and copy it by hand.' });
+        }
+      }}
+    >
+      {copied ? <Check className="size-3" aria-hidden="true" /> : <Copy className="size-3" aria-hidden="true" />}
+      {copied ? 'Copied' : label}
+    </button>
+  );
+}
+
+export function LocalEnvEnrollmentPanel({
+  envName,
+  machineLabel,
+  enrollment,
+}: {
+  envName: string;
+  machineLabel: string;
+  enrollment: LocalEnvEnrollmentIssue;
+}) {
+  const host = useAppOrigin();
+  const commands = enrollmentCommands({ host, enrollmentId: enrollment.enrollmentId, code: enrollment.code });
+  const expires = new Date(enrollment.expiresAt);
+  const minutesLeft = Math.max(0, Math.round((expires.getTime() - Date.now()) / 60_000));
+  const expiresLabel = expires.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' });
+
+  return (
+    <div className="space-y-4 text-sm" data-testid="enrollment-panel">
+      <p className="text-muted-foreground">
+        “{envName}” is a local environment: sessions in it run on {machineLabel}, not in a cloud sandbox. On that
+        computer, install the PageSpace CLI if you have not (<code className="text-xs">npm install -g @pagespace/cli</code>), then run:
+      </p>
+      {/* Said BEFORE the commands, because the first one succeeds anywhere: on
+          Windows `env enroll` would pin this environment to a machine that
+          `env connect` refuses (t08 gated the daemon to POSIX), and an enrolled
+          environment can never be issued another code. */}
+      <p className="text-xs text-muted-foreground">
+        <span className="font-medium text-foreground">macOS and Linux only.</span> The bridge daemon does not run on
+        Windows. Do not enrol from a Windows machine: enrolling would tie this environment to a computer that cannot
+        connect, and it could not then be moved to another one.
+      </p>
+
+      <div className="space-y-1.5">
+        <pre
+          data-testid="enrollment-commands"
+          className="overflow-x-auto rounded-md border border-input bg-muted/40 p-2 font-mono text-xs leading-relaxed"
+        >
+          {commands}
+        </pre>
+        <div className="flex justify-end">
+          <CopyButton text={commands} label="Copy commands" />
+        </div>
+      </div>
+
+      <div className="space-y-1.5">
+        <div className="text-xs font-medium text-muted-foreground">Enrollment code</div>
+        <div className="flex items-center gap-2">
+          <code
+            data-testid="enrollment-code"
+            className="flex-1 select-all rounded-md border border-input bg-muted/40 px-2 py-1.5 font-mono text-sm tracking-wider"
+          >
+            {enrollment.code}
+          </code>
+          <CopyButton text={enrollment.code} label="Copy code" />
+        </div>
+        <p className="text-xs text-muted-foreground">
+          It works once and expires at {expiresLabel} ({minutesLeft} {minutesLeft === 1 ? 'minute' : 'minutes'} from now). If you
+          lose it, choose <span className="font-medium">Show a new code</span> from the environment’s menu in the sidebar.
+        </p>
+      </div>
+
+      <p className="text-xs text-muted-foreground">
+        <span className="font-medium text-foreground">What you are agreeing to.</span> Everything runs as you, on your computer,
+        with no sandbox: anything your account can reach, an agent driving this environment can reach. In <code>ask</code> mode,
+        approving one command also covers every later command of that kind for the rest of that session, without showing it to
+        you.{' '}
+        <a href={CLI_BOUNDARY_DOCS_URL} target="_blank" rel="noreferrer" className="underline hover:text-foreground">
+          Read the full statement
+        </a>{' '}
+        before you enrol.
+      </p>
+    </div>
+  );
+}

--- a/apps/web/src/components/agents/useSpawnSession.tsx
+++ b/apps/web/src/components/agents/useSpawnSession.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { useCallback, useEffect, useId, useMemo, useRef, useState } from 'react';
-import { Bot, Boxes, Plus, SquareTerminal, Zap } from 'lucide-react';
+import { Bot, Boxes, Laptop, Plus, SquareTerminal, Zap } from 'lucide-react';
 import { toast } from 'sonner';
 import { useSWRConfig } from 'swr';
 
@@ -22,9 +22,29 @@ import { useDriveStore } from '@/hooks/useDrive';
 import { canManageDrive } from '@/hooks/usePermissions';
 import { useEditingSession } from '@/stores/useEditingSession';
 import type { DriveWithAgents } from '@/hooks/page-agents/usePageAgents';
-import { MAX_DRIVE_ENV_NAME_LENGTH, type DriveEnvDTO } from '@pagespace/lib/drive-envs/env-contract';
+import { MAX_DRIVE_ENV_LABEL_LENGTH, MAX_DRIVE_ENV_NAME_LENGTH, type DriveEnvDTO } from '@pagespace/lib/drive-envs/env-contract';
+import { LocalEnvEnrollmentPanel, type LocalEnvEnrollmentIssue } from './LocalEnvEnrollment';
 
 export type SpawnKind = 'agent' | 'shell' | 'assistant';
+
+/**
+ * What the create step asks for. A cloud sandbox is the default and the common
+ * case, and its request body is `{ name }` — byte-identical to before a
+ * substrate existed. A LOCAL environment ([D-3]: the user's own machine as a
+ * substrate of an ordinary environment) also names the machine.
+ */
+type NewEnvironmentInput = { name: string; substrate: 'sprite' } | { name: string; substrate: 'local'; label: string };
+
+/**
+ * A local create's handoff, held until the person has read it: the env it
+ * belongs to and the one-time code the API returned. Rendered from this and
+ * from nothing else — there is no endpoint that returns an existing code.
+ */
+interface PendingEnrollment {
+  envName: string;
+  machineLabel: string;
+  issue: LocalEnvEnrollmentIssue;
+}
 
 /** What the palette's first step picked — drives the naming step's placeholder and spawn() call. */
 export interface SpawnPick {
@@ -99,6 +119,18 @@ export function useSpawnSession(agentsByDrive: DriveWithAgents[], onSpawned?: ()
    * the flow goes straight on to naming with it selected.
    */
   const [newEnvFrom, setNewEnvFrom] = useState<'target' | 'env' | null>(null);
+  /**
+   * The enrollment code of a LOCAL environment just created, until dismissed.
+   *
+   * Set whenever a local create lands — NOT gated on `flowToken` like the rest
+   * of the continuation, and that is the point: the code exists on the wire
+   * exactly once, so a create that lands after the palette was closed must
+   * still put it in front of the person rather than drop it. (Losing it is
+   * recoverable now — the row offers "Show a new code" — but recoverable is
+   * not a reason to lose it.) While set, the palette is open on this step
+   * regardless of whether a spawn flow is still on screen behind it.
+   */
+  const [enrollment, setEnrollment] = useState<PendingEnrollment | null>(null);
   /**
    * WHICH OPENING OF THIS PALETTE A DEFERRED ANSWER BELONGS TO.
    *
@@ -265,6 +297,18 @@ export function useSpawnSession(agentsByDrive: DriveWithAgents[], onSpawned?: ()
     return canManageDrive(drive);
   }, [drives, spawnTarget]);
 
+  /**
+   * Whether the create step may offer "This computer" ([D-3]). The deployment
+   * flag (`LOCAL_ENVS_ENABLED`) is server-side and rides the drive entry the
+   * way `sandboxEligible` does; unlike that one it defaults FALSE while the
+   * entry has not resolved, because the option's absence is the safe state.
+   * Same permission bar as any create — a local env is still an env.
+   */
+  const canCreateLocalEnv = useMemo(
+    () => canCreateEnv && (agentsByDrive.find((entry) => entry.driveId === spawnTarget?.driveId)?.localEnvsEnabled ?? false),
+    [canCreateEnv, agentsByDrive, spawnTarget],
+  );
+
   const { mutate: globalMutate } = useSWRConfig();
 
   /**
@@ -277,12 +321,15 @@ export function useSpawnSession(agentsByDrive: DriveWithAgents[], onSpawned?: ()
    * this palette's own next step is reading a listing that contains it.
    */
   const createEnvironment = useCallback(
-    async (name: string): Promise<'retry' | 'failed' | { envId: string }> => {
+    async (input: NewEnvironmentInput): Promise<'retry' | 'failed' | { envId: string; local: boolean }> => {
       const driveId = spawnTarget?.driveId;
       if (!driveId) return 'failed';
-      let created: { env: DriveEnvDTO };
+      let created: { env: DriveEnvDTO; enrollment?: LocalEnvEnrollmentIssue };
       try {
-        created = await post<{ env: DriveEnvDTO }>(`/api/drives/${encodeURIComponent(driveId)}/envs`, { name });
+        // The cloud body is `{ name }` and nothing else — a user who never
+        // wants a local env must not be able to tell this shipped.
+        const body = input.substrate === 'local' ? { name: input.name, substrate: 'local', label: input.label } : { name: input.name };
+        created = await post<{ env: DriveEnvDTO; enrollment?: LocalEnvEnrollmentIssue }>(`/api/drives/${encodeURIComponent(driveId)}/envs`, body);
       } catch (error) {
         // `'retry'` is the one refusal retyping fixes; everything else has been
         // toasted and is `'failed'`.
@@ -318,16 +365,21 @@ export function useSpawnSession(agentsByDrive: DriveWithAgents[], onSpawned?: ()
         },
         { revalidate: true },
       );
-      return { envId: created.env.id };
+      // A LOCAL create carries the one-time code. Shown now, unconditionally —
+      // see `enrollment` for why this is not behind the flow token.
+      if (created.env.substrate === 'local' && created.enrollment) {
+        setEnrollment({ envName: created.env.name, machineLabel: created.env.label, issue: created.enrollment });
+      }
+      return { envId: created.env.id, local: created.env.substrate === 'local' };
     },
     [spawnTarget, globalMutate],
   );
 
   const handleCreateEnv = useCallback(
-    async (name: string) => {
+    async (input: NewEnvironmentInput) => {
       const from = newEnvFrom;
       const token = flowToken.current;
-      const result = await createEnvironment(name);
+      const result = await createEnvironment(input);
       // The flow that asked is gone — closed, or replaced by another opening.
       // Its answer must not be applied to whatever took its place.
       if (flowToken.current !== token) return;
@@ -339,11 +391,18 @@ export function useSpawnSession(agentsByDrive: DriveWithAgents[], onSpawned?: ()
         setNewEnvFrom(null);
         return;
       }
-      if (from === 'env') {
+      if (from === 'env' && !result.local) {
         // The environment the env step was asking about now exists, and it is
         // the answer: go on to naming with it selected rather than making the
         // user pick the thing they just created.
         setSpawnPick((current) => (current ? { ...current, envId: result.envId } : current));
+      } else if (result.local) {
+        // A LOCAL environment is not an answer yet: no machine has enrolled, so
+        // a session bound to it would be refused (`not_connected`). The code
+        // step is on screen on top of this flow; when it is dismissed, the env
+        // step re-asks with the new environment listed, and any row preset is
+        // dropped for the same reason as the target case below.
+        setSpawnTarget((current) => (current ? { ...current, envId: null } : current));
       } else {
         // From the TARGET step, where the OPENING may already carry an
         // environment: this flow can have been started by one environment's "+"
@@ -361,7 +420,7 @@ export function useSpawnSession(agentsByDrive: DriveWithAgents[], onSpawned?: ()
 
   const paletteElement = (
     <SpawnSessionPalette
-      open={spawnTarget !== null}
+      open={spawnTarget !== null || enrollment !== null}
       driveName={spawnTarget?.driveName ?? null}
       agents={paletteAgents}
       envs={paletteEnvs}
@@ -370,6 +429,9 @@ export function useSpawnSession(agentsByDrive: DriveWithAgents[], onSpawned?: ()
       onRetryEnvs={retryPaletteEnvs}
       canRunSandbox={canRunSandbox}
       canCreateEnv={canCreateEnv}
+      canCreateLocalEnv={canCreateLocalEnv}
+      enrollment={enrollment}
+      onDismissEnrollment={() => setEnrollment(null)}
       newEnvFrom={newEnvFrom}
       onStartNewEnv={setNewEnvFrom}
       onCancelNewEnv={() => setNewEnvFrom(null)}
@@ -382,6 +444,7 @@ export function useSpawnSession(agentsByDrive: DriveWithAgents[], onSpawned?: ()
         setSpawnTarget(null);
         setSpawnPick(null);
         setNewEnvFrom(null);
+        setEnrollment(null);
       }}
       onPickTarget={(pick) =>
         // The opening's environment, when it had one, is the answer the env
@@ -425,6 +488,9 @@ function SpawnSessionPalette({
   onRetryEnvs,
   canRunSandbox,
   canCreateEnv,
+  canCreateLocalEnv,
+  enrollment,
+  onDismissEnrollment,
   newEnvFrom,
   onStartNewEnv,
   onCancelNewEnv,
@@ -473,6 +539,11 @@ function SpawnSessionPalette({
   canRunSandbox: boolean;
   /** Whether to offer creating one at all — drive OWNER/ADMIN, on a live drive. */
   canCreateEnv: boolean;
+  /** Whether the create step may offer "This computer" — `canCreateEnv` AND the deployment flag. Off ⇒ no choice is rendered at all. */
+  canCreateLocalEnv: boolean;
+  /** A just-created LOCAL env's one-time code, shown until dismissed; pre-empts every other step. */
+  enrollment: PendingEnrollment | null;
+  onDismissEnrollment: () => void;
   /**
    * Which step asked to create an environment, or null when none did. Doubles
    * as the create step's on-screen flag and its return address.
@@ -480,7 +551,7 @@ function SpawnSessionPalette({
   newEnvFrom: 'target' | 'env' | null;
   onStartNewEnv: (from: 'target' | 'env') => void;
   onCancelNewEnv: () => void;
-  onCreateEnv: (name: string) => Promise<void>;
+  onCreateEnv: (input: NewEnvironmentInput) => Promise<void>;
   pick: SpawnPick | null;
   spawning: boolean;
   onOpenChange: (open: boolean) => void;
@@ -494,8 +565,13 @@ function SpawnSessionPalette({
   // be refused (a name already taken) and hold its text while the session name
   // below is still blank, and neither must ever prefill the other.
   const [envName, setEnvName] = useState('');
+  // The substrate choice and the machine label, reset with the step like the
+  // name. Cloud is the default every time; nothing remembers "local".
+  const [envSubstrate, setEnvSubstrate] = useState<'sprite' | 'local'>('sprite');
+  const [envLabel, setEnvLabel] = useState('');
   const [creatingEnv, setCreatingEnv] = useState(false);
   const createEnvInputId = useId();
+  const substrateGroupId = useId();
   /**
    * WHICH ATTEMPT AT CREATING ONE the pending request belongs to.
    *
@@ -520,6 +596,11 @@ function SpawnSessionPalette({
   useEditingSession(`spawn-new-env-${createEnvInputId}`, newEnvFrom !== null, 'form', {
     componentName: 'SpawnSessionPalette',
   });
+  // The code step too: it is not typed text, but it IS the one rendering of a
+  // credential, and a refresh tearing it down would be the same loss.
+  useEditingSession(`spawn-enrollment-${createEnvInputId}`, enrollment !== null, 'form', {
+    componentName: 'SpawnSessionPalette',
+  });
 
   // Blank by default every time a new naming step starts — a stale typed
   // value from resolving one spawn must never prefill the next.
@@ -535,6 +616,8 @@ function SpawnSessionPalette({
     createAttempt.current += 1;
     if (newEnvFrom === null) return;
     setEnvName('');
+    setEnvSubstrate('sprite');
+    setEnvLabel('');
     // `creatingEnv` too, and for a reason worth naming: a create still in
     // flight when the palette was closed never runs its `finally` against a
     // visible form, so without this the next create step would open with its
@@ -571,8 +654,14 @@ function SpawnSessionPalette({
   // `'new-env'` PRE-EMPTS all of them, because it is a question asked ON TOP of
   // whichever step asked it — the target step and the env step both open it,
   // and `newEnvFrom` is what each of them returns to.
-  const step: 'target' | 'pending' | 'error' | 'env' | 'name' | 'new-env' =
-    newEnvFrom !== null
+  //
+  // `'enrollment'` pre-empts even that: it is the one-time code of a local env
+  // that was just created, and it is shown wherever the flow is — or is not,
+  // since a create can land after the palette closed.
+  const step: 'target' | 'pending' | 'error' | 'env' | 'name' | 'new-env' | 'enrollment' =
+    enrollment !== null
+      ? 'enrollment'
+      : newEnvFrom !== null
       ? 'new-env'
       : pick === null
         ? 'target'
@@ -604,7 +693,9 @@ function SpawnSessionPalette({
       open={open}
       onOpenChange={onOpenChange}
       title={
-        step === 'new-env'
+        step === 'enrollment'
+          ? `Enrol ${enrollment?.machineLabel ?? 'your computer'}`
+          : step === 'new-env'
           ? 'New environment'
           : step === 'target'
             ? 'New session'
@@ -613,7 +704,9 @@ function SpawnSessionPalette({
               : 'Name your session'
       }
       description={
-        step === 'new-env'
+        step === 'enrollment'
+          ? 'Run these on the computer to connect it. The code is shown here once; a new one is a menu away if you lose it.'
+          : step === 'new-env'
           ? `A persistent machine ${driveName ? `${driveName}'s` : 'this drive’s'} sessions can run inside, sharing one filesystem that survives every session that ends. Name it for what it is for — “dev”, “staging”, “data-import”.`
         : step === 'name'
           ? chosenEnv
@@ -630,9 +723,22 @@ function SpawnSessionPalette({
                 : 'Choose an agent to start a session with'
       }
       showCloseButton={false}
-      className="max-w-[420px]"
+      className={step === 'enrollment' ? 'max-w-[560px]' : 'max-w-[420px]'}
     >
-      {step === 'new-env' ? (
+      {step === 'enrollment' && enrollment ? (
+        <div className="space-y-4 p-4">
+          <LocalEnvEnrollmentPanel envName={enrollment.envName} machineLabel={enrollment.machineLabel} enrollment={enrollment.issue} />
+          <div className="flex justify-end">
+            <button
+              type="button"
+              className="rounded-md border border-input px-3 py-1.5 text-sm hover:bg-accent"
+              onClick={onDismissEnrollment}
+            >
+              Done
+            </button>
+          </div>
+        </div>
+      ) : step === 'new-env' ? (
         /* The create form lives IN the palette rather than in a dialog over it:
            this is one continuous keyboard flow, and a second Radix layer would
            put two focus traps on screen at once. Cancel returns to whichever
@@ -642,10 +748,15 @@ function SpawnSessionPalette({
           onSubmit={(event) => {
             event.preventDefault();
             const trimmed = envName.trim();
+            const trimmedLabel = envLabel.trim();
             if (!trimmed || creatingEnv) return;
+            // Local only when it was OFFERED: a stale 'local' can never reach
+            // the request if the option is not on screen.
+            const local = canCreateLocalEnv && envSubstrate === 'local';
+            if (local && !trimmedLabel) return;
             const attempt = createAttempt.current;
             setCreatingEnv(true);
-            void onCreateEnv(trimmed).finally(() => {
+            void onCreateEnv(local ? { name: trimmed, substrate: 'local', label: trimmedLabel } : { name: trimmed, substrate: 'sprite' }).finally(() => {
               // Only the attempt still on screen may re-enable the form. An
               // older one landing must leave the current request's POST looking
               // exactly as in-flight as it is.
@@ -663,11 +774,61 @@ function SpawnSessionPalette({
             disabled={creatingEnv}
             className="flex h-10 w-full rounded-md border border-input bg-transparent px-3 py-2 text-sm outline-hidden placeholder:text-muted-foreground disabled:cursor-not-allowed disabled:opacity-50"
           />
+          {/* The substrate ([D-3]): a machine is a KIND of environment, chosen
+              here, not a second concept with its own flow. Rendered only when
+              the deployment offers it — with the flag off the form is exactly
+              the form it was. Native radios, so the choice is keyboard-native
+              inside the palette's focus trap. */}
+          {canCreateLocalEnv && (
+            <fieldset className="space-y-1.5" disabled={creatingEnv}>
+              <legend className="text-xs font-medium text-muted-foreground">Runs on</legend>
+              <label className="flex items-start gap-2 text-sm">
+                <input
+                  type="radio"
+                  name={substrateGroupId}
+                  aria-label="Cloud sandbox"
+                  className="mt-1"
+                  checked={envSubstrate === 'sprite'}
+                  onChange={() => setEnvSubstrate('sprite')}
+                />
+                <span>
+                  <span className="font-medium">Cloud sandbox</span>
+                  <span className="block text-xs text-muted-foreground">A machine PageSpace runs for this drive.</span>
+                </span>
+              </label>
+              <label className="flex items-start gap-2 text-sm">
+                <input
+                  type="radio"
+                  name={substrateGroupId}
+                  aria-label="This computer"
+                  className="mt-1"
+                  checked={envSubstrate === 'local'}
+                  onChange={() => setEnvSubstrate('local')}
+                />
+                <span>
+                  <span className="font-medium">This computer</span>
+                  <span className="block text-xs text-muted-foreground">
+                    Your own machine, enrolled with the PageSpace CLI. You will be shown a one-time code next.
+                  </span>
+                </span>
+              </label>
+              {envSubstrate === 'local' && (
+                <input
+                  aria-label="Machine label"
+                  value={envLabel}
+                  onChange={(event) => setEnvLabel(event.target.value)}
+                  maxLength={MAX_DRIVE_ENV_LABEL_LENGTH}
+                  placeholder="Machine label, e.g. my-laptop"
+                  className="flex h-10 w-full rounded-md border border-input bg-transparent px-3 py-2 text-sm outline-hidden placeholder:text-muted-foreground disabled:cursor-not-allowed disabled:opacity-50"
+                />
+              )}
+            </fieldset>
+          )}
           <div className="flex items-center gap-2">
             <button
               type="submit"
               className="rounded-md border border-input px-3 py-1.5 text-sm hover:bg-accent disabled:cursor-not-allowed disabled:opacity-50"
-              disabled={creatingEnv || envName.trim().length === 0}
+              disabled={creatingEnv || envName.trim().length === 0 || (canCreateLocalEnv && envSubstrate === 'local' && envLabel.trim().length === 0)}
             >
               {creatingEnv ? 'Creating…' : 'Create environment'}
             </button>
@@ -762,8 +923,16 @@ function SpawnSessionPalette({
                   disabled={spawning}
                   onSelect={() => onPickEnv(env.id)}
                 >
-                  <Boxes className="size-3.5 shrink-0 text-muted-foreground" aria-hidden="true" />
+                  {/* A LOCAL env is somebody's computer, and says so. */}
+                  {env.substrate === 'local' ? (
+                    <Laptop className="size-3.5 shrink-0 text-muted-foreground" aria-hidden="true" />
+                  ) : (
+                    <Boxes className="size-3.5 shrink-0 text-muted-foreground" aria-hidden="true" />
+                  )}
                   <span className="truncate">in {env.name}</span>
+                  {env.substrate === 'local' && (
+                    <span className="ml-auto shrink-0 truncate text-xs text-muted-foreground">on {env.label}</span>
+                  )}
                 </CommandItem>
               ))}
             </CommandGroup>

--- a/apps/web/src/components/ai/shared/__tests__/AISelector.test.tsx
+++ b/apps/web/src/components/ai/shared/__tests__/AISelector.test.tsx
@@ -22,6 +22,7 @@ describe('AISelector', () => {
       driveSlug: 'my-workspace',
       agentCount: 1,
       sandboxEligible: true,
+      localEnvsEnabled: false,
       agents: [
         {
           id: 'agent_456',

--- a/apps/web/src/components/layout/left-sidebar/AgentsSidebar.tsx
+++ b/apps/web/src/components/layout/left-sidebar/AgentsSidebar.tsx
@@ -8,6 +8,8 @@ import {
   ChevronRight,
   FileText,
   Folder,
+  KeyRound,
+  Laptop,
   Pencil,
   Plus,
   RefreshCw,
@@ -64,7 +66,8 @@ import { decideClosePane } from '@/components/agents/panes/close-pane';
 import { buildSessionGroups, ASSISTANT_GROUP_KEY } from './session-groups';
 import { partitionSessionsByEnv, type EnvGroup } from './env-groups';
 import { RowMenu, type RowMenuItem } from './RowMenu';
-import { DeleteDriveEnvDialog, DriveEnvNameDialog, RebuildDriveEnvDialog } from './DriveEnvDialogs';
+import { DeleteDriveEnvDialog, DriveEnvNameDialog, EnrollmentCodeDialog, RebuildDriveEnvDialog } from './DriveEnvDialogs';
+import type { LocalEnvEnrollmentIssue } from '@/components/agents/LocalEnvEnrollment';
 import { DriveEnvAppPane } from './DriveEnvAppPane';
 import { DevPreviewAffordance } from '@/components/dev-preview/DevPreviewAffordance';
 import { envDevPreviewPath } from '@/hooks/dev-preview/useDevPreviewStatus';
@@ -798,9 +801,14 @@ function DriveGroupRows({
  * the environment had, so `'none'` gets a dimmed dot and a name for the state
  * rather than nothing at all.
  */
-function EnvStatusDot({ status }: { status: DriveEnvStatus | null }) {
+function EnvStatusDot({ status, enrolled }: { status: DriveEnvStatus | null; enrolled: boolean | null }) {
   const { className, label } =
-    status === 'running'
+    // A LOCAL env whose machine has never enrolled is not "disconnected" the
+    // way a sleeping machine is: nothing has ever been there. The derived
+    // status cannot tell the two apart; the DTO's `enrolled` fact can.
+    enrolled === false
+      ? { className: 'bg-amber-500', label: 'Awaiting enrollment' }
+      : status === 'running'
       ? { className: 'bg-emerald-500', label: 'Environment running' }
       : status === 'stopped'
         ? { className: 'bg-amber-500', label: 'Environment stopped' }
@@ -812,7 +820,7 @@ function EnvStatusDot({ status }: { status: DriveEnvStatus | null }) {
             : status === 'connecting'
               ? { className: 'bg-amber-500', label: 'Machine connecting' }
               : status === 'disconnected'
-                ? { className: 'bg-muted-foreground/40', label: 'Machine disconnected' }
+                ? { className: 'bg-muted-foreground/40', label: 'Machine not connected' }
                 : { className: 'bg-muted-foreground/40', label: 'Environment status unknown' };
   // `role="img"` so the label is announced — aria-label on a bare span is not.
   return <span role="img" aria-label={label} className={cn('size-1.5 shrink-0 rounded-full', className)} />;
@@ -859,6 +867,7 @@ function DriveEnvRow({
   const [renaming, setRenaming] = useState(false);
   const [deleting, setDeleting] = useState(false);
   const [rebuilding, setRebuilding] = useState(false);
+  const [showingCode, setShowingCode] = useState(false);
 
   const isOrphan = group.envName === null;
   // A LOCAL env is the user's own machine reached through the bridge. Until
@@ -937,13 +946,38 @@ function DriveEnvRow({
     toast.success(`“${displayName}” was rebuilt`, { description: 'It came back blank.' });
   }, [envPath, onEnvsChanged, mutate, displayName]);
 
+  /**
+   * A fresh one-time enrollment code (M3). The server re-issues only while no
+   * machine has enrolled — its compare-and-set, not this row, is what refuses
+   * an enrolled env — so a refusal here is reported and the dialog closes.
+   */
+  const reissueCode = useCallback(async (): Promise<LocalEnvEnrollmentIssue | null> => {
+    try {
+      const { enrollment } = await post<{ enrollment: LocalEnvEnrollmentIssue }>(`${envPath}/enrollment-code`);
+      return enrollment;
+    } catch (error) {
+      toast.error('Could not issue a new code', {
+        description: error instanceof Error ? error.message : 'Please try again.',
+      });
+      // `already_enrolled` means this row is STALE — a machine enrolled and the
+      // listing has not caught up. Re-read it so the row heals itself.
+      if (error instanceof ApiRequestError && error.status === 409) onEnvsChanged();
+      return null;
+    }
+  }, [envPath, onEnvsChanged]);
+
+  // Only an AWAITING-ENROLLMENT local env offers a new code: once a machine
+  // has enrolled the server would refuse, and offering a refusal is noise.
+  const awaitingEnrollment = isLocal && group.enrolled === false;
+
   const menuItems: RowMenuItem[] = useMemo(
     () => [
+      ...(awaitingEnrollment ? [{ label: 'Show a new code', icon: KeyRound, onSelect: () => setShowingCode(true) }] : []),
       { label: 'Rename', icon: Pencil, onSelect: () => setRenaming(true) },
       ...(isLocal ? [] : [{ label: 'Rebuild to blank', icon: RefreshCw, onSelect: () => setRebuilding(true), destructive: true }]),
       { label: 'Delete environment', icon: Trash2, onSelect: () => setDeleting(true), destructive: true },
     ],
-    [isLocal],
+    [isLocal, awaitingEnrollment],
   );
 
   const rowInner = (
@@ -957,9 +991,21 @@ function DriveEnvRow({
         {expanded ? <ChevronDown className="size-3.5" /> : <ChevronRight className="size-3.5" />}
       </button>
       <span className="flex min-w-0 flex-1 items-center gap-1.5">
-        <Boxes className="size-3.5 shrink-0 text-muted-foreground" aria-hidden="true" />
-        <EnvStatusDot status={group.status} />
+        {/* A LOCAL env is somebody's computer, not a cloud sandbox, and the row
+            says so twice: the laptop instead of the boxes, and the machine's
+            own label after the environment's name. */}
+        {isLocal ? (
+          <Laptop role="img" aria-label="Local environment" className="size-3.5 shrink-0 text-muted-foreground" />
+        ) : (
+          <Boxes className="size-3.5 shrink-0 text-muted-foreground" aria-hidden="true" />
+        )}
+        <EnvStatusDot status={group.status} enrolled={group.enrolled} />
         <span className="truncate font-medium text-foreground">{displayName}</span>
+        {group.machineLabel !== null && (
+          <span className="truncate text-muted-foreground" title={`On ${group.machineLabel}`}>
+            {group.machineLabel}
+          </span>
+        )}
       </span>
       {/* Every other level of this tree offers one; the level that IS a place to
           come back to was the only one that did not. Not gated on `canManage`:
@@ -1023,6 +1069,15 @@ function DriveEnvRow({
         envName={displayName}
         onRebuild={rebuildEnv}
       />
+      {awaitingEnrollment && (
+        <EnrollmentCodeDialog
+          open={showingCode}
+          onOpenChange={setShowingCode}
+          envName={displayName}
+          machineLabel={group.machineLabel ?? displayName}
+          onIssue={reissueCode}
+        />
+      )}
 
       {expanded && (
         <div className="ml-4 space-y-0.5 border-l border-border pl-1.5">

--- a/apps/web/src/components/layout/left-sidebar/DriveEnvDialogs.tsx
+++ b/apps/web/src/components/layout/left-sidebar/DriveEnvDialogs.tsx
@@ -42,6 +42,7 @@ import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import { MAX_DRIVE_ENV_NAME_LENGTH } from '@pagespace/lib/drive-envs/env-contract';
 import { useEditingSession } from '@/stores/useEditingSession';
+import { LocalEnvEnrollmentPanel, type LocalEnvEnrollmentIssue } from '@/components/agents/LocalEnvEnrollment';
 
 /**
  * Rename — the only edit an environment has (it has exactly one editable
@@ -280,5 +281,83 @@ export function RebuildDriveEnvDialog({
         </AlertDialogFooter>
       </AlertDialogContent>
     </AlertDialog>
+  );
+}
+
+/**
+ * "Show a new code" — a fresh one-time enrollment code for a LOCAL environment
+ * whose machine has not enrolled (Local Environments epic, M3).
+ *
+ * The create step shows the code once; this is the recovery for a closed
+ * dialog, a lost clipboard or the ten-minute expiry. It ISSUES on open (the
+ * server replaces the code — there is no endpoint that returns an existing
+ * one) and renders the same handoff the create step did. A refusal — the
+ * machine enrolled meanwhile, the enrollment was revoked — is the caller's to
+ * toast; this dialog just closes without a code.
+ */
+export function EnrollmentCodeDialog({
+  open,
+  onOpenChange,
+  envName,
+  machineLabel,
+  onIssue,
+}: {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  envName: string;
+  machineLabel: string;
+  /** Ask the server for a new code. `null` means it refused (already reported); the dialog closes. */
+  onIssue: () => Promise<LocalEnvEnrollmentIssue | null>;
+}) {
+  const [issue, setIssue] = useState<LocalEnvEnrollmentIssue | null>(null);
+  const dialogId = useId();
+  const wasOpen = useRef(false);
+
+  // The dialog is the one rendering of a credential; a refresh landing under
+  // it must not tear it down, exactly as for typed text.
+  useEditingSession(`drive-env-enrollment-${dialogId}`, open, 'form', { componentName: 'EnrollmentCodeDialog' });
+
+  // Issue ONCE per opening, on the open transition — never on a re-render.
+  useEffect(() => {
+    if (open && !wasOpen.current) {
+      setIssue(null);
+      let cancelled = false;
+      void onIssue().then((result) => {
+        if (cancelled) return;
+        if (result === null) onOpenChange(false);
+        else setIssue(result);
+      });
+      wasOpen.current = open;
+      return () => {
+        cancelled = true;
+      };
+    }
+    wasOpen.current = open;
+    return undefined;
+  }, [open, onIssue, onOpenChange]);
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="sm:max-w-[560px]">
+        <DialogHeader>
+          <DialogTitle>Enrol {machineLabel}</DialogTitle>
+          <DialogDescription>
+            A new code replaces the previous one, which stops working now. Run these on the computer to connect it.
+          </DialogDescription>
+        </DialogHeader>
+        {issue ? (
+          <LocalEnvEnrollmentPanel envName={envName} machineLabel={machineLabel} enrollment={issue} />
+        ) : (
+          <p className="text-sm text-muted-foreground" role="status">
+            Issuing a new code…
+          </p>
+        )}
+        <DialogFooter>
+          <Button type="button" variant="outline" onClick={() => onOpenChange(false)}>
+            Done
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
   );
 }

--- a/apps/web/src/components/layout/left-sidebar/__tests__/AgentsSidebar.test.tsx
+++ b/apps/web/src/components/layout/left-sidebar/__tests__/AgentsSidebar.test.tsx
@@ -50,6 +50,8 @@ interface PageAgentsResult {
     driveName: string;
     agentCount: number;
     agents: { id: string; title: string | null; driveId: string }[];
+    /** The deployment's `LOCAL_ENVS_ENABLED`, ridden per drive the way `sandboxEligible` is. Absent = off. */
+    localEnvsEnabled?: boolean;
   }[];
   isLoading: boolean;
   isError: boolean;
@@ -126,6 +128,7 @@ import type { WorkspaceNodeTarget } from '@pagespace/lib/agent-workspaces/worksp
 import { useLayoutStore } from '@/stores/useLayoutStore';
 import { useDriveStore, type Drive } from '@/hooks/useDrive';
 import { useEditingStore } from '@/stores/useEditingStore';
+import { LOCAL_ENV_ENROLLMENT_POLL_MS } from '@/hooks/drive-envs/useDriveEnvs';
 
 const driveFixture = (id: string, name: string, overrides: Partial<Drive> = {}): Drive => ({
   id,
@@ -197,7 +200,10 @@ const SESSION: SessionFixture = {
 interface EnvFixture {
   id: string;
   name: string;
-  status: 'none' | 'running' | 'stopped';
+  status: 'none' | 'running' | 'stopped' | 'connecting' | 'connected' | 'disconnected';
+  substrate?: 'sprite' | 'local';
+  label?: string;
+  enrolled?: boolean;
 }
 
 /**
@@ -2543,6 +2549,299 @@ describe('AgentsSidebar', () => {
 
       expect(screen.getByText('inside staging')).toBeDefined();
       expect(screen.queryByTestId('sidebar-env-env-1')).toBeNull();
+    });
+  });
+
+  /**
+   * LOCAL ENVIRONMENTS (Local Environments epic, [D-3]): a machine is a
+   * SUBSTRATE of an environment, chosen in the ordinary create step — and that
+   * step is the one place the one-time enrollment code is shown. Losing the
+   * code is recoverable: an env whose machine has not enrolled offers "Show a
+   * new code" from its row, backed by a server re-issue.
+   */
+  describe('local environments', () => {
+    beforeEach(() => {
+      useDriveStore.setState({ drives: [driveFixture('drive-1', 'Alpha')] });
+    });
+    const CODE = 'ABCDEFGHJKMNPQRSTVWX';
+    const expiresAt = () => new Date(Date.now() + 10 * 60 * 1000).toISOString();
+    const localEnv = { id: 'env-mac', name: 'mac', driveId: 'drive-1', substrate: 'local' as const, status: 'disconnected' as const, label: 'jono-macstudio', enrolled: false };
+    const enableLocalEnvs = () =>
+      mockUsePageAgents.mockImplementation((driveId?: string, options?: { enabled?: boolean }) => {
+        const base = defaultPageAgents(driveId, options);
+        return { ...base, agentsByDrive: base.agentsByDrive.map((entry) => ({ ...entry, localEnvsEnabled: true })) };
+      });
+    const openCreateStep = async (user: ReturnType<typeof userEvent.setup>) => {
+      await user.click(await screen.findByLabelText('New session'));
+      await user.click(await screen.findByText('New environment'));
+      await screen.findByLabelText('Environment name');
+    };
+
+    test('with the deployment flag off (the default), the create step offers no substrate choice at all — absent, not present-and-refusing', async () => {
+      const user = userEvent.setup();
+      respondWithSessions([], []);
+      renderSidebar();
+      await openCreateStep(user);
+      expect(screen.queryByLabelText('This computer')).toBeNull();
+      expect(screen.queryByLabelText('Cloud sandbox')).toBeNull();
+      expect(screen.queryByLabelText('Machine label')).toBeNull();
+    });
+
+    test('with the flag on, leaving the default (cloud) selected posts the byte-identical body the cloud path always sent', async () => {
+      const user = userEvent.setup();
+      enableLocalEnvs();
+      respondWithSessions([], []);
+      mockPost.mockResolvedValue({ env: { id: 'env-new', name: 'dev', driveId: 'drive-1', substrate: 'sprite', status: 'none' } });
+      renderSidebar();
+      await openCreateStep(user);
+      expect((screen.getByLabelText('Cloud sandbox') as HTMLInputElement).checked).toBe(true);
+      expect(screen.queryByLabelText('Machine label')).toBeNull();
+      await user.type(screen.getByLabelText('Environment name'), 'dev');
+      await user.click(screen.getByRole('button', { name: 'Create environment' }));
+      await waitFor(() => expect(mockPost).toHaveBeenCalledWith('/api/drives/drive-1/envs', { name: 'dev' }));
+      // No code step for a cloud env: straight back to the target step.
+      expect(await screen.findByText('Researcher')).toBeDefined();
+      expect(screen.queryByText(/enrol/i)).toBeNull();
+    });
+
+    test('choosing "This computer" asks for a machine label and posts substrate local with it', async () => {
+      const user = userEvent.setup();
+      enableLocalEnvs();
+      respondWithSessions([], []);
+      mockPost.mockResolvedValue({ env: localEnv, enrollment: { enrollmentId: 'enr_1', code: CODE, expiresAt: expiresAt() } });
+      renderSidebar();
+      await openCreateStep(user);
+      await user.click(screen.getByLabelText('This computer'));
+      await user.type(screen.getByLabelText('Environment name'), 'mac');
+      await user.type(await screen.findByLabelText('Machine label'), 'jono-macstudio');
+      await user.click(screen.getByRole('button', { name: 'Create environment' }));
+      await waitFor(() =>
+        expect(mockPost).toHaveBeenCalledWith('/api/drives/drive-1/envs', { name: 'mac', substrate: 'local', label: 'jono-macstudio' }),
+      );
+    });
+
+    test('a local create shows the code ONCE with the exact commands for this origin, its expiry, and the boundary statement; Done returns to the flow and the code is gone', async () => {
+      const user = userEvent.setup();
+      enableLocalEnvs();
+      respondWithSessions([], []);
+      mockPost.mockResolvedValue({ env: localEnv, enrollment: { enrollmentId: 'enr_1', code: CODE, expiresAt: expiresAt() } });
+      renderSidebar();
+      await openCreateStep(user);
+      await user.click(screen.getByLabelText('This computer'));
+      await user.type(screen.getByLabelText('Environment name'), 'mac');
+      await user.type(await screen.findByLabelText('Machine label'), 'jono-macstudio');
+      await user.click(screen.getByRole('button', { name: 'Create environment' }));
+
+      // The code, exactly once on screen, in its own element.
+      const code = await screen.findByTestId('enrollment-code');
+      expect(code.textContent).toBe(CODE);
+      // The commands, with the real values and the origin the app is served from.
+      const commands = screen.getByTestId('enrollment-commands').textContent ?? '';
+      expect(commands).toContain(`pagespace env enroll enr_1 ${CODE} --host ${window.location.origin}`);
+      expect(commands).toContain(`pagespace env connect enr_1 --host ${window.location.origin}`);
+      expect(commands.indexOf('env enroll')).toBeLessThan(commands.indexOf('env connect'));
+      // The expiry, and what the person is agreeing to (the README's words, not softer ones).
+      expect(screen.getByText(/expires/i)).toBeDefined();
+      expect(screen.getByText(/runs as you/i)).toBeDefined();
+      expect(screen.getByText(/every later command of that kind/i)).toBeDefined();
+      // Never refetched: the only request that ever carried the code is the create.
+      expect(mockPost).toHaveBeenCalledTimes(1);
+
+      await user.click(screen.getByRole('button', { name: 'Done' }));
+      // Back on the target step (where the create was asked from), and the code is gone.
+      expect(await screen.findByText('Researcher')).toBeDefined();
+      expect(screen.queryByTestId('enrollment-code')).toBeNull();
+      expect(screen.queryByText(CODE)).toBeNull();
+    });
+
+    test('copying puts the code on the clipboard', async () => {
+      const user = userEvent.setup();
+      enableLocalEnvs();
+      respondWithSessions([], []);
+      mockPost.mockResolvedValue({ env: localEnv, enrollment: { enrollmentId: 'enr_1', code: CODE, expiresAt: expiresAt() } });
+      renderSidebar();
+      await openCreateStep(user);
+      await user.click(screen.getByLabelText('This computer'));
+      await user.type(screen.getByLabelText('Environment name'), 'mac');
+      await user.type(await screen.findByLabelText('Machine label'), 'jono-macstudio');
+      await user.click(screen.getByRole('button', { name: 'Create environment' }));
+      await user.click(await screen.findByRole('button', { name: 'Copy code' }));
+      expect(await navigator.clipboard.readText()).toBe(CODE);
+      await user.click(screen.getByRole('button', { name: 'Copy commands' }));
+      expect(await navigator.clipboard.readText()).toContain(`pagespace env enroll enr_1 ${CODE}`);
+    });
+
+    test('a local env created from the ENV step is not auto-selected (its machine has not enrolled): the env step re-asks, now listing it as a local machine', async () => {
+      const user = userEvent.setup();
+      enableLocalEnvs();
+      // The listing the server would return AFTER the create: the palette
+      // revalidates behind its optimistic write, so the mock must answer with
+      // the new env or the revalidation would (in the test only) erase it.
+      const listed: EnvFixture[] = [{ id: 'env-1', name: 'staging', status: 'running' }];
+      respondWithSessions([], listed);
+      mockPost.mockImplementationOnce(async () => {
+        listed.push({ id: 'env-mac', name: 'mac', status: 'disconnected', substrate: 'local', label: 'jono-macstudio', enrolled: false });
+        return { env: localEnv, enrollment: { enrollmentId: 'enr_1', code: CODE, expiresAt: expiresAt() } };
+      });
+      renderSidebar();
+      await screen.findByTestId('sidebar-env-env-1');
+      await user.click(screen.getByLabelText('New session'));
+      await user.click(await screen.findByText('Researcher'));
+      await user.click(await screen.findByText('New environment…'));
+      await user.click(await screen.findByLabelText('This computer'));
+      await user.type(screen.getByLabelText('Environment name'), 'mac');
+      await user.type(await screen.findByLabelText('Machine label'), 'jono-macstudio');
+      await user.click(screen.getByRole('button', { name: 'Create environment' }));
+      await user.click(await screen.findByRole('button', { name: 'Done' }));
+      // The env step again — NOT the name step with the new env preselected.
+      expect(await screen.findByText('New sandbox')).toBeDefined();
+      expect(screen.queryByPlaceholderText('Researcher')).toBeNull();
+      expect(screen.getByText('in mac')).toBeDefined();
+      expect(screen.getByText('on jono-macstudio')).toBeDefined();
+    });
+
+    test('a local create that lands after the palette was closed still shows the code — the credential is never silently dropped', async () => {
+      const user = userEvent.setup();
+      enableLocalEnvs();
+      respondWithSessions([], []);
+      let resolveCreate: ((value: unknown) => void) | undefined;
+      mockPost.mockImplementationOnce(() => new Promise((resolve) => { resolveCreate = resolve; }));
+      renderSidebar();
+      await openCreateStep(user);
+      await user.click(screen.getByLabelText('This computer'));
+      await user.type(screen.getByLabelText('Environment name'), 'mac');
+      await user.type(await screen.findByLabelText('Machine label'), 'jono-macstudio');
+      await user.click(screen.getByRole('button', { name: 'Create environment' }));
+      await user.keyboard('{Escape}');
+      expect(screen.queryByLabelText('Environment name')).toBeNull();
+
+      await act(async () => {
+        resolveCreate?.({ env: localEnv, enrollment: { enrollmentId: 'enr_1', code: CODE, expiresAt: expiresAt() } });
+      });
+      expect((await screen.findByTestId('enrollment-code')).textContent).toBe(CODE);
+      await user.click(screen.getByRole('button', { name: 'Done' }));
+      expect(screen.queryByTestId('enrollment-code')).toBeNull();
+    });
+
+    test('a local env row says it is a computer, names the machine, and reads as awaiting enrollment until a machine enrols', async () => {
+      respondWithSessions([], [{ id: 'env-mac', name: 'mac', status: 'disconnected', substrate: 'local', label: 'jono-macstudio', enrolled: false }]);
+      renderSidebar();
+      const row = await screen.findByTestId('sidebar-env-env-mac');
+      expect(within(row).getByText('mac')).toBeDefined();
+      expect(within(row).getByText('jono-macstudio')).toBeDefined();
+      expect(within(row).getByLabelText('Local environment')).toBeDefined();
+      expect(within(row).getByLabelText('Awaiting enrollment')).toBeDefined();
+    });
+
+    test('an enrolled local env whose machine is away reads as not connected — never as awaiting enrollment', async () => {
+      respondWithSessions([], [{ id: 'env-mac', name: 'mac', status: 'disconnected', substrate: 'local', label: 'jono-macstudio', enrolled: true }]);
+      renderSidebar();
+      const row = await screen.findByTestId('sidebar-env-env-mac');
+      expect(within(row).getByLabelText('Machine not connected')).toBeDefined();
+      expect(within(row).queryByLabelText('Awaiting enrollment')).toBeNull();
+    });
+
+    test('an admin gets "Show a new code" on an awaiting-enrollment row, which re-issues on the server and shows the fresh code once', async () => {
+      const user = userEvent.setup();
+      respondWithSessions([], [{ id: 'env-mac', name: 'mac', status: 'disconnected', substrate: 'local', label: 'jono-macstudio', enrolled: false }]);
+      mockPost.mockResolvedValue({ enrollment: { enrollmentId: 'enr_1', code: CODE, expiresAt: expiresAt() } });
+      renderSidebar();
+      const row = await screen.findByTestId('sidebar-env-env-mac');
+      await user.click(within(row).getByLabelText('Environment actions'));
+      await user.click(await screen.findByText('Show a new code'));
+      await waitFor(() => expect(mockPost).toHaveBeenCalledWith('/api/drives/drive-1/envs/env-mac/enrollment-code'));
+      expect((await screen.findByTestId('enrollment-code')).textContent).toBe(CODE);
+      expect(screen.getByTestId('enrollment-commands').textContent).toContain(`pagespace env enroll enr_1 ${CODE}`);
+      await user.click(screen.getByRole('button', { name: 'Done' }));
+      await waitFor(() => expect(screen.queryByTestId('enrollment-code')).toBeNull());
+    });
+
+    test('"Show a new code" is withheld once a machine has enrolled, and from a member', async () => {
+      const user = userEvent.setup();
+      respondWithSessions([], [{ id: 'env-mac', name: 'mac', status: 'connected', substrate: 'local', label: 'jono-macstudio', enrolled: true }]);
+      renderSidebar();
+      const row = await screen.findByTestId('sidebar-env-env-mac');
+      await user.click(within(row).getByLabelText('Environment actions'));
+      expect(await screen.findByText('Rename')).toBeDefined();
+      expect(screen.queryByText('Show a new code')).toBeNull();
+    });
+
+    /**
+     * THE ROW MUST MOVE ON ITS OWN. `enrolledAt` changes from the CLI, outside
+     * every write path this app has, and the env listing neither polls nor
+     * revalidates on focus. Without this a person follows the dialog's two
+     * commands and watches a row that never stops saying "Awaiting
+     * enrollment" (Codex P1 on #2564).
+     */
+    test('a row awaiting enrollment picks up enrolled + connected without a reload — the listing polls while any local env awaits, and stops once none does', async () => {
+      vi.useFakeTimers({ shouldAdvanceTime: true });
+      try {
+        const listed: EnvFixture[] = [{ id: 'env-mac', name: 'mac', status: 'disconnected', substrate: 'local', label: 'jono-macstudio', enrolled: false }];
+        respondWithSessions([], listed);
+        renderSidebar();
+        const row = await screen.findByTestId('sidebar-env-env-mac');
+        expect(within(row).getByLabelText('Awaiting enrollment')).toBeDefined();
+        const envCallsBefore = mockFetchWithAuth.mock.calls.filter(([url]) => String(url).includes('/envs')).length;
+
+        // The machine enrols and connects, on the CLI.
+        listed[0] = { ...listed[0]!, status: 'connected', enrolled: true };
+        await act(async () => { await vi.advanceTimersByTimeAsync(LOCAL_ENV_ENROLLMENT_POLL_MS + 50); });
+        await waitFor(() => expect(within(screen.getByTestId('sidebar-env-env-mac')).getByLabelText('Machine connected')).toBeDefined());
+        expect(mockFetchWithAuth.mock.calls.filter(([url]) => String(url).includes('/envs')).length).toBeGreaterThan(envCallsBefore);
+
+        // Nothing awaits any more: the poll stops.
+        const settled = mockFetchWithAuth.mock.calls.filter(([url]) => String(url).includes('/envs')).length;
+        await act(async () => { await vi.advanceTimersByTimeAsync(LOCAL_ENV_ENROLLMENT_POLL_MS * 3); });
+        expect(mockFetchWithAuth.mock.calls.filter(([url]) => String(url).includes('/envs')).length).toBe(settled);
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+
+    test('an already_enrolled refusal refreshes the listing so the row self-heals', async () => {
+      const user = userEvent.setup();
+      const listed: EnvFixture[] = [{ id: 'env-mac', name: 'mac', status: 'disconnected', substrate: 'local', label: 'jono-macstudio', enrolled: false }];
+      respondWithSessions([], listed);
+      mockPost.mockImplementation(async () => {
+        listed[0] = { ...listed[0]!, status: 'connected', enrolled: true };
+        throw new ApiRequestError('A machine has already enrolled in this environment', 409, { reason: 'already_enrolled' });
+      });
+      renderSidebar();
+      const row = await screen.findByTestId('sidebar-env-env-mac');
+      await user.click(within(row).getByLabelText('Environment actions'));
+      await user.click(await screen.findByText('Show a new code'));
+      await waitFor(() => expect(within(screen.getByTestId('sidebar-env-env-mac')).getByLabelText('Machine connected')).toBeDefined());
+      expect(within(screen.getByTestId('sidebar-env-env-mac')).queryByLabelText('Awaiting enrollment')).toBeNull();
+    });
+
+    test('the code step says, BEFORE the commands, that the daemon runs on macOS and Linux only — enrolling from Windows would pin a machine that can never connect', async () => {
+      const user = userEvent.setup();
+      enableLocalEnvs();
+      respondWithSessions([], []);
+      mockPost.mockResolvedValue({ env: localEnv, enrollment: { enrollmentId: 'enr_1', code: CODE, expiresAt: expiresAt() } });
+      renderSidebar();
+      await openCreateStep(user);
+      await user.click(screen.getByLabelText('This computer'));
+      await user.type(screen.getByLabelText('Environment name'), 'mac');
+      await user.type(await screen.findByLabelText('Machine label'), 'jono-macstudio');
+      await user.click(screen.getByRole('button', { name: 'Create environment' }));
+      const panel = (await screen.findByTestId('enrollment-commands')).closest('[data-testid="enrollment-panel"]') as HTMLElement;
+      const text = panel.textContent ?? '';
+      expect(text).toMatch(/macOS and Linux only/);
+      expect(text).toMatch(/Windows/);
+      expect(text.indexOf('macOS and Linux only')).toBeLessThan(text.indexOf('pagespace env enroll'));
+    });
+
+    test('a refused re-issue (the machine enrolled meanwhile) is reported, not shown as a code', async () => {
+      const user = userEvent.setup();
+      respondWithSessions([], [{ id: 'env-mac', name: 'mac', status: 'disconnected', substrate: 'local', label: 'jono-macstudio', enrolled: false }]);
+      mockPost.mockRejectedValue(new ApiRequestError('A machine has already enrolled in this environment', 409, { reason: 'already_enrolled' }));
+      renderSidebar();
+      const row = await screen.findByTestId('sidebar-env-env-mac');
+      await user.click(within(row).getByLabelText('Environment actions'));
+      await user.click(await screen.findByText('Show a new code'));
+      await waitFor(() => expect(mockToastError).toHaveBeenCalled());
+      expect(screen.queryByTestId('enrollment-code')).toBeNull();
     });
   });
 });

--- a/apps/web/src/components/layout/left-sidebar/__tests__/env-groups.test.ts
+++ b/apps/web/src/components/layout/left-sidebar/__tests__/env-groups.test.ts
@@ -22,12 +22,22 @@ const session = (workspaceId: string, envId: string | null) => ({ workspaceId, e
 
 describe('partitionSessionsByEnv — the substrate rides along', () => {
   it('given a local env, should carry substrate local on its group so the row can withhold Sprite-only actions; an orphan carries null', () => {
-    const local: DriveEnvDTO = { id: 'env-l', driveId: 'drive-1', name: 'mac', substrate: 'local', status: 'disconnected', label: 'jono-macstudio', createdAt: '2026-08-01T00:00:00.000Z' };
+    const local: DriveEnvDTO = { id: 'env-l', driveId: 'drive-1', name: 'mac', substrate: 'local', status: 'disconnected', label: 'jono-macstudio', enrolled: false, createdAt: '2026-08-01T00:00:00.000Z' };
     const r = partitionSessionsByEnv([session('x', 'env-ghost')], [env({ id: 'env-s', name: 'cloud' }), local]);
     expect(r.envGroups.map((g) => [g.envId, g.substrate])).toEqual([
       ['env-s', 'sprite'],
       ['env-l', 'local'],
       ['env-ghost', null],
+    ]);
+  });
+
+  it('given a local env, should carry its machine label and enrollment fact; a Sprite env and an orphan carry null for both', () => {
+    const local: DriveEnvDTO = { id: 'env-l', driveId: 'drive-1', name: 'mac', substrate: 'local', status: 'disconnected', label: 'jono-macstudio', enrolled: false, createdAt: '2026-08-01T00:00:00.000Z' };
+    const r = partitionSessionsByEnv([session('x', 'env-ghost')], [env({ id: 'env-s', name: 'cloud' }), local]);
+    expect(r.envGroups.map((g) => [g.envId, g.machineLabel, g.enrolled])).toEqual([
+      ['env-s', null, null],
+      ['env-l', 'jono-macstudio', false],
+      ['env-ghost', null, null],
     ]);
   });
 });

--- a/apps/web/src/components/layout/left-sidebar/env-groups.ts
+++ b/apps/web/src/components/layout/left-sidebar/env-groups.ts
@@ -37,6 +37,14 @@ export interface EnvGroup<T> {
    * null for an orphan.
    */
   substrate: DriveEnvDTO['substrate'] | null;
+  /** A LOCAL env's machine label ("jono-macstudio"); null for a Sprite env or an orphan. */
+  machineLabel: string | null;
+  /**
+   * A LOCAL env's enrollment fact: `false` is AWAITING ENROLLMENT — the one
+   * state the row offers "Show a new code" in. Null for a Sprite env or an
+   * orphan (the question does not apply).
+   */
+  enrolled: boolean | null;
   sessions: T[];
 }
 
@@ -80,6 +88,8 @@ export function partitionSessionsByEnv<T extends { envId: string | null }>(
       envName: env.name,
       status: env.status,
       substrate: env.substrate,
+      machineLabel: env.substrate === 'local' ? env.label : null,
+      enrolled: env.substrate === 'local' ? env.enrolled : null,
       sessions: sessionsByEnv.get(env.id) ?? [],
     }))
     .sort(byEnvDisplayName);
@@ -91,6 +101,8 @@ export function partitionSessionsByEnv<T extends { envId: string | null }>(
       envName: null,
       status: null,
       substrate: null,
+      machineLabel: null,
+      enrolled: null,
       sessions: sessionsByEnv.get(envId) ?? [],
     }))
     .sort(byEnvDisplayName);

--- a/apps/web/src/hooks/drive-envs/useDriveEnvs.ts
+++ b/apps/web/src/hooks/drive-envs/useDriveEnvs.ts
@@ -30,6 +30,19 @@ import type { DriveEnvDTO } from '@pagespace/lib/drive-envs/env-contract';
 export const driveEnvsKey = (driveId: string | null | undefined): string | null =>
   driveId ? `/api/drives/${encodeURIComponent(driveId)}/envs` : null;
 
+/**
+ * How often to re-read a drive's listing WHILE one of its local envs is
+ * awaiting enrollment. That is the one change to an env that happens outside
+ * every write path this app has — `enrolledAt` is stamped by `pagespace env
+ * enroll` on the machine — so without this the row would say "Awaiting
+ * enrollment" until a full reload. Bounded: the moment nothing awaits, the
+ * interval is 0 and the listing is back to never polling.
+ */
+export const LOCAL_ENV_ENROLLMENT_POLL_MS = 5_000;
+
+const awaitsEnrollment = (data: { envs: DriveEnvDTO[] } | undefined): boolean =>
+  (data?.envs ?? []).some((env) => env.substrate === 'local' && !env.enrolled);
+
 async function envsFetcher(url: string): Promise<{ envs: DriveEnvDTO[] }> {
   const response = await fetchWithAuth(url);
   if (!response.ok) throw new Error(`Failed to list environments (${response.status})`);
@@ -54,8 +67,10 @@ export function useDriveEnvs(
       // An environment is created and destroyed deliberately, by a person, and
       // its derived status only moves when a machine is provisioned or torn
       // down. Nothing here changes on its own often enough to poll for — the
-      // acts that DO change it all run through this hook's own `mutate`.
-      refreshInterval: 0,
+      // acts that DO change it all run through this hook's own `mutate` — with
+      // ONE exception: a local env's enrollment lands from the CLI, so while
+      // any local env awaits one the listing polls, and stops when none does.
+      refreshInterval: (latest) => (awaitsEnrollment(latest) ? LOCAL_ENV_ENROLLMENT_POLL_MS : 0),
     },
   );
 

--- a/apps/web/src/hooks/page-agents/usePageAgents.ts
+++ b/apps/web/src/hooks/page-agents/usePageAgents.ts
@@ -39,6 +39,12 @@ export interface DriveWithAgents {
   agents: AgentSummary[];
   /** Whether THIS requester can use the sandbox in this drive (payer tier + actor edit access + kill switch). */
   sandboxEligible: boolean;
+  /**
+   * Whether this deployment offers LOCAL environments (`LOCAL_ENVS_ENABLED`,
+   * server-side). Ridden per drive the way `sandboxEligible` is, so the spawn
+   * palette resolves it from the drive entry it already reads; absent = off.
+   */
+  localEnvsEnabled: boolean;
 }
 
 /**

--- a/apps/web/src/lib/drive-envs/drive-envs-runtime.ts
+++ b/apps/web/src/lib/drive-envs/drive-envs-runtime.ts
@@ -57,11 +57,13 @@ import {
   enrollLocalDriveEnv,
   issueLocalEnvChallenge,
   redeemLocalEnvChallenge,
+  reissueLocalEnvEnrollmentCode,
   type LocalEnvIdentityDeps,
   type LocalEnvIdentityServiceDeps,
   type EnrollLocalDriveEnvResult,
   type IssueLocalEnvChallengeResult,
   type RedeemLocalEnvChallengeResult,
+  type ReissueLocalEnvEnrollmentCodeResult,
 } from '@pagespace/lib/services/drive-envs/drive-envs';
 
 export { toDriveEnvDTO };
@@ -219,6 +221,16 @@ export async function createEnvInDrive(input: {
       identity: input.local ? envBridgeIdentity() : undefined,
     },
   });
+}
+
+/**
+ * A fresh one-time code for a local env whose machine has not enrolled (M3).
+ * Same identity primitives as the create path; the store's compare-and-set on
+ * `enrolledAt IS NULL AND revokedAt IS NULL` is what makes it safe.
+ */
+export async function reissueEnvEnrollmentCode(input: { envId: string }): Promise<ReissueLocalEnvEnrollmentCodeResult> {
+  const store = await getDriveEnvStore();
+  return reissueLocalEnvEnrollmentCode({ envId: input.envId, deps: { store, now: () => new Date(), identity: envBridgeIdentity() } });
 }
 
 export async function enrollLocalEnv(input: { enrollmentId: string; code: unknown; machinePublicKey: unknown }): Promise<EnrollLocalDriveEnvResult> {

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -294,8 +294,11 @@ one was considered for this release and not adopted, because a list of program n
 walk around (`sh -c …`, an interpreter, a script inside a root) and would suggest a guarantee the
 daemon cannot keep. If you want per-command review, use `ask` and leave `exec` out of `ops`.
 
-A drive owner or admin can create an Environment with `substrate: "local"` and is shown a
-**one-time enrollment code** (valid ten minutes, single use). On the machine:
+A drive owner or admin creates a local Environment from the ordinary "New environment" step (choose
+**This computer** and name the machine) and is shown a **one-time enrollment code** (valid ten
+minutes, single use) beside these exact commands. Losing the code is not fatal: until a machine has
+enrolled, the Environment's menu in the sidebar offers **Show a new code**, which replaces the old
+one. Once a machine has enrolled, no new code can ever be issued for that Environment. On the machine:
 
 ```text
 pagespace env enroll <enrollmentId> <code> [--host <url>]

--- a/packages/lib/src/drive-envs/__tests__/env-contract.test.ts
+++ b/packages/lib/src/drive-envs/__tests__/env-contract.test.ts
@@ -73,14 +73,18 @@ describe('drive-env contract — the substrate axis (Local Environments epic)', 
     it('given a local env, should reject a Sprite-only status, and vice versa (the vocabularies do not mix)', () => {
       expect(driveEnvDtoSchema.safeParse({ ...BASE_DTO, substrate: 'local', status: 'running' }).success).toBe(false);
       expect(driveEnvDtoSchema.safeParse({ ...BASE_DTO, substrate: 'sprite', status: 'connected' }).success).toBe(false);
-      expect(driveEnvDtoSchema.safeParse({ ...BASE_DTO, substrate: 'local', status: 'connected', label: 'm' }).success).toBe(true);
+      expect(driveEnvDtoSchema.safeParse({ ...BASE_DTO, substrate: 'local', status: 'connected', label: 'm', enrolled: true }).success).toBe(true);
     });
 
-    it('given a local env DTO, should carry the label', () => {
-      const dto = driveEnvDtoSchema.parse({ ...BASE_DTO, substrate: 'local', status: 'disconnected', label: 'jono-macstudio' });
+    it('given a local env DTO, should carry the label AND whether a machine has enrolled — the fact the UI needs to offer a new code only while none has', () => {
+      const dto = driveEnvDtoSchema.parse({ ...BASE_DTO, substrate: 'local', status: 'disconnected', label: 'jono-macstudio', enrolled: false });
       expect(dto.substrate).toBe('local');
-      if (dto.substrate === 'local') expect(dto.label).toBe('jono-macstudio');
-      expect(driveEnvDtoSchema.safeParse({ ...BASE_DTO, substrate: 'local', status: 'disconnected' }).success).toBe(false);
+      if (dto.substrate === 'local') {
+        expect(dto.label).toBe('jono-macstudio');
+        expect(dto.enrolled).toBe(false);
+      }
+      expect(driveEnvDtoSchema.safeParse({ ...BASE_DTO, substrate: 'local', status: 'disconnected', enrolled: false }).success).toBe(false);
+      expect(driveEnvDtoSchema.safeParse({ ...BASE_DTO, substrate: 'local', status: 'disconnected', label: 'm' }).success).toBe(false);
     });
   });
 });

--- a/packages/lib/src/drive-envs/env-contract.ts
+++ b/packages/lib/src/drive-envs/env-contract.ts
@@ -155,6 +155,15 @@ export const driveEnvDtoSchema = z.discriminatedUnion('substrate', [
     status: z.enum(DRIVE_ENV_LOCAL_STATUSES),
     /** Human name of the machine. */
     label: z.string().min(1),
+    /**
+     * Whether a machine has pinned its key. `false` is the AWAITING-ENROLLMENT
+     * row: the one state in which a drive owner may ask for a fresh one-time
+     * code (`POST …/envs/<id>/enrollment-code`). Carried as a fact rather than
+     * folded into `status`, because a never-enrolled env and an enrolled one
+     * whose machine is asleep are both `'disconnected'`, and only this
+     * distinguishes them.
+     */
+    enrolled: z.boolean(),
   }),
 ]);
 

--- a/packages/lib/src/services/drive-envs/__tests__/drive-envs-store.integration.test.ts
+++ b/packages/lib/src/services/drive-envs/__tests__/drive-envs-store.integration.test.ts
@@ -646,7 +646,7 @@ describe('the local-env identity slice — compare-and-set predicates, in SQL', 
 
   it('pinMachineKey: should enroll ONCE — the second attempt loses the compare-and-set, and a revoked row cannot be enrolled at all', async () => {
     const { envId } = await createLocal();
-    const pin = { envId, machinePublicKey: 'pk', machineKeyFingerprint: 'sha256:fp', serverKeyId: 'k1', now: NOW };
+    const pin = { envId, machinePublicKey: 'pk', machineKeyFingerprint: 'sha256:fp', serverKeyId: 'k1', enrollmentCodeHash: 'hash', now: NOW };
     expect(await store.pinMachineKey(pin)).toBe(true);
     const [row] = await db.select().from(driveEnvLocal).where(eq(driveEnvLocal.envId, envId));
     expect(row).toMatchObject({ machinePublicKey: 'pk', machineKeyFingerprint: 'sha256:fp', serverKeyId: 'k1', enrollmentCodeHash: null });
@@ -660,10 +660,50 @@ describe('the local-env identity slice — compare-and-set predicates, in SQL', 
     expect(await store.pinMachineKey({ ...pin, envId: other.envId })).toBe(false);
   });
 
+  it('reissueEnrollmentCode: given a PENDING row, should replace the code hash and expiry, clear any used stamp, and leave the enrollment id alone', async () => {
+    const { envId, enrollmentId } = await createLocal();
+    const later = new Date(NOW.getTime() + 60_000);
+    const exp = new Date(later.getTime() + 600_000);
+    expect(await store.reissueEnrollmentCode({ envId, enrollmentCodeHash: 'hash2', enrollmentCodeExpiresAt: exp, now: later })).toBe(true);
+    const [row] = await db.select().from(driveEnvLocal).where(eq(driveEnvLocal.envId, envId));
+    expect(row).toMatchObject({ enrollmentId, enrollmentCodeHash: 'hash2', enrollmentCodeUsedAt: null, enrolledAt: null, machinePublicKey: null });
+    expect(row?.enrollmentCodeExpiresAt?.getTime()).toBe(exp.getTime());
+    expect(row?.updatedAt?.getTime()).toBe(later.getTime());
+  });
+
+  it('pinMachineKey: given the code was RE-ISSUED after an enrollment verified the old one, the pin bound to the OLD hash must lose and change nothing; the new hash pins (Codex P1 on #2564)', async () => {
+    const { envId } = await createLocal();
+    expect(await store.reissueEnrollmentCode({ envId, enrollmentCodeHash: 'hash2', enrollmentCodeExpiresAt: new Date(NOW.getTime() + 600_000), now: NOW })).toBe(true);
+    const stale = { envId, machinePublicKey: 'pk-old', machineKeyFingerprint: 'fp-old', serverKeyId: 'k1', enrollmentCodeHash: 'hash', now: NOW };
+    expect(await store.pinMachineKey(stale)).toBe(false);
+    const [row] = await db.select().from(driveEnvLocal).where(eq(driveEnvLocal.envId, envId));
+    expect(row).toMatchObject({ enrolledAt: null, machinePublicKey: null, enrollmentCodeHash: 'hash2', enrollmentCodeUsedAt: null });
+    expect(await store.pinMachineKey({ ...stale, machinePublicKey: 'pk-new', enrollmentCodeHash: 'hash2' })).toBe(true);
+    expect((await db.select().from(driveEnvLocal).where(eq(driveEnvLocal.envId, envId)))[0]?.machinePublicKey).toBe('pk-new');
+  });
+
+  it('reissueEnrollmentCode: given an ENROLLED row, should lose the compare-and-set and change nothing — a pinned machine is never re-opened to a second key', async () => {
+    const { envId } = await createLocal();
+    expect(await store.pinMachineKey({ envId, machinePublicKey: 'pk', machineKeyFingerprint: 'fp', serverKeyId: 'k1', enrollmentCodeHash: 'hash', now: NOW })).toBe(true);
+    const [before] = await db.select().from(driveEnvLocal).where(eq(driveEnvLocal.envId, envId));
+    expect(await store.reissueEnrollmentCode({ envId, enrollmentCodeHash: 'hash2', enrollmentCodeExpiresAt: new Date(NOW.getTime() + 600_000), now: new Date(NOW.getTime() + 1) })).toBe(false);
+    const [after] = await db.select().from(driveEnvLocal).where(eq(driveEnvLocal.envId, envId));
+    expect(after).toEqual(before);
+  });
+
+  it('reissueEnrollmentCode: given a REVOKED (never enrolled) row, should lose the compare-and-set and change nothing', async () => {
+    const { envId } = await createLocal();
+    await db.update(driveEnvLocal).set({ revokedAt: NOW }).where(eq(driveEnvLocal.envId, envId));
+    const [before] = await db.select().from(driveEnvLocal).where(eq(driveEnvLocal.envId, envId));
+    expect(await store.reissueEnrollmentCode({ envId, enrollmentCodeHash: 'hash2', enrollmentCodeExpiresAt: new Date(NOW.getTime() + 600_000), now: new Date(NOW.getTime() + 1) })).toBe(false);
+    const [after] = await db.select().from(driveEnvLocal).where(eq(driveEnvLocal.envId, envId));
+    expect(after).toEqual(before);
+  });
+
   it('setChallenge: should refuse before enrollment, then store the nonce, replacing a previous one and clearing its consumption', async () => {
     const { envId } = await createLocal();
     expect(await store.setChallenge({ envId, nonce: 'n1', expiresAt: NOW, now: NOW })).toBe(false);
-    await store.pinMachineKey({ envId, machinePublicKey: 'pk', machineKeyFingerprint: 'fp', serverKeyId: 'k1', now: NOW });
+    await store.pinMachineKey({ envId, machinePublicKey: 'pk', machineKeyFingerprint: 'fp', serverKeyId: 'k1', enrollmentCodeHash: 'hash', now: NOW });
     expect(await store.setChallenge({ envId, nonce: 'n1', expiresAt: NOW, now: NOW })).toBe(true);
     expect(await store.consumeChallenge({ envId, nonce: 'n1', now: NOW })).toBe(true);
     expect(await store.setChallenge({ envId, nonce: 'n2', expiresAt: NOW, now: NOW })).toBe(true);
@@ -677,7 +717,7 @@ describe('the local-env identity slice — compare-and-set predicates, in SQL', 
   // cluster whose session timezone is not UTC, where a `now()` would drift.
   async function enrolledLocal() {
     const { envId } = await createLocal();
-    await store.pinMachineKey({ envId, machinePublicKey: 'pk', machineKeyFingerprint: 'fp', serverKeyId: 'k1', now: NOW });
+    await store.pinMachineKey({ envId, machinePublicKey: 'pk', machineKeyFingerprint: 'fp', serverKeyId: 'k1', enrollmentCodeHash: 'hash', now: NOW });
     return envId;
   }
   const LIVE = new Date(NOW.getTime() + 60_000);
@@ -754,7 +794,7 @@ describe('the local-env identity slice — compare-and-set predicates, in SQL', 
 
   it('consumeChallenge: given the enrollment was REVOKED after the challenge was issued, should lose the compare-and-set — revocation wins the race, nothing mints', async () => {
     const { envId } = await createLocal();
-    await store.pinMachineKey({ envId, machinePublicKey: 'pk', machineKeyFingerprint: 'fp', serverKeyId: 'k1', now: NOW });
+    await store.pinMachineKey({ envId, machinePublicKey: 'pk', machineKeyFingerprint: 'fp', serverKeyId: 'k1', enrollmentCodeHash: 'hash', now: NOW });
     await store.setChallenge({ envId, nonce: 'n1', expiresAt: NOW, now: NOW });
     await db.update(driveEnvLocal).set({ revokedAt: NOW }).where(eq(driveEnvLocal.envId, envId));
     expect(await store.consumeChallenge({ envId, nonce: 'n1', now: NOW })).toBe(false);
@@ -765,7 +805,7 @@ describe('the local-env identity slice — compare-and-set predicates, in SQL', 
 
   it('consumeChallenge: should consume exactly the outstanding nonce ONCE, stamping lastSeenAt; a wrong nonce or a replay loses', async () => {
     const { envId } = await createLocal();
-    await store.pinMachineKey({ envId, machinePublicKey: 'pk', machineKeyFingerprint: 'fp', serverKeyId: 'k1', now: NOW });
+    await store.pinMachineKey({ envId, machinePublicKey: 'pk', machineKeyFingerprint: 'fp', serverKeyId: 'k1', enrollmentCodeHash: 'hash', now: NOW });
     await store.setChallenge({ envId, nonce: 'n1', expiresAt: NOW, now: NOW });
     expect(await store.consumeChallenge({ envId, nonce: 'wrong', now: NOW })).toBe(false);
     const later = new Date(NOW.getTime() + 5_000);
@@ -792,7 +832,7 @@ describe('the local-env connection slice (t07) — recordHello / recordHeartbeat
       local: { ownerId: payerId, label: 'jono-macstudio', enrollmentId, enrollmentCodeHash: 'hash', enrollmentCodeExpiresAt: new Date(NOW.getTime() + 600_000) },
     });
     if (!created.ok) throw new Error(created.reason);
-    if (enroll) await store.pinMachineKey({ envId: created.env.id, machinePublicKey: 'pk', machineKeyFingerprint: 'fp', serverKeyId: 'k1', now: NOW });
+    if (enroll) await store.pinMachineKey({ envId: created.env.id, machinePublicKey: 'pk', machineKeyFingerprint: 'fp', serverKeyId: 'k1', enrollmentCodeHash: 'hash', now: NOW });
     return created.env.id;
   }
   const rowOf = async (envId: string) => (await db.select().from(driveEnvLocal).where(eq(driveEnvLocal.envId, envId)))[0];

--- a/packages/lib/src/services/drive-envs/__tests__/drive-envs.test.ts
+++ b/packages/lib/src/services/drive-envs/__tests__/drive-envs.test.ts
@@ -179,13 +179,13 @@ describe('listDriveEnvs / the DTO', () => {
     });
 
     it('given a local row WITH its drive_env_local facts, should project substrate local, the machine label, and the CONNECTION status — never a Sprite status', () => {
-      const dto = toDriveEnvDTO(makeEnvRecord({ substrate: 'local' }), { label: 'jono-macstudio', status: 'connected' });
-      expect(dto).toEqual({ id: ENV_ID, driveId: DRIVE_ID, name: 'staging', substrate: 'local', status: 'connected', label: 'jono-macstudio', createdAt: NOW.toISOString() });
+      const dto = toDriveEnvDTO(makeEnvRecord({ substrate: 'local' }), { label: 'jono-macstudio', status: 'connected', enrolled: true });
+      expect(dto).toEqual({ id: ENV_ID, driveId: DRIVE_ID, name: 'staging', substrate: 'local', status: 'connected', label: 'jono-macstudio', enrolled: true, createdAt: NOW.toISOString() });
       expect(driveEnvDtoSchema.safeParse(dto).success).toBe(true);
     });
 
     it('given a local row, should ignore the Sprite pointer columns for status (they are CHECK-forbidden anyway)', () => {
-      const dto = toDriveEnvDTO(makeEnvRecord({ substrate: 'local' }), { label: 'm', status: 'disconnected' });
+      const dto = toDriveEnvDTO(makeEnvRecord({ substrate: 'local' }), { label: 'm', status: 'disconnected', enrolled: false });
       expect(dto.status).toBe('disconnected');
     });
 
@@ -194,7 +194,7 @@ describe('listDriveEnvs / the DTO', () => {
     });
 
     it('given a Sprite row WITH stray local facts, should ignore them (facts do not change the substrate)', () => {
-      const dto = toDriveEnvDTO(makeEnvRecord({ sandboxId: SANDBOX_ID }), { label: 'x', status: 'connected' });
+      const dto = toDriveEnvDTO(makeEnvRecord({ sandboxId: SANDBOX_ID }), { label: 'x', status: 'connected', enrolled: true });
       expect(dto.substrate).toBe('sprite');
       expect(dto.status).toBe('running');
       expect('label' in dto).toBe(false);
@@ -212,6 +212,14 @@ describe('listDriveEnvs / the DTO', () => {
       ]);
       const local = dtos[1];
       expect(local?.substrate === 'local' && local.label).toBe('jono-macstudio');
+      expect(local?.substrate === 'local' && local.enrolled).toBe(true);
+    });
+
+    it('given a local env whose machine has NOT enrolled yet, should project enrolled: false and disconnected — the awaiting-enrollment row the sidebar offers a new code for', async () => {
+      const fake = makeDriveEnvStore([makeEnvRecord({ id: 'env-l', name: 'mac', substrate: 'local' })]);
+      fake.local.set('env-l', makeLocalRecord({ envId: 'env-l', enrolledAt: null, enrollmentCodeHash: 'hash', enrollmentCodeExpiresAt: new Date(NOW.getTime() + 600_000) }));
+      const [dto] = await listDriveEnvs({ driveId: DRIVE_ID, deps: { store: fake.store, now: () => NOW, liveConnection: () => null } });
+      expect(dto?.substrate === 'local' && { status: dto.status, enrolled: dto.enrolled }).toEqual({ status: 'disconnected', enrolled: false });
     });
 
     it('given a local env whose sibling is GONE (owner erased under Art 17), should still list it as disconnected with the env name as its label rather than throw for the whole drive', async () => {

--- a/packages/lib/src/services/drive-envs/__tests__/env-sessions.integration.test.ts
+++ b/packages/lib/src/services/drive-envs/__tests__/env-sessions.integration.test.ts
@@ -626,7 +626,7 @@ describe('spawnAgentSession into a LOCAL env — the bind gate, for real (C1)', 
     if (!created.ok) throw new Error(`seedLocalEnv refused: ${created.reason}`);
     const envId = created.env.id;
     if (input.enrolled) {
-      await envStore.pinMachineKey({ envId, machinePublicKey: 'pk', machineKeyFingerprint: 'fp', serverKeyId: 'k1', now: new Date() });
+      await envStore.pinMachineKey({ envId, machinePublicKey: 'pk', machineKeyFingerprint: 'fp', serverKeyId: 'k1', enrollmentCodeHash: 'hash', now: new Date() });
     }
     if (input.heartbeat || input.revoked) {
       await db.update(driveEnvLocal).set({ ...(input.heartbeat && { lastSeenAt: input.heartbeat }), ...(input.revoked && { revokedAt: new Date() }) }).where(eq(driveEnvLocal.envId, envId));

--- a/packages/lib/src/services/drive-envs/__tests__/fakes.ts
+++ b/packages/lib/src/services/drive-envs/__tests__/fakes.ts
@@ -156,12 +156,22 @@ export function makeDriveEnvStore(seed: DriveEnvRecord[] = [], now: () => Date =
       return [...local.values()].filter((sibling) => sibling.driveId === driveId);
     },
 
-    async pinMachineKey({ envId, machinePublicKey, machineKeyFingerprint, serverKeyId, now: at }) {
+    async pinMachineKey({ envId, machinePublicKey, machineKeyFingerprint, serverKeyId, enrollmentCodeHash, now: at }) {
       const sibling = local.get(envId);
       // The real store's compare-and-set: only a pending, unrevoked row with an
-      // unconsumed code may be enrolled, and enrolling consumes the code.
+      // unconsumed code — still the code that was VERIFIED — may be enrolled,
+      // and enrolling consumes the code.
       if (!sibling || sibling.enrolledAt !== null || sibling.enrollmentCodeUsedAt !== null || sibling.revokedAt !== null) return false;
+      if (sibling.enrollmentCodeHash !== enrollmentCodeHash) return false;
       local.set(envId, { ...sibling, machinePublicKey, machineKeyFingerprint, serverKeyId, enrolledAt: at, enrollmentCodeUsedAt: at, enrollmentCodeHash: null, updatedAt: at });
+      return true;
+    },
+
+    async reissueEnrollmentCode({ envId, enrollmentCodeHash, enrollmentCodeExpiresAt, now: at }) {
+      const sibling = local.get(envId);
+      // The real store's CAS: only a pending, unrevoked row gets a new code.
+      if (!sibling || sibling.enrolledAt !== null || sibling.revokedAt !== null) return false;
+      local.set(envId, { ...sibling, enrollmentCodeHash, enrollmentCodeExpiresAt, enrollmentCodeUsedAt: null, updatedAt: at });
       return true;
     },
 

--- a/packages/lib/src/services/drive-envs/__tests__/local-env-reissue.test.ts
+++ b/packages/lib/src/services/drive-envs/__tests__/local-env-reissue.test.ts
@@ -1,0 +1,157 @@
+/**
+ * Re-issuing the one-time enrollment code (Local Environments epic, M3).
+ *
+ * The code hash is written at creation and shown to the user exactly once. A
+ * closed dialog, a lost clipboard or a ten-minute expiry used to leave a local
+ * env PERMANENTLY unenrollable — a row that could only be deleted and made
+ * again. Re-issue closes that gap for a row that has NOT yet enrolled, and
+ * nothing else: an enrolled machine's env must never be re-opened to a second
+ * key (that would be a takeover), so the store's compare-and-set on
+ * `enrolledAt IS NULL AND revokedAt IS NULL` is the whole security claim and
+ * the service only chooses the honest typed answer around it.
+ */
+import { describe, it, expect } from 'vitest';
+import { createHash, generateKeyPairSync, randomBytes, createPublicKey, verify as nodeVerify } from 'node:crypto';
+import {
+  createDriveEnv,
+  enrollLocalDriveEnv,
+  reissueLocalEnvEnrollmentCode,
+  type LocalEnvIdentityDeps,
+} from '../drive-envs';
+import { makeDriveEnvStore, makeEnvRecord, makeLocalRecord, DRIVE_ID, PAYER_ID, NOW } from './fakes';
+
+const machine = generateKeyPairSync('ed25519');
+const machinePublicKey = machine.publicKey.export({ type: 'spki', format: 'der' }).toString('base64');
+
+const identity: LocalEnvIdentityDeps = {
+  random: (length) => new Uint8Array(randomBytes(length)),
+  hash: (bytes) => createHash('sha3-256').update(bytes).digest('hex'),
+  fingerprint: (bytes) => `sha256:${createHash('sha256').update(bytes).digest('hex')}`,
+  isEd25519PublicKey: (spki) => {
+    try {
+      return createPublicKey({ key: Buffer.from(spki), type: 'spki', format: 'der' }).asymmetricKeyType === 'ed25519';
+    } catch {
+      return false;
+    }
+  },
+  verify: (message, signature, publicKey) =>
+    nodeVerify(null, message, createPublicKey({ key: Buffer.from(publicKey), type: 'spki', format: 'der' }), signature),
+  newEnrollmentId: () => 'enr-1',
+  signingKey: { keyId: 'srv-k1', publicKey: new Uint8Array(32) },
+};
+
+function harness(now: Date = NOW) {
+  const fake = makeDriveEnvStore([], () => now);
+  const deps = { store: fake.store, resolvePayer: async () => ({ payerId: PAYER_ID, tier: 'pro' as const }), now: () => now, identity };
+  return { fake, deps };
+}
+
+async function createLocal(h: ReturnType<typeof harness>) {
+  const result = await createDriveEnv({ driveId: DRIVE_ID, name: 'mac', createdBy: 'user-1', local: { label: 'jono-macstudio', ownerId: 'user-1' }, deps: h.deps });
+  if (!result.ok || !result.enrollment) throw new Error(`create failed: ${JSON.stringify(result)}`);
+  return { env: result.env, enrollment: result.enrollment };
+}
+
+describe('reissueLocalEnvEnrollmentCode', () => {
+  it('given a local env that has not enrolled, should mint a NEW code (replacing hash and expiry), keep the enrollment id, and the OLD code must stop working', async () => {
+    const h = harness();
+    const { env, enrollment: first } = await createLocal(h);
+    const before = h.fake.local.get(env.id)!;
+
+    const later = new Date(NOW.getTime() + 60_000);
+    h.deps.now = () => later;
+    const result = await reissueLocalEnvEnrollmentCode({ envId: env.id, deps: h.deps });
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.enrollment.enrollmentId).toBe(first.enrollmentId);
+    expect(result.enrollment.code).not.toBe(first.code);
+    expect(result.enrollment.expiresAt.getTime()).toBe(later.getTime() + 10 * 60 * 1000);
+
+    const after = h.fake.local.get(env.id)!;
+    expect(after.enrollmentId).toBe(before.enrollmentId);
+    expect(after.enrollmentCodeHash).not.toBe(before.enrollmentCodeHash);
+    expect(after.enrollmentCodeExpiresAt?.getTime()).toBe(result.enrollment.expiresAt.getTime());
+    expect(after.enrolledAt).toBeNull();
+    expect(after.machinePublicKey).toBeNull();
+
+    // The superseded code is dead; the new one enrols.
+    expect(await enrollLocalDriveEnv({ enrollmentId: 'enr-1', code: first.code, machinePublicKey, deps: h.deps })).toEqual({ ok: false, reason: 'mismatch' });
+    const enrolled = await enrollLocalDriveEnv({ enrollmentId: 'enr-1', code: result.enrollment.code, machinePublicKey, deps: h.deps });
+    expect(enrolled.ok).toBe(true);
+  });
+
+  it('given the first code has EXPIRED, should still re-issue — expiry is the case this exists for', async () => {
+    const h = harness();
+    const { env, enrollment: first } = await createLocal(h);
+    const afterExpiry = new Date(first.expiresAt.getTime() + 1);
+    h.deps.now = () => afterExpiry;
+    expect(await enrollLocalDriveEnv({ enrollmentId: 'enr-1', code: first.code, machinePublicKey, deps: h.deps })).toEqual({ ok: false, reason: 'expired' });
+    const result = await reissueLocalEnvEnrollmentCode({ envId: env.id, deps: h.deps });
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect((await enrollLocalDriveEnv({ enrollmentId: 'enr-1', code: result.enrollment.code, machinePublicKey, deps: h.deps })).ok).toBe(true);
+  });
+
+  it('given the machine has ALREADY ENROLLED, should refuse as already_enrolled and change NOTHING — re-opening an enrolled env would be a takeover', async () => {
+    const h = harness();
+    const { env, enrollment } = await createLocal(h);
+    expect((await enrollLocalDriveEnv({ enrollmentId: 'enr-1', code: enrollment.code, machinePublicKey, deps: h.deps })).ok).toBe(true);
+    const before = h.fake.local.get(env.id)!;
+
+    const result = await reissueLocalEnvEnrollmentCode({ envId: env.id, deps: h.deps });
+    expect(result).toEqual({ ok: false, reason: 'already_enrolled' });
+    expect(h.fake.local.get(env.id)).toEqual(before);
+  });
+
+  it('given a REVOKED enrollment (enrolled or not), should refuse as revoked and change nothing', async () => {
+    const h = harness();
+    const { env } = await createLocal(h);
+    await h.fake.store.revokeLocal({ envId: env.id, now: NOW });
+    const before = h.fake.local.get(env.id)!;
+    expect(await reissueLocalEnvEnrollmentCode({ envId: env.id, deps: h.deps })).toEqual({ ok: false, reason: 'revoked' });
+    expect(h.fake.local.get(env.id)).toEqual(before);
+  });
+
+  it('given an env with no drive_env_local sibling (a Sprite env, or a local env whose owner was erased), should refuse as not_found', async () => {
+    const h = harness();
+    h.fake.rows.set('env-s', makeEnvRecord({ id: 'env-s', name: 'cloud' }));
+    expect(await reissueLocalEnvEnrollmentCode({ envId: 'env-s', deps: h.deps })).toEqual({ ok: false, reason: 'not_found' });
+    expect(await reissueLocalEnvEnrollmentCode({ envId: 'env-missing', deps: h.deps })).toEqual({ ok: false, reason: 'not_found' });
+  });
+
+  it('given the pre-read says pending but the compare-and-set LOSES (an enrollment landed in between), should re-read and answer already_enrolled — never claim a code it did not store', async () => {
+    const h = harness();
+    const { env } = await createLocal(h);
+    const real = h.fake.store.reissueEnrollmentCode.bind(h.fake.store);
+    // The interleaving: the machine enrols between the service's read and its write.
+    h.fake.store.reissueEnrollmentCode = async (input) => {
+      h.fake.local.set(env.id, makeLocalRecord({ ...h.fake.local.get(env.id)!, enrolledAt: NOW, machinePublicKey: 'pk', machineKeyFingerprint: 'fp', serverKeyId: 'k1', enrollmentCodeUsedAt: NOW, enrollmentCodeHash: null }));
+      return real(input);
+    };
+    expect(await reissueLocalEnvEnrollmentCode({ envId: env.id, deps: h.deps })).toEqual({ ok: false, reason: 'already_enrolled' });
+    expect(h.fake.local.get(env.id)!.enrollmentCodeHash).toBeNull();
+  });
+
+  it('given an enrollment that verified the OLD code just before a re-issue landed, the pin must LOSE (the code it verified is no longer the stored one) and the NEW code must still enrol (Codex P1 on #2564)', async () => {
+    const h = harness();
+    const { env, enrollment: first } = await createLocal(h);
+    const realPin = h.fake.store.pinMachineKey.bind(h.fake.store);
+    let reissued: string | null = null;
+    // The interleaving: the daemon's enroll has already verified `first.code`
+    // and is about to pin; the owner's re-issue lands in between.
+    h.fake.store.pinMachineKey = async (input) => {
+      if (reissued === null) {
+        const result = await reissueLocalEnvEnrollmentCode({ envId: env.id, deps: h.deps });
+        if (!result.ok) throw new Error(result.reason);
+        reissued = result.enrollment.code;
+      }
+      return realPin(input);
+    };
+    const stale = await enrollLocalDriveEnv({ enrollmentId: 'enr-1', code: first.code, machinePublicKey, deps: h.deps });
+    expect(stale).toEqual({ ok: false, reason: 'race' });
+    expect(h.fake.local.get(env.id)!.enrolledAt).toBeNull();
+    expect(h.fake.local.get(env.id)!.machinePublicKey).toBeNull();
+    // The code the owner was just shown is the one that works.
+    expect((await enrollLocalDriveEnv({ enrollmentId: 'enr-1', code: reissued!, machinePublicKey, deps: h.deps })).ok).toBe(true);
+  });
+});

--- a/packages/lib/src/services/drive-envs/drive-envs-store.ts
+++ b/packages/lib/src/services/drive-envs/drive-envs-store.ts
@@ -206,9 +206,21 @@ export interface DriveEnvStore {
   /**
    * Enroll: pin the machine key and consume the code, IFF the row is pending
    * (`enrolledAt IS NULL AND enrollmentCodeUsedAt IS NULL AND revokedAt IS
-   * NULL`). Clears the code hash — a consumed code is not kept around.
+   * NULL`) AND the stored code hash is still the one the caller VERIFIED
+   * (`enrollmentCodeHash = <verified hash>`). The hash predicate is what makes
+   * a re-issue real: an enrollment that verified the old code just before a
+   * re-issue landed must lose here, or the superseded code would pin its key
+   * and silently invalidate the code the owner was just shown (Codex P1 on
+   * #2564). Clears the code hash — a consumed code is not kept around.
    */
-  pinMachineKey(input: { envId: string; machinePublicKey: string; machineKeyFingerprint: string; serverKeyId: string; now: Date }): Promise<boolean>;
+  pinMachineKey(input: { envId: string; machinePublicKey: string; machineKeyFingerprint: string; serverKeyId: string; enrollmentCodeHash: string; now: Date }): Promise<boolean>;
+  /**
+   * Replace the one-time code (hash + expiry, used stamp cleared) IFF the row
+   * is still pending: `enrolledAt IS NULL AND revokedAt IS NULL`. The
+   * enrollment id is never touched. An enrolled row loses the compare-and-set
+   * — a pinned machine is never re-opened to a second key (M3).
+   */
+  reissueEnrollmentCode(input: { envId: string; enrollmentCodeHash: string; enrollmentCodeExpiresAt: Date; now: Date }): Promise<boolean>;
   /**
    * Store the outstanding challenge (issued `now`) IFF enrolled, not revoked,
    * AND no live challenge is outstanding — i.e. the previous one is absent,
@@ -636,11 +648,29 @@ export async function createDbDriveEnvStore(now: () => Date = () => new Date()):
       return rows as DriveEnvLocalRecord[];
     },
 
-    async pinMachineKey({ envId, machinePublicKey, machineKeyFingerprint, serverKeyId, now: at }) {
+    async pinMachineKey({ envId, machinePublicKey, machineKeyFingerprint, serverKeyId, enrollmentCodeHash, now: at }) {
       const updated = await db
         .update(driveEnvLocal)
         .set({ machinePublicKey, machineKeyFingerprint, serverKeyId, enrolledAt: at, enrollmentCodeUsedAt: at, enrollmentCodeHash: null, updatedAt: at })
-        .where(and(eq(driveEnvLocal.envId, envId), isNull(driveEnvLocal.enrolledAt), isNull(driveEnvLocal.enrollmentCodeUsedAt), isNull(driveEnvLocal.revokedAt)))
+        .where(
+          and(
+            eq(driveEnvLocal.envId, envId),
+            isNull(driveEnvLocal.enrolledAt),
+            isNull(driveEnvLocal.enrollmentCodeUsedAt),
+            isNull(driveEnvLocal.revokedAt),
+            // Bound to the code that was verified: a re-issued row no longer matches.
+            eq(driveEnvLocal.enrollmentCodeHash, enrollmentCodeHash),
+          ),
+        )
+        .returning({ envId: driveEnvLocal.envId });
+      return updated.length === 1;
+    },
+
+    async reissueEnrollmentCode({ envId, enrollmentCodeHash, enrollmentCodeExpiresAt, now: at }) {
+      const updated = await db
+        .update(driveEnvLocal)
+        .set({ enrollmentCodeHash, enrollmentCodeExpiresAt, enrollmentCodeUsedAt: null, updatedAt: at })
+        .where(and(eq(driveEnvLocal.envId, envId), isNull(driveEnvLocal.enrolledAt), isNull(driveEnvLocal.revokedAt)))
         .returning({ envId: driveEnvLocal.envId });
       return updated.length === 1;
     },

--- a/packages/lib/src/services/drive-envs/drive-envs.ts
+++ b/packages/lib/src/services/drive-envs/drive-envs.ts
@@ -94,6 +94,8 @@ export interface LocalEnvFacts {
   label: string;
   /** Derived from `lastSeenAt` + the socket registry — never stored. */
   status: DriveEnvLocalStatus;
+  /** `drive_env_local.enrolledAt IS NOT NULL` — a machine has pinned its key. */
+  enrolled: boolean;
 }
 
 export function toDriveEnvDTO(row: DriveEnvRecord, local?: LocalEnvFacts): DriveEnvDTO {
@@ -110,7 +112,7 @@ export function toDriveEnvDTO(row: DriveEnvRecord, local?: LocalEnvFacts): Drive
     if (local === undefined) {
       throw new Error(`drive env ${row.id} is local but no drive_env_local facts were supplied to toDriveEnvDTO`);
     }
-    return { ...base, substrate: 'local', status: local.status, label: local.label };
+    return { ...base, substrate: 'local', status: local.status, label: local.label, enrolled: local.enrolled };
   }
   return { ...base, substrate: 'sprite', status: deriveDriveEnvStatus(row) };
 }
@@ -260,8 +262,63 @@ export async function createDriveEnv({
 }
 
 // ---------------------------------------------------------------------------
-// Local env identity: enroll → challenge → redeem
+// Local env identity: re-issue the code → enroll → challenge → redeem
 // ---------------------------------------------------------------------------
+
+export interface ReissueLocalEnvEnrollmentCodeDeps {
+  store: Pick<DriveEnvStore, 'findLocalByEnvId' | 'reissueEnrollmentCode'>;
+  now: () => Date;
+  identity: Pick<LocalEnvIdentityDeps, 'random' | 'hash'>;
+}
+
+export type ReissueLocalEnvEnrollmentCodeResult =
+  | { ok: true; enrollment: LocalEnvEnrollmentIssue }
+  /** No `drive_env_local` row: a Sprite env, an unknown id, or a local env whose owner was erased. */
+  | { ok: false; reason: 'not_found' }
+  /** A machine already pinned its key. Re-opening it to a second key would be a takeover, so this is final. */
+  | { ok: false; reason: 'already_enrolled' }
+  | { ok: false; reason: 'revoked' };
+
+/**
+ * A fresh one-time enrollment code for a local env whose machine has NOT
+ * enrolled yet (Local Environments epic, M3).
+ *
+ * The code hash is written at creation and the code shown once; a closed
+ * dialog, a lost clipboard or the ten-minute expiry used to leave the env
+ * permanently unenrollable. This replaces the hash and expiry (and clears any
+ * used stamp) under the SAME issuance the create path uses — the enrollment id
+ * is untouched, so the daemon's `enroll <enrollmentId> <code>` shape is the
+ * same command with a new code.
+ *
+ * **The security claim is the store's compare-and-set**, not the pre-read:
+ * `enrolledAt IS NULL AND revokedAt IS NULL` is the predicate of the UPDATE,
+ * so a machine that enrols between this read and this write wins, and no
+ * second key can ever be admitted to an enrolled env. The pre-read only
+ * chooses the honest typed answer without a write; a lost CAS re-reads and
+ * answers from the row as it now is, never with a code it did not store.
+ */
+export async function reissueLocalEnvEnrollmentCode({
+  envId,
+  deps,
+}: {
+  envId: string;
+  deps: ReissueLocalEnvEnrollmentCodeDeps;
+}): Promise<ReissueLocalEnvEnrollmentCodeResult> {
+  const refusalFor = (row: DriveEnvLocalRecord | null): ReissueLocalEnvEnrollmentCodeResult => {
+    if (!row) return { ok: false, reason: 'not_found' };
+    if (row.revokedAt !== null) return { ok: false, reason: 'revoked' };
+    return { ok: false, reason: 'already_enrolled' };
+  };
+  const row = await deps.store.findLocalByEnvId(envId);
+  if (!row || row.revokedAt !== null || row.enrolledAt !== null) return refusalFor(row);
+
+  const now = deps.now();
+  const issued = issueEnrollmentCode({ random: deps.identity.random, hash: deps.identity.hash, now: now.getTime() });
+  const expiresAt = new Date(issued.exp);
+  const stored = await deps.store.reissueEnrollmentCode({ envId, enrollmentCodeHash: issued.codeHash, enrollmentCodeExpiresAt: expiresAt, now });
+  if (!stored) return refusalFor(await deps.store.findLocalByEnvId(envId));
+  return { ok: true, enrollment: { enrollmentId: row.enrollmentId, code: issued.code, expiresAt } };
+}
 
 export interface LocalEnvIdentityServiceDeps {
   store: Pick<DriveEnvStore, 'findLocalByEnrollmentId' | 'pinMachineKey' | 'setChallenge' | 'consumeChallenge'>;
@@ -330,10 +387,13 @@ export async function enrollLocalDriveEnv({
     machinePublicKey: machinePublicKey as string,
     machineKeyFingerprint: deps.identity.fingerprint(spki),
     serverKeyId: deps.identity.signingKey.keyId,
+    // The hash this call VERIFIED, so a re-issue that replaced it in the
+    // meantime makes this pin lose rather than admit a superseded code.
+    enrollmentCodeHash: row.enrollmentCodeHash,
     now,
   });
-  // The CAS lost: a concurrent enrollment (or revoke) landed between the read
-  // and the write. Honest answer, nothing pinned twice.
+  // The CAS lost: a concurrent enrollment, revoke or re-issue landed between
+  // the read and the write. Honest answer, nothing pinned twice.
   if (!pinned) return { ok: false, reason: 'race' };
 
   return {
@@ -511,10 +571,14 @@ function localFactsFor(row: DriveEnvRecord, sibling: DriveEnvLocalRecord | undef
   // No sibling: the owner was erased (Art 17 cascades the machine's identity
   // facts) and the env row survives as the drive's dead local env. It is
   // listed — disconnected, under its own name — rather than hidden or thrown.
-  if (!sibling) return { label: row.name, status: 'disconnected' };
+  // `enrolled: true` for the dead row, deliberately: with no sibling there is
+  // no code to re-issue, and `false` would offer the owner a "new code" that
+  // the store must refuse as `not_found`.
+  if (!sibling) return { label: row.name, status: 'disconnected', enrolled: true };
   return {
     label: sibling.label,
     status: deriveLocalEnvStatus({ enrolledAt: sibling.enrolledAt, revokedAt: sibling.revokedAt, lastSeenAt: sibling.lastSeenAt, liveConnection, now }),
+    enrolled: sibling.enrolledAt !== null,
   };
 }
 


### PR DESCRIPTION
Implements **[D-3]** (epic `j945few5ssv75k5ad0bowbb4`, task `aulzf9oh7trd7ghql8c8ogeo`): a local machine is a **substrate of an environment**, created in the ordinary "New environment" step, and that step is where the one-time enrollment code is shown. Targets the story branch `pu/local-env-story`, not master.

**Scope correction applied (founder, 2026-09-07):** the code hash was written once at creation with no re-issue path, so a closed dialog, a lost clipboard or the ten-minute expiry left a local env *permanently* unenrollable. Warning harder about that cliff would have been a workaround, so this PR adds the load-bearing fix — a server-side re-issue for an env whose machine has **not** enrolled — and the dialog carries no discard warning at all. Abandon-delete was deliberately not built (client-dependent, orphans on a dropped tab, races a user already typing the code).

## What / why / tests, per deliverable

### 1 · Re-issue (backend) — `POST /api/drives/<driveId>/envs/<envId>/enrollment-code` → `201 { enrollment }`
- **Store** `reissueEnrollmentCode`: ONE `UPDATE drive_env_local SET hash, expiry, usedAt = NULL WHERE envId = ? AND enrolledAt IS NULL AND revokedAt IS NULL`. The enrollment id is never touched. An enrolled row loses the CAS — a pinned machine is never re-opened to a second key (the takeover vector this must close).
- **Service** `reissueLocalEnvEnrollmentCode`: reuses `issueEnrollmentCode` (same alphabet, hash, TTL as create). Typed: `not_found` · `already_enrolled` (final) · `revoked`. A lost CAS re-reads and answers from the row as it now is — never with a code it did not store.
- **Route**: owner/admin via `isPrincipalDriveOwnerOrAdmin` (same bar as rename/delete/rebuild), CSRF, `LOCAL_ENVS_ENABLED` (501 off), env-in-drive (404), `not_local` 409, `already_enrolled` 409, `revoked` 410; audits `data.write`.
- **Tests**: unit vs fake store 6 (incl. "old code stops working, new one enrols", "expired → re-issue → enrols", CAS-loss interleaving); **real Postgres** 3 new rows in `drive-envs-store.integration.test.ts` (pending → replaced; enrolled → row byte-identical; revoked → unchanged), run on a non-UTC session TZ; route contract 8 new.
- **Mutation (line index, control per group): 8/8 killed.** Store: drop `enrolledAt IS NULL` ✗killed, drop `revokedAt IS NULL` ✗killed, control survived. Service: ignore lost CAS ✗killed, wrong enrollmentId ✗killed, `enrolled` always true ✗killed, control survived; *dropping the pre-read enrolled guard SURVIVED BY DESIGN* — the CAS still refuses, which is the security claim. Route: flag gate / substrate gate / owner-admin gate all ✗killed, control survived.

### 2 · `enrolled` on the local DTO (contract, additive)
`deriveLocalEnvStatus` cannot tell never-enrolled from asleep (both `disconnected`), and inventing a status was ruled out. The local DTO variant now carries `enrolled: boolean` (`drive_env_local.enrolledAt IS NOT NULL`), so the sidebar can say **Awaiting enrollment** truthfully and offer a new code only then. Contract, DTO projection and listing tests updated; no schema change.

### 3 · Substrate choice in the create step (`useSpawnSession.tsx`)
- With the flag off (default): the form is byte-for-byte the old form — no radio, no label field. Flag reaches the client the way `sandboxEligible` does: `/api/ai/page-agents/multi-drive` adds `localEnvsEnabled` per drive entry (server reads `isLocalEnvsEnabled()`); the palette reads it off the entry it already has. Absent ⇒ off.
- With it on: **Cloud sandbox** (default) / **This computer** + required machine label. Cloud posts `{ name }` exactly as before; local posts `{ name, substrate: 'local', label }`. Same OWNER/ADMIN gate as any create.
- A local env created from the env step is **not** auto-selected (no machine has enrolled; a bind would be refused `not_connected`); the env step re-asks with it listed.
- **Tests**: flag-off absence, byte-identical cloud body, local body, env-step re-ask.

### 4 · The code step (`LocalEnvEnrollment.tsx`, shared)
Rendered from the create response and from nothing else; there is no endpoint that returns an existing code. Shows the code (copy), the two exact commands from `packages/cli/README.md` with the real values and `--host <window.location.origin>` (copy), the expiry, and the boundary statement. Shown even when the create lands after the palette was closed (the credential is never silently dropped). Registered with `useEditingStore` while on screen, as the rename dialog is.
- **Tests**: code rendered once (`data-testid`), exact commands in order for this origin, expiry + boundary phrases present, `mockPost` called exactly once (never refetched), Done returns to the flow and the code is gone, clipboard contents, late-landing create still shows the code.

### 5 · Honest sidebar rows (`AgentsSidebar.tsx`, `env-groups.ts`)
Local rows show a laptop (`aria-label="Local environment"`) and the machine label; dot reads **Awaiting enrollment** when `enrolled === false`, **Machine not connected** otherwise (was "Machine disconnected", which implied it had once connected). Menu gains **Show a new code** only while awaiting enrollment (owner/admin), opening `EnrollmentCodeDialog`, which issues on open and renders the same panel; a refusal is toasted and the dialog closes.
- **Tests**: row copy/labels, enrolled-but-away never reads as awaiting, re-issue flow shows the fresh code once, withheld once enrolled and from a member, refusal toasted with no code shown.

### UI mutation (line index, controls per group)
Run against the full sidebar + env-groups suites (120 tests) per mutant. **9/9 killed**, both controls survived.

| Mutant | Result |
|---|---|
| U0 control (no-op comment) | survived (120 passed) |
| U1 cloud body gains `substrate: 'sprite'` (cloud path changed) | **killed** (2 failed) |
| U2 local option ignores the deployment flag | **killed** (1 failed) |
| U3 Done does not clear the code | **killed** (3 failed) |
| U4 palette not opened by a late-landing code | **killed** (1 failed) |
| U5 code never captured from the create response | **killed** (4 failed) |
| U6 local env auto-selected from the env step | **killed** (1 failed) |
| W0 control (no-op) | survived (120 passed) |
| W1 "Show a new code" offered to every local env | **killed** (1 failed) |
| W2 dot says "Awaiting enrollment" for any local env | **killed** (1 failed) |
| W3 groups drop the `enrolled` fact | **killed** (2 failed) |

Not mutation-checked: the `localEnvsEnabled` pass-through in the multi-drive route (a DB-backed route with no contract test; the client-side gate above is what the flag-off claim rests on, and the field's shape is typechecked).


## Codex review round 1 (3 threads, all confirmed and fixed in 3e31d0ecf; left open for the reviewer)
- **P1 store:** `pinMachineKey` is now bound to the code hash the enrollment VERIFIED (`AND enrollmentCodeHash = <verified>`), so a re-issue genuinely invalidates the old code even against an in-flight enrollment. Real-Postgres interleaving row + service-level interleaving test; mutation: hash dropped from the UPDATE → red, fake ignores hash → red.
- **P1 sidebar:** the listing polls (5 s) while any local env awaits enrollment and stops when none does (`useDriveEnvs` `refreshInterval` function — no env event channel exists); an `already_enrolled` refusal re-reads the listing. Test under fake timers: awaiting → enrolled + connected with no reload, then no further reads. Mutation: never poll → red, poll forever → red, no 409 refetch → red.
- **P2 copy:** "macOS and Linux only …" stated BEFORE the commands, with why. Test pins presence and order; removal → red.

## The copy, verbatim (so a reviewer can weigh the wording)

Palette create step, under "Runs on":
> **Cloud sandbox** — A machine PageSpace runs for this drive.
> **This computer** — Your own machine, enrolled with the PageSpace CLI. You will be shown a one-time code next.

Code step title: **Enrol {machineLabel}**. Description: *Run these on the computer to connect it. The code is shown here once; a new one is a menu away if you lose it.*

Panel:
> “{envName}” is a local environment: sessions in it run on {machineLabel}, not in a cloud sandbox. On that computer, install the PageSpace CLI if you have not (`npm install -g @pagespace/cli`), then run:
> *macOS and Linux only. The bridge daemon does not run on Windows. Do not enrol from a Windows machine: enrolling would tie this environment to a computer that cannot connect, and it could not then be moved to another one.*
> ```
> pagespace env enroll {enrollmentId} {code} --host {origin}
> pagespace env connect {enrollmentId} --host {origin}
> ```
> **Enrollment code** `{code}`
> It works once and expires at {HH:MM} ({n} minutes from now). If you lose it, choose **Show a new code** from the environment’s menu in the sidebar.
>
> **What you are agreeing to.** Everything runs as you, on your computer, with no sandbox: anything your account can reach, an agent driving this environment can reach. In `ask` mode, approving one command also covers every later command of that kind for the rest of that session, without showing it to you. [Read the full statement] before you enrol.

"Show a new code" dialog description: *A new code replaces the previous one, which stops working now. Run these on the computer to connect it.*

Sidebar: **Awaiting enrollment** / **Machine not connected** / **Local environment** (icon label) / **Show a new code**.

The substance is the CLI README §"What you are agreeing to" (#2555): runs as you, no sandbox; one `ask` approval covers later commands of that kind, unseen. The link points at that section; nothing is softened.

## Deliberately NOT built ([D-4] / [D-5] / adjacent)
- Global-assistant access to any env — structurally refused at `agent-workspaces.ts:147`; task `ecn5xkq190d4uztsvqiawp01`.
- A user-level "may my machines be used" setting — task `dxvhcmppr8zqexhkbuun27mc`.
- Nothing in enrollment, the daemon, grants, the socket, or the schema.
- **Recorded on the task page, not built:** no way to REPLACE the machine on an existing env after revoke (wipe the laptop ⇒ env dead though owned). Same primitive as re-issue with a different CAS; the founder is filing it.
- The row's "+ New session in <env>" stays withheld for local envs (pre-existing); the palette's env step lists them, so binding is reachable.

## Verification notes
- Vitest does not typecheck: `apps/web` `tsc --noEmit` and `packages/lib` build were run once, sequentially, after the last edit (machine load from other agents was 30–40 throughout; no full monorepo build here — CI is the gate).
- Real-Postgres rows ran against a scratch DB (`pagespace_m3ui`, PG16) with `TZ=America/New_York`.
- Not exercised here: enrolling a real machine end to end from the rendered commands (needs a running deployment with `LOCAL_ENVS_ENABLED` + `ENV_BRIDGE_SIGNING_KEY`, and the M1 exit gate is itself still waiting on a build slot). The commands rendered are the README's, byte for byte, with the values substituted.

Changelog: entry under Unreleased › Added. CLI README: the "one-time code" paragraph now says where a new code comes from.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011LxEGYbL5NYtiX74a89utB
