### PR TITLE
feat(ios): route universal links, and close the iOS billing gaps

### DIFF
--- a/apps/android/README.md
+++ b/apps/android/README.md
@@ -232,10 +232,11 @@ succeed — which is prerequisite 1.
 
 ### The filter to add, once both prerequisites are met
 
-iOS is deferred for the same reason and claims no paths either — see
+iOS now routes these links — `apps/web/src/components/DeepLinkHandler.tsx` consumes
+`appUrlOpen` and `getLaunchUrl`, so **Prerequisite 2 above is met for both platforms**;
+what remains for Android is the signing cert and `assetlinks.json`. Paths mirror
 `apps/marketing/public/.well-known/apple-app-site-association` (the copy Caddy actually
-serves) and the "Universal links" section of `apps/ios/README.md`. Whenever the two
-platforms do start capturing links, they should capture the same ones. Widening beyond these paths should still wait on prerequisite 2 — whole-host
+serves), currently `/invite/*` only, so the two platforms capture the same links. Widening beyond these paths should still wait on prerequisite 2 — whole-host
 capture would strand users on `/dashboard` from every marketing, blog, or docs link.
 
 A third prerequisite applies to the auth-callback paths specifically: `/api/auth/desktop/exchange`

--- a/apps/android/README.md
+++ b/apps/android/README.md
@@ -232,11 +232,14 @@ succeed — which is prerequisite 1.
 
 ### The filter to add, once both prerequisites are met
 
-iOS now routes these links — `apps/web/src/components/DeepLinkHandler.tsx` consumes
-`appUrlOpen` and `getLaunchUrl`, so **Prerequisite 2 above is met for both platforms**;
-what remains for Android is the signing cert and `assetlinks.json`. Paths mirror
-`apps/marketing/public/.well-known/apple-app-site-association` (the copy Caddy actually
-serves), currently `/invite/*` only, so the two platforms capture the same links. Widening beyond these paths should still wait on prerequisite 2 — whole-host
+**Prerequisite 2 is now met** — `apps/web/src/components/DeepLinkHandler.tsx` consumes
+`appUrlOpen` and `getLaunchUrl`, and it lives in the shared web layer, so the routing is
+already there for Android the moment it starts receiving links. What remains for Android is
+prerequisite 1: the release signing certificate and a real `assetlinks.json`. Until those
+exist **Android captures nothing** — no https intent-filter is registered.
+
+When it does, mirror `apps/marketing/public/.well-known/apple-app-site-association` (the copy
+Caddy actually serves), currently `/invite/*` only, so both platforms capture the same links. Widening beyond these paths should still wait on prerequisite 2 — whole-host
 capture would strand users on `/dashboard` from every marketing, blog, or docs link.
 
 A third prerequisite applies to the auth-callback paths specifically: `/api/auth/desktop/exchange`

--- a/apps/ios/README.md
+++ b/apps/ios/README.md
@@ -20,11 +20,8 @@ This is a **remote-loading** app. The WebView loads the live site directly:
 
 > **App Review note (Guideline 4.2):** Apple scrutinizes thin WebView wrappers. Our native
 > value — push notifications, Sign in with Apple, native social login, the keychain plugin,
-> and app-icon badge sync — is what clears this bar. Always submit with reviewer notes calling
-> these out plus a working demo account (see "Submitting", below).
->
-> Universal links are **not** on that list: the entitlement is declared but the AASA claims no
-> paths, because nothing routes an incoming link yet. See below.
+> app-icon badge sync, and universal links — is what clears this bar. Always submit with
+> reviewer notes calling these out plus a working demo account (see "Submitting", below).
 
 ## Native capabilities (entitlements)
 
@@ -34,32 +31,41 @@ This is a **remote-loading** app. The WebView loads the live site directly:
 - Associated domains: `applinks:pagespace.ai`, `webcredentials:pagespace.ai`
 - Sign in with Apple
 
-### Universal links (associated domains) — claimed paths deferred
+### Universal links (associated domains)
 
-The entitlement declares `applinks:pagespace.ai`, but the served AASA claims **no paths**, on
-purpose. Claiming a path without routing it is worse than not claiming it: the link stops opening
-in Safari, where it works, and instead launches the app at `server.url` (`/dashboard`) — silently
-dropping the invite token. `apps/android/README.md` ("Prerequisite 2") documents the same trap,
-which is why Android has not claimed App Links either.
+`https://pagespace.ai/invite/*` opens in the app. Three pieces have to agree, and they broke
+independently before:
 
-**The prerequisite:** nothing consumes the `@capacitor/app` plugin's `appUrlOpen` event or
-`getLaunchUrl()` on either platform. Both are needed — `getLaunchUrl` for a cold start, `appUrlOpen`
-for a warm one — before any path goes into `paths`.
+1. **Entitlement** — `applinks:pagespace.ai` in `App.entitlements`.
+2. **The AASA** — Caddy routes `/.well-known/*` to **marketing** (only `oauth-*` reaches web), so
+   the single source of truth is `apps/marketing/public/.well-known/apple-app-site-association`.
+   `appID` is team plus bundle id (`M96WTV3CKX.ai.pagespace.ios`), and it must be served as
+   `application/json` — the file is deliberately extensionless, so `apps/marketing/next.config.ts`
+   sets the header.
+3. **Routing** — `apps/web/src/components/DeepLinkHandler.tsx`, mounted in
+   `DashboardLayoutClient`. Both halves are required: `App.getLaunchUrl()` for a cold start (the
+   URL is spent before any listener exists) and the `appUrlOpen` listener for a warm one (the
+   native side only notifies plugins, it never calls `loadUrl`, so without a listener the WebView
+   simply stays put). Which URLs resolve to which route is
+   `apps/web/src/lib/navigation/deep-links.ts`.
 
