### PR TITLE
fix(dev-preview): host route reads the browser's original pathname — the preview frame was a 404

### DIFF
--- a/apps/web/src/__tests__/middleware-dev-preview.test.ts
+++ b/apps/web/src/__tests__/middleware-dev-preview.test.ts
@@ -73,6 +73,7 @@ describe('middleware — preview host branch', () => {
   it('rewrites /_next/static/* on a preview host onto the forwarder — a proxied Next dev server serves its own /_next', async () => {
     const res = await middleware(request('/_next/static/chunks/main.js?v=1'), undefined as unknown as NextFetchEvent);
     expect(rewriteTarget(res)).toBe('/api/dev-preview/host/env/env1/_next/static/chunks/main.js');
+    expect(res?.headers.get('x-middleware-request-x-dev-preview-path')).toBe('/_next/static/chunks/main.js');
     expect(new URL(res!.headers.get('x-middleware-rewrite')!).search).toBe('?v=1');
   });
 
@@ -86,8 +87,17 @@ describe('middleware — preview host branch', () => {
   it('rewrites the root and deep paths, and adds no security headers of its own', async () => {
     const res = await middleware(request('/'), undefined as unknown as NextFetchEvent);
     expect(rewriteTarget(res)).toBe('/api/dev-preview/host/env/env1/');
+    // The ORIGINAL pathname is stamped on the rewritten REQUEST (Next carries
+    // request-header overrides as `x-middleware-request-*`): the handler sees
+    // the original pathname after a rewrite and must not guess by shape.
+    expect(res?.headers.get('x-middleware-request-x-dev-preview-path')).toBe('/');
     expect(res?.headers.get('x-frame-options')).toBeNull();
     expect(res?.headers.get('content-security-policy')).toBeNull();
+  });
+
+  it('overwrites a client-sent stamp — on a preview host the header is ours', async () => {
+    const res = await middleware(request('/real', { 'x-dev-preview-path': '/forged' }), undefined as unknown as NextFetchEvent);
+    expect(res?.headers.get('x-middleware-request-x-dev-preview-path')).toBe('/real');
   });
 
   it('does nothing for a preview-shaped host when the feature is dark', async () => {

--- a/apps/web/src/app/api/dev-preview/__tests__/host-route.test.ts
+++ b/apps/web/src/app/api/dev-preview/__tests__/host-route.test.ts
@@ -237,3 +237,40 @@ describe('authorize + decide, per request', () => {
     expect(vi.mocked(loggers.security.warn).mock.calls.map((c) => (c[1] as { outcome: string }).outcome)).toEqual(['limit-exceeded', 'upstream-error']);
   });
 });
+
+describe('after the middleware rewrite the handler sees the ORIGINAL pathname', () => {
+  // Production shape: the browser asked the preview host for `/`; the
+  // middleware rewrote it onto the mount, but `request.nextUrl.pathname`
+  // inside the handler is still `/` (Next 15.5, self-hosted). The route must
+  // not demand the mount — the first real preview 404'd on every path.
+  const rawReq = (path: string, headers: Record<string, string> = {}): NextRequest => {
+    const h = new Headers(headers);
+    h.set('host', HOST);
+    return new NextRequest(`https://${HOST}${path}`, { headers: h });
+  };
+  const forwardable = () => {
+    vi.mocked(resolvePreviewTargetForRequest).mockResolvedValue({ decision: { kind: 'forward', wake: false }, authorization: { allowed: true, driveId: 'd', wakeSubject: { driveId: 'd', ownerId: 'o' }, sandboxId: 's' }, spriteUrl: 'https://ps-x-org.sprites.app', handle: {} as never });
+    vi.mocked(forwardPreviewRequest).mockResolvedValue({ kind: 'response', response: new Response('ok'), upstreamStatus: 200 });
+  };
+
+  it('reaches the cookie stage for `/` with no mount in the path — 401 no-cookie, not 404', async () => {
+    const res = await GET(rawReq('/'), ctx());
+    expect(res.status).toBe(401);
+    expect(await res.json()).toMatchObject({ reason: 'no-cookie' });
+  });
+
+  it('forwards the original path and query verbatim: `/` and a Next chunk', async () => {
+    forwardable();
+    expect((await GET(rawReq('/', { cookie: cookie() }), ctx())).status).toBe(200);
+    expect(forwardPreviewRequest).toHaveBeenLastCalledWith(expect.objectContaining({ pathAndQuery: '/' }));
+    expect((await GET(rawReq('/_next/static/a.js?v=1', { cookie: cookie() }), ctx())).status).toBe(200);
+    expect(forwardPreviewRequest).toHaveBeenLastCalledWith(expect.objectContaining({ pathAndQuery: '/_next/static/a.js?v=1' }));
+    expect(loggers.security.info).toHaveBeenLastCalledWith('dev-preview.access', expect.objectContaining({ outcome: 'forwarded', path: '/_next/static/a.js' }));
+  });
+
+  it('still strips the mount when the request carries it itself', async () => {
+    forwardable();
+    expect((await GET(req('/items?x=1', { headers: { cookie: cookie() } }), ctx())).status).toBe(200);
+    expect(forwardPreviewRequest).toHaveBeenLastCalledWith(expect.objectContaining({ pathAndQuery: '/items?x=1' }));
+  });
+});

--- a/apps/web/src/app/api/dev-preview/__tests__/host-route.test.ts
+++ b/apps/web/src/app/api/dev-preview/__tests__/host-route.test.ts
@@ -9,6 +9,7 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest';
 import { NextRequest } from 'next/server';
 import { derivePreviewCookieKey, signPreviewCookie, PREVIEW_COOKIE_NAME } from '@pagespace/lib/services/sandbox/preview/preview-grant';
+import { DEV_PREVIEW_PATH_HEADER } from '@/lib/dev-preview/preview-path-header';
 
 vi.mock('@pagespace/lib/audit/audit-log', () => ({ auditRequest: vi.fn() }));
 vi.mock('@pagespace/lib/logging/logger-config', () => ({
@@ -240,12 +241,15 @@ describe('authorize + decide, per request', () => {
 
 describe('after the middleware rewrite the handler sees the ORIGINAL pathname', () => {
   // Production shape: the browser asked the preview host for `/`; the
-  // middleware rewrote it onto the mount, but `request.nextUrl.pathname`
-  // inside the handler is still `/` (Next 15.5, self-hosted). The route must
-  // not demand the mount — the first real preview 404'd on every path.
+  // middleware rewrote it onto the mount and stamped the original pathname
+  // on the request, but `request.nextUrl.pathname` inside the handler is
+  // still `/` (Next 15.5, self-hosted). The route must not demand the mount
+  // — the first real preview 404'd on every path — and must not guess the
+  // path by shape either: it takes the stamped one.
   const rawReq = (path: string, headers: Record<string, string> = {}): NextRequest => {
     const h = new Headers(headers);
     h.set('host', HOST);
+    h.set(DEV_PREVIEW_PATH_HEADER, path.split('?')[0]);
     return new NextRequest(`https://${HOST}${path}`, { headers: h });
   };
   const forwardable = () => {
@@ -268,7 +272,24 @@ describe('after the middleware rewrite the handler sees the ORIGINAL pathname', 
     expect(loggers.security.info).toHaveBeenLastCalledWith('dev-preview.access', expect.objectContaining({ outcome: 'forwarded', path: '/_next/static/a.js' }));
   });
 
-  it('still strips the mount when the request carries it itself', async () => {
+  it('a preview path that LOOKS like the mount, or like a sibling of it, is forwarded verbatim — never stripped, never refused', async () => {
+    forwardable();
+    const mountShaped = `/api/dev-preview/host/${HOLDER.kind}/${HOLDER.id}/assets/app.js`;
+    expect((await GET(rawReq(mountShaped, { cookie: cookie() }), ctx())).status).toBe(200);
+    expect(forwardPreviewRequest).toHaveBeenLastCalledWith(expect.objectContaining({ pathAndQuery: mountShaped }));
+    const sibling = `/api/dev-preview/host/${HOLDER.kind}/${HOLDER.id}-assets`;
+    expect((await GET(rawReq(sibling, { cookie: cookie() }), ctx())).status).toBe(200);
+    expect(forwardPreviewRequest).toHaveBeenLastCalledWith(expect.objectContaining({ pathAndQuery: sibling }));
+  });
+
+  it('a stamped path that is not a path is ignored — the mount-stripping fallback decides', async () => {
+    forwardable();
+    const res = await GET(req('/items', { headers: { cookie: cookie(), [DEV_PREVIEW_PATH_HEADER]: 'https://evil.example/x' } }), ctx());
+    expect(res.status).toBe(200);
+    expect(forwardPreviewRequest).toHaveBeenLastCalledWith(expect.objectContaining({ pathAndQuery: '/items' }));
+  });
+
+  it('still strips the mount when the request carries it itself and nothing is stamped', async () => {
     forwardable();
     expect((await GET(req('/items?x=1', { headers: { cookie: cookie() } }), ctx())).status).toBe(200);
     expect(forwardPreviewRequest).toHaveBeenLastCalledWith(expect.objectContaining({ pathAndQuery: '/items?x=1' }));

--- a/apps/web/src/app/api/dev-preview/host/[kind]/[holderId]/[[...path]]/route.ts
+++ b/apps/web/src/app/api/dev-preview/host/[kind]/[holderId]/[[...path]]/route.ts
@@ -115,8 +115,19 @@ async function handle(request: NextRequest, context: RouteContext): Promise<Resp
   const holder = hostHolder;
 
   const mount = `${DEV_PREVIEW_HOST_ROUTE_PREFIX}/${holder.kind}/${holder.id}`;
-  const path = extractPreviewPath(request.nextUrl.pathname, mount);
-  if (path === null) return notFound();
+  // After the middleware rewrite the handler's `nextUrl.pathname` is the
+  // browser's ORIGINAL path (`/`, `/_next/static/x.js`), not the mount-
+  // prefixed one it was rewritten onto — the mount only appears on a request
+  // that carried it itself (a test-built one, or a direct hit that the Host
+  // guard above has already ruled out of the app origin). The Host guard is
+  // what proves this request is for a preview, so the original path IS the
+  // preview path; strip the mount only when it is there.
+  const rawPath = request.nextUrl.pathname;
+  const path = rawPath.startsWith(mount) ? extractPreviewPath(rawPath, mount) : rawPath;
+  if (path === null) {
+    loggers.security.info('dev-preview.access', buildPreviewAccessLog({ userId: 'anonymous', holder, method: request.method, path: rawPath, outcome: 'refused', reason: 'path-outside-mount', status: 404, transport: 'http' }));
+    return notFound();
+  }
   const pathAndQuery = `${path}${request.nextUrl.search}`;
   const now = new Date();
 

--- a/apps/web/src/app/api/dev-preview/host/[kind]/[holderId]/[[...path]]/route.ts
+++ b/apps/web/src/app/api/dev-preview/host/[kind]/[holderId]/[[...path]]/route.ts
@@ -55,6 +55,7 @@ import { buildPreviewAccessLog, extractPreviewPath } from '@pagespace/lib/servic
 import { resolveSpritesToken } from '@pagespace/lib/services/sandbox/sandbox-client/sprites';
 import type { DevPreviewHolderRef } from '@pagespace/lib/services/sandbox/preview/dev-preview-core';
 import { forwardPreviewRequest } from '@/lib/dev-preview/preview-forward';
+import { DEV_PREVIEW_PATH_HEADER } from '@/lib/dev-preview/preview-path-header';
 import { getPreviewCookieKey, getPreviewGrantsStore, resolveAppOrigin, resolvePreviewOpenPath, resolvePreviewTargetForRequest } from '@/lib/dev-preview/preview-runtime';
 
 type RouteContext = { params: Promise<{ kind: string; holderId: string; path?: string[] }> };
@@ -115,15 +116,16 @@ async function handle(request: NextRequest, context: RouteContext): Promise<Resp
   const holder = hostHolder;
 
   const mount = `${DEV_PREVIEW_HOST_ROUTE_PREFIX}/${holder.kind}/${holder.id}`;
-  // After the middleware rewrite the handler's `nextUrl.pathname` is the
-  // browser's ORIGINAL path (`/`, `/_next/static/x.js`), not the mount-
-  // prefixed one it was rewritten onto — the mount only appears on a request
-  // that carried it itself (a test-built one, or a direct hit that the Host
-  // guard above has already ruled out of the app origin). The Host guard is
-  // what proves this request is for a preview, so the original path IS the
-  // preview path; strip the mount only when it is there.
+  // The middleware stamps the browser's ORIGINAL pathname on the rewritten
+  // request (`DEV_PREVIEW_PATH_HEADER`): after a rewrite `nextUrl.pathname`
+  // is that original path, not the mount-prefixed one, and a preview app may
+  // legitimately serve a path that LOOKS like the mount — so the path is
+  // taken from the header verbatim, never inferred from shape. Without the
+  // header (a direct or test-built request, which carries the mount in its
+  // URL) the mount is stripped, and a path outside it is refused.
+  const stamped = request.headers.get(DEV_PREVIEW_PATH_HEADER);
   const rawPath = request.nextUrl.pathname;
-  const path = rawPath.startsWith(mount) ? extractPreviewPath(rawPath, mount) : rawPath;
+  const path = stamped !== null && stamped.startsWith('/') ? stamped : extractPreviewPath(rawPath, mount);
   if (path === null) {
     loggers.security.info('dev-preview.access', buildPreviewAccessLog({ userId: 'anonymous', holder, method: request.method, path: rawPath, outcome: 'refused', reason: 'path-outside-mount', status: 404, transport: 'http' }));
     return notFound();

--- a/apps/web/src/lib/dev-preview/preview-path-header.ts
+++ b/apps/web/src/lib/dev-preview/preview-path-header.ts
@@ -1,0 +1,17 @@
+/**
+ * The request header the middleware stamps on a rewritten preview-host
+ * request with the browser's ORIGINAL pathname, verbatim.
+ *
+ * The handler cannot recover that path from `nextUrl` reliably — after a
+ * middleware rewrite Next hands it the ORIGINAL pathname (not the mount it
+ * was rewritten onto), while a direct or test-built request carries the
+ * mount — and it must not guess by shape, because a preview app may serve a
+ * path that looks like the mount. Set unconditionally on preview hosts, so a
+ * client-sent value never survives; on the app origin the Host guard refuses
+ * before the path is read.
+ *
+ * Lives in web (not `@pagespace/lib`) because only the middleware and the
+ * host route read it — and the middleware is an Edge graph of leaf modules;
+ * this file imports nothing.
+ */
+export const DEV_PREVIEW_PATH_HEADER = 'x-dev-preview-path';

--- a/apps/web/src/middleware.ts
+++ b/apps/web/src/middleware.ts
@@ -16,6 +16,7 @@ import {
 import { isCanvasPreviewRoute } from '@/app/api/canvas/_shared/previewRoute';
 import { isDevPreviewEnabled, resolveDevPreviewApex } from '@pagespace/lib/services/sandbox/preview/dev-preview-env';
 import { parsePreviewHost, rewritePreviewHostPath } from '@pagespace/lib/services/sandbox/preview/preview-host';
+import { DEV_PREVIEW_PATH_HEADER } from '@/lib/dev-preview/preview-path-header';
 import { isSafeNextPath, SIGNIN_NEXT_ALLOWED_PREFIXES } from '@/lib/auth/url-utils';
 import { logSecurityEvent } from '@/lib/logging/edge-logger';
 import {
@@ -153,7 +154,13 @@ export async function middleware(req: NextRequest, event?: NextFetchEvent) {
     if (previewHolder !== null) {
       const rewritten = new URL(req.url);
       rewritten.pathname = rewritePreviewHostPath(previewHolder, pathname);
-      return NextResponse.rewrite(rewritten);
+      // The handler sees the ORIGINAL pathname after a rewrite, not this one,
+      // and cannot tell a mount-shaped preview path from a mount-carrying
+      // request by shape — so hand it the original explicitly. Overwrites
+      // any client-sent value: on a preview host this header is ours.
+      const requestHeaders = new Headers(req.headers);
+      requestHeaders.set(DEV_PREVIEW_PATH_HEADER, pathname);
+      return NextResponse.rewrite(rewritten, { request: { headers: requestHeaders } });
     }
 
     // Non-cloud route blocking (defense-in-depth)

--- a/apps/web/src/test/next-server-stub.ts
+++ b/apps/web/src/test/next-server-stub.ts
@@ -20,8 +20,18 @@ class NextResponseStub extends Response {
     destination: string | URL,
     init?: { request?: { headers?: Headers } },
   ) {
-    void init;
     const headers = new Headers({ 'x-middleware-rewrite': destination.toString() });
+    // Request-header overrides travel on the response exactly as the real
+    // `handleMiddlewareField` encodes them: one `x-middleware-request-<key>`
+    // per header plus the key list — which is what a test can assert on.
+    if (init?.request?.headers) {
+      const keys: string[] = [];
+      for (const [key, value] of init.request.headers) {
+        headers.set(`x-middleware-request-${key}`, value);
+        keys.push(key);
+      }
+      headers.set('x-middleware-override-headers', keys.join(','));
+    }
     return new NextResponseStub(null, { status: 200, headers });
   }
 }


### PR DESCRIPTION
## What broke

The first dev-server preview ever opened in production was a blank frame: every request to `https://env-<id>.preview.pagespace.io/` answered `404 {"error":"Not found"}` — the host route's own `notFound()` — with no `dev-preview.access` log line. Everything before the frame worked (DNS, TLS, Caddy `@devpreview` → web, `DEV_PREVIEW_*` on the web machine, the grant, the pick, the relay).

## Root cause

After the middleware rewrite, `request.nextUrl.pathname` inside the route handler is the browser's **original** path (`/`), not the mount-prefixed path it was rewritten onto (Next 15.5.18, self-hosted). `extractPreviewPath('/', mount)` returned `null` → 404 for every path.

Proven read-only against prod:

| request on the preview host | answer |
|---|---|
| `GET /x` | 404 `Not found`, no log |
| `GET /api/dev-preview/host/env/<id>/x` | **401 `no-cookie`** — the cookie stage was reached only when the request carried the mount itself |

and the response carried `x-middleware-rewrite: /api/dev-preview/host/env/<id>/`, so the rewrite itself was correct.

The unit test never saw it because its request builder used the rewritten URL.

## Fix

- The Host guard already proves the request is for a preview, so the original pathname **is** the preview path; the mount is stripped only when present (test-built / direct shape).
- The path guard's refusal is logged (`reason: path-outside-mount`) instead of being silent.
- Realtime's WebSocket half reads the raw upgrade URL — unaffected (read-only check).

## Tests

Requests built the way production delivers them (no mount in the URL): `/` reaches the cookie stage (401 `no-cookie`); with a cookie, `/` and `/_next/static/a.js?v=1` are forwarded verbatim; a mount-carrying request still strips. Mutation-checked: restoring the old line fails exactly those two tests.

## Verify after deploy

`curl -sSI https://env-<id>.preview.pagespace.io/` → **401 text/html** (re-auth page), not 404; web log shows `dev-preview.access … refused no-cookie`. Then open the preview from the session — the frame renders.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01P8A8KLYCoViP7ouH5QzbnB


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Preview host routes now correctly process the browser’s original path after rewrites.
  - Root requests without a cookie return the expected authentication response instead of a not-found error.
  - Forwarded paths and query strings, including Next.js asset requests, are preserved accurately.
  - Requests using the preview mount path continue to be handled correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->