### PR TITLE
feat(dev-preview): ports in the pane picker — pick a port, the pane becomes the preview

### DIFF
--- a/apps/web/src/components/agents/panes/AgentPanes.tsx
+++ b/apps/web/src/components/agents/panes/AgentPanes.tsx
@@ -1480,10 +1480,11 @@ export default function AgentPanes({
     [bindPane, sessionId],
   );
 
-  // A ports pane addresses this workspace's one sandbox, so the target IS the
-  // workspace. Synchronous like a page: nothing is minted, and the pane
-  // probes nothing until its Scan button is pressed.
-  const handlePickPorts = useCallback(
+  // A port was picked in the picker — the SELECT is already posted there —
+  // so this pane becomes the preview. The target is the workspace itself:
+  // one sandbox has one preview, so the pane addresses the workspace, not the
+  // port. Synchronous like a page: nothing is minted here.
+  const handlePickPort = useCallback(
     (nodeId: string) => bindPane(sessionId, nodeId, { kind: 'ports', id: sessionId }),
     [bindPane, sessionId],
   );
@@ -1587,7 +1588,8 @@ export default function AgentPanes({
               onPickShell={() => void handlePickShell(node.id)}
               onReattachShell={(shellId) => handleReattachShell(node.id, shellId)}
               onPickPage={(pageId) => handlePickPage(node.id, pageId)}
-              onPickPorts={() => handlePickPorts(node.id)}
+              sessionId={sessionId}
+              onPickPort={() => handlePickPort(node.id)}
             />
           ) : surface.surface === 'loading' ? (
             <div className="flex h-full items-center justify-center">

--- a/apps/web/src/components/agents/panes/AgentPanes.tsx
+++ b/apps/web/src/components/agents/panes/AgentPanes.tsx
@@ -1590,6 +1590,9 @@ export default function AgentPanes({
               onPickPage={(pageId) => handlePickPage(node.id, pageId)}
               sessionId={sessionId}
               onPickPort={() => handlePickPort(node.id)}
+              // The same signal as `autoFocus`: a picker THIS client just
+              // split into probes on open; a persisted one waits for Scan.
+              probePortsOnOpen={tree?.pendingPickerNodeId === node.id}
             />
           ) : surface.surface === 'loading' ? (
             <div className="flex h-full items-center justify-center">

--- a/apps/web/src/components/agents/panes/PanePicker.tsx
+++ b/apps/web/src/components/agents/panes/PanePicker.tsx
@@ -124,6 +124,14 @@ export interface PanePickerProps {
    * job is to turn this pane into the preview. Absent ⇒ no Ports section.
    */
   onPickPort?(port: number, spriteInstanceId: string): void;
+  /**
+   * Probe the sandbox's ports as soon as the picker opens. TRUE only for a
+   * picker born of a split gesture in THIS client (`pendingPickerNodeId`) —
+   * an unbound pane is persisted, so a reload or another viewer mounts this
+   * same picker, and a probe is an exec that can wake a billed sprite. Those
+   * get an explicit Scan instead.
+   */
+  probePortsOnOpen?: boolean;
 }
 
 export default function PanePicker({
@@ -135,6 +143,7 @@ export default function PanePicker({
   canPickAssistant = false,
   sessionId,
   onPickPort,
+  probePortsOnOpen = false,
   existingShells = [],
   onPickAgent,
   onPickShell,
@@ -208,7 +217,7 @@ export default function PanePicker({
       {/* What is listening in this session's sandbox — pick one and this pane
           becomes its preview. Same sandbox as the shell, same tier gate. */}
       {onPickPort && sessionId !== undefined && (
-        <PortsSection sessionId={sessionId} canRunSandbox={canRunSandbox} onPickPort={onPickPort} />
+        <PortsSection sessionId={sessionId} canRunSandbox={canRunSandbox} probeOnOpen={probePortsOnOpen} onPickPort={onPickPort} />
       )}
 
       {/* The agents of this drive. Listed BELOW the two fixed choices rather than
@@ -303,13 +312,15 @@ function ShellPickButton({
 }
 
 /**
- * The "Ports" section: what is listening in the session's sandbox, probed
- * when the picker opens. That probe is an exec and may wake a paused sprite —
- * acceptable HERE because the picker is a user gesture (a split), not a
- * persisted node that comes back on every reload; the ports PANE never
- * probes on mount for exactly that reason. Gated on the server's `canManage`
- * (listing is the first half of exposing) so a viewer who cannot pick is
- * told so instead of being refused, and hidden on a dark deployment.
+ * The "Ports" section: what is listening in the session's sandbox. The
+ * probe is an exec and may wake a paused sprite, so it runs on open ONLY for
+ * a picker a split gesture just created in this client (`probeOnOpen`); an
+ * unbound pane is persisted, and the picker a reload or another viewer
+ * mounts offers an explicit Scan instead — the same rule the ports PANE
+ * follows. Gated on the server's `canManage` (listing is the first half of
+ * exposing) so a viewer who cannot pick is told so instead of being refused,
+ * and hidden on a dark deployment. A status read that fails is shown with
+ * a retry rather than left as "Loading…" forever.
  *
  * A click IS the pick: the audience is stated beside the list, the SELECT is
  * posted from here, and only a pick that took (including one the planner
@@ -318,6 +329,7 @@ function ShellPickButton({
  * here, as the server's sentence, so the pane is never bound to nothing.
  */
 type PortsScan =
+  | { state: 'idle' }
   | { state: 'scanning' }
   | { state: 'listed'; listing: PortsListing }
   | { state: 'failed'; message: string };
@@ -325,32 +337,35 @@ type PortsScan =
 function PortsSection({
   sessionId,
   canRunSandbox,
+  probeOnOpen,
   onPickPort,
 }: {
   sessionId: string;
   canRunSandbox: boolean;
+  probeOnOpen: boolean;
   onPickPort(port: number, spriteInstanceId: string): void;
 }) {
   const enabled = useDevPreviewCapability();
   const statusPath = sessionDevPreviewPath(sessionId);
   // One status read (no polling): it carries `canManage` and the holder the
   // audience sentence is written for. The picker is short-lived.
-  const { preview } = useDevPreviewStatus(statusPath, { enabled: enabled === true && canRunSandbox, polling: false });
+  const { preview, error: statusError, mutate: retryStatus } = useDevPreviewStatus(statusPath, { enabled: enabled === true && canRunSandbox, polling: false });
   const canManage = preview?.canManage === true;
-  const [scan, setScan] = useState<PortsScan>({ state: 'scanning' });
+  const [scan, setScan] = useState<PortsScan>({ state: 'idle' });
   const [picking, setPicking] = useState<number | null>(null);
   const [pickError, setPickError] = useState<string | null>(null);
+  // 0 = no explicit Scan yet; the open-probe counts only when `probeOnOpen`.
   const [attempt, setAttempt] = useState(0);
 
   useEffect(() => {
-    if (!canManage) return;
+    if (!canManage || (attempt === 0 && !probeOnOpen)) return;
     let cancelled = false;
     setScan({ state: 'scanning' });
     post<PortsListing>(devPreviewPortsPath(statusPath), {})
       .then((listing) => { if (!cancelled) setScan({ state: 'listed', listing }); })
       .catch((error: unknown) => { if (!cancelled) setScan({ state: 'failed', message: messageOf(error, 'The sandbox could not be asked which ports are listening.') }); });
     return () => { cancelled = true; };
-  }, [canManage, statusPath, attempt]);
+  }, [canManage, statusPath, attempt, probeOnOpen]);
 
   const pick = useCallback(
     async (port: number, spriteInstanceId: string) => {
@@ -376,9 +391,18 @@ function PortsSection({
       {!canRunSandbox ? (
         <ShellPickButton label="Ports" disabled onClick={() => undefined} testId="pick-ports" />
       ) : preview === undefined ? (
-        <p className="text-xs text-muted-foreground">Loading preview status…</p>
+        statusError ? (
+          <>
+            <p className="text-xs text-destructive" role="alert" data-testid="ports-status-error">{messageOf(statusError, 'The preview status could not be read.')}</p>
+            <Button variant="ghost" size="sm" className="h-8 justify-start px-2" onClick={() => retryStatus()} data-testid="ports-status-retry">Retry</Button>
+          </>
+        ) : (
+          <p className="text-xs text-muted-foreground">Loading preview status…</p>
+        )
       ) : !canManage ? (
         <p className="text-xs text-muted-foreground" data-testid="ports-cannot-manage">{CANNOT_MANAGE_PORTS}.</p>
+      ) : scan.state === 'idle' ? (
+        <ShellPickButton label="Scan ports" disabled={false} onClick={() => setAttempt((n) => n + 1)} testId="ports-scan" />
       ) : scan.state === 'scanning' ? (
         <p className="flex items-center gap-2 text-xs text-muted-foreground" data-testid="ports-scanning">
           <Loader2 className="size-3.5 animate-spin" aria-hidden="true" />

--- a/apps/web/src/components/agents/panes/PanePicker.tsx
+++ b/apps/web/src/components/agents/panes/PanePicker.tsx
@@ -13,8 +13,8 @@
  * the only thing that knows whether a pick should reuse an existing row.
  */
 
-import { useEffect, useRef, useState, type Ref } from 'react';
-import { Bot, Search, TerminalSquare } from 'lucide-react';
+import { useCallback, useEffect, useRef, useState, useState, type Ref } from 'react';
+import { Bot, Loader2, Search, TerminalSquare } from 'lucide-react';
 import useSWR from 'swr';
 import { PageType } from '@pagespace/lib/utils/enums';
 import { isPaneablePageType } from '@pagespace/lib/content/page-types.config';
@@ -24,6 +24,11 @@ import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip
 import { PageTypeIcon } from '@/components/common/PageTypeIcon';
 import { fetchWithAuth } from '@/lib/auth/auth-fetch';
 import { useDebounce } from '@/hooks/useDebounce';
+import { post } from '@/lib/auth/auth-fetch';
+import { useDevPreviewCapability } from '@/hooks/dev-preview/useDevPreviewCapability';
+import { devPreviewActionsPath, devPreviewPortsPath, sessionDevPreviewPath, useDevPreviewStatus } from '@/hooks/dev-preview/useDevPreviewStatus';
+import { PortsList, messageOf, type PortsListing } from '@/components/dev-preview/PortsList';
+import { CANNOT_MANAGE_PORTS, devPreviewApprovalAudience } from '@/components/dev-preview/dev-preview-copy';
 
 /** The picker needs a label and an id — never the whole agent record. */
 export interface PickableAgent {
@@ -109,11 +114,16 @@ export interface PanePickerProps {
   /** Bind this pane to a page — `title` is a display label, never an address. */
   onPickPage?(pageId: string, title: string): void;
   /**
-   * Bind this pane to the sandbox's ports: what is listening, and a preview
-   * of the one you pick. Synchronous like a page — nothing is minted, and
-   * the pane probes nothing until Scan is pressed.
+   * The workspace whose sandbox the Ports section lists — the address the
+   * picker probes when it opens. Required for that section to render.
    */
-  onPickPorts?(): void;
+  sessionId?: string;
+  /**
+   * A port was picked: the SELECT has already been posted (the pick is the
+   * consent gesture, made here beside its audience), so the caller's only
+   * job is to turn this pane into the preview. Absent ⇒ no Ports section.
+   */
+  onPickPort?(port: number, spriteInstanceId: string): void;
 }
 
 export default function PanePicker({
@@ -123,7 +133,8 @@ export default function PanePicker({
   canRunSandbox,
   autoFocus = false,
   canPickAssistant = false,
-  onPickPorts,
+  sessionId,
+  onPickPort,
   existingShells = [],
   onPickAgent,
   onPickShell,
@@ -162,18 +173,6 @@ export default function PanePicker({
           testId="pick-shell"
         />
 
-        {/* Same sandbox as the shell, same gate: a tier that cannot run a
-            sandbox has no ports to list. Disabled rather than hidden, like
-            Shell, so the choice is visible and the reason is the tooltip. */}
-        {onPickPorts && (
-          <ShellPickButton
-            label="Ports"
-            disabled={!canRunSandbox}
-            onClick={onPickPorts}
-            testId="pick-ports"
-          />
-        )}
-
         {canPickAssistant && (
           <Button
             variant="ghost"
@@ -204,6 +203,12 @@ export default function PanePicker({
             />
           ))}
         </div>
+      )}
+
+      {/* What is listening in this session's sandbox — pick one and this pane
+          becomes its preview. Same sandbox as the shell, same tier gate. */}
+      {onPickPort && sessionId !== undefined && (
+        <PortsSection sessionId={sessionId} canRunSandbox={canRunSandbox} onPickPort={onPickPort} />
       )}
 
       {/* The agents of this drive. Listed BELOW the two fixed choices rather than
@@ -294,6 +299,113 @@ function ShellPickButton({
           all but the tier case (codex round 9). */}
       <TooltipContent>Sandbox terminals aren&apos;t available in this session — they need a Pro-plan workspace with edit access</TooltipContent>
     </Tooltip>
+  );
+}
+
+/**
+ * The "Ports" section: what is listening in the session's sandbox, probed
+ * when the picker opens. That probe is an exec and may wake a paused sprite —
+ * acceptable HERE because the picker is a user gesture (a split), not a
+ * persisted node that comes back on every reload; the ports PANE never
+ * probes on mount for exactly that reason. Gated on the server's `canManage`
+ * (listing is the first half of exposing) so a viewer who cannot pick is
+ * told so instead of being refused, and hidden on a dark deployment.
+ *
+ * A click IS the pick: the audience is stated beside the list, the SELECT is
+ * posted from here, and only a pick that took (including one the planner
+ * refused inside a 200 — the pick is recorded, and the pane will say why it
+ * is not serving) turns the pane into the preview. A thrown refusal stays
+ * here, as the server's sentence, so the pane is never bound to nothing.
+ */
+type PortsScan =
+  | { state: 'scanning' }
+  | { state: 'listed'; listing: PortsListing }
+  | { state: 'failed'; message: string };
+
+function PortsSection({
+  sessionId,
+  canRunSandbox,
+  onPickPort,
+}: {
+  sessionId: string;
+  canRunSandbox: boolean;
+  onPickPort(port: number, spriteInstanceId: string): void;
+}) {
+  const enabled = useDevPreviewCapability();
+  const statusPath = sessionDevPreviewPath(sessionId);
+  // One status read (no polling): it carries `canManage` and the holder the
+  // audience sentence is written for. The picker is short-lived.
+  const { preview } = useDevPreviewStatus(statusPath, { enabled: enabled === true && canRunSandbox, polling: false });
+  const canManage = preview?.canManage === true;
+  const [scan, setScan] = useState<PortsScan>({ state: 'scanning' });
+  const [picking, setPicking] = useState<number | null>(null);
+  const [pickError, setPickError] = useState<string | null>(null);
+  const [attempt, setAttempt] = useState(0);
+
+  useEffect(() => {
+    if (!canManage) return;
+    let cancelled = false;
+    setScan({ state: 'scanning' });
+    post<PortsListing>(devPreviewPortsPath(statusPath), {})
+      .then((listing) => { if (!cancelled) setScan({ state: 'listed', listing }); })
+      .catch((error: unknown) => { if (!cancelled) setScan({ state: 'failed', message: messageOf(error, 'The sandbox could not be asked which ports are listening.') }); });
+    return () => { cancelled = true; };
+  }, [canManage, statusPath, attempt]);
+
+  const pick = useCallback(
+    async (port: number, spriteInstanceId: string) => {
+      setPicking(port);
+      setPickError(null);
+      try {
+        await post(devPreviewActionsPath(statusPath), { action: 'select', port, spriteInstanceId });
+      } catch (error) {
+        setPickError(messageOf(error, 'Could not start the preview.'));
+        setPicking(null);
+        return;
+      }
+      onPickPort(port, spriteInstanceId);
+    },
+    [statusPath, onPickPort],
+  );
+
+  if (enabled !== true) return null;
+
+  return (
+    <div className="flex shrink-0 flex-col gap-1" data-testid="pane-picker-ports">
+      <p className="shrink-0 pt-1 text-xs font-medium text-muted-foreground">Ports</p>
+      {!canRunSandbox ? (
+        <ShellPickButton label="Ports" disabled onClick={() => undefined} testId="pick-ports" />
+      ) : preview === undefined ? (
+        <p className="text-xs text-muted-foreground">Loading preview status…</p>
+      ) : !canManage ? (
+        <p className="text-xs text-muted-foreground" data-testid="ports-cannot-manage">{CANNOT_MANAGE_PORTS}.</p>
+      ) : scan.state === 'scanning' ? (
+        <p className="flex items-center gap-2 text-xs text-muted-foreground" data-testid="ports-scanning">
+          <Loader2 className="size-3.5 animate-spin" aria-hidden="true" />
+          Scanning the sandbox…
+        </p>
+      ) : scan.state === 'failed' ? (
+        <>
+          <p className="text-xs text-destructive" role="alert" data-testid="ports-scan-error">{scan.message}</p>
+          <Button variant="ghost" size="sm" className="h-8 justify-start px-2" onClick={() => setAttempt((n) => n + 1)} data-testid="ports-retry">Retry</Button>
+        </>
+      ) : (
+        <>
+          <PortsList
+            listing={scan.listing}
+            audience={devPreviewApprovalAudience(preview.holder)}
+            canOpen={preview.canOpen === true}
+            picking={picking}
+            disabled={false}
+            onPick={(port, instance) => void pick(port, instance)}
+          />
+          {scan.listing.ports.length === 0 && (
+            <Button variant="ghost" size="sm" className="h-8 justify-start px-2" onClick={() => setAttempt((n) => n + 1)} data-testid="ports-retry">Rescan</Button>
+          )}
+          {pickError && <p className="text-xs text-destructive" role="alert" data-testid="ports-pick-error">{pickError}</p>}
+        </>
+      )}
+    </div>
   );
 }
 

--- a/apps/web/src/components/agents/panes/PanePicker.tsx
+++ b/apps/web/src/components/agents/panes/PanePicker.tsx
@@ -13,7 +13,7 @@
  * the only thing that knows whether a pick should reuse an existing row.
  */
 
-import { useCallback, useEffect, useRef, useState, useState, type Ref } from 'react';
+import { useCallback, useEffect, useRef, useState, type Ref } from 'react';
 import { Bot, Loader2, Search, TerminalSquare } from 'lucide-react';
 import useSWR from 'swr';
 import { PageType } from '@pagespace/lib/utils/enums';

--- a/apps/web/src/components/agents/panes/__tests__/PanePicker.test.tsx
+++ b/apps/web/src/components/agents/panes/__tests__/PanePicker.test.tsx
@@ -3,9 +3,20 @@
  * is on the menu at all — a picker offering only shells is what tabs degraded
  * into, and it is why splitting had nothing worth splitting into.
  */
-import { describe, it, expect, vi } from 'vitest';
-import { render, screen } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
+import { SWRConfig } from 'swr';
+
+const mockFetchJSON = vi.hoisted(() => vi.fn());
+const mockPost = vi.hoisted(() => vi.fn());
+vi.mock('@/lib/auth/auth-fetch', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@/lib/auth/auth-fetch')>();
+  return { ...actual, fetchJSON: (...args: unknown[]) => mockFetchJSON(...args), post: (...args: unknown[]) => mockPost(...args) };
+});
+const mockCapability = vi.hoisted(() => vi.fn<() => boolean | undefined>(() => true));
+vi.mock('@/hooks/dev-preview/useDevPreviewCapability', () => ({ useDevPreviewCapability: () => mockCapability() }));
+
 import PanePicker from '../PanePicker';
 
 const agents = [
@@ -204,17 +215,112 @@ describe('PanePicker', () => {
 });
 
 describe('ports', () => {
-  it('offers Ports beside Shell only when a handler is supplied, and calls it', async () => {
-    const onPickPorts = vi.fn();
-    render(<PanePicker agents={agents} canRunSandbox onPickAgent={vi.fn()} onPickShell={vi.fn()} onPickPorts={onPickPorts} />);
-    await userEvent.click(screen.getByTestId('pick-ports'));
-    expect(onPickPorts).toHaveBeenCalledTimes(1);
+  const STATUS_PATH = '/api/agent-workspaces/ws1/preview';
+  const PORTS_PATH = `${STATUS_PATH}/ports`;
+  const ACTIONS_PATH = `${STATUS_PATH}/actions`;
+  const LISTING = {
+    spriteInstanceId: 'inst-live',
+    currentPort: null,
+    ports: [
+      { port: 3000, pid: 2311, kind: 'dev-server', likelihood: 'known-dev-port', current: false },
+      { port: 5432, pid: 9, kind: 'ignored', reason: 'non-http-service-port', current: false },
+    ],
+  };
+  let canManage = true;
+
+  beforeEach(() => {
+    canManage = true;
+    mockCapability.mockReturnValue(true);
+    mockFetchJSON.mockReset();
+    mockFetchJSON.mockImplementation(async () => ({ preview: { holder: { kind: 'workspace', id: 'ws1' }, canManage, canOpen: false, openPath: null, state: { status: 'none', message: 'No dev server has been detected in this sandbox yet.' } } }));
+    mockPost.mockReset();
   });
 
-  it('is absent without a handler, and DISABLED (not hidden) when the tier cannot run a sandbox — same gate as Shell', () => {
-    const { rerender } = render(<PanePicker agents={agents} canRunSandbox onPickAgent={vi.fn()} onPickShell={vi.fn()} />);
-    expect(screen.queryByTestId('pick-ports')).toBeNull();
-    rerender(<PanePicker agents={agents} canRunSandbox={false} onPickAgent={vi.fn()} onPickShell={vi.fn()} onPickPorts={vi.fn()} />);
+  const renderPicker = (over: { canRunSandbox?: boolean; onPickPort?: (port: number, instance: string) => void; sessionId?: string } = {}) =>
+    render(
+      <SWRConfig value={{ provider: () => new Map(), dedupingInterval: 0 }}>
+        <PanePicker agents={agents} canRunSandbox={over.canRunSandbox ?? true} sessionId={'sessionId' in over ? over.sessionId : 'ws1'} onPickAgent={vi.fn()} onPickShell={vi.fn()} onPickPort={'onPickPort' in over ? over.onPickPort : vi.fn()} />
+      </SWRConfig>,
+    );
+
+  it('probes the session\'s sandbox ONCE when the picker opens and lists what is listening beside Shell and Agents', async () => {
+    mockPost.mockResolvedValueOnce(LISTING);
+    renderPicker();
+    await screen.findByTestId('ports-scanning');
+    await screen.findByTestId('ports-pick-3000');
+    expect(mockPost).toHaveBeenCalledTimes(1);
+    expect(mockPost).toHaveBeenCalledWith(PORTS_PATH, {});
+    expect(screen.getByTestId('pick-shell')).toBeInTheDocument();
+    expect(screen.getByTestId('pick-agent-agent-1')).toBeInTheDocument();
+    expect(screen.getByTestId('ports-pick-5432')).toBeDisabled();
+  });
+
+  it('a click IS the pick: SELECT is posted with the listed instance, and the pane is handed the port only once that took', async () => {
+    const onPickPort = vi.fn();
+    let resolveSelect: (v: unknown) => void = () => undefined;
+    mockPost.mockResolvedValueOnce(LISTING).mockImplementationOnce(() => new Promise((r) => { resolveSelect = r; }));
+    renderPicker({ onPickPort });
+    await userEvent.click(await screen.findByTestId('ports-pick-3000'));
+    expect(mockPost).toHaveBeenLastCalledWith(ACTIONS_PATH, { action: 'select', port: 3000, spriteInstanceId: 'inst-live' });
+    expect(screen.getByTestId('ports-pick-3000')).toHaveTextContent('Starting…');
+    expect(onPickPort).not.toHaveBeenCalled();
+    resolveSelect({ ok: true, applied: { action: 'start-relay' } });
+    await waitFor(() => expect(onPickPort).toHaveBeenCalledWith(3000, 'inst-live'));
+  });
+
+  it('a pick the planner refused inside a 200 still binds the pane — the pick is recorded and the pane says why it is not serving', async () => {
+    const onPickPort = vi.fn();
+    mockPost.mockResolvedValueOnce(LISTING).mockResolvedValueOnce({ ok: true, applied: { action: 'refuse', reason: 'http-port-busy' } });
+    renderPicker({ onPickPort });
+    await userEvent.click(await screen.findByTestId('ports-pick-3000'));
+    await waitFor(() => expect(onPickPort).toHaveBeenCalledWith(3000, 'inst-live'));
+  });
+
+  it('a thrown refusal stays in the picker as the server\'s sentence — the pane is never bound to nothing', async () => {
+    const onPickPort = vi.fn();
+    mockPost.mockResolvedValueOnce(LISTING).mockRejectedValueOnce(new Error('Nothing is listening on port 3000 any more. Scan again to see what is running now.'));
+    renderPicker({ onPickPort });
+    await userEvent.click(await screen.findByTestId('ports-pick-3000'));
+    expect(await screen.findByTestId('ports-pick-error')).toHaveTextContent('Nothing is listening on port 3000 any more');
+    expect(onPickPort).not.toHaveBeenCalled();
+    expect(screen.getByTestId('ports-pick-3000')).toBeEnabled();
+  });
+
+  it('a failed probe shows the server\'s sentence with Retry, which probes again; an empty listing offers Rescan', async () => {
+    mockPost
+      .mockRejectedValueOnce(new Error('The sandbox did not answer in time when asked which ports are listening. Try Scan again.'))
+      .mockResolvedValueOnce({ ...LISTING, ports: [] })
+      .mockResolvedValueOnce(LISTING);
+    renderPicker();
+    expect(await screen.findByTestId('ports-scan-error')).toHaveTextContent('did not answer in time');
+    await userEvent.click(screen.getByTestId('ports-retry'));
+    expect(await screen.findByTestId('ports-list')).toHaveTextContent('Start your dev server');
+    await userEvent.click(screen.getByTestId('ports-retry'));
+    await screen.findByTestId('ports-pick-3000');
+    expect(mockPost).toHaveBeenCalledTimes(3);
+  });
+
+  it('never probes for a viewer the SERVER says cannot manage the preview, for a tier that cannot run a sandbox (disabled row, same gate as Shell), on a dark deployment, or without a handler', async () => {
+    canManage = false;
+    const { unmount } = renderPicker();
+    expect(await screen.findByTestId('ports-cannot-manage')).toHaveTextContent('owner');
+    unmount();
+
+    canManage = true;
+    const tier = renderPicker({ canRunSandbox: false });
     expect(screen.getByTestId('pick-ports')).toBeDisabled();
+    expect(screen.getByTestId('pick-shell')).toBeDisabled();
+    tier.unmount();
+
+    mockCapability.mockReturnValue(false);
+    const dark = renderPicker();
+    expect(screen.queryByTestId('pane-picker-ports')).toBeNull();
+    dark.unmount();
+    mockCapability.mockReturnValue(true);
+
+    render(<PanePicker agents={agents} canRunSandbox sessionId="ws1" onPickAgent={vi.fn()} onPickShell={vi.fn()} />);
+    expect(screen.queryByTestId('pane-picker-ports')).toBeNull();
+    await new Promise((r) => setTimeout(r, 20));
+    expect(mockPost).not.toHaveBeenCalled();
   });
 });

--- a/apps/web/src/components/agents/panes/__tests__/PanePicker.test.tsx
+++ b/apps/web/src/components/agents/panes/__tests__/PanePicker.test.tsx
@@ -236,17 +236,37 @@ describe('ports', () => {
     mockPost.mockReset();
   });
 
-  const renderPicker = (over: { canRunSandbox?: boolean; onPickPort?: (port: number, instance: string) => void; sessionId?: string } = {}) =>
+  const renderPicker = (over: { canRunSandbox?: boolean; onPickPort?: (port: number, instance: string) => void; sessionId?: string; probePortsOnOpen?: boolean } = {}) =>
     render(
-      <SWRConfig value={{ provider: () => new Map(), dedupingInterval: 0 }}>
-        <PanePicker agents={agents} canRunSandbox={over.canRunSandbox ?? true} sessionId={'sessionId' in over ? over.sessionId : 'ws1'} onPickAgent={vi.fn()} onPickShell={vi.fn()} onPickPort={'onPickPort' in over ? over.onPickPort : vi.fn()} />
+      <SWRConfig value={{ provider: () => new Map(), dedupingInterval: 0, shouldRetryOnError: false }}>
+        <PanePicker agents={agents} canRunSandbox={over.canRunSandbox ?? true} sessionId={'sessionId' in over ? over.sessionId : 'ws1'} probePortsOnOpen={over.probePortsOnOpen ?? true} onPickAgent={vi.fn()} onPickShell={vi.fn()} onPickPort={'onPickPort' in over ? over.onPickPort : vi.fn()} />
       </SWRConfig>,
     );
+
+  it('a PERSISTED picker (a reload, another viewer) never probes on mount — it offers Scan, and only Scan probes', async () => {
+    mockPost.mockResolvedValueOnce(LISTING);
+    renderPicker({ probePortsOnOpen: false });
+    const scanButton = await screen.findByTestId('ports-scan');
+    await new Promise((r) => setTimeout(r, 20));
+    expect(mockPost).not.toHaveBeenCalled();
+    await userEvent.click(scanButton);
+    await screen.findByTestId('ports-pick-3000');
+    expect(mockPost).toHaveBeenCalledTimes(1);
+  });
+
+  it('a status read that fails shows the sentence with Retry — never "Loading…" forever — and Retry re-reads', async () => {
+    mockFetchJSON.mockRejectedValueOnce(new Error('Service unavailable'));
+    mockPost.mockResolvedValueOnce(LISTING);
+    renderPicker();
+    expect(await screen.findByTestId('ports-status-error')).toHaveTextContent('Service unavailable');
+    expect(mockPost).not.toHaveBeenCalled();
+    await userEvent.click(screen.getByTestId('ports-status-retry'));
+    await screen.findByTestId('ports-pick-3000');
+  });
 
   it('probes the session\'s sandbox ONCE when the picker opens and lists what is listening beside Shell and Agents', async () => {
     mockPost.mockResolvedValueOnce(LISTING);
     renderPicker();
-    await screen.findByTestId('ports-scanning');
     await screen.findByTestId('ports-pick-3000');
     expect(mockPost).toHaveBeenCalledTimes(1);
     expect(mockPost).toHaveBeenCalledWith(PORTS_PATH, {});

--- a/apps/web/src/components/dev-preview/DevPreviewPane.tsx
+++ b/apps/web/src/components/dev-preview/DevPreviewPane.tsx
@@ -72,7 +72,7 @@ import { DETECTION_UNAVAILABLE_MESSAGE } from '@pagespace/lib/services/sandbox/p
 import { devPreviewApprovalAudience, devPreviewBadge } from './dev-preview-copy';
 
 /** The open pane polls faster than the affordance: its chrome should notice a relay crash within a few seconds. */
-const PANE_POLL_MS = 5_000;
+export const PANE_POLL_MS = 5_000;
 
 /** A re-auth is a grant mint; one per this window is plenty for a cookie that lives ten minutes. */
 export const REAUTH_DEBOUNCE_MS = 5_000;

--- a/apps/web/src/components/dev-preview/PortsList.tsx
+++ b/apps/web/src/components/dev-preview/PortsList.tsx
@@ -1,0 +1,95 @@
+/**
+ * The listening-ports list, shared by the pane picker (where it is the way a
+ * pane BECOMES a preview) and the ports pane's header (where it is the way to
+ * diagnose one). One copy of the rows so the words are the same in both.
+ *
+ * Presentational: the host decides when to probe and what a pick does; this
+ * renders a listing and reports the click. Two rules carried from the pane:
+ * PICKING IS CONSENT — so the audience is stated beside the choice, before
+ * it is made — and THE SENTENCE COMES FROM THE SERVER for every refusal.
+ */
+
+'use client';
+
+import { ApiRequestError } from '@/lib/auth/auth-fetch';
+import type { DevPreviewProbedPort } from '@pagespace/lib/services/sandbox/preview/dev-preview-status';
+import { NOTHING_LISTENING } from './dev-preview-copy';
+
+export interface PortsListing {
+  spriteInstanceId: string;
+  ports: DevPreviewProbedPort[];
+  currentPort: number | null;
+}
+
+/** The server's sentence, or a neutral one — never a stack trace, never silence. */
+export function messageOf(error: unknown, fallback: string): string {
+  if (error instanceof ApiRequestError && error.message.trim() !== '') return error.message;
+  if (error instanceof Error && error.message.trim() !== '') return error.message;
+  return fallback;
+}
+
+/** Why a row is (not) pickable — the tooltip, and the trailing text for an ignored row. */
+export function describeProbedPort(entry: DevPreviewProbedPort): string {
+  if (entry.kind === 'ignored') {
+    return entry.reason === 'non-http-service-port' ? 'Looks like a database or service port, not a web server'
+      : entry.reason === 'relay-own-listener' ? 'The preview relay itself'
+      : 'Cannot be previewed';
+  }
+  return entry.likelihood === 'known-dev-port' ? 'Looks like a dev server' : 'Unlisted port';
+}
+
+export function PortsList({
+  listing,
+  audience,
+  canOpen,
+  picking,
+  disabled,
+  onPick,
+}: {
+  listing: PortsListing;
+  /** WHO can reach the preview once a port is picked — null when unknown (never invented). */
+  audience: string | null;
+  /** Whether the current port is actually serving — decides "Previewing" vs "Selected". */
+  canOpen: boolean;
+  /** The port whose pick is in flight, if any. */
+  picking: number | null;
+  /** Every row disabled — the host has no authority to pick, or a pick is in flight. */
+  disabled: boolean;
+  onPick(port: number, spriteInstanceId: string): void;
+}) {
+  if (listing.ports.length === 0) {
+    return <p className="text-xs text-muted-foreground" data-testid="ports-list">{NOTHING_LISTENING}</p>;
+  }
+  return (
+    <div role="radiogroup" aria-label="Listening ports" className="flex flex-col gap-1 text-xs" data-testid="ports-list">
+      {audience && <p className="pb-1 text-muted-foreground">{audience}</p>}
+      {listing.ports.map((entry) => {
+        const why = describeProbedPort(entry);
+        return (
+          <button
+            key={entry.port}
+            type="button"
+            role="radio"
+            aria-checked={entry.current}
+            disabled={disabled || entry.kind === 'ignored' || picking !== null}
+            onClick={() => onPick(entry.port, listing.spriteInstanceId)}
+            className="flex items-center justify-between rounded px-2 py-1 text-left hover:bg-accent disabled:cursor-not-allowed disabled:opacity-60"
+            title={why}
+            data-testid={`ports-pick-${entry.port}`}
+          >
+            <span className="font-mono">:{entry.port}{entry.pid !== null ? <span className="ml-2 text-muted-foreground">pid {entry.pid}</span> : null}</span>
+            <span className="text-muted-foreground">
+              {picking === entry.port ? 'Starting…'
+                // `current` is the persisted TARGET; whether it is actually
+                // serving is the status's `canOpen`. A pick whose relay could
+                // not start (a stranger on 8080) is selected, not previewing.
+                : entry.current ? (canOpen ? 'Previewing' : 'Selected')
+                : entry.kind === 'ignored' ? why
+                : 'Preview this' + (listing.currentPort !== null ? ' instead' : '')}
+            </span>
+          </button>
+        );
+      })}
+    </div>
+  );
+}

--- a/apps/web/src/components/dev-preview/PortsPane.tsx
+++ b/apps/web/src/components/dev-preview/PortsPane.tsx
@@ -1,25 +1,29 @@
 /**
- * The ports pane: what is actually listening in this session's sandbox, and a
- * preview of the port you pick.
+ * The preview pane: the dev server the session is previewing, framed — and,
+ * behind one header control, what is actually listening in the sandbox.
  *
- * It exists because passive detection cannot see everything — Fly Sprites'
- * `ports/watch` never reports a Next.js dev server's bind — and because a
- * preview that fails should SAY so. Three rules shape it:
+ * A pane is bound to this surface by picking a port in the pane picker (the
+ * select already happened there), so the body is the FRAME, first and by
+ * default; until the relay is up it shows the server's status sentence.
+ * The ports list stays reachable from the header because passive detection
+ * cannot see everything — Fly Sprites' `ports/watch` never reports a Next.js
+ * dev server's bind — and a preview that fails should SAY so. Three rules:
  *
  *  1. NEVER PROBE ON MOUNT. This pane is a persisted grid node: it comes back
  *     on every reload, on every device, for every viewer of the session. A
  *     probe is an exec, an exec wakes a paused sprite, and a wake is billed.
- *     So the list appears only behind an explicit Scan, and the status it
- *     shows before that is the cheap, already-cached one.
+ *     So the list appears only behind an explicit click, and the status it
+ *     shows before that is the cheap, already-cached one. (The PICKER probes
+ *     when it opens — that is a user gesture, not a persisted node.)
  *  2. PICKING IS CONSENT. Choosing a port from the list is the deliberate act
  *     the Share step was invented to require, so there is no second click —
  *     but the audience is stated right beside the choice, before it is made.
  *  3. THE SENTENCE COMES FROM THE SERVER. Every failure renders the route's
  *     own message inline. The client chooses loudness, never wording.
  *
- * One sandbox has exactly one preview, so several ports panes are several
- * views of the same state; the radio group marks which port is current and
- * a second pick reads as "Preview this instead" — which is what it does.
+ * One sandbox has exactly one preview, so several of these panes are several
+ * views of the same state; the list marks which port is current and a second
+ * pick reads as "Preview this instead" — which is what it does.
  */
 
 'use client';
@@ -27,7 +31,7 @@
 import { useCallback, useState } from 'react';
 import { AlertCircle, Loader2, RefreshCw, ScanSearch } from 'lucide-react';
 import { Button } from '@/components/ui/button';
-import { post, ApiRequestError } from '@/lib/auth/auth-fetch';
+import { post } from '@/lib/auth/auth-fetch';
 import { useDevPreviewCapability } from '@/hooks/dev-preview/useDevPreviewCapability';
 import {
   devPreviewActionsPath,
@@ -35,15 +39,9 @@ import {
   sessionDevPreviewPath,
   useDevPreviewStatus,
 } from '@/hooks/dev-preview/useDevPreviewStatus';
-import { DEV_PREVIEW_FRAME_SANDBOX, buildFrameSrc } from './DevPreviewPane';
-import { devPreviewApprovalAudience } from './dev-preview-copy';
-import type { DevPreviewProbedPort } from '@pagespace/lib/services/sandbox/preview/dev-preview-status';
-
-interface PortsListing {
-  spriteInstanceId: string;
-  ports: DevPreviewProbedPort[];
-  currentPort: number | null;
-}
+import { DEV_PREVIEW_FRAME_SANDBOX, PANE_POLL_MS, buildFrameSrc } from './DevPreviewPane';
+import { CANNOT_MANAGE_PORTS, PICK_REFUSED, PICK_REFUSED_HTTP_PORT_BUSY, devPreviewApprovalAudience } from './dev-preview-copy';
+import { PortsList, messageOf, type PortsListing } from './PortsList';
 
 type Scan =
   | { state: 'idle' }
@@ -51,19 +49,12 @@ type Scan =
   | { state: 'listed'; listing: PortsListing }
   | { state: 'failed'; message: string };
 
-/** The server's sentence, or a neutral one — never a stack trace, never silence. */
-function messageOf(error: unknown, fallback: string): string {
-  if (error instanceof ApiRequestError && error.message.trim() !== '') return error.message;
-  if (error instanceof Error && error.message.trim() !== '') return error.message;
-  return fallback;
-}
-
 export function PortsPane({ workspaceId }: { workspaceId: string }) {
   const enabled = useDevPreviewCapability();
   const statusPath = sessionDevPreviewPath(workspaceId);
-  // The cheap, cached status — polled slowly, never an exec. This is all the
-  // pane shows until Scan is pressed.
-  const { preview, mutate } = useDevPreviewStatus(statusPath, { enabled: enabled === true, pauseWhenIdle: false });
+  // The cheap, cached status — polled at the open pane's cadence so the frame
+  // appears as soon as the relay the pick started is up. Never an exec.
+  const { preview, mutate } = useDevPreviewStatus(statusPath, { enabled: enabled === true, pauseWhenIdle: false, intervalMs: PANE_POLL_MS });
   const [scan, setScan] = useState<Scan>({ state: 'idle' });
   const [picking, setPicking] = useState<number | null>(null);
   const [pickError, setPickError] = useState<string | null>(null);
@@ -80,6 +71,11 @@ export function PortsPane({ workspaceId }: { workspaceId: string }) {
     }
   }, [statusPath]);
 
+  const toggleList = useCallback(() => {
+    if (scan.state === 'idle') void runScan();
+    else setScan({ state: 'idle' });
+  }, [scan.state, runScan]);
+
   const pick = useCallback(
     async (port: number, spriteInstanceId: string) => {
       setPicking(port);
@@ -91,29 +87,18 @@ export function PortsPane({ workspaceId }: { workspaceId: string }) {
           // sandbox that was rebuilt in between is refused, not applied.
           { action: 'select', port, spriteInstanceId },
         );
-        // A refused plan is a 200 with the refusal inside — `http-port-busy`
-        // when something else holds 8080. Say so; the pick was recorded.
-        if (answer.applied?.action === 'refuse') {
-          setPickError(
-            answer.applied.reason === 'http-port-busy'
-              ? 'Port 8080 is held by another process in the sandbox, so the preview relay cannot start. Stop that process and pick again.'
-              : 'The preview could not be started right now.',
-          );
-        }
         mutate();
+        // A refused plan is a 200 with the refusal inside — `http-port-busy`
+        // when something else holds 8080. Say so, and keep the list open; the
+        // pick was recorded.
+        if (answer.applied?.action === 'refuse') {
+          setPickError(answer.applied.reason === 'http-port-busy' ? PICK_REFUSED_HTTP_PORT_BUSY : PICK_REFUSED);
+          return;
+        }
+        // The pick took: the pane is the preview again, the list folds away.
+        setScan({ state: 'idle' });
       } catch (error) {
         setPickError(messageOf(error, 'Could not start the preview.'));
-        setPicking(null);
-        return;
-      }
-      // The pick is PERSISTED by now; re-listing is a separate act so that a
-      // failed rescan reports as a scan problem and cannot masquerade as
-      // "could not start the preview" over a selection that took effect.
-      try {
-        const listing = await post<PortsListing>(devPreviewPortsPath(statusPath), {});
-        setScan({ state: 'listed', listing });
-      } catch (error) {
-        setScan({ state: 'failed', message: messageOf(error, 'The port list could not be refreshed. Scan again.') });
       } finally {
         setPicking(null);
       }
@@ -130,23 +115,24 @@ export function PortsPane({ workspaceId }: { workspaceId: string }) {
     );
   }
 
-  // `openPath` is null until the holder has something to open; narrow at the
-  // use site so the frame cannot be built from a null.
   // Listing ports is the first half of exposing one, so it takes the same
   // authority as sharing — and the route enforces that with a 403. Gate the
-  // button on the SERVER's verdict rather than let a viewer who cannot manage
-  // the preview press Scan and be refused every time; and hold it until the
-  // status has loaded at all, because a pick is the consent gesture and the
-  // audience it consents to is not on screen until then.
+  // control on the SERVER's verdict rather than let a viewer who cannot
+  // manage the preview open the list and be refused every time; and hold it
+  // until the status has loaded at all, because a pick is the consent
+  // gesture and the audience it consents to is not on screen until then.
   const canManage = preview?.canManage === true;
+  // `openPath` is null until the holder has something to open; narrow at the
+  // use site so the frame cannot be built from a null.
   const openPath = preview?.canOpen === true && typeof preview.openPath === 'string' ? preview.openPath : null;
-  const canOpen = openPath !== null;
   const frameSrc = openPath !== null ? buildFrameSrc(openPath, nonce) : null;
   const audience = preview ? devPreviewApprovalAudience(preview.holder) : null;
+  const targetPort = preview && 'targetPort' in preview.state ? preview.state.targetPort : null;
 
   return (
     <div className="flex h-full min-h-0 flex-col" data-testid="ports-pane">
       <div className="flex shrink-0 items-center gap-2 border-b border-border px-2 py-1.5 text-xs">
+        {targetPort !== null && <span className="shrink-0 font-mono" data-testid="ports-pane-port">:{targetPort}</span>}
         <span className="min-w-0 flex-1 truncate text-muted-foreground" title={preview?.state.message} data-testid="ports-pane-status">
           {preview ? preview.state.message : 'Loading preview status…'}
         </span>
@@ -154,15 +140,16 @@ export function PortsPane({ workspaceId }: { workspaceId: string }) {
           variant="ghost"
           size="sm"
           className="h-7 gap-1.5 px-2"
-          onClick={() => void runScan()}
+          onClick={toggleList}
           disabled={scan.state === 'scanning' || !canManage}
-          title={preview === undefined ? 'Loading preview status…' : canManage ? 'Ask the sandbox which ports are listening' : 'Only the session owner, or a drive owner or admin, can share a port from this sandbox'}
+          aria-pressed={scan.state !== 'idle'}
+          title={preview === undefined ? 'Loading preview status…' : canManage ? 'Ask the sandbox which ports are listening' : CANNOT_MANAGE_PORTS}
           data-testid="ports-scan"
         >
           {scan.state === 'scanning' ? <Loader2 className="size-3.5 animate-spin" aria-hidden="true" /> : <ScanSearch className="size-3.5" aria-hidden="true" />}
-          Scan ports
+          Ports
         </Button>
-        {canOpen && (
+        {frameSrc !== null && (
           <Button variant="ghost" size="sm" className="h-7 px-2" onClick={() => setNonce((n) => n + 1)} title="Reload the preview" data-testid="ports-reload">
             <RefreshCw className="size-3.5" aria-hidden="true" />
           </Button>
@@ -177,46 +164,8 @@ export function PortsPane({ workspaceId }: { workspaceId: string }) {
       )}
 
       {scan.state === 'listed' && (
-        <div className="shrink-0 border-b border-border px-3 py-2 text-xs" data-testid="ports-list">
-          {scan.listing.ports.length === 0 ? (
-            <p className="text-muted-foreground">Nothing is listening in the sandbox. Start your dev server, then Scan again.</p>
-          ) : (
-            <div role="radiogroup" aria-label="Listening ports" className="flex flex-col gap-1">
-              {audience && <p className="pb-1 text-muted-foreground">{audience}</p>}
-              {scan.listing.ports.map((entry) => {
-                const disabled = entry.kind === 'ignored' || picking !== null || !canManage;
-                const why = entry.kind === 'ignored'
-                  ? entry.reason === 'non-http-service-port' ? 'Looks like a database or service port, not a web server'
-                    : entry.reason === 'relay-own-listener' ? 'The preview relay itself'
-                    : 'Cannot be previewed'
-                  : entry.likelihood === 'known-dev-port' ? 'Looks like a dev server' : 'Unlisted port';
-                return (
-                  <button
-                    key={entry.port}
-                    type="button"
-                    role="radio"
-                    aria-checked={entry.current}
-                    disabled={disabled}
-                    onClick={() => void pick(entry.port, scan.listing.spriteInstanceId)}
-                    className="flex items-center justify-between rounded px-2 py-1 text-left hover:bg-accent disabled:cursor-not-allowed disabled:opacity-60"
-                    title={why}
-                    data-testid={`ports-pick-${entry.port}`}
-                  >
-                    <span className="font-mono">:{entry.port}{entry.pid !== null ? <span className="ml-2 text-muted-foreground">pid {entry.pid}</span> : null}</span>
-                    <span className="text-muted-foreground">
-                      {picking === entry.port ? 'Starting…'
-                        // `current` is the persisted TARGET; whether it is actually
-                        // serving is the status's `canOpen`. A pick whose relay could
-                        // not start (a stranger on 8080) is selected, not previewing.
-                        : entry.current ? (canOpen ? 'Previewing' : 'Selected')
-                        : entry.kind === 'ignored' ? why
-                        : 'Preview this' + (scan.listing.currentPort !== null ? ' instead' : '')}
-                    </span>
-                  </button>
-                );
-              })}
-            </div>
-          )}
+        <div className="shrink-0 border-b border-border px-3 py-2">
+          <PortsList listing={scan.listing} audience={audience} canOpen={frameSrc !== null} picking={picking} disabled={!canManage} onPick={(port, instance) => void pick(port, instance)} />
         </div>
       )}
 
@@ -232,7 +181,11 @@ export function PortsPane({ workspaceId }: { workspaceId: string }) {
         />
       ) : (
         <div className="flex min-h-0 flex-1 flex-col items-center justify-center gap-2 p-6 text-center text-xs text-muted-foreground" data-testid="ports-placeholder">
-          <p className="max-w-sm">{scan.state === 'idle' ? 'Scan to see what is listening in the sandbox, then pick a port to preview it.' : preview?.state.message ?? ''}</p>
+          {preview === undefined || preview.state.status === 'starting' ? <Loader2 className="size-4 animate-spin" aria-hidden="true" /> : null}
+          <p className="max-w-sm">{preview ? preview.state.message : 'Loading preview status…'}</p>
+          {preview && preview.state.status === 'none' && canManage && (
+            <p className="max-w-sm">Open <span className="font-medium">Ports</span> above to choose what to preview.</p>
+          )}
         </div>
       )}
     </div>

--- a/apps/web/src/components/dev-preview/__tests__/PortsList.test.tsx
+++ b/apps/web/src/components/dev-preview/__tests__/PortsList.test.tsx
@@ -1,0 +1,64 @@
+/**
+ * The shared rows: a dev port is pickable with its audience stated, an
+ * ignored port is disabled with its reason, "current" reads by whether it is
+ * actually serving, and an empty listing is an instruction — not a failure.
+ */
+import { describe, test, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { PortsList, describeProbedPort, messageOf, type PortsListing } from '../PortsList';
+import { ApiRequestError } from '@/lib/auth/auth-fetch';
+
+const LISTING: PortsListing = {
+  spriteInstanceId: 'inst-live',
+  currentPort: null,
+  ports: [
+    { port: 3000, pid: 2311, kind: 'dev-server', likelihood: 'known-dev-port', current: false },
+    { port: 5432, pid: 9, kind: 'ignored', reason: 'non-http-service-port', current: false },
+  ] as PortsListing['ports'],
+};
+
+describe('PortsList', () => {
+  test('a dev port is pickable and reports the port AND the instance it was listed against; a database port is disabled with its reason', () => {
+    const onPick = vi.fn();
+    render(<PortsList listing={LISTING} audience="Anyone who can open this session will be able to open it." canOpen={false} picking={null} disabled={false} onPick={onPick} />);
+    expect(screen.getByText('Anyone who can open this session will be able to open it.')).toBeInTheDocument();
+    fireEvent.click(screen.getByTestId('ports-pick-3000'));
+    expect(onPick).toHaveBeenCalledWith(3000, 'inst-live');
+    const db = screen.getByTestId('ports-pick-5432');
+    expect(db).toBeDisabled();
+    expect(db).toHaveAttribute('title', expect.stringContaining('database'));
+  });
+
+  test('the current port reads "Previewing" only when it is serving, else "Selected"; another row offers "instead"', () => {
+    const listing = { ...LISTING, currentPort: 3000, ports: LISTING.ports.map((p) => ({ ...p, current: p.port === 3000 })) };
+    const { rerender } = render(<PortsList listing={listing} audience={null} canOpen={false} picking={null} disabled={false} onPick={vi.fn()} />);
+    expect(screen.getByTestId('ports-pick-3000')).toHaveTextContent('Selected');
+    expect(screen.getByTestId('ports-pick-3000')).toHaveAttribute('aria-checked', 'true');
+    rerender(<PortsList listing={listing} audience={null} canOpen picking={null} disabled={false} onPick={vi.fn()} />);
+    expect(screen.getByTestId('ports-pick-3000')).toHaveTextContent('Previewing');
+    const other = { ...listing, ports: [...listing.ports, { port: 5173, pid: 7, kind: 'dev-server', likelihood: 'known-dev-port', current: false }] as PortsListing['ports'] };
+    rerender(<PortsList listing={other} audience={null} canOpen picking={null} disabled={false} onPick={vi.fn()} />);
+    expect(screen.getByTestId('ports-pick-5173')).toHaveTextContent('Preview this instead');
+  });
+
+  test('every row is disabled while a pick is in flight (that row says Starting…) or when the host has no authority', () => {
+    const { rerender } = render(<PortsList listing={LISTING} audience={null} canOpen={false} picking={3000} disabled={false} onPick={vi.fn()} />);
+    expect(screen.getByTestId('ports-pick-3000')).toBeDisabled();
+    expect(screen.getByTestId('ports-pick-3000')).toHaveTextContent('Starting…');
+    rerender(<PortsList listing={LISTING} audience={null} canOpen={false} picking={null} disabled onPick={vi.fn()} />);
+    expect(screen.getByTestId('ports-pick-3000')).toBeDisabled();
+  });
+
+  test('an empty listing is an instruction, not an error', () => {
+    render(<PortsList listing={{ ...LISTING, ports: [] }} audience={null} canOpen={false} picking={null} disabled={false} onPick={vi.fn()} />);
+    expect(screen.getByTestId('ports-list')).toHaveTextContent('Start your dev server');
+  });
+
+  test('describeProbedPort and messageOf: the reason for every kind, and the server\'s sentence over a fallback', () => {
+    expect(describeProbedPort({ port: 8080, pid: 1, kind: 'ignored', reason: 'relay-own-listener', current: false } as PortsListing['ports'][number])).toContain('relay');
+    expect(describeProbedPort({ port: 4444, pid: 1, kind: 'dev-server', likelihood: 'unlisted', current: false } as PortsListing['ports'][number])).toBe('Unlisted port');
+    expect(messageOf(new ApiRequestError('Nothing is listening on port 3000 any more.', 409), 'fallback')).toBe('Nothing is listening on port 3000 any more.');
+    expect(messageOf(new Error(''), 'fallback')).toBe('fallback');
+    expect(messageOf('weird', 'fallback')).toBe('fallback');
+  });
+});

--- a/apps/web/src/components/dev-preview/__tests__/PortsPane.test.tsx
+++ b/apps/web/src/components/dev-preview/__tests__/PortsPane.test.tsx
@@ -1,8 +1,9 @@
 /**
- * The ports pane against real hooks: it NEVER probes on mount (a persisted,
+ * The preview pane against real hooks: it NEVER probes on mount (a persisted,
  * multi-viewer pane must not bill a wake per reload), the list appears only
- * behind Scan, a pick echoes the listing's instance, and every failure is the
- * server's own sentence, inline — never silence.
+ * behind the header's Ports control, a pick echoes the listing's instance and
+ * folds the list away, and every failure is the server's own sentence,
+ * inline — never silence.
  */
 import { describe, test, expect, beforeEach, afterEach, vi } from 'vitest';
 import { act, render, screen, waitFor, fireEvent } from '@testing-library/react';
@@ -112,18 +113,22 @@ describe('PortsPane', () => {
     expect(db).toHaveAttribute('title', expect.stringContaining('database'));
   });
 
-  test('a pick posts SELECT with the port and the instance the list was shown against, then re-lists', async () => {
+  test('a pick posts SELECT with the port and the instance the list was shown against, refetches the status, and folds the list away', async () => {
     mockPost
       .mockResolvedValueOnce(LISTING) // scan
-      .mockResolvedValueOnce({ ok: true, applied: { action: 'start-relay' } }) // select
-      .mockResolvedValueOnce({ ...LISTING, currentPort: 3000, ports: LISTING.ports.map((p) => ({ ...p, current: p.port === 3000 })) }); // re-list
+      .mockResolvedValueOnce({ ok: true, applied: { action: 'start-relay' } }); // select
     renderPane();
     await waitFor(() => expect(screen.getByTestId('ports-scan')).toBeEnabled());
     fireEvent.click(screen.getByTestId('ports-scan'));
     await screen.findByTestId('ports-pick-3000');
+    const statusReads = mockFetchJSON.mock.calls.length;
     fireEvent.click(screen.getByTestId('ports-pick-3000'));
     await waitFor(() => expect(mockPost).toHaveBeenCalledWith(ACTIONS_PATH, { action: 'select', port: 3000, spriteInstanceId: 'inst-live' }));
-    await waitFor(() => expect(screen.getByTestId('ports-pick-3000')).toHaveAttribute('aria-checked', 'true'));
+    // The pane is the preview again: no list, no re-probe (the status poll
+    // is what surfaces the relay coming up), and the status was re-asked.
+    await waitFor(() => expect(screen.queryByTestId('ports-list')).toBeNull());
+    expect(mockPost).toHaveBeenCalledTimes(2);
+    await waitFor(() => expect(mockFetchJSON.mock.calls.length).toBeGreaterThan(statusReads));
     expect(screen.queryByTestId('ports-pick-error')).toBeNull();
   });
 
@@ -143,8 +148,7 @@ describe('PortsPane', () => {
   test('a plan the server REFUSED inside a 200 (a stranger on 8080) is explained, not swallowed', async () => {
     mockPost
       .mockResolvedValueOnce(LISTING)
-      .mockResolvedValueOnce({ ok: true, applied: { action: 'refuse', reason: 'http-port-busy', targetPort: 3000 } })
-      .mockResolvedValueOnce(LISTING);
+      .mockResolvedValueOnce({ ok: true, applied: { action: 'refuse', reason: 'http-port-busy', targetPort: 3000 } });
     renderPane();
     await waitFor(() => expect(screen.getByTestId('ports-scan')).toBeEnabled());
     fireEvent.click(screen.getByTestId('ports-scan'));
@@ -152,20 +156,8 @@ describe('PortsPane', () => {
     fireEvent.click(screen.getByTestId('ports-pick-3000'));
     const error = await screen.findByTestId('ports-pick-error');
     expect(error).toHaveTextContent('8080');
-  });
-
-  test('a rescan that fails AFTER a persisted pick reports as a scan problem, not a failed pick', async () => {
-    mockPost
-      .mockResolvedValueOnce(LISTING)
-      .mockResolvedValueOnce({ ok: true, applied: { action: 'start-relay' } })
-      .mockRejectedValueOnce(new Error('The sandbox did not answer in time when asked which ports are listening. Try Scan again.'));
-    renderPane();
-    await waitFor(() => expect(screen.getByTestId('ports-scan')).toBeEnabled());
-    fireEvent.click(screen.getByTestId('ports-scan'));
-    await screen.findByTestId('ports-pick-3000');
-    fireEvent.click(screen.getByTestId('ports-pick-3000'));
-    expect(await screen.findByTestId('ports-scan-error')).toHaveTextContent('did not answer');
-    expect(screen.queryByTestId('ports-pick-error')).toBeNull();
+    // The list stays open so the user can act on the sentence.
+    expect(screen.getByTestId('ports-list')).toBeInTheDocument();
   });
 
   test('a current port that is NOT serving reads "Selected", not "Previewing"', async () => {
@@ -193,6 +185,8 @@ describe('PortsPane', () => {
     renderPane();
     const frame = await screen.findByTestId('ports-frame');
     expect(frame).toHaveAttribute('src', '/api/agent-workspaces/ws1/preview/open');
+    expect(screen.getByTestId('ports-pane-port')).toHaveTextContent(':3000');
+    expect(screen.queryByTestId('ports-list')).toBeNull();
     expect(frame).toHaveAttribute('sandbox', expect.stringContaining('allow-scripts'));
     // Reload bumps the nonce, forcing a fresh navigation through the handshake.
     await act(async () => { fireEvent.click(screen.getByTestId('ports-reload')); });

--- a/apps/web/src/components/dev-preview/dev-preview-copy.ts
+++ b/apps/web/src/components/dev-preview/dev-preview-copy.ts
@@ -104,3 +104,13 @@ export function devPreviewApprovalAudience(holder: DevPreviewStatusDTO['holder']
     ? 'Everyone with access to this drive will be able to open it.'
     : 'Anyone who can open this session will be able to open it.';
 }
+
+/** The empty listing. A probe that found nothing is a fact, not a failure — so it reads as an instruction. */
+export const NOTHING_LISTENING = 'Nothing is listening in the sandbox. Start your dev server, then scan again.';
+
+/** The pick was RECORDED but the plan refused: something else holds 8080 so the relay cannot start. */
+export const PICK_REFUSED_HTTP_PORT_BUSY = 'Port 8080 is held by another process in the sandbox, so the preview relay cannot start. Stop that process and pick again.';
+export const PICK_REFUSED = 'The preview could not be started right now.';
+
+/** Why Scan/pick is withheld from a viewer the SERVER says cannot manage the preview. */
+export const CANNOT_MANAGE_PORTS = 'Only the session owner, or a drive owner or admin, can share a port from this sandbox';

--- a/docs/sprites/dev-preview-runbook.md
+++ b/docs/sprites/dev-preview-runbook.md
@@ -250,21 +250,27 @@ order matters: switch the feature off and CONFIRM it before rotating
 `SPRITES_API_TOKEN`. Rotating first while forwarding is still up simply hands
 the previewed dev server the new credential.
 
-## 8. The Ports pane — when detection cannot see your server
+## 8. Ports in the pane picker — when detection cannot see your server
 
 `ports/watch` does not report a Next.js dev server's bind at all (reproduced on
 a clean sprite; the platform docs say otherwise). For any server the channel
-misses, the affordance never appears and the user sees nothing. The Ports pane
-is the reliable path and the diagnostic:
+misses, the affordance never appears and the user sees nothing. The picker's
+Ports section is the reliable path and the diagnostic:
 
-- **Split a pane → Ports.** It binds like a page (nothing is minted) and
-  **never probes on mount** — a grid pane is persisted across reloads,
-  devices and viewers, and a probe is an exec that wakes a paused sprite,
-  which is billed. It shows the cached status until you press **Scan**.
-- **Scan** runs `ss -ltnp` in the sandbox (`POST …/preview/ports` — POST
-  because a GET that can wake is unsafe by HTTP semantics), classified
+- **Split a pane → the Ports section lists what is listening,** beside
+  Shell, Agents and Pages. The picker probes when it opens — that is a user
+  gesture, so the exec (and the wake it may cost) is one the user asked
+  for. The probe runs `ss -ltnp` in the sandbox (`POST …/preview/ports` —
+  POST because a GET that can wake is unsafe by HTTP semantics), classified
   server-side: database/broker ports and the relay's own 8080 come back
-  disabled with a reason.
+  disabled with a reason. A viewer the server says cannot manage the
+  preview is told so and nothing is probed.
+- **Click a port → that pane becomes the preview.** The select is posted
+  from the picker; only a pick that took binds the pane (`'ports'` kind, id
+  = the workspace). The pane itself **never probes on mount** — it is
+  persisted across reloads, devices and viewers, and a probe is an exec that
+  wakes a paused sprite, which is billed. Its header keeps a **Ports**
+  control that lists again on demand, for diagnosis and for switching.
 - **Picking a port is the consent.** The audience is stated beside the list.
   `POST …/preview/actions {action:'select', port, spriteInstanceId}` checks
   the instance against the live handle, re-probes under the holder's lock,


### PR DESCRIPTION
## What changes

Splitting a pane now lists the sandbox's listening ports **in the picker**, beside Shell / Agents / Pages, and clicking a port turns that pane straight into the preview frame. The intermediate "Ports" pane with a **Scan ports** button is gone from the picker.

The persisted `'ports'` pane kind stays (it is what a preview pane *is* — target = the workspace's one sandbox). It now renders **preview-first**: the frame is the body as soon as the status says it can open; before that, the server's status sentence. A **Ports** control in its header lists again on demand — kept for diagnosis and for switching ports.

## How it works

- **`PortsList`** (new): one copy of the rows (audience line, per-port reasons, Previewing/Selected wording) shared by the picker section and the pane; sentences live in `dev-preview-copy.ts`.
- **`PanePicker` → `PortsSection`**: probes `POST …/preview/ports` when the picker opens. That is a user gesture (a split), not a persisted node — the pane itself still **never probes on mount**. Gated on the server's `canManage` (a viewer who cannot pick is told so and nothing is probed); hidden on a dark deployment; a disabled row for a tier that cannot run a sandbox (same gate as Shell). A click posts the `select` itself and hands the pane the port **only once the pick took** — including a plan the server refused inside a 200 (the pick is recorded; the pane says why it is not serving). A thrown refusal stays in the picker as the server's sentence, so a pane is never bound to nothing. Failed probe → Retry; empty listing → Rescan.
- **`PortsPane`**: frame first; polls at the open pane's cadence (`PANE_POLL_MS`, now exported) so the relay's arrival shows without a click; header shows `:port`; a pick from the header list folds the list away and refetches the status.
- **`AgentPanes`**: `onPickPort` → bind the pane as `'ports'` (the select already happened).

No server changes.

## Tests

- `PortsList.test.tsx` (new): rows, reasons, Previewing/Selected, in-flight/disabled, empty listing, `messageOf`.
- `PanePicker.test.tsx`: probes exactly once on open; select-then-bind ordering (the pane is not handed the port before the POST resolves); refuse-in-200 still binds; thrown refusal does not and shows the sentence; Retry/Rescan probe again; the four no-probe cases (cannot manage, tier, dark, no handler).
- `PortsPane.test.tsx`: updated for the pick folding the list away and refetching status; the header port; frame with no list open.
- Mutation-checked: removing the `await post(select)` before the bind fails exactly the two pick tests.

Follow-up (not here): a cold sprite makes the picker's probe wait for the 20 s backstop before the route's sentence + Retry; the handle cannot distinguish warm from cold, so an honest "asleep" answer without an exec is not available yet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01P8A8KLYCoViP7ouH5QzbnB
