### PR TITLE
Add applyFormatOps and readTabFormatting to the sheet store

### DIFF
--- a/packages/lib/src/sheets/__tests__/sheet-store.integration.test.ts
+++ b/packages/lib/src/sheets/__tests__/sheet-store.integration.test.ts
@@ -168,13 +168,21 @@ function holdFirst(
 const holdBeforeInsert = (exec: StoreExecutor, hook: () => Promise<void>) => holdFirst(exec, 'insert', hook);
 const holdBeforeUpdate = (exec: StoreExecutor, hook: () => Promise<void>) => holdFirst(exec, 'update', hook);
 
-/** Resolves once another connection is waiting on a `sheet_tabs` lock. */
-async function waitForLockWaiter(timeoutMs = 10_000): Promise<void> {
+/**
+ * Resolves once ANOTHER connection is waiting on a `sheet_tabs` lock while
+ * `pending` is still unsettled — so a test that releases a held transaction
+ * after this knows the other writer really was blocked behind it, rather than
+ * having quietly finished first and turned the race into a sequence.
+ */
+async function waitForLockWaiter(pending: Promise<unknown>, timeoutMs = 10_000): Promise<void> {
+  let settled = false;
+  void pending.then(() => { settled = true; }, () => { settled = true; });
   const deadline = Date.now() + timeoutMs;
   for (;;) {
+    if (settled) throw new Error('The other writer finished before it was seen waiting on the lock');
     const result = await db.execute(
       sql`SELECT count(*)::int AS waiting FROM pg_stat_activity
-          WHERE wait_event_type = 'Lock' AND query ILIKE '%sheet_tabs%'`
+          WHERE pid <> pg_backend_pid() AND wait_event_type = 'Lock' AND query ILIKE '%sheet_tabs%'`
     );
     if (Number((result.rows[0] as { waiting: number }).waiting) > 0) return;
     if (Date.now() > deadline) throw new Error('No transaction ever waited on the sheet_tabs lock');
@@ -1333,7 +1341,7 @@ describe('sheet store (integration)', () => {
       return row;
     };
 
-    it('formats one row of a 50,000-row sheet by writing one row', async () => {
+    it('formats one row of a 50,000-row sheet by writing one row', { timeout: 30_000 }, async () => {
       // Kills: selecting or persisting rows by anything other than the plan's
       // row indexes. "A1 is bold" afterwards is identical under a whole-sheet
       // rewrite, so the assertion is on the MECHANISM — the reported count and
@@ -1661,7 +1669,7 @@ describe('sheet store (integration)', () => {
           { userId: ownerId },
           holdBeforeUpdate(tx, async () => {
             other ??= applyFormatOps({ pageId }, [{ type: 'addConditionalRule', rule: second }], { userId: ownerId });
-            await waitForLockWaiter();
+            await waitForLockWaiter(other);
           })
         )
       );
@@ -1671,6 +1679,68 @@ describe('sheet store (integration)', () => {
       expect((tab.conditionalFormats as { id: string }[]).map((rule) => rule.id).sort()).toEqual(
         ['over-100', 'second']
       );
+    });
+
+    it('refuses under the lock when a concurrent call took the rule id first', async () => {
+      // Kills: writing the pre-lock plan (which would silently overwrite the
+      // first rule with a same-id twin) and any re-plan that does not refuse.
+      // The second call passes validation on its snapshot, waits on the tab
+      // lock, and is refused by the plan it makes once it holds it.
+      const { pageId, ownerId } = await makeSheet({ rowCount: 20 });
+
+      let other: Promise<unknown> | null = null;
+      await db.transaction(async (tx) =>
+        applyFormatOps(
+          { pageId },
+          [{ type: 'addConditionalRule', rule: FORMAT_RULE }],
+          { userId: ownerId },
+          holdBeforeUpdate(tx, async () => {
+            other ??= applyFormatOps(
+              { pageId },
+              [{ type: 'addConditionalRule', rule: { ...FORMAT_RULE, format: { bold: true } } }],
+              { userId: ownerId }
+            );
+            await waitForLockWaiter(other);
+          })
+        )
+      );
+
+      await expect(other).rejects.toBeInstanceOf(SheetFormatError);
+      expect((await getTab({ pageId }))?.conditionalFormats).toEqual([FORMAT_RULE]);
+    });
+
+    it('treats a set that is cleared again in the same request as no change', async () => {
+      // Kills: staging patches per step rather than from the net change —
+      // which would create a tombstone row, bump the revision and log an
+      // entry whose before and after agree.
+      const { pageId, tabId, ownerId } = await makeSheet({ rowCount: 10 });
+      const before = await revisionOf(pageId);
+
+      const result = await applyFormatOps(
+        { pageId },
+        [
+          { type: 'setCellFormat', range: 'B2', patch: BOLD },
+          { type: 'clearCellFormat', range: 'B2' },
+        ],
+        { userId: ownerId }
+      );
+
+      expect(result).toMatchObject({ cellsFormatted: 0, rowsTouched: 0 });
+      expect(await revisionOf(pageId)).toEqual(before);
+      expect(await readRows(tabId, { limit: 10 })).toEqual([]);
+    });
+
+    it('does not count freezing nothing on a tab that stores a zero freeze', async () => {
+      // The document path stores `frozenRows: 0`; `setFrozen` normalises 0 to
+      // "none". They must compare equal or the request counts as an edit.
+      const { pageId, tabId, ownerId } = await makeSheet({ rowCount: 10 });
+      await db.update(sheetTabs).set({ frozenRows: 0, frozenColumns: 0 }).where(eq(sheetTabs.id, tabId));
+      const before = await revisionOf(pageId);
+
+      const result = await applyFormatOps({ pageId }, [{ type: 'setFrozen', rows: 0, columns: null }], { userId: ownerId });
+
+      expect(result.tabFieldsChanged).toEqual([]);
+      expect(await revisionOf(pageId)).toEqual(before);
     });
 
     it('re-evaluates open-ended range formulas when the extent grows', async () => {
@@ -1828,8 +1898,8 @@ describe('sheet store (integration)', () => {
 
     it('refuses a range it cannot address or that is too large to expand', async () => {
       const { pageId } = await makeSheet({ rowCount: 20 });
-      await expect(readTabFormatting({ pageId }, { ranges: ['A0:B2'] })).rejects.toThrow(/Invalid range/);
-      await expect(readTabFormatting({ pageId }, { ranges: ['A1:ZZ50000'] })).rejects.toThrow(/cells/);
+      await expect(readTabFormatting({ pageId }, { ranges: ['A0:B2'] })).rejects.toBeInstanceOf(SheetFormatError);
+      await expect(readTabFormatting({ pageId }, { ranges: ['A1:ZZ50000'] })).rejects.toThrow(/cells between them/);
     });
   });
 });

--- a/packages/lib/src/sheets/__tests__/sheet-store.integration.test.ts
+++ b/packages/lib/src/sheets/__tests__/sheet-store.integration.test.ts
@@ -16,7 +16,7 @@
 import { describe, it, expect, afterEach } from 'vitest';
 import { factories } from '@pagespace/db/test/factories';
 import { db } from '@pagespace/db/db';
-import { eq, and, sql, inArray } from '@pagespace/db/operators';
+import { eq, and, gt, sql, inArray } from '@pagespace/db/operators';
 import { users } from '@pagespace/db/schema/auth';
 import { pages } from '@pagespace/db/schema/core';
 import { sheetTabs, sheetRows, sheetRangeDeps, sheetChanges } from '@pagespace/db/schema';
@@ -34,7 +34,10 @@ import {
   copySheetRows,
   listTabs,
   sheetMatchingRowsByPage,
+  applyFormatOps,
+  readTabFormatting,
 } from '../store';
+import { SheetFormatError } from '../format-request';
 import type { StoredRow } from '../projection';
 import { parseSheetContent, serializeSheetContent } from '../io';
 import { sheetCellsMatchIlike, sheetCellsMatchRegex } from '../search-sql';
@@ -95,6 +98,126 @@ const matchingRowsFor = async (
 
 const cellAt = (rows: StoredRow[], rowIndex: number, column: string) =>
   rows.find((row) => row.rowIndex === rowIndex)?.cells[column];
+
+
+const BOLD = { bold: true };
+
+/** A rule the format tests add; its own constant so the block is self-contained. */
+const FORMAT_RULE = {
+  id: 'over-100',
+  kind: 'cell' as const,
+  ranges: ['A1:A9'],
+  condition: { operator: 'greaterThan' as const, value: '100' },
+  format: { background: '#fee2e2' },
+};
+
+const REGION = {
+  id: 'orders',
+  name: 'Orders',
+  range: 'A1:D',
+  headerRows: 1,
+  columns: [{ column: 'C', role: 'currency' as const, currency: 'USD' }],
+};
+
+type StoreExecutor = NonNullable<Parameters<typeof applyFormatOps>[3]>;
+
+/**
+ * `exec` with the FIRST call to `method` held until `hook` resolves.
+ *
+ * Drizzle builders are thenables, so the hold goes in `then`: the query is
+ * built as normal and only its execution waits. This is what makes a
+ * concurrency test deterministic — the transaction is paused at exactly the
+ * statement whose timing matters, and another connection does its work in
+ * the gap.
+ */
+function holdFirst(
+  exec: StoreExecutor,
+  method: 'insert' | 'update',
+  hook: () => Promise<void>
+): StoreExecutor {
+  let held = false;
+  const gate = (query: object): object =>
+    new Proxy(query, {
+      get(target, prop) {
+        const value: unknown = Reflect.get(target, prop);
+        if (prop === 'then') {
+          return (resolve: (value: unknown) => unknown, reject: (reason: unknown) => unknown) =>
+            hook().then(() => target).then(resolve, reject);
+        }
+        if (typeof value === 'function') {
+          return (...args: unknown[]) => gate((value as (...inner: unknown[]) => object).apply(target, args));
+        }
+        return value;
+      },
+    });
+
+  return new Proxy(exec, {
+    get(target, prop) {
+      const value: unknown = Reflect.get(target, prop);
+      if (prop === method && typeof value === 'function' && !held) {
+        return (...args: unknown[]) => {
+          held = true;
+          return gate((value as (...inner: unknown[]) => object).apply(target, args));
+        };
+      }
+      return value;
+    },
+  }) as StoreExecutor;
+}
+
+const holdBeforeInsert = (exec: StoreExecutor, hook: () => Promise<void>) => holdFirst(exec, 'insert', hook);
+const holdBeforeUpdate = (exec: StoreExecutor, hook: () => Promise<void>) => holdFirst(exec, 'update', hook);
+
+/** Resolves once another connection is waiting on a `sheet_tabs` lock. */
+async function waitForLockWaiter(timeoutMs = 10_000): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  for (;;) {
+    const result = await db.execute(
+      sql`SELECT count(*)::int AS waiting FROM pg_stat_activity
+          WHERE wait_event_type = 'Lock' AND query ILIKE '%sheet_tabs%'`
+    );
+    if (Number((result.rows[0] as { waiting: number }).waiting) > 0) return;
+    if (Date.now() > deadline) throw new Error('No transaction ever waited on the sheet_tabs lock');
+    await new Promise((resolve) => setTimeout(resolve, 25));
+  }
+}
+
+/**
+ * Counts `UPDATE` statements against one tab row, by trigger. A stored value
+ * cannot tell one statement from four; a row-level trigger can.
+ */
+async function countTabUpdates(tabId: string) {
+  const suffix = tabId.replace(/[^a-z0-9]/gi, '').toLowerCase();
+  const table = `fmt_audit_${suffix}`;
+  const fn = `fmt_audit_fn_${suffix}`;
+  const trigger = `fmt_audit_trg_${suffix}`;
+
+  await db.execute(sql.raw(`CREATE TABLE ${table} (n serial PRIMARY KEY)`));
+  await db.execute(
+    sql.raw(
+      `CREATE FUNCTION ${fn}() RETURNS trigger LANGUAGE plpgsql AS $$
+       BEGIN
+         IF NEW.id = '${tabId}' THEN INSERT INTO ${table} DEFAULT VALUES; END IF;
+         RETURN NEW;
+       END $$`
+    )
+  );
+  await db.execute(
+    sql.raw(`CREATE TRIGGER ${trigger} AFTER UPDATE ON sheet_tabs FOR EACH ROW EXECUTE FUNCTION ${fn}()`)
+  );
+
+  return {
+    count: async () => {
+      const result = await db.execute(sql.raw(`SELECT count(*)::int AS n FROM ${table}`));
+      return Number((result.rows[0] as { n: number }).n);
+    },
+    drop: async () => {
+      await db.execute(sql.raw(`DROP TRIGGER IF EXISTS ${trigger} ON sheet_tabs`));
+      await db.execute(sql.raw(`DROP FUNCTION IF EXISTS ${fn}()`));
+      await db.execute(sql.raw(`DROP TABLE IF EXISTS ${table}`));
+    },
+  };
+}
 
 describe('sheet store (integration)', () => {
   // Row-scoped, and after rather than before: every sheet table cascades from
@@ -1169,6 +1292,476 @@ describe('sheet store (integration)', () => {
         .from(sheetRows)
         .where(eq(sheetRows.pageId, pageId));
       expect(count).toBe(0);
+    });
+  });
+
+  describe('applyFormatOps', () => {
+
+    /** Rows 0..count-1, each with one cell, inserted directly and back-dated. */
+    async function seedRows(tabId: string, pageId: string, count: number) {
+      const stale = new Date(Date.now() - 60_000);
+      const CHUNK = 500;
+      for (let start = 0; start < count; start += CHUNK) {
+        const values = [];
+        for (let rowIndex = start; rowIndex < Math.min(count, start + CHUNK); rowIndex++) {
+          values.push({
+            tabId,
+            pageId,
+            rowIndex,
+            cells: { A: { raw: String(rowIndex), value: rowIndex, type: 'number' as const } },
+            updatedAt: stale,
+          });
+        }
+        await db.insert(sheetRows).values(values);
+      }
+    }
+
+    /** How many of a tab's rows were written since `marker`. */
+    const rowsWrittenSince = async (tabId: string, marker: Date) => {
+      const [{ count }] = await db
+        .select({ count: sql<number>`count(*)::int` })
+        .from(sheetRows)
+        .where(and(eq(sheetRows.tabId, tabId), gt(sheetRows.updatedAt, marker)));
+      return count;
+    };
+
+    const revisionOf = async (pageId: string) => {
+      const [row] = await db
+        .select({ revision: pages.revision, stateHash: pages.stateHash })
+        .from(pages)
+        .where(eq(pages.id, pageId));
+      return row;
+    };
+
+    it('formats one row of a 50,000-row sheet by writing one row', async () => {
+      // Kills: selecting or persisting rows by anything other than the plan's
+      // row indexes. "A1 is bold" afterwards is identical under a whole-sheet
+      // rewrite, so the assertion is on the MECHANISM — the reported count and
+      // the number of rows whose `updatedAt` moved.
+      const { pageId, tabId, ownerId } = await makeSheet({ rowCount: 50_000 });
+      await seedRows(tabId, pageId, 50_000);
+      const marker = new Date();
+
+      const result = await applyFormatOps(
+        { pageId },
+        [{ type: 'setCellFormat', range: 'A1:H1', patch: BOLD }],
+        { userId: ownerId }
+      );
+
+      expect(result.rowsTouched).toBe(1);
+      expect(result.cellsFormatted).toBe(8);
+      expect(await rowsWrittenSince(tabId, marker)).toBe(1);
+
+      const rows = await readRows(tabId, { limit: 2 });
+      expect(cellAt(rows, 0, 'A')?.format).toEqual(BOLD);
+      expect(cellAt(rows, 0, 'H')?.format).toEqual(BOLD);
+      // The value the row already held survives beside the new format.
+      expect(cellAt(rows, 0, 'A')?.value).toBe(0);
+    });
+
+    it('formats C2:C5001 by writing exactly those 5,000 rows', async () => {
+      // Kills: a span read that over-reaches (rows 5002+ untouched) and a
+      // per-row write that misses part of a chunked range.
+      const { pageId, tabId, ownerId } = await makeSheet({ rowCount: 6_000 });
+      await seedRows(tabId, pageId, 6_000);
+      const marker = new Date();
+
+      const result = await applyFormatOps(
+        { pageId },
+        [{ type: 'setCellFormat', range: 'C2:C5001', patch: { italic: true } }],
+        { userId: ownerId }
+      );
+
+      expect(result.rowsTouched).toBe(5_000);
+      expect(await rowsWrittenSince(tabId, marker)).toBe(5_000);
+
+      const [{ untouched }] = await db
+        .select({ untouched: sql<number>`count(*)::int` })
+        .from(sheetRows)
+        .where(
+          and(
+            eq(sheetRows.tabId, tabId),
+            sql`${sheetRows.rowIndex} >= 5001`,
+            gt(sheetRows.updatedAt, marker)
+          )
+        );
+      expect(untouched).toBe(0);
+    });
+
+    it('keeps a concurrent value write to the same row, as a real transaction pair', async () => {
+      // Kills: `persistRows` in replace mode, or any write that upserts a
+      // whole `cells` object rather than the columns this call touched.
+      //
+      // The interleaving that loses the update: the row does not exist yet,
+      // so there is no row lock to take; the format write reads nothing, a
+      // `setCells` to column A of the same row commits, and then the format
+      // write upserts column C. Sequentially those two calls prove nothing —
+      // the second reads the first's row. So the format write runs inside an
+      // open transaction whose first `sheet_rows` insert is held back until
+      // the value write has committed on another connection.
+      const { pageId, tabId, ownerId } = await makeSheet({ rowCount: 10 });
+
+      let valueWrite: Promise<unknown> | null = null;
+      const gated = await db.transaction(async (tx) =>
+        applyFormatOps(
+          { pageId },
+          [{ type: 'setCellFormat', range: 'C5', patch: BOLD }],
+          { userId: ownerId },
+          holdBeforeInsert(tx, async () => {
+            valueWrite ??= setCells({ pageId }, [{ address: 'A5', value: 'kept' }], { userId: ownerId });
+            await valueWrite;
+          })
+        )
+      );
+      expect(gated.rowsTouched).toBe(1);
+      await valueWrite;
+
+      const rows = await readRows(tabId, { limit: 10 });
+      expect(cellAt(rows, 4, 'A')?.value).toBe('kept');
+      expect(cellAt(rows, 4, 'C')?.format).toEqual(BOLD);
+    });
+
+    it('leaves a formula cell’s raw, value and type untouched', async () => {
+      // Kills: fabricating a `StoredCell` instead of spreading the loaded one.
+      const { pageId, tabId, ownerId } = await makeSheet({ rowCount: 10 });
+      await setCells({ pageId }, [
+        { address: 'B1', value: '1' },
+        { address: 'B2', value: '2' },
+        { address: 'B3', value: '3' },
+        { address: 'A1', value: '=SUM(B1:B9)' },
+      ], { userId: ownerId });
+
+      await applyFormatOps(
+        { pageId },
+        [{ type: 'setCellFormat', range: 'A1', patch: { number: { kind: 'currency', currency: 'USD' } } }],
+        { userId: ownerId }
+      );
+
+      const cell = cellAt(await readRows(tabId, { limit: 1 }), 0, 'A');
+      expect(cell?.raw).toBe('=SUM(B1:B9)');
+      expect(cell?.value).toBe(6);
+      expect(cell?.type).toBe('number');
+      expect(cell?.format).toEqual({ number: { kind: 'currency', currency: 'USD' } });
+    });
+
+    it('formats an empty cell so it projects as a format and not as a cell', async () => {
+      // Kills: writing an empty cell with any `raw` other than '', which the
+      // projection would then surface as content.
+      const { pageId, ownerId } = await makeSheet({ rowCount: 10 });
+
+      await applyFormatOps(
+        { pageId },
+        [{ type: 'setCellFormat', range: 'D9', patch: { background: '#fee2e2' } }],
+        { userId: ownerId }
+      );
+
+      const sheet = (await readSheetData({ pageId }))!;
+      expect(sheet.formats?.D9).toEqual({ background: '#fee2e2' });
+      expect(sheet.cells.D9).toBeUndefined();
+    });
+
+    it('clears a format into a tombstone the projection ignores', async () => {
+      // Documents, rather than fixes, the `{ raw: '' }` left behind: the jsonb
+      // merge cannot delete a key, and the alternative is the lost update the
+      // merge exists to prevent.
+      const { pageId, tabId, ownerId } = await makeSheet({ rowCount: 10 });
+      await applyFormatOps({ pageId }, [{ type: 'setCellFormat', range: 'D9', patch: BOLD }], { userId: ownerId });
+
+      const cleared = await applyFormatOps(
+        { pageId },
+        [{ type: 'clearCellFormat', range: 'D9' }],
+        { userId: ownerId }
+      );
+      expect(cleared.cellsFormatted).toBe(1);
+
+      expect(cellAt(await readRows(tabId, { fromRow: 8, limit: 1 }), 8, 'D')).toEqual({ raw: '' });
+      const sheet = (await readSheetData({ pageId }))!;
+      expect(sheet.formats?.D9).toBeUndefined();
+      expect(sheet.cells.D9).toBeUndefined();
+
+      // Clearing a cell that never existed writes nothing at all.
+      const noop = await applyFormatOps({ pageId }, [{ type: 'clearCellFormat', range: 'E9' }], { userId: ownerId });
+      expect(noop.rowsTouched).toBe(0);
+    });
+
+    it('writes every tab-level change of one call in one UPDATE and one revision bump', async () => {
+      // Kills: a per-op `UPDATE sheet_tabs`, and a per-op `touchPage`. An
+      // editor holding the sheet open sees one conflict per revision bump, so
+      // N bumps for one request is N conflicts. The count is taken by a
+      // trigger: a stored value cannot distinguish one statement from four.
+      const { pageId, tabId, ownerId } = await makeSheet({ rowCount: 20, columnCount: 6 });
+      const audit = await countTabUpdates(tabId);
+      const before = await revisionOf(pageId);
+
+      try {
+        const result = await applyFormatOps(
+          { pageId },
+          [
+            { type: 'setColumnWidth', column: 'B', width: 240 },
+            { type: 'setFrozen', rows: 1, columns: null },
+            { type: 'addConditionalRule', rule: FORMAT_RULE },
+            { type: 'setRegions', regions: [REGION] },
+          ],
+          { userId: ownerId }
+        );
+
+        expect(result.tabFieldsChanged.sort()).toEqual(
+          ['columnWidths', 'conditionalFormats', 'frozenRows', 'regions'].sort()
+        );
+        expect(await audit.count()).toBe(1);
+      } finally {
+        await audit.drop();
+      }
+
+      const after = await revisionOf(pageId);
+      expect(after.revision).toBe(before.revision + 1);
+
+      const tab = (await getTab({ pageId }))!;
+      expect(tab.columnWidths).toEqual({ B: 240 });
+      expect(tab.frozenRows).toBe(1);
+      expect(tab.conditionalFormats).toEqual([FORMAT_RULE]);
+      expect(tab.regions).toEqual([REGION]);
+    });
+
+    it('bumps the page revision and stateHash — the silent-revert guard', async () => {
+      // Kills: a missing `touchPage`. Without it `replaceFromDocument` from a
+      // stale editor passes its revision check and rewrites every tab-level
+      // field from the old document, reverting the formatting.
+      const { pageId, ownerId } = await makeSheet({ rowCount: 10 });
+      const before = await revisionOf(pageId);
+
+      await applyFormatOps({ pageId }, [{ type: 'setCellFormat', range: 'A1', patch: BOLD }], { userId: ownerId });
+
+      const after = await revisionOf(pageId);
+      expect(after.revision).toBe(before.revision + 1);
+      expect(after.stateHash).not.toBe(before.stateHash);
+    });
+
+    it('refuses before writing anything, so a bad op bumps nothing', async () => {
+      // Kills: validating after a lock or a write. The plan throws first.
+      const { pageId, ownerId } = await makeSheet({ rowCount: 10 });
+      const before = await revisionOf(pageId);
+
+      await expect(
+        applyFormatOps(
+          { pageId },
+          [
+            { type: 'setCellFormat', range: 'A1', patch: BOLD },
+            { type: 'removeConditionalRule', id: 'missing' },
+          ],
+          { userId: ownerId }
+        )
+      ).rejects.toBeInstanceOf(SheetFormatError);
+
+      expect((await revisionOf(pageId)).revision).toBe(before.revision);
+      expect((await readSheetData({ pageId }))?.formats).toBeUndefined();
+    });
+
+    it('materialises an unmigrated sheet with the document’s rows intact', async () => {
+      // Kills: `getTab` where `ensureTab` belongs — the write would throw for
+      // every sheet nobody had backfilled — and a materialisation that loses
+      // the document's content.
+      const { pageId, ownerId } = await makeUnmigratedSheet(
+        '#%PAGESPACE_SHEETDOC v1\npage_id = "x"\n\n[[sheets]]\nname = "Sheet1"\norder = 0\n\n[sheets.meta]\nrowCount = 5\ncolumnCount = 3\n\n[sheets.cells.A1]\nvalue = "existing"\n'
+      );
+
+      await applyFormatOps({ pageId }, [{ type: 'setCellFormat', range: 'B1', patch: BOLD }], { userId: ownerId });
+
+      const tab = await getTab({ pageId });
+      expect(tab).not.toBeNull();
+      const rows = await readRows(tab!.id, { limit: 10 });
+      expect(cellAt(rows, 0, 'A')?.value).toBe('existing');
+      expect(cellAt(rows, 0, 'B')?.format).toEqual(BOLD);
+    });
+
+    it('lands both rules when two calls add different ones concurrently', async () => {
+      // Kills: skipping the tab `FOR UPDATE`, and taking it but writing the
+      // rule list planned BEFORE it — either way the second writer overwrites
+      // the first's rule with a list that never had it.
+      //
+      // Deterministic rather than a `Promise.all` race: the first call is
+      // held just before its `UPDATE sheet_tabs`, with the tab lock already
+      // taken, until the second call is observed waiting on that lock.
+      const { pageId, ownerId } = await makeSheet({ rowCount: 20 });
+      const second = { ...FORMAT_RULE, id: 'second' };
+
+      let other: Promise<unknown> | null = null;
+      await db.transaction(async (tx) =>
+        applyFormatOps(
+          { pageId },
+          [{ type: 'addConditionalRule', rule: FORMAT_RULE }],
+          { userId: ownerId },
+          holdBeforeUpdate(tx, async () => {
+            other ??= applyFormatOps({ pageId }, [{ type: 'addConditionalRule', rule: second }], { userId: ownerId });
+            await waitForLockWaiter();
+          })
+        )
+      );
+      await other;
+
+      const tab = (await getTab({ pageId }))!;
+      expect((tab.conditionalFormats as { id: string }[]).map((rule) => rule.id).sort()).toEqual(
+        ['over-100', 'second']
+      );
+    });
+
+    it('re-evaluates open-ended range formulas when the extent grows', async () => {
+      // `rowCount` is an input to a formula over an open range —
+      // `evaluateClosure` resolves `rect.rowEnd ?? rowCount - 1` — and a
+      // format write past the extent grows it, so a stored total would be
+      // wrong and presented as correct.
+      //
+      // HONEST SCOPE: the parser rejects `A:A` today (see `deps.ts`), so no
+      // formula can put an open edge into `sheet_range_deps` through the
+      // write path. The edge is seeded directly, and the input the recompute
+      // must pick up is a row past the extent whose value the stale
+      // materialisation never saw. What this kills: skipping the open-edge
+      // query, skipping the closure walk, or evaluating with the old extent
+      // (which would never load row 10).
+      const { pageId, tabId, ownerId } = await makeSheet({ rowCount: 3, columnCount: 3 });
+      await setCells({ pageId }, [
+        { address: 'A1', value: '1' },
+        { address: 'A2', value: '2' },
+        { address: 'A3', value: '3' },
+        { address: 'B1', value: '=SUM(A1:A10)' },
+      ], { userId: ownerId });
+      expect(cellAt(await readRows(tabId, { limit: 1 }), 0, 'B')?.value).toBe(6);
+
+      // A row past the extent, and the open edge the parser cannot yet write.
+      await db.insert(sheetRows).values({
+        tabId,
+        pageId,
+        rowIndex: 9,
+        cells: { A: { raw: '100', value: 100, type: 'number' } },
+      });
+      await db.delete(sheetRangeDeps).where(eq(sheetRangeDeps.tabId, tabId));
+      await db.insert(sheetRangeDeps).values({
+        tabId,
+        formulaAddress: 'B1',
+        rowStart: 0,
+        rowEnd: null,
+        colStart: 0,
+        colEnd: 0,
+      });
+
+      // No growth: no recompute, and the stale total stands.
+      const inside = await applyFormatOps(
+        { pageId },
+        [{ type: 'setCellFormat', range: 'C3', patch: BOLD }],
+        { userId: ownerId }
+      );
+      expect(inside.recomputed).toEqual([]);
+      expect(cellAt(await readRows(tabId, { limit: 1 }), 0, 'B')?.value).toBe(6);
+
+      // Growth: the formula is re-evaluated against the taller sheet.
+      const grown = await applyFormatOps(
+        { pageId },
+        [{ type: 'setCellFormat', range: 'C10', patch: BOLD }],
+        { userId: ownerId }
+      );
+      expect(grown.rowCount).toBe(10);
+      expect(grown.recomputed).toEqual(['B1']);
+      expect((await getTab({ pageId }))?.rowCount).toBe(10);
+      expect(cellAt(await readRows(tabId, { limit: 1 }), 0, 'B')?.value).toBe(106);
+    });
+
+    it('round-trips regions through the document and back', async () => {
+      // Kills: writing regions somewhere the projection does not read, or a
+      // shape the parser drops on the way back in.
+      const { pageId, ownerId } = await makeSheet({ rowCount: 20, columnCount: 6 });
+
+      await applyFormatOps({ pageId }, [{ type: 'setRegions', regions: [REGION] }], { userId: ownerId });
+
+      const document = (await readSheetDocument(pageId))!;
+      expect(parseSheetContent(document).regions).toEqual([REGION]);
+
+      await replaceFromDocument({ pageId }, document, { userId: ownerId });
+
+      expect((await readTabFormatting({ pageId }))?.regions).toEqual([REGION]);
+    });
+
+    it('logs a large range as one summary entry and a small one per cell', async () => {
+      // Kills: per-cell log rows past `CHANGE_LOG_SUMMARY_THRESHOLD` — the
+      // write amplification the row store removed, back in the audit trail.
+      const { pageId, tabId, ownerId } = await makeSheet({ rowCount: 1_000 });
+
+      await applyFormatOps({ pageId }, [{ type: 'setCellFormat', range: 'A1:A600', patch: BOLD }], { userId: ownerId });
+      const bulk = await db
+        .select({ address: sheetChanges.address, after: sheetChanges.after })
+        .from(sheetChanges)
+        .where(and(eq(sheetChanges.tabId, tabId), eq(sheetChanges.op, 'format')));
+      expect(bulk).toHaveLength(1);
+      expect(bulk[0].address).toBeNull();
+      expect(bulk[0].after).toMatchObject({ cells: 600, firstAddress: 'A1', lastAddress: 'A600' });
+
+      await applyFormatOps({ pageId }, [{ type: 'setCellFormat', range: 'B1:B2', patch: BOLD }], { userId: ownerId });
+      const small = await db
+        .select({ address: sheetChanges.address, before: sheetChanges.before, after: sheetChanges.after })
+        .from(sheetChanges)
+        .where(and(eq(sheetChanges.tabId, tabId), inArray(sheetChanges.address, ['B1', 'B2'])));
+      expect(small.map((entry) => entry.address).sort()).toEqual(['B1', 'B2']);
+      expect(small[0].before).toBeNull();
+      expect(small[0].after).toEqual(BOLD);
+    });
+  });
+
+  describe('readTabFormatting', () => {
+    it('returns null for an unmigrated sheet without materialising it', async () => {
+      // A read must never write. The `null` alone passes vacuously — a read
+      // that materialised and then failed would also return it — so the
+      // assertion that matters is that no tab row appeared.
+      const { pageId } = await makeUnmigratedSheet(
+        '#%PAGESPACE_SHEETDOC v1\npage_id = "x"\n\n[[sheets]]\nname = "Sheet1"\norder = 0\n\n[sheets.meta]\nrowCount = 5\ncolumnCount = 3\n\n[sheets.cells.A1]\nvalue = "existing"\n'
+      );
+
+      expect(await readTabFormatting({ pageId }, { ranges: ['A1:C5'] })).toBeNull();
+
+      const tabs = await db.select({ id: sheetTabs.id }).from(sheetTabs).where(eq(sheetTabs.pageId, pageId));
+      expect(tabs).toHaveLength(0);
+    });
+
+    it('returns tab fields, parsed rules and regions, and per-cell formats inside the ranges', async () => {
+      // Kills: returning the raw rule column (the bogus entry would come back
+      // and be written again by any caller that round-trips), and returning
+      // formats outside the requested rectangles.
+      const { pageId, tabId, ownerId } = await makeSheet({ rowCount: 20, columnCount: 6 });
+      await applyFormatOps(
+        { pageId },
+        [
+          { type: 'setCellFormat', range: 'B2:C3', patch: BOLD },
+          { type: 'setCellFormat', range: 'E9', patch: { italic: true } },
+          { type: 'setColumnFormat', column: 'A', patch: { align: 'right' } },
+          { type: 'setRowHeight', row: 2, height: 40 },
+          { type: 'setFrozen', rows: 1, columns: 1 },
+          { type: 'setRegions', regions: [REGION] },
+        ],
+        { userId: ownerId }
+      );
+      await db
+        .update(sheetTabs)
+        .set({ conditionalFormats: [FORMAT_RULE, { id: 'bogus', kind: 'formula', formula: '' }] })
+        .where(eq(sheetTabs.id, tabId));
+
+      const formatting = (await readTabFormatting({ pageId }, { ranges: ['B2:B9', 'C3'] }))!;
+
+      expect(formatting.conditionalFormats).toEqual([FORMAT_RULE]);
+      expect(formatting.regions).toEqual([REGION]);
+      expect(formatting.columnFormats).toEqual({ A: { align: 'right' } });
+      expect(formatting.rowHeights).toEqual({ '2': 40 });
+      expect(formatting.frozenRows).toBe(1);
+      expect(formatting.frozenColumns).toBe(1);
+      // B2, B3 and C3 are inside; C2 is outside both ranges and E9 is far away.
+      expect(Object.keys(formatting.cellFormats).sort()).toEqual(['B2', 'B3', 'C3']);
+      expect(formatting.cellFormats.B2).toEqual(BOLD);
+
+      // No ranges: no per-cell read at all.
+      expect((await readTabFormatting({ pageId }))?.cellFormats).toEqual({});
+    });
+
+    it('refuses a range it cannot address or that is too large to expand', async () => {
+      const { pageId } = await makeSheet({ rowCount: 20 });
+      await expect(readTabFormatting({ pageId }, { ranges: ['A0:B2'] })).rejects.toThrow(/Invalid range/);
+      await expect(readTabFormatting({ pageId }, { ranges: ['A1:ZZ50000'] })).rejects.toThrow(/cells/);
     });
   });
 });

--- a/packages/lib/src/sheets/__tests__/sheet-store.integration.test.ts
+++ b/packages/lib/src/sheets/__tests__/sheet-store.integration.test.ts
@@ -1421,6 +1421,74 @@ describe('sheet store (integration)', () => {
       expect(cellAt(rows, 4, 'C')?.format).toEqual(BOLD);
     });
 
+    it('composes a value write and a format write to the SAME empty cell in either order', async () => {
+      // Kills: a column-level merge. An empty cell has no row to lock, so a
+      // value write and a format write to it can both read nothing and both
+      // upsert; if the cell object under the column is replaced whole, the
+      // second commit either drops the format or overwrites the just-entered
+      // value with `raw: ''`. Both orders are forced, the same way as above.
+      const { pageId, tabId, ownerId } = await makeSheet({ rowCount: 10 });
+
+      // Format commits second.
+      let value: Promise<unknown> | null = null;
+      await db.transaction(async (tx) =>
+        applyFormatOps(
+          { pageId },
+          [{ type: 'setCellFormat', range: 'C5', patch: BOLD }],
+          { userId: ownerId },
+          holdBeforeInsert(tx, async () => {
+            value ??= setCells({ pageId }, [{ address: 'C5', value: '=1+1' }], { userId: ownerId });
+            await value;
+          })
+        )
+      );
+      await value;
+      let cell = cellAt(await readRows(tabId, { limit: 10 }), 4, 'C');
+      expect(cell).toMatchObject({ raw: '=1+1', value: 2, type: 'number', format: BOLD });
+
+      // Value commits second — `setCells`'s own merge must leave the format.
+      // A different row: row 5 now exists, so a write to it would take its
+      // lock and the held transaction would block the one it is waiting for.
+      let format: Promise<unknown> | null = null;
+      await db.transaction(async (tx) =>
+        setCells(
+          { pageId },
+          [{ address: 'D7', value: 'typed' }],
+          { userId: ownerId },
+          holdBeforeInsert(tx, async () => {
+            format ??= applyFormatOps({ pageId }, [{ type: 'setCellFormat', range: 'D7', patch: { italic: true } }], { userId: ownerId });
+            await format;
+          })
+        )
+      );
+      await format;
+      cell = cellAt(await readRows(tabId, { limit: 10 }), 6, 'D');
+      expect(cell).toMatchObject({ raw: 'typed', value: 'typed', format: { italic: true } });
+    });
+
+    it('does not bump the revision or log when a request changes nothing', async () => {
+      // Kills: an unconditional `touchPage`. A retried or redundant request —
+      // the width a column already has, a bold that is already bold — is not
+      // an edit, and bumping for it forces an open editor into a conflict over
+      // a sheet that did not move.
+      const { pageId, tabId, ownerId } = await makeSheet({ rowCount: 10 });
+      const ops = [
+        { type: 'setCellFormat' as const, range: 'A1:B2', patch: BOLD },
+        { type: 'setColumnWidth' as const, column: 'B', width: 240 },
+      ];
+      await applyFormatOps({ pageId }, ops, { userId: ownerId });
+      const before = await revisionOf(pageId);
+      const logged = (await db.select({ id: sheetChanges.id }).from(sheetChanges).where(eq(sheetChanges.tabId, tabId))).length;
+
+      const again = await applyFormatOps({ pageId }, ops, { userId: ownerId });
+
+      expect(again.rowsTouched).toBe(0);
+      expect(again.cellsFormatted).toBe(0);
+      expect(again.tabFieldsChanged).toEqual([]);
+      expect(await revisionOf(pageId)).toEqual(before);
+      expect((await db.select({ id: sheetChanges.id }).from(sheetChanges).where(eq(sheetChanges.tabId, tabId))).length).toBe(logged);
+    });
+
     it('leaves a formula cell’s raw, value and type untouched', async () => {
       // Kills: fabricating a `StoredCell` instead of spreading the loaded one.
       const { pageId, tabId, ownerId } = await makeSheet({ rowCount: 10 });

--- a/packages/lib/src/sheets/format-request.ts
+++ b/packages/lib/src/sheets/format-request.ts
@@ -559,7 +559,8 @@ const refuse: (message: string, opIndex?: number) => never = (message, opIndex) 
 const refuseOp: (index: number, type: string, message: string) => never = (index, type, message) =>
   refuse(`Op ${index} (${type}): ${message}`, index);
 
-interface RangeSpan {
+/** The 0-based, inclusive bounds of a cell range. */
+export interface RangeSpan {
   rowStart: number;
   rowEnd: number;
   colStart: number;
@@ -606,8 +607,12 @@ function rangeHint(range: string): string {
  * the bound exists to prevent. This walks the same acceptances it does,
  * including rejecting the truncated `A1:` and the row-0 addresses
  * `decodeCellAddress` will happily decode to -1.
+ *
+ * Exported for the store's read side, which accepts the same range notation
+ * this module accepts on the write side — one definition of "a cell range",
+ * so nothing a caller can format is unreadable and vice versa.
  */
-function parseRangeSpan(range: string): RangeSpan | null {
+export function parseRangeSpan(range: string): RangeSpan | null {
   const normalized = range.trim().toUpperCase();
   const [rawStart, rawEnd, ...extra] = normalized.split(':');
   if (!rawStart || extra.length > 0) return null;

--- a/packages/lib/src/sheets/store.ts
+++ b/packages/lib/src/sheets/store.ts
@@ -28,7 +28,7 @@ import {
   sheetChanges,
   type StoredCell,
 } from '@pagespace/db/schema';
-import type { SheetData, SheetCellUpdate } from './types';
+import type { SheetData, SheetCellUpdate, CellFormat } from './types';
 import {
   MAX_ADDRESSABLE_ROW,
   MAX_ADDRESSABLE_COLUMN,
@@ -47,6 +47,20 @@ import {
 } from './io';
 import { SHEET_DEFAULT_ROWS, SHEET_DEFAULT_COLUMNS } from './constants';
 import { evaluateAddresses } from './evaluation';
+import {
+  planFormatOps,
+  parseRangeSpan,
+  MAX_FORMAT_OPS,
+  MAX_FORMAT_CELLS_PER_REQUEST,
+  type SheetFormatOp,
+  type SheetFormatPlan,
+  type SheetFormatTarget,
+  type RangeSpan,
+} from './format-request';
+import { parseConditionalRules, type ConditionalRule } from './conditional';
+import { parseRegions, type SheetRegion } from './regions';
+import { setColumnFormat, setColumnWidth, setRowHeight, setFrozen } from './format-ops';
+import { isEmptyFormat } from './format';
 import {
   sheetDataFromRows,
   rowsFromSheetData,
@@ -1030,6 +1044,696 @@ export async function setCells(
   };
 
   return exec ? run(exec) : db.transaction(run);
+}
+
+// ---------------------------------------------------------------------------
+// Formatting
+// ---------------------------------------------------------------------------
+
+export interface ApplyFormatOpsResult {
+  /** Cells whose stored `format` changed. */
+  cellsFormatted: number;
+  /**
+   * `sheet_rows` rows this call wrote, formulas re-evaluated for growth
+   * included.
+   *
+   * Reported because a stored value cannot show it: `A1` being bold after a
+   * call looks identical whether the call wrote one row or rewrote fifty
+   * thousand. A caller — and the test that pins this — asserts the write was
+   * O(touched) from this number.
+   */
+  rowsTouched: number;
+  /** The `sheet_tabs` columns whose stored value changed, by column name. */
+  tabFieldsChanged: string[];
+  /** Conditional rules on the tab after the write. */
+  conditionalRules: number;
+  /** Regions on the tab after the write. */
+  regions: number;
+  rowCount: number;
+  columnCount: number;
+  /**
+   * Formulas re-evaluated because the extent grew. Empty for every other
+   * format write — see the growth note in `applyFormatOps`.
+   */
+  recomputed: string[];
+}
+
+/**
+ * The `sheet_tabs` columns a format write may touch, in the order the change
+ * log reports them. `rowCount`/`columnCount` are here because growth is a
+ * format write's side effect on the same row.
+ */
+const TAB_FORMAT_FIELDS = [
+  'columnFormats',
+  'columnWidths',
+  'rowHeights',
+  'frozenRows',
+  'frozenColumns',
+  'conditionalFormats',
+  'regions',
+  'rowCount',
+  'columnCount',
+] as const;
+
+type TabFormatField = (typeof TAB_FORMAT_FIELDS)[number];
+
+/**
+ * Values for those columns. A field absent from the object is one the write
+ * does not touch; `null` is an explicit "store nothing", which is what the
+ * document path writes for an empty map or list.
+ */
+interface TabFieldValues {
+  columnFormats?: Record<string, CellFormat> | null;
+  columnWidths?: Record<string, number> | null;
+  rowHeights?: Record<string, number> | null;
+  frozenRows?: number | null;
+  frozenColumns?: number | null;
+  conditionalFormats?: ConditionalRule[] | null;
+  regions?: SheetRegion[] | null;
+  rowCount?: number;
+  columnCount?: number;
+}
+
+/**
+ * Apply presentation edits — cell formats, column defaults, widths, heights,
+ * freezes, conditional rules, regions — and nothing else.
+ *
+ * The write path for everything `format-ops` can express, which until now had
+ * only browser callers: an agent could set a cell's value and not one thing
+ * about how it looked. Validation is `planFormatOps`'s job and every refusal
+ * is a `SheetFormatError` thrown before any lock is taken; this function is the
+ * persistence that plan describes, and it deliberately second-guesses none of
+ * it.
+ *
+ * Persistence is split. A cell's own format lives on its row in
+ * `sheet_rows.cells`, so a per-cell op is a row write scoped to the rows the
+ * plan names — formatting `A1:H1` on a 50,000-row sheet reads, locks and
+ * writes one row. Everything else lives on the tab record and is written as
+ * ONE `UPDATE` however many ops asked for it: an editor holding the sheet open
+ * sees one conflict, not one per op.
+ *
+ * Ops may address past the declared extent, and the sheet GROWS to cover them
+ * — the decision `edit_sheet_cells` already made for values, applied to
+ * formats. Growth carries an obligation the write would otherwise skip:
+ * `evaluateClosure` resolves an open range's end from `rowCount`, so
+ * `=SUM(A:A)` means something different once the sheet is taller, and a format
+ * write does no recompute of its own. On growth, every formula holding an
+ * open-ended range is re-evaluated along with its dependents. When the extent
+ * does not grow no value can change — the evaluator's sheet carries no
+ * formats and `StoredCell` has no rendered form — so no recompute runs.
+ */
+export async function applyFormatOps(
+  ref: TabRef,
+  ops: readonly SheetFormatOp[],
+  actor: SheetActor = {},
+  exec?: Executor
+): Promise<ApplyFormatOpsResult> {
+  const run = async (tx: Executor): Promise<ApplyFormatOpsResult> => {
+    const tab = await ensureTab(ref, tx);
+
+    // 1. Validate and plan, before any lock.
+    //
+    // `planFormatOps` refuses everything it is going to refuse here, on the
+    // pre-lock snapshot, so a bad request costs no transaction time. The plan
+    // is also what the locks are derived from: `plan.rows` is exactly the set
+    // of `sheet_rows` a per-cell op will write, and the tab-field flag and the
+    // extent decision below settle whether the tab record is written at all.
+    const preview = planFormatOps(ops, formatTarget(tab));
+    const rowIndexes = Array.from(preview.rows);
+    const growth = formatGrowth(tab, preview);
+
+    if (rowIndexes.length === 0 && !preview.touchesTabFields && !growth) {
+      // Nothing to write, so nothing to lock, bump or log.
+      return {
+        cellsFormatted: 0,
+        rowsTouched: 0,
+        tabFieldsChanged: [],
+        conditionalRules: preview.conditionalFormats.length,
+        regions: preview.regions.length,
+        rowCount: tab.rowCount,
+        columnCount: tab.columnCount,
+        recomputed: [],
+      };
+    }
+
+    // 2. If the extent grows, resolve what has to be re-evaluated — BEFORE the
+    // locks, because the locks are derived from it, exactly as `setCells`
+    // resolves its closure. Locking the formula rows later, after the rows
+    // this call formats, would be a second ordered acquisition — and two
+    // ordered statements are not globally ordered. A `setCells` holding a
+    // formula's row while it waits for one of ours is then a cycle.
+    //
+    // Only formulas with an OPEN-ENDED range are seeded: a bounded rectangle
+    // reads the same cells whatever the extent, and the rows a format op
+    // creates carry no values. The narrow race `setCells` documents applies
+    // here too — a formula created concurrently in another row after this
+    // snapshot keeps a stale result until something touches it.
+    let recomputeTargets: string[] = [];
+    if (growth) {
+      const open = await openRangeFormulas(tab.id, tx);
+      if (open.length > 0) {
+        const closure = await resolveDependentClosure(tab.id, open, tx);
+        recomputeTargets = unique([...open, ...closure]);
+      }
+    }
+    const recomputeRowIndexes = unique(
+      recomputeTargets.map((address) => decodeCellAddress(address).row)
+    );
+    const allRowIndexes = unique([...rowIndexes, ...recomputeRowIndexes]);
+
+    // 3. TAB BEFORE ROWS, and only when this write will touch the tab — the
+    // same conditional order `setCells` uses, for the same two reasons.
+    // `appendRows`, `deleteRows` and `replaceFromDocument` all take the tab
+    // first and then reach rows, so rows-then-tab is a deadlock against every
+    // one of them; and taking the tab unconditionally would serialise every
+    // write to the sheet behind one exclusive lock, undoing the concurrency
+    // the row store exists to provide. Whether the tab will be written is
+    // decidable from the ops and the extent, both known here.
+    const touchesTab = preview.touchesTabFields || growth !== null;
+    if (touchesTab) {
+      await tx.select({ id: sheetTabs.id }).from(sheetTabs).where(eq(sheetTabs.id, tab.id)).for('update');
+    }
+    await lockRows(tab.id, allRowIndexes, tx);
+
+    // 4. Re-read UNDER the lock and plan again against what is actually there.
+    //
+    // The `tab` from `ensureTab` is a snapshot taken before any lock. A rule
+    // another transaction added while this one waited for the tab is absent
+    // from it, and a plan built on it would write a rule list without that
+    // rule — a lost update with a success returned to both. Planning twice is
+    // pure and bounded; the second plan is the one that is written, and the
+    // first exists only to decide what to lock. Rows depend on the ops alone,
+    // so the two agree on what was locked.
+    const current = await getTab(ref, tx);
+    if (!current) throw new Error(`Sheet tab not found for page ${ref.pageId}`);
+    const plan = planFormatOps(ops, formatTarget(current));
+
+    // Growth is re-derived from the locked extent, and only if the snapshot
+    // said so: if it did not, no tab lock is held and the recompute seeds were
+    // never resolved, and the window where the extent SHRANK in between is
+    // the same one `setCells` accepts rather than acquiring more locks out of
+    // order for it.
+    const grown = growth ? formatGrowth(current, plan) : null;
+    const extent = {
+      rowCount: grown?.rowCount ?? current.rowCount,
+      columnCount: grown?.columnCount ?? current.columnCount,
+    };
+
+    // 5. Rows. Read whole — a `StoredCell` cannot be fabricated, since `raw`,
+    // `value`, `type`, `error` and `notes` must all survive untouched — but
+    // written PARTIAL: `pending` carries only the column letters this call
+    // formats, so the jsonb merge in `persistRows` contributes those keys and
+    // leaves a concurrent `setCells` to column A of the same row alone. That
+    // is the lost-update guard `persistRows` was written for, not an
+    // optimisation.
+    //
+    // `lockRows` already holds the locks, so this read takes none.
+    const working = await loadRowsByIndex(tab.id, allRowIndexes, tx, false);
+    const pending = new Map<number, StoredRow>();
+    const stage = (rowIndex: number, label: string, cell: StoredCell) => {
+      for (const map of [working, pending]) {
+        let row = map.get(rowIndex);
+        if (!row) {
+          row = { rowIndex, cells: {} };
+          map.set(rowIndex, row);
+        }
+        row.cells[label] = cell;
+      }
+    };
+
+    // The format each written cell had before this call, keyed by address in
+    // the order cells were first touched. Doubles as the count of cells
+    // formatted and as the change log's `before`.
+    const before = new Map<string, CellFormat | null>();
+
+    for (const step of plan.steps) {
+      if (step.type !== 'setCellFormat' && step.type !== 'clearCellFormat') continue;
+
+      for (const address of step.addresses) {
+        const { row: rowIndex, column } = decodeCellAddress(address);
+        const label = encodeColumnLabel(column);
+        const existing = working.get(rowIndex)?.cells[label];
+
+        const next =
+          step.type === 'setCellFormat'
+            ? mergeCellFormat(existing?.format, step.patch)
+            : undefined;
+        if (sameJson(existing?.format, next)) continue;
+
+        // An empty cell has no `StoredCell` to carry a format, so one is
+        // created as `{ raw: '', format }`. This round-trips: the projection
+        // skips `raw === ''` for `cells` and keeps `formats[address]`.
+        //
+        // Clearing the last format of such a cell leaves `{ raw: '' }` behind
+        // — a tombstone. jsonb `||` cannot delete a key, and the alternative,
+        // replace mode, would reintroduce the lost update above to remove an
+        // inert object. The tombstone projects to nothing and `rebuildTab`
+        // collects it. Do not "fix" this with replace mode.
+        const cell: StoredCell = { ...(existing ?? { raw: '' }) };
+        if (next) cell.format = next;
+        else delete cell.format;
+
+        if (!before.has(address)) before.set(address, existing?.format ?? null);
+        stage(rowIndex, label, cell);
+      }
+    }
+
+    // 6. Re-evaluate what growth changed the meaning of. `evaluateClosure`
+    // reads the extent from the tab it is handed, so it gets the GROWN one.
+    // `applyEvaluation` writes into `working`, whose formula rows were loaded
+    // whole; only the cells it re-evaluated are copied into `pending`.
+    let recomputed: string[] = [];
+    if (grown && recomputeTargets.length > 0) {
+      const evaluated = await evaluateClosure({ ...current, ...extent }, recomputeTargets, working, tx);
+      applyEvaluation(working, evaluated);
+      for (const address of Object.keys(evaluated)) {
+        const { row: rowIndex, column } = decodeCellAddress(address);
+        const label = encodeColumnLabel(column);
+        const cell = working.get(rowIndex)?.cells[label];
+        // `applyEvaluation` fabricates neither rows nor cells; neither does this.
+        if (!cell) continue;
+        stage(rowIndex, label, cell);
+        recomputed.push(address);
+      }
+      recomputed = unique(recomputed);
+    }
+
+    // 7. Persist — merge mode, which is the default and the point.
+    await persistRows(tab.id, ref.pageId, pending, tx);
+
+    // 8. The tab record, in ONE statement.
+    //
+    // Only the columns whose stored value differs are set, and only if any do:
+    // a `setColumnWidth` to the width a column already has is not a write.
+    // Rules and regions are compared as the lists the parser produces, so a
+    // stored entry the parser drops does not register as a change here — and
+    // is not resurrected, because what is written is the parsed list.
+    const tabFieldsChanged: TabFormatField[] = [];
+    const next: TabFieldValues = touchesTab ? tabFieldsAfter(current, plan, grown) : {};
+    if (touchesTab) {
+      const patch: TabFieldValues = {};
+      for (const field of TAB_FORMAT_FIELDS) {
+        if (!(field in next)) continue;
+        if (sameJson(currentTabField(current, field), next[field])) continue;
+        tabFieldsChanged.push(field);
+        Object.assign(patch, { [field]: next[field] });
+      }
+      if (tabFieldsChanged.length > 0) {
+        await tx
+          .update(sheetTabs)
+          .set({ ...patch, updatedAt: new Date() })
+          .where(eq(sheetTabs.id, tab.id));
+      }
+    }
+
+    // 9. Not optional. `replaceFromDocument` rewrites EVERY tab-level field
+    // from the editor's document, and it is the only other writer of these
+    // fields. An editor that had the sheet open before this call and saves
+    // after it would, without the revision bump, pass its conflict check and
+    // silently revert everything written above — cell formats included, since
+    // its document carries `formats` too.
+    await touchPage(ref.pageId, tx);
+
+    // 10. The log. Per cell up to the summary threshold, then one entry: a
+    // 5,000-cell range is one act, and 5,000 rows for it is the write
+    // amplification the row store removed from the data coming back in the
+    // audit trail. Tab-level changes are one entry per field, carrying the
+    // whole before/after map — bounded by the column count, never the rows.
+    const entries: Parameters<typeof appendChanges>[3] = [];
+    if (!actor.suppressCellLog && before.size > 0) {
+      const addresses = Array.from(before.keys());
+      if (addresses.length > CHANGE_LOG_SUMMARY_THRESHOLD) {
+        entries.push({
+          op: 'format',
+          address: null,
+          rowIndex: decodeCellAddress(addresses[0]).row,
+          before: null,
+          after: {
+            cells: addresses.length,
+            firstAddress: addresses[0],
+            lastAddress: addresses[addresses.length - 1],
+          },
+        });
+      } else {
+        for (const address of addresses) {
+          const { row: rowIndex, column } = decodeCellAddress(address);
+          entries.push({
+            op: 'format',
+            address,
+            rowIndex,
+            before: before.get(address) ?? null,
+            after: working.get(rowIndex)?.cells[encodeColumnLabel(column)]?.format ?? null,
+          });
+        }
+      }
+    }
+    for (const field of tabFieldsChanged) {
+      entries.push({
+        op: TAB_FIELD_LOG_OP[field],
+        address: null,
+        rowIndex: null,
+        before: { [field]: currentTabField(current, field) ?? null },
+        after: { [field]: next[field] ?? null },
+      });
+    }
+    await appendChanges(ref.pageId, tab.id, actor, entries, tx);
+
+    return {
+      cellsFormatted: before.size,
+      rowsTouched: pending.size,
+      tabFieldsChanged,
+      conditionalRules: plan.conditionalFormats.length,
+      regions: plan.regions.length,
+      rowCount: extent.rowCount,
+      columnCount: extent.columnCount,
+      recomputed,
+    };
+  };
+
+  return exec ? run(exec) : db.transaction(run);
+}
+
+export interface ReadTabFormattingOptions {
+  /**
+   * A1 ranges — `"B2:D40"`, or a single cell — whose per-cell formats to
+   * return. Omitted, none are read: they live on the rows, and reading them
+   * for a whole sheet is the O(sheet) read this store exists to avoid. Bounded
+   * by `MAX_FORMAT_CELLS_PER_REQUEST` across all ranges, the same ceiling a
+   * write has.
+   */
+  ranges?: readonly string[];
+}
+
+export interface TabFormatting {
+  rowCount: number;
+  columnCount: number;
+  frozenRows: number | null;
+  frozenColumns: number | null;
+  /** Column defaults, keyed by column letters. */
+  columnFormats: Record<string, CellFormat>;
+  columnWidths: Record<string, number>;
+  /** Keyed by 1-based row number as a string, as stored. */
+  rowHeights: Record<string, number>;
+  /** Parsed — what the sheet will actually apply, not the raw column. */
+  conditionalFormats: ConditionalRule[];
+  regions: SheetRegion[];
+  /**
+   * Explicit per-cell formats within `options.ranges`, keyed by A1 address.
+   * Explicit only: the format in force for a cell also depends on its column
+   * default and its region, and `resolveCellFormat` is the one definition of
+   * that precedence. A second one here is how the grid and an export come to
+   * disagree.
+   */
+  cellFormats: Record<string, CellFormat>;
+}
+
+/**
+ * Everything about how a tab looks, in one read.
+ *
+ * A read, so it never writes: `getTab` rather than `ensureTab`, and an
+ * unmigrated sheet answers `null` instead of being materialised on the way
+ * past. Rules and regions come back PARSED — a caller that read the raw jsonb
+ * and wrote it back would resurrect entries the parser drops on every load.
+ *
+ * Per-cell formats are read by row span, one statement for every range asked
+ * for however many there are, and only the cells inside a requested rectangle
+ * are returned.
+ */
+export async function readTabFormatting(
+  ref: TabRef,
+  options: ReadTabFormattingOptions = {},
+  exec: Executor = db
+): Promise<TabFormatting | null> {
+  const tab = await getTab(ref, exec);
+  if (!tab) return null;
+
+  const cellFormats: Record<string, CellFormat> = {};
+  const ranges = options.ranges ?? [];
+  if (ranges.length > MAX_FORMAT_OPS) {
+    throw new SheetAddressError(`At most ${MAX_FORMAT_OPS} ranges can be read at once; got ${ranges.length}`);
+  }
+
+  if (ranges.length > 0) {
+    const spans: RangeSpan[] = [];
+    let cells = 0;
+    for (const range of ranges) {
+      const span = parseRangeSpan(range);
+      if (!span) throw new SheetAddressError(`Invalid range: ${range}`);
+      // Counted before anything is read, so the cap bounds the read and not
+      // just the result. A one-column range still costs a row per cell.
+      cells += (span.rowEnd - span.rowStart + 1) * (span.colEnd - span.colStart + 1);
+      if (cells > MAX_FORMAT_CELLS_PER_REQUEST) {
+        throw new SheetAddressError(
+          `Ranges cover more than ${MAX_FORMAT_CELLS_PER_REQUEST.toLocaleString()} cells; narrow them`
+        );
+      }
+      spans.push(span);
+    }
+
+    const rows = new Map<number, StoredRow>();
+    await mergeMissingSpans(
+      rows,
+      tab.id,
+      spans.map((span) => ({ start: span.rowStart, end: span.rowEnd })),
+      exec
+    );
+
+    for (const row of rows.values()) {
+      for (const [label, cell] of Object.entries(row.cells)) {
+        if (!cell.format) continue;
+        const column = decodeColumnLabel(label);
+        const inside = spans.some(
+          (span) =>
+            row.rowIndex >= span.rowStart &&
+            row.rowIndex <= span.rowEnd &&
+            column >= span.colStart &&
+            column <= span.colEnd
+        );
+        if (inside) cellFormats[`${label}${row.rowIndex + 1}`] = cell.format;
+      }
+    }
+  }
+
+  return {
+    rowCount: tab.rowCount,
+    columnCount: tab.columnCount,
+    frozenRows: tab.frozenRows ?? null,
+    frozenColumns: tab.frozenColumns ?? null,
+    columnFormats: tab.columnFormats ?? {},
+    columnWidths: tab.columnWidths ?? {},
+    rowHeights: tab.rowHeights ?? {},
+    conditionalFormats: parseConditionalRules(tab.conditionalFormats ?? undefined) ?? [],
+    regions: parseRegions(tab.regions ?? undefined) ?? [],
+    cellFormats,
+  };
+}
+
+/**
+ * The tab as `planFormatOps` wants to see it: rules and regions parsed, so the
+ * plan is checked against — and folds its edits into — the list the sheet
+ * actually applies rather than whatever the column holds.
+ */
+function formatTarget(tab: StoredTab): SheetFormatTarget {
+  return {
+    rowCount: tab.rowCount,
+    columnCount: tab.columnCount,
+    conditionalFormats: parseConditionalRules(tab.conditionalFormats ?? undefined) ?? [],
+    regions: parseRegions(tab.regions ?? undefined) ?? [],
+  };
+}
+
+/**
+ * The extent a plan needs, or null if the tab already covers it.
+ *
+ * Cells, columns and row heights past the extent grow it; a rule's ranges and
+ * a region do not. Both are declared over rows that do not exist yet by
+ * design — a region's whole point is to cover the table as it grows — and a
+ * declaration is not a request for the rows to exist.
+ */
+function formatGrowth(
+  tab: StoredTab,
+  plan: SheetFormatPlan
+): { rowCount: number; columnCount: number } | null {
+  let rowCount = tab.rowCount;
+  let columnCount = tab.columnCount;
+
+  for (const row of plan.rows) rowCount = Math.max(rowCount, row + 1);
+
+  for (const step of plan.steps) {
+    switch (step.type) {
+      case 'setCellFormat':
+      case 'clearCellFormat':
+        for (const address of step.addresses) {
+          columnCount = Math.max(columnCount, decodeCellAddress(address).column + 1);
+        }
+        break;
+      case 'setColumnFormat':
+      case 'setColumnWidth':
+        columnCount = Math.max(columnCount, step.columnIndex + 1);
+        break;
+      case 'setRowHeight':
+        rowCount = Math.max(rowCount, step.rowIndex + 1);
+        break;
+      default:
+        break;
+    }
+  }
+
+  return rowCount === tab.rowCount && columnCount === tab.columnCount
+    ? null
+    : { rowCount, columnCount };
+}
+
+/**
+ * Every formula on the tab that reads an open-ended range — `A:A`, `3:3` —
+ * whose meaning depends on the declared extent.
+ */
+async function openRangeFormulas(tabId: string, exec: Executor): Promise<string[]> {
+  const found = await exec
+    .select({ address: sheetRangeDeps.formulaAddress })
+    .from(sheetRangeDeps)
+    .where(
+      and(
+        eq(sheetRangeDeps.tabId, tabId),
+        sql`(${sheetRangeDeps.rowEnd} IS NULL OR ${sheetRangeDeps.colEnd} IS NULL)`
+      )
+    )
+    .limit(MAX_RECOMPUTE_CLOSURE + 1);
+
+  // The same ceiling `resolveDependentClosure` enforces, and for the same
+  // reason: silently recomputing a truncated set would leave stale values
+  // presented as correct.
+  if (found.length > MAX_RECOMPUTE_CLOSURE) {
+    throw new Error(
+      `Recompute closure reached ${MAX_RECOMPUTE_CLOSURE} cells; rebuild the sheet instead`
+    );
+  }
+
+  return unique(found.map((row) => row.address.toUpperCase()));
+}
+
+/**
+ * The tab-level fields as they will be after `plan`, computed by running the
+ * plan's tab steps through `format-ops` — the single mutation surface for
+ * these maps, so clamping and "delete the key when cleared" are defined once.
+ * A field the plan does not touch is absent, not null.
+ *
+ * Empty maps and lists are stored as `null`, matching what the document path
+ * writes for a sheet that has none.
+ */
+function tabFieldsAfter(
+  current: StoredTab,
+  plan: SheetFormatPlan,
+  grown: { rowCount: number; columnCount: number } | null
+): TabFieldValues {
+  let sheet: SheetData = {
+    version: 0,
+    rowCount: current.rowCount,
+    columnCount: current.columnCount,
+    cells: {},
+    columnFormats: current.columnFormats ?? undefined,
+    columnWidths: current.columnWidths ?? undefined,
+    rowHeights: current.rowHeights ?? undefined,
+    frozenRows: current.frozenRows ?? undefined,
+    frozenColumns: current.frozenColumns ?? undefined,
+  };
+
+  const next: TabFieldValues = {};
+  for (const step of plan.steps) {
+    switch (step.type) {
+      case 'setColumnFormat':
+        sheet = setColumnFormat(sheet, step.columnIndex, step.patch);
+        next.columnFormats = sheet.columnFormats ?? null;
+        break;
+      case 'setColumnWidth':
+        sheet = setColumnWidth(sheet, step.columnIndex, step.width);
+        next.columnWidths = sheet.columnWidths ?? null;
+        break;
+      case 'setRowHeight':
+        sheet = setRowHeight(sheet, step.rowIndex, step.height);
+        next.rowHeights = sheet.rowHeights ?? null;
+        break;
+      case 'setFrozen':
+        sheet = setFrozen(sheet, step.rows, step.columns);
+        next.frozenRows = sheet.frozenRows ?? null;
+        next.frozenColumns = sheet.frozenColumns ?? null;
+        break;
+      case 'setConditionalRules':
+        next.conditionalFormats = step.rules.length > 0 ? [...step.rules] : null;
+        break;
+      case 'setRegions':
+        next.regions = step.regions.length > 0 ? [...step.regions] : null;
+        break;
+      default:
+        break;
+    }
+  }
+
+  if (grown) {
+    next.rowCount = grown.rowCount;
+    next.columnCount = grown.columnCount;
+  }
+
+  return next;
+}
+
+/**
+ * A tab field as it is stored, normalised for comparison: rules and regions
+ * through the parser (what the sheet applies), everything else as-is with
+ * "absent" and `null` the same thing.
+ */
+function currentTabField(tab: StoredTab, field: TabFormatField): unknown {
+  switch (field) {
+    case 'conditionalFormats':
+      return parseConditionalRules(tab.conditionalFormats ?? undefined) ?? null;
+    case 'regions':
+      return parseRegions(tab.regions ?? undefined) ?? null;
+    default:
+      return tab[field] ?? null;
+  }
+}
+
+const TAB_FIELD_LOG_OP: Record<TabFormatField, 'format' | 'resize' | 'tab'> = {
+  columnFormats: 'format',
+  conditionalFormats: 'format',
+  columnWidths: 'resize',
+  rowHeights: 'resize',
+  rowCount: 'resize',
+  columnCount: 'resize',
+  frozenRows: 'tab',
+  frozenColumns: 'tab',
+  regions: 'tab',
+};
+
+/**
+ * `patch` merged over `existing`, as `setCellFormats` does it: a field set to
+ * `undefined` clears that field, and a format left with nothing in it is no
+ * format at all.
+ */
+function mergeCellFormat(existing: CellFormat | undefined, patch: CellFormat): CellFormat | undefined {
+  const merged: CellFormat = { ...(existing ?? {}), ...patch };
+  for (const key of Object.keys(merged) as Array<keyof CellFormat>) {
+    if (merged[key] === undefined) delete merged[key];
+  }
+  return isEmptyFormat(merged) ? undefined : merged;
+}
+
+/** Structural equality with key order ignored; `undefined` and `null` agree. */
+function sameJson(a: unknown, b: unknown): boolean {
+  return stableJson(a ?? null) === stableJson(b ?? null);
+}
+
+function stableJson(value: unknown): string {
+  return JSON.stringify(value, (_key, inner: unknown) => {
+    if (typeof inner !== 'object' || inner === null || Array.isArray(inner)) return inner;
+    const record = inner as Record<string, unknown>;
+    return Object.keys(record)
+      .sort()
+      .reduce<Record<string, unknown>>((sorted, key) => {
+        sorted[key] = record[key];
+        return sorted;
+      }, {});
+  });
 }
 
 export interface AppendRowsResult {

--- a/packages/lib/src/sheets/store.ts
+++ b/packages/lib/src/sheets/store.ts
@@ -1239,26 +1239,31 @@ export async function applyFormatOps(
       columnCount: grown?.columnCount ?? current.columnCount,
     };
 
-    // 5. Rows. Read whole — a `StoredCell` cannot be fabricated, since `raw`,
-    // `value`, `type`, `error` and `notes` must all survive untouched — but
-    // written PARTIAL: `pending` carries only the column letters this call
-    // formats, so the jsonb merge in `persistRows` contributes those keys and
-    // leaves a concurrent `setCells` to column A of the same row alone. That
-    // is the lost-update guard `persistRows` was written for, not an
+    // 5. Rows. Read whole — the format each cell has now, and the content that
+    // has to survive, are both only knowable from the stored cell — but
+    // written as PATCHES: `patches` carries, per row, only the columns this
+    // call formats, and per column only the format. `persistRows` in
+    // `'format'` mode merges that under whatever content the cell holds when
+    // the statement runs, so a concurrent `setCells` to column A of the same
+    // row — or to this very cell, if the row did not exist to be locked —
+    // survives in either commit order. That is a lost-update guard, not an
     // optimisation.
     //
     // `lockRows` already holds the locks, so this read takes none.
     const working = await loadRowsByIndex(tab.id, allRowIndexes, tx, false);
-    const pending = new Map<number, StoredRow>();
-    const stage = (rowIndex: number, label: string, cell: StoredCell) => {
-      for (const map of [working, pending]) {
-        let row = map.get(rowIndex);
-        if (!row) {
-          row = { rowIndex, cells: {} };
-          map.set(rowIndex, row);
-        }
-        row.cells[label] = cell;
+    const patches = new Map<number, FormatPatchRow>();
+    const stage = <Cell,>(
+      map: Map<number, { rowIndex: number; cells: Record<string, Cell> }>,
+      rowIndex: number,
+      label: string,
+      cell: Cell
+    ) => {
+      let row = map.get(rowIndex);
+      if (!row) {
+        row = { rowIndex, cells: {} };
+        map.set(rowIndex, row);
       }
+      row.cells[label] = cell;
     };
 
     // The format each written cell had before this call, keyed by address in
@@ -1294,7 +1299,8 @@ export async function applyFormatOps(
         else delete cell.format;
 
         if (!before.has(address)) before.set(address, existing?.format ?? null);
-        stage(rowIndex, label, cell);
+        stage(working, rowIndex, label, cell);
+        stage(patches, rowIndex, label, { raw: cell.raw, format: next ?? null });
       }
     }
 
@@ -1302,6 +1308,10 @@ export async function applyFormatOps(
     // reads the extent from the tab it is handed, so it gets the GROWN one.
     // `applyEvaluation` writes into `working`, whose formula rows were loaded
     // whole; only the cells it re-evaluated are copied into `pending`.
+    // Re-evaluated cells are CONTENT, written through the content merge like
+    // any other materialised value; a format patch has no way to say "and the
+    // value is now 106".
+    const recomputedRows = new Map<number, StoredRow>();
     let recomputed: string[] = [];
     if (grown && recomputeTargets.length > 0) {
       const evaluated = await evaluateClosure({ ...current, ...extent }, recomputeTargets, working, tx);
@@ -1312,14 +1322,17 @@ export async function applyFormatOps(
         const cell = working.get(rowIndex)?.cells[label];
         // `applyEvaluation` fabricates neither rows nor cells; neither does this.
         if (!cell) continue;
-        stage(rowIndex, label, cell);
+        stage(recomputedRows, rowIndex, label, cell);
         recomputed.push(address);
       }
       recomputed = unique(recomputed);
     }
 
-    // 7. Persist — merge mode, which is the default and the point.
-    await persistRows(tab.id, ref.pageId, pending, tx);
+    // 7. Persist: formats through the per-cell format merge, re-evaluated
+    // values through the content merge.
+    await persistRows(tab.id, ref.pageId, patches, tx, 'format');
+    await persistRows(tab.id, ref.pageId, recomputedRows, tx);
+    const rowsTouched = unique([...patches.keys(), ...recomputedRows.keys()]).length;
 
     // 8. The tab record, in ONE statement.
     //
@@ -1345,6 +1358,25 @@ export async function applyFormatOps(
           .where(eq(sheetTabs.id, tab.id));
       }
     }
+
+    const result: ApplyFormatOpsResult = {
+      cellsFormatted: before.size,
+      rowsTouched,
+      tabFieldsChanged,
+      conditionalRules: plan.conditionalFormats.length,
+      regions: plan.regions.length,
+      rowCount: extent.rowCount,
+      columnCount: extent.columnCount,
+      recomputed,
+    };
+
+    // A request that changed nothing — a width the column already has, a bold
+    // that is already bold, a clear of a cell with nothing to clear — is not
+    // an edit. Bumping the revision for it would hand an open editor a
+    // conflict over a sheet that did not move, and log a change that is not
+    // one. Locks were taken for nothing, which is the honest cost of finding
+    // that out under them.
+    if (rowsTouched === 0 && tabFieldsChanged.length === 0) return result;
 
     // 9. Not optional. `replaceFromDocument` rewrites EVERY tab-level field
     // from the editor's document, and it is the only other writer of these
@@ -1398,16 +1430,7 @@ export async function applyFormatOps(
     }
     await appendChanges(ref.pageId, tab.id, actor, entries, tx);
 
-    return {
-      cellsFormatted: before.size,
-      rowsTouched: pending.size,
-      tabFieldsChanged,
-      conditionalRules: plan.conditionalFormats.length,
-      regions: plan.regions.length,
-      rowCount: extent.rowCount,
-      columnCount: extent.columnCount,
-      recomputed,
-    };
+    return result;
   };
 
   return exec ? run(exec) : db.transaction(run);
@@ -2581,24 +2604,112 @@ function applyEvaluation(
 }
 
 /**
- * @param mode `'merge'` contributes only the keys the caller touched, so a
- * concurrent write to a different column of the same row survives. `'replace'`
- * writes the row's cells verbatim — required by the repair path, which is the
- * only caller that legitimately needs a cell to DISAPPEAR, and which holds the
- * whole row anyway.
+/**
+ * How an upsert combines the cells it carries with the cells already stored.
+ *
+ * `'merge'` is for a CONTENT writer (`setCells`, materialisation): each cell
+ * it carries replaces the stored cell's `raw`, `value`, `type` and `error` —
+ * the keys a content write owns — and every other key the stored cell has
+ * (`format`, `notes`) survives underneath. `'format'` is the mirror image, for
+ * `applyFormatOps`: each carried cell contributes only its `format`, over
+ * whatever content the stored cell holds by the time the statement runs.
+ * `'replace'` writes the row's cells verbatim — required by the repair path,
+ * which is the only caller that legitimately needs a cell to DISAPPEAR, and
+ * which holds the whole row anyway.
  */
+type PersistMode = 'merge' | 'replace' | 'format';
+
+/**
+ * One cell as a `'format'`-mode upsert carries it: `raw` for the insert path
+ * only, and `format: null` as the wire form of a clear. Not a `StoredCell` —
+ * that type has no null format, and this shape never survives the statement
+ * that carries it (see `CELL_MERGE_SQL`).
+ */
+interface FormatPatchCell {
+  raw: string;
+  format: CellFormat | null;
+}
+
+interface FormatPatchRow {
+  rowIndex: number;
+  cells: Record<string, FormatPatchCell>;
+}
+
+/**
+ * The SET expression for `cells` in each mode, evaluated per stored row
+ * against `excluded` — the row this statement tried to insert.
+ *
+ * `excluded.cells` alone loses concurrent writes: two callers each set a
+ * different column of the same row, both read the row, both write back their
+ * own merged copy, and the second commit erases the first cell — with a
+ * success returned to both. A jsonb `||` of the two is a merge keyed by column
+ * letter, so each write contributes only the columns it touched.
+ *
+ * A column-level merge is not enough on its own, though, because a row that
+ * does not exist yet cannot be locked. A value write and a format write to the
+ * SAME empty cell can therefore both read nothing and both upsert, and with
+ * `||` the cell object under that column is replaced whole: whichever commits
+ * second wins, and it either drops the format or overwrites the just-entered
+ * value with `raw: ''`. So the merge goes one level deeper — per cell, keyed by
+ * what each kind of writer OWNS — and the two commits compose in either order.
+ *
+ * `jsonb_each` over `excluded.cells` visits exactly the columns the caller
+ * carried, so a merge cannot resurrect a cell legitimately removed within the
+ * same call. `jsonb_object_agg` of no rows is NULL, hence the coalesce.
+ */
+const CELL_MERGE_SQL: Record<PersistMode, ReturnType<typeof sql>> = {
+  replace: sql`excluded."cells"`,
+  merge: sql`${sheetRows.cells} || (
+    SELECT coalesce(jsonb_object_agg(
+      patch.key,
+      (coalesce(${sheetRows.cells} -> patch.key, '{}'::jsonb) - '{raw,value,type,error}'::text[]) || patch.value
+    ), '{}'::jsonb)
+    FROM jsonb_each(excluded."cells") AS patch
+  )`,
+  // A format cell arrives as `{ raw, format }` — `raw` so a brand-new row
+  // inserts a well-formed `StoredCell`, and dropped here because the stored
+  // cell's own content is the truth once one exists. `format: null` is how a
+  // clear travels (jsonb `||` cannot delete a key); `jsonb_strip_nulls` turns
+  // it into the deletion it means, and touches nothing else because no
+  // `StoredCell` field is ever legitimately null.
+  format: sql`${sheetRows.cells} || (
+    SELECT coalesce(jsonb_object_agg(
+      patch.key,
+      jsonb_strip_nulls(coalesce(${sheetRows.cells} -> patch.key, '{"raw": ""}'::jsonb) || (patch.value - 'raw'))
+    ), '{}'::jsonb)
+    FROM jsonb_each(excluded."cells") AS patch
+  )`,
+};
+
 async function persistRows(
   tabId: string,
   pageId: string,
   rows: Map<number, StoredRow>,
   exec: Executor,
-  mode: 'merge' | 'replace' = 'merge'
+  mode?: 'merge' | 'replace'
+): Promise<void>;
+async function persistRows(
+  tabId: string,
+  pageId: string,
+  rows: Map<number, FormatPatchRow>,
+  exec: Executor,
+  mode: 'format'
+): Promise<void>;
+async function persistRows(
+  tabId: string,
+  pageId: string,
+  rows: Map<number, StoredRow | FormatPatchRow>,
+  exec: Executor,
+  mode: PersistMode = 'merge'
 ): Promise<void> {
   const values = Array.from(rows.values()).map((row) => ({
     tabId,
     pageId,
     rowIndex: row.rowIndex,
-    cells: row.cells,
+    // A format patch is a wire shape the column type does not describe; the
+    // overloads above pin which shape each mode accepts, and the `'format'`
+    // expression consumes it before anything of that shape is stored.
+    cells: row.cells as Record<string, StoredCell>,
   }));
   if (values.length === 0) return;
 
@@ -2611,22 +2722,7 @@ async function persistRows(
       .onConflictDoUpdate({
         target: [sheetRows.tabId, sheetRows.rowIndex],
         set: {
-          // MERGE by default, not replace.
-          //
-          // `excluded.cells` alone loses concurrent writes: two callers each
-          // set a different column of the same row, both read the row, both
-          // write back their own merged copy, and the second commit erases the
-          // first cell — with a success returned to both. `||` is a jsonb
-          // shallow merge, so each write contributes only the keys it actually
-          // touched and columns it never saw survive.
-          //
-          // The keys this statement carries are exactly the cells the caller
-          // wrote plus those it recomputed, so a merge cannot resurrect a cell
-          // that was legitimately removed within the same call.
-          cells:
-            mode === 'replace'
-              ? sql`excluded."cells"`
-              : sql`${sheetRows.cells} || excluded."cells"`,
+          cells: CELL_MERGE_SQL[mode],
           updatedAt: new Date(),
         },
       });

--- a/packages/lib/src/sheets/store.ts
+++ b/packages/lib/src/sheets/store.ts
@@ -50,6 +50,7 @@ import { evaluateAddresses } from './evaluation';
 import {
   planFormatOps,
   parseRangeSpan,
+  SheetFormatError,
   MAX_FORMAT_OPS,
   MAX_FORMAT_CELLS_PER_REQUEST,
   type SheetFormatOp,
@@ -1121,9 +1122,11 @@ interface TabFieldValues {
  * The write path for everything `format-ops` can express, which until now had
  * only browser callers: an agent could set a cell's value and not one thing
  * about how it looked. Validation is `planFormatOps`'s job and every refusal
- * is a `SheetFormatError` thrown before any lock is taken; this function is the
- * persistence that plan describes, and it deliberately second-guesses none of
- * it.
+ * is a `SheetFormatError`; this function is the persistence that plan
+ * describes, and it deliberately second-guesses none of it. The plan runs once
+ * on a snapshot, so a bad request costs no lock, and again under the lock, so
+ * a request the tab has moved out from under — a rule id another writer just
+ * took — is refused and rolled back rather than written over.
  *
  * Persistence is split. A cell's own format lives on its row in
  * `sheet_rows.cells`, so a per-cell op is a row write scoped to the rows the
@@ -1135,12 +1138,18 @@ interface TabFieldValues {
  * Ops may address past the declared extent, and the sheet GROWS to cover them
  * — the decision `edit_sheet_cells` already made for values, applied to
  * formats. Growth carries an obligation the write would otherwise skip:
- * `evaluateClosure` resolves an open range's end from `rowCount`, so
- * `=SUM(A:A)` means something different once the sheet is taller, and a format
+ * `evaluateClosure` resolves an open range's end from `rowCount`, so a formula
+ * over `A:A` means something different once the sheet is taller, and a format
  * write does no recompute of its own. On growth, every formula holding an
- * open-ended range is re-evaluated along with its dependents. When the extent
- * does not grow no value can change — the evaluator's sheet carries no
- * formats and `StoredCell` has no rendered form — so no recompute runs.
+ * open-ended range edge is re-evaluated along with its dependents.
+ *
+ * Today that set is always empty: `FormulaParser.parseRange` rejects `A:A`,
+ * so no storable formula reads the extent (see the `deps.ts` module doc) and
+ * `sheet_range_deps` never holds a NULL bound through any write path. The
+ * recompute is kept as the contract growth owes, so the day open ranges parse
+ * this path does not start presenting stale totals as correct. When the extent
+ * does not grow no value can change — the evaluator's sheet carries no formats
+ * and `StoredCell` has no rendered form — so no recompute runs.
  */
 export async function applyFormatOps(
   ref: TabRef,
@@ -1153,11 +1162,13 @@ export async function applyFormatOps(
 
     // 1. Validate and plan, before any lock.
     //
-    // `planFormatOps` refuses everything it is going to refuse here, on the
-    // pre-lock snapshot, so a bad request costs no transaction time. The plan
-    // is also what the locks are derived from: `plan.rows` is exactly the set
-    // of `sheet_rows` a per-cell op will write, and the tab-field flag and the
-    // extent decision below settle whether the tab record is written at all.
+    // Everything a request can be refused for on its own is refused here, on
+    // the pre-lock snapshot, so a bad request costs no transaction time. (The
+    // re-plan in step 4 can still refuse, when the tab moved in between.) The
+    // plan is also what the locks are derived from: `plan.rows` is exactly the
+    // set of `sheet_rows` a per-cell op will write, and the tab-field flag and
+    // the extent decision below settle whether the tab record is written at
+    // all.
     const preview = planFormatOps(ops, formatTarget(tab));
     const rowIndexes = Array.from(preview.rows);
     const growth = formatGrowth(tab, preview);
@@ -1300,8 +1311,23 @@ export async function applyFormatOps(
 
         if (!before.has(address)) before.set(address, existing?.format ?? null);
         stage(working, rowIndex, label, cell);
-        stage(patches, rowIndex, label, { raw: cell.raw, format: next ?? null });
       }
+    }
+
+    // Patches are staged from the NET change, after every step has run: a
+    // bold set and cleared again in one request ends where it began, and
+    // writing that would create a tombstone row, bump the revision and log an
+    // entry whose before and after agree.
+    for (const [address, previous] of before) {
+      const { row: rowIndex, column } = decodeCellAddress(address);
+      const label = encodeColumnLabel(column);
+      const cell = working.get(rowIndex)?.cells[label];
+      const final = cell?.format ?? null;
+      if (sameJson(previous, final)) {
+        before.delete(address);
+        continue;
+      }
+      stage(patches, rowIndex, label, { raw: cell?.raw ?? '', format: final });
     }
 
     // 6. Re-evaluate what growth changed the meaning of. `evaluateClosure`
@@ -1492,8 +1518,11 @@ export async function readTabFormatting(
 
   const cellFormats: Record<string, CellFormat> = {};
   const ranges = options.ranges ?? [];
+  // `SheetFormatError`, as on the write side: a route maps one class to 400
+  // for the whole formatting surface, and the same bad range must not be a
+  // 400 when written and a 500 when read.
   if (ranges.length > MAX_FORMAT_OPS) {
-    throw new SheetAddressError(`At most ${MAX_FORMAT_OPS} ranges can be read at once; got ${ranges.length}`);
+    throw new SheetFormatError(`At most ${MAX_FORMAT_OPS} ranges can be read at once; got ${ranges.length}.`);
   }
 
   if (ranges.length > 0) {
@@ -1501,13 +1530,13 @@ export async function readTabFormatting(
     let cells = 0;
     for (const range of ranges) {
       const span = parseRangeSpan(range);
-      if (!span) throw new SheetAddressError(`Invalid range: ${range}`);
+      if (!span) throw new SheetFormatError(`"${range}" is not a range this sheet can address.`);
       // Counted before anything is read, so the cap bounds the read and not
       // just the result. A one-column range still costs a row per cell.
       cells += (span.rowEnd - span.rowStart + 1) * (span.colEnd - span.colStart + 1);
       if (cells > MAX_FORMAT_CELLS_PER_REQUEST) {
-        throw new SheetAddressError(
-          `Ranges cover more than ${MAX_FORMAT_CELLS_PER_REQUEST.toLocaleString()} cells; narrow them`
+        throw new SheetFormatError(
+          `The ranges cover more than ${MAX_FORMAT_CELLS_PER_REQUEST.toLocaleString()} cells between them; narrow them.`
         );
       }
       spans.push(span);
@@ -1609,7 +1638,8 @@ function formatGrowth(
 
 /**
  * Every formula on the tab that reads an open-ended range — `A:A`, `3:3` —
- * whose meaning depends on the declared extent.
+ * whose meaning depends on the declared extent. Always empty today; see the
+ * growth note on `applyFormatOps`.
  */
 async function openRangeFormulas(tabId: string, exec: Executor): Promise<string[]> {
   const found = await exec
@@ -1711,6 +1741,12 @@ function currentTabField(tab: StoredTab, field: TabFormatField): unknown {
       return parseConditionalRules(tab.conditionalFormats ?? undefined) ?? null;
     case 'regions':
       return parseRegions(tab.regions ?? undefined) ?? null;
+    case 'frozenRows':
+    case 'frozenColumns':
+      // The document path stores a freeze of 0; `setFrozen` normalises 0 to
+      // "none". They mean the same thing, so they compare the same, or a
+      // request to freeze nothing on such a tab would count as a change.
+      return tab[field] || null;
     default:
       return tab[field] ?? null;
   }
@@ -2653,16 +2689,29 @@ interface FormatPatchRow {
  * value with `raw: ''`. So the merge goes one level deeper — per cell, keyed by
  * what each kind of writer OWNS — and the two commits compose in either order.
  *
+ * What this does NOT do is arbitrate two writers of the same KIND on the same
+ * empty cell: two format writes there are last-writer-wins on `format`, as two
+ * value writes are on `raw` — the same-key semantics every writer already has.
+ *
  * `jsonb_each` over `excluded.cells` visits exactly the columns the caller
  * carried, so a merge cannot resurrect a cell legitimately removed within the
- * same call. `jsonb_object_agg` of no rows is NULL, hence the coalesce.
+ * same call. `jsonb_object_agg` of no rows is NULL, hence the coalesce. A
+ * stored cell that is somehow not an object (`storedObject`) is treated as
+ * absent rather than raising "cannot delete from scalar" on every later write
+ * to its row until a rebuild — the old column-level merge replaced it, and a
+ * write to a damaged row should stay possible.
  */
+
+/** `stored -> key` when it is an object, else `fallback`. */
+const storedObject = (key: ReturnType<typeof sql>, fallback: string) =>
+  sql`coalesce(CASE WHEN jsonb_typeof(${sheetRows.cells} -> ${key}) = 'object' THEN ${sheetRows.cells} -> ${key} END, ${sql.raw(fallback)}::jsonb)`;
+
 const CELL_MERGE_SQL: Record<PersistMode, ReturnType<typeof sql>> = {
   replace: sql`excluded."cells"`,
   merge: sql`${sheetRows.cells} || (
     SELECT coalesce(jsonb_object_agg(
       patch.key,
-      (coalesce(${sheetRows.cells} -> patch.key, '{}'::jsonb) - '{raw,value,type,error}'::text[]) || patch.value
+      (${storedObject(sql`patch.key`, "'{}'")} - '{raw,value,type,error}'::text[]) || patch.value
     ), '{}'::jsonb)
     FROM jsonb_each(excluded."cells") AS patch
   )`,
@@ -2675,7 +2724,7 @@ const CELL_MERGE_SQL: Record<PersistMode, ReturnType<typeof sql>> = {
   format: sql`${sheetRows.cells} || (
     SELECT coalesce(jsonb_object_agg(
       patch.key,
-      jsonb_strip_nulls(coalesce(${sheetRows.cells} -> patch.key, '{"raw": ""}'::jsonb) || (patch.value - 'raw'))
+      jsonb_strip_nulls(${storedObject(sql`patch.key`, `'{"raw": ""}'`)} || (patch.value - 'raw'))
     ), '{}'::jsonb)
     FROM jsonb_each(excluded."cells") AS patch
   )`,
@@ -2702,15 +2751,21 @@ async function persistRows(
   exec: Executor,
   mode: PersistMode = 'merge'
 ): Promise<void> {
-  const values = Array.from(rows.values()).map((row) => ({
-    tabId,
-    pageId,
-    rowIndex: row.rowIndex,
-    // A format patch is a wire shape the column type does not describe; the
-    // overloads above pin which shape each mode accepts, and the `'format'`
-    // expression consumes it before anything of that shape is stored.
-    cells: row.cells as Record<string, StoredCell>,
-  }));
+  // Ascending by row, for the same reason `lockRows` is: rows that do not
+  // exist yet cannot be locked ahead of time, so a multi-row insert takes its
+  // speculative locks in statement order, and two writers creating the same
+  // new rows in opposite orders would deadlock mid-statement.
+  const values = Array.from(rows.values())
+    .sort((a, b) => a.rowIndex - b.rowIndex)
+    .map((row) => ({
+      tabId,
+      pageId,
+      rowIndex: row.rowIndex,
+      // A format patch is a wire shape the column type does not describe; the
+      // overloads above pin which shape each mode accepts, and the `'format'`
+      // expression consumes it before anything of that shape is stored.
+      cells: row.cells as Record<string, StoredCell>,
+    }));
   if (values.length === 0) return;
 
   // One statement per batch, upserting on the tab/row identity so an append and

--- a/packages/lib/src/sheets/store.ts
+++ b/packages/lib/src/sheets/store.ts
@@ -2702,16 +2702,23 @@ interface FormatPatchRow {
  * write to a damaged row should stay possible.
  */
 
-/** `stored -> key` when it is an object, else `fallback`. */
-const storedObject = (key: ReturnType<typeof sql>, fallback: string) =>
-  sql`coalesce(CASE WHEN jsonb_typeof(${sheetRows.cells} -> ${key}) = 'object' THEN ${sheetRows.cells} -> ${key} END, ${sql.raw(fallback)}::jsonb)`;
+/**
+ * `stored -> key` when it is an object, else `fallback`.
+ *
+ * Plain `sql` fragments throughout, never `sql.raw`: this runs at module load,
+ * and a legacy test that partially mocks the operators module has a `sql`
+ * without `raw` — the import of anything that pulls in this store would then
+ * throw before a single test ran.
+ */
+const storedObject = (key: ReturnType<typeof sql>, fallback: ReturnType<typeof sql>) =>
+  sql`coalesce(CASE WHEN jsonb_typeof(${sheetRows.cells} -> ${key}) = 'object' THEN ${sheetRows.cells} -> ${key} END, ${fallback})`;
 
 const CELL_MERGE_SQL: Record<PersistMode, ReturnType<typeof sql>> = {
   replace: sql`excluded."cells"`,
   merge: sql`${sheetRows.cells} || (
     SELECT coalesce(jsonb_object_agg(
       patch.key,
-      (${storedObject(sql`patch.key`, "'{}'")} - '{raw,value,type,error}'::text[]) || patch.value
+      (${storedObject(sql`patch.key`, sql`'{}'::jsonb`)} - '{raw,value,type,error}'::text[]) || patch.value
     ), '{}'::jsonb)
     FROM jsonb_each(excluded."cells") AS patch
   )`,
@@ -2724,7 +2731,7 @@ const CELL_MERGE_SQL: Record<PersistMode, ReturnType<typeof sql>> = {
   format: sql`${sheetRows.cells} || (
     SELECT coalesce(jsonb_object_agg(
       patch.key,
-      jsonb_strip_nulls(${storedObject(sql`patch.key`, `'{"raw": ""}'`)} || (patch.value - 'raw'))
+      jsonb_strip_nulls(${storedObject(sql`patch.key`, sql`'{"raw": ""}'::jsonb`)} || (patch.value - 'raw'))
     ), '{}'::jsonb)
     FROM jsonb_each(excluded."cells") AS patch
   )`,


### PR DESCRIPTION
## Why

Sheets have a full presentation model and no server-side write path for any of it: `format-ops.ts` is only ever called from browser toolbars, so an agent could set a cell's value and nothing else. This is task 3 of 5 in the dashboard epic — `format_sheet` has nothing to call until `applyFormatOps` exists.

## What

Two new exports in `packages/lib/src/sheets/store.ts`, alongside `setCells` and sharing its module-private invariants (`lockRows`, `loadRowsByIndex`, `persistRows`, `touchPage`, `appendChanges`, `evaluateClosure`):

- **`applyFormatOps(ref, ops, actor?, exec?)`** — validates via `planFormatOps` (no duplicated validation; every refusal is a `SheetFormatError` thrown before any lock), then persists the plan. Returns `{ cellsFormatted, rowsTouched, tabFieldsChanged, conditionalRules, regions, rowCount, columnCount, recomputed }`.
- **`readTabFormatting(ref, options?, exec?)`** — `getTab` only (never writes; `null` for an unmigrated sheet), returns tab-level fields with rules and regions **parsed**, plus explicit per-cell formats inside optional ranges read with one span query. No merged "effective" format — `resolveCellFormat` stays the single definition of precedence.

`parseRangeSpan` / `RangeSpan` are now exported from `format-request.ts` so the read side accepts exactly the notation the write side validates.

## How

- **Split persistence.** Per-cell formats go to `sheet_rows.cells` as *patches* — per row only the touched columns, per column only the format — through a new `'format'` mode of `persistRows`. Column formats/widths, row heights, freezes, rules, regions and extent go to `sheet_tabs` in **one** `UPDATE`, and only the columns whose value actually changed.
- **Per-cell merge (review fix).** The upsert merges one level deeper than the column-level `||`, keyed by what each writer owns (`CELL_MERGE_SQL`): a content write (`setCells`, `'merge'`) replaces `raw`/`value`/`type`/`error` and leaves `format`/`notes` underneath; a format write (`'format'`) contributes only `format` over whatever content the cell holds when the statement runs, with `format: null` + `jsonb_strip_nulls` as the wire form of a clear. So a value write and a format write to the same *empty* cell — which has no row to lock — compose in either commit order.
- **No-op requests are not edits (review fix).** When no row and no tab field changed, the call returns before `touchPage`/`appendChanges`, so a retried or redundant request does not bump the revision or log. Patches are staged from the *net* change after all steps run (a set-then-clear in one request writes nothing), and a stored freeze of 0 compares equal to "none".
- **Second review pass.** Refusals happen on the pre-lock snapshot *and* can happen again under the lock when the tab moved (a rule id taken concurrently is refused and rolled back; pinned by a race test). `persistRows` inserts rows ascending so two writers creating the same new rows in opposite orders cannot deadlock mid-statement. A non-object stored cell is treated as absent by the per-cell merges instead of failing every later write to its row. `readTabFormatting` refuses a bad range with `SheetFormatError`, the same class as the write side, so one route mapping (task 4) covers the whole surface.
- **Lock order** mirrors `setCells`: tab `FOR UPDATE` only when the tab will be written, then rows ascending in one acquisition, then `getTab` re-read **and a second `planFormatOps` under the lock**, so a rule another transaction added while we waited is folded in rather than overwritten.
- **Growth.** Ops past the extent grow it. On growth, formulas holding an open-ended edge in `sheet_range_deps` (`rowEnd`/`colEnd` NULL) seed `resolveDependentClosure` and the union is re-evaluated against the grown extent; rows for that closure are resolved before the locks so the acquisition stays single-ordered. No growth ⇒ no recompute.
- **`touchPage`** always runs — without it a stale editor save passes its revision check and `replaceFromDocument` reverts every tab-level field.
- **Change log** uses the existing `format` / `resize` / `tab` op kinds; per-cell entries up to `CHANGE_LOG_SUMMARY_THRESHOLD`, one summary past it; tab-level changes are one entry per field.
- **Tombstone, documented not fixed:** clearing the last format of an empty cell leaves `{ raw: '' }`. jsonb `||` cannot delete a key and replace mode would reintroduce the lost update. The projection ignores it; `rebuildTab` collects it.

No migration: `regions` already landed in 0287.

## Tests

23 new integration tests in `sheet-store.integration.test.ts`, each naming the mutation it kills. The mechanism-level ones:

1. `A1:H1` on a **50,000-row** sheet → `rowsTouched === 1` and exactly one `sheet_rows.updatedAt` moved.
2. `C2:C5001` → 5,000 rows written, rows 5002+ untouched.
3. Concurrent `setCells` to `A5` while a format write to `C5` is mid-transaction — a **real transaction pair**: the format write's first `sheet_rows` insert is held (via an executor proxy) until the value write commits on another connection. Plus the **same-cell** version in both commit orders (value-then-format and format-then-value), and an idempotent request leaving revision and log untouched.
4. Formula cell: `raw`/`value`/`type` untouched.
5. Empty cell → `formats.D9` present, `cells.D9` absent. Plus the tombstone test.
6. Width + freeze + rule + regions in one call → **exactly one** `sheet_tabs` UPDATE (counted by a row trigger) and one revision bump.
7. `pages.revision` and `stateHash` move.
8. Unmigrated sheet materialises with document rows intact.
9. `readTabFormatting` on an unmigrated sheet → `null` **and** zero `sheet_tabs` rows.
10. Two concurrent rule adds → both land; deterministic (first call held before its tab UPDATE until `pg_stat_activity` shows the second waiting on the lock).
11. Growth recompute — see the honest-scope note below.
12. Regions round-trip through `readSheetDocument` → `replaceFromDocument`.
- Also: refusal writes nothing; log summary threshold; read returns parsed rules (a bogus stored entry is dropped) and only in-range cell formats; read refuses bad/oversized ranges.

**Honest scope on test 11:** the parser rejects `A:A` today (`deps.ts` module doc), so no formula can put an open edge into `sheet_range_deps` through the write path and the growth recompute is currently a contract, not a live path — the code comments now say so. The test seeds the edge directly and a row past the extent whose value the stale materialisation never saw; it kills skipping the open-edge query, the closure walk, and persisting the recompute. It cannot observe "extent passed to `evaluateClosure`" because no formula's value depends on `rowCount` yet.

## Verification

Ran locally against a scratch homebrew Postgres 17 on :5433 (Docker daemon down), migrated from this branch, stopped and removed afterwards:

- `bun run --filter @pagespace/lib test:integration -- sheet-store` → **88/88** (65 existing + 23 new)
- `bun run --filter @pagespace/lib typecheck` → clean
- eslint on `store.ts`, `format-request.ts` → clean

**Mutation sweep** (by line index, source restored after each; script kept in the session scratchpad): 23 probes, **20 killed**, 3 survived for reasons stated below.

| probe | result |
|---|---|
| M1 format merge falls back to column-level `\|\|` | RED (same-cell pair, formula cell, tombstone) |
| M1b content merge replaces the whole cell | RED (same-cell pair) |
| M1c no `jsonb_strip_nulls` on a clear | RED (tombstone) |
| M1d patch `raw` not stripped in the conflict path | RED (same-cell pair) |
| M16 bump the revision when nothing changed | RED (no-op request) |
| M17 stage patches per step instead of net change | RED (set-then-clear) |
| M18 stored freeze 0 counted as a change | RED (freeze-nothing) |
| M19 insert rows in descending order | **SURVIVED** — the mid-statement deadlock needs two multi-row inserts interleaved inside one statement, which no test harness here can force; the sort mirrors `lockRows`' reasoning |
| M2 load+write every row (O(sheet)) | RED (50k-row, 5,000-row, growth) |
| M3 skip tab `FOR UPDATE` | RED (concurrent rule adds) |
| M4 write the pre-lock plan | RED (concurrent rule adds) |
| M5 skip `touchPage` | RED (one UPDATE/bump, revision guard) |
| M6 a second `sheet_tabs` UPDATE | RED (one UPDATE) |
| M7 skip open-edge recompute seed | RED (growth) |
| M8 evaluate with the pre-growth extent | **SURVIVED** — unobservable today, see above |
| M9 empty cell `raw: ' '` | RED (empty cell, tombstone) |
| M10 no log summary | RED (log threshold) |
| M11 `ensureTab` in the read | RED (read-never-writes) |
| M12 return raw rules from the read | RED (parsed read) |
| M13 drop the range filter in the read | RED (parsed read) |
| M14 fabricate `StoredCell` in memory | **SURVIVED** — by design now: stored content is preserved by the SQL merge, not by the in-memory spread, so the in-memory cell only feeds the log's `after` |
| M15 skip clears | RED (tombstone) |

**CI:** `test.yml` only triggers for PRs into master/develop, so a PR into `pu/sheet-agent-regions` gets no automatic run (sibling #2561 had none either). I dispatched `test.yml` manually on this branch via `workflow_dispatch` — see the Actions tab for the run on the head commit.

Not run locally (per instructions): monorepo build/typecheck. No changelog entry: nothing user-visible until task 4 wires `format_sheet`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YSPEJfj2pDqtUwgE2RQjRV
