### PR TITLE
fix(sandbox): resolve a probe on its own sentinel — the runtime holds the exec socket open 5–10s after exit

### DIFF
--- a/packages/lib/src/services/sandbox/preview/__tests__/dev-preview-effects.test.ts
+++ b/packages/lib/src/services/sandbox/preview/__tests__/dev-preview-effects.test.ts
@@ -232,7 +232,10 @@ describe('probeRelayRuntime — socat is preferred only when the sprite proves i
     let seen: { cmd: string; args?: string[] } | undefined;
     const runtime = await probeRelayRuntime(async (args) => { seen = args; return { exitCode: 0, stdout: '/usr/bin/socat\n', stderr: '' }; });
     assert({ given: 'exit 0', should: 'socat', actual: runtime, expected: 'socat' });
-    assert({ given: 'the probe', should: 'ask sh for socat', actual: seen, expected: { cmd: 'sh', args: ['-c', 'command -v socat'], timeoutMs: 10_000 } });
+    // Ends with a sentinel and asks the driver to resolve on it: the runtime
+    // holds the exec socket open 5–10s after exit, so waiting for `exit`
+    // would spend the whole budget on a close (see `RunCommandArgs.stdoutSentinel`).
+    assert({ given: 'the probe', should: 'ask sh for socat, sentinel-terminated', actual: seen, expected: { cmd: 'sh', args: ['-c', 'command -v socat >/dev/null 2>&1; echo "__PS_RT_END__ $?"'], timeoutMs: 10_000, stdoutSentinel: '__PS_RT_END__' } });
   });
 
   it('falls back to the verified node default on a non-zero exit or a thrown probe', async () => {

--- a/packages/lib/src/services/sandbox/preview/__tests__/port-probe.test.ts
+++ b/packages/lib/src/services/sandbox/preview/__tests__/port-probe.test.ts
@@ -9,7 +9,7 @@
  */
 import { describe, it } from 'vitest';
 import { assert } from '../../__tests__/riteway';
-import { parseListeningPorts, probeListeningPorts, PORT_PROBE_TIMEOUT_MS } from '../port-probe';
+import { parseListeningPorts, probeListeningPorts, PORT_PROBE_TIMEOUT_MS, PORT_PROBE_SENTINEL } from '../port-probe';
 import type { RunCommandArgs, SandboxRunResult } from '../../sandbox-client/types';
 
 // Captured verbatim from the sandbox running `next dev` — the case that
@@ -75,6 +75,32 @@ describe('parseListeningPorts', () => {
       should: 'report it once, carrying the pid',
       actual: parseListeningPorts(dual),
       expected: [{ port: 3000, pid: 7 }],
+    });
+  });
+});
+
+describe('the sentinel', () => {
+  it('is what the command ends with, and the probe asks the driver to resolve on it', async () => {
+    // The runtime holds the exec socket open 5–10s after exit and `exit`
+    // only arrives on close; the sentinel is how the probe answers in ~200ms
+    // instead of never inside its cap.
+    let seen: RunCommandArgs | null = null;
+    await probeListeningPorts(async (args) => { seen = args; return ok({ stdout: NEXT_OUTPUT }); });
+    const args = seen as unknown as RunCommandArgs;
+    assert({
+      given: 'the probe run',
+      should: 'end its command with the sentinel and pass it to the driver',
+      actual: [args.args?.[1]?.includes(`echo "${PORT_PROBE_SENTINEL} $?"`), args.stdoutSentinel],
+      expected: [true, PORT_PROBE_SENTINEL],
+    });
+  });
+
+  it('a sentinel line that reaches the parser anyway is neither a port nor a reason to call the output unparsable', async () => {
+    assert({
+      given: 'header + sentinel only (a driver that did not strip it)',
+      should: 'still be an honest empty answer',
+      actual: await probeListeningPorts(async () => ok({ stdout: `State Recv-Q Send-Q Local Address:Port\n${PORT_PROBE_SENTINEL} 0\n` })),
+      expected: { ok: true, ports: [] },
     });
   });
 });

--- a/packages/lib/src/services/sandbox/preview/dev-preview-effects.ts
+++ b/packages/lib/src/services/sandbox/preview/dev-preview-effects.ts
@@ -57,7 +57,11 @@ const RUNTIME_PROBE_TIMEOUT_MS = 10_000;
  */
 export async function probeRelayRuntime(exec: (args: RunCommandArgs) => Promise<SandboxRunResult>): Promise<PreviewRelayRuntime> {
   try {
-    const result = await exec({ cmd: 'sh', args: ['-c', 'command -v socat'], timeoutMs: RUNTIME_PROBE_TIMEOUT_MS });
+    // The sentinel makes this answer at first-byte latency instead of at
+    // socket close, which the runtime delays 5–10s after exit — see
+    // `RunCommandArgs.stdoutSentinel`. Without it a relay create on a
+    // long-lived sprite spent its whole budget waiting for a close.
+    const result = await exec({ cmd: 'sh', args: ['-c', 'command -v socat >/dev/null 2>&1; echo "__PS_RT_END__ $?"'], timeoutMs: RUNTIME_PROBE_TIMEOUT_MS, stdoutSentinel: '__PS_RT_END__' });
     return result.exitCode === 0 ? 'socat' : 'node';
   } catch {
     return 'node';

--- a/packages/lib/src/services/sandbox/preview/port-probe.ts
+++ b/packages/lib/src/services/sandbox/preview/port-probe.ts
@@ -26,8 +26,18 @@
 import type { ListeningPort } from './dev-preview-core';
 import type { RunCommandArgs, SandboxRunResult } from '../sandbox-client/types';
 
-/** Bounded: this runs inside the holder's advisory lock on the select path. */
-export const PORT_PROBE_TIMEOUT_MS = 5_000;
+/**
+ * The BACKSTOP, not the expected duration. With the sentinel below the answer
+ * arrives at first-byte latency (~200ms measured); this cap only fires if the
+ * socket never opens or the command never prints. 20s matches
+ * `sandbox-storage-measure`'s bound for the same kind of user-gesture exec —
+ * 5s was the shortest exec cap in the codebase and could never succeed, because
+ * the runtime holds the exec socket open 5–10s after the process ends and the
+ * SDK's `exit` only arrives on close (see `RunCommandArgs.stdoutSentinel`).
+ */
+export const PORT_PROBE_TIMEOUT_MS = 20_000;
+/** Ends the probe's output; the driver resolves on it instead of on socket close. */
+export const PORT_PROBE_SENTINEL = '__PS_PORTS_END__';
 /** `ss` output for a sandbox is a few KB; anything past this is not output we understand. */
 export const PORT_PROBE_MAX_BYTES = 256 * 1024;
 
@@ -49,7 +59,7 @@ export type PortProbeResult =
  * `DevPreviewSlotReport.pid` would be permanently null. `-n` keeps ports
  * numeric so nothing has to un-resolve a service name.
  */
-const PROBE_COMMAND = 'ss -ltnp 2>/dev/null || netstat -ltnp 2>/dev/null';
+const PROBE_COMMAND = `(ss -ltnp 2>/dev/null || netstat -ltnp 2>/dev/null); echo "${PORT_PROBE_SENTINEL} $?"`;
 
 /**
  * Pure: parse `ss -ltnp` / `netstat -ltnp` output into listening ports.
@@ -98,6 +108,7 @@ export async function probeListeningPorts(
       args: ['-c', PROBE_COMMAND],
       timeoutMs: PORT_PROBE_TIMEOUT_MS,
       maxBytes: PORT_PROBE_MAX_BYTES,
+      stdoutSentinel: PORT_PROBE_SENTINEL,
     });
   } catch (error) {
     // The driver SIGKILLs at the cap and surfaces it as a throw; anything else
@@ -121,6 +132,8 @@ export function isHeaderOnly(stdout: string): boolean {
   return stdout.split('\n').every((line) => {
     const trimmed = line.trim();
     // `ss` prints "State Recv-Q …"; `netstat` prints "Active Internet…" then "Proto …".
-    return trimmed === '' || /^(State|Active|Proto)\b/.test(trimmed);
+    // The sentinel line is ours and the driver strips it — but tolerate it
+    // here too, so a driver that did not is still an honest empty.
+    return trimmed === '' || /^(State|Active|Proto)\b/.test(trimmed) || trimmed.startsWith(PORT_PROBE_SENTINEL);
   });
 }

--- a/packages/lib/src/services/sandbox/sandbox-client/__tests__/sprites.test.ts
+++ b/packages/lib/src/services/sandbox/sandbox-client/__tests__/sprites.test.ts
@@ -18,6 +18,8 @@ import {
   type SpriteCommandLike,
   type SpriteFsLike,
   type SpriteCheckpointStreamLike,
+  runSpawned,
+  findSentinel,
 } from '../sprites';
 import { SandboxProvisionError } from '../../sandbox-options';
 import { SANDBOX_EGRESS_ALLOWLIST } from '../../execution-policy';
@@ -1696,5 +1698,42 @@ describe('withKillSession', () => {
     } finally {
       vi.unstubAllGlobals();
     }
+  });
+});
+
+describe('runSpawned — the stdout sentinel short-circuit', () => {
+  // Measured 2026-09-08: the Sprites runtime holds an exec socket open ~5s on a
+  // fresh sprite and ~10s on a long-lived one AFTER the process exits, and the
+  // SDK emits `exit` only on close. A command that ends with `<sentinel> <code>`
+  // must therefore resolve on that LINE, without waiting for a close that a
+  // 5s cap can never see.
+  it('resolves on the sentinel line for a command whose socket never closes, strips the line, reports the code, and kills the socket', async () => {
+    const command = fakeCommand({ stdout: ['LISTEN 0 511 *:3000 *:*\n', '__END__ 0\n'], hang: true });
+    const result = await runSpawned(command, 0, 2_000, '__END__');
+    expect(result).toEqual({ exitCode: 0, stdout: 'LISTEN 0 511 *:3000 *:*', stderr: '' });
+    expect(command.killed).toEqual(['SIGKILL']);
+  });
+
+  it('carries a non-zero code through the sentinel', async () => {
+    const command = fakeCommand({ stdout: ['__END__ 127\n'], hang: true });
+    expect((await runSpawned(command, 0, 2_000, '__END__')).exitCode).toBe(127);
+  });
+
+  it('is inert without a sentinel: the same hanging command still runs to the timeout', async () => {
+    const command = fakeCommand({ stdout: ['__END__ 0\n'], hang: true });
+    await expect(runSpawned(command, 0, 50)).rejects.toThrow(/timed out/);
+  });
+});
+
+describe('findSentinel', () => {
+  it('needs a COMPLETE line — a sentinel at the end of a chunk with no newline is not yet an answer', () => {
+    // `12` might be the first two bytes of `127`.
+    expect(findSentinel('out\n__END__ 12', '__END__')).toBeNull();
+    expect(findSentinel('out\n__END__ 127\n', '__END__')).toEqual({ stdout: 'out', exitCode: 127 });
+  });
+
+  it('ignores a sentinel with no numeric code, and returns the stdout BEFORE the line', () => {
+    expect(findSentinel('__END__ nope\n', '__END__')).toBeNull();
+    expect(findSentinel('a\nb\n__END__ 0\ntrailing\n', '__END__')).toEqual({ stdout: 'a\nb', exitCode: 0 });
   });
 });

--- a/packages/lib/src/services/sandbox/sandbox-client/sprites.ts
+++ b/packages/lib/src/services/sandbox/sandbox-client/sprites.ts
@@ -611,6 +611,27 @@ function toBuffer(chunk: Buffer | string): Buffer {
 }
 
 /**
+ * Pure: locate a `<sentinel> <exit-code>` line in collected stdout. Returns the
+ * stdout BEFORE that line and the parsed code, or null when the sentinel has not
+ * arrived yet (or arrived without a numeric code — treated as not-yet, so a
+ * partial chunk boundary cannot fake a result).
+ */
+export function findSentinel(stdout: string, sentinel: string): { stdout: string; exitCode: number } | null {
+  const lines = stdout.split('\n');
+  for (let i = 0; i < lines.length; i += 1) {
+    const line = lines[i];
+    if (!line.startsWith(sentinel)) continue;
+    const code = Number(line.slice(sentinel.length).trim());
+    if (!Number.isInteger(code)) return null;
+    // Only a COMPLETE line counts: a sentinel at the very end with no newline
+    // may still be mid-chunk (the code could be `12` of `127`).
+    if (i === lines.length - 1) return null;
+    return { stdout: lines.slice(0, i).join('\n'), exitCode: code };
+  }
+  return null;
+}
+
+/**
  * Run a command through the SDK's `spawn` (structured `file` + `args[]`, never a
  * host-side shell string) and buffer its output. Faithfully replicates the SDK's
  * own `execFile` collection — stdout/stderr `data` listeners with a `maxBuffer`
@@ -631,6 +652,7 @@ export function runSpawned(
   command: SpriteCommandLike,
   maxBytes: number,
   timeoutMs: number | undefined,
+  stdoutSentinel?: string,
 ): Promise<SandboxRunResult> {
   const maxBuffer = maxBytes > 0 ? maxBytes : DEFAULT_MAX_OUTPUT_BYTES;
   return new Promise<SandboxRunResult>((resolve, reject) => {
@@ -688,6 +710,20 @@ export function runSpawned(
       // Output proves the connection opened, even if the 'spawn' event was missed.
       opened = true;
       stdoutLen = collect(stdoutChunks, chunk, stdoutLen);
+      if (stdoutSentinel === undefined || settled) return;
+      // THE SENTINEL SHORT-CIRCUIT (see `RunCommandArgs.stdoutSentinel`): the
+      // runtime holds the socket open 5–10s after exit, and `exit` arrives only
+      // on close. A caller that ends its command with `<sentinel> <code>` has
+      // told us everything the close would; take it now and kill the lingering
+      // socket ourselves. The sentinel line is stripped from the result.
+      const found = findSentinel(Buffer.concat(stdoutChunks).toString('utf8'), stdoutSentinel);
+      if (found === null) return;
+      try {
+        command.kill('SIGKILL');
+      } catch {
+        // Best-effort: the socket closes on its own within the runtime's grace.
+      }
+      succeed({ exitCode: found.exitCode, stdout: found.stdout, stderr: Buffer.concat(stderrChunks).toString('utf8') });
     });
     command.stderr.on('data', (chunk) => {
       opened = true;
@@ -867,8 +903,9 @@ function runSpawnedWithWakeRetry(
   spawnFn: () => SpriteCommandLike,
   maxBytes: number,
   timeoutMs: number | undefined,
+  stdoutSentinel?: string,
 ): Promise<SandboxRunResult> {
-  return withWakeRetry(() => runSpawned(spawnFn(), maxBytes, timeoutMs));
+  return withWakeRetry(() => runSpawned(spawnFn(), maxBytes, timeoutMs, stdoutSentinel));
 }
 
 /** Reject if `p` has not settled within `ms` — the Sprite filesystem API uses a
@@ -1179,7 +1216,7 @@ function wrap(sprite: SpriteInstanceLike, egressPolicyToken?: string): Executabl
     // identity is unknown — both of which the caller must treat as "unproven".
     egressPolicyToken,
 
-    async runCommand({ cmd, args = [], cwd, env, timeoutMs, maxBytes }: RunCommandArgs): Promise<SandboxRunResult> {
+    async runCommand({ cmd, args = [], cwd, env, timeoutMs, maxBytes, stdoutSentinel }: RunCommandArgs): Promise<SandboxRunResult> {
       // spawn (arg array), never a host-side shell string. The untrusted command
       // runs under the Sprite's own `sh -c`, contained by the VM. Re-spawned per
       // attempt so a cold-start wake drop reconnects on a fresh WebSocket.
@@ -1190,7 +1227,7 @@ function wrap(sprite: SpriteInstanceLike, egressPolicyToken?: string): Executabl
       const spawnFn = cwd === undefined
         ? () => sprite.spawn(cmd, args, { env })
         : () => sprite.spawn(...spawnWithSelfHealingCwd({ command: cmd, args, cwd }), { env });
-      return runSpawnedWithWakeRetry(spawnFn, maxBytes ?? 0, timeoutMs);
+      return runSpawnedWithWakeRetry(spawnFn, maxBytes ?? 0, timeoutMs, stdoutSentinel);
     },
 
     async writeFiles(files: WriteFileEntry[]): Promise<void> {

--- a/packages/lib/src/services/sandbox/sandbox-client/types.ts
+++ b/packages/lib/src/services/sandbox/sandbox-client/types.ts
@@ -36,6 +36,24 @@ export interface RunCommandArgs {
    * command and fails the run, bounding host memory against an output flood.
    */
   maxBytes?: number;
+  /**
+   * OPT-IN: resolve as soon as a stdout LINE begins with this token, instead
+   * of waiting for the exec socket to close.
+   *
+   * Why this exists (measured 2026-09-08 against real sprites): the Sprites
+   * runtime holds an exec WebSocket open for ~5s on a fresh sprite and ~10s
+   * on a long-lived one AFTER the process has exited — even for `true` — and
+   * the SDK delivers `exit` only when the socket closes. So every run through
+   * this driver carries a 5–10s tail the command did not spend, and any cap
+   * under that can never succeed. A caller whose command prints
+   * `<sentinel> <exit-code>` as its last line gets its answer at first-byte
+   * latency (~200ms); the driver reads the code from that line, stops
+   * collecting, and SIGKILLs the lingering socket itself.
+   *
+   * Inert unless set. Callers that need the process's own exit (a long build,
+   * a shell) keep the close-based contract untouched.
+   */
+  stdoutSentinel?: string;
 }
 
 export interface WriteFileEntry {


### PR DESCRIPTION
The Ports pane's first real use in production failed the way it was built to fail — loudly — with `probe-failed: timed-out`, four times running. This is the diagnosis, measured, and the fix.

## What was measured

Through the **shipped driver** (`createSpritesSandboxClient` → `runCommand`), instrumented per phase, against a fresh sprite and the long-lived env sprite the user was on:

| | fresh | env (running) |
|---|---|---|
| socket open | +151 ms | +194 ms |
| first stdout | +161 ms | +223 ms |
| **`exit`** | **+5 348 ms** | **+10 483 ms** |

— for `true`, `ss -ltn` and `ss -ltnp` alike. The command finishes in ~200 ms; the Sprites runtime then holds the exec WebSocket open for 5–10 s before closing it, and the SDK emits `exit` only on close (`websocket.js` `handleClose`). So every run through this driver carries a 5–10 s tail the command did not spend, a 5 s cap can never succeed, and `-p` had nothing to do with it. `probeRelayRuntime` (10 s) shares the path and would have failed on the env sprite's first relay create.

## Why I had not seen it

Every probe test ran against a fake `exec` or the SDK's `execFile` from a laptop — never the shipped driver. And 5 s was set by feel: it was the shortest exec cap in the codebase, whose only other 5 s is fenced to a just-created sprite, while every user-gesture exec elsewhere uses 10–30 s.

## The fix: an opt-in stdout sentinel

`RunCommandArgs.stdoutSentinel`. When set, `runSpawned` resolves as soon as a stdout **line** begins with the token, reads the exit code from that line, strips it from the result, and SIGKILLs the lingering socket itself. **Inert unless set** — a long build or a shell keeps the close-based contract untouched. `findSentinel` requires a complete line, so a chunk boundary inside the code (`12` of `127`) cannot fake a result.

Both probes now end their command with `echo "<sentinel> $?"` and pass the token. Re-measured through the driver against the env sprite: **120 ms, 206 ms, 270 ms** for the full `probeListeningPorts`, returning `:3000` with its pid. The cap is raised to 20 s as a backstop (matching `sandbox-storage-measure`); with the sentinel it is not expected to fire.

## Verification

- Mutation-checked: disabling the sentinel branch fails the new driver tests (a hanging command with a sentinel must resolve; the same command without one must still time out).
- sandbox-client 114/114 · lib preview + client suites 587/587 · realtime 1266/1266 · `tsc` clean on lib, web, realtime.
- **After deploy:** Scan in the same `next dev` session should list `:3000` in well under a second. I'll be watching the row and realtime.

## Worth knowing beyond this PR

Every `runCommand` caller in the codebase pays this 5–10 s tail today (file browser, storage measure, agent tools). This PR deliberately does not change their contract; adopting the sentinel where a caller controls its own command is a cheap follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01P8A8KLYCoViP7ouH5QzbnB