-What the file does carry is `webcredentials`, which needs no routing: it enables associated-domain
-password autofill for `pagespace.ai`.
+**Keep `paths` and the resolver in step.** Claiming a path the resolver returns `null` for stops
+the link working in Safari and does nothing in the app — strictly worse than never claiming it. The
+resolver hands any unrecognised URL on the claimed host to the browser rather than swallowing it,
+which limits the blast radius but is not a licence to claim loosely.
 
-Mechanics, for whoever picks this up: Caddy routes `/.well-known/*` to **marketing** (only
-`oauth-*` reaches web), so the single source of truth is
-`apps/marketing/public/.well-known/apple-app-site-association`. `appID` is team plus bundle id —
-`M96WTV3CKX.ai.pagespace.ios` — and it must be served as `application/json` (the file is
-deliberately extensionless, so `apps/marketing/next.config.ts` sets the header). Apple's CDN caches
-it, so after any change: redeploy marketing, curl the live URL, then reinstall the app before
-testing on device.
+Navigation goes through the router, never `window.location`: in the iOS shell a top-level location
+change reaches Capacitor's `WKNavigationDelegate`, which cancels anything outside `server.url`'s
+`/dashboard` prefix and opens system Safari, blanking the WebView. `/invite/*` is outside that
+prefix.
 
-When paths are eventually claimed, do **not** add the OAuth callbacks: native sign-in returns
-through the `pagespace://auth-exchange` custom scheme, and claiming those paths would hijack the
-web fallback.
+Do **not** claim the OAuth callback paths. Native sign-in returns through the
+`pagespace://auth-exchange` custom scheme, and `/api/auth/desktop/exchange` redeems its code with
+no PKCE binding — whichever app receives the code can take a session. The resolver ignores that
+scheme outright, and binding the exchange is a prerequisite for ever changing that.
+
+Apple's CDN caches the AASA, so after any change: redeploy marketing, curl the live URL, then
+reinstall the app before testing on device.
 
 Push is driven from the web layer (`apps/web/src/hooks/usePushNotifications.ts`), device tokens
 POST to `/api/notifications/push-tokens`, and the server sends via
@@ -147,8 +153,9 @@ bundle exec fastlane release   # deliver: push metadata + submit the App Store v
 - [ ] `cap sync` run immediately before archiving; `capacitor.config.json` matches `capacitor.config.ts`
 - [ ] Archive signed with an **Apple Distribution** identity (check Xcode Organizer before uploading)
 - [ ] AASA verified live: `curl https://pagespace.ai/.well-known/apple-app-site-association`
-      returns `M96WTV3CKX.ai.pagespace.ios` as `application/json` with **no** claimed `applinks`
-      paths (see "Universal links", above)
+      returns `M96WTV3CKX.ai.pagespace.ios` as `application/json`, **and** an
+      `https://pagespace.ai/invite/...` link opens the app on a device from both a cold start and
+      with the app already running (the two paths are handled separately — verify both)
 - [ ] Build uploaded and finished **Processing** in App Store Connect
 - [ ] App privacy answers match `ios/App/PrivacyInfo.xcprivacy` (Email + User ID linked / App
       Functionality; Device ID / Analytics and Crash + Performance Data, not linked; Product
@@ -164,9 +171,35 @@ bundle exec fastlane release   # deliver: push metadata + submit the App Store v
 - [ ] No purchase surface reachable on iOS — walk `/settings/billing`, `/settings/usage`, and any
       in-app link that reaches marketing pricing (Guideline 3.1.1)
 - [ ] Reviewer notes emphasize native features — push, Sign in with Apple, native Google sign-in,
-      keychain session persistence, app-icon badge — and **not** universal links, plus a working
-      demo account with seeded content
+      keychain session persistence, app-icon badge, universal links — plus a working demo account
+      with seeded content
 - [ ] Submit for review
+
+## The Facebook SDK that ships but never runs
+
+`Package.resolved` pins `facebook-ios-sdk 18.x`. Nothing here configures Facebook login — it
+arrives because `@capgo/capacitor-social-login` hard-depends on `FacebookCore` and `FacebookLogin`
+in its own plugin target, so it cannot be excluded without forking the plugin.
+
+It is linked but inert, and each link in that chain was checked:
+
+- `Info.plist` declares no `FacebookAppID` and no `FacebookClientToken`. The SDK cannot initialize
+  or send anything without them.
+- `FacebookProvider.init()` only configures an `ISO8601DateFormatter`; its `initialize()` is an
+  empty method.
+- The plugin only reaches Facebook when `SocialLogin.initialize` is called with a `facebook` object
+  carrying an `appId`. We call it with `apple` (`native-apple-auth.ts`) and `google`
+  (`native-google-auth.ts`) only.
+
+So `NSPrivacyTracking = false` is accurate. Facebook ships the SDK signature and privacy manifest
+Apple requires of it, so the binary is compliant as-is.
+
+**If Facebook login is ever added**, revisit this: the SDK auto-logs app events and collects the
+advertiser ID once an app ID exists, which changes both the tracking declaration and the App Store
+Connect nutrition labels. `FacebookAutoLogAppEventsEnabled` and
+`FacebookAdvertiserIDCollectionEnabled` (both `false`) are the plist keys that turn that off. They
+are deliberately absent today — with no app ID there is nothing to disable, and dead configuration
+rots.
 
 ## Privacy manifest
 

--- a/apps/marketing/public/.well-known/apple-app-site-association
+++ b/apps/marketing/public/.well-known/apple-app-site-association
@@ -1,7 +1,14 @@
 {
   "applinks": {
     "apps": [],
-    "details": []
+    "details": [
+      {
+        "appID": "M96WTV3CKX.ai.pagespace.ios",
+        "paths": [
+          "/invite/*"
+        ]
+      }
+    ]
   },
   "webcredentials": {
     "apps": [

--- a/apps/web/src/app/dashboard/DashboardLayoutClient.tsx
+++ b/apps/web/src/app/dashboard/DashboardLayoutClient.tsx
@@ -4,6 +4,7 @@ import { usePathname } from "next/navigation";
 import Layout from "@/components/layout/Layout";
 import { PushNotificationManager } from "@/components/PushNotificationManager";
 import { PushActionHandler } from "@/components/PushActionHandler";
+import { DeepLinkHandler } from "@/components/DeepLinkHandler";
 import QuickCreatePalette from "@/components/create/QuickCreatePalette";
 import { OnboardingGate } from "@/components/onboarding/OnboardingGate";
 import { useHotkeyPreferences } from "@/hooks/useHotkeyPreferences";
@@ -40,6 +41,7 @@ export default function DashboardLayoutClient({ children }: { children: React.Re
     <>
       <PushNotificationManager />
       <PushActionHandler />
+      <DeepLinkHandler />
       <QuickCreatePalette />
       <OnboardingGate />
       {isFullPageRoute ? <Layout>{children}</Layout> : <Layout />}

--- a/apps/web/src/app/dashboard/DashboardLayoutClient.tsx
+++ b/apps/web/src/app/dashboard/DashboardLayoutClient.tsx
@@ -4,7 +4,6 @@ import { usePathname } from "next/navigation";
 import Layout from "@/components/layout/Layout";
 import { PushNotificationManager } from "@/components/PushNotificationManager";
 import { PushActionHandler } from "@/components/PushActionHandler";
-import { DeepLinkHandler } from "@/components/DeepLinkHandler";
 import QuickCreatePalette from "@/components/create/QuickCreatePalette";
 import { OnboardingGate } from "@/components/onboarding/OnboardingGate";
 import { useHotkeyPreferences } from "@/hooks/useHotkeyPreferences";
@@ -41,7 +40,6 @@ export default function DashboardLayoutClient({ children }: { children: React.Re
     <>
       <PushNotificationManager />
       <PushActionHandler />
-      <DeepLinkHandler />
       <QuickCreatePalette />
       <OnboardingGate />
       {isFullPageRoute ? <Layout>{children}</Layout> : <Layout />}

--- a/apps/web/src/app/layout.tsx
+++ b/apps/web/src/app/layout.tsx
@@ -7,6 +7,7 @@ import "@/styles/editor-readonly.css";
 import { ThemeProvider } from "@/components/providers/ThemeProvider";
 import { THEME_COOKIE_NAME } from "@/lib/theme-cookie";
 import ClientTrackingProvider from "@/components/providers/ClientTrackingProvider";
+import { DeepLinkHandler } from "@/components/DeepLinkHandler";
 import ConsentProvider from "@/components/providers/ConsentProvider";
 import { Toaster } from "@/components/ui/sonner";
 import { getRequestNonce } from "@/lib/request-nonce";
@@ -187,6 +188,10 @@ export default async function RootLayout({
           nonce={nonce}
         >
           <ClientTrackingProvider />
+          {/* Root, not the dashboard layout: a signed-out `/dashboard` is
+              rewritten to `/auth/signin`, and an invite tap is very often
+              signed out — mounted any lower, the launch URL is never read. */}
+          <DeepLinkHandler />
           {children}
           <ConsentProvider />
           <Toaster position="top-right" />

--- a/apps/web/src/app/settings/billing/page.tsx
+++ b/apps/web/src/app/settings/billing/page.tsx
@@ -24,6 +24,7 @@ import { fetchWithAuth } from '@/lib/auth/auth-fetch';
 import { InvoiceList, type Invoice } from '@/components/billing/InvoiceList';
 import { UpcomingInvoice } from '@/components/billing/UpcomingInvoice';
 import { BillingAddressForm, type BillingAddress } from '@/components/billing/BillingAddressForm';
+import { BillingGuard } from '@/components/billing/BillingGuard';
 import { useBillingVisibility } from '@/hooks/useBillingVisibility';
 import { getPlan, getPlanFromPriceId, type SubscriptionTier } from '@/lib/subscription/plans';
 import { post } from '@/lib/auth/auth-fetch';
@@ -50,7 +51,7 @@ interface UpcomingInvoiceData {
   } | null;
 }
 
-export default function BillingPage() {
+function BillingPageContent() {
   const router = useRouter();
   const searchParams = useSearchParams();
   const { isReady, hideBilling } = useBillingVisibility();
@@ -455,5 +456,19 @@ export default function BillingPage() {
         </>
       )}
     </div>
+  );
+}
+
+/**
+ * Every section on this page is billing, so on iOS the route rendered as a bare
+ * "Billing" header over nothing — and still fetched `/api/stripe/*` on mount.
+ * Guarding the whole route (the pattern `/settings/plan` already uses) redirects
+ * instead, and stops the child mounting at all so those fetches never fire.
+ */
+export default function BillingPage() {
+  return (
+    <BillingGuard>
+      <BillingPageContent />
+    </BillingGuard>
   );
 }

--- a/apps/web/src/app/settings/usage/page.tsx
+++ b/apps/web/src/app/settings/usage/page.tsx
@@ -5,6 +5,7 @@ import { useRouter, useSearchParams } from 'next/navigation';
 import { Button } from '@/components/ui/button';
 import { Alert, AlertDescription } from '@/components/ui/alert';
 import { ArrowLeft, CheckCircle, AlertTriangle } from 'lucide-react';
+import { useBillingVisibility } from '@/hooks/useBillingVisibility';
 import { CreditBalanceCard } from '@/components/billing/CreditBalanceCard';
 import { UsageBreakdownCard } from '@/components/billing/UsageBreakdownCard';
 import { AgentSessionUsageCard } from '@/components/billing/AgentSessionUsageCard';
@@ -16,6 +17,7 @@ import { StorageUsageCard } from '@/components/billing/StorageUsageCard';
 export default function UsagePage() {
   const router = useRouter();
   const searchParams = useSearchParams();
+  const { showBilling } = useBillingVisibility();
   const creditsParam = searchParams.get('credits');
 
   useEffect(() => {
@@ -47,7 +49,7 @@ export default function UsagePage() {
         </div>
       </div>
 
-      {creditsParam === 'success' && (
+      {showBilling && creditsParam === 'success' && (
         <Alert className="border-green-200 bg-green-50 dark:border-green-800 dark:bg-green-950/20">
           <CheckCircle className="h-4 w-4 text-green-600" />
           <AlertDescription className="text-green-800 dark:text-green-200">
@@ -55,7 +57,7 @@ export default function UsagePage() {
           </AlertDescription>
         </Alert>
       )}
-      {creditsParam === 'canceled' && (
+      {showBilling && creditsParam === 'canceled' && (
         <Alert>
           <AlertTriangle className="h-4 w-4" />
           <AlertDescription>

--- a/apps/web/src/components/DeepLinkHandler.tsx
+++ b/apps/web/src/components/DeepLinkHandler.tsx
@@ -1,0 +1,81 @@
+'use client';
+
+import { useEffect } from 'react';
+import { useRouter } from 'next/navigation';
+import { isCapacitorApp } from '@/lib/capacitor-bridge';
+import { resolveDeepLink } from '@/lib/navigation/deep-links';
+import { openExternalUrl } from '@/lib/navigation/app-navigation';
+
+/**
+ * Routes universal links into the app.
+ *
+ * Both halves are required and they are not interchangeable:
+ *
+ * - **Cold start** — the shell launches, loads `server.url` (`/dashboard`), and
+ *   the link is only recoverable from `App.getLaunchUrl()`.
+ * - **Warm start** — the app is already running. `Bridge.onNewIntent` (Android)
+ *   and the iOS equivalent only *notify plugins*; neither calls `loadUrl`. So
+ *   without a listener the WebView simply stays where it was and nothing at all
+ *   happens.
+ *
+ * Navigation goes through the router, never `window.location`: in the iOS shell
+ * a top-level location change is handed to Capacitor's `WKNavigationDelegate`,
+ * which cancels anything outside `server.url`'s `/dashboard` prefix and opens
+ * system Safari, blanking the WebView. `/invite/*` is outside that prefix, so
+ * `window.location` would be exactly the wrong tool. A router transition is
+ * pushState and never reaches the delegate.
+ */
+export function DeepLinkHandler() {
+  const router = useRouter();
+
+  useEffect(() => {
+    if (!isCapacitorApp()) return;
+
+    let mounted = true;
+    let cleanup: (() => void) | undefined;
+
+    const handle = (url: string | undefined | null) => {
+      if (!mounted || !url) return;
+      const target = resolveDeepLink(url);
+      if (!target) return;
+      if (target.kind === 'route') {
+        router.push(target.path);
+        return;
+      }
+      // Claimed by the app but not routable here. Handing it to the browser
+      // keeps a half-configured AASA from turning a working link into a dead
+      // one.
+      void openExternalUrl(target.url);
+    };
+
+    const setup = async () => {
+      try {
+        const { App } = await import('@capacitor/app');
+        if (!mounted) return;
+
+        // Cold start: the launch URL is already spent by the time we mount, so
+        // read it before wiring the listener that only covers warm starts.
+        const launch = await App.getLaunchUrl();
+        handle(launch?.url);
+
+        const listener = await App.addListener('appUrlOpen', ({ url }) => handle(url));
+        if (!mounted) {
+          listener.remove();
+          return;
+        }
+        cleanup = () => listener.remove();
+      } catch {
+        // Plugin unavailable — expected on web, and never fatal.
+      }
+    };
+
+    void setup();
+
+    return () => {
+      mounted = false;
+      cleanup?.();
+    };
+  }, [router]);
+
+  return null;
+}

--- a/apps/web/src/components/DeepLinkHandler.tsx
+++ b/apps/web/src/components/DeepLinkHandler.tsx
@@ -33,9 +33,14 @@ export function DeepLinkHandler() {
 
     let mounted = true;
     let cleanup: (() => void) | undefined;
+    let lastHandled: string | undefined;
 
     const handle = (url: string | undefined | null) => {
       if (!mounted || !url) return;
+      // A link that launches the app can surface through both paths. Acting
+      // twice would push a duplicate history entry, so the first one wins.
+      if (url === lastHandled) return;
+      lastHandled = url;
       const target = resolveDeepLink(url);
       if (!target) return;
       if (target.kind === 'route') {
@@ -53,17 +58,19 @@ export function DeepLinkHandler() {
         const { App } = await import('@capacitor/app');
         if (!mounted) return;
 
-        // Cold start: the launch URL is already spent by the time we mount, so
-        // read it before wiring the listener that only covers warm starts.
-        const launch = await App.getLaunchUrl();
-        handle(launch?.url);
-
+        // Listener first: an `appUrlOpen` that fires while `getLaunchUrl()` is
+        // still pending would otherwise land with nothing listening and be lost.
         const listener = await App.addListener('appUrlOpen', ({ url }) => handle(url));
         if (!mounted) {
           listener.remove();
           return;
         }
         cleanup = () => listener.remove();
+
+        // Cold start: the launch URL is already spent by the time we mount, so
+        // it is only recoverable here — the listener never sees it.
+        const launch = await App.getLaunchUrl();
+        handle(launch?.url);
       } catch {
         // Plugin unavailable — expected on web, and never fatal.
       }

--- a/apps/web/src/components/__tests__/DeepLinkHandler.test.tsx
+++ b/apps/web/src/components/__tests__/DeepLinkHandler.test.tsx
@@ -97,6 +97,32 @@ describe('DeepLinkHandler', () => {
     expect(mockAddListener).not.toHaveBeenCalled();
   });
 
+  it('registers the warm-start listener before awaiting the launch URL', async () => {
+    // An appUrlOpen that fires while getLaunchUrl() is pending would otherwise
+    // land with nothing listening.
+    const order: string[] = [];
+    mockAddListener.mockImplementation(async () => {
+      order.push('addListener');
+      return { remove: mockRemove };
+    });
+    mockGetLaunchUrl.mockImplementation(async () => {
+      order.push('getLaunchUrl');
+      return null;
+    });
+    render(<DeepLinkHandler />);
+    await waitFor(() => expect(order).toEqual(['addListener', 'getLaunchUrl']));
+  });
+
+  it('acts once when a launching link arrives through both paths', async () => {
+    // A link that launches the app can surface as both the launch URL and an
+    // appUrlOpen event; pushing twice would leave a duplicate history entry.
+    mockGetLaunchUrl.mockResolvedValue({ url: 'https://pagespace.ai/invite/dup' });
+    render(<DeepLinkHandler />);
+    await waitFor(() => expect(mockPush).toHaveBeenCalledTimes(1));
+    warmStartHandler()({ url: 'https://pagespace.ai/invite/dup' });
+    expect(mockPush).toHaveBeenCalledTimes(1);
+  });
+
   it('removes the listener on unmount', async () => {
     const { unmount } = render(<DeepLinkHandler />);
     await waitFor(() => expect(mockAddListener).toHaveBeenCalled());

--- a/apps/web/src/components/__tests__/DeepLinkHandler.test.tsx
+++ b/apps/web/src/components/__tests__/DeepLinkHandler.test.tsx
@@ -1,0 +1,113 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, waitFor } from '@testing-library/react';
+
+const {
+  mockPush,
+  mockAddListener,
+  mockGetLaunchUrl,
+  mockRemove,
+  mockOpenExternalUrl,
+  mockIsCapacitorApp,
+} = vi.hoisted(() => ({
+  mockPush: vi.fn(),
+  mockAddListener: vi.fn(),
+  mockGetLaunchUrl: vi.fn(),
+  mockRemove: vi.fn(),
+  mockOpenExternalUrl: vi.fn(),
+  mockIsCapacitorApp: vi.fn(),
+}));
+
+vi.mock('next/navigation', () => ({ useRouter: () => ({ push: mockPush }) }));
+
+// Spread the real module: other imports pull getPlatform etc. from here.
+vi.mock('@/lib/capacitor-bridge', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('@/lib/capacitor-bridge')>()),
+  isCapacitorApp: () => mockIsCapacitorApp(),
+}));
+
+vi.mock('@/lib/navigation/app-navigation', () => ({ openExternalUrl: mockOpenExternalUrl }));
+
+vi.mock('@capacitor/app', () => ({
+  App: { getLaunchUrl: mockGetLaunchUrl, addListener: mockAddListener },
+}));
+
+import { DeepLinkHandler } from '../DeepLinkHandler';
+
+/** Hand back the `appUrlOpen` handler the component registered. */
+function warmStartHandler(): (event: { url: string }) => void {
+  const call = mockAddListener.mock.calls.find(([event]) => event === 'appUrlOpen');
+  if (!call) throw new Error('no appUrlOpen listener was registered');
+  return call[1] as (event: { url: string }) => void;
+}
+
+describe('DeepLinkHandler', () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+    mockIsCapacitorApp.mockReturnValue(true);
+    mockGetLaunchUrl.mockResolvedValue(null);
+    mockAddListener.mockResolvedValue({ remove: mockRemove });
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('routes the launch URL on a cold start', async () => {
+    // The launch URL is already spent by mount time, so a listener alone would
+    // never see it.
+    mockGetLaunchUrl.mockResolvedValue({ url: 'https://pagespace.ai/invite/cold' });
+    render(<DeepLinkHandler />);
+    await waitFor(() => expect(mockPush).toHaveBeenCalledWith('/invite/cold'));
+  });
+
+  it('routes a link that arrives while already running', async () => {
+    render(<DeepLinkHandler />);
+    await waitFor(() => expect(mockAddListener).toHaveBeenCalled());
+    warmStartHandler()({ url: 'https://pagespace.ai/invite/warm' });
+    expect(mockPush).toHaveBeenCalledWith('/invite/warm');
+  });
+
+  it('registers the warm-start listener even when there is no launch URL', async () => {
+    render(<DeepLinkHandler />);
+    await waitFor(() =>
+      expect(mockAddListener).toHaveBeenCalledWith('appUrlOpen', expect.any(Function)),
+    );
+  });
+
+  it('hands an unrouted claimed URL to the browser instead of swallowing it', async () => {
+    render(<DeepLinkHandler />);
+    await waitFor(() => expect(mockAddListener).toHaveBeenCalled());
+    warmStartHandler()({ url: 'https://pagespace.ai/pricing' });
+    expect(mockOpenExternalUrl).toHaveBeenCalledWith('https://pagespace.ai/pricing');
+    expect(mockPush).not.toHaveBeenCalled();
+  });
+
+  it('ignores a URL from another host', async () => {
+    render(<DeepLinkHandler />);
+    await waitFor(() => expect(mockAddListener).toHaveBeenCalled());
+    warmStartHandler()({ url: 'https://evil.example/invite/x' });
+    expect(mockPush).not.toHaveBeenCalled();
+    expect(mockOpenExternalUrl).not.toHaveBeenCalled();
+  });
+
+  it('does nothing at all on web', async () => {
+    mockIsCapacitorApp.mockReturnValue(false);
+    render(<DeepLinkHandler />);
+    await waitFor(() => expect(mockGetLaunchUrl).not.toHaveBeenCalled());
+    expect(mockAddListener).not.toHaveBeenCalled();
+  });
+
+  it('removes the listener on unmount', async () => {
+    const { unmount } = render(<DeepLinkHandler />);
+    await waitFor(() => expect(mockAddListener).toHaveBeenCalled());
+    unmount();
+    await waitFor(() => expect(mockRemove).toHaveBeenCalled());
+  });
+
+  it('survives the plugin failing to load', async () => {
+    mockGetLaunchUrl.mockRejectedValue(new Error('plugin unavailable'));
+    expect(() => render(<DeepLinkHandler />)).not.toThrow();
+    await waitFor(() => expect(mockGetLaunchUrl).toHaveBeenCalled());
+    expect(mockPush).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/src/hooks/__tests__/useBillingVisibility.test.ts
+++ b/apps/web/src/hooks/__tests__/useBillingVisibility.test.ts
@@ -1,0 +1,57 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { renderHook } from '@testing-library/react';
+
+const { mockUseCapacitor, mockIsBillingEnabled } = vi.hoisted(() => ({
+  mockUseCapacitor: vi.fn(),
+  mockIsBillingEnabled: vi.fn(),
+}));
+
+vi.mock('@/hooks/useCapacitor', () => ({ useCapacitor: () => mockUseCapacitor() }));
+vi.mock('@/lib/deployment-mode', () => ({ isBillingEnabled: () => mockIsBillingEnabled() }));
+
+import { useBillingVisibility } from '../useBillingVisibility';
+
+describe('useBillingVisibility', () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+    mockIsBillingEnabled.mockReturnValue(true);
+  });
+
+  it('hides purchase UI while platform detection is still pending', () => {
+    // The unsafe direction is showing a purchase surface we later retract — on
+    // iOS that renders a buy affordance for a frame. Six callers gate purchase
+    // UI on this flag, so the default lives here.
+    mockUseCapacitor.mockReturnValue({ isIOS: false, isReady: false });
+    expect(renderHook(() => useBillingVisibility()).result.current.showBilling).toBe(false);
+  });
+
+  it('does not redirect while detection is pending', () => {
+    // hideBilling drives redirects; bouncing before detection would throw web
+    // users off their own billing pages.
+    mockUseCapacitor.mockReturnValue({ isIOS: false, isReady: false });
+    expect(renderHook(() => useBillingVisibility()).result.current.hideBilling).toBe(false);
+  });
+
+  it('shows billing on a non-iOS platform once ready', () => {
+    mockUseCapacitor.mockReturnValue({ isIOS: false, isReady: true });
+    const { showBilling, hideBilling } = renderHook(() => useBillingVisibility()).result.current;
+    expect(showBilling).toBe(true);
+    expect(hideBilling).toBe(false);
+  });
+
+  it('hides billing on iOS once ready', () => {
+    mockUseCapacitor.mockReturnValue({ isIOS: true, isReady: true });
+    const { showBilling, hideBilling } = renderHook(() => useBillingVisibility()).result.current;
+    expect(showBilling).toBe(false);
+    expect(hideBilling).toBe(true);
+  });
+
+  it('hides billing immediately when the deployment has no billing at all', () => {
+    mockIsBillingEnabled.mockReturnValue(false);
+    mockUseCapacitor.mockReturnValue({ isIOS: false, isReady: false });
+    const { showBilling, hideBilling, isReady } = renderHook(() => useBillingVisibility()).result.current;
+    expect(showBilling).toBe(false);
+    expect(hideBilling).toBe(true);
+    expect(isReady).toBe(true);
+  });
+});

--- a/apps/web/src/hooks/useBillingVisibility.ts
+++ b/apps/web/src/hooks/useBillingVisibility.ts
@@ -31,9 +31,23 @@ export function useBillingVisibility() {
   }
 
   return {
-    /** Whether billing UI should be shown (true on web/android, false on iOS) */
-    showBilling: isReady ? !isIOS : true,
-    /** Whether billing UI should be hidden (true on iOS) */
+    /**
+     * Whether billing UI should be shown. False until platform detection
+     * finishes, not true.
+     *
+     * This gates purchase surfaces, so the unsafe direction is showing one we
+     * later retract: on iOS the old default rendered "buy credits" affordances
+     * for a frame before `useCapacitor` resolved. Every one of the six callers
+     * is a purchase surface, so the default belongs here rather than as
+     * `isReady && showBilling` repeated at each of them. The cost on web is one
+     * frame without a buy button.
+     */
+    showBilling: isReady && !isIOS,
+    /**
+     * Whether billing UI should be hidden (true on iOS). Deliberately NOT the
+     * negation of `showBilling`: this drives redirects, and redirecting before
+     * detection completes would bounce web users off their own billing pages.
+     */
     hideBilling: isReady && isIOS,
     /** Whether platform detection is complete (for SSR hydration safety) */
     isReady,

--- a/apps/web/src/lib/navigation/__tests__/deep-links.test.ts
+++ b/apps/web/src/lib/navigation/__tests__/deep-links.test.ts
@@ -1,0 +1,71 @@
+import { describe, it, expect } from 'vitest';
+import { resolveDeepLink } from '../deep-links';
+
+describe('resolveDeepLink', () => {
+  it('routes a claimed invite link to the in-app invite route', () => {
+    expect(resolveDeepLink('https://pagespace.ai/invite/abc123')).toEqual({
+      kind: 'route',
+      path: '/invite/abc123',
+    });
+  });
+
+  it('tolerates a trailing slash', () => {
+    expect(resolveDeepLink('https://pagespace.ai/invite/abc123/')).toEqual({
+      kind: 'route',
+      path: '/invite/abc123',
+    });
+  });
+
+  it('ignores query and hash, which the invite route does not read', () => {
+    expect(resolveDeepLink('https://pagespace.ai/invite/abc123?utm=x#frag')).toEqual({
+      kind: 'route',
+      path: '/invite/abc123',
+    });
+  });
+
+  it('re-encodes a token so it survives being put back into a path', () => {
+    expect(resolveDeepLink('https://pagespace.ai/invite/a%20b')).toEqual({
+      kind: 'route',
+      path: '/invite/a%20b',
+    });
+  });
+
+  it('does not treat a multi-segment path as an invite token', () => {
+    // Invite params are a single opaque segment; anything deeper is not ours.
+    expect(resolveDeepLink('https://pagespace.ai/invite/a/b')).toEqual({
+      kind: 'external',
+      url: 'https://pagespace.ai/invite/a/b',
+    });
+  });
+
+  it('hands an unrouted path on the claimed host back to the browser', () => {
+    // A link the app cannot complete must still complete somewhere, or claiming
+    // the path would turn a working Safari link into a dead one.
+    expect(resolveDeepLink('https://pagespace.ai/pricing')).toEqual({
+      kind: 'external',
+      url: 'https://pagespace.ai/pricing',
+    });
+  });
+
+  it.each([
+    ['a different host', 'https://evil.example/invite/abc123'],
+    ['a suffix lookalike host', 'https://pagespace.ai.evil.example/invite/abc123'],
+    // Guards exact-match specifically: this is the host an `endsWith`
+    // check would wave through, and the suffix case above would not catch
+    // that regression.
+    ['a prefix lookalike host', 'https://evilpagespace.ai/invite/abc123'],
+    ['a subdomain the entitlement does not claim', 'https://app.pagespace.ai/invite/abc123'],
+    ['plain http', 'http://pagespace.ai/invite/abc123'],
+    ['a relative path', '/invite/abc123'],
+    ['unparseable input', 'not a url'],
+  ])('returns null for %s', (_label, url) => {
+    expect(resolveDeepLink(url)).toBeNull();
+  });
+
+  it('ignores the auth-exchange custom scheme', () => {
+    // /api/auth/desktop/exchange redeems its code with no PKCE binding, so
+    // whichever app receives the code can take a session. Routing it from here
+    // would extend that surface before the binding exists.
+    expect(resolveDeepLink('pagespace://auth-exchange?code=stolen')).toBeNull();
+  });
+});

--- a/apps/web/src/lib/navigation/__tests__/deep-links.test.ts
+++ b/apps/web/src/lib/navigation/__tests__/deep-links.test.ts
@@ -62,6 +62,17 @@ describe('resolveDeepLink', () => {
     expect(resolveDeepLink(url)).toBeNull();
   });
 
+  it('does not throw on a malformed escape sequence', () => {
+    // `decodeURIComponent('%')` raises URIError. This runs during listener
+    // setup, so a throw here would abort it and leave the app with no
+    // warm-start listener for the rest of the session.
+    expect(() => resolveDeepLink('https://pagespace.ai/invite/%')).not.toThrow();
+    expect(resolveDeepLink('https://pagespace.ai/invite/%')).toEqual({
+      kind: 'external',
+      url: 'https://pagespace.ai/invite/%',
+    });
+  });
+
   it('ignores the auth-exchange custom scheme', () => {
     // /api/auth/desktop/exchange redeems its code with no PKCE binding, so
     // whichever app receives the code can take a session. Routing it from here

--- a/apps/web/src/lib/navigation/deep-links.ts
+++ b/apps/web/src/lib/navigation/deep-links.ts
@@ -50,7 +50,15 @@ export function resolveDeepLink(rawUrl: string): DeepLinkTarget | null {
   const invite = INVITE_PATH.exec(url.pathname);
   if (invite) {
     // Re-encode: the token came off the wire and goes back into a path.
-    return { kind: 'route', path: `/invite/${encodeURIComponent(decodeURIComponent(invite[1]))}` };
+    // `decodeURIComponent` throws URIError on a malformed escape (`/invite/%`),
+    // and this runs during listener setup — an escaping throw would abort it and
+    // leave the app with no warm-start listener for the rest of the session.
+    try {
+      return { kind: 'route', path: `/invite/${encodeURIComponent(decodeURIComponent(invite[1]))}` };
+    } catch {
+      // Not a token we could have issued. Let the browser render the error.
+      return { kind: 'external', url: url.toString() };
+    }
   }
 
   // On the claimed host but not a route we know. Never swallow it — a link the

--- a/apps/web/src/lib/navigation/deep-links.ts
+++ b/apps/web/src/lib/navigation/deep-links.ts
@@ -1,0 +1,59 @@
+/**
+ * Resolving a universal link the shell handed us into an in-app route.
+ *
+ * The AASA at `apps/marketing/public/.well-known/apple-app-site-association`
+ * decides which URLs ever reach this code. Keep the two in step: claiming a
+ * path Apple sends us that this resolver returns `null` for means the link
+ * stops working in Safari and does nothing in the app instead — strictly worse
+ * than never claiming it.
+ *
+ * Deliberately an allowlist, not a general "navigate to whatever path arrived".
+ * The URL is external input, and a universal link can name any path on the
+ * host.
+ */
+
+/** The one host the entitlement claims (`applinks:pagespace.ai`). */
+const CLAIMED_HOST = 'pagespace.ai';
+
+/**
+ * Invite tokens are a single opaque path segment — see
+ * `apps/web/src/app/invite/[token]/page.tsx`, whose params are `{ token }`.
+ * A token with a slash in it is not a token we issued.
+ */
+const INVITE_PATH = /^\/invite\/([^/]+)\/?$/;
+
+export type DeepLinkTarget =
+  /** An in-app route. Navigate with the router — never `window.location`. */
+  | { kind: 'route'; path: string }
+  /** Claimed but not routable here. Hand back to the browser so it completes. */
+  | { kind: 'external'; url: string };
+
+/**
+ * `null` means "not ours" — the caller should ignore it rather than guess.
+ *
+ * Note what is *not* handled: the `pagespace://auth-exchange` custom scheme.
+ * `/api/auth/desktop/exchange` redeems its code with no PKCE binding, so
+ * whichever app receives the code can take a session; routing it from here
+ * would extend that surface. That binding is a prerequisite, tracked
+ * separately, and until it exists this resolver ignores the scheme entirely.
+ */
+export function resolveDeepLink(rawUrl: string): DeepLinkTarget | null {
+  let url: URL;
+  try {
+    url = new URL(rawUrl);
+  } catch {
+    return null;
+  }
+
+  if (url.protocol !== 'https:' || url.hostname !== CLAIMED_HOST) return null;
+
+  const invite = INVITE_PATH.exec(url.pathname);
+  if (invite) {
+    // Re-encode: the token came off the wire and goes back into a path.
+    return { kind: 'route', path: `/invite/${encodeURIComponent(decodeURIComponent(invite[1]))}` };
+  }
+
+  // On the claimed host but not a route we know. Never swallow it — a link the
+  // app cannot complete must still complete somewhere.
+  return { kind: 'external', url: url.toString() };
+}


### PR DESCRIPTION
Follow-up to #2568. That PR deferred claiming `/invite/*` because nothing routed it; this adds the routing and restores the claim **together**, plus the two remaining code-doable items from the submission epic.

## Universal links now actually work

`DeepLinkHandler` handles two cases that are **not** interchangeable, and shipping one without the other leaves half the links dead:

| Start | Delivery | Why a listener alone isn't enough |
|---|---|---|
| **Cold** | `App.getLaunchUrl()` | The URL is spent before any listener can exist — the app just loads `/dashboard`. |
| **Warm** | `appUrlOpen` | The native side only *notifies plugins*; it never calls `loadUrl`. With no listener the WebView silently stays where it was. |

Navigation goes through the router, never `window.location`: in the iOS shell a top-level location change reaches Capacitor's `WKNavigationDelegate`, which cancels anything outside `server.url`'s `/dashboard` prefix and opens Safari, blanking the WebView. `/invite/*` is outside that prefix, so this distinction is load-bearing.

`resolveDeepLink` is an **allowlist**, not "navigate to whatever path arrived" — the URL is external input and a universal link can name any path on the host. Two deliberate choices:

- It ignores `pagespace://auth-exchange` outright. `/api/auth/desktop/exchange` redeems its code with no PKCE binding, so whichever app receives the code can take a session. Routing it here would extend that surface.
- Anything unrecognised **on the claimed host** goes to the browser rather than being swallowed, so a half-configured AASA degrades to today's behaviour instead of killing the link.

## Guideline 3.1.1 — two real gaps

- **`/settings/billing`** rendered a bare "Billing — Your subscription, payment methods, and invoices" header over nothing on iOS. Every *section* was gated; the *route* was not. It also fetched `/api/stripe/invoices` and `/api/stripe/upcoming-invoice` on mount regardless of platform. Now wrapped in the same `BillingGuard` that `/settings/plan` already uses — which also prevents the child mounting, so those fetches never fire.
- **`/settings/usage`** stays reachable (usage is not a purchase, and its nav item is deliberately not `mobileHidden`), but its two credit banners were ungated purchase copy — *"Credit purchase canceled. You can buy credits anytime."* — now behind `showBilling`.

## Facebook SDK — documented, not removed

It's a hard dependency of `@capgo/capacitor-social-login`'s own target, so removing it means forking the plugin. Checked each link in the chain instead: no `FacebookAppID`/`FacebookClientToken` in `Info.plist`, `FacebookProvider.init()` only builds an `ISO8601DateFormatter`, its `initialize()` is empty, and we only ever call `SocialLogin.initialize` with `apple` or `google`. Linked but never initialized, so `NSPrivacyTracking = false` is accurate. Deliberately did **not** add `FacebookAutoLogAppEventsEnabled` — with no app ID there is nothing to disable, and dead config rots.

## Verification

20 pu agents were live and this worktree has no `node_modules`, so no vitest run locally — CI is the gate for the test files. But `deep-links.ts` imports nothing, so I executed **the real resolver** under `node --experimental-strip-types` against all 13 cases:

```
PASS  https://pagespace.ai/invite/abc123        -> {"kind":"route","path":"/invite/abc123"}
PASS  https://pagespace.ai/invite/a/b           -> {"kind":"external",...}
PASS  https://evil.example/invite/abc123        -> null
PASS  https://pagespace.ai.evil.example/...     -> null
PASS  http://pagespace.ai/invite/abc123         -> null
PASS  pagespace://auth-exchange?code=stolen     -> null
all 13 cases pass
```

Then mutation-checked the guards, which **found a gap in my own tests**: swapping exact-match for `endsWith` did not flip any assertion. `pagespace.ai.evil.example` fails `endsWith` too — the host that slips through is a *prefix* lookalike, `evilpagespace.ai`. The code already rejected it; the test did not guard it. Added that case. Dropping the `https:` check and loosening the invite regex both flip correctly.

## Still needs a device — not in this PR

**The AASA claim must be device-verified before archiving 1.4.** Unit-level evidence is not device evidence: after merge and a marketing deploy, reinstall the app (Apple's CDN caches the AASA) and confirm an `/invite/` link opens it from **both** a cold start and with the app already running. The two paths are handled separately and only one is exercised by any given tap.

Same for the billing sweep — the gate reads `window.Capacitor`, so it only means anything on a real build.

Epic: `iOS App Store Submission Epic` (`pcmu8yj2cvfk60y9d4r10ovo`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014B1XUKffgMpNUtvFR1xLeH


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for opening `/invite/*` links directly in the iOS and web apps from cold or warm starts.
  - Unrecognized claimed links now open in the browser, while unsupported or unrelated links are ignored.
  - Billing settings and usage purchase alerts are now shown only when billing access is available.

- **Documentation**
  - Updated Android and iOS setup, review, and verification guidance for universal links.
  - Documented the Facebook iOS SDK configuration.

- **Tests**
  - Added coverage for deep-link routing, validation, and lifecycle behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->