### PR TITLE
Register format_sheet and set_conditional_format, and teach the spreadsheets skill

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ All notable user-facing changes to PageSpace are documented here. Format follows
 
 ### Added
 
+- **AI agents can format spreadsheets** — two new workspace tools, **Format Sheet** and
+  **Conditional Formatting**, let an agent make a SHEET page presentable instead of leaving a grid
+  of bare numbers. An agent declares what a table *is* (its range, header rows, which columns are
+  money, percentages or dates, which rows are totals, an accent colour) and the sheet derives the
+  header band, number formats and total emphasis from that — so rows added later inherit the
+  formatting, and the agent never hand-picks colours. Conditional rules (highlight when a value
+  crosses a threshold, colour scales, data bars) follow the values as they change. Both tools are
+  write tools: a read-only agent does not get them. The chat shows a card for each call listing the
+  tables declared, ranges touched and rules added, with a swatch per colour, so you can see what
+  changed without opening the sheet. The spreadsheets skill now teaches all of this; the
+  workspace-tool count in the docs goes from 81 to 83.
 - **Dev-server preview: see the app you're building, live, from inside its session (ships dark)** —
   when a dev server (Vite, Next, anything that binds a port) starts inside an agent session or a
   drive Environment, PageSpace notices and shows one quiet line in that session's header or beneath

--- a/README.md
+++ b/README.md
@@ -179,7 +179,7 @@ in favor of `pagespace mcp`, part of `@pagespace/cli`; see the
 ## Core Features
 
 ### AI Agent Infrastructure
-- **81 workspace tools** for AI to manipulate content directly. The same operation registry
+- **83 workspace tools** for AI to manipulate content directly. The same operation registry
   generates every `pagespace` CLI verb, SDK method, and MCP tool, so none of the three can drift
 - **Tool permissions**: Control what each AI can do in your workspace
 - **MCP protocol support**: Connect external AI tools like Claude Desktop, Cursor, and Claude Code

--- a/apps/marketing/src/app/docs/getting-started/page.tsx
+++ b/apps/marketing/src/app/docs/getting-started/page.tsx
@@ -79,7 +79,7 @@ AI Chat pages are specialized AI conversations with custom configuration:
 1. Right-click in the file tree and select **New AI Chat**
 2. Open the agent's settings to configure:
    - **System prompt**: custom instructions for the agent's behavior
-   - **Enabled tools**: which of the 81 workspace tools the agent can call
+   - **Enabled tools**: which of the 83 workspace tools the agent can call
    - **Read-only toggle**: when on, the agent can only read and search — no writes, no trash, no task updates
    - **Web search toggle**: enables the \`web_search\` tool
    - **Provider / Model**: which AI model powers this agent

--- a/apps/web/src/components/ai/shared/chat/tool-calls/SheetFormatRenderer.tsx
+++ b/apps/web/src/components/ai/shared/chat/tool-calls/SheetFormatRenderer.tsx
@@ -32,7 +32,13 @@ interface SheetFormatRendererProps {
   regionMode?: 'merge' | 'replaceAll';
   ops?: FormatOpInput[];
   rules?: RuleInput[];
+  /** From the result: rule ids the store confirmed it removed under its lock. */
   removedRuleIds?: string[];
+  /** From the result: the ids the call's rules landed under, by index. */
+  ruleIds?: string[];
+  /** From the result: which of those ids were NEW on the tab. */
+  ruleIdsAdded?: string[];
+  ruleMode?: 'append' | 'replaceAll';
   /** From the result: what landed, when it differs from what was asked. */
   regionsApplied?: number;
   opsApplied?: number;
@@ -156,6 +162,9 @@ export const SheetFormatRenderer: React.FC<SheetFormatRendererProps> = memo(func
   ops = NONE,
   rules = NONE,
   removedRuleIds = NONE,
+  ruleIds = NONE,
+  ruleIdsAdded = NONE,
+  ruleMode,
   regionsApplied,
   opsApplied,
   cellsFormatted,
@@ -175,6 +184,10 @@ export const SheetFormatRenderer: React.FC<SheetFormatRendererProps> = memo(func
   const opCount = opsApplied ?? ops.length;
   const added = rulesAdded ?? 0;
   const removed = rulesRemoved ?? removedIds.length;
+  // A replaceAll that neither added nor removed but did write reordered the
+  // rules — a real, precedence-changing change with no row to show for it.
+  const reordered = ruleMode === 'replaceAll' && changed === true && added === 0 && removed === 0 && rules.length > 0;
+  const addedIds = new Set(ruleIdsAdded);
   const replacedAll = regionMode === 'replaceAll';
   const summary = [
     ...(regionCount > 0 ? [count(regionCount, 'region')] : []),
@@ -182,6 +195,8 @@ export const SheetFormatRenderer: React.FC<SheetFormatRendererProps> = memo(func
     ...(opCount > 0 ? [count(opCount, 'op')] : []),
     ...(cellsFormatted ? [count(cellsFormatted, 'cell')] : []),
     ...(added > 0 ? [`${count(added, 'rule')} added`] : []),
+    ...(reordered ? ['rules reordered'] : []),
+    ...(ruleMode === 'replaceAll' && !reordered && rules.length - added > 0 ? [`${rules.length - added} kept`] : []),
     ...(duplicateIndexes.size > 0 ? [`${duplicateIndexes.size} already present`] : []),
     ...(removed > 0 ? [`${removed} removed`] : []),
   ].join(' · ');
@@ -272,17 +287,23 @@ export const SheetFormatRenderer: React.FC<SheetFormatRendererProps> = memo(func
               </div>
             ))}
             {rules.map((rule, i) => {
+              // In append mode a rule the tab already held is "already
+              // present" (skipped). In replaceAll every rule in the call is
+              // on the tab afterwards; the ones that were there before are
+              // "kept", which is not a skip — their order may have changed.
               const duplicate = duplicateIndexes.has(i);
+              const kept = ruleMode === 'replaceAll' && ruleIds[i] !== undefined && !addedIds.has(ruleIds[i]);
+              const badge = duplicate ? 'already present' : kept ? 'kept' : undefined;
               return (
                 <div
                   key={`rule-${i}`}
-                  className={cn(ROW, duplicate && 'text-muted-foreground')}
-                  data-testid={duplicate ? 'sheet-format-rule-duplicate' : 'sheet-format-rule'}
+                  className={cn(ROW, badge && 'text-muted-foreground')}
+                  data-testid={duplicate ? 'sheet-format-rule-duplicate' : kept ? 'sheet-format-rule-kept' : 'sheet-format-rule'}
                 >
                   <Paintbrush className="h-3.5 w-3.5 text-muted-foreground shrink-0" />
                   <span className="flex-1 min-w-0 truncate font-mono text-xs">{describeRule(rule)}</span>
                   <Swatches colours={ruleColours(rule)} />
-                  {duplicate && <span className="text-[11px] px-1.5 py-0.5 rounded bg-muted shrink-0">already present</span>}
+                  {badge && <span className="text-[11px] px-1.5 py-0.5 rounded bg-muted shrink-0">{badge}</span>}
                 </div>
               );
             })}

--- a/apps/web/src/components/ai/shared/chat/tool-calls/SheetFormatRenderer.tsx
+++ b/apps/web/src/components/ai/shared/chat/tool-calls/SheetFormatRenderer.tsx
@@ -28,6 +28,8 @@ interface SheetFormatRendererProps {
   title?: string;
   pageId?: string;
   regions?: RegionInput[];
+  /** `replaceAll` removed every region on the tab that is not in `regions`. */
+  regionMode?: 'merge' | 'replaceAll';
   ops?: FormatOpInput[];
   rules?: RuleInput[];
   removedRuleIds?: string[];
@@ -148,6 +150,7 @@ export const SheetFormatRenderer: React.FC<SheetFormatRendererProps> = memo(func
   title = 'Sheet',
   pageId,
   regions = NONE,
+  regionMode,
   ops = NONE,
   rules = NONE,
   removedRuleIds = NONE,
@@ -167,8 +170,10 @@ export const SheetFormatRenderer: React.FC<SheetFormatRendererProps> = memo(func
   const opCount = opsApplied ?? ops.length;
   const added = rulesAdded ?? 0;
   const removed = rulesRemoved ?? removedRuleIds.length;
+  const replacedAll = regionMode === 'replaceAll';
   const summary = [
     ...(regionCount > 0 ? [count(regionCount, 'region')] : []),
+    ...(replacedAll ? ['other regions removed'] : []),
     ...(opCount > 0 ? [count(opCount, 'op')] : []),
     ...(cellsFormatted ? [count(cellsFormatted, 'cell')] : []),
     ...(added > 0 ? [`${count(added, 'rule')} added`] : []),
@@ -176,7 +181,7 @@ export const SheetFormatRenderer: React.FC<SheetFormatRendererProps> = memo(func
     ...(removed > 0 ? [`${removed} removed`] : []),
   ].join(' · ');
 
-  const empty = regions.length === 0 && ops.length === 0 && rules.length === 0 && removedRuleIds.length === 0;
+  const empty = regions.length === 0 && ops.length === 0 && rules.length === 0 && removedRuleIds.length === 0 && !replacedAll;
 
   return (
     <div className="rounded-lg border bg-card overflow-hidden my-2 shadow-sm">
@@ -236,6 +241,15 @@ export const SheetFormatRenderer: React.FC<SheetFormatRendererProps> = memo(func
                 </div>
               );
             })}
+            {replacedAll && (
+              <div className={cn(ROW, 'text-muted-foreground')} data-testid="sheet-format-regions-replaced">
+                <Table2 className="h-3.5 w-3.5 shrink-0" />
+                <span className="flex-1 min-w-0 truncate text-xs">
+                  {regions.length === 0 ? 'Every region on the tab removed' : 'Every other region on the tab removed'}
+                </span>
+                <span className="text-[11px] shrink-0">replaceAll</span>
+              </div>
+            )}
             {ops.map((op, i) => (
               <div key={`op-${i}`} className={ROW} data-testid="sheet-format-op">
                 <code className="w-14 shrink-0 font-mono text-xs text-muted-foreground truncate">{describeOpTarget(op)}</code>

--- a/apps/web/src/components/ai/shared/chat/tool-calls/SheetFormatRenderer.tsx
+++ b/apps/web/src/components/ai/shared/chat/tool-calls/SheetFormatRenderer.tsx
@@ -164,12 +164,14 @@ export const SheetFormatRenderer: React.FC<SheetFormatRendererProps> = memo(func
 }) {
   const { navigateToPage } = usePageNavigation();
   const colours = collectColours(regions, ops, rules);
+  // The executor removes a repeated id once; the card must not list it twice.
+  const removedIds = [...new Set(removedRuleIds)];
   const duplicateIndexes = new Set(skippedDuplicates.map((entry) => entry.index));
 
   const regionCount = regionsApplied ?? regions.length;
   const opCount = opsApplied ?? ops.length;
   const added = rulesAdded ?? 0;
-  const removed = rulesRemoved ?? removedRuleIds.length;
+  const removed = rulesRemoved ?? removedIds.length;
   const replacedAll = regionMode === 'replaceAll';
   const summary = [
     ...(regionCount > 0 ? [count(regionCount, 'region')] : []),
@@ -181,7 +183,7 @@ export const SheetFormatRenderer: React.FC<SheetFormatRendererProps> = memo(func
     ...(removed > 0 ? [`${removed} removed`] : []),
   ].join(' · ');
 
-  const empty = regions.length === 0 && ops.length === 0 && rules.length === 0 && removedRuleIds.length === 0 && !replacedAll;
+  const empty = regions.length === 0 && ops.length === 0 && rules.length === 0 && removedIds.length === 0 && !replacedAll;
 
   return (
     <div className="rounded-lg border bg-card overflow-hidden my-2 shadow-sm">
@@ -272,7 +274,7 @@ export const SheetFormatRenderer: React.FC<SheetFormatRendererProps> = memo(func
                 </div>
               );
             })}
-            {removedRuleIds.map((id) => (
+            {removedIds.map((id) => (
               <div key={`removed-${id}`} className={cn(ROW, 'text-muted-foreground')} data-testid="sheet-format-removed">
                 <Paintbrush className="h-3.5 w-3.5 shrink-0" />
                 <span className="flex-1 min-w-0 truncate font-mono text-xs line-through">{id}</span>

--- a/apps/web/src/components/ai/shared/chat/tool-calls/SheetFormatRenderer.tsx
+++ b/apps/web/src/components/ai/shared/chat/tool-calls/SheetFormatRenderer.tsx
@@ -1,0 +1,290 @@
+'use client';
+
+import React, { memo, useMemo } from 'react';
+import { usePageNavigation } from '@/hooks/usePageNavigation';
+import { Table2, ExternalLink, Paintbrush } from 'lucide-react';
+import { PALETTE, normalizeHex } from '@pagespace/lib/sheets/sheet';
+import { cn } from '@/lib/utils';
+
+/**
+ * SheetFormatRenderer — what `format_sheet` / `set_conditional_format` did.
+ *
+ * Deliberately NOT `SheetEditRenderer`: that card is an address → VALUE table,
+ * and a formatting call has no values. What a person wants to see here is the
+ * shape of the change — which tables were declared and over what ranges, how
+ * many escape-hatch ops ran, which rules were added or removed — plus a swatch
+ * per distinct colour so a "make it green" request is visibly green without
+ * opening the sheet. Reads the tool INPUT for the structure (the result only
+ * carries counts and ids) and the OUTPUT for what actually landed.
+ */
+
+export interface SheetFormatRegionInput {
+  id?: string;
+  name?: string;
+  range: string;
+  headerRows?: number;
+  totalRows?: number[];
+  columns?: Array<{ column: string; role: string; currency?: string }>;
+  theme?: string;
+  freezeHeader?: boolean;
+}
+
+interface FormatLike {
+  color?: string;
+  background?: string;
+}
+
+export interface SheetFormatOpInput {
+  op: string;
+  range?: string;
+  column?: string;
+  row?: number;
+  format?: FormatLike;
+  width?: number;
+  height?: number;
+  frozenRows?: number;
+  frozenColumns?: number;
+  clear?: true;
+}
+
+export interface SheetRuleInput {
+  kind: string;
+  ranges: string[];
+  operator?: string;
+  value?: string | number;
+  value2?: string | number;
+  formula?: string;
+  format?: FormatLike;
+  min?: { color?: string };
+  mid?: { color?: string };
+  max?: { color?: string };
+  color?: string;
+}
+
+interface SheetFormatRendererProps {
+  title?: string;
+  pageId?: string;
+  driveId?: string;
+  regions?: SheetFormatRegionInput[];
+  ops?: SheetFormatOpInput[];
+  rules?: SheetRuleInput[];
+  /** From the result: what landed, when it differs from what was asked. */
+  opsApplied?: number;
+  regionsApplied?: number;
+  cellsFormatted?: number;
+  rulesAdded?: number;
+  rulesRemoved?: number;
+  removedRuleIds?: string[];
+  message?: string;
+  maxHeight?: number;
+  className?: string;
+}
+
+const themeSwatch = (theme: string | undefined): string | null => {
+  if (!theme) return null;
+  const hue = PALETTE.find((entry) => entry.name === theme);
+  return hue ? hue.mid : null;
+};
+
+/** The target an op touched, in the words the op used. */
+const describeOpTarget = (op: SheetFormatOpInput): string => {
+  if (op.op === 'freeze') {
+    if (op.clear) return 'unfreeze';
+    const parts: string[] = [];
+    if (op.frozenRows !== undefined) parts.push(`${op.frozenRows} row${op.frozenRows === 1 ? '' : 's'}`);
+    if (op.frozenColumns !== undefined) parts.push(`${op.frozenColumns} col${op.frozenColumns === 1 ? '' : 's'}`);
+    return parts.join(', ') || 'freeze';
+  }
+  if (op.range) return op.range.toUpperCase();
+  if (op.column) {
+    const suffix = op.width !== undefined ? ` ${op.width}px` : op.clear ? ' reset' : '';
+    return `column ${op.column.toUpperCase()}${suffix}`;
+  }
+  if (op.row !== undefined) {
+    const suffix = op.height !== undefined ? ` ${op.height}px` : op.clear ? ' reset' : '';
+    return `row ${op.row}${suffix}`;
+  }
+  return '';
+};
+
+const describeRule = (rule: SheetRuleInput): string => {
+  const ranges = rule.ranges.map((r) => r.toUpperCase()).join(', ');
+  switch (rule.kind) {
+    case 'cell': {
+      const operand = rule.value !== undefined ? ` ${String(rule.value)}` : '';
+      const upper = rule.value2 !== undefined ? ` and ${String(rule.value2)}` : '';
+      return `${ranges} · ${rule.operator ?? 'cell'}${operand}${upper}`;
+    }
+    case 'formula':
+      return `${ranges} · ${rule.formula ?? 'formula'}`;
+    case 'colorScale':
+      return `${ranges} · colour scale`;
+    case 'dataBar':
+      return `${ranges} · data bar`;
+    default:
+      return ranges;
+  }
+};
+
+/** Every distinct colour the call named, normalised so `#FFF` and `#ffffff` are one swatch. */
+const collectColours = (ops: SheetFormatOpInput[], rules: SheetRuleInput[], regions: SheetFormatRegionInput[]): string[] => {
+  const seen = new Set<string>();
+  const add = (value: string | undefined | null) => {
+    if (!value) return;
+    const hex = normalizeHex(value) ?? value;
+    seen.add(hex);
+  };
+  for (const region of regions) add(themeSwatch(region.theme));
+  for (const op of ops) {
+    add(op.format?.color);
+    add(op.format?.background);
+  }
+  for (const rule of rules) {
+    add(rule.format?.color);
+    add(rule.format?.background);
+    add(rule.min?.color);
+    add(rule.mid?.color);
+    add(rule.max?.color);
+    add(rule.color);
+  }
+  return [...seen];
+};
+
+const Swatch: React.FC<{ colour: string; label?: string }> = ({ colour, label }) => (
+  <span
+    className="inline-block h-3 w-3 rounded-sm border border-border/60 shrink-0"
+    style={{ backgroundColor: colour }}
+    title={label ?? colour}
+    aria-label={label ?? colour}
+  />
+);
+
+export const SheetFormatRenderer: React.FC<SheetFormatRendererProps> = memo(function SheetFormatRenderer({
+  title = 'Sheet',
+  pageId,
+  driveId,
+  regions = [],
+  ops = [],
+  rules = [],
+  opsApplied,
+  regionsApplied,
+  cellsFormatted,
+  rulesAdded,
+  rulesRemoved,
+  removedRuleIds = [],
+  message,
+  maxHeight = 280,
+  className,
+}) {
+  const { navigateToPage } = usePageNavigation();
+  const colours = useMemo(() => collectColours(ops, rules, regions), [ops, rules, regions]);
+
+  const summary = useMemo(() => {
+    const parts: string[] = [];
+    const regionCount = regionsApplied ?? regions.length;
+    const opCount = opsApplied ?? ops.length;
+    const added = rulesAdded ?? rules.length;
+    const removed = rulesRemoved ?? removedRuleIds.length;
+    if (regionCount > 0) parts.push(`${regionCount} ${regionCount === 1 ? 'region' : 'regions'}`);
+    if (opCount > 0) parts.push(`${opCount} ${opCount === 1 ? 'op' : 'ops'}`);
+    if (cellsFormatted) parts.push(`${cellsFormatted} ${cellsFormatted === 1 ? 'cell' : 'cells'}`);
+    if (added > 0) parts.push(`${added} ${added === 1 ? 'rule' : 'rules'} added`);
+    if (removed > 0) parts.push(`${removed} removed`);
+    return parts.join(' · ');
+  }, [regionsApplied, regions.length, opsApplied, ops.length, cellsFormatted, rulesAdded, rules.length, rulesRemoved, removedRuleIds.length]);
+
+  const empty = regions.length === 0 && ops.length === 0 && rules.length === 0 && removedRuleIds.length === 0;
+
+  return (
+    <div className={cn('rounded-lg border bg-card overflow-hidden my-2 shadow-sm', className)}>
+      <button
+        type="button"
+        onClick={() => pageId && navigateToPage(pageId, driveId)}
+        disabled={!pageId}
+        className={cn(
+          'w-full flex items-center justify-between px-3 py-2 bg-muted/30 border-b text-left',
+          'hover:bg-muted/50 transition-colors',
+          !pageId && 'cursor-default'
+        )}
+      >
+        <div className="flex items-center gap-2 min-w-0">
+          <Table2 className="h-4 w-4 text-muted-foreground shrink-0" />
+          <span className="text-sm font-medium truncate" title={title}>
+            {title}
+          </span>
+        </div>
+        <span className="flex items-center gap-2 shrink-0">
+          {colours.length > 0 && (
+            <span className="flex items-center gap-1" data-testid="sheet-format-swatches">
+              {colours.map((colour) => (
+                <Swatch key={colour} colour={colour} />
+              ))}
+            </span>
+          )}
+          {summary && <span className="text-xs text-muted-foreground">{summary}</span>}
+          {pageId && <ExternalLink className="h-3.5 w-3.5 text-muted-foreground" />}
+        </span>
+      </button>
+
+      <div className="bg-background overflow-auto divide-y divide-border" style={{ maxHeight: `${maxHeight}px` }}>
+        {empty ? (
+          <div className="text-sm text-muted-foreground text-center py-4">{message ?? 'Nothing changed'}</div>
+        ) : (
+          <>
+            {regions.map((region, i) => {
+              const swatch = themeSwatch(region.theme);
+              const details: string[] = [];
+              if (region.headerRows !== undefined && region.headerRows !== 1) details.push(`${region.headerRows} header rows`);
+              for (const column of region.columns ?? []) {
+                details.push(`${column.column.toUpperCase()} ${column.role}${column.currency ? ` ${column.currency}` : ''}`);
+              }
+              if (region.totalRows && region.totalRows.length > 0) details.push(`total ${region.totalRows.join(', ')}`);
+              if (region.freezeHeader) details.push('frozen header');
+              return (
+                <div key={`region-${i}`} className="flex items-center gap-3 px-3 py-1.5 text-sm" data-testid="sheet-format-region">
+                  <code className="w-14 shrink-0 font-mono text-xs text-muted-foreground">{region.range.toUpperCase()}</code>
+                  <span className="flex-1 min-w-0 truncate text-xs">
+                    <span className="font-medium">{region.name ?? 'Table'}</span>
+                    {details.length > 0 && <span className="text-muted-foreground"> · {details.join(' · ')}</span>}
+                  </span>
+                  <span className="flex items-center gap-1 text-[11px] px-1.5 py-0.5 rounded shrink-0 bg-muted text-muted-foreground">
+                    {swatch && <Swatch colour={swatch} label={region.theme} />}
+                    region
+                  </span>
+                </div>
+              );
+            })}
+            {ops.map((op, i) => (
+              <div key={`op-${i}`} className="flex items-center gap-3 px-3 py-1.5 text-sm" data-testid="sheet-format-op">
+                <code className="w-14 shrink-0 font-mono text-xs text-muted-foreground truncate">{describeOpTarget(op)}</code>
+                <span className="flex-1 min-w-0 truncate font-mono text-xs">{op.op}</span>
+                <span className="flex items-center gap-1 shrink-0">
+                  {op.format?.background && <Swatch colour={op.format.background} />}
+                  {op.format?.color && <Swatch colour={op.format.color} />}
+                </span>
+              </div>
+            ))}
+            {rules.map((rule, i) => (
+              <div key={`rule-${i}`} className="flex items-center gap-3 px-3 py-1.5 text-sm" data-testid="sheet-format-rule">
+                <Paintbrush className="h-3.5 w-3.5 text-muted-foreground shrink-0" />
+                <span className="flex-1 min-w-0 truncate font-mono text-xs">{describeRule(rule)}</span>
+                <span className="flex items-center gap-1 shrink-0">
+                  {[rule.format?.background, rule.format?.color, rule.min?.color, rule.mid?.color, rule.max?.color, rule.color]
+                    .filter((c): c is string => Boolean(c))
+                    .map((c, j) => <Swatch key={`${c}-${j}`} colour={c} />)}
+                </span>
+              </div>
+            ))}
+            {removedRuleIds.map((id) => (
+              <div key={`removed-${id}`} className="flex items-center gap-3 px-3 py-1.5 text-sm text-muted-foreground" data-testid="sheet-format-removed">
+                <Paintbrush className="h-3.5 w-3.5 shrink-0" />
+                <span className="flex-1 min-w-0 truncate font-mono text-xs line-through">{id}</span>
+                <span className="text-[11px] shrink-0">removed</span>
+              </div>
+            ))}
+          </>
+        )}
+      </div>
+    </div>
+  );
+});

--- a/apps/web/src/components/ai/shared/chat/tool-calls/SheetFormatRenderer.tsx
+++ b/apps/web/src/components/ai/shared/chat/tool-calls/SheetFormatRenderer.tsx
@@ -28,8 +28,8 @@ interface SheetFormatRendererProps {
   title?: string;
   pageId?: string;
   regions?: RegionInput[];
-  /** `replaceAll` removed every region on the tab that is not in `regions`. */
-  regionMode?: 'merge' | 'replaceAll';
+  /** From the result: region ids the store confirmed it removed under its lock (a replaceAll). */
+  removedRegionIds?: string[];
   ops?: FormatOpInput[];
   rules?: RuleInput[];
   /** From the result: rule ids the store confirmed it removed under its lock. */
@@ -158,7 +158,7 @@ export const SheetFormatRenderer: React.FC<SheetFormatRendererProps> = memo(func
   title = 'Sheet',
   pageId,
   regions = NONE,
-  regionMode,
+  removedRegionIds = NONE,
   ops = NONE,
   rules = NONE,
   removedRuleIds = NONE,
@@ -188,10 +188,10 @@ export const SheetFormatRenderer: React.FC<SheetFormatRendererProps> = memo(func
   // rules — a real, precedence-changing change with no row to show for it.
   const reordered = ruleMode === 'replaceAll' && changed === true && added === 0 && removed === 0 && rules.length > 0;
   const addedIds = new Set(ruleIdsAdded);
-  const replacedAll = regionMode === 'replaceAll';
+  const regionsRemoved = removedRegionIds.length;
   const summary = [
     ...(regionCount > 0 ? [count(regionCount, 'region')] : []),
-    ...(replacedAll ? ['other regions removed'] : []),
+    ...(regionsRemoved > 0 ? [`${count(regionsRemoved, 'other region')} removed`] : []),
     ...(opCount > 0 ? [count(opCount, 'op')] : []),
     ...(cellsFormatted ? [count(cellsFormatted, 'cell')] : []),
     ...(added > 0 ? [`${count(added, 'rule')} added`] : []),
@@ -204,7 +204,7 @@ export const SheetFormatRenderer: React.FC<SheetFormatRendererProps> = memo(func
   // A call the store reports as a no-op is shown as one, not as the list of
   // formatting it would have applied — that formatting was already there.
   const unchanged = changed === false;
-  const empty = unchanged || (regions.length === 0 && ops.length === 0 && rules.length === 0 && removedIds.length === 0 && !replacedAll);
+  const empty = unchanged || (regions.length === 0 && ops.length === 0 && rules.length === 0 && removedIds.length === 0 && regionsRemoved === 0);
 
   return (
     <div className="rounded-lg border bg-card overflow-hidden my-2 shadow-sm">
@@ -270,11 +270,13 @@ export const SheetFormatRenderer: React.FC<SheetFormatRendererProps> = memo(func
                 </div>
               );
             })}
-            {replacedAll && (
+            {regionsRemoved > 0 && (
               <div className={cn(ROW, 'text-muted-foreground')} data-testid="sheet-format-regions-replaced">
                 <Table2 className="h-3.5 w-3.5 shrink-0" />
                 <span className="flex-1 min-w-0 truncate text-xs">
-                  {regions.length === 0 ? 'Every region on the tab removed' : 'Every other region on the tab removed'}
+                  {regions.length === 0
+                    ? `Every region on the tab removed (${regionsRemoved})`
+                    : `${count(regionsRemoved, 'other region')} on the tab removed`}
                 </span>
                 <span className="text-[11px] shrink-0">replaceAll</span>
               </div>

--- a/apps/web/src/components/ai/shared/chat/tool-calls/SheetFormatRenderer.tsx
+++ b/apps/web/src/components/ai/shared/chat/tool-calls/SheetFormatRenderer.tsx
@@ -45,6 +45,8 @@ interface SheetFormatRendererProps {
    * without this the card would present them as changes that never landed.
    */
   skippedDuplicates?: Array<{ index: number }>;
+  /** From the result: false when the sheet already looked like this and nothing was written. */
+  changed?: boolean;
   message?: string;
 }
 
@@ -160,6 +162,7 @@ export const SheetFormatRenderer: React.FC<SheetFormatRendererProps> = memo(func
   rulesAdded,
   rulesRemoved,
   skippedDuplicates = NONE,
+  changed,
   message,
 }) {
   const { navigateToPage } = usePageNavigation();
@@ -183,7 +186,10 @@ export const SheetFormatRenderer: React.FC<SheetFormatRendererProps> = memo(func
     ...(removed > 0 ? [`${removed} removed`] : []),
   ].join(' · ');
 
-  const empty = regions.length === 0 && ops.length === 0 && rules.length === 0 && removedIds.length === 0 && !replacedAll;
+  // A call the store reports as a no-op is shown as one, not as the list of
+  // formatting it would have applied — that formatting was already there.
+  const unchanged = changed === false;
+  const empty = unchanged || (regions.length === 0 && ops.length === 0 && rules.length === 0 && removedIds.length === 0 && !replacedAll);
 
   return (
     <div className="rounded-lg border bg-card overflow-hidden my-2 shadow-sm">
@@ -209,14 +215,20 @@ export const SheetFormatRenderer: React.FC<SheetFormatRendererProps> = memo(func
               <Swatches colours={colours} />
             </span>
           )}
-          {summary && <span className="text-xs text-muted-foreground">{summary}</span>}
+          {unchanged ? (
+            <span className="text-xs text-muted-foreground">already formatted this way</span>
+          ) : (
+            summary && <span className="text-xs text-muted-foreground">{summary}</span>
+          )}
           {pageId && <ExternalLink className="h-3.5 w-3.5 text-muted-foreground" />}
         </span>
       </button>
 
       <div className="bg-background overflow-auto divide-y divide-border max-h-[280px]">
         {empty ? (
-          <div className="text-sm text-muted-foreground text-center py-4">{message ?? 'Nothing changed'}</div>
+          <div className="text-sm text-muted-foreground text-center py-4" data-testid="sheet-format-empty">
+            {unchanged ? 'Nothing changed — the sheet already had this formatting.' : (message ?? 'Nothing changed')}
+          </div>
         ) : (
           <>
             {regions.map((region, i) => {

--- a/apps/web/src/components/ai/shared/chat/tool-calls/SheetFormatRenderer.tsx
+++ b/apps/web/src/components/ai/shared/chat/tool-calls/SheetFormatRenderer.tsx
@@ -74,6 +74,12 @@ interface SheetFormatRendererProps {
   cellsFormatted?: number;
   rulesAdded?: number;
   rulesRemoved?: number;
+  /**
+   * From the result: rules in the call that were already on the tab, by index
+   * into `rules`. A retried append reports every rule here with `added: 0`;
+   * without this the card would present them as changes that never landed.
+   */
+  skippedDuplicates?: Array<{ index: number; existingRuleId: string }>;
   removedRuleIds?: string[];
   message?: string;
   maxHeight?: number;
@@ -171,6 +177,7 @@ export const SheetFormatRenderer: React.FC<SheetFormatRendererProps> = memo(func
   cellsFormatted,
   rulesAdded,
   rulesRemoved,
+  skippedDuplicates = [],
   removedRuleIds = [],
   message,
   maxHeight = 280,
@@ -178,20 +185,22 @@ export const SheetFormatRenderer: React.FC<SheetFormatRendererProps> = memo(func
 }) {
   const { navigateToPage } = usePageNavigation();
   const colours = useMemo(() => collectColours(ops, rules, regions), [ops, rules, regions]);
+  const duplicateIndexes = useMemo(() => new Set(skippedDuplicates.map((entry) => entry.index)), [skippedDuplicates]);
 
   const summary = useMemo(() => {
     const parts: string[] = [];
     const regionCount = regionsApplied ?? regions.length;
     const opCount = opsApplied ?? ops.length;
-    const added = rulesAdded ?? rules.length;
+    const added = rulesAdded ?? rules.length - duplicateIndexes.size;
     const removed = rulesRemoved ?? removedRuleIds.length;
     if (regionCount > 0) parts.push(`${regionCount} ${regionCount === 1 ? 'region' : 'regions'}`);
     if (opCount > 0) parts.push(`${opCount} ${opCount === 1 ? 'op' : 'ops'}`);
     if (cellsFormatted) parts.push(`${cellsFormatted} ${cellsFormatted === 1 ? 'cell' : 'cells'}`);
     if (added > 0) parts.push(`${added} ${added === 1 ? 'rule' : 'rules'} added`);
+    if (duplicateIndexes.size > 0) parts.push(`${duplicateIndexes.size} already present`);
     if (removed > 0) parts.push(`${removed} removed`);
     return parts.join(' · ');
-  }, [regionsApplied, regions.length, opsApplied, ops.length, cellsFormatted, rulesAdded, rules.length, rulesRemoved, removedRuleIds.length]);
+  }, [regionsApplied, regions.length, opsApplied, ops.length, cellsFormatted, rulesAdded, rules.length, duplicateIndexes, rulesRemoved, removedRuleIds.length]);
 
   const empty = regions.length === 0 && ops.length === 0 && rules.length === 0 && removedRuleIds.length === 0;
 
@@ -264,17 +273,25 @@ export const SheetFormatRenderer: React.FC<SheetFormatRendererProps> = memo(func
                 </span>
               </div>
             ))}
-            {rules.map((rule, i) => (
-              <div key={`rule-${i}`} className="flex items-center gap-3 px-3 py-1.5 text-sm" data-testid="sheet-format-rule">
-                <Paintbrush className="h-3.5 w-3.5 text-muted-foreground shrink-0" />
-                <span className="flex-1 min-w-0 truncate font-mono text-xs">{describeRule(rule)}</span>
-                <span className="flex items-center gap-1 shrink-0">
-                  {[rule.format?.background, rule.format?.color, rule.min?.color, rule.mid?.color, rule.max?.color, rule.color]
-                    .filter((c): c is string => Boolean(c))
-                    .map((c, j) => <Swatch key={`${c}-${j}`} colour={c} />)}
-                </span>
-              </div>
-            ))}
+            {rules.map((rule, i) => {
+              const duplicate = duplicateIndexes.has(i);
+              return (
+                <div
+                  key={`rule-${i}`}
+                  className={cn('flex items-center gap-3 px-3 py-1.5 text-sm', duplicate && 'text-muted-foreground')}
+                  data-testid={duplicate ? 'sheet-format-rule-duplicate' : 'sheet-format-rule'}
+                >
+                  <Paintbrush className="h-3.5 w-3.5 text-muted-foreground shrink-0" />
+                  <span className="flex-1 min-w-0 truncate font-mono text-xs">{describeRule(rule)}</span>
+                  <span className="flex items-center gap-1 shrink-0">
+                    {[rule.format?.background, rule.format?.color, rule.min?.color, rule.mid?.color, rule.max?.color, rule.color]
+                      .filter((c): c is string => Boolean(c))
+                      .map((c, j) => <Swatch key={`${c}-${j}`} colour={c} />)}
+                    {duplicate && <span className="text-[11px] px-1.5 py-0.5 rounded bg-muted">already present</span>}
+                  </span>
+                </div>
+              );
+            })}
             {removedRuleIds.map((id) => (
               <div key={`removed-${id}`} className="flex items-center gap-3 px-3 py-1.5 text-sm text-muted-foreground" data-testid="sheet-format-removed">
                 <Paintbrush className="h-3.5 w-3.5 shrink-0" />

--- a/apps/web/src/components/ai/shared/chat/tool-calls/SheetFormatRenderer.tsx
+++ b/apps/web/src/components/ai/shared/chat/tool-calls/SheetFormatRenderer.tsx
@@ -1,9 +1,11 @@
 'use client';
 
-import React, { memo, useMemo } from 'react';
+import React, { memo } from 'react';
 import { usePageNavigation } from '@/hooks/usePageNavigation';
 import { Table2, ExternalLink, Paintbrush } from 'lucide-react';
-import { PALETTE, normalizeHex } from '@pagespace/lib/sheets/sheet';
+import { normalizeHex, regionTheme } from '@pagespace/lib/sheets/sheet';
+import { describeCondition } from '@/components/layout/middle-content/page-views/sheet/core/rule-presets';
+import type { FormatOpInput, RegionInput, RuleInput } from '@/lib/ai/tools/sheet-format-tools';
 import { cn } from '@/lib/utils';
 
 /**
@@ -16,61 +18,22 @@ import { cn } from '@/lib/utils';
  * per distinct colour so a "make it green" request is visibly green without
  * opening the sheet. Reads the tool INPUT for the structure (the result only
  * carries counts and ids) and the OUTPUT for what actually landed.
+ *
+ * The input is the model's, validated by the tool only on the success path
+ * the registry guards for; every deref below tolerates a missing field so a
+ * malformed call can never take the message list down.
  */
-
-export interface SheetFormatRegionInput {
-  id?: string;
-  name?: string;
-  range: string;
-  headerRows?: number;
-  totalRows?: number[];
-  columns?: Array<{ column: string; role: string; currency?: string }>;
-  theme?: string;
-  freezeHeader?: boolean;
-}
-
-interface FormatLike {
-  color?: string;
-  background?: string;
-}
-
-export interface SheetFormatOpInput {
-  op: string;
-  range?: string;
-  column?: string;
-  row?: number;
-  format?: FormatLike;
-  width?: number;
-  height?: number;
-  frozenRows?: number;
-  frozenColumns?: number;
-  clear?: true;
-}
-
-export interface SheetRuleInput {
-  kind: string;
-  ranges: string[];
-  operator?: string;
-  value?: string | number;
-  value2?: string | number;
-  formula?: string;
-  format?: FormatLike;
-  min?: { color?: string };
-  mid?: { color?: string };
-  max?: { color?: string };
-  color?: string;
-}
 
 interface SheetFormatRendererProps {
   title?: string;
   pageId?: string;
-  driveId?: string;
-  regions?: SheetFormatRegionInput[];
-  ops?: SheetFormatOpInput[];
-  rules?: SheetRuleInput[];
+  regions?: RegionInput[];
+  ops?: FormatOpInput[];
+  rules?: RuleInput[];
+  removedRuleIds?: string[];
   /** From the result: what landed, when it differs from what was asked. */
-  opsApplied?: number;
   regionsApplied?: number;
+  opsApplied?: number;
   cellsFormatted?: number;
   rulesAdded?: number;
   rulesRemoved?: number;
@@ -79,26 +42,40 @@ interface SheetFormatRendererProps {
    * into `rules`. A retried append reports every rule here with `added: 0`;
    * without this the card would present them as changes that never landed.
    */
-  skippedDuplicates?: Array<{ index: number; existingRuleId: string }>;
-  removedRuleIds?: string[];
+  skippedDuplicates?: Array<{ index: number }>;
   message?: string;
-  maxHeight?: number;
-  className?: string;
 }
 
-const themeSwatch = (theme: string | undefined): string | null => {
-  if (!theme) return null;
-  const hue = PALETTE.find((entry) => entry.name === theme);
-  return hue ? hue.mid : null;
+const NONE: never[] = [];
+const ROW = 'flex items-center gap-3 px-3 py-1.5 text-sm';
+
+const count = (n: number, noun: string): string => `${n} ${noun}${n === 1 ? '' : 's'}`;
+
+/**
+ * The colour the sheet actually paints for this region's header band — the
+ * same resolution `region-format` uses, slate fallback included — so the
+ * swatch can never drift from the sheet.
+ */
+const regionSwatch = (theme: string | undefined): { colour: string; name: string } => {
+  const { hue, header } = regionTheme(theme);
+  return { colour: header.background ?? hue.deep, name: hue.name };
 };
 
+const isColour = (value: string | undefined): value is string => Boolean(value);
+
+const opColours = (op: FormatOpInput): string[] =>
+  [op.format?.background, op.format?.color].filter(isColour);
+
+const ruleColours = (rule: RuleInput): string[] =>
+  [rule.format?.background, rule.format?.color, rule.min?.color, rule.mid?.color, rule.max?.color, rule.color].filter(isColour);
+
 /** The target an op touched, in the words the op used. */
-const describeOpTarget = (op: SheetFormatOpInput): string => {
+const describeOpTarget = (op: FormatOpInput): string => {
   if (op.op === 'freeze') {
     if (op.clear) return 'unfreeze';
     const parts: string[] = [];
-    if (op.frozenRows !== undefined) parts.push(`${op.frozenRows} row${op.frozenRows === 1 ? '' : 's'}`);
-    if (op.frozenColumns !== undefined) parts.push(`${op.frozenColumns} col${op.frozenColumns === 1 ? '' : 's'}`);
+    if (op.frozenRows !== undefined) parts.push(count(op.frozenRows, 'row'));
+    if (op.frozenColumns !== undefined) parts.push(count(op.frozenColumns, 'col'));
     return parts.join(', ') || 'freeze';
   }
   if (op.range) return op.range.toUpperCase();
@@ -113,14 +90,22 @@ const describeOpTarget = (op: SheetFormatOpInput): string => {
   return '';
 };
 
-const describeRule = (rule: SheetRuleInput): string => {
-  const ranges = rule.ranges.map((r) => r.toUpperCase()).join(', ');
+const operand = (value: string | number | undefined): string | undefined =>
+  value === undefined ? undefined : String(value);
+
+/**
+ * One line per rule, in the sheet's own words. `describeCondition` is what the
+ * rule panel uses, and it already omits the operands the executor drops — none
+ * for isEmpty/isNotEmpty/isError, no `value2` outside between/notBetween — so
+ * the card describes the rule that was stored, not the raw input.
+ */
+const describeRule = (rule: RuleInput): string => {
+  const ranges = (rule.ranges ?? []).map((r) => r.toUpperCase()).join(', ');
   switch (rule.kind) {
-    case 'cell': {
-      const operand = rule.value !== undefined ? ` ${String(rule.value)}` : '';
-      const upper = rule.value2 !== undefined ? ` and ${String(rule.value2)}` : '';
-      return `${ranges} · ${rule.operator ?? 'cell'}${operand}${upper}`;
-    }
+    case 'cell':
+      return rule.operator
+        ? `${ranges} · ${describeCondition({ operator: rule.operator, value: operand(rule.value), value2: operand(rule.value2) })}`
+        : ranges;
     case 'formula':
       return `${ranges} · ${rule.formula ?? 'formula'}`;
     case 'colorScale':
@@ -133,27 +118,13 @@ const describeRule = (rule: SheetRuleInput): string => {
 };
 
 /** Every distinct colour the call named, normalised so `#FFF` and `#ffffff` are one swatch. */
-const collectColours = (ops: SheetFormatOpInput[], rules: SheetRuleInput[], regions: SheetFormatRegionInput[]): string[] => {
-  const seen = new Set<string>();
-  const add = (value: string | undefined | null) => {
-    if (!value) return;
-    const hex = normalizeHex(value) ?? value;
-    seen.add(hex);
-  };
-  for (const region of regions) add(themeSwatch(region.theme));
-  for (const op of ops) {
-    add(op.format?.color);
-    add(op.format?.background);
-  }
-  for (const rule of rules) {
-    add(rule.format?.color);
-    add(rule.format?.background);
-    add(rule.min?.color);
-    add(rule.mid?.color);
-    add(rule.max?.color);
-    add(rule.color);
-  }
-  return [...seen];
+const collectColours = (regions: RegionInput[], ops: FormatOpInput[], rules: RuleInput[]): string[] => {
+  const named = [
+    ...regions.map((region) => regionSwatch(region.theme).colour),
+    ...ops.flatMap(opColours),
+    ...rules.flatMap(ruleColours),
+  ];
+  return [...new Set(named.map((value) => normalizeHex(value) ?? value))];
 };
 
 const Swatch: React.FC<{ colour: string; label?: string }> = ({ colour, label }) => (
@@ -165,50 +136,53 @@ const Swatch: React.FC<{ colour: string; label?: string }> = ({ colour, label })
   />
 );
 
+const Swatches: React.FC<{ colours: string[] }> = ({ colours }) => (
+  <span className="flex items-center gap-1 shrink-0">
+    {colours.map((colour, i) => (
+      <Swatch key={`${colour}-${i}`} colour={colour} />
+    ))}
+  </span>
+);
+
 export const SheetFormatRenderer: React.FC<SheetFormatRendererProps> = memo(function SheetFormatRenderer({
   title = 'Sheet',
   pageId,
-  driveId,
-  regions = [],
-  ops = [],
-  rules = [],
-  opsApplied,
+  regions = NONE,
+  ops = NONE,
+  rules = NONE,
+  removedRuleIds = NONE,
   regionsApplied,
+  opsApplied,
   cellsFormatted,
   rulesAdded,
   rulesRemoved,
-  skippedDuplicates = [],
-  removedRuleIds = [],
+  skippedDuplicates = NONE,
   message,
-  maxHeight = 280,
-  className,
 }) {
   const { navigateToPage } = usePageNavigation();
-  const colours = useMemo(() => collectColours(ops, rules, regions), [ops, rules, regions]);
-  const duplicateIndexes = useMemo(() => new Set(skippedDuplicates.map((entry) => entry.index)), [skippedDuplicates]);
+  const colours = collectColours(regions, ops, rules);
+  const duplicateIndexes = new Set(skippedDuplicates.map((entry) => entry.index));
 
-  const summary = useMemo(() => {
-    const parts: string[] = [];
-    const regionCount = regionsApplied ?? regions.length;
-    const opCount = opsApplied ?? ops.length;
-    const added = rulesAdded ?? rules.length - duplicateIndexes.size;
-    const removed = rulesRemoved ?? removedRuleIds.length;
-    if (regionCount > 0) parts.push(`${regionCount} ${regionCount === 1 ? 'region' : 'regions'}`);
-    if (opCount > 0) parts.push(`${opCount} ${opCount === 1 ? 'op' : 'ops'}`);
-    if (cellsFormatted) parts.push(`${cellsFormatted} ${cellsFormatted === 1 ? 'cell' : 'cells'}`);
-    if (added > 0) parts.push(`${added} ${added === 1 ? 'rule' : 'rules'} added`);
-    if (duplicateIndexes.size > 0) parts.push(`${duplicateIndexes.size} already present`);
-    if (removed > 0) parts.push(`${removed} removed`);
-    return parts.join(' · ');
-  }, [regionsApplied, regions.length, opsApplied, ops.length, cellsFormatted, rulesAdded, rules.length, duplicateIndexes, rulesRemoved, removedRuleIds.length]);
+  const regionCount = regionsApplied ?? regions.length;
+  const opCount = opsApplied ?? ops.length;
+  const added = rulesAdded ?? 0;
+  const removed = rulesRemoved ?? removedRuleIds.length;
+  const summary = [
+    ...(regionCount > 0 ? [count(regionCount, 'region')] : []),
+    ...(opCount > 0 ? [count(opCount, 'op')] : []),
+    ...(cellsFormatted ? [count(cellsFormatted, 'cell')] : []),
+    ...(added > 0 ? [`${count(added, 'rule')} added`] : []),
+    ...(duplicateIndexes.size > 0 ? [`${duplicateIndexes.size} already present`] : []),
+    ...(removed > 0 ? [`${removed} removed`] : []),
+  ].join(' · ');
 
   const empty = regions.length === 0 && ops.length === 0 && rules.length === 0 && removedRuleIds.length === 0;
 
   return (
-    <div className={cn('rounded-lg border bg-card overflow-hidden my-2 shadow-sm', className)}>
+    <div className="rounded-lg border bg-card overflow-hidden my-2 shadow-sm">
       <button
         type="button"
-        onClick={() => pageId && navigateToPage(pageId, driveId)}
+        onClick={() => pageId && navigateToPage(pageId)}
         disabled={!pageId}
         className={cn(
           'w-full flex items-center justify-between px-3 py-2 bg-muted/30 border-b text-left',
@@ -224,10 +198,8 @@ export const SheetFormatRenderer: React.FC<SheetFormatRendererProps> = memo(func
         </div>
         <span className="flex items-center gap-2 shrink-0">
           {colours.length > 0 && (
-            <span className="flex items-center gap-1" data-testid="sheet-format-swatches">
-              {colours.map((colour) => (
-                <Swatch key={colour} colour={colour} />
-              ))}
+            <span data-testid="sheet-format-swatches">
+              <Swatches colours={colours} />
             </span>
           )}
           {summary && <span className="text-xs text-muted-foreground">{summary}</span>}
@@ -235,42 +207,40 @@ export const SheetFormatRenderer: React.FC<SheetFormatRendererProps> = memo(func
         </span>
       </button>
 
-      <div className="bg-background overflow-auto divide-y divide-border" style={{ maxHeight: `${maxHeight}px` }}>
+      <div className="bg-background overflow-auto divide-y divide-border max-h-[280px]">
         {empty ? (
           <div className="text-sm text-muted-foreground text-center py-4">{message ?? 'Nothing changed'}</div>
         ) : (
           <>
             {regions.map((region, i) => {
-              const swatch = themeSwatch(region.theme);
-              const details: string[] = [];
-              if (region.headerRows !== undefined && region.headerRows !== 1) details.push(`${region.headerRows} header rows`);
-              for (const column of region.columns ?? []) {
-                details.push(`${column.column.toUpperCase()} ${column.role}${column.currency ? ` ${column.currency}` : ''}`);
-              }
-              if (region.totalRows && region.totalRows.length > 0) details.push(`total ${region.totalRows.join(', ')}`);
-              if (region.freezeHeader) details.push('frozen header');
+              const swatch = regionSwatch(region.theme);
+              const details = [
+                ...(region.headerRows !== undefined && region.headerRows !== 1 ? [count(region.headerRows, 'header row')] : []),
+                ...(region.columns ?? []).map(
+                  (column) => `${column.column.toUpperCase()} ${column.role}${column.currency ? ` ${column.currency}` : ''}`
+                ),
+                ...(region.totalRows && region.totalRows.length > 0 ? [`total ${region.totalRows.join(', ')}`] : []),
+                ...(region.freezeHeader ? ['frozen header'] : []),
+              ];
               return (
-                <div key={`region-${i}`} className="flex items-center gap-3 px-3 py-1.5 text-sm" data-testid="sheet-format-region">
-                  <code className="w-14 shrink-0 font-mono text-xs text-muted-foreground">{region.range.toUpperCase()}</code>
+                <div key={`region-${i}`} className={ROW} data-testid="sheet-format-region">
+                  <code className="w-14 shrink-0 font-mono text-xs text-muted-foreground">{(region.range ?? '').toUpperCase()}</code>
                   <span className="flex-1 min-w-0 truncate text-xs">
                     <span className="font-medium">{region.name ?? 'Table'}</span>
                     {details.length > 0 && <span className="text-muted-foreground"> · {details.join(' · ')}</span>}
                   </span>
                   <span className="flex items-center gap-1 text-[11px] px-1.5 py-0.5 rounded shrink-0 bg-muted text-muted-foreground">
-                    {swatch && <Swatch colour={swatch} label={region.theme} />}
+                    <Swatch colour={swatch.colour} label={swatch.name} />
                     region
                   </span>
                 </div>
               );
             })}
             {ops.map((op, i) => (
-              <div key={`op-${i}`} className="flex items-center gap-3 px-3 py-1.5 text-sm" data-testid="sheet-format-op">
+              <div key={`op-${i}`} className={ROW} data-testid="sheet-format-op">
                 <code className="w-14 shrink-0 font-mono text-xs text-muted-foreground truncate">{describeOpTarget(op)}</code>
                 <span className="flex-1 min-w-0 truncate font-mono text-xs">{op.op}</span>
-                <span className="flex items-center gap-1 shrink-0">
-                  {op.format?.background && <Swatch colour={op.format.background} />}
-                  {op.format?.color && <Swatch colour={op.format.color} />}
-                </span>
+                <Swatches colours={opColours(op)} />
               </div>
             ))}
             {rules.map((rule, i) => {
@@ -278,22 +248,18 @@ export const SheetFormatRenderer: React.FC<SheetFormatRendererProps> = memo(func
               return (
                 <div
                   key={`rule-${i}`}
-                  className={cn('flex items-center gap-3 px-3 py-1.5 text-sm', duplicate && 'text-muted-foreground')}
+                  className={cn(ROW, duplicate && 'text-muted-foreground')}
                   data-testid={duplicate ? 'sheet-format-rule-duplicate' : 'sheet-format-rule'}
                 >
                   <Paintbrush className="h-3.5 w-3.5 text-muted-foreground shrink-0" />
                   <span className="flex-1 min-w-0 truncate font-mono text-xs">{describeRule(rule)}</span>
-                  <span className="flex items-center gap-1 shrink-0">
-                    {[rule.format?.background, rule.format?.color, rule.min?.color, rule.mid?.color, rule.max?.color, rule.color]
-                      .filter((c): c is string => Boolean(c))
-                      .map((c, j) => <Swatch key={`${c}-${j}`} colour={c} />)}
-                    {duplicate && <span className="text-[11px] px-1.5 py-0.5 rounded bg-muted">already present</span>}
-                  </span>
+                  <Swatches colours={ruleColours(rule)} />
+                  {duplicate && <span className="text-[11px] px-1.5 py-0.5 rounded bg-muted shrink-0">already present</span>}
                 </div>
               );
             })}
             {removedRuleIds.map((id) => (
-              <div key={`removed-${id}`} className="flex items-center gap-3 px-3 py-1.5 text-sm text-muted-foreground" data-testid="sheet-format-removed">
+              <div key={`removed-${id}`} className={cn(ROW, 'text-muted-foreground')} data-testid="sheet-format-removed">
                 <Paintbrush className="h-3.5 w-3.5 shrink-0" />
                 <span className="flex-1 min-w-0 truncate font-mono text-xs line-through">{id}</span>
                 <span className="text-[11px] shrink-0">removed</span>

--- a/apps/web/src/components/ai/shared/chat/tool-calls/__tests__/registry-sheet-format.test.tsx
+++ b/apps/web/src/components/ai/shared/chat/tool-calls/__tests__/registry-sheet-format.test.tsx
@@ -84,6 +84,25 @@ describe('format_sheet renderer', () => {
     expect(swatches.map((s) => (s as HTMLElement).style.backgroundColor)).toEqual(['rgb(29, 78, 216)', 'rgb(51, 65, 85)']);
   });
 
+  it('shows the destructive half of a replaceAll: the regions it removed', () => {
+    // A replaceAll keeps only the regions in the call and deletes the rest.
+    // The result reports the mode; the card must say so instead of "1 region"
+    // as though nothing was taken away — and an EMPTY replaceAll is not an
+    // empty card, it is "every region removed".
+    const one = render(
+      <>{renderTool('format_sheet', { regionMode: 'replaceAll', regions: [{ range: 'A1:B' }] }, { success: true, title: 'S', regionsApplied: 1, regionMode: 'replaceAll' })}</>,
+    );
+    expect(one.getByText('1 region · other regions removed')).toBeTruthy();
+    expect(one.container.querySelector('[data-testid="sheet-format-regions-replaced"]')?.textContent).toContain('Every other region on the tab removed');
+    one.unmount();
+
+    const none = render(
+      <>{renderTool('format_sheet', { regionMode: 'replaceAll', regions: [] }, { success: true, title: 'S', regionsApplied: 0, regionMode: 'replaceAll' })}</>,
+    );
+    expect(none.container.querySelector('[data-testid="sheet-format-regions-replaced"]')?.textContent).toContain('Every region on the tab removed');
+    expect(none.queryByText('Nothing changed')).toBeNull();
+  });
+
   it("falls through to the generic envelope on the tool's own refusal", () => {
     const refusal = { success: false, error: 'invalid_range', message: 'Nothing was applied.', suggestion: 'Fix op 0.' };
     expect(renderTool('format_sheet', input, refusal)).toBeNull();

--- a/apps/web/src/components/ai/shared/chat/tool-calls/__tests__/registry-sheet-format.test.tsx
+++ b/apps/web/src/components/ai/shared/chat/tool-calls/__tests__/registry-sheet-format.test.tsx
@@ -203,6 +203,14 @@ describe('set_conditional_format renderer', () => {
     expect(queryByTestId('sheet-format-removed')).toBeNull();
   });
 
+  it('lists a repeated removeRuleIds entry once, as the executor removes it once', () => {
+    const { getAllByTestId, getByText } = render(
+      <>{renderTool('set_conditional_format', { removeRuleIds: ['r-1', 'r-1', 'r-2'] }, { success: true, title: 'S', added: 0, removed: 2 })}</>,
+    );
+    expect(getAllByTestId('sheet-format-removed')).toHaveLength(2);
+    expect(getByText('2 removed')).toBeTruthy();
+  });
+
   it('falls through on the execute_tool error envelope even when the input looks well-formed', () => {
     // A read-only agent in search mode gets `{ error: 'not permitted' }` with
     // valid-looking rules as the input; nothing landed, so no card.

--- a/apps/web/src/components/ai/shared/chat/tool-calls/__tests__/registry-sheet-format.test.tsx
+++ b/apps/web/src/components/ai/shared/chat/tool-calls/__tests__/registry-sheet-format.test.tsx
@@ -1,16 +1,13 @@
 /**
- * `format_sheet` / `set_conditional_format` render as a formatting card, not
- * as the address→value table `edit_sheet_cells` uses (formatting has no
- * values). The card carries the op/region/rule count, the ranges touched, and
- * one swatch per distinct colour, so a person sees what changed without
- * opening the sheet.
+ * `format_sheet` / `set_conditional_format` render as a formatting card: the
+ * op/region/rule counts, the ranges touched, and one swatch per distinct
+ * colour, so a person sees what changed without opening the sheet.
  */
 import { describe, it, expect, vi } from 'vitest';
 import { isValidElement } from 'react';
 import { render } from '@testing-library/react';
-import { toolRenderers } from '../registry';
+import { toolRenderers, type ToolRenderContext } from '../registry';
 import { SheetFormatRenderer } from '../SheetFormatRenderer';
-import { SheetEditRenderer } from '../SheetEditRenderer';
 
 vi.mock('@/hooks/usePageNavigation', () => ({
   usePageNavigation: () => ({ navigateToPage: vi.fn() }),
@@ -20,13 +17,9 @@ const renderTool = (
   toolName: 'format_sheet' | 'set_conditional_format',
   parsedInput: Record<string, unknown> | null,
   parsedOutput: Record<string, unknown>,
-) =>
-  toolRenderers[toolName]({
-    toolName,
-    parsedInput,
-    parsedOutput,
-    output: parsedOutput,
-  } as Parameters<(typeof toolRenderers)[typeof toolName]>[0]);
+) => toolRenderers[toolName]({ toolName, parsedInput, parsedOutput, output: parsedOutput } as ToolRenderContext);
+
+const swatchCount = (root: HTMLElement) => root.querySelectorAll('[data-testid="sheet-format-swatches"] span span').length;
 
 describe('format_sheet renderer', () => {
   const input = {
@@ -56,14 +49,13 @@ describe('format_sheet renderer', () => {
     message: 'Formatted "Q3 Budget": 1 region(s) declared, 3 op(s) applied, 9 cell(s) restyled.',
   };
 
-  it('uses the formatting card, not the cell-value table', () => {
+  it('uses the formatting card', () => {
     const element = renderTool('format_sheet', input, output);
     expect(isValidElement(element) && element.type).toBe(SheetFormatRenderer);
-    expect(isValidElement(element) && element.type).not.toBe(SheetEditRenderer);
   });
 
   it('shows the counts, the ranges touched, and a swatch per DISTINCT colour', () => {
-    const { getByText, getAllByTestId, getByTestId } = render(<>{renderTool('format_sheet', input, output)}</>);
+    const { container, getByText, getAllByTestId } = render(<>{renderTool('format_sheet', input, output)}</>);
     expect(getByText('Q3 Budget')).toBeTruthy();
     expect(getByText('1 region · 3 ops · 9 cells')).toBeTruthy();
 
@@ -75,14 +67,35 @@ describe('format_sheet renderer', () => {
     expect(getByText(/C currency USD/)).toBeTruthy();
     expect(getByText(/total 40/)).toBeTruthy();
 
-    // `#FFF` and `#ffffff` are ONE colour; the theme hue and the red text are
-    // the other two. Four colour mentions, three swatches.
-    expect(getByTestId('sheet-format-swatches').querySelectorAll('span')).toHaveLength(3);
+    // `#FFF` and `#ffffff` are ONE colour; the theme's header band and the
+    // red text are the other two. Four colour mentions, three swatches.
+    expect(swatchCount(container)).toBe(3);
   });
 
-  it('falls through to the generic envelope on a refusal', () => {
+  it('paints the region swatch with the header colour the sheet itself uses, slate when no theme is named', () => {
+    // region-format derives the header band from the theme (deep strength)
+    // and falls back to slate; the card must show that colour, not a hue the
+    // sheet never paints and not nothing.
+    const { container } = render(
+      <>{renderTool('format_sheet', { regions: [{ range: 'A1:B', theme: 'blue' }, { range: 'D1:E' }] }, { success: true, title: 'S' })}</>,
+    );
+    const swatches = [...container.querySelectorAll('[data-testid="sheet-format-region"] span[aria-label]')];
+    expect(swatches.map((s) => s.getAttribute('aria-label'))).toEqual(['blue', 'slate']);
+    expect(swatches.map((s) => (s as HTMLElement).style.backgroundColor)).toEqual(['rgb(29, 78, 216)', 'rgb(51, 65, 85)']);
+  });
+
+  it("falls through to the generic envelope on the tool's own refusal", () => {
     const refusal = { success: false, error: 'invalid_range', message: 'Nothing was applied.', suggestion: 'Fix op 0.' };
     expect(renderTool('format_sheet', input, refusal)).toBeNull();
+  });
+
+  it('falls through on the execute_tool error envelope, which has no success key and unvalidated input', () => {
+    // In search exposure the wrapper returns `{ error }` as a normal output
+    // with the model's raw parameters as the input. Rendering that as a
+    // success card would show a change that never landed — and a region
+    // without a range would crash the card.
+    const envelope = { error: 'Invalid parameters for "format_sheet": regions[0].range is required.' };
+    expect(renderTool('format_sheet', { regions: [{ name: 'no range' }] }, envelope)).toBeNull();
   });
 });
 
@@ -110,23 +123,48 @@ describe('set_conditional_format renderer', () => {
     expect(isValidElement(element) && element.type).toBe(SheetFormatRenderer);
   });
 
-  it('lists every rule with its range, the removed id, and the distinct colours', () => {
-    const { getAllByTestId, getByText, getByTestId } = render(<>{renderTool('set_conditional_format', input, output)}</>);
+  it("lists every rule in the sheet's own words, the removed id, and the distinct colours", () => {
+    const { container, getAllByTestId, getByText } = render(<>{renderTool('set_conditional_format', input, output)}</>);
     expect(getAllByTestId('sheet-format-rule')).toHaveLength(4);
     expect(getAllByTestId('sheet-format-removed')).toHaveLength(1);
     expect(getByText('4 rules added · 1 removed')).toBeTruthy();
-    expect(getByText('C2:C40 · greaterThan 1000')).toBeTruthy();
+    // The same wording the sheet's rule panel uses.
+    expect(getByText('C2:C40 · is greater than 1000')).toBeTruthy();
     expect(getByText('A2:A40 · =C2>AVERAGE(C2:C40)')).toBeTruthy();
     expect(getByText('rule-old')).toBeTruthy();
     // #dcfce7 appears twice (cell rule + scale max) — one swatch.
-    expect(getByTestId('sheet-format-swatches').querySelectorAll('span')).toHaveLength(4);
+    expect(swatchCount(container)).toBe(4);
+  });
+
+  it('omits the operands the executor drops, so the card describes the stored rule', () => {
+    // isEmpty/isNotEmpty/isError store no operand; only between/notBetween
+    // keep value2. The tool warns and drops the rest; the card must not
+    // print what was dropped.
+    const { getByText, queryByText } = render(
+      <>{renderTool(
+        'set_conditional_format',
+        {
+          rules: [
+            { kind: 'cell', ranges: ['A1:A9'], operator: 'isEmpty', value: 'stray' },
+            { kind: 'cell', ranges: ['B1:B9'], operator: 'lessThan', value: 5, value2: 99 },
+            { kind: 'cell', ranges: ['C1:C9'], operator: 'between', value: 1, value2: 10 },
+          ],
+        },
+        { success: true, title: 'S', added: 3, removed: 0 },
+      )}</>,
+    );
+    expect(getByText('A1:A9 · is empty')).toBeTruthy();
+    expect(getByText('B1:B9 · is less than 5')).toBeTruthy();
+    expect(getByText('C1:C9 · is between 1 and 10')).toBeTruthy();
+    expect(queryByText(/stray/)).toBeNull();
+    expect(queryByText(/99/)).toBeNull();
   });
 
   it('labels rules the result reports as already present, instead of showing them as changes', () => {
     // An append that overlaps what is already on the tab lands only the new
     // rules; the result names the rest by index in `skippedDuplicates`. The
     // card must not present those rows as changes.
-    const retried = {
+    const overlapping = {
       success: true,
       title: 'Q3 Budget',
       added: 2,
@@ -137,13 +175,19 @@ describe('set_conditional_format renderer', () => {
       ],
     };
     const { getAllByTestId, getByText, queryByTestId } = render(
-      <>{renderTool('set_conditional_format', { rules: input.rules }, retried)}</>,
+      <>{renderTool('set_conditional_format', { rules: input.rules }, overlapping)}</>,
     );
     expect(getAllByTestId('sheet-format-rule-duplicate')).toHaveLength(2);
     expect(getAllByTestId('sheet-format-rule')).toHaveLength(2);
     expect(getAllByTestId('sheet-format-rule-duplicate')[0].textContent).toContain('already present');
     expect(getByText('2 rules added · 2 already present')).toBeTruthy();
     expect(queryByTestId('sheet-format-removed')).toBeNull();
+  });
+
+  it('falls through on the execute_tool error envelope even when the input looks well-formed', () => {
+    // A read-only agent in search mode gets `{ error: 'not permitted' }` with
+    // valid-looking rules as the input; nothing landed, so no card.
+    expect(renderTool('set_conditional_format', input, { error: 'Tool "set_conditional_format" is not permitted for this agent.' })).toBeNull();
   });
 
   it('given nothing to show, says so instead of an empty card', () => {

--- a/apps/web/src/components/ai/shared/chat/tool-calls/__tests__/registry-sheet-format.test.tsx
+++ b/apps/web/src/components/ai/shared/chat/tool-calls/__tests__/registry-sheet-format.test.tsx
@@ -145,9 +145,13 @@ describe('set_conditional_format renderer', () => {
     success: true,
     pageId: 'page-1',
     title: 'Q3 Budget',
+    mode: 'append',
     added: 4,
     removed: 1,
+    changed: true,
     ruleIds: ['r1', 'r2', 'r3', 'r4'],
+    ruleIdsAdded: ['r1', 'r2', 'r3', 'r4'],
+    removedRuleIds: ['rule-old'],
   };
 
   it('uses the formatting card', () => {
@@ -216,12 +220,36 @@ describe('set_conditional_format renderer', () => {
     expect(queryByTestId('sheet-format-removed')).toBeNull();
   });
 
-  it('lists a repeated removeRuleIds entry once, as the executor removes it once', () => {
-    const { getAllByTestId, getByText } = render(
-      <>{renderTool('set_conditional_format', { removeRuleIds: ['r-1', 'r-1', 'r-2'] }, { success: true, title: 'S', added: 0, removed: 2 })}</>,
+  it('lists removals as the result confirmed them, not as the input asked for them', () => {
+    // A repeated id is removed once; an id the tab never held is not a
+    // removal at all (the tool warns and treats it as already gone). The
+    // card must show exactly what the store removed under its lock.
+    const { getAllByTestId, getByText, queryByText } = render(
+      <>{renderTool(
+        'set_conditional_format',
+        { removeRuleIds: ['r-1', 'r-1', 'r-zzz'] },
+        { success: true, title: 'S', mode: 'append', added: 0, removed: 1, changed: true, removedRuleIds: ['r-1'] },
+      )}</>,
     );
-    expect(getAllByTestId('sheet-format-removed')).toHaveLength(2);
-    expect(getByText('2 removed')).toBeTruthy();
+    expect(getAllByTestId('sheet-format-removed')).toHaveLength(1);
+    expect(getByText('1 removed')).toBeTruthy();
+    expect(queryByText('r-zzz')).toBeNull();
+  });
+
+  it('shows a replaceAll that only reordered as a reorder, with its rules kept rather than skipped', () => {
+    // Both rules already existed and kept their ids, but the write changed
+    // their precedence. That is neither "already present" nor a no-op.
+    const { getByText, getAllByTestId, queryByTestId } = render(
+      <>{renderTool(
+        'set_conditional_format',
+        { mode: 'replaceAll', rules: [input.rules[1], input.rules[0]] },
+        { success: true, title: 'S', mode: 'replaceAll', added: 0, removed: 0, changed: true, ruleIds: ['r2', 'r1'], ruleIdsAdded: [], removedRuleIds: [] },
+      )}</>,
+    );
+    expect(getByText('rules reordered')).toBeTruthy();
+    expect(getAllByTestId('sheet-format-rule-kept')).toHaveLength(2);
+    expect(queryByTestId('sheet-format-rule-duplicate')).toBeNull();
+    expect(getAllByTestId('sheet-format-rule-kept')[0].textContent).toContain('kept');
   });
 
   it('falls through on the execute_tool error envelope even when the input looks well-formed', () => {

--- a/apps/web/src/components/ai/shared/chat/tool-calls/__tests__/registry-sheet-format.test.tsx
+++ b/apps/web/src/components/ai/shared/chat/tool-calls/__tests__/registry-sheet-format.test.tsx
@@ -84,23 +84,29 @@ describe('format_sheet renderer', () => {
     expect(swatches.map((s) => (s as HTMLElement).style.backgroundColor)).toEqual(['rgb(29, 78, 216)', 'rgb(51, 65, 85)']);
   });
 
-  it('shows the destructive half of a replaceAll: the regions it removed', () => {
-    // A replaceAll keeps only the regions in the call and deletes the rest.
-    // The result reports the mode; the card must say so instead of "1 region"
-    // as though nothing was taken away — and an EMPTY replaceAll is not an
-    // empty card, it is "every region removed".
+  it('shows the destructive half of a replaceAll — the regions the store confirmed it removed — and only then', () => {
+    // The result names what was removed under the lock. A replaceAll that
+    // removed nothing (restyling the sole region) must not claim otherwise,
+    // and an EMPTY replaceAll that cleared the tab is not an empty card.
     const one = render(
-      <>{renderTool('format_sheet', { regionMode: 'replaceAll', regions: [{ range: 'A1:B' }] }, { success: true, title: 'S', regionsApplied: 1, regionMode: 'replaceAll' })}</>,
+      <>{renderTool('format_sheet', { regionMode: 'replaceAll', regions: [{ range: 'A1:B' }] }, { success: true, title: 'S', regionsApplied: 1, regionMode: 'replaceAll', removedRegionIds: ['old-1', 'old-2'] })}</>,
     );
-    expect(one.getByText('1 region · other regions removed')).toBeTruthy();
-    expect(one.container.querySelector('[data-testid="sheet-format-regions-replaced"]')?.textContent).toContain('Every other region on the tab removed');
+    expect(one.getByText('1 region · 2 other regions removed')).toBeTruthy();
+    expect(one.container.querySelector('[data-testid="sheet-format-regions-replaced"]')?.textContent).toContain('2 other regions on the tab removed');
     one.unmount();
 
     const none = render(
-      <>{renderTool('format_sheet', { regionMode: 'replaceAll', regions: [] }, { success: true, title: 'S', regionsApplied: 0, regionMode: 'replaceAll' })}</>,
+      <>{renderTool('format_sheet', { regionMode: 'replaceAll', regions: [] }, { success: true, title: 'S', regionsApplied: 0, regionMode: 'replaceAll', removedRegionIds: ['old-1'] })}</>,
     );
-    expect(none.container.querySelector('[data-testid="sheet-format-regions-replaced"]')?.textContent).toContain('Every region on the tab removed');
+    expect(none.container.querySelector('[data-testid="sheet-format-regions-replaced"]')?.textContent).toContain('Every region on the tab removed (1)');
     expect(none.queryByText('Nothing changed')).toBeNull();
+    none.unmount();
+
+    const restyle = render(
+      <>{renderTool('format_sheet', { regionMode: 'replaceAll', regions: [{ id: 'only', range: 'A1:B', theme: 'blue' }] }, { success: true, title: 'S', regionsApplied: 1, regionMode: 'replaceAll', removedRegionIds: [] })}</>,
+    );
+    expect(restyle.queryByText(/removed/)).toBeNull();
+    expect(restyle.container.querySelector('[data-testid="sheet-format-regions-replaced"]')).toBeNull();
   });
 
   it('shows a no-op result as unchanged, not as the formatting it would have applied', () => {

--- a/apps/web/src/components/ai/shared/chat/tool-calls/__tests__/registry-sheet-format.test.tsx
+++ b/apps/web/src/components/ai/shared/chat/tool-calls/__tests__/registry-sheet-format.test.tsx
@@ -1,0 +1,131 @@
+/**
+ * `format_sheet` / `set_conditional_format` render as a formatting card, not
+ * as the address→value table `edit_sheet_cells` uses (formatting has no
+ * values). The card carries the op/region/rule count, the ranges touched, and
+ * one swatch per distinct colour, so a person sees what changed without
+ * opening the sheet.
+ */
+import { describe, it, expect, vi } from 'vitest';
+import { isValidElement } from 'react';
+import { render } from '@testing-library/react';
+import { toolRenderers } from '../registry';
+import { SheetFormatRenderer } from '../SheetFormatRenderer';
+import { SheetEditRenderer } from '../SheetEditRenderer';
+
+vi.mock('@/hooks/usePageNavigation', () => ({
+  usePageNavigation: () => ({ navigateToPage: vi.fn() }),
+}));
+
+const renderTool = (
+  toolName: 'format_sheet' | 'set_conditional_format',
+  parsedInput: Record<string, unknown> | null,
+  parsedOutput: Record<string, unknown>,
+) =>
+  toolRenderers[toolName]({
+    toolName,
+    parsedInput,
+    parsedOutput,
+    output: parsedOutput,
+  } as Parameters<(typeof toolRenderers)[typeof toolName]>[0]);
+
+describe('format_sheet renderer', () => {
+  const input = {
+    regions: [
+      {
+        name: 'Budget',
+        range: 'A1:D',
+        headerRows: 1,
+        columns: [{ column: 'C', role: 'currency', currency: 'USD' }],
+        totalRows: [40],
+        theme: 'blue',
+      },
+    ],
+    ops: [
+      { op: 'setFormat', range: 'B2:B9', format: { background: '#FFF' } },
+      { op: 'setFormat', range: 'E1', format: { background: '#ffffff', color: '#b91c1c' } },
+      { op: 'columnWidth', column: 'a', width: 140 },
+    ],
+  };
+  const output = {
+    success: true,
+    pageId: 'page-1',
+    title: 'Q3 Budget',
+    regionsApplied: 1,
+    opsApplied: 3,
+    cellsFormatted: 9,
+    message: 'Formatted "Q3 Budget": 1 region(s) declared, 3 op(s) applied, 9 cell(s) restyled.',
+  };
+
+  it('uses the formatting card, not the cell-value table', () => {
+    const element = renderTool('format_sheet', input, output);
+    expect(isValidElement(element) && element.type).toBe(SheetFormatRenderer);
+    expect(isValidElement(element) && element.type).not.toBe(SheetEditRenderer);
+  });
+
+  it('shows the counts, the ranges touched, and a swatch per DISTINCT colour', () => {
+    const { getByText, getAllByTestId, getByTestId } = render(<>{renderTool('format_sheet', input, output)}</>);
+    expect(getByText('Q3 Budget')).toBeTruthy();
+    expect(getByText('1 region · 3 ops · 9 cells')).toBeTruthy();
+
+    expect(getAllByTestId('sheet-format-region')).toHaveLength(1);
+    expect(getAllByTestId('sheet-format-op')).toHaveLength(3);
+    expect(getByText('A1:D')).toBeTruthy();
+    expect(getByText('B2:B9')).toBeTruthy();
+    expect(getByText('column A 140px')).toBeTruthy();
+    expect(getByText(/C currency USD/)).toBeTruthy();
+    expect(getByText(/total 40/)).toBeTruthy();
+
+    // `#FFF` and `#ffffff` are ONE colour; the theme hue and the red text are
+    // the other two. Four colour mentions, three swatches.
+    expect(getByTestId('sheet-format-swatches').querySelectorAll('span')).toHaveLength(3);
+  });
+
+  it('falls through to the generic envelope on a refusal', () => {
+    const refusal = { success: false, error: 'invalid_range', message: 'Nothing was applied.', suggestion: 'Fix op 0.' };
+    expect(renderTool('format_sheet', input, refusal)).toBeNull();
+  });
+});
+
+describe('set_conditional_format renderer', () => {
+  const input = {
+    rules: [
+      { kind: 'cell', ranges: ['C2:C40'], operator: 'greaterThan', value: 1000, format: { background: '#dcfce7' } },
+      { kind: 'colorScale', ranges: ['D2:D40'], min: { type: 'min', color: '#fee2e2' }, max: { type: 'max', color: '#dcfce7' } },
+      { kind: 'dataBar', ranges: ['E2:E40'], color: '#3b82f6' },
+      { kind: 'formula', ranges: ['A2:A40'], formula: '=C2>AVERAGE(C2:C40)', format: { color: '#b91c1c' } },
+    ],
+    removeRuleIds: ['rule-old'],
+  };
+  const output = {
+    success: true,
+    pageId: 'page-1',
+    title: 'Q3 Budget',
+    added: 4,
+    removed: 1,
+    ruleIds: ['r1', 'r2', 'r3', 'r4'],
+  };
+
+  it('uses the formatting card', () => {
+    const element = renderTool('set_conditional_format', input, output);
+    expect(isValidElement(element) && element.type).toBe(SheetFormatRenderer);
+  });
+
+  it('lists every rule with its range, the removed id, and the distinct colours', () => {
+    const { getAllByTestId, getByText, getByTestId } = render(<>{renderTool('set_conditional_format', input, output)}</>);
+    expect(getAllByTestId('sheet-format-rule')).toHaveLength(4);
+    expect(getAllByTestId('sheet-format-removed')).toHaveLength(1);
+    expect(getByText('4 rules added · 1 removed')).toBeTruthy();
+    expect(getByText('C2:C40 · greaterThan 1000')).toBeTruthy();
+    expect(getByText('A2:A40 · =C2>AVERAGE(C2:C40)')).toBeTruthy();
+    expect(getByText('rule-old')).toBeTruthy();
+    // #dcfce7 appears twice (cell rule + scale max) — one swatch.
+    expect(getByTestId('sheet-format-swatches').querySelectorAll('span')).toHaveLength(4);
+  });
+
+  it('given nothing to show, says so instead of an empty card', () => {
+    const { getByText } = render(
+      <>{renderTool('set_conditional_format', { rules: [] }, { success: true, title: 'Q3 Budget', added: 0, removed: 0, message: 'Every rule in this call is already on "Q3 Budget"; nothing was added.' })}</>,
+    );
+    expect(getByText(/nothing was added/)).toBeTruthy();
+  });
+});

--- a/apps/web/src/components/ai/shared/chat/tool-calls/__tests__/registry-sheet-format.test.tsx
+++ b/apps/web/src/components/ai/shared/chat/tool-calls/__tests__/registry-sheet-format.test.tsx
@@ -122,6 +122,30 @@ describe('set_conditional_format renderer', () => {
     expect(getByTestId('sheet-format-swatches').querySelectorAll('span')).toHaveLength(4);
   });
 
+  it('labels rules the result reports as already present, instead of showing them as changes', () => {
+    // An append that overlaps what is already on the tab lands only the new
+    // rules; the result names the rest by index in `skippedDuplicates`. The
+    // card must not present those rows as changes.
+    const retried = {
+      success: true,
+      title: 'Q3 Budget',
+      added: 2,
+      removed: 0,
+      skippedDuplicates: [
+        { index: 0, existingRuleId: 'r-old-1' },
+        { index: 2, existingRuleId: 'r-old-3' },
+      ],
+    };
+    const { getAllByTestId, getByText, queryByTestId } = render(
+      <>{renderTool('set_conditional_format', { rules: input.rules }, retried)}</>,
+    );
+    expect(getAllByTestId('sheet-format-rule-duplicate')).toHaveLength(2);
+    expect(getAllByTestId('sheet-format-rule')).toHaveLength(2);
+    expect(getAllByTestId('sheet-format-rule-duplicate')[0].textContent).toContain('already present');
+    expect(getByText('2 rules added · 2 already present')).toBeTruthy();
+    expect(queryByTestId('sheet-format-removed')).toBeNull();
+  });
+
   it('given nothing to show, says so instead of an empty card', () => {
     const { getByText } = render(
       <>{renderTool('set_conditional_format', { rules: [] }, { success: true, title: 'Q3 Budget', added: 0, removed: 0, message: 'Every rule in this call is already on "Q3 Budget"; nothing was added.' })}</>,

--- a/apps/web/src/components/ai/shared/chat/tool-calls/__tests__/registry-sheet-format.test.tsx
+++ b/apps/web/src/components/ai/shared/chat/tool-calls/__tests__/registry-sheet-format.test.tsx
@@ -103,6 +103,19 @@ describe('format_sheet renderer', () => {
     expect(none.queryByText('Nothing changed')).toBeNull();
   });
 
+  it('shows a no-op result as unchanged, not as the formatting it would have applied', () => {
+    // The store reports a retry (or a bold that was already bold) with
+    // nothing written; the result says `changed: false`. The card must not
+    // list "1 op" as though something landed.
+    const { getByTestId, getByText, queryByTestId } = render(
+      <>{renderTool('format_sheet', input, { ...output, changed: false })}</>,
+    );
+    expect(getByText('already formatted this way')).toBeTruthy();
+    expect(getByTestId('sheet-format-empty').textContent).toContain('already had this formatting');
+    expect(queryByTestId('sheet-format-op')).toBeNull();
+    expect(queryByTestId('sheet-format-region')).toBeNull();
+  });
+
   it("falls through to the generic envelope on the tool's own refusal", () => {
     const refusal = { success: false, error: 'invalid_range', message: 'Nothing was applied.', suggestion: 'Fix op 0.' };
     expect(renderTool('format_sheet', input, refusal)).toBeNull();

--- a/apps/web/src/components/ai/shared/chat/tool-calls/index.ts
+++ b/apps/web/src/components/ai/shared/chat/tool-calls/index.ts
@@ -33,6 +33,7 @@ export { WebFetchRenderer } from './WebFetchRenderer';
 export { MemberListRenderer } from './MemberListRenderer';
 export { AgentConfigRenderer } from './AgentConfigRenderer';
 export { SheetEditRenderer } from './SheetEditRenderer';
+export { SheetFormatRenderer } from './SheetFormatRenderer';
 export { TaskStatusRenderer } from './TaskStatusRenderer';
 
 // Calendar renderers

--- a/apps/web/src/components/ai/shared/chat/tool-calls/registry.tsx
+++ b/apps/web/src/components/ai/shared/chat/tool-calls/registry.tsx
@@ -13,6 +13,12 @@ import { ActivityRenderer, type ActivityItem } from './ActivityRenderer';
 import { WebSearchRenderer, type WebSearchResult } from './WebSearchRenderer';
 import { MemberListRenderer, type MemberInfo } from './MemberListRenderer';
 import { SheetEditRenderer } from './SheetEditRenderer';
+import {
+  SheetFormatRenderer,
+  type SheetFormatRegionInput,
+  type SheetFormatOpInput,
+  type SheetRuleInput,
+} from './SheetFormatRenderer';
 import { AgentConfigRenderer, type AgentConfigData } from './AgentConfigRenderer';
 import { ModelListRenderer, type ModelListProvider } from './ModelListRenderer';
 import { WebFetchRenderer } from './WebFetchRenderer';
@@ -601,6 +607,39 @@ export const toolRenderers: Record<string, ToolRenderer> = {
         pageId={parsedOutput.pageId as string | undefined}
         driveId={parsedOutput.driveId as string | undefined}
         cellsUpdated={parsedOutput.cellsUpdated as number | undefined}
+      />
+    );
+  },
+  // Formatting has no values to tabulate, so it does not share SheetEditRenderer:
+  // the card shows the declared regions, the escape-hatch ops and the rules,
+  // with a swatch per distinct colour. A refusal falls through to the generic
+  // envelope, which already prints the error + suggestion.
+  format_sheet: ({ parsedInput, parsedOutput }) => {
+    if (parsedOutput.success === false) return null;
+    return (
+      <SheetFormatRenderer
+        title={(parsedOutput.title as string | undefined) || 'Sheet'}
+        pageId={parsedOutput.pageId as string | undefined}
+        regions={parsedInput?.regions as SheetFormatRegionInput[] | undefined}
+        ops={parsedInput?.ops as SheetFormatOpInput[] | undefined}
+        regionsApplied={parsedOutput.regionsApplied as number | undefined}
+        opsApplied={parsedOutput.opsApplied as number | undefined}
+        cellsFormatted={parsedOutput.cellsFormatted as number | undefined}
+        message={parsedOutput.message as string | undefined}
+      />
+    );
+  },
+  set_conditional_format: ({ parsedInput, parsedOutput }) => {
+    if (parsedOutput.success === false) return null;
+    return (
+      <SheetFormatRenderer
+        title={(parsedOutput.title as string | undefined) || 'Sheet'}
+        pageId={parsedOutput.pageId as string | undefined}
+        rules={parsedInput?.rules as SheetRuleInput[] | undefined}
+        removedRuleIds={parsedInput?.removeRuleIds as string[] | undefined}
+        rulesAdded={parsedOutput.added as number | undefined}
+        rulesRemoved={parsedOutput.removed as number | undefined}
+        message={parsedOutput.message as string | undefined}
       />
     );
   },

--- a/apps/web/src/components/ai/shared/chat/tool-calls/registry.tsx
+++ b/apps/web/src/components/ai/shared/chat/tool-calls/registry.tsx
@@ -639,6 +639,7 @@ export const toolRenderers: Record<string, ToolRenderer> = {
         removedRuleIds={parsedInput?.removeRuleIds as string[] | undefined}
         rulesAdded={parsedOutput.added as number | undefined}
         rulesRemoved={parsedOutput.removed as number | undefined}
+        skippedDuplicates={parsedOutput.skippedDuplicates as Array<{ index: number; existingRuleId: string }> | undefined}
         message={parsedOutput.message as string | undefined}
       />
     );

--- a/apps/web/src/components/ai/shared/chat/tool-calls/registry.tsx
+++ b/apps/web/src/components/ai/shared/chat/tool-calls/registry.tsx
@@ -629,6 +629,7 @@ export const toolRenderers: Record<string, ToolRenderer> = {
         regionsApplied={parsedOutput.regionsApplied as number | undefined}
         opsApplied={parsedOutput.opsApplied as number | undefined}
         cellsFormatted={parsedOutput.cellsFormatted as number | undefined}
+        changed={parsedOutput.changed as boolean | undefined}
       />
     );
   },

--- a/apps/web/src/components/ai/shared/chat/tool-calls/registry.tsx
+++ b/apps/web/src/components/ai/shared/chat/tool-calls/registry.tsx
@@ -624,7 +624,7 @@ export const toolRenderers: Record<string, ToolRenderer> = {
       <SheetFormatRenderer
         {...sheetFormatCard(parsedOutput)}
         regions={parsedInput?.regions as RegionInput[] | undefined}
-        regionMode={parsedOutput.regionMode as 'merge' | 'replaceAll' | undefined}
+        removedRegionIds={parsedOutput.removedRegionIds as string[] | undefined}
         ops={parsedInput?.ops as FormatOpInput[] | undefined}
         regionsApplied={parsedOutput.regionsApplied as number | undefined}
         opsApplied={parsedOutput.opsApplied as number | undefined}

--- a/apps/web/src/components/ai/shared/chat/tool-calls/registry.tsx
+++ b/apps/web/src/components/ai/shared/chat/tool-calls/registry.tsx
@@ -624,6 +624,7 @@ export const toolRenderers: Record<string, ToolRenderer> = {
       <SheetFormatRenderer
         {...sheetFormatCard(parsedOutput)}
         regions={parsedInput?.regions as RegionInput[] | undefined}
+        regionMode={parsedOutput.regionMode as 'merge' | 'replaceAll' | undefined}
         ops={parsedInput?.ops as FormatOpInput[] | undefined}
         regionsApplied={parsedOutput.regionsApplied as number | undefined}
         opsApplied={parsedOutput.opsApplied as number | undefined}

--- a/apps/web/src/components/ai/shared/chat/tool-calls/registry.tsx
+++ b/apps/web/src/components/ai/shared/chat/tool-calls/registry.tsx
@@ -639,9 +639,15 @@ export const toolRenderers: Record<string, ToolRenderer> = {
       <SheetFormatRenderer
         {...sheetFormatCard(parsedOutput)}
         rules={parsedInput?.rules as RuleInput[] | undefined}
-        removedRuleIds={parsedInput?.removeRuleIds as string[] | undefined}
+        // Removals as the store confirmed them under its lock — an id the
+        // tab did not hold was never a removal and is not listed.
+        removedRuleIds={parsedOutput.removedRuleIds as string[] | undefined}
+        ruleIds={parsedOutput.ruleIds as string[] | undefined}
+        ruleIdsAdded={parsedOutput.ruleIdsAdded as string[] | undefined}
+        ruleMode={parsedOutput.mode as 'append' | 'replaceAll' | undefined}
         rulesAdded={parsedOutput.added as number | undefined}
         rulesRemoved={parsedOutput.removed as number | undefined}
+        changed={parsedOutput.changed as boolean | undefined}
         skippedDuplicates={parsedOutput.skippedDuplicates as Array<{ index: number }> | undefined}
       />
     );

--- a/apps/web/src/components/ai/shared/chat/tool-calls/registry.tsx
+++ b/apps/web/src/components/ai/shared/chat/tool-calls/registry.tsx
@@ -13,12 +13,8 @@ import { ActivityRenderer, type ActivityItem } from './ActivityRenderer';
 import { WebSearchRenderer, type WebSearchResult } from './WebSearchRenderer';
 import { MemberListRenderer, type MemberInfo } from './MemberListRenderer';
 import { SheetEditRenderer } from './SheetEditRenderer';
-import {
-  SheetFormatRenderer,
-  type SheetFormatRegionInput,
-  type SheetFormatOpInput,
-  type SheetRuleInput,
-} from './SheetFormatRenderer';
+import { SheetFormatRenderer } from './SheetFormatRenderer';
+import type { FormatOpInput, RegionInput, RuleInput } from '@/lib/ai/tools/sheet-format-tools';
 import { AgentConfigRenderer, type AgentConfigData } from './AgentConfigRenderer';
 import { ModelListRenderer, type ModelListProvider } from './ModelListRenderer';
 import { WebFetchRenderer } from './WebFetchRenderer';
@@ -214,6 +210,13 @@ const parsePathsToTree = (paths: string[]): TreeItem[] => {
 
   return buildTreeFromParsed(parsedPages, 1, []);
 };
+
+/** The card chrome both sheet-formatting tools share. */
+const sheetFormatCard = (output: Record<string, unknown>) => ({
+  title: (output.title as string | undefined) || 'Sheet',
+  pageId: output.pageId as string | undefined,
+  message: output.message as string | undefined,
+});
 
 /**
  * Tools handled outside this registry as full-width cards in the wrapper
@@ -610,37 +613,34 @@ export const toolRenderers: Record<string, ToolRenderer> = {
       />
     );
   },
-  // Formatting has no values to tabulate, so it does not share SheetEditRenderer:
-  // the card shows the declared regions, the escape-hatch ops and the rules,
-  // with a swatch per distinct colour. A refusal falls through to the generic
-  // envelope, which already prints the error + suggestion.
+  // Formatting card, not the value table — see SheetFormatRenderer. Two shapes
+  // mean "nothing landed": the tool's own refusal (`success: false`) and the
+  // execute_tool wrapper's `{ error }` envelope, which carries no `success`
+  // key and arrives with the model's UNVALIDATED parameters as the input.
+  // Both fall through to the generic envelope, which prints the error.
   format_sheet: ({ parsedInput, parsedOutput }) => {
-    if (parsedOutput.success === false) return null;
+    if (parsedOutput.success === false || parsedOutput.error) return null;
     return (
       <SheetFormatRenderer
-        title={(parsedOutput.title as string | undefined) || 'Sheet'}
-        pageId={parsedOutput.pageId as string | undefined}
-        regions={parsedInput?.regions as SheetFormatRegionInput[] | undefined}
-        ops={parsedInput?.ops as SheetFormatOpInput[] | undefined}
+        {...sheetFormatCard(parsedOutput)}
+        regions={parsedInput?.regions as RegionInput[] | undefined}
+        ops={parsedInput?.ops as FormatOpInput[] | undefined}
         regionsApplied={parsedOutput.regionsApplied as number | undefined}
         opsApplied={parsedOutput.opsApplied as number | undefined}
         cellsFormatted={parsedOutput.cellsFormatted as number | undefined}
-        message={parsedOutput.message as string | undefined}
       />
     );
   },
   set_conditional_format: ({ parsedInput, parsedOutput }) => {
-    if (parsedOutput.success === false) return null;
+    if (parsedOutput.success === false || parsedOutput.error) return null;
     return (
       <SheetFormatRenderer
-        title={(parsedOutput.title as string | undefined) || 'Sheet'}
-        pageId={parsedOutput.pageId as string | undefined}
-        rules={parsedInput?.rules as SheetRuleInput[] | undefined}
+        {...sheetFormatCard(parsedOutput)}
+        rules={parsedInput?.rules as RuleInput[] | undefined}
         removedRuleIds={parsedInput?.removeRuleIds as string[] | undefined}
         rulesAdded={parsedOutput.added as number | undefined}
         rulesRemoved={parsedOutput.removed as number | undefined}
-        skippedDuplicates={parsedOutput.skippedDuplicates as Array<{ index: number; existingRuleId: string }> | undefined}
-        message={parsedOutput.message as string | undefined}
+        skippedDuplicates={parsedOutput.skippedDuplicates as Array<{ index: number }> | undefined}
       />
     );
   },

--- a/apps/web/src/lib/ai/core/__tests__/ai-tools.test.ts
+++ b/apps/web/src/lib/ai/core/__tests__/ai-tools.test.ts
@@ -179,7 +179,7 @@ vi.mock('../../tools/sandbox-tools-runtime', () => ({
   }),
 }));
 
-import { pageSpaceTools, corePageSpaceTools, buildPageSpaceTools } from '../ai-tools';
+import { pageSpaceTools, corePageSpaceTools, buildPageSpaceTools, TOOL_REGISTRY } from '../ai-tools';
 import { CORE_TOOL_NAMES } from '../stub-tools';
 import { memberTools } from '../../tools/member-tools';
 import { roleManagementTools } from '../../tools/role-management-tools';
@@ -266,30 +266,13 @@ describe('ai-tools', () => {
     });
 
     it('has no key collisions between tool modules', () => {
-      const moduleKeysets = [
-        Object.keys(memberTools),
-        Object.keys(roleManagementTools),
-        Object.keys(driveTools),
-        Object.keys(pageReadTools),
-        Object.keys(pageWriteTools),
-        Object.keys(searchTools),
-        Object.keys(taskManagementTools),
-        Object.keys(agentTools),
-        Object.keys(agentCommunicationTools),
-        Object.keys(webSearchTools),
-        Object.keys(activityTools),
-        Object.keys(calendarReadTools),
-        Object.keys(calendarWriteTools),
-        Object.keys(channelTools),
-        Object.keys(workflowTools),
-        Object.keys(triggerTools),
-        Object.keys(modelTools),
-        Object.keys(commandTools),
-        Object.keys(formTools),
-        Object.keys(imageGenerationTools),
-        Object.keys(pagePaneTools),
-        Object.keys(planTools),
-      ];
+      // Derived from the registry's own per-category projection rather than a
+      // second hand-written module list: the hand list had drifted (it omitted
+      // copyContent, sheetsRead and skills), so a collision involving those
+      // modules was invisible while this case stayed green.
+      const moduleKeysets = Object.values(TOOL_REGISTRY).map((names) => [...names]);
+      expect(moduleKeysets.length).toBe(Object.keys(TOOL_REGISTRY).length);
+      expect(moduleKeysets.flat()).toEqual(expect.arrayContaining(['read_sheet', 'format_sheet', 'copy_content', 'load_skill']));
 
       const allKeys = moduleKeysets.flat();
       const uniqueKeys = new Set(allKeys);

--- a/apps/web/src/lib/ai/core/__tests__/ai-tools.test.ts
+++ b/apps/web/src/lib/ai/core/__tests__/ai-tools.test.ts
@@ -188,6 +188,7 @@ import { pageReadTools } from '../../tools/page-read-tools';
 import { pageWriteTools } from '../../tools/page-write-tools';
 import { copyContentTools } from '../../tools/copy-content-tools-runtime';
 import { sheetReadTools } from '../../tools/sheet-read-tools';
+import { sheetFormatTools } from '../../tools/sheet-format-tools';
 import { searchTools } from '../../tools/search-tools';
 import { taskManagementTools } from '../../tools/task-management-tools';
 import { agentTools } from '../../tools/agent-tools';
@@ -242,6 +243,7 @@ describe('ai-tools', () => {
         ...pageWriteTools,
         ...copyContentTools,
         ...sheetReadTools,
+        ...sheetFormatTools,
         ...searchTools,
         ...taskManagementTools,
         ...agentTools,

--- a/apps/web/src/lib/ai/core/__tests__/inline-instructions.test.ts
+++ b/apps/web/src/lib/ai/core/__tests__/inline-instructions.test.ts
@@ -405,8 +405,8 @@ describe('SHEET bullet vs the agent allowlist', () => {
   });
 
   it('names no tool the agent lacks, whichever subset it holds', () => {
-    // The bullet can name three tools. Gating only read_sheet left the other
-    // two able to do exactly what the gate exists to prevent: an agent holding
+    // The bullet can name four tools. Gating only read_sheet left the others
+    // able to do exactly what the gate exists to prevent: an agent holding
     // only read_sheet was still told about edit_sheet_cells.
     const sheetLine = (tools: string[]) =>
       buildInlineInstructions(tools).split('\n').find(l => l.startsWith('• SHEET')) ?? '';
@@ -414,16 +414,26 @@ describe('SHEET bullet vs the agent allowlist', () => {
     const readOnly = sheetLine(['read_sheet']);
     expect(readOnly).toContain('read_sheet');
     expect(readOnly).not.toContain('edit_sheet_cells');
+    expect(readOnly).not.toContain('format_sheet');
 
     const writeOnly = sheetLine(['edit_sheet_cells']);
     expect(writeOnly).toContain('edit_sheet_cells');
     expect(writeOnly).not.toContain('read_sheet');
     expect(writeOnly).not.toContain('read_page');
+    expect(writeOnly).not.toContain('format_sheet');
+
+    // The formatting fragment must not smuggle in the cell editor's name
+    // either: an agent holding only format_sheet cannot call edit_sheet_cells.
+    const formatOnly = sheetLine(['format_sheet']);
+    expect(formatOnly).toContain('format_sheet');
+    expect(formatOnly).not.toContain('edit_sheet_cells');
+    expect(formatOnly).not.toContain('read_sheet');
 
     const nothing = sheetLine([]);
     expect(nothing).not.toContain('read_sheet');
     expect(nothing).not.toContain('read_page');
     expect(nothing).not.toContain('edit_sheet_cells');
+    expect(nothing).not.toContain('format_sheet');
   });
 
   it('points at read_page instead when the agent does not', () => {

--- a/apps/web/src/lib/ai/core/__tests__/sheet-format-registration.test.ts
+++ b/apps/web/src/lib/ai/core/__tests__/sheet-format-registration.test.ts
@@ -65,9 +65,14 @@ describe('sheet formatting tools — registration', () => {
     expect(TOOL_NAME_MAP.set_conditional_format).toBe('Conditional Formatting');
   });
 
-  it('the spreadsheets skill is discoverable through format_sheet and its description names formatting', () => {
+  it('the spreadsheets skill is discoverable through either formatting tool and its description names formatting', () => {
+    // requiredTools is .some()-gated: an agent whose allowlist holds only
+    // set_conditional_format (plus load_skill) must still be offered the
+    // skill that carries the rule semantics.
     const skill = BUILTIN_SKILLS.find((s) => s.trigger === 'spreadsheets')!;
-    expect(skill.requiredTools).toContain('format_sheet');
+    for (const name of SHEET_FORMAT_TOOLS) {
+      expect(skill.requiredTools, name).toContain(name);
+    }
     // The description is the model's only retrieval signal; these are the
     // words a person types.
     for (const word of ['format', 'dashboard', 'presentable']) {

--- a/apps/web/src/lib/ai/core/__tests__/sheet-format-registration.test.ts
+++ b/apps/web/src/lib/ai/core/__tests__/sheet-format-registration.test.ts
@@ -11,40 +11,32 @@
  * plus `tool_search` / `execute_tool` as top-level keys — neither sheet tool is
  * core (`CORE_TOOL_NAMES`) — so `expect(Object.keys(tools)).not.toContain(
  * 'format_sheet')` passes no matter what the read-only filter does. Reachability
- * is probed through `tool_search('select:format_sheet')` (the corpus
- * `execute_tool` dispatches from) and through a dispatch call itself.
+ * is probed through `tool_search('select:name')` (the corpus `execute_tool`
+ * dispatches from) and through a dispatch call itself.
  */
 import { describe, it, expect } from 'vitest';
 import type { Tool } from 'ai';
 import { buildPageSpaceTools, TOOL_REGISTRY, WORKSPACE_TOOL_NAMES } from '../ai-tools';
-import { WRITE_TOOLS, filterToolsForReadOnly, isWriteTool } from '../tool-filtering';
+import { WRITE_TOOLS, filterToolsForReadOnly } from '../tool-filtering';
 import { CORE_TOOL_NAMES } from '../stub-tools';
 import { applyToolExposureMode } from '../../tools/tool-exposure';
+import { BUILTIN_SKILLS } from '@pagespace/lib/commands/command-core';
 import { TOOL_NAME_MAP } from '../../tools/tool-labels';
-import { buildInlineInstructions } from '../inline-instructions';
-import { buildSystemPrompt } from '../system-prompt';
-import { BUILTIN_SKILLS, validateCommandDescription } from '@pagespace/lib/commands/command-core';
 
 const SHEET_FORMAT_TOOLS = ['format_sheet', 'set_conditional_format'] as const;
 
-type SearchResult = { tools: Array<{ name: string }> };
-type ExecuteResult = { error?: string } | Record<string, unknown>;
+const base = buildPageSpaceTools({ codeExecutionEnabled: false });
+const fullSearch = applyToolExposureMode(base, 'search').tools as Record<string, Tool>;
+const readOnlySearch = applyToolExposureMode(filterToolsForReadOnly(base, true), 'search').tools as Record<string, Tool>;
 
 const probe = async (tools: Record<string, Tool>, name: string): Promise<string[]> => {
-  const search = tools.tool_search as Tool;
-  const result = (await (search.execute as (a: unknown, o: unknown) => Promise<SearchResult>)(
-    { query: `select:${name}` },
-    {},
-  )) as SearchResult;
-  return result.tools.map((t) => t.name);
+  const search = tools.tool_search.execute as (a: unknown, o: unknown) => Promise<{ tools: Array<{ name: string }> }>;
+  return (await search({ query: `select:${name}` }, {})).tools.map((t) => t.name);
 };
 
-const dispatch = async (tools: Record<string, Tool>, name: string): Promise<ExecuteResult> => {
-  const exec = tools.execute_tool as Tool;
-  return (await (exec.execute as (a: unknown, o: unknown) => Promise<ExecuteResult>)(
-    { tool_name: name, parameters: {} },
-    { experimental_context: {} },
-  )) as ExecuteResult;
+const dispatch = (tools: Record<string, Tool>, name: string): Promise<{ error?: string }> => {
+  const exec = tools.execute_tool.execute as (a: unknown, o: unknown) => Promise<{ error?: string }>;
+  return exec({ tool_name: name, parameters: {} }, { experimental_context: {} });
 };
 
 describe('sheet formatting tools — registration', () => {
@@ -53,7 +45,6 @@ describe('sheet formatting tools — registration', () => {
   });
 
   it('both names are workspace tools on the code-exec-off build', () => {
-    const base = buildPageSpaceTools({ codeExecutionEnabled: false });
     for (const name of SHEET_FORMAT_TOOLS) {
       expect(WORKSPACE_TOOL_NAMES).toContain(name);
       expect(base[name]).toBeDefined();
@@ -68,17 +59,15 @@ describe('sheet formatting tools — registration', () => {
   it('the spreadsheets skill is discoverable through either formatting tool and its description names formatting', () => {
     // requiredTools is .some()-gated: an agent whose allowlist holds only
     // set_conditional_format (plus load_skill) must still be offered the
-    // skill that carries the rule semantics.
+    // skill that carries the rule semantics. The description is the model's
+    // only retrieval signal; these are the words a person types.
     const skill = BUILTIN_SKILLS.find((s) => s.trigger === 'spreadsheets')!;
     for (const name of SHEET_FORMAT_TOOLS) {
       expect(skill.requiredTools, name).toContain(name);
     }
-    // The description is the model's only retrieval signal; these are the
-    // words a person types.
     for (const word of ['format', 'dashboard', 'presentable']) {
       expect(skill.description.toLowerCase()).toContain(word);
     }
-    expect(validateCommandDescription(skill.description)).toEqual({ valid: true });
   });
 });
 
@@ -86,12 +75,10 @@ describe('sheet formatting tools — gating', () => {
   it('WRITE_TOOLS contains both names (direct)', () => {
     for (const name of SHEET_FORMAT_TOOLS) {
       expect(WRITE_TOOLS.has(name), name).toBe(true);
-      expect(isWriteTool(name)).toBe(true);
     }
   });
 
   it('a read-only agent loses both, and keeps read_sheet', () => {
-    const base = buildPageSpaceTools({ codeExecutionEnabled: false });
     const readOnly = filterToolsForReadOnly(base, true);
     for (const name of SHEET_FORMAT_TOOLS) {
       expect(readOnly[name], name).toBeUndefined();
@@ -100,62 +87,44 @@ describe('sheet formatting tools — gating', () => {
   });
 
   it('neither is a core tool, so the search-mode key-set assertion would be vacuous', () => {
-    // This is the premise of the probes below, pinned so that a future edit
-    // making one of them core does not silently turn the probes into no-ops
-    // of a different kind.
+    // The premise of the probes below, pinned so that a future edit making
+    // one of them core does not silently turn the probes into no-ops of a
+    // different kind.
     for (const name of SHEET_FORMAT_TOOLS) {
       expect(CORE_TOOL_NAMES.has(name), name).toBe(false);
     }
   });
 
   it('search mode: tool_search finds both on a full agent and neither on a read-only agent', async () => {
-    const base = buildPageSpaceTools({ codeExecutionEnabled: false });
-    const full = applyToolExposureMode(base, 'search').tools as Record<string, Tool>;
-    const readOnly = applyToolExposureMode(filterToolsForReadOnly(base, true), 'search').tools as Record<string, Tool>;
-
     for (const name of SHEET_FORMAT_TOOLS) {
-      expect(await probe(full, name), `${name} on a full agent`).toEqual([name]);
-      expect(await probe(readOnly, name), `${name} on a read-only agent`).toEqual([]);
+      expect(await probe(fullSearch, name), `${name} on a full agent`).toEqual([name]);
+      expect(await probe(readOnlySearch, name), `${name} on a read-only agent`).toEqual([]);
     }
-    // The probe itself is live: a core read tool is still found on the
-    // read-only set, so an empty result above is the filter, not a dead probe.
-    expect(await probe(readOnly, 'read_sheet')).toEqual(['read_sheet']);
+    // The probe itself is live: a read tool is still found on the read-only
+    // set, so an empty result above is the filter, not a dead probe.
+    expect(await probe(readOnlySearch, 'read_sheet')).toEqual(['read_sheet']);
   });
 
   it('search mode: execute_tool dispatches to both on a full agent and reports them unknown on a read-only agent', async () => {
-    const base = buildPageSpaceTools({ codeExecutionEnabled: false });
-    const full = applyToolExposureMode(base, 'search').tools as Record<string, Tool>;
-    const readOnly = applyToolExposureMode(filterToolsForReadOnly(base, true), 'search').tools as Record<string, Tool>;
-
     for (const name of SHEET_FORMAT_TOOLS) {
       // On the full set the call REACHES the tool: with an empty context the
       // tool's own auth guard throws, which is a different failure from the
       // dispatcher's unknown-tool envelope.
-      await expect(dispatch(full, name), `${name} on a full agent`).rejects.toThrow('User authentication required');
-
-      const refused = await dispatch(readOnly, name);
-      expect(refused.error, `${name} on a read-only agent`).toContain(`Unknown tool "${name}"`);
+      await expect(dispatch(fullSearch, name), `${name} on a full agent`).rejects.toThrow('User authentication required');
+      expect((await dispatch(readOnlySearch, name)).error, `${name} on a read-only agent`).toContain(`Unknown tool "${name}"`);
     }
   });
-});
 
-describe('sheet formatting tools — prompts', () => {
-  const sheetLine = (tools: string[]) =>
-    buildInlineInstructions(tools).split('\n').find((l) => l.startsWith('• SHEET')) ?? '';
-
-  it('the SHEET bullet names format_sheet only to an agent that holds it', () => {
-    expect(sheetLine(['read_sheet', 'edit_sheet_cells', 'format_sheet'])).toContain('format_sheet');
-    expect(sheetLine(['read_sheet', 'edit_sheet_cells'])).not.toContain('format_sheet');
-    expect(sheetLine(['format_sheet'])).toContain('format_sheet');
-    expect(sheetLine([])).not.toContain('format_sheet');
-  });
-
-  it('a formatting tool does NOT make a Sheet a sandbox-output destination', () => {
-    // SHEET_WRITE_TOOL_NAMES answers "can this agent put sandbox OUTPUT into
-    // a Sheet". format_sheet cannot put data anywhere, so an agent holding
-    // only it must not be told a Sheet is a valid destination.
-    const result = buildSystemPrompt(false, undefined, true, ['read_page', 'bash', 'format_sheet', 'set_conditional_format']);
-    expect(result).not.toContain('write meaningful output back into the drive');
-    expect(result).not.toContain('(a Sheet)');
+  it('search mode: the read-only filter composes with search exposure for EVERY registered write tool', async () => {
+    // The general form of the two cases above, so the next write tool cannot
+    // be discoverable through tool_search on a read-only agent without a
+    // test noticing. Neither tool-filtering.test nor tool-exposure.test runs
+    // the two mechanisms together against the real registry.
+    const writeTools = Object.keys(base).filter((name) => WRITE_TOOLS.has(name) && !CORE_TOOL_NAMES.has(name));
+    expect(writeTools).toEqual(expect.arrayContaining([...SHEET_FORMAT_TOOLS]));
+    for (const name of writeTools) {
+      expect(await probe(fullSearch, name), `${name} on a full agent`).toEqual([name]);
+      expect(await probe(readOnlySearch, name), `${name} on a read-only agent`).toEqual([]);
+    }
   });
 });

--- a/apps/web/src/lib/ai/core/__tests__/sheet-format-registration.test.ts
+++ b/apps/web/src/lib/ai/core/__tests__/sheet-format-registration.test.ts
@@ -1,0 +1,156 @@
+/**
+ * `format_sheet` / `set_conditional_format` are reachable, and gated.
+ *
+ * The tools existed for a whole epic before anything registered them: the
+ * skill told the model the capability did not exist and no tool set carried
+ * the names. Each case here pins one seam of the wiring, against the REAL
+ * registry, so the next tool module cannot ship the same way.
+ *
+ * The search-mode cases are written the only way they can mean anything. A
+ * tool set built by `applyToolExposureMode(..., 'search')` has ONLY core tools
+ * plus `tool_search` / `execute_tool` as top-level keys — neither sheet tool is
+ * core (`CORE_TOOL_NAMES`) — so `expect(Object.keys(tools)).not.toContain(
+ * 'format_sheet')` passes no matter what the read-only filter does. Reachability
+ * is probed through `tool_search('select:format_sheet')` (the corpus
+ * `execute_tool` dispatches from) and through a dispatch call itself.
+ */
+import { describe, it, expect } from 'vitest';
+import type { Tool } from 'ai';
+import { buildPageSpaceTools, TOOL_REGISTRY, WORKSPACE_TOOL_NAMES } from '../ai-tools';
+import { WRITE_TOOLS, filterToolsForReadOnly, isWriteTool } from '../tool-filtering';
+import { CORE_TOOL_NAMES } from '../stub-tools';
+import { applyToolExposureMode } from '../../tools/tool-exposure';
+import { TOOL_NAME_MAP } from '../../tools/tool-labels';
+import { buildInlineInstructions } from '../inline-instructions';
+import { buildSystemPrompt } from '../system-prompt';
+import { BUILTIN_SKILLS, validateCommandDescription } from '@pagespace/lib/commands/command-core';
+
+const SHEET_FORMAT_TOOLS = ['format_sheet', 'set_conditional_format'] as const;
+
+type SearchResult = { tools: Array<{ name: string }> };
+type ExecuteResult = { error?: string } | Record<string, unknown>;
+
+const probe = async (tools: Record<string, Tool>, name: string): Promise<string[]> => {
+  const search = tools.tool_search as Tool;
+  const result = (await (search.execute as (a: unknown, o: unknown) => Promise<SearchResult>)(
+    { query: `select:${name}` },
+    {},
+  )) as SearchResult;
+  return result.tools.map((t) => t.name);
+};
+
+const dispatch = async (tools: Record<string, Tool>, name: string): Promise<ExecuteResult> => {
+  const exec = tools.execute_tool as Tool;
+  return (await (exec.execute as (a: unknown, o: unknown) => Promise<ExecuteResult>)(
+    { tool_name: name, parameters: {} },
+    { experimental_context: {} },
+  )) as ExecuteResult;
+};
+
+describe('sheet formatting tools — registration', () => {
+  it('TOOL_REGISTRY.sheetsFormat is exactly the two tools', () => {
+    expect([...TOOL_REGISTRY.sheetsFormat].sort()).toEqual([...SHEET_FORMAT_TOOLS].sort());
+  });
+
+  it('both names are workspace tools on the code-exec-off build', () => {
+    const base = buildPageSpaceTools({ codeExecutionEnabled: false });
+    for (const name of SHEET_FORMAT_TOOLS) {
+      expect(WORKSPACE_TOOL_NAMES).toContain(name);
+      expect(base[name]).toBeDefined();
+    }
+  });
+
+  it('both have a curated label', () => {
+    expect(TOOL_NAME_MAP.format_sheet).toBe('Format Sheet');
+    expect(TOOL_NAME_MAP.set_conditional_format).toBe('Conditional Formatting');
+  });
+
+  it('the spreadsheets skill is discoverable through format_sheet and its description names formatting', () => {
+    const skill = BUILTIN_SKILLS.find((s) => s.trigger === 'spreadsheets')!;
+    expect(skill.requiredTools).toContain('format_sheet');
+    // The description is the model's only retrieval signal; these are the
+    // words a person types.
+    for (const word of ['format', 'dashboard', 'presentable']) {
+      expect(skill.description.toLowerCase()).toContain(word);
+    }
+    expect(validateCommandDescription(skill.description)).toEqual({ valid: true });
+  });
+});
+
+describe('sheet formatting tools — gating', () => {
+  it('WRITE_TOOLS contains both names (direct)', () => {
+    for (const name of SHEET_FORMAT_TOOLS) {
+      expect(WRITE_TOOLS.has(name), name).toBe(true);
+      expect(isWriteTool(name)).toBe(true);
+    }
+  });
+
+  it('a read-only agent loses both, and keeps read_sheet', () => {
+    const base = buildPageSpaceTools({ codeExecutionEnabled: false });
+    const readOnly = filterToolsForReadOnly(base, true);
+    for (const name of SHEET_FORMAT_TOOLS) {
+      expect(readOnly[name], name).toBeUndefined();
+    }
+    expect(readOnly.read_sheet).toBeDefined();
+  });
+
+  it('neither is a core tool, so the search-mode key-set assertion would be vacuous', () => {
+    // This is the premise of the probes below, pinned so that a future edit
+    // making one of them core does not silently turn the probes into no-ops
+    // of a different kind.
+    for (const name of SHEET_FORMAT_TOOLS) {
+      expect(CORE_TOOL_NAMES.has(name), name).toBe(false);
+    }
+  });
+
+  it('search mode: tool_search finds both on a full agent and neither on a read-only agent', async () => {
+    const base = buildPageSpaceTools({ codeExecutionEnabled: false });
+    const full = applyToolExposureMode(base, 'search').tools as Record<string, Tool>;
+    const readOnly = applyToolExposureMode(filterToolsForReadOnly(base, true), 'search').tools as Record<string, Tool>;
+
+    for (const name of SHEET_FORMAT_TOOLS) {
+      expect(await probe(full, name), `${name} on a full agent`).toEqual([name]);
+      expect(await probe(readOnly, name), `${name} on a read-only agent`).toEqual([]);
+    }
+    // The probe itself is live: a core read tool is still found on the
+    // read-only set, so an empty result above is the filter, not a dead probe.
+    expect(await probe(readOnly, 'read_sheet')).toEqual(['read_sheet']);
+  });
+
+  it('search mode: execute_tool dispatches to both on a full agent and reports them unknown on a read-only agent', async () => {
+    const base = buildPageSpaceTools({ codeExecutionEnabled: false });
+    const full = applyToolExposureMode(base, 'search').tools as Record<string, Tool>;
+    const readOnly = applyToolExposureMode(filterToolsForReadOnly(base, true), 'search').tools as Record<string, Tool>;
+
+    for (const name of SHEET_FORMAT_TOOLS) {
+      // On the full set the call REACHES the tool: with an empty context the
+      // tool's own auth guard throws, which is a different failure from the
+      // dispatcher's unknown-tool envelope.
+      await expect(dispatch(full, name), `${name} on a full agent`).rejects.toThrow('User authentication required');
+
+      const refused = await dispatch(readOnly, name);
+      expect(refused.error, `${name} on a read-only agent`).toContain(`Unknown tool "${name}"`);
+    }
+  });
+});
+
+describe('sheet formatting tools — prompts', () => {
+  const sheetLine = (tools: string[]) =>
+    buildInlineInstructions(tools).split('\n').find((l) => l.startsWith('• SHEET')) ?? '';
+
+  it('the SHEET bullet names format_sheet only to an agent that holds it', () => {
+    expect(sheetLine(['read_sheet', 'edit_sheet_cells', 'format_sheet'])).toContain('format_sheet');
+    expect(sheetLine(['read_sheet', 'edit_sheet_cells'])).not.toContain('format_sheet');
+    expect(sheetLine(['format_sheet'])).toContain('format_sheet');
+    expect(sheetLine([])).not.toContain('format_sheet');
+  });
+
+  it('a formatting tool does NOT make a Sheet a sandbox-output destination', () => {
+    // SHEET_WRITE_TOOL_NAMES answers "can this agent put sandbox OUTPUT into
+    // a Sheet". format_sheet cannot put data anywhere, so an agent holding
+    // only it must not be told a Sheet is a valid destination.
+    const result = buildSystemPrompt(false, undefined, true, ['read_page', 'bash', 'format_sheet', 'set_conditional_format']);
+    expect(result).not.toContain('write meaningful output back into the drive');
+    expect(result).not.toContain('(a Sheet)');
+  });
+});

--- a/apps/web/src/lib/ai/core/__tests__/system-prompt.test.ts
+++ b/apps/web/src/lib/ai/core/__tests__/system-prompt.test.ts
@@ -194,6 +194,16 @@ describe('buildSystemPrompt — sandbox guidance', () => {
     expect(result).toContain('write meaningful output back into the drive (a Sheet)');
   });
 
+  it('given only the sheet FORMATTING tools, does NOT claim a Sheet as a destination', () => {
+    // SHEET_WRITE_TOOL_NAMES answers "can this agent put sandbox OUTPUT into
+    // a Sheet". format_sheet / set_conditional_format restyle a sheet but
+    // cannot put data into one, so an agent holding only them must not be
+    // told a Sheet is a valid destination.
+    const result = buildSystemPrompt(false, undefined, true, ['read_page', 'bash', 'format_sheet', 'set_conditional_format']);
+    expect(result).not.toContain('write meaningful output back into the drive');
+    expect(result).not.toContain('(a Sheet)');
+  });
+
   it('given both a Document-writer and the Sheet-writer, claims a Sheet or Document', () => {
     const result = buildSystemPrompt(false, undefined, true, ['read_page', 'bash', 'replace_lines', 'edit_sheet_cells']);
     expect(result).toContain('write meaningful output back into the drive (a Sheet or a Document)');

--- a/apps/web/src/lib/ai/core/__tests__/tool-registry-docs.test.ts
+++ b/apps/web/src/lib/ai/core/__tests__/tool-registry-docs.test.ts
@@ -17,7 +17,7 @@
  * Adding a new doc line that cites the count = add one entry to DOC_COUNT_ASSERTIONS.
  */
 import { describe, it, expect } from 'vitest';
-import { readFileSync, existsSync } from 'node:fs';
+import { readFileSync, existsSync, readdirSync } from 'node:fs';
 import { resolve, dirname } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { buildPageSpaceTools } from '../ai-tools';
@@ -89,6 +89,42 @@ describe('tool registry — internal consistency', () => {
       }
     }
   });
+});
+
+/**
+ * Tools declared in a `*-tools.ts` module that are deliberately NOT part of
+ * `pageSpaceTools`. `ask_user` is the only one: it is attached by the chat
+ * route to the one turn that can answer it, never to the registry.
+ */
+const DECLARED_BUT_NOT_REGISTERED = new Set(['ask_user']);
+
+describe('every declared tool is registered', () => {
+  it('a `name: tool(` in any *-tools.ts module is a key of the full registry, or ledgered here', () => {
+    // The class of bug the sheet-formatting epic shipped with: a tool module
+    // written, tested and merged, then nothing assembled it into
+    // TOOL_MODULES, so the tools were dead code for four tasks. Every other
+    // registration test starts FROM the registry and so cannot see a module
+    // the registry does not know about. This one starts from the source.
+    // (registry-coverage.test.ts scans the same way but only against the
+    // renderer map, and deliberately never imports the tool graph.)
+    const dir = resolve(dirname(fileURLToPath(import.meta.url)), '../../tools');
+    const declared = new Set<string>();
+    for (const file of readdirSync(dir).filter((f) => f.endsWith('-tools.ts'))) {
+      for (const match of readFileSync(resolve(dir, file), 'utf8').matchAll(/^ {2,}([a-zA-Z_][a-zA-Z0-9_]*): tool\(/gm)) {
+        declared.add(match[1]);
+      }
+    }
+    expect(declared.size).toBeGreaterThan(80);
+    expect(declared.has('format_sheet')).toBe(true);
+
+    const registered = new Set(Object.keys(buildPageSpaceTools({ codeExecutionEnabled: true })));
+    const missing = [...declared].filter((name) => !registered.has(name) && !DECLARED_BUT_NOT_REGISTERED.has(name)).sort();
+    expect(missing, `declared in a tool module but never registered: ${missing.join(', ')}`).toEqual([]);
+
+    const stale = [...DECLARED_BUT_NOT_REGISTERED].filter((name) => registered.has(name) || !declared.has(name));
+    expect(stale, `ledger entries that are registered or no longer declared: ${stale.join(', ')}`).toEqual([]);
+  });
+
 });
 
 describe('docs cite the derived workspace-tool count', () => {

--- a/apps/web/src/lib/ai/core/ai-tools.ts
+++ b/apps/web/src/lib/ai/core/ai-tools.ts
@@ -7,6 +7,7 @@ import { pageReadTools } from '../tools/page-read-tools';
 import { pageWriteTools } from '../tools/page-write-tools';
 import { copyContentTools } from '../tools/copy-content-tools-runtime';
 import { sheetReadTools } from '../tools/sheet-read-tools';
+import { sheetFormatTools } from '../tools/sheet-format-tools';
 import { searchTools } from '../tools/search-tools';
 import { taskManagementTools } from '../tools/task-management-tools';
 import { agentTools } from '../tools/agent-tools';
@@ -55,6 +56,7 @@ const TOOL_MODULES = {
   // sandbox switch is enforced at call time inside the file arms instead.
   copyContent: copyContentTools,
   sheetsRead: sheetReadTools,
+  sheetsFormat: sheetFormatTools,
   search: searchTools,
   tasks: taskManagementTools,
   agents: agentTools,

--- a/apps/web/src/lib/ai/core/inline-instructions.ts
+++ b/apps/web/src/lib/ai/core/inline-instructions.ts
@@ -85,9 +85,9 @@ const PAGE_TYPE_BULLETS: ReadonlyArray<{
   {
     // Composed rather than picked from fixed variants. A bullet naming a tool
     // the agent does not hold produces an unknown-tool call before the model
-    // recovers, and this bullet names up to three — read_sheet, read_page and
-    // edit_sheet_cells. Gating only one of them left the other two able to do
-    // exactly what the gate exists to prevent.
+    // recovers, and this bullet names up to four — read_sheet, read_page,
+    // edit_sheet_cells and format_sheet. Gating only one of them left the
+    // others able to do exactly what the gate exists to prevent.
     compose: (availableTools?: string[]) => {
       const has = (tool: string) => hasAny(availableTools, [tool]);
       const parts = ['• SHEET: Spreadsheet stored as rows.'];
@@ -98,6 +98,9 @@ const PAGE_TYPE_BULLETS: ReadonlyArray<{
       }
       if (has('edit_sheet_cells')) {
         parts.push('Use edit_sheet_cells for cell-level edits.');
+      }
+      if (has('format_sheet')) {
+        parts.push('Use format_sheet to declare a table (header rows, column roles, totals, theme) so its presentation is derived; edit_sheet_cells never formats.');
       }
       return parts.join(' ');
     },

--- a/apps/web/src/lib/ai/core/inline-instructions.ts
+++ b/apps/web/src/lib/ai/core/inline-instructions.ts
@@ -100,7 +100,7 @@ const PAGE_TYPE_BULLETS: ReadonlyArray<{
         parts.push('Use edit_sheet_cells for cell-level edits.');
       }
       if (has('format_sheet')) {
-        parts.push('Use format_sheet to declare a table (header rows, column roles, totals, theme) so its presentation is derived; edit_sheet_cells never formats.');
+        parts.push('Use format_sheet to declare a table (header rows, column roles, totals, theme) so its presentation is derived; cell edits never format.');
       }
       return parts.join(' ');
     },

--- a/apps/web/src/lib/ai/core/system-prompt.ts
+++ b/apps/web/src/lib/ai/core/system-prompt.ts
@@ -42,6 +42,7 @@ const CATEGORY_MAP: Record<string, string> = {
   create_drive: 'drive', rename_drive: 'drive', update_drive_context: 'drive',
   list_trash: 'pages', list_conversations: 'pages', read_conversation: 'pages',
   rename_page: 'pages', move_page: 'pages', read_sheet: 'pages', edit_sheet_cells: 'pages',
+  format_sheet: 'pages', set_conditional_format: 'pages',
   trash_page: 'pages', trash_drive: 'pages', restore_page: 'pages', restore_drive: 'pages',
   glob_search: 'search', web_fetch: 'search', web_search: 'search',
   update_task: 'tasks', create_task: 'tasks', delete_task: 'tasks', reorder_task: 'tasks', get_assigned_tasks: 'tasks',

--- a/apps/web/src/lib/ai/core/system-prompt.ts
+++ b/apps/web/src/lib/ai/core/system-prompt.ts
@@ -136,6 +136,10 @@ const DOCUMENT_WRITE_TOOL_NAMES = ['replace_lines', 'insert_content', 'copy_cont
  * document editing", page-write-tools.ts). Conversely an agent holding only
  * this can write a Sheet, never a Document.
  */
+// Deliberately NOT format_sheet / set_conditional_format: they restyle a Sheet
+// but cannot put sandbox OUTPUT into one, and this list answers only that
+// question (it feeds buildDriveDestinationPhrase). Listing them would tell an
+// agent holding only a formatting tool that a Sheet is a valid destination.
 const SHEET_WRITE_TOOL_NAMES = ['edit_sheet_cells'];
 
 function hasAnyToolName(availableTools: string[] | undefined, names: readonly string[]): boolean {

--- a/apps/web/src/lib/ai/core/tool-filtering.ts
+++ b/apps/web/src/lib/ai/core/tool-filtering.ts
@@ -19,8 +19,9 @@ export const WRITE_TOOLS = new Set([
   'move_page',
   'edit_sheet_cells',
   // Presentation writes. They never touch a value, but a read-only agent must
-  // not restyle a sheet either — and membership here is what makes
-  // cap-step-tool-payloads keep their results intact.
+  // not restyle a sheet either. Membership here also keeps their results out
+  // of elision (tool-result-eliding.ts) and makes cap-step-tool-payloads' stub
+  // say the write already happened rather than "call it again".
   'format_sheet',
   'set_conditional_format',
   // Mutates a page or a sandbox file, so a read-only agent must not get it.

--- a/apps/web/src/lib/ai/core/tool-filtering.ts
+++ b/apps/web/src/lib/ai/core/tool-filtering.ts
@@ -18,6 +18,11 @@ export const WRITE_TOOLS = new Set([
   'insert_content',
   'move_page',
   'edit_sheet_cells',
+  // Presentation writes. They never touch a value, but a read-only agent must
+  // not restyle a sheet either — and membership here is what makes
+  // cap-step-tool-payloads keep their results intact.
+  'format_sheet',
+  'set_conditional_format',
   // Mutates a page or a sandbox file, so a read-only agent must not get it.
   // Deliberately NOT in SANDBOX_TOOL_NAMES: that set is stripped wholesale when
   // an agent's sandbox switch is off, which would also remove the page->page

--- a/apps/web/src/lib/ai/skills/__tests__/skill-bodies.test.ts
+++ b/apps/web/src/lib/ai/skills/__tests__/skill-bodies.test.ts
@@ -41,6 +41,26 @@ describe('skill bodies', () => {
     expect(stale, `requiredTools naming tools that do not exist: ${stale.join(', ')}`).toEqual([]);
   });
 
+  it.each(BUILTIN_SKILLS.map((s) => s.trigger))('%s body names only tools that exist', (trigger) => {
+    // A body that names a tool the registry lacks sends the model into an
+    // unknown-tool call. Backticked snake_case is how every body spells a
+    // tool name; the task-management body also backticks task STATUS and
+    // FIELD names in the same style, listed here so they are not mistaken
+    // for tools (same device as starter-skill-tool-references.test.ts).
+    const NOT_TOOLS = new Set(['in_progress', 'in_review', 'due_date']);
+    const known = new Set(WORKSPACE_TOOL_NAMES);
+    const mentioned = [...new Set([...getSkillBody(trigger)!.matchAll(/`([a-z]+(?:_[a-z]+)+)`/g)].map((m) => m[1]))];
+    const unknown = mentioned.filter((name) => !known.has(name) && !NOT_TOOLS.has(name));
+    expect(unknown, `${trigger} names tools that do not exist: ${unknown.join(', ')}`).toEqual([]);
+  });
+
+  it('the spreadsheets body extractor is live: it sees all four sheet tools', () => {
+    const mentioned = new Set([...getSkillBody('spreadsheets')!.matchAll(/`([a-z]+(?:_[a-z]+)+)`/g)].map((m) => m[1]));
+    for (const name of ['read_sheet', 'edit_sheet_cells', 'format_sheet', 'set_conditional_format']) {
+      expect(mentioned.has(name), name).toBe(true);
+    }
+  });
+
   it('unknown triggers return null', () => {
     expect(getSkillBody('nonexistent-skill')).toBeNull();
     expect(getSkillBody('help')).toBeNull();

--- a/apps/web/src/lib/ai/skills/__tests__/spreadsheets-skill-body.test.ts
+++ b/apps/web/src/lib/ai/skills/__tests__/spreadsheets-skill-body.test.ts
@@ -4,75 +4,51 @@
  *
  * Before `format_sheet` was registered the body said `edit_sheet_cells` was
  * "the only write path" and pitfall 7 said to enter bare numbers and stop
- * there. Each case names one line the rewrite had to carry, so a future trim
- * against MAX_BODY_CHARS cannot quietly drop the capability it exists to teach.
+ * there. Each case pins a FACT the rewrite had to carry — not its wording, so
+ * the body stays free to be trimmed against MAX_BODY_CHARS — and the last
+ * two pin the claims the tool schema cannot convey and the tool would refuse.
  */
 import { describe, it, expect } from 'vitest';
 import { SPREADSHEETS_SKILL_BODY as body } from '../bodies/spreadsheets';
-import { WORKSPACE_TOOL_NAMES } from '@/lib/ai/core/ai-tools';
 
-/** Every backticked snake_case token — the way the body spells a tool name. */
-const backtickedToolNames = (text: string): string[] => {
-  const names = new Set<string>();
-  for (const match of text.matchAll(/`([a-z]+(?:_[a-z]+)+)`/g)) {
-    names.add(match[1]);
-  }
-  return [...names].sort();
-};
+const section = (from: string, to: string) => body.slice(body.indexOf(from), body.indexOf(to));
 
 describe('spreadsheets skill body', () => {
-  it('every tool name it mentions is a workspace tool', () => {
-    const known = new Set(WORKSPACE_TOOL_NAMES);
-    const mentioned = backtickedToolNames(body);
-    // The extractor is live: it must at least see the four sheet tools.
-    expect(mentioned).toEqual(expect.arrayContaining(['read_sheet', 'edit_sheet_cells', 'format_sheet', 'set_conditional_format']));
-    const unknown = mentioned.filter((name) => !known.has(name));
-    expect(unknown, `body names tools that do not exist: ${unknown.join(', ')}`).toEqual([]);
-  });
-
   it('no longer claims edit_sheet_cells is the only write path', () => {
-    const offending = body
-      .split('\n')
-      .filter((line) => /only write path/i.test(line) || /always use edit_sheet_cells/i.test(line));
-    expect(offending).toEqual([]);
+    expect(body).not.toMatch(/only write path|always use edit_sheet_cells/i);
+    expect(body).toContain('`format_sheet`');
+    expect(body).toContain('`set_conditional_format`');
   });
 
   it('teaches regions before ops, with the lines the model cannot infer from the schema', () => {
-    const regionsAt = body.indexOf('describe the table');
-    const opsAt = body.indexOf('escape hatch');
-    expect(regionsAt).toBeGreaterThan(0);
-    expect(opsAt).toBeGreaterThan(regionsAt);
-
-    expect(body).toContain('do NOT cover rows added later; regions do');
-    expect(body).toContain('costs nothing per row');
-    expect(body).toContain('4,999');
-    expect(body).toContain("column default < region < the cell's own format < conditional rule");
-    expect(body).toMatch(/computed, unformatted\*\* value: `"1200"`, never `"\$1,200\.00"`/);
+    const formatting = section('## Formatting', '## Common pitfalls');
+    expect(formatting.indexOf('regions')).toBeLessThan(formatting.indexOf('escape hatch'));
+    expect(formatting).toMatch(/do NOT cover rows added later; regions do/);
+    expect(formatting).toContain('4,999');
+    expect(formatting).toMatch(/column default < region < .* < conditional rule/);
+    expect(formatting).toMatch(/computed, unformatted\*\* value/);
+    expect(formatting).toContain('format_sheet({');
   });
 
-  it('carries a worked one-call budget example', () => {
-    const example = body.slice(body.indexOf('format_sheet({'), body.indexOf('```', body.indexOf('format_sheet({')));
-    expect(example).toContain('headerRows');
-    expect(example).toContain('role: "currency"');
-    expect(example).toContain('totalRows');
-    expect(example).toContain('theme');
-  });
-
-  it('covers the four rule kinds and the replaceAll read-first rule', () => {
+  it('covers the four rule kinds, requires the data-bar colour, and reads before replaceAll', () => {
+    const rules = section('### Conditional formatting', '## Common pitfalls');
     for (const kind of ['`cell`', '`formula`', '`colorScale`', '`dataBar`']) {
-      expect(body).toContain(kind);
+      expect(rules).toContain(kind);
     }
-    const replaceAll = body.indexOf('`mode: "replaceAll"`');
+    // buildRule refuses a dataBar without `color` (all-or-nothing), so the
+    // body must not call it optional.
+    expect(rules).toMatch(/`dataBar`[^\n]*`color` is required/);
+    expect(rules).not.toMatch(/optional `color`/);
+    const replaceAll = rules.indexOf('`mode: "replaceAll"`');
     expect(replaceAll).toBeGreaterThan(0);
-    expect(body.slice(replaceAll, replaceAll + 200)).toContain('includeFormatting: true');
+    expect(rules.slice(replaceAll, replaceAll + 200)).toContain('includeFormatting: true');
   });
 
   it('pitfall 7 keeps raw values raw AND opens the door to display formatting', () => {
     const pitfall = body.split('\n').find((line) => line.startsWith('7. **Formatted numbers.**')) ?? '';
     expect(pitfall).toContain('Enter `1200` and `0.85`');
     expect(pitfall).toContain('format_sheet');
-    expect(pitfall).toContain('`SUM` still works');
-    expect(pitfall).toContain('`"1200"`');
+    expect(pitfall).toMatch(/`SUM` still works/);
   });
 
   it('names the two new pitfalls', () => {
@@ -80,8 +56,15 @@ describe('spreadsheets skill body', () => {
     expect(body).toMatch(/^\d+\. \*\*Formatting a table cell-by-cell instead of declaring a region\.\*\*/m);
   });
 
-  it('tells the reader about includeFormatting on read_sheet', () => {
-    const readSection = body.slice(body.indexOf('## Reading a sheet'), body.indexOf('## Structuring a new sheet'));
-    expect(readSection).toContain('`includeFormatting: true`');
+  it('keeps the never-computed-formula exception on unformatted reads', () => {
+    // sheet-view emits `unformatted` only for computed cells; a legacy formula
+    // cell that was never evaluated returns the formula TEXT in `cells`. The
+    // rewrite dropped this clause once (review), and a model without it
+    // treats "=SUM(B2:B10)" as the value.
+    expect(section('## Reading a sheet', '## Structuring a new sheet')).toMatch(/never computed[^\n]*`cells` holds the formula text/);
+  });
+
+  it('warns that MIN/MAX error on text like SUM does', () => {
+    expect(body).toMatch(/`SUM`\/`MIN`\/`MAX` range errors/);
   });
 });

--- a/apps/web/src/lib/ai/skills/__tests__/spreadsheets-skill-body.test.ts
+++ b/apps/web/src/lib/ai/skills/__tests__/spreadsheets-skill-body.test.ts
@@ -1,0 +1,87 @@
+/**
+ * The spreadsheets skill teaches the formatting capability, and tells no lies
+ * about the write paths.
+ *
+ * Before `format_sheet` was registered the body said `edit_sheet_cells` was
+ * "the only write path" and pitfall 7 said to enter bare numbers and stop
+ * there. Each case names one line the rewrite had to carry, so a future trim
+ * against MAX_BODY_CHARS cannot quietly drop the capability it exists to teach.
+ */
+import { describe, it, expect } from 'vitest';
+import { SPREADSHEETS_SKILL_BODY as body } from '../bodies/spreadsheets';
+import { WORKSPACE_TOOL_NAMES } from '@/lib/ai/core/ai-tools';
+
+/** Every backticked snake_case token — the way the body spells a tool name. */
+const backtickedToolNames = (text: string): string[] => {
+  const names = new Set<string>();
+  for (const match of text.matchAll(/`([a-z]+(?:_[a-z]+)+)`/g)) {
+    names.add(match[1]);
+  }
+  return [...names].sort();
+};
+
+describe('spreadsheets skill body', () => {
+  it('every tool name it mentions is a workspace tool', () => {
+    const known = new Set(WORKSPACE_TOOL_NAMES);
+    const mentioned = backtickedToolNames(body);
+    // The extractor is live: it must at least see the four sheet tools.
+    expect(mentioned).toEqual(expect.arrayContaining(['read_sheet', 'edit_sheet_cells', 'format_sheet', 'set_conditional_format']));
+    const unknown = mentioned.filter((name) => !known.has(name));
+    expect(unknown, `body names tools that do not exist: ${unknown.join(', ')}`).toEqual([]);
+  });
+
+  it('no longer claims edit_sheet_cells is the only write path', () => {
+    const offending = body
+      .split('\n')
+      .filter((line) => /only write path/i.test(line) || /always use edit_sheet_cells/i.test(line));
+    expect(offending).toEqual([]);
+  });
+
+  it('teaches regions before ops, with the lines the model cannot infer from the schema', () => {
+    const regionsAt = body.indexOf('describe the table');
+    const opsAt = body.indexOf('escape hatch');
+    expect(regionsAt).toBeGreaterThan(0);
+    expect(opsAt).toBeGreaterThan(regionsAt);
+
+    expect(body).toContain('do NOT cover rows added later; regions do');
+    expect(body).toContain('costs nothing per row');
+    expect(body).toContain('4,999');
+    expect(body).toContain("column default < region < the cell's own format < conditional rule");
+    expect(body).toMatch(/computed, unformatted\*\* value: `"1200"`, never `"\$1,200\.00"`/);
+  });
+
+  it('carries a worked one-call budget example', () => {
+    const example = body.slice(body.indexOf('format_sheet({'), body.indexOf('```', body.indexOf('format_sheet({')));
+    expect(example).toContain('headerRows');
+    expect(example).toContain('role: "currency"');
+    expect(example).toContain('totalRows');
+    expect(example).toContain('theme');
+  });
+
+  it('covers the four rule kinds and the replaceAll read-first rule', () => {
+    for (const kind of ['`cell`', '`formula`', '`colorScale`', '`dataBar`']) {
+      expect(body).toContain(kind);
+    }
+    const replaceAll = body.indexOf('`mode: "replaceAll"`');
+    expect(replaceAll).toBeGreaterThan(0);
+    expect(body.slice(replaceAll, replaceAll + 200)).toContain('includeFormatting: true');
+  });
+
+  it('pitfall 7 keeps raw values raw AND opens the door to display formatting', () => {
+    const pitfall = body.split('\n').find((line) => line.startsWith('7. **Formatted numbers.**')) ?? '';
+    expect(pitfall).toContain('Enter `1200` and `0.85`');
+    expect(pitfall).toContain('format_sheet');
+    expect(pitfall).toContain('`SUM` still works');
+    expect(pitfall).toContain('`"1200"`');
+  });
+
+  it('names the two new pitfalls', () => {
+    expect(body).toMatch(/^\d+\. \*\*Colouring cells instead of writing a rule\.\*\*/m);
+    expect(body).toMatch(/^\d+\. \*\*Formatting a table cell-by-cell instead of declaring a region\.\*\*/m);
+  });
+
+  it('tells the reader about includeFormatting on read_sheet', () => {
+    const readSection = body.slice(body.indexOf('## Reading a sheet'), body.indexOf('## Structuring a new sheet'));
+    expect(readSection).toContain('`includeFormatting: true`');
+  });
+});

--- a/apps/web/src/lib/ai/skills/bodies/spreadsheets.ts
+++ b/apps/web/src/lib/ai/skills/bodies/spreadsheets.ts
@@ -146,7 +146,7 @@ Sheets are stored as rows in the database, not as text, and they are read as row
 - **Projection:** \`select: ["A", "C", "D"]\` returns only those columns, on range reads and filtered reads alike — use it on any wide sheet you only need a few columns of. \`orderBy: [{ column, direction, numeric }]\` sorts (set \`numeric\` or "10" sorts before "9"). \`offset\` pages through matches.
 - **Tabs:** \`tabIndex\` picks a tab, and every response lists the tabs the sheet has. A tab index that does not exist is refused, never answered with tab 0's rows.
 - Filters and sorts run in the database against each cell's **computed, unformatted** value, so a formula column matches on its result. \`cells\` gives you the DISPLAY text, so a cell shown as \`$1,200.00\` is matched by \`1200\` and \`85%\` by \`0.85\` — never build a filter by parsing the displayed string; take the number from \`unformatted\` (below).
-- \`includeFormatting: true\` adds a \`formatting\` block: the tab's \`regions\` (its declared structure, re-writable exactly as read), \`layout\` (freezes, widths, heights), \`columnFormats\`, the explicit \`cellFormats\` within the rows returned, and each conditional rule as \`{ id, kind, ranges, summary }\`. Ask for it before you restyle a sheet. \`regions\` can be handed straight back to \`format_sheet\`; a rule entry is a DESCRIPTION, not a rule you can write — to change one, rebuild it and remove the old \`id\`. \`cellFormats\` is capped and reports \`formattingTruncated\` when it drops cells. Works on unmigrated sheets too.
+- \`includeFormatting: true\` adds a \`formatting\` block: the tab's \`regions\` (its declared structure), \`layout\` (freezes, widths, heights), \`columnFormats\`, the explicit \`cellFormats\` within the rows returned, and each conditional rule as \`{ id, kind, ranges, summary }\`. Ask for it before you restyle a sheet. \`regions\` can be handed straight back to \`format_sheet\`; a rule entry is a DESCRIPTION, not a rule you can write — to change one, rebuild it and remove the old \`id\`. \`cellFormats\` is capped and reports \`formattingTruncated\` when it drops cells. Works on unmigrated sheets too.
 - \`startRow\` and \`where\`/\`orderBy\`/\`offset\` are different coordinate systems and cannot be combined — the call is rejected rather than quietly ignoring one.
 - Returns at most 500 rows per call, with \`dimensions\`, \`hasMore\`, and each row as \`{ rowNumber, cells, formulas?, errors?, unformatted? }\` plus a rendered \`table\`. \`cells\` holds display values keyed by column letter; \`formulas\` holds the authored formula for the cells that have one.
 
@@ -156,7 +156,7 @@ Reading either way:
 
 - Only non-empty cells appear. A row's \`rowNumber\` is its A1 row, so a row read at 417 is written with \`C417\`.
 - Formula cells report both the computed value (in \`cells\`) and the formula (in \`formulas\`) — you never need to re-derive results, and you never lose the formula.
-- Formatted cells report both the display text and the number underneath. \`read_sheet\` puts the machine value on the row as \`unformatted\` (keyed by column letter: \`unformatted: { "C": 1200 }\` beside \`cells: { "C": "$1,200.00" }\`); \`read_page\` keys it by A1 address, like \`formulas\` and \`errors\`. Only cells whose display differs from their value appear. Always filter, compute and write back from that number, never from the rendered string.
+- Formatted cells report both the display text and the number underneath. \`read_sheet\` puts the machine value on the row as \`unformatted\` (keyed by column letter: \`unformatted: { "C": 1200 }\` beside \`cells: { "C": "$1,200.00" }\`); \`read_page\` keys it by A1 address, like \`formulas\` and \`errors\`. Only cells whose display differs from their value appear — unless the cell is also in \`formulas\` and was never computed, in which case \`cells\` holds the formula text. Always filter, compute and write back from that number, never from the rendered string.
 - Errored cells show \`#ERROR\` as their value and carry the message in \`errors\`, keyed by A1 address in \`read_page\` and by column letter within the row in \`read_sheet\`.
 - Everything except the raw inputs (formula text and literal values) is **derived and regenerated on every save**. Never try to write values, types, errors or dependencies yourself; \`edit_sheet_cells\` recomputes them.
 - Cell values are truncated at 120 characters in the rendered \`table\` only, and the response says how many were cut (\`tableTruncatedCells\`); the structured \`rows\` always carry the full text. Never write a value back that you read from the table if that count is non-zero.
@@ -171,7 +171,7 @@ Reading either way:
 - One record per row, one field per column; keep a column consistently numeric or consistently text.
 - Put totals/aggregates in a clearly labeled row below the data (e.g. \`A11\` = "Total", \`B11\` = \`=SUM(B2:B10)\`) or a summary block to the right — and leave a blank row so the data range can grow.
 - Since blank cells coerce to 0, make aggregate ranges slightly generous (\`=SUM(B2:B20)\` over 10 data rows is safe for SUM/AVERAGE).
-- Store numbers as bare numbers (\`1200\`, not \`"$1,200"\` — currency symbols and thousands separators make the value text and break math) — set the display format instead, with a region column role.
+- Store numbers as bare numbers (\`1200\`, not \`"$1,200"\` — currency symbols and thousands separators make the value text and break math) — set the display format instead (pitfall 7).
 - Store dates as \`YYYY-MM-DD\` strings so YEAR/MONTH/DAY can parse them.
 - Send the whole initial population — headers, data, formulas — as one \`edit_sheet_cells\` batch, then one \`format_sheet\` call declaring the table.
 
@@ -186,7 +186,7 @@ format_sheet({ regions: [{ name: "Budget", range: "A1:D", headerRows: 1,
 \`\`\`
 
 - Column roles: \`text number currency percent date datetime id\`; \`currency\` and \`decimals\` refine one. A range with no end row (\`"A1:D"\`) runs to the bottom of the sheet. Themes are named hues (\`slate blue cyan teal green amber orange red pink purple violet indigo\`).
-- **Ops applied to a range do NOT cover rows added later; regions do.** That is the difference that matters.
+- **Ops applied to a range do NOT cover rows added later; regions do.**
 - A region costs nothing per row. \`A2:A5000\` as ops costs 4,999 against the cell budget (100 ops, 20,000 cells per range op, 50,000 per call); a \`columnFormat\` op for a whole column is free too.
 - \`ops\` is the escape hatch for what a region cannot say: \`setFormat\` (range + format) for one emphasised cell, \`clearFormat\`, \`columnFormat\`, \`columnWidth\`, \`rowHeight\`, \`freeze\`. A \`format\` is \`{ number: { kind, decimals, currency }, bold, italic, align, wrap, color, background, … }\`.
 - Precedence: column default < region < the cell's own format < conditional rule.
@@ -200,7 +200,7 @@ format_sheet({ regions: [{ name: "Budget", range: "A1:D", headerRows: 1,
 - \`cell\` — \`operator\` (\`greaterThan lessThan between equal contains isEmpty isError\` …) + \`value\` (\`value2\` for between) + \`format\`. Values compare against the **computed, unformatted** value: \`"1200"\`, never \`"$1,200.00"\`.
 - \`formula\` — \`formula\` anchored at the range's top-left, e.g. \`"=C2>AVERAGE(C2:C40)"\`, + \`format\`.
 - \`colorScale\` — \`min\`/\`mid\`/\`max\` anchors \`{ type: min|max|number|percent|percentile, value, color }\`.
-- \`dataBar\` — an in-cell bar; optional \`color\`.
+- \`dataBar\` — an in-cell bar; \`color\` is required.
 
 \`mode: "append"\` (default) adds; \`removeRuleIds\` drops rules by id. \`mode: "replaceAll"\` keeps only the rules in the call — read the sheet with \`includeFormatting: true\` first, or you discard rules you never saw.
 
@@ -210,12 +210,12 @@ format_sheet({ regions: [{ name: "Budget", range: "A1:D", headerRows: 1,
 2. **Unbounded ranges.** \`=SUM(A:A)\` is a parse error. Always use bounded ranges like \`A2:A50\`.
 3. **Newlines in cell values.** A line break inside a cell value is stored correctly and survives a round trip. The grid renders it on one line unless the cell is set to wrap, so prefer single-line values for readability — but a multi-line value is safe, not destructive.
 4. **Leading \`=\` on literal text.** Any value starting with \`=\` becomes a formula; there is no apostrophe-escape. Don't start plain-text values with \`=\`.
-5. **Text in numeric ranges.** One non-numeric string inside \`SUM\`'s range errors the whole formula (AVERAGE skips it instead). Keep data columns clean; don't mix "N/A" into number columns — leave the cell empty.
+5. **Text in numeric ranges.** One non-numeric string inside a \`SUM\`/\`MIN\`/\`MAX\` range errors the whole formula (AVERAGE skips it instead). Keep data columns clean; don't mix "N/A" into number columns — leave the cell empty.
 6. **FIND/SEARCH on a miss is an error**, not -1 or blank. Wrap in \`IFERROR\` if absence is expected.
 7. **Formatted numbers.** \`"$1,200"\` or \`"85%"\` are text. Enter \`1200\` and \`0.85\`, THEN make them *display* as currency or percent with a \`format_sheet\` column role. Formatting changes display only, so \`SUM\` still works and a \`read_sheet\` \`where\` still matches \`"1200"\`.
 8. **Cross-sheet error right after writing** ("Cross-page references are not supported in this context") is expected on save — see Cross-sheet references above.
 9. **Editing the sheet as text.** Never write SheetDoc TOML via any text tool — hand-built TOML that parses incorrectly resets the sheet to empty. All writes go through the sheet tools.
 10. **Reading a sheet to search it.** Paging a whole sheet through \`read_page\` to find one row wastes the context the sheet was supposed to save you. Ask \`read_sheet\` with a \`where\` instead.
-11. **Colouring cells instead of writing a rule.** Forty cells hand-filled green go stale the moment a number changes; a \`set_conditional_format\` rule follows the values.
-12. **Formatting a table cell-by-cell instead of declaring a region.** Range ops cover only the cells that existed when applied; a region covers the rows added next week.
+11. **Colouring cells instead of writing a rule.** Hand-filled colour goes stale the moment a number changes; a \`set_conditional_format\` rule follows the values.
+12. **Formatting a table cell-by-cell instead of declaring a region.** Range ops stop at today's last row; a region does not.
 `;

--- a/apps/web/src/lib/ai/skills/bodies/spreadsheets.ts
+++ b/apps/web/src/lib/ai/skills/bodies/spreadsheets.ts
@@ -1,20 +1,20 @@
 /**
- * spreadsheets skill body — code-shipped instructions for creating and
- * editing SHEET pages. Loaded on demand via load_skill / the /spreadsheets
+ * spreadsheets skill body — code-shipped instructions for creating,
+ * editing and formatting SHEET pages. Loaded on demand via load_skill / the /spreadsheets
  * chip; keep in sync with packages/lib/src/sheets.
  */
 export const SPREADSHEETS_SKILL_BODY = `# Spreadsheets (SHEET pages)
 
 A SHEET page is PageSpace's interactive spreadsheet: a single grid of cells with a formula engine. New sheets start at 20 rows x 10 columns and grow automatically when you write outside the current bounds. Like any page, a sheet can be nested anywhere and can contain child pages.
 
-## Editing: always use edit_sheet_cells
+## Two write paths: values and presentation
 
-Sheets store structured cell data, not editable text. \`replace_lines\` (and other line/text editing tools) **refuse SHEET pages** with "Cannot use line editing on sheets" — the stored text is a generated serialization that includes computed values and dependency tables, so editing it as text would corrupt or discard state. \`edit_sheet_cells\` is the only write path.
+Sheets store structured cell data, not editable text. \`replace_lines\` (and other line/text editing tools) **refuse SHEET pages** with "Cannot use line editing on sheets" — the stored text is a generated serialization, and editing it as text would corrupt state. Values and formulas go through \`edit_sheet_cells\`; presentation (how a number displays, header bands, themes, highlight rules) goes through \`format_sheet\` and \`set_conditional_format\` (below), which never change a value.
 
-Tool contract:
+\`edit_sheet_cells\` contract:
 
 - \`pageId\` (optional) — the sheet page to edit; defaults to the page currently in view.
-- \`cells\` — an array of \`{ address, value }\` updates. Batch cells into one call instead of calling once per cell, up to the hard limit of **500 cells per call**; split anything larger across calls. The whole array is generated as one tool call, so a batch of long values can exhaust your own output budget well before 500 — if a large call fails to be produced at all, halve the batch.
+- \`cells\` — an array of \`{ address, value }\` updates. Batch cells into one call, up to **500 cells per call**; split anything larger. A batch of long values can exhaust your output budget well before 500 — if a large call fails to be produced at all, halve the batch.
 - \`address\` — A1-style, e.g. \`"A1"\`, \`"B2"\`, \`"AA100"\`. Case-insensitive; normalized to uppercase.
 - \`value\` — always a string:
   - Starts with \`=\` → stored as a formula.
@@ -55,43 +55,43 @@ These 43 functions (46 names counting the aliases AVG, CONCATENATE, and POW) are
 
 | Function | Signature | Notes |
 |---|---|---|
-| SUM | \`SUM(v1, ...)\` | Coerces every value; non-numeric text anywhere in the range errors the formula |
-| AVERAGE / AVG | \`AVERAGE(v1, ...)\` | Skips blanks and non-numeric values; 0 when nothing numeric |
-| MIN | \`MIN(v1, ...)\` | Coerces all values; 0 on empty input |
-| MAX | \`MAX(v1, ...)\` | Coerces all values; 0 on empty input |
-| COUNT | \`COUNT(v1, ...)\` | Counts numbers, booleans, and numeric strings |
-| COUNTA | \`COUNTA(v1, ...)\` | Counts all non-empty values |
+| SUM | \`SUM(v1, ...)\` | Non-numeric text in the range errors the formula |
+| AVERAGE / AVG | \`AVERAGE(v1, ...)\` | Skips blanks and text; 0 when nothing numeric |
+| MIN | \`MIN(v1, ...)\` | 0 on empty input |
+| MAX | \`MAX(v1, ...)\` | 0 on empty input |
+| COUNT | \`COUNT(v1, ...)\` | Numbers, booleans, numeric strings |
+| COUNTA | \`COUNTA(v1, ...)\` | Non-empty values |
 | ABS | \`ABS(n)\` | |
 | ROUND | \`ROUND(n, [digits])\` | digits defaults to 0 |
-| FLOOR | \`FLOOR(n, [significance])\` | significance defaults to 1; must not be 0 |
-| CEILING | \`CEILING(n, [significance])\` | significance defaults to 1; must not be 0 |
+| FLOOR | \`FLOOR(n, [significance])\` | significance defaults to 1, never 0 |
+| CEILING | \`CEILING(n, [significance])\` | As FLOOR |
 | INT | \`INT(n)\` | Floor to integer |
 | SQRT | \`SQRT(n)\` | Errors on negative input |
-| POWER / POW | \`POWER(base, exp)\` | Same as the \`^\` operator |
+| POWER / POW | \`POWER(base, exp)\` | Same as \`^\` |
 | MOD | \`MOD(n, divisor)\` | Errors when divisor is 0 |
 | SIGN | \`SIGN(n)\` | Returns -1, 0, or 1 |
 | PI | \`PI()\` | |
 | RAND | \`RAND()\` | Random in [0, 1) |
-| RANDBETWEEN | \`RANDBETWEEN(low, high)\` | Random integer, inclusive |
+| RANDBETWEEN | \`RANDBETWEEN(low, high)\` | Inclusive integer |
 
 **Logical and type tests**
 
 | Function | Signature | Notes |
 |---|---|---|
-| IF | \`IF(cond, then, [else])\` | else defaults to empty string. **All three arguments evaluate eagerly — IF does NOT short-circuit**, so \`=IF(B2=0, "", A2/B2)\` still errors when B2 is 0. Use IFERROR to guard, not IF |
+| IF | \`IF(cond, then, [else])\` | else defaults to "". **IF does NOT short-circuit**: \`=IF(B2=0, "", A2/B2)\` still errors when B2 is 0. Guard with IFERROR |
 | IFERROR | \`IFERROR(expr, fallback)\` | The only lazy function and the only working error guard |
 | AND | \`AND(v1, ...)\` | |
 | OR | \`OR(v1, ...)\` | |
 | NOT | \`NOT(v)\` | |
 | ISBLANK | \`ISBLANK(v)\` | |
-| ISNUMBER | \`ISNUMBER(v)\` | True only for actual numbers, not numeric text |
+| ISNUMBER | \`ISNUMBER(v)\` | Actual numbers only, not numeric text |
 | ISTEXT | \`ISTEXT(v)\` | |
 
 **Text**
 
 | Function | Signature | Notes |
 |---|---|---|
-| CONCAT / CONCATENATE | \`CONCAT(v1, ...)\` | Same as chained \`&\` |
+| CONCAT / CONCATENATE | \`CONCAT(v1, ...)\` | Chained \`&\` |
 | UPPER | \`UPPER(text)\` | |
 | LOWER | \`LOWER(text)\` | |
 | TRIM | \`TRIM(text)\` | |
@@ -99,28 +99,28 @@ These 43 functions (46 names counting the aliases AVG, CONCATENATE, and POW) are
 | LEFT | \`LEFT(text, [n])\` | n defaults to 1 |
 | RIGHT | \`RIGHT(text, [n])\` | n defaults to 1 |
 | MID | \`MID(text, start, count)\` | start is 1-indexed |
-| SUBSTITUTE | \`SUBSTITUTE(text, old, new, [instance])\` | Replaces all occurrences unless instance given |
-| REPT | \`REPT(text, times)\` | times over 10000 is an error (not clamped) |
-| FIND | \`FIND(needle, haystack, [start])\` | Case-sensitive; returns 1-indexed position; **errors** when not found (wrap in IFERROR) |
-| SEARCH | \`SEARCH(needle, haystack, [start])\` | Like FIND but case-insensitive |
+| SUBSTITUTE | \`SUBSTITUTE(text, old, new, [instance])\` | All occurrences unless instance given |
+| REPT | \`REPT(text, times)\` | times > 10000 errors |
+| FIND | \`FIND(needle, haystack, [start])\` | Case-sensitive; 1-indexed; **errors** on a miss (wrap in IFERROR) |
+| SEARCH | \`SEARCH(needle, haystack, [start])\` | Case-insensitive FIND |
 
 **Date**
 
 | Function | Signature | Notes |
 |---|---|---|
-| TODAY | \`TODAY()\` | Returns the string "YYYY-MM-DD" |
-| NOW | \`NOW()\` | Returns an ISO-8601 timestamp string |
-| YEAR | \`YEAR(dateText)\` | Parses a date string; errors on invalid dates |
+| TODAY | \`TODAY()\` | The string "YYYY-MM-DD" |
+| NOW | \`NOW()\` | ISO-8601 timestamp string |
+| YEAR | \`YEAR(dateText)\` | Errors on invalid dates |
 | MONTH | \`MONTH(dateText)\` | 1-12 |
 | DAY | \`DAY(dateText)\` | |
 
-Dates are plain strings — there are no date serial numbers and no date arithmetic (no DATE, DATEDIF, EDATE, or subtracting dates). Caveat: YEAR/MONTH/DAY parse a bare "YYYY-MM-DD" as UTC midnight but extract with local time, so in negative-UTC-offset environments the result can be off by one day/month near boundaries — don't rely on them for exact date boundaries.
+Dates are plain strings — no serial numbers and no date arithmetic (no DATE, DATEDIF, EDATE, or subtracting dates). Caveat: YEAR/MONTH/DAY parse "YYYY-MM-DD" as UTC midnight but extract in local time, so the result can be off by one near day/month boundaries.
 
 ### Error values
 
-Every failed cell **displays** \`#ERROR\` — there are no Excel-style \`#DIV/0!\`, \`#N/A\`, \`#REF!\`, or \`#VALUE!\` displays, and circular references also render as \`#ERROR\` in the grid. The distinction lives in the stored data: read the page and each errored cell carries \`error = { type = "EVAL_ERROR" | "CIRCULAR_REF", message = "..." }\` with the exact failure message (for a cycle, the details list the cell and its direct precedents). Causes include: unsupported function, non-numeric operand, division by zero, FIND miss, invalid date, unavailable cross-page reference, circular reference.
+Every failed cell **displays** \`#ERROR\` — no Excel-style \`#DIV/0!\`, \`#N/A\`, \`#REF!\` or \`#VALUE!\`, and circular references render the same. The detail is in the read: each errored cell carries \`error = { type = "EVAL_ERROR" | "CIRCULAR_REF", message = "..." }\`. Causes: unsupported function, non-numeric operand, division by zero, FIND miss, invalid date, unavailable cross-page reference, cycle.
 
-An errored cell's value is empty, so any formula referencing it errors too — errors propagate through dependents. Fix the offending cell with \`edit_sheet_cells\` (usually: replace an unsupported function, quote text properly, or break the cycle). \`IFERROR(expr, fallback)\` is the only in-formula way to absorb an expected error (remember IF does not short-circuit). One edge: a non-finite result (e.g. \`=2^2000\`) displays \`#ERROR\` but stores no \`error\` object and serializes its value as 0.
+An errored cell's value is empty, so formulas referencing it error too. Fix the offending cell with \`edit_sheet_cells\` (replace the function, quote text, or break the cycle). \`IFERROR(expr, fallback)\` is the only in-formula way to absorb an expected error. Edge: a non-finite result (\`=2^2000\`) displays \`#ERROR\` but stores no \`error\` and serializes as 0.
 
 ## Cross-sheet references
 
@@ -132,7 +132,7 @@ Reference cells in *another SHEET page* with an \`@[...]\` mention inside a form
 
 Resolution: the identifier is tried first (must be a SHEET page); otherwise the label is matched case-insensitively against sheet page titles in the drive tree. Duplicate titles are ranked (siblings of the current sheet first, then most shared ancestry, then shallowest, then position) — so **include the page ID whenever you know it**. The label must be non-empty and the target must be a SHEET page.
 
-Important: cross-page references only resolve in the live sheet view. The evaluation that runs when \`edit_sheet_cells\` saves has no page resolver, so immediately after writing a cross-sheet formula a read shows that cell as \`#ERROR\`, with "Cross-page references are not supported in this context" under the cell's A1 address in \`errors\` (\`read_page\`) or in that row's \`errors\` (\`read_sheet\`). The formula itself is stored correctly and evaluates for users viewing the sheet — do not "fix" this error by removing the reference.
+Important: cross-page references only resolve in the live sheet view. The save-time evaluation has no page resolver, so right after writing one a read shows \`#ERROR\` with "Cross-page references are not supported in this context" in \`errors\`. The formula is stored correctly and evaluates for users viewing the sheet — do not "fix" it by removing the reference.
 
 ## Reading a sheet
 
@@ -140,30 +140,30 @@ Sheets are stored as rows in the database, not as text, and they are read as row
 
 **\`read_sheet\`** — the tool to reach for on any sheet with real data in it. One call does a row range, a lookup by column value, or a column projection:
 
-- \`pageId\` (optional) — defaults to the sheet currently in view. \`tabIndex\` (optional) picks a tab; the response lists them all.
+- \`pageId\` (optional) — defaults to the sheet currently in view.
 - **Range:** \`startRow\` (1-based, the number shown in front of each row and the row in its A1 addresses) + \`limit\`. Page on with the \`nextStartRow\` the response returns.
 - **Lookup:** \`where: { match: "all" | "any", conditions: [{ column, op, value }] }\`. Ops: \`eq neq gt gte lt lte contains startsWith endsWith isEmpty isNotEmpty in\`. So "the row where column C is 28605" is \`where: { conditions: [{ column: "C", op: "eq", value: "28605" }] }\` — never read the sheet and filter it yourself while filtering is available (the one exception is an unmigrated sheet, below).
 - **Projection:** \`select: ["A", "C", "D"]\` returns only those columns, on range reads and filtered reads alike — use it on any wide sheet you only need a few columns of. \`orderBy: [{ column, direction, numeric }]\` sorts (set \`numeric\` or "10" sorts before "9"). \`offset\` pages through matches.
 - **Tabs:** \`tabIndex\` picks a tab, and every response lists the tabs the sheet has. A tab index that does not exist is refused, never answered with tab 0's rows.
 - Filters and sorts run in the database against each cell's **computed, unformatted** value, so a formula column matches on its result. \`cells\` gives you the DISPLAY text, so a cell shown as \`$1,200.00\` is matched by \`1200\` and \`85%\` by \`0.85\` — never build a filter by parsing the displayed string; take the number from \`unformatted\` (below).
-- \`includeFormatting: true\` adds a \`formatting\` block: the tab's \`regions\` (its declared structure — which table is where, which rows are headers or totals, what each column means — and re-writable exactly as you read them), \`layout\` (freezes, widths, heights), \`columnFormats\`, the explicit \`cellFormats\` within the rows returned, and each conditional rule as \`{ id, kind, ranges, summary }\`. Ask for it before you restyle a sheet, so you build on the structure that is there. \`regions\` is the part you can hand straight back when you change something; the rule entries are a DESCRIPTION, not a rule you can write — the \`summary\` is one line of prose, so to change a rule you rebuild it from scratch against its \`id\`. \`cellFormats\` is capped and reports \`formattingTruncated\` when it drops cells — a missing cell there is not proof it has no format. It works on unmigrated sheets too — their styling is read back out of the stored document, so you never have to guess whether a legacy sheet is already designed.
+- \`includeFormatting: true\` adds a \`formatting\` block: the tab's \`regions\` (its declared structure, re-writable exactly as read), \`layout\` (freezes, widths, heights), \`columnFormats\`, the explicit \`cellFormats\` within the rows returned, and each conditional rule as \`{ id, kind, ranges, summary }\`. Ask for it before you restyle a sheet. \`regions\` can be handed straight back to \`format_sheet\`; a rule entry is a DESCRIPTION, not a rule you can write — to change one, rebuild it and remove the old \`id\`. \`cellFormats\` is capped and reports \`formattingTruncated\` when it drops cells. Works on unmigrated sheets too.
 - \`startRow\` and \`where\`/\`orderBy\`/\`offset\` are different coordinate systems and cannot be combined — the call is rejected rather than quietly ignoring one.
 - Returns at most 500 rows per call, with \`dimensions\`, \`hasMore\`, and each row as \`{ rowNumber, cells, formulas?, errors?, unformatted? }\` plus a rendered \`table\`. \`cells\` holds display values keyed by column letter; \`formulas\` holds the authored formula for the cells that have one.
 
-**\`read_page\`** on a SHEET gives the sheet's dimensions, its tabs, and its first 25 rows as a table — an orientation read, not a data read. \`lineStart\`/\`lineEnd\` select **row numbers** there rather than lines of text. It is enough to confirm a small write or see a sheet's shape; for anything larger, or any question about specific rows, use \`read_sheet\`.
+**\`read_page\`** on a SHEET gives dimensions, tabs, and the first 25 rows as a table — an orientation read. \`lineStart\`/\`lineEnd\` select **row numbers** there. Enough to confirm a small write; for anything larger use \`read_sheet\`.
 
 Reading either way:
 
 - Only non-empty cells appear. A row's \`rowNumber\` is its A1 row, so a row read at 417 is written with \`C417\`.
 - Formula cells report both the computed value (in \`cells\`) and the formula (in \`formulas\`) — you never need to re-derive results, and you never lose the formula.
-- Formatted cells report both the display text and the number underneath, so a read is never one-way. \`read_sheet\` puts the machine value on the row as \`unformatted\` (keyed by column letter, e.g. \`unformatted: { "C": 1200 }\` beside \`cells: { "C": "$1,200.00" }\`); \`read_page\` flattens it to \`unformatted\` keyed by A1 address, the same way it flattens \`formulas\` and \`errors\`. Only cells whose display differs from their value appear — a column absent from it means \`cells\` already holds the value, unless the cell also appears in \`formulas\` and was never computed, in which case \`cells\` holds the formula text. Always filter, compute and write back from that number, never from the rendered string.
+- Formatted cells report both the display text and the number underneath. \`read_sheet\` puts the machine value on the row as \`unformatted\` (keyed by column letter: \`unformatted: { "C": 1200 }\` beside \`cells: { "C": "$1,200.00" }\`); \`read_page\` keys it by A1 address, like \`formulas\` and \`errors\`. Only cells whose display differs from their value appear. Always filter, compute and write back from that number, never from the rendered string.
 - Errored cells show \`#ERROR\` as their value and carry the message in \`errors\`, keyed by A1 address in \`read_page\` and by column letter within the row in \`read_sheet\`.
 - Everything except the raw inputs (formula text and literal values) is **derived and regenerated on every save**. Never try to write values, types, errors or dependencies yourself; \`edit_sheet_cells\` recomputes them.
 - Cell values are truncated at 120 characters in the rendered \`table\` only, and the response says how many were cut (\`tableTruncatedCells\`); the structured \`rows\` always carry the full text. Never write a value back that you read from the table if that count is non-zero.
 - A sheet whose stored document cannot be parsed is reported as **unreadable**, not as empty. If you see that, do NOT write to the sheet — its data may still be intact, and writing would replace it.
 - Two refusals you may hit on older sheets, both meaning "do not write here":
   - *"Page holds text, not a spreadsheet"* — the page is a SHEET but its content is plain text or HTML. Read it with \`read_page\`. Writing cells would replace that text.
-  - *"Sheet not migrated to row storage"* — only from a FILTERED \`read_sheet\`. Filtering runs in the database and this sheet's rows are not there yet; reading is never allowed to write, so the tool will not migrate it for you. Read it positionally instead (\`startRow\`/\`limit\`, which works regardless and returns the same rows) and filter those returned rows yourself — this is the one case where local filtering is correct, because the database cannot do it. Page with \`nextStartRow\` until \`hasMore\` is false, and use \`select\` to keep each page small. Do NOT edit a cell to make filtering available: that is a write performed to enable a read, and on a read-only request it changes the user's sheet for no reason they asked for. The sheet migrates on its own the next time someone genuinely edits it.
+  - *"Sheet not migrated to row storage"* — only from a FILTERED \`read_sheet\`. Filtering runs in the database and this sheet's rows are not there yet; reading never writes, so the tool will not migrate it for you. Read it positionally instead (\`startRow\`/\`limit\`) and filter the returned rows yourself — the one case where local filtering is correct. Page with \`nextStartRow\` until \`hasMore\` is false, using \`select\` to keep pages small. Do NOT edit a cell to make filtering available: that changes the user's sheet to serve a read. It migrates on its own the next time someone genuinely edits it.
 
 ## Structuring a new sheet
 
@@ -171,9 +171,38 @@ Reading either way:
 - One record per row, one field per column; keep a column consistently numeric or consistently text.
 - Put totals/aggregates in a clearly labeled row below the data (e.g. \`A11\` = "Total", \`B11\` = \`=SUM(B2:B10)\`) or a summary block to the right — and leave a blank row so the data range can grow.
 - Since blank cells coerce to 0, make aggregate ranges slightly generous (\`=SUM(B2:B20)\` over 10 data rows is safe for SUM/AVERAGE).
-- Store numbers as bare numbers (\`1200\`, not \`"$1,200"\` — currency symbols and thousands separators make the value text and break math). Put units in the header.
+- Store numbers as bare numbers (\`1200\`, not \`"$1,200"\` — currency symbols and thousands separators make the value text and break math) — set the display format instead, with a region column role.
 - Store dates as \`YYYY-MM-DD\` strings so YEAR/MONTH/DAY can parse them.
-- Send the whole initial population — headers, data, formulas — as one \`edit_sheet_cells\` batch.
+- Send the whole initial population — headers, data, formulas — as one \`edit_sheet_cells\` batch, then one \`format_sheet\` call declaring the table.
+
+## Formatting: describe the table, don't paint it
+
+\`format_sheet\` takes \`regions\` first. A region declares what an area IS — its range, which rows are headers, what each column means, which rows are totals, an accent hue — and the header band, number formats, total emphasis and palette are DERIVED at render time; you never pick a colour. A budget table, declared in one call:
+
+\`\`\`
+format_sheet({ regions: [{ name: "Budget", range: "A1:D", headerRows: 1,
+  columns: [{ column: "C", role: "currency", currency: "USD" }, { column: "D", role: "percent" }],
+  totalRows: [40], theme: "blue", freezeHeader: true }] })
+\`\`\`
+
+- Column roles: \`text number currency percent date datetime id\`; \`currency\` and \`decimals\` refine one. A range with no end row (\`"A1:D"\`) runs to the bottom of the sheet. Themes are named hues (\`slate blue cyan teal green amber orange red pink purple violet indigo\`).
+- **Ops applied to a range do NOT cover rows added later; regions do.** That is the difference that matters.
+- A region costs nothing per row. \`A2:A5000\` as ops costs 4,999 against the cell budget (100 ops, 20,000 cells per range op, 50,000 per call); a \`columnFormat\` op for a whole column is free too.
+- \`ops\` is the escape hatch for what a region cannot say: \`setFormat\` (range + format) for one emphasised cell, \`clearFormat\`, \`columnFormat\`, \`columnWidth\`, \`rowHeight\`, \`freeze\`. A \`format\` is \`{ number: { kind, decimals, currency }, bold, italic, align, wrap, color, background, … }\`.
+- Precedence: column default < region < the cell's own format < conditional rule.
+- \`regionMode: "merge"\` (default) upserts by \`id\` — pass back the id from \`read_sheet\` to restyle an existing table; \`"replaceAll"\` keeps only the regions in the call.
+- All-or-nothing: one bad op refuses the whole call and nothing is applied. Verify with \`read_sheet\` and \`includeFormatting: true\`.
+
+### Conditional formatting
+
+\`set_conditional_format\` rules recolour cells by what they hold and stay correct when the numbers change. Four \`kind\`s, each over \`ranges\`:
+
+- \`cell\` — \`operator\` (\`greaterThan lessThan between equal contains isEmpty isError\` …) + \`value\` (\`value2\` for between) + \`format\`. Values compare against the **computed, unformatted** value: \`"1200"\`, never \`"$1,200.00"\`.
+- \`formula\` — \`formula\` anchored at the range's top-left, e.g. \`"=C2>AVERAGE(C2:C40)"\`, + \`format\`.
+- \`colorScale\` — \`min\`/\`mid\`/\`max\` anchors \`{ type: min|max|number|percent|percentile, value, color }\`.
+- \`dataBar\` — an in-cell bar; optional \`color\`.
+
+\`mode: "append"\` (default) adds; \`removeRuleIds\` drops rules by id. \`mode: "replaceAll"\` keeps only the rules in the call — read the sheet with \`includeFormatting: true\` first, or you discard rules you never saw.
 
 ## Common pitfalls
 
@@ -183,8 +212,10 @@ Reading either way:
 4. **Leading \`=\` on literal text.** Any value starting with \`=\` becomes a formula; there is no apostrophe-escape. Don't start plain-text values with \`=\`.
 5. **Text in numeric ranges.** One non-numeric string inside \`SUM\`'s range errors the whole formula (AVERAGE skips it instead). Keep data columns clean; don't mix "N/A" into number columns — leave the cell empty.
 6. **FIND/SEARCH on a miss is an error**, not -1 or blank. Wrap in \`IFERROR\` if absence is expected.
-7. **Formatted numbers.** \`"$1,200"\` or \`"85%"\` are text. Enter \`1200\` and \`0.85\`.
+7. **Formatted numbers.** \`"$1,200"\` or \`"85%"\` are text. Enter \`1200\` and \`0.85\`, THEN make them *display* as currency or percent with a \`format_sheet\` column role. Formatting changes display only, so \`SUM\` still works and a \`read_sheet\` \`where\` still matches \`"1200"\`.
 8. **Cross-sheet error right after writing** ("Cross-page references are not supported in this context") is expected on save — see Cross-sheet references above.
-9. **Editing the sheet as text.** Never write SheetDoc TOML via any text tool — hand-built TOML that parses incorrectly resets the sheet to empty. All writes go through \`edit_sheet_cells\`.
+9. **Editing the sheet as text.** Never write SheetDoc TOML via any text tool — hand-built TOML that parses incorrectly resets the sheet to empty. All writes go through the sheet tools.
 10. **Reading a sheet to search it.** Paging a whole sheet through \`read_page\` to find one row wastes the context the sheet was supposed to save you. Ask \`read_sheet\` with a \`where\` instead.
+11. **Colouring cells instead of writing a rule.** Forty cells hand-filled green go stale the moment a number changes; a \`set_conditional_format\` rule follows the values.
+12. **Formatting a table cell-by-cell instead of declaring a region.** Range ops cover only the cells that existed when applied; a region covers the rows added next week.
 `;

--- a/apps/web/src/lib/ai/skills/bodies/spreadsheets.ts
+++ b/apps/web/src/lib/ai/skills/bodies/spreadsheets.ts
@@ -190,7 +190,7 @@ format_sheet({ regions: [{ name: "Budget", range: "A1:D", headerRows: 1,
 - A region costs nothing per row. \`A2:A5000\` as ops costs 4,999 against the cell budget (100 ops, 20,000 cells per range op, 50,000 per call); a \`columnFormat\` op for a whole column is free too.
 - \`ops\` is the escape hatch for what a region cannot say: \`setFormat\` (range + format) for one emphasised cell, \`clearFormat\`, \`columnFormat\`, \`columnWidth\`, \`rowHeight\`, \`freeze\`. A \`format\` is \`{ number: { kind, decimals, currency }, bold, italic, align, wrap, color, background, … }\`.
 - Precedence: column default < region < the cell's own format < conditional rule.
-- \`regionMode: "merge"\` (default) upserts by \`id\` — pass back the id from \`read_sheet\` to restyle an existing table; \`"replaceAll"\` keeps only the regions in the call.
+- \`regionMode: "merge"\` (default) upserts by \`id\` — pass back the id from \`read_sheet\` to restyle an existing table; \`"replaceAll"\` keeps only the regions in the call (an empty list clears them all).
 - All-or-nothing: one bad op refuses the whole call and nothing is applied. Verify with \`read_sheet\` and \`includeFormatting: true\`.
 
 ### Conditional formatting

--- a/apps/web/src/lib/ai/tools/__tests__/sheet-format-tools.test.ts
+++ b/apps/web/src/lib/ai/tools/__tests__/sheet-format-tools.test.ts
@@ -622,16 +622,21 @@ describe('set_conditional_format', () => {
     assert({ given: 'the tab after', should: 'hold only the other writer’s rule', actual: state.conditionalFormats.length, expected: 1 });
   });
 
-  it('removeRuleIds naming an absent id lists the ids that exist', async () => {
+  it('removeRuleIds naming an absent id is treated as already removed, and the warning lists the ids that exist', async () => {
+    // Not a refusal: a retried call whose removal already landed reads a tab
+    // where the id is gone, and must not report failure for a request that
+    // succeeded. The warning still tells a caller who got the id wrong.
     state.conditionalFormats = [
       { id: 'rule-a', kind: 'dataBar', ranges: ['A1'], color: '#3b82f6' },
       { id: 'rule-b', kind: 'dataBar', ranges: ['A2'], color: '#3b82f6' },
     ];
-    const result = await conditional({ removeRuleIds: ['rule-zzz'] });
-    assert({ given: 'an unknown id', should: 'refuse', actual: result.success, expected: false });
-    expect(message(result)).toContain('removeRuleIds[0]');
-    expect(message(result)).toContain('"rule-a"');
-    expect(message(result)).toContain('"rule-b"');
+    const result = (await conditional({ removeRuleIds: ['rule-zzz'] })) as { success: boolean; removed?: number; warnings?: string[] };
+    assert({ given: 'an unknown id', should: 'succeed with nothing removed', actual: [result.success, result.removed], expected: [true, 0] });
+    const warning = result.warnings?.join(' ') ?? '';
+    expect(warning).toContain('removeRuleIds[0]');
+    expect(warning).toContain('already removed');
+    expect(warning).toContain('"rule-a"');
+    expect(warning).toContain('"rule-b"');
     expect(mockApplyFormatOps).not.toHaveBeenCalled();
   });
 
@@ -761,6 +766,23 @@ describe('set_conditional_format', () => {
     assert({ given: 'the tab after', should: 'hold them in the NEW order and nothing else', actual: state.conditionalFormats.map((rule) => rule.id), expected: [first.ruleIds![1], first.ruleIds![0]] });
     assert({ given: 'the concurrent rule', should: 'be counted as removed', actual: reordered.removed, expected: 1 });
     expect(vi.mocked(logSheetCellActivity)).toHaveBeenCalled();
+  });
+
+  it('replaying an append that removed and added is a satisfied retry, not a refusal', async () => {
+    // The first attempt commits (rule "old" removed, rule X added) but its
+    // response is lost. The identical retry must succeed: the removal is
+    // reported as already done and the addition as already present.
+    state.conditionalFormats = [{ id: 'old', kind: 'dataBar', ranges: ['Z1:Z9'], color: '#000000' }];
+    const x = { kind: 'dataBar' as const, ranges: ['A1:A9'], color: '#3b82f6' };
+    const first = (await conditional({ rules: [x], removeRuleIds: ['old'] })) as { ruleIds?: string[]; added?: number; removed?: number };
+    assert({ given: 'the first attempt', should: 'add one and remove one', actual: [first.added, first.removed], expected: [1, 1] });
+
+    const retry = (await conditional({ rules: [x], removeRuleIds: ['old'] })) as { success: boolean; ruleIds?: string[]; added?: number; removed?: number; warnings?: string[] };
+    assert({ given: 'the identical retry', should: 'succeed', actual: retry.success, expected: true });
+    assert({ given: 'the identical retry', should: 'add and remove nothing', actual: [retry.added, retry.removed], expected: [0, 0] });
+    assert({ given: 'the identical retry', should: 'return the id the first attempt minted', actual: retry.ruleIds, expected: first.ruleIds });
+    expect(retry.warnings?.join(' ')).toContain('treated as already removed');
+    assert({ given: 'the tab after', should: 'hold exactly X', actual: state.conditionalFormats.map((rule) => rule.id), expected: first.ruleIds });
   });
 
   it('replaceAll refuses the same rule twice in one call', async () => {

--- a/apps/web/src/lib/ai/tools/__tests__/sheet-format-tools.test.ts
+++ b/apps/web/src/lib/ai/tools/__tests__/sheet-format-tools.test.ts
@@ -628,6 +628,18 @@ describe('set_conditional_format', () => {
     expect(mockApplyFormatOps).not.toHaveBeenCalled();
   });
 
+  it('format_sheet: replaceAll with an empty region list clears every region', async () => {
+    // Mirrors the rule case below. The nothing-given guard used to fire
+    // first, so the documented "keep only these" could not express "none".
+    state.regions = [{ id: 'orders', range: 'A1:D', headerRows: 1 } as SheetRegion];
+    const result = await format({ regionMode: 'replaceAll', regions: [] });
+    assert({ given: 'replaceAll with nothing', should: 'accept', actual: result.success, expected: true });
+    assert({ given: 'the tab after', should: 'hold no regions', actual: state.regions.length, expected: 0 });
+    expect(message(result)).toContain('every other region on the tab removed');
+    const bare = await format({});
+    assert({ given: 'no regions, no ops, no mode', should: 'still refuse', actual: bare.success, expected: false });
+  });
+
   it('replaceAll with an empty list clears every rule', async () => {
     state.conditionalFormats = [{ id: 'rule-a', kind: 'dataBar', ranges: ['A1'], color: '#3b82f6' }];
     const result = await conditional({ mode: 'replaceAll', rules: [] });

--- a/apps/web/src/lib/ai/tools/__tests__/sheet-format-tools.test.ts
+++ b/apps/web/src/lib/ai/tools/__tests__/sheet-format-tools.test.ts
@@ -61,6 +61,9 @@ let applied: SheetFormatOp[][] = [];
 const mockApplyFormatOps = vi.fn(async (_ref: unknown, ops: readonly SheetFormatOp[]) => {
   const plan = planFormatOps(ops, state);
   applied.push([...ops]);
+  // Mirrors the store: a tab field counts as changed only when the value it
+  // would store differs from what it holds, compared as JSON.
+  const tabBefore = JSON.stringify([state.conditionalFormats, state.regions, state.frozenRows, state.frozenColumns]);
   state = { ...state, conditionalFormats: [...plan.conditionalFormats], regions: [...plan.regions] };
   for (const step of plan.steps) {
     if (step.type === 'setFrozen') {
@@ -68,10 +71,12 @@ const mockApplyFormatOps = vi.fn(async (_ref: unknown, ops: readonly SheetFormat
       state.frozenColumns = step.columns ?? null;
     }
   }
+  const tabChanged =
+    JSON.stringify([state.conditionalFormats, state.regions, state.frozenRows, state.frozenColumns]) !== tabBefore;
   return {
     cellsFormatted: plan.rows.size,
     rowsTouched: plan.rows.size,
-    tabFieldsChanged: plan.touchesTabFields ? ['tab'] : [],
+    tabFieldsChanged: tabChanged ? ['tab'] : [],
     conditionalRules: plan.conditionalFormats.length,
     regions: plan.regions.length,
     rowCount: state.rowCount,
@@ -714,25 +719,71 @@ describe('set_conditional_format', () => {
     assert({ given: 'no regions, no ops, no mode', should: 'still refuse', actual: bare.success, expected: false });
   });
 
-  it('a retried replaceAll plans nothing and keeps the ids the first attempt returned', async () => {
+  it('a retried replaceAll writes nothing, fires nothing, and keeps the ids the first attempt returned', async () => {
     const rules = [
       { kind: 'dataBar' as const, ranges: ['A1:A9'], color: '#3b82f6' },
       { kind: 'cell' as const, ranges: ['B1:B9'], operator: 'greaterThan' as const, value: 5, format: { bold: true } },
     ];
     const first = (await conditional({ mode: 'replaceAll', rules })) as { ruleIds?: string[]; added?: number };
     assert({ given: 'the first replaceAll', should: 'add both', actual: first.added, expected: 2 });
-    const calls = mockApplyFormatOps.mock.calls.length;
+    vi.mocked(logSheetCellActivity).mockClear();
+    vi.mocked(broadcastPageEvent).mockClear();
 
+    // The list is sent again — it must be, so a rule another writer added in
+    // between is removed under the lock — but it equals what the tab holds,
+    // so the store reports no change and nothing downstream fires.
     const retry = (await conditional({ mode: 'replaceAll', rules })) as { ruleIds?: string[]; added?: number; removed?: number };
     assert({ given: 'the identical replaceAll again', should: 'add nothing', actual: retry.added, expected: 0 });
     assert({ given: 'the identical replaceAll again', should: 'remove nothing', actual: retry.removed, expected: 0 });
     assert({ given: 'the retry', should: 'return the same ids', actual: retry.ruleIds, expected: first.ruleIds });
-    assert({ given: 'the retry', should: 'reach the store zero times', actual: mockApplyFormatOps.mock.calls.length, expected: calls });
+    expect(message(retry)).toContain('nothing changed');
+    expect(vi.mocked(logSheetCellActivity)).not.toHaveBeenCalled();
+    expect(vi.mocked(broadcastPageEvent)).not.toHaveBeenCalled();
 
     const changed = (await conditional({ mode: 'replaceAll', rules: [rules[0]] })) as { ruleIds?: string[]; added?: number; removed?: number };
     assert({ given: 'a replaceAll that drops one rule', should: 'remove exactly that one', actual: changed.removed, expected: 1 });
     assert({ given: 'a replaceAll that drops one rule', should: 'keep the other rule under its id', actual: changed.ruleIds, expected: [first.ruleIds![0]] });
     assert({ given: 'the tab after', should: 'hold one rule', actual: state.conditionalFormats.map((rule) => rule.id), expected: [first.ruleIds![0]] });
+  });
+
+  it('replaceAll in a different order is a real change, and removes a rule added concurrently', async () => {
+    const a = { kind: 'dataBar' as const, ranges: ['A1:A9'], color: '#3b82f6' };
+    const b = { kind: 'cell' as const, ranges: ['B1:B9'], operator: 'greaterThan' as const, value: 5, format: { bold: true } };
+    const first = (await conditional({ mode: 'replaceAll', rules: [a, b] })) as { ruleIds?: string[] };
+    // Another writer lands a rule after this call's read and before its write:
+    // it is on the tab the store sees, so the whole-list op removes it.
+    state.conditionalFormats = [
+      ...state.conditionalFormats,
+      { id: 'concurrent', kind: 'dataBar', ranges: ['Z1:Z9'], color: '#000000' },
+    ];
+    const reordered = (await conditional({ mode: 'replaceAll', rules: [b, a] })) as { ruleIds?: string[]; added?: number; removed?: number };
+    assert({ given: 'the same two rules reversed', should: 'keep both ids, reversed', actual: reordered.ruleIds, expected: [first.ruleIds![1], first.ruleIds![0]] });
+    assert({ given: 'the tab after', should: 'hold them in the NEW order and nothing else', actual: state.conditionalFormats.map((rule) => rule.id), expected: [first.ruleIds![1], first.ruleIds![0]] });
+    assert({ given: 'the concurrent rule', should: 'be counted as removed', actual: reordered.removed, expected: 1 });
+    expect(vi.mocked(logSheetCellActivity)).toHaveBeenCalled();
+  });
+
+  it('replaceAll refuses the same rule twice in one call', async () => {
+    const a = { kind: 'dataBar' as const, ranges: ['A1:A9'], color: '#3b82f6' };
+    const result = await conditional({ mode: 'replaceAll', rules: [a, { ...a }] });
+    assert({ given: 'a duplicated rule', should: 'refuse', actual: result.success, expected: false });
+    expect(message(result)).toContain('rules[1] is identical to rules[0]');
+  });
+
+  it('a same-call duplicate region is refused however the ids were supplied', async () => {
+    // Explicit id + none, none + explicit id, and two different explicit ids:
+    // every pairing is an overlapping twin that costs two region slots.
+    const region = { range: 'A1:D', headerRows: 1, name: 'Orders' };
+    for (const pair of [
+      [{ ...region, id: 'one' }, { ...region }],
+      [{ ...region }, { ...region, id: 'two' }],
+      [{ ...region, id: 'one' }, { ...region, id: 'two' }],
+    ]) {
+      const result = await format({ regions: pair });
+      assert({ given: `ids ${pair.map((r) => ('id' in r ? r.id : 'none')).join('+')}`, should: 'refuse', actual: result.success, expected: false });
+      expect(message(result)).toContain('regions[1] declares the same region as regions[0]');
+    }
+    expect(mockApplyFormatOps).not.toHaveBeenCalled();
   });
 
   it('a rule declared without an id gets the same content-derived id on every execution', async () => {

--- a/apps/web/src/lib/ai/tools/__tests__/sheet-format-tools.test.ts
+++ b/apps/web/src/lib/ai/tools/__tests__/sheet-format-tools.test.ts
@@ -324,17 +324,19 @@ describe('format_sheet refuses an op that is wrong across its fields, before any
     state.frozenColumns = 2;
     const result = await format({ ops: [{ op: 'freeze', frozenRows: 1 }] });
     assert({ given: 'frozenRows only', should: 'accept', actual: result.success, expected: true });
+    // Only the axis named goes to the store; it keeps the other one as it
+    // finds it under its lock (see the lock-race case below).
     assert({
       given: 'a tab with two frozen columns',
-      should: 'freeze one row and keep the two columns',
-      actual: applied[0][0],
-      expected: { type: 'setFrozen', rows: 1, columns: 2 },
+      should: 'send the row and leave the columns to the store',
+      actual: [applied[0][0], state.frozenRows, state.frozenColumns],
+      expected: [{ type: 'setFrozen', rows: 1 }, 1, 2],
     });
   });
 
-  // Kills: resolving an omitted axis from the tab snapshot instead of the
-  // running state — the second op would then emit {rows: null, columns: 1}
-  // and unfreeze the row the first op had just frozen.
+  // Kills: the store resolving an omitted axis from the tab instead of its
+  // running plan — the second op would then unfreeze the row the first had
+  // just frozen.
   it('two freeze ops naming one axis each compose, the second keeping the first', async () => {
     const result = await format({
       ops: [
@@ -345,12 +347,9 @@ describe('format_sheet refuses an op that is wrong across its fields, before any
     assert({ given: 'freeze rows then freeze columns', should: 'accept', actual: result.success, expected: true });
     assert({
       given: 'a tab with nothing frozen',
-      should: 'freeze one row and, in the second op, keep it while freezing one column',
-      actual: applied[0],
-      expected: [
-        { type: 'setFrozen', rows: 1, columns: null },
-        { type: 'setFrozen', rows: 1, columns: 1 },
-      ],
+      should: 'send each axis on its own and end with both frozen',
+      actual: [applied[0], state.frozenRows, state.frozenColumns],
+      expected: [[{ type: 'setFrozen', rows: 1 }, { type: 'setFrozen', columns: 1 }], 1, 1],
     });
   });
 
@@ -367,11 +366,8 @@ describe('format_sheet refuses an op that is wrong across its fields, before any
     assert({
       given: 'two header rows pinned by the region',
       should: 'keep those two rows when the op names only columns',
-      actual: ops.filter((op) => op.type === 'setFrozen'),
-      expected: [
-        { type: 'setFrozen', rows: 2, columns: null },
-        { type: 'setFrozen', rows: 2, columns: 1 },
-      ],
+      actual: [ops.filter((op) => op.type === 'setFrozen'), state.frozenRows, state.frozenColumns],
+      expected: [[{ type: 'setFrozen', rows: 2 }, { type: 'setFrozen', columns: 1 }], 2, 1],
     });
   });
 
@@ -391,11 +387,11 @@ describe('format_sheet refuses an op that is wrong across its fields, before any
     assert({
       given: 'a tab with three rows and two columns frozen',
       should: 'clear both, then freeze one column with no rows',
-      actual: applied[0],
-      expected: [
+      actual: [applied[0], state.frozenRows, state.frozenColumns],
+      expected: [[
         { type: 'setFrozen', rows: null, columns: null },
-        { type: 'setFrozen', rows: null, columns: 1 },
-      ],
+        { type: 'setFrozen', columns: 1 },
+      ], null, 1],
     });
   });
 
@@ -417,7 +413,7 @@ describe('format_sheet refuses an op that is wrong across its fields, before any
     const ops = applied[0];
     expect(ops[0].type).toBe('upsertRegion');
     expect((ops[0] as { region: SheetRegion }).region).not.toHaveProperty('freezeHeader');
-    assert({ given: 'two header rows', should: 'freeze two rows', actual: ops[1], expected: { type: 'setFrozen', rows: 2, columns: null } });
+    assert({ given: 'two header rows', should: 'freeze two rows', actual: ops[1], expected: { type: 'setFrozen', rows: 2 } });
   });
 
   it('freezeHeader on a region that does not start at row 1 is refused', async () => {
@@ -821,6 +817,29 @@ describe('set_conditional_format', () => {
     assert({ given: 'the overlapping retry', should: 'report the landed id', actual: retry.ruleIds, expected: ['rule-first'] });
     assert({ given: 'the overlapping retry', should: 'add and remove nothing itself', actual: [retry.added, retry.removed], expected: [0, 0] });
     assert({ given: 'the tab after', should: 'hold exactly what the first execution landed', actual: state.conditionalFormats.map((rule) => rule.id), expected: ['rule-first'] });
+  });
+
+  it('a one-axis freeze keeps the other axis as the store finds it under the lock, not as the snapshot had it', async () => {
+    // The tool read frozenColumns 2; another writer sets 3 before the store
+    // takes its lock. Freezing one row must leave 3, not write back 2.
+    state.frozenColumns = 2;
+    const real = mockApplyFormatOps.getMockImplementation()!;
+    mockApplyFormatOps.mockImplementationOnce(async (ref, ops) => {
+      state.frozenColumns = 3;
+      return real(ref, ops);
+    });
+    const result = await format({ ops: [{ op: 'freeze', frozenRows: 1 }] });
+    assert({ given: 'a rows-only freeze', should: 'succeed', actual: result.success, expected: true });
+    assert({ given: 'the tab after', should: 'keep the columns the store found', actual: [state.frozenRows, state.frozenColumns], expected: [1, 3] });
+    assert({ given: 'the op sent', should: 'name only rows', actual: applied.at(-1), expected: [{ type: 'setFrozen', rows: 1 }] });
+  });
+
+  it('two one-axis freezes in one call, and a freezeHeader followed by a columns freeze, compose', async () => {
+    const both = await format({ ops: [{ op: 'freeze', frozenRows: 1 }, { op: 'freeze', frozenColumns: 1 }] });
+    assert({ given: 'rows then columns', should: 'pin both', actual: [both.success, state.frozenRows, state.frozenColumns], expected: [true, 1, 1] });
+    state = freshTab();
+    const region = await format({ regions: [{ range: 'A1:F', headerRows: 2, freezeHeader: true }], ops: [{ op: 'freeze', frozenColumns: 1 }] });
+    assert({ given: 'freezeHeader then a columns freeze', should: 'keep the header rows the region pinned', actual: [region.success, state.frozenRows, state.frozenColumns], expected: [true, 2, 1] });
   });
 
   it('the formula examples the model sees use bounded ranges', () => {

--- a/apps/web/src/lib/ai/tools/__tests__/sheet-format-tools.test.ts
+++ b/apps/web/src/lib/ai/tools/__tests__/sheet-format-tools.test.ts
@@ -64,7 +64,9 @@ const mockApplyFormatOps = vi.fn(async (_ref: unknown, ops: readonly SheetFormat
   // Mirrors the store: a tab field counts as changed only when the value it
   // would store differs from what it holds, compared as JSON.
   const tabBefore = JSON.stringify([state.conditionalFormats, state.regions, state.frozenRows, state.frozenColumns]);
+  const ruleIdsBefore = new Set(state.conditionalFormats.map((rule) => rule.id));
   state = { ...state, conditionalFormats: [...plan.conditionalFormats], regions: [...plan.regions] };
+  const ruleIdsAfter = new Set(state.conditionalFormats.map((rule) => rule.id));
   for (const step of plan.steps) {
     if (step.type === 'setFrozen') {
       state.frozenRows = step.rows ?? null;
@@ -77,6 +79,8 @@ const mockApplyFormatOps = vi.fn(async (_ref: unknown, ops: readonly SheetFormat
     cellsFormatted: plan.rows.size,
     rowsTouched: plan.rows.size,
     tabFieldsChanged: tabChanged ? ['tab'] : [],
+    ruleIdsAdded: [...ruleIdsAfter].filter((id) => !ruleIdsBefore.has(id)),
+    ruleIdsRemoved: [...ruleIdsBefore].filter((id) => !ruleIdsAfter.has(id)),
     conditionalRules: plan.conditionalFormats.length,
     regions: plan.regions.length,
     rowCount: state.rowCount,
@@ -693,6 +697,8 @@ describe('set_conditional_format', () => {
       rowsTouched: 0,
       tabFieldsChanged: [],
       conditionalRules: 0,
+      ruleIdsAdded: [],
+      ruleIdsRemoved: [],
       regions: 0,
       rowCount: 500,
       columnCount: 16,
@@ -783,6 +789,34 @@ describe('set_conditional_format', () => {
     assert({ given: 'the identical retry', should: 'return the id the first attempt minted', actual: retry.ruleIds, expected: first.ruleIds });
     expect(retry.warnings?.join(' ')).toContain('treated as already removed');
     assert({ given: 'the tab after', should: 'hold exactly X', actual: state.conditionalFormats.map((rule) => rule.id), expected: first.ruleIds });
+  });
+
+  it('an overlapping retry whose removal already landed under the lock is recovered, not refused', async () => {
+    // Both executions read a tab holding "old"; the first commits (removes
+    // "old", adds X). The second reaches the store, which refuses the
+    // now-absent removal under its lock. The tool re-reads and finds the
+    // whole requested state in place, so it reports the landed retry.
+    state.conditionalFormats = [{ id: 'old', kind: 'dataBar', ranges: ['Z1:Z9'], color: '#000000' }];
+    const x = { kind: 'dataBar' as const, ranges: ['A1:A9'], color: '#3b82f6' };
+    const real = mockApplyFormatOps.getMockImplementation()!;
+    mockApplyFormatOps.mockImplementationOnce(async (ref, ops) => {
+      // The first execution commits between this one's read and its write.
+      state.conditionalFormats = [{ id: 'rule-first', kind: 'dataBar', ranges: ['A1:A9'], color: '#3b82f6' }];
+      return real(ref, ops);
+    });
+    const retry = (await conditional({ rules: [x], removeRuleIds: ['old'] })) as { success: boolean; ruleIds?: string[]; added?: number; removed?: number };
+    assert({ given: 'the overlapping retry', should: 'succeed', actual: retry.success, expected: true });
+    assert({ given: 'the overlapping retry', should: 'report the landed id', actual: retry.ruleIds, expected: ['rule-first'] });
+    assert({ given: 'the overlapping retry', should: 'add and remove nothing itself', actual: [retry.added, retry.removed], expected: [0, 0] });
+    assert({ given: 'the tab after', should: 'hold exactly what the first execution landed', actual: state.conditionalFormats.map((rule) => rule.id), expected: ['rule-first'] });
+  });
+
+  it('the formula examples the model sees use bounded ranges', () => {
+    // `C:C` parses as nothing here; a model following the example would
+    // produce a refused call.
+    const schema = JSON.stringify(z.toJSONSchema(sheetFormatTools.set_conditional_format.inputSchema as z.ZodType));
+    expect(schema).not.toContain('C:C');
+    expect(schema).toContain('C2:C40');
   });
 
   it('replaceAll refuses the same rule twice in one call', async () => {

--- a/apps/web/src/lib/ai/tools/__tests__/sheet-format-tools.test.ts
+++ b/apps/web/src/lib/ai/tools/__tests__/sheet-format-tools.test.ts
@@ -65,8 +65,10 @@ const mockApplyFormatOps = vi.fn(async (_ref: unknown, ops: readonly SheetFormat
   // would store differs from what it holds, compared as JSON.
   const tabBefore = JSON.stringify([state.conditionalFormats, state.regions, state.frozenRows, state.frozenColumns]);
   const ruleIdsBefore = new Set(state.conditionalFormats.map((rule) => rule.id));
+  const regionIdsBefore = new Set(state.regions.map((region) => region.id));
   state = { ...state, conditionalFormats: [...plan.conditionalFormats], regions: [...plan.regions] };
   const ruleIdsAfter = new Set(state.conditionalFormats.map((rule) => rule.id));
+  const regionIdsAfter = new Set(state.regions.map((region) => region.id));
   for (const step of plan.steps) {
     if (step.type === 'setFrozen') {
       state.frozenRows = step.rows ?? null;
@@ -81,6 +83,8 @@ const mockApplyFormatOps = vi.fn(async (_ref: unknown, ops: readonly SheetFormat
     tabFieldsChanged: tabChanged ? ['tab'] : [],
     ruleIdsAdded: [...ruleIdsAfter].filter((id) => !ruleIdsBefore.has(id)),
     ruleIdsRemoved: [...ruleIdsBefore].filter((id) => !ruleIdsAfter.has(id)),
+    regionIdsAdded: [...regionIdsAfter].filter((id) => !regionIdsBefore.has(id)),
+    regionIdsRemoved: [...regionIdsBefore].filter((id) => !regionIdsAfter.has(id)),
     conditionalRules: plan.conditionalFormats.length,
     regions: plan.regions.length,
     rowCount: state.rowCount,
@@ -700,6 +704,8 @@ describe('set_conditional_format', () => {
       ruleIdsAdded: [],
       ruleIdsRemoved: [],
       regions: 0,
+      regionIdsAdded: [],
+      regionIdsRemoved: [],
       rowCount: 500,
       columnCount: 16,
       recomputed: [],
@@ -722,10 +728,16 @@ describe('set_conditional_format', () => {
     // Mirrors the rule case below. The nothing-given guard used to fire
     // first, so the documented "keep only these" could not express "none".
     state.regions = [{ id: 'orders', range: 'A1:D', headerRows: 1 } as SheetRegion];
-    const result = await format({ regionMode: 'replaceAll', regions: [] });
+    const result = (await format({ regionMode: 'replaceAll', regions: [] })) as Result & { removedRegionIds?: string[] };
     assert({ given: 'replaceAll with nothing', should: 'accept', actual: result.success, expected: true });
     assert({ given: 'the tab after', should: 'hold no regions', actual: state.regions.length, expected: 0 });
-    expect(message(result)).toContain('every other region on the tab removed');
+    assert({ given: 'the result', should: 'name the region the store removed', actual: result.removedRegionIds, expected: ['orders'] });
+    expect(message(result)).toContain('1 other region(s) removed');
+    // Restyling the only region under its own id removes nothing, and says so.
+    state.regions = [{ id: 'orders', range: 'A1:D', headerRows: 1 } as SheetRegion];
+    const restyled = (await format({ regionMode: 'replaceAll', regions: [{ id: 'orders', range: 'A1:D', headerRows: 1, theme: 'blue' }] })) as Result & { removedRegionIds?: string[] };
+    assert({ given: 'a replaceAll that restyles the sole region', should: 'remove nothing', actual: restyled.removedRegionIds, expected: [] });
+    expect(message(restyled)).not.toContain('removed');
     const bare = await format({});
     assert({ given: 'no regions, no ops, no mode', should: 'still refuse', actual: bare.success, expected: false });
   });
@@ -832,6 +844,9 @@ describe('set_conditional_format', () => {
     const result = (await conditional({ mode: 'replaceAll', rules: [a] })) as { removed?: number; removedRuleIds?: string[] };
     assert({ given: 'a rule added between read and write', should: 'be counted as removed', actual: result.removed, expected: 1 });
     assert({ given: 'a rule added between read and write', should: 'be named as removed', actual: result.removedRuleIds, expected: ['concurrent'] });
+    // The activity entry (what the workflow trigger sees) carries the locked delta too.
+    const activity = vi.mocked(logSheetCellActivity).mock.calls.at(-1)?.[0] as { metadata?: Record<string, unknown> } | undefined;
+    expect(activity?.metadata).toMatchObject({ tool: 'set_conditional_format', rulesRemoved: 1, rulesAdded: 1 });
   });
 
   it('replaceAll refuses the same rule twice in one call', async () => {
@@ -839,6 +854,15 @@ describe('set_conditional_format', () => {
     const result = await conditional({ mode: 'replaceAll', rules: [a, { ...a }] });
     assert({ given: 'a duplicated rule', should: 'refuse', actual: result.success, expected: false });
     expect(message(result)).toContain('rules[1] is identical to rules[0]');
+  });
+
+  it('an explicit id that is not the existing twin\'s id is refused, not landed beside it', async () => {
+    state.regions = [{ id: 'orders', range: 'A1:D', headerRows: 1, name: 'Orders' } as SheetRegion];
+    const result = await format({ regions: [{ id: 'invented', range: 'A1:D', headerRows: 1, name: 'Orders' }] });
+    assert({ given: 'identical content under a different explicit id', should: 'refuse', actual: result.success, expected: false });
+    expect(message(result)).toContain('already exists as "orders"');
+    const restyle = await format({ regions: [{ id: 'orders', range: 'A1:D', headerRows: 1, name: 'Orders' }] });
+    assert({ given: 'the existing id itself', should: 'still be accepted', actual: restyle.success, expected: true });
   });
 
   it('a same-call duplicate region is refused however the ids were supplied', async () => {

--- a/apps/web/src/lib/ai/tools/__tests__/sheet-format-tools.test.ts
+++ b/apps/web/src/lib/ai/tools/__tests__/sheet-format-tools.test.ts
@@ -651,6 +651,20 @@ describe('set_conditional_format', () => {
     expect(changed.success).toBe(true);
   });
 
+  it('a region declared without an id gets the SAME id on every execution, even with no twin in the snapshot', async () => {
+    // Two overlapping executions of a retried call are both planned before
+    // either commits, so neither snapshot shows the other's region. Only a
+    // content-derived id makes the store's upsert-by-id absorb the second.
+    const region = { range: 'A1:D', headerRows: 1, name: 'Orders' };
+    const first = (await format({ regions: [region] })) as { regionIds?: string[] };
+    state = freshTab(); // as if the first commit is not visible yet
+    const again = (await format({ regions: [region] })) as { regionIds?: string[] };
+    assert({ given: 'the same declaration on an empty snapshot', should: 'mint the same id', actual: again.regionIds, expected: first.regionIds });
+    state = freshTab();
+    const other = (await format({ regions: [{ ...region, name: 'Invoices' }] })) as { regionIds?: string[] };
+    expect(other.regionIds).not.toEqual(first.regionIds);
+  });
+
   it('a call that changed nothing logs no activity and broadcasts nothing', async () => {
     // The store reports a no-op (a bold that was already bold, a retry) with
     // rowsTouched 0 and no tab field changed, and bumps no revision. The tool
@@ -668,11 +682,14 @@ describe('set_conditional_format', () => {
     }));
     const noop = await format({ ops: [{ op: 'setFormat', range: 'A1', format: { bold: true } }] });
     assert({ given: 'a no-op format', should: 'still succeed', actual: noop.success, expected: true });
+    assert({ given: 'a no-op format', should: 'report changed: false', actual: (noop as { changed?: boolean }).changed, expected: false });
+    expect(message(noop)).toContain('already had this formatting');
     expect(vi.mocked(logSheetCellActivity)).not.toHaveBeenCalled();
     expect(vi.mocked(broadcastPageEvent)).not.toHaveBeenCalled();
 
     const real = await format({ ops: [{ op: 'setFormat', range: 'A1', format: { bold: true } }] });
     assert({ given: 'a format that changed a row', should: 'succeed', actual: real.success, expected: true });
+    assert({ given: 'a real change', should: 'report changed: true', actual: (real as { changed?: boolean }).changed, expected: true });
     expect(vi.mocked(logSheetCellActivity)).toHaveBeenCalledTimes(1);
     expect(vi.mocked(broadcastPageEvent)).toHaveBeenCalledTimes(1);
   });

--- a/apps/web/src/lib/ai/tools/__tests__/sheet-format-tools.test.ts
+++ b/apps/web/src/lib/ai/tools/__tests__/sheet-format-tools.test.ts
@@ -819,6 +819,21 @@ describe('set_conditional_format', () => {
     expect(schema).toContain('C2:C40');
   });
 
+  it('replaceAll reports a rule that landed between its read and its write as removed', async () => {
+    // The snapshot the tool planned from never saw the concurrent rule; only
+    // the store, under its lock, did. The count and the id must come from
+    // there, or the destructive half of the call is invisible.
+    const a = { kind: 'dataBar' as const, ranges: ['A1:A9'], color: '#3b82f6' };
+    const real = mockApplyFormatOps.getMockImplementation()!;
+    mockApplyFormatOps.mockImplementationOnce(async (ref, ops) => {
+      state.conditionalFormats = [...state.conditionalFormats, { id: 'concurrent', kind: 'dataBar', ranges: ['Z1:Z9'], color: '#000000' }];
+      return real(ref, ops);
+    });
+    const result = (await conditional({ mode: 'replaceAll', rules: [a] })) as { removed?: number; removedRuleIds?: string[] };
+    assert({ given: 'a rule added between read and write', should: 'be counted as removed', actual: result.removed, expected: 1 });
+    assert({ given: 'a rule added between read and write', should: 'be named as removed', actual: result.removedRuleIds, expected: ['concurrent'] });
+  });
+
   it('replaceAll refuses the same rule twice in one call', async () => {
     const a = { kind: 'dataBar' as const, ranges: ['A1:A9'], color: '#3b82f6' };
     const result = await conditional({ mode: 'replaceAll', rules: [a, { ...a }] });

--- a/apps/web/src/lib/ai/tools/__tests__/sheet-format-tools.test.ts
+++ b/apps/web/src/lib/ai/tools/__tests__/sheet-format-tools.test.ts
@@ -11,6 +11,8 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { z } from 'zod';
 import { assert } from './riteway';
+import { logSheetCellActivity } from '@/services/api/sheet-activity';
+import { broadcastPageEvent } from '@/lib/websocket';
 import type * as SheetStore from '@pagespace/lib/sheets/store';
 import {
   MAX_CONDITIONAL_RULES,
@@ -626,6 +628,53 @@ describe('set_conditional_format', () => {
     expect(message(result)).toContain('"rule-a"');
     expect(message(result)).toContain('"rule-b"');
     expect(mockApplyFormatOps).not.toHaveBeenCalled();
+  });
+
+  it('format_sheet: retrying a new-region call is idempotent — the twin reuses the existing id', async () => {
+    // A region declared without an id gets a minted one. The same call
+    // retried after a timed-out response used to mint a second id and land a
+    // content-identical, overlapping twin on every attempt.
+    const region = { range: 'A1:D', headerRows: 1, name: 'Orders', columns: [{ column: 'C', role: 'currency' as const }] };
+    const first = await format({ regions: [region] });
+    assert({ given: 'the first call', should: 'declare one region', actual: state.regions.length, expected: 1 });
+    const second = await format({ regions: [region] });
+    assert({ given: 'the identical call again', should: 'still succeed', actual: second.success, expected: true });
+    assert({ given: 'the tab after the retry', should: 'hold ONE region', actual: state.regions.length, expected: 1 });
+    assert({
+      given: 'the retry',
+      should: 'report the id the first call minted',
+      actual: (second as { regionIds?: string[] }).regionIds,
+      expected: (first as { regionIds?: string[] }).regionIds,
+    });
+    const changed = await format({ regions: [{ ...region, theme: 'blue' }] });
+    assert({ given: 'a different region', should: 'still get its own id', actual: state.regions.length, expected: 2 });
+    expect(changed.success).toBe(true);
+  });
+
+  it('a call that changed nothing logs no activity and broadcasts nothing', async () => {
+    // The store reports a no-op (a bold that was already bold, a retry) with
+    // rowsTouched 0 and no tab field changed, and bumps no revision. The tool
+    // must not turn that into an activity entry, a workflow trigger and a
+    // content-updated broadcast.
+    mockApplyFormatOps.mockImplementationOnce(async () => ({
+      cellsFormatted: 0,
+      rowsTouched: 0,
+      tabFieldsChanged: [],
+      conditionalRules: 0,
+      regions: 0,
+      rowCount: 500,
+      columnCount: 16,
+      recomputed: [],
+    }));
+    const noop = await format({ ops: [{ op: 'setFormat', range: 'A1', format: { bold: true } }] });
+    assert({ given: 'a no-op format', should: 'still succeed', actual: noop.success, expected: true });
+    expect(vi.mocked(logSheetCellActivity)).not.toHaveBeenCalled();
+    expect(vi.mocked(broadcastPageEvent)).not.toHaveBeenCalled();
+
+    const real = await format({ ops: [{ op: 'setFormat', range: 'A1', format: { bold: true } }] });
+    assert({ given: 'a format that changed a row', should: 'succeed', actual: real.success, expected: true });
+    expect(vi.mocked(logSheetCellActivity)).toHaveBeenCalledTimes(1);
+    expect(vi.mocked(broadcastPageEvent)).toHaveBeenCalledTimes(1);
   });
 
   it('format_sheet: replaceAll with an empty region list clears every region', async () => {

--- a/apps/web/src/lib/ai/tools/__tests__/sheet-format-tools.test.ts
+++ b/apps/web/src/lib/ai/tools/__tests__/sheet-format-tools.test.ts
@@ -665,6 +665,14 @@ describe('set_conditional_format', () => {
     expect(other.regionIds).not.toEqual(first.regionIds);
   });
 
+  it('the same region declared twice in one call is refused, not landed twice', async () => {
+    const region = { range: 'A1:D', headerRows: 1, name: 'Orders' };
+    const result = await format({ regions: [region, { ...region }] });
+    assert({ given: 'a duplicated declaration', should: 'refuse', actual: result.success, expected: false });
+    expect(message(result)).toContain('regions[1] declares the same region as regions[0]');
+    expect(mockApplyFormatOps).not.toHaveBeenCalled();
+  });
+
   it('a call that changed nothing logs no activity and broadcasts nothing', async () => {
     // The store reports a no-op (a bold that was already bold, a retry) with
     // rowsTouched 0 and no tab field changed, and bumps no revision. The tool
@@ -704,6 +712,35 @@ describe('set_conditional_format', () => {
     expect(message(result)).toContain('every other region on the tab removed');
     const bare = await format({});
     assert({ given: 'no regions, no ops, no mode', should: 'still refuse', actual: bare.success, expected: false });
+  });
+
+  it('a retried replaceAll plans nothing and keeps the ids the first attempt returned', async () => {
+    const rules = [
+      { kind: 'dataBar' as const, ranges: ['A1:A9'], color: '#3b82f6' },
+      { kind: 'cell' as const, ranges: ['B1:B9'], operator: 'greaterThan' as const, value: 5, format: { bold: true } },
+    ];
+    const first = (await conditional({ mode: 'replaceAll', rules })) as { ruleIds?: string[]; added?: number };
+    assert({ given: 'the first replaceAll', should: 'add both', actual: first.added, expected: 2 });
+    const calls = mockApplyFormatOps.mock.calls.length;
+
+    const retry = (await conditional({ mode: 'replaceAll', rules })) as { ruleIds?: string[]; added?: number; removed?: number };
+    assert({ given: 'the identical replaceAll again', should: 'add nothing', actual: retry.added, expected: 0 });
+    assert({ given: 'the identical replaceAll again', should: 'remove nothing', actual: retry.removed, expected: 0 });
+    assert({ given: 'the retry', should: 'return the same ids', actual: retry.ruleIds, expected: first.ruleIds });
+    assert({ given: 'the retry', should: 'reach the store zero times', actual: mockApplyFormatOps.mock.calls.length, expected: calls });
+
+    const changed = (await conditional({ mode: 'replaceAll', rules: [rules[0]] })) as { ruleIds?: string[]; added?: number; removed?: number };
+    assert({ given: 'a replaceAll that drops one rule', should: 'remove exactly that one', actual: changed.removed, expected: 1 });
+    assert({ given: 'a replaceAll that drops one rule', should: 'keep the other rule under its id', actual: changed.ruleIds, expected: [first.ruleIds![0]] });
+    assert({ given: 'the tab after', should: 'hold one rule', actual: state.conditionalFormats.map((rule) => rule.id), expected: [first.ruleIds![0]] });
+  });
+
+  it('a rule declared without an id gets the same content-derived id on every execution', async () => {
+    const rule = { kind: 'dataBar' as const, ranges: ['A1:A9'], color: '#3b82f6' };
+    const first = (await conditional({ rules: [rule] })) as { ruleIds?: string[] };
+    state = freshTab();
+    const again = (await conditional({ rules: [rule] })) as { ruleIds?: string[] };
+    assert({ given: 'the same rule on an empty snapshot', should: 'mint the same id', actual: again.ruleIds, expected: first.ruleIds });
   });
 
   it('replaceAll with an empty list clears every rule', async () => {

--- a/apps/web/src/lib/ai/tools/sheet-format-tools.ts
+++ b/apps/web/src/lib/ai/tools/sheet-format-tools.ts
@@ -78,6 +78,7 @@ import { tool } from 'ai';
 import { z } from 'zod';
 import { PageType } from '@pagespace/lib/utils/enums';
 import {
+  regionContentKey,
   MAX_ADDRESSABLE_ROW,
   MAX_CONDITIONAL_RULES,
   MAX_DECIMALS,
@@ -779,11 +780,12 @@ const mintId = (prefix: string, taken: ReadonlySet<string>): string => {
  */
 function validateRegions(
   regions: readonly RegionInput[],
-  existingIds: ReadonlySet<string>
+  existing: readonly SheetRegion[]
 ): { regions: SheetRegion[]; labels: string[]; frozenRows: number | undefined } {
   const out: SheetRegion[] = [];
   const labels: string[] = [];
-  const taken = new Set(existingIds);
+  const taken = new Set(existing.map((region) => region.id));
+  const existingByContent = new Map(existing.map((region) => [regionContentKey(region), region.id]));
   let frozenRows: number | undefined;
 
   regions.forEach((input, index) => {
@@ -831,6 +833,18 @@ function validateRegions(
       region.columns = [...byColumn.values()];
     }
     if (input.theme !== undefined) region.theme = input.theme;
+
+    // A new region (no id) that is content-identical to one already on the
+    // tab IS that region: a retried call after a timed-out response would
+    // otherwise mint a twin under a fresh id on every attempt, and the
+    // store upserts by id. Reusing the id makes the retry a no-op upsert.
+    if (input.id === undefined) {
+      const twin = existingByContent.get(regionContentKey(region));
+      if (twin !== undefined) {
+        taken.delete(id);
+        region.id = twin;
+      }
+    }
 
     const freezeHeader = input.freezeHeader;
     if (freezeHeader === true) {
@@ -1214,6 +1228,15 @@ async function applyPlanned(
     throw cause;
   }
 
+  // The store reports a request that changed nothing — a bold that was
+  // already bold, a retried call — with no rows touched and no tab field
+  // changed, and deliberately bumps no revision for it. Logging an activity
+  // entry, firing the workflow trigger and broadcasting content-updated for
+  // that would turn a harmless retry into an observable automation run.
+  if (result.rowsTouched === 0 && result.tabFieldsChanged.length === 0) {
+    return result;
+  }
+
   await logSheetCellActivity({
     pageId: page.id,
     driveId: page.driveId,
@@ -1291,10 +1314,7 @@ export const sheetFormatTools = {
         // Regions first, then the freeze a region asked for, then the
         // model's own ops — so an explicit op layers over what a region
         // implies, never under it.
-        const declared = validateRegions(
-          regions ?? [],
-          new Set(formatting.regions.map((region) => region.id))
-        );
+        const declared = validateRegions(regions ?? [], formatting.regions);
         if (regionMode === 'replaceAll') {
           planned.push({ label: 'regions', op: { type: 'setRegions', regions: declared.regions } });
         } else {

--- a/apps/web/src/lib/ai/tools/sheet-format-tools.ts
+++ b/apps/web/src/lib/ai/tools/sheet-format-tools.ts
@@ -1263,7 +1263,11 @@ export const sheetFormatTools = {
       const pageId = resolveOrThrowPageId(pageIdArg, toolContext);
 
       try {
-        if ((regions?.length ?? 0) === 0 && (ops?.length ?? 0) === 0) {
+        // An empty `replaceAll` is a request in its own right — "keep only
+        // these" with nothing to keep clears every region, the way the
+        // conditional tool's replaceAll clears every rule — so it passes
+        // this guard and plans a `setRegions` of the empty list.
+        if ((regions?.length ?? 0) === 0 && (ops?.length ?? 0) === 0 && regionMode !== 'replaceAll') {
           return refusal(
             INVALID_FORMAT_REQUEST,
             'Neither regions nor ops were given, so there is nothing to apply.',
@@ -1335,6 +1339,7 @@ export const sheetFormatTools = {
           title: page.title,
           tabIndex: ref.tabIndex,
           regionsApplied: declared.regions.length,
+          regionMode: regionMode ?? 'merge',
           regionIds,
           opsApplied: ops?.length ?? 0,
           cellsFormatted: outcome.cellsFormatted,
@@ -1342,7 +1347,9 @@ export const sheetFormatTools = {
           regionsOnTab: outcome.regions,
           sheetDimensions: { rows: outcome.rowCount, columns: outcome.columnCount },
           message:
-            `Formatted "${page.title}": ${declared.regions.length} region(s) declared, ${ops?.length ?? 0} op(s) applied` +
+            `Formatted "${page.title}": ${declared.regions.length} region(s) declared` +
+            (regionMode === 'replaceAll' ? ' (every other region on the tab removed)' : '') +
+            `, ${ops?.length ?? 0} op(s) applied` +
             (outcome.cellsFormatted > 0 ? `, ${outcome.cellsFormatted} cell(s) restyled` : '') +
             '.',
           nextSteps: [

--- a/apps/web/src/lib/ai/tools/sheet-format-tools.ts
+++ b/apps/web/src/lib/ai/tools/sheet-format-tools.ts
@@ -799,6 +799,7 @@ function validateRegions(
   const labels: string[] = [];
   const taken = new Set(existing.map((region) => region.id));
   const existingByContent = new Map(existing.map((region) => [regionContentKey(region), region.id]));
+  const declaredByContent = new Map<string, string>();
   let frozenRows: number | undefined;
 
   regions.forEach((input, index) => {
@@ -852,7 +853,16 @@ function validateRegions(
     // by id. Otherwise the id is derived from the content (see `contentId`),
     // so overlapping executions of the same call agree on it too.
     if (input.id === undefined) {
-      region.id = existingByContent.get(regionContentKey(region)) ?? contentId('region', region, taken);
+      const key = regionContentKey(region);
+      const earlier = declaredByContent.get(key);
+      if (earlier !== undefined) {
+        // The same declaration twice in one call is a mistake, not two
+        // regions: the content id would already be taken, and a random
+        // fallback would land an overlapping twin.
+        refuse(INVALID_FORMAT_REQUEST, `${label} declares the same region as ${earlier}.`, NOTHING_APPLIED);
+      }
+      declaredByContent.set(key, label);
+      region.id = existingByContent.get(key) ?? contentId('region', region, taken);
     }
     taken.add(region.id);
 
@@ -1059,6 +1069,12 @@ function buildRule(input: RuleInput, label: string): BuiltRule {
  * is told failed.
  */
 const contentKey = (rule: ConditionalRule | RuleContent): string => conditionalRuleContentKey(rule);
+
+/** A rule's id from its content — the same declaration mints the same id on every execution. */
+const ruleContentId = (key: string, taken: ReadonlySet<string>): string => {
+  const id = `rule-${createHash('sha256').update(key).digest('hex').slice(0, 8)}`;
+  return taken.has(id) ? mintId('rule', taken) : id;
+};
 
 // ---------------------------------------------------------------------------
 // Shared: locating the tab
@@ -1462,8 +1478,17 @@ export const sheetFormatTools = {
 
         let remaining: ConditionalRule[];
         if (mode === 'replaceAll') {
-          planned.push({ label: 'mode', op: { type: 'clearConditionalRules' } });
-          remaining = [];
+          // A diff, not a clear-and-rebuild: rules already on the tab that
+          // match one in the call keep their ids (a retried replaceAll then
+          // plans nothing, bumps no revision, and the ids an earlier attempt
+          // returned stay valid); only the rest are removed.
+          const wanted = new Set(built.map((entry) => contentKey(entry.rule)));
+          remaining = existing.filter((rule) => wanted.has(contentKey(rule)));
+          for (const rule of existing) {
+            if (!wanted.has(contentKey(rule))) {
+              planned.push({ label: 'mode', op: { type: 'removeConditionalRule', id: rule.id } });
+            }
+          }
         } else {
           const removals = new Set<string>();
           (removeRuleIds ?? []).forEach((id, index) => {
@@ -1500,7 +1525,7 @@ export const sheetFormatTools = {
             skippedDuplicates.push({ index, existingRuleId: duplicateOf });
             return;
           }
-          const id = mintId('rule', taken);
+          const id = ruleContentId(key, taken);
           taken.add(id);
           byContent.set(key, id);
           const rule = { ...entry.rule, id } as ConditionalRule;

--- a/apps/web/src/lib/ai/tools/sheet-format-tools.ts
+++ b/apps/web/src/lib/ai/tools/sheet-format-tools.ts
@@ -1549,19 +1549,24 @@ export const sheetFormatTools = {
             ],
           };
         } else {
+          // An id that is not on the tab is treated as already removed, with a
+          // warning, not refused: a retried call whose first attempt committed
+          // but lost its response reads a tab where the id is already gone,
+          // and refusing it would report failure for a request that landed.
+          // The store would refuse the op (a remove names an id and asserts it
+          // exists), so it is simply not planned.
           const removals = new Set<string>();
           (removeRuleIds ?? []).forEach((id, index) => {
-            if (!existingIds.includes(id)) {
-              refuse(
-                INVALID_RULE_REQUEST,
-                `removeRuleIds[${index}]: no rule "${id}" on this tab. Rules that exist: ` +
-                  (existingIds.length > 0 ? existingIds.map((existingId) => `"${existingId}"`).join(', ') : 'none') +
-                  '.',
-                NOTHING_APPLIED
-              );
-            }
             if (removals.has(id)) return;
             removals.add(id);
+            if (!existingIds.includes(id)) {
+              warnings.push(
+                `removeRuleIds[${index}]: no rule "${id}" on this tab — treated as already removed. Rules that exist: ` +
+                  (existingIds.length > 0 ? existingIds.map((existingId) => `"${existingId}"`).join(', ') : 'none') +
+                  '.'
+              );
+              return;
+            }
             planned.push({ label: `removeRuleIds[${index}]`, op: { type: 'removeConditionalRule', id } });
           });
           remaining = existing.filter((rule) => !removals.has(rule.id));

--- a/apps/web/src/lib/ai/tools/sheet-format-tools.ts
+++ b/apps/web/src/lib/ai/tools/sheet-format-tools.ts
@@ -378,7 +378,7 @@ const ruleSchema = z
     operator: z.enum(OPERATORS).optional().describe('cell.'),
     value: operandSchema.optional().describe('cell: the operand. Not for isEmpty/isNotEmpty/isError.'),
     value2: operandSchema.optional().describe('cell: upper bound for between/notBetween.'),
-    formula: z.string().max(4000).optional().describe('formula: e.g. "=C2>AVERAGE(C:C)", anchored at the range\'s top-left.'),
+    formula: z.string().max(4000).optional().describe('formula: e.g. "=C2>AVERAGE(C2:C40)", anchored at the range\'s top-left; ranges must be bounded.'),
     format: aiCellFormatSchema.optional().describe('cell/formula: applied where the rule matches.'),
     min: anchorSchema.optional().describe('colorScale (needs color) / dataBar.'),
     mid: anchorSchema.optional().describe('colorScale.'),
@@ -1011,7 +1011,7 @@ function buildRule(input: RuleInput, label: string): BuiltRule {
       };
     }
     case 'formula': {
-      need('formula', '(e.g. "=C2>AVERAGE(C:C)")');
+      need('formula', '(e.g. "=C2>AVERAGE(C2:C40)" — ranges must be bounded)');
       need('format', '(what to apply where the formula is true)');
       const formula = (input.formula as string).trim();
       if (formula === '') {
@@ -1193,12 +1193,13 @@ async function locateTab(
 /**
  * The write, with the store's refusals turned into the envelope.
  *
- * `onDuplicateRule: 'throw'` lets the store's content-twin refusal
- * (`SheetDuplicateRuleError`) escape instead of becoming an envelope. Only
- * `set_conditional_format` asks for it: that tool minted the ids, so a twin
- * refused under the lock is its own retry racing it, and it has the rules in
- * hand to check. `format_sheet` relays the model's ids and has no such
- * standing, so for it the twin is a refusal like any other.
+ * `onStoreRefusal: 'throw'` lets the store's refusal under its lock (a
+ * content twin, an id already gone) escape instead of becoming an envelope.
+ * Only `set_conditional_format`'s append path asks for it: that tool minted
+ * the ids and planned the removals from a snapshot, so a refusal under the
+ * lock may be its own retry racing it, and it has the requested final state
+ * in hand to re-verify. `format_sheet` relays the model's ids and has no such
+ * standing, so for it every refusal is a refusal.
  */
 async function applyPlanned(
   ref: TabRef,
@@ -1209,7 +1210,7 @@ async function applyPlanned(
   toolName: string,
   error: string,
   metadata: Record<string, unknown>,
-  onDuplicateRule: 'refuse' | 'throw' = 'refuse'
+  onStoreRefusal: 'refuse' | 'throw' = 'refuse'
 ) {
   const ops = planned.map((entry) => entry.op);
   const labels = planned.map((entry) => entry.label);
@@ -1245,7 +1246,7 @@ async function applyPlanned(
       metadata: { source: 'ai-tool', tool: toolName, ...metadata },
     });
   } catch (cause) {
-    if (cause instanceof SheetDuplicateRuleError && onDuplicateRule === 'throw') {
+    if (cause instanceof SheetFormatError && onStoreRefusal === 'throw') {
       throw cause;
     }
     if (cause instanceof SheetFormatError) {
@@ -1512,8 +1513,6 @@ export const sheetFormatTools = {
             ruleIds.push(id);
             final.push({ ...entry.rule, id } as ConditionalRule);
           }
-          const finalIds = new Set(final.map((rule) => rule.id));
-          const removedCount = existing.filter((rule) => !finalIds.has(rule.id)).length;
           planned.push({ label: 'mode', op: { type: 'setConditionalRules', rules: final } });
 
           const outcome = await applyPlanned(
@@ -1524,25 +1523,34 @@ export const sheetFormatTools = {
             page,
             'set_conditional_format',
             INVALID_RULE_REQUEST,
-            { mode, rulesAdded: addedCount, rulesRemoved: removedCount }
+            { mode, rulesAdded: addedCount, rulesRemoved: existing.length - skippedDuplicates.length }
           );
           if (isRefusal(outcome)) return outcome;
-          const unchanged = outcome.rowsTouched === 0 && outcome.tabFieldsChanged.length === 0;
+          // Counts from what the store found under its lock, not from the
+          // snapshot: a rule another writer added in between was removed
+          // too, and is reported.
+          const changed = outcome.rowsTouched > 0 || outcome.tabFieldsChanged.length > 0;
+          const reordered = changed && outcome.ruleIdsAdded.length === 0 && outcome.ruleIdsRemoved.length === 0;
           return {
             success: true as const,
             pageId: page.id,
             title: page.title,
             tabIndex: ref.tabIndex,
+            mode: 'replaceAll' as const,
             ruleIds,
-            added: addedCount,
-            removed: removedCount,
-            skippedDuplicates,
+            ruleIdsAdded: outcome.ruleIdsAdded,
+            removedRuleIds: outcome.ruleIdsRemoved,
+            added: outcome.ruleIdsAdded.length,
+            removed: outcome.ruleIdsRemoved.length,
+            changed,
             conditionalRules: outcome.conditionalRules,
             ...(warnings.length > 0 ? { warnings } : {}),
-            message: unchanged
+            message: !changed
               ? `"${page.title}" already held exactly these rules; nothing changed.`
-              : `Conditional formatting on "${page.title}": now exactly the ${final.length} rule(s) in this call ` +
-                `(${addedCount} added, ${removedCount} removed).`,
+              : reordered
+                ? `Conditional formatting on "${page.title}": the same ${final.length} rule(s), reordered (later rules win).`
+                : `Conditional formatting on "${page.title}": now exactly the ${final.length} rule(s) in this call ` +
+                  `(${outcome.ruleIdsAdded.length} added, ${outcome.ruleIdsRemoved.length} removed).`,
             nextSteps: [
               'Call read_sheet with includeFormatting to verify the rules.',
               'Keep the returned ruleIds to remove or replace these rules later.',
@@ -1619,9 +1627,13 @@ export const sheetFormatTools = {
             pageId: page.id,
             title: page.title,
             tabIndex: ref.tabIndex,
+            mode: 'append' as const,
             ruleIds,
+            ruleIdsAdded: [],
+            removedRuleIds: [],
             added: 0,
             removed: 0,
+            changed: false,
             skippedDuplicates,
             conditionalRules: existing.length,
             ...(warnings.length > 0 ? { warnings } : {}),
@@ -1644,21 +1656,21 @@ export const sheetFormatTools = {
             'throw'
           );
         } catch (cause) {
-          if (!(cause instanceof SheetDuplicateRuleError)) throw cause;
+          if (!(cause instanceof SheetFormatError)) throw cause;
 
-          // The store refused a content twin under its lock: a rule with this
-          // content landed between the read above and the write. The dedupe
-          // above cannot see that — it ran against a snapshot — and this is
-          // the one case it exists for: a timeout retry overlapping the call
-          // it retries. Both read no rule, both minted an id, and the lock
-          // let exactly one through. To the model that IS the landed retry,
-          // so the answer is the same success the dedupe gives when the
-          // snapshot already held every rule.
+          // The store refused under its lock what the snapshot allowed: a
+          // content twin that landed in between, or a removal whose id was
+          // already gone. Both are what a timeout retry overlapping the call
+          // it retries looks like — both executions read the same tab, and
+          // the lock let exactly one through. To the model that IS the landed
+          // retry, so the answer is the same success the dedupe gives when
+          // the snapshot already held every rule.
           //
-          // Only if the fresh read accounts for the WHOLE call, though. The
-          // store refused every op atomically, so a twin that explains one
-          // rule and not the others (another writer added it) means nothing
-          // in this call was written, and reporting success would tell the
+          // Only if the fresh read accounts for the WHOLE call, though: every
+          // rule present by content and every removal absent. The store
+          // refused every op atomically, so a fresh read that explains one
+          // part and not the rest (another writer did it) means nothing in
+          // this call was written, and reporting success would tell the
           // model the rest landed too.
           const fresh = await readTabFormatting(ref);
           if (!fresh) {
@@ -1684,9 +1696,13 @@ export const sheetFormatTools = {
             pageId: page.id,
             title: page.title,
             tabIndex: ref.tabIndex,
+            mode: 'append' as const,
             ruleIds: landedIds,
+            ruleIdsAdded: [],
+            removedRuleIds: [],
             added: 0,
             removed: 0,
+            changed: false,
             skippedDuplicates: landedIds.map((existingRuleId, index) => ({ index, existingRuleId })),
             conditionalRules: fresh.conditionalFormats.length,
             ...(warnings.length > 0 ? { warnings } : {}),
@@ -1701,15 +1717,21 @@ export const sheetFormatTools = {
           pageId: page.id,
           title: page.title,
           tabIndex: ref.tabIndex,
+          mode: 'append' as const,
           ruleIds,
-          added: toAdd.length,
-          removed: existing.length - remaining.length,
+          ruleIdsAdded: outcome.ruleIdsAdded,
+          // Confirmed under the lock — an id the snapshot lacked was never a
+          // removal, and is not listed.
+          removedRuleIds: outcome.ruleIdsRemoved,
+          added: outcome.ruleIdsAdded.length,
+          removed: outcome.ruleIdsRemoved.length,
+          changed: outcome.rowsTouched > 0 || outcome.tabFieldsChanged.length > 0,
           skippedDuplicates,
           conditionalRules: outcome.conditionalRules,
           ...(warnings.length > 0 ? { warnings } : {}),
           message:
-            `Conditional formatting on "${page.title}": ${toAdd.length} rule(s) added, ` +
-            `${existing.length - remaining.length} removed, ${outcome.conditionalRules} on the tab now.`,
+            `Conditional formatting on "${page.title}": ${outcome.ruleIdsAdded.length} rule(s) added, ` +
+            `${outcome.ruleIdsRemoved.length} removed, ${outcome.conditionalRules} on the tab now.`,
           nextSteps: [
             'Call read_sheet with includeFormatting to verify the rules.',
             'Keep the returned ruleIds to remove or replace these rules later.',

--- a/apps/web/src/lib/ai/tools/sheet-format-tools.ts
+++ b/apps/web/src/lib/ai/tools/sheet-format-tools.ts
@@ -68,8 +68,10 @@
  * `sheet-read-is-read-only.guard.test.ts` against every mutating store export,
  * and this one imports the write path on purpose.
  *
- * Not registered anywhere yet: wiring into `ai-tools.ts`, `WRITE_TOOLS`,
- * `tool-labels.ts` and the sheet skill is a separate change.
+ * Registered through `TOOL_MODULES.sheetsFormat` in `core/ai-tools.ts`, gated
+ * in `WRITE_TOOLS`, labelled in `tool-labels.ts`, taught by the spreadsheets
+ * skill, and rendered by `SheetFormatRenderer` — which imports the input
+ * types below (type-only, so nothing here reaches the client bundle).
  */
 import { randomUUID } from 'node:crypto';
 import { tool } from 'ai';
@@ -267,7 +269,7 @@ const regionSchema = z
   })
   .strict();
 
-type RegionInput = z.infer<typeof regionSchema>;
+export type RegionInput = z.infer<typeof regionSchema>;
 
 const FORMAT_OPS = ['setFormat', 'clearFormat', 'columnFormat', 'columnWidth', 'rowHeight', 'freeze'] as const;
 type FormatOpName = (typeof FORMAT_OPS)[number];
@@ -299,7 +301,7 @@ const formatOpSchema = z
   })
   .strict();
 
-type FormatOpInput = z.infer<typeof formatOpSchema>;
+export type FormatOpInput = z.infer<typeof formatOpSchema>;
 
 const formatSheetInputSchema = z.object({
   pageId: z.string().optional().describe('Defaults to the page in view.'),
@@ -384,7 +386,7 @@ const ruleSchema = z
   })
   .strict();
 
-type RuleInput = z.infer<typeof ruleSchema>;
+export type RuleInput = z.infer<typeof ruleSchema>;
 
 const setConditionalFormatInputSchema = z.object({
   pageId: z.string().optional().describe('Defaults to the page in view.'),

--- a/apps/web/src/lib/ai/tools/sheet-format-tools.ts
+++ b/apps/web/src/lib/ai/tools/sheet-format-tools.ts
@@ -73,7 +73,7 @@
  * skill, and rendered by `SheetFormatRenderer` — which imports the input
  * types below (type-only, so nothing here reaches the client bundle).
  */
-import { randomUUID } from 'node:crypto';
+import { createHash, randomUUID } from 'node:crypto';
 import { tool } from 'ai';
 import { z } from 'zod';
 import { PageType } from '@pagespace/lib/utils/enums';
@@ -766,6 +766,19 @@ const mintId = (prefix: string, taken: ReadonlySet<string>): string => {
 };
 
 /**
+ * The id a region declared without one gets: derived from its CONTENT, so
+ * the same declaration mints the same id every time. Two executions of a
+ * retried call that overlap — both planned before either commits, so neither
+ * snapshot shows the other's region — then send the same id, and the store's
+ * upsert-by-id under its lock makes the second a no-op instead of a twin.
+ * Random only when that id is already taken by something else.
+ */
+const contentId = (prefix: string, region: SheetRegion, taken: ReadonlySet<string>): string => {
+  const id = `${prefix}-${createHash('sha256').update(regionContentKey(region)).digest('hex').slice(0, 8)}`;
+  return taken.has(id) ? mintId(prefix, taken) : id;
+};
+
+/**
  * Normalise a declared region into what the store stores, and split off the
  * one input that is not a region field: `freezeHeader`.
  *
@@ -805,15 +818,14 @@ function validateRegions(
     if (input.id !== undefined && out.some((region) => region.id === input.id)) {
       refuse(INVALID_FORMAT_REQUEST, `${label}: two regions in this call share the id "${input.id}".`, NOTHING_APPLIED);
     }
-    const id = input.id ?? mintId('region', taken);
-    taken.add(id);
 
     // Built field by field in the parser's own normal form — trimmed name,
     // uppercase columns and currency codes, sorted unique total rows — because
     // the store compares what it was sent against what `parseRegion` makes of
     // it and refuses any difference. A region the parser would tidy is one the
     // store would turn away, so the tidying happens here, where it is visible.
-    const region: SheetRegion = { id, range };
+    // The id is settled LAST, because without one it is derived from the rest.
+    const region: SheetRegion = { id: input.id ?? '', range };
     const name = input.name?.trim();
     if (name) region.name = name.slice(0, 200);
     if (input.headerRows !== undefined) region.headerRows = input.headerRows;
@@ -835,16 +847,14 @@ function validateRegions(
     if (input.theme !== undefined) region.theme = input.theme;
 
     // A new region (no id) that is content-identical to one already on the
-    // tab IS that region: a retried call after a timed-out response would
-    // otherwise mint a twin under a fresh id on every attempt, and the
-    // store upserts by id. Reusing the id makes the retry a no-op upsert.
+    // tab IS that region, whatever id that one carries: a retried call after
+    // a timed-out response would otherwise mint a twin, and the store upserts
+    // by id. Otherwise the id is derived from the content (see `contentId`),
+    // so overlapping executions of the same call agree on it too.
     if (input.id === undefined) {
-      const twin = existingByContent.get(regionContentKey(region));
-      if (twin !== undefined) {
-        taken.delete(id);
-        region.id = twin;
-      }
+      region.id = existingByContent.get(regionContentKey(region)) ?? contentId('region', region, taken);
     }
+    taken.add(region.id);
 
     const freezeHeader = input.freezeHeader;
     if (freezeHeader === true) {
@@ -1364,9 +1374,16 @@ export const sheetFormatTools = {
           opsApplied: ops?.length ?? 0,
           cellsFormatted: outcome.cellsFormatted,
           tabFieldsChanged: outcome.tabFieldsChanged,
+          // False when the sheet already looked like this (a retry, a bold
+          // that was already bold): nothing was written and no revision
+          // bumped, and the card must not present the request as a change.
+          changed: outcome.rowsTouched > 0 || outcome.tabFieldsChanged.length > 0,
           regionsOnTab: outcome.regions,
           sheetDimensions: { rows: outcome.rowCount, columns: outcome.columnCount },
           message:
+            (outcome.rowsTouched === 0 && outcome.tabFieldsChanged.length === 0
+              ? `"${page.title}" already had this formatting; nothing changed. `
+              : '') +
             `Formatted "${page.title}": ${declared.regions.length} region(s) declared` +
             (regionMode === 'replaceAll' ? ' (every other region on the tab removed)' : '') +
             `, ${ops?.length ?? 0} op(s) applied` +

--- a/apps/web/src/lib/ai/tools/sheet-format-tools.ts
+++ b/apps/web/src/lib/ai/tools/sheet-format-tools.ts
@@ -852,16 +852,16 @@ function validateRegions(
     // a timed-out response would otherwise mint a twin, and the store upserts
     // by id. Otherwise the id is derived from the content (see `contentId`),
     // so overlapping executions of the same call agree on it too.
+    // The same declaration twice in one call is a mistake, not two regions,
+    // however the ids were supplied: two ids over identical content is an
+    // overlapping twin that costs two region slots.
+    const key = regionContentKey(region);
+    const earlier = declaredByContent.get(key);
+    if (earlier !== undefined) {
+      refuse(INVALID_FORMAT_REQUEST, `${label} declares the same region as ${earlier}.`, NOTHING_APPLIED);
+    }
+    declaredByContent.set(key, label);
     if (input.id === undefined) {
-      const key = regionContentKey(region);
-      const earlier = declaredByContent.get(key);
-      if (earlier !== undefined) {
-        // The same declaration twice in one call is a mistake, not two
-        // regions: the content id would already be taken, and a random
-        // fallback would land an overlapping twin.
-        refuse(INVALID_FORMAT_REQUEST, `${label} declares the same region as ${earlier}.`, NOTHING_APPLIED);
-      }
-      declaredByContent.set(key, label);
       region.id = existingByContent.get(key) ?? contentId('region', region, taken);
     }
     taken.add(region.id);
@@ -1478,17 +1478,76 @@ export const sheetFormatTools = {
 
         let remaining: ConditionalRule[];
         if (mode === 'replaceAll') {
-          // A diff, not a clear-and-rebuild: rules already on the tab that
-          // match one in the call keep their ids (a retried replaceAll then
-          // plans nothing, bumps no revision, and the ids an earlier attempt
-          // returned stay valid); only the rest are removed.
-          const wanted = new Set(built.map((entry) => contentKey(entry.rule)));
-          remaining = existing.filter((rule) => wanted.has(contentKey(rule)));
-          for (const rule of existing) {
-            if (!wanted.has(contentKey(rule))) {
-              planned.push({ label: 'mode', op: { type: 'removeConditionalRule', id: rule.id } });
+          // The FINAL list, in the caller's order, as one op the store
+          // reconciles under its lock: a rule another writer added between
+          // this read and that write is removed too, reordering existing
+          // rules is a real change (later rules win), and an identical retry
+          // sends the list the tab already holds — which the store compares
+          // as JSON and does not write. Rules that match an existing one by
+          // content keep its id, so ids an earlier attempt returned stay
+          // valid; new ones get content-derived ids.
+          const byExistingContent = new Map(existing.map((rule) => [contentKey(rule), rule.id]));
+          const seen = new Map<string, number>();
+          const takenIds = new Set(existingIds);
+          const final: ConditionalRule[] = [];
+          const ruleIds: string[] = [];
+          const skippedDuplicates: { index: number; existingRuleId: string }[] = [];
+          let addedCount = 0;
+          for (const [index, entry] of built.entries()) {
+            const key = contentKey(entry.rule);
+            const earlier = seen.get(key);
+            if (earlier !== undefined) {
+              return refusal(
+                INVALID_RULE_REQUEST,
+                `rules[${index}] is identical to rules[${earlier}].`,
+                'Send each rule once; give one rule several ranges instead of the same rule twice.'
+              );
             }
+            seen.set(key, index);
+            const existingId = byExistingContent.get(key);
+            const id = existingId ?? ruleContentId(key, takenIds);
+            takenIds.add(id);
+            if (existingId !== undefined) skippedDuplicates.push({ index, existingRuleId: existingId });
+            else addedCount += 1;
+            ruleIds.push(id);
+            final.push({ ...entry.rule, id } as ConditionalRule);
           }
+          const finalIds = new Set(final.map((rule) => rule.id));
+          const removedCount = existing.filter((rule) => !finalIds.has(rule.id)).length;
+          planned.push({ label: 'mode', op: { type: 'setConditionalRules', rules: final } });
+
+          const outcome = await applyPlanned(
+            ref,
+            planned,
+            formatting,
+            toolContext,
+            page,
+            'set_conditional_format',
+            INVALID_RULE_REQUEST,
+            { mode, rulesAdded: addedCount, rulesRemoved: removedCount }
+          );
+          if (isRefusal(outcome)) return outcome;
+          const unchanged = outcome.rowsTouched === 0 && outcome.tabFieldsChanged.length === 0;
+          return {
+            success: true as const,
+            pageId: page.id,
+            title: page.title,
+            tabIndex: ref.tabIndex,
+            ruleIds,
+            added: addedCount,
+            removed: removedCount,
+            skippedDuplicates,
+            conditionalRules: outcome.conditionalRules,
+            ...(warnings.length > 0 ? { warnings } : {}),
+            message: unchanged
+              ? `"${page.title}" already held exactly these rules; nothing changed.`
+              : `Conditional formatting on "${page.title}": now exactly the ${final.length} rule(s) in this call ` +
+                `(${addedCount} added, ${removedCount} removed).`,
+            nextSteps: [
+              'Call read_sheet with includeFormatting to verify the rules.',
+              'Keep the returned ruleIds to remove or replace these rules later.',
+            ],
+          };
         } else {
           const removals = new Set<string>();
           (removeRuleIds ?? []).forEach((id, index) => {

--- a/apps/web/src/lib/ai/tools/sheet-format-tools.ts
+++ b/apps/web/src/lib/ai/tools/sheet-format-tools.ts
@@ -91,7 +91,6 @@ import {
   MIN_ROW_HEIGHT,
   PALETTE,
   RANGE_OPERATORS,
-  SheetDuplicateRuleError,
   SheetFormatError,
   VALUELESS_OPERATORS,
   conditionalRuleContentKey,
@@ -861,8 +860,19 @@ function validateRegions(
       refuse(INVALID_FORMAT_REQUEST, `${label} declares the same region as ${earlier}.`, NOTHING_APPLIED);
     }
     declaredByContent.set(key, label);
+    const existingTwin = existingByContent.get(key);
     if (input.id === undefined) {
-      region.id = existingByContent.get(key) ?? contentId('region', region, taken);
+      region.id = existingTwin ?? contentId('region', region, taken);
+    } else if (existingTwin !== undefined && existingTwin !== input.id) {
+      // An explicit id that is NOT the existing region's, over identical
+      // content: a stale or invented id. Upserting it would land an
+      // overlapping twin under a second id.
+      refuse(
+        INVALID_FORMAT_REQUEST,
+        `${label}: a region with exactly this content already exists as "${existingTwin}". Pass that id to ` +
+          'restyle it, omit the id, or change the region.',
+        NOTHING_APPLIED
+      );
     }
     taken.add(region.id);
 
@@ -1264,6 +1274,8 @@ async function applyPlanned(
     return result;
   }
 
+  // What the write DID, from under the lock — not what the caller planned
+  // from its snapshot. The workflow trigger reads this.
   await logSheetCellActivity({
     pageId: page.id,
     driveId: page.driveId,
@@ -1273,7 +1285,17 @@ async function applyPlanned(
     actorDisplayName: mutationContext.actorDisplayName,
     changeGroupId: mutationContext.changeGroupId,
     isAiGenerated: true,
-    metadata: { source: 'ai-tool', tool: toolName, ...metadata },
+    metadata: {
+      source: 'ai-tool',
+      tool: toolName,
+      ...metadata,
+      cellsFormatted: result.cellsFormatted,
+      tabFieldsChanged: result.tabFieldsChanged,
+      rulesAdded: result.ruleIdsAdded.length,
+      rulesRemoved: result.ruleIdsRemoved.length,
+      regionsAdded: result.regionIdsAdded.length,
+      regionsRemoved: result.regionIdsRemoved.length,
+    },
   });
 
   await broadcastPageEvent(createPageEventPayload(page.driveId, page.id, 'content-updated', { title: page.title }));
@@ -1375,7 +1397,7 @@ export const sheetFormatTools = {
           page,
           'format_sheet',
           INVALID_FORMAT_REQUEST,
-          { regions: declared.regions.length, ops: ops?.length ?? 0, regionMode: regionMode ?? 'merge' }
+          { regionsDeclared: declared.regions.length, ops: ops?.length ?? 0, regionMode: regionMode ?? 'merge' }
         );
         if (isRefusal(outcome)) return outcome;
 
@@ -1388,6 +1410,9 @@ export const sheetFormatTools = {
           regionsApplied: declared.regions.length,
           regionMode: regionMode ?? 'merge',
           regionIds,
+          // From under the lock: what a replaceAll actually removed.
+          regionIdsAdded: outcome.regionIdsAdded,
+          removedRegionIds: outcome.regionIdsRemoved,
           opsApplied: ops?.length ?? 0,
           cellsFormatted: outcome.cellsFormatted,
           tabFieldsChanged: outcome.tabFieldsChanged,
@@ -1402,7 +1427,7 @@ export const sheetFormatTools = {
               ? `"${page.title}" already had this formatting; nothing changed. `
               : '') +
             `Formatted "${page.title}": ${declared.regions.length} region(s) declared` +
-            (regionMode === 'replaceAll' ? ' (every other region on the tab removed)' : '') +
+            (outcome.regionIdsRemoved.length > 0 ? ` (${outcome.regionIdsRemoved.length} other region(s) removed)` : '') +
             `, ${ops?.length ?? 0} op(s) applied` +
             (outcome.cellsFormatted > 0 ? `, ${outcome.cellsFormatted} cell(s) restyled` : '') +
             '.',
@@ -1493,7 +1518,6 @@ export const sheetFormatTools = {
           const final: ConditionalRule[] = [];
           const ruleIds: string[] = [];
           const skippedDuplicates: { index: number; existingRuleId: string }[] = [];
-          let addedCount = 0;
           for (const [index, entry] of built.entries()) {
             const key = contentKey(entry.rule);
             const earlier = seen.get(key);
@@ -1509,7 +1533,6 @@ export const sheetFormatTools = {
             const id = existingId ?? ruleContentId(key, takenIds);
             takenIds.add(id);
             if (existingId !== undefined) skippedDuplicates.push({ index, existingRuleId: existingId });
-            else addedCount += 1;
             ruleIds.push(id);
             final.push({ ...entry.rule, id } as ConditionalRule);
           }
@@ -1523,7 +1546,7 @@ export const sheetFormatTools = {
             page,
             'set_conditional_format',
             INVALID_RULE_REQUEST,
-            { mode, rulesAdded: addedCount, rulesRemoved: existing.length - skippedDuplicates.length }
+            { mode }
           );
           if (isRefusal(outcome)) return outcome;
           // Counts from what the store found under its lock, not from the
@@ -1652,7 +1675,7 @@ export const sheetFormatTools = {
             page,
             'set_conditional_format',
             INVALID_RULE_REQUEST,
-            { mode, rulesAdded: toAdd.length, rulesRemoved: existing.length - remaining.length },
+            { mode },
             'throw'
           );
         } catch (cause) {

--- a/apps/web/src/lib/ai/tools/sheet-format-tools.ts
+++ b/apps/web/src/lib/ai/tools/sheet-format-tools.ts
@@ -598,35 +598,15 @@ function chargeRange(range: string, label: string, budget: { used: number }): vo
   }
 }
 
-/**
- * The freeze in force, for a `freeze` op that names only one axis.
- *
- * The store's `setFrozen` sets both axes at once and reads `null` as "clear",
- * so a freeze op that mentioned only `frozenRows` would have cleared the
- * frozen columns as a side effect. An omitted axis keeps what is frozen at
- * that point in the call — the tab's snapshot, as updated by every earlier
- * op that froze or cleared. Resolving from the snapshot alone would make
- * `[freeze rows 1, freeze columns 1]` emit `{rows: null, columns: 1}` second
- * and unfreeze the row the first op had just pinned.
- */
-interface CurrentFreeze {
-  frozenRows: number | null;
-  frozenColumns: number | null;
-}
-
 /** Validated, resolved to the store's op, and labelled for the refusal path. */
 interface PlannedOp {
   op: SheetFormatOp;
   label: string;
 }
 
-function validateFormatOps(ops: readonly FormatOpInput[], initial: CurrentFreeze): PlannedOp[] {
+function validateFormatOps(ops: readonly FormatOpInput[]): PlannedOp[] {
   const planned: PlannedOp[] = [];
   const budget = { used: 0 };
-  // Running, not the snapshot: each freeze op is resolved against what the
-  // ops before it left frozen (see CurrentFreeze). The caller's copy is not
-  // mutated, so a refusal mid-list leaves no trace.
-  let current: CurrentFreeze = { ...initial };
 
   ops.forEach((input, index) => {
     const label = `ops[${index}]`;
@@ -723,10 +703,6 @@ function validateFormatOps(ops: readonly FormatOpInput[], initial: CurrentFreeze
             );
           }
           planned.push({ label, op: { type: 'setFrozen', rows: null, columns: null } });
-          // Later ops in this call resolve their omitted axis against the
-          // clear, not the snapshot — otherwise a freeze after a clear would
-          // resurrect the axis the clear removed.
-          current = { frozenRows: null, frozenColumns: null };
           break;
         }
         if (input.frozenRows === undefined && input.frozenColumns === undefined) {
@@ -736,15 +712,17 @@ function validateFormatOps(ops: readonly FormatOpInput[], initial: CurrentFreeze
             NOTHING_APPLIED
           );
         }
-        const frozen: CurrentFreeze = {
-          frozenRows: input.frozenRows ?? current.frozenRows,
-          frozenColumns: input.frozenColumns ?? current.frozenColumns,
-        };
+        // Only the axis the model named. The store keeps the other one as
+        // it finds it UNDER ITS LOCK — resolving it here, from the snapshot,
+        // would write back a value another writer may have changed since.
         planned.push({
           label,
-          op: { type: 'setFrozen', rows: frozen.frozenRows, columns: frozen.frozenColumns },
+          op: {
+            type: 'setFrozen',
+            ...(input.frozenRows !== undefined ? { rows: input.frozenRows } : {}),
+            ...(input.frozenColumns !== undefined ? { columns: input.frozenColumns } : {}),
+          },
         });
-        current = frozen;
         break;
       }
     }
@@ -1371,23 +1349,15 @@ export const sheetFormatTools = {
             planned.push({ label: declared.labels[index], op: { type: 'upsertRegion', region } });
           });
         }
-        // The freeze the model's ops start from. A region's freezeHeader
-        // lands in it, so a later `{op: 'freeze', frozenColumns: 1}` keeps
-        // the header rows the region pinned instead of resolving its omitted
-        // rows from the snapshot and erasing them.
-        const current: CurrentFreeze = {
-          frozenRows: formatting.frozenRows,
-          frozenColumns: formatting.frozenColumns,
-        };
+        // A region's freezeHeader pins rows only; the columns axis is left
+        // to the store, which keeps what it finds under its lock. A later
+        // `{op: 'freeze', frozenColumns: 1}` in the same call resolves its
+        // omitted rows against this op, in the store's running plan.
         if (declared.frozenRows !== undefined) {
-          current.frozenRows = declared.frozenRows;
-          planned.push({
-            label: 'regions (freezeHeader)',
-            op: { type: 'setFrozen', rows: current.frozenRows, columns: current.frozenColumns },
-          });
+          planned.push({ label: 'regions (freezeHeader)', op: { type: 'setFrozen', rows: declared.frozenRows } });
         }
 
-        planned.push(...validateFormatOps(ops ?? [], current));
+        planned.push(...validateFormatOps(ops ?? []));
 
         const outcome = await applyPlanned(
           ref,

--- a/apps/web/src/lib/ai/tools/tool-labels.ts
+++ b/apps/web/src/lib/ai/tools/tool-labels.ts
@@ -55,6 +55,8 @@ export const TOOL_NAME_MAP: Record<string, string> = {
   'move_page': 'Move Page',
   'read_sheet': 'Read Sheet',
   'edit_sheet_cells': 'Edit Sheet',
+  'format_sheet': 'Format Sheet',
+  'set_conditional_format': 'Conditional Formatting',
   // Search tools
   'regex_search': 'Search',
   'glob_search': 'Find Pages',

--- a/packages/lib/src/__tests__/sheet-format-request.test.ts
+++ b/packages/lib/src/__tests__/sheet-format-request.test.ts
@@ -695,6 +695,22 @@ describe('planFormatOps — conditional rules', () => {
     expect(plan([{ type: 'clearConditionalRules' }]).conditionalFormats).toEqual([]);
   });
 
+  it('addConditionalRule with the same id AND the same content is the duplicate, not an id collision', () => {
+    // A caller deriving ids from content sends the same id on a retry; the
+    // retry must surface as SheetDuplicateRuleError (recoverable), which
+    // means content is compared before the id.
+    const tab = tabWith({ conditionalFormats: [rule('a')] });
+    let caught: unknown;
+    try {
+      plan([{ type: 'addConditionalRule', rule: rule('a') }], tab);
+    } catch (error) {
+      caught = error;
+    }
+    expect(caught).toBeInstanceOf(SheetDuplicateRuleError);
+    // Same id, different content is still the id collision.
+    expect(refusalOf([{ type: 'addConditionalRule', rule: rule('a', '2') }], tab)).toContain('is already on this sheet');
+  });
+
   it('setConditionalRules replaces the whole list in the given order', () => {
     // Order is load-bearing: later rules win. A list that reverses two
     // existing rules is a real change, not two duplicates.
@@ -2245,8 +2261,10 @@ describe('planFormatOps — rule identity', () => {
     // Two rules under one id: `update` and `move` reach the first by index
     // while `remove` filters out both, so the new rule is not addressable at
     // all. The region path already refused this.
+    // Different content under the same id — identical content is the
+    // duplicate case, tested separately.
     const tab = tabWith({ conditionalFormats: [rule('a')] });
-    const message = refusalOf([{ type: 'addConditionalRule', rule: rule('a') }], tab);
+    const message = refusalOf([{ type: 'addConditionalRule', rule: rule('a', '2') }], tab);
     expect(message).toContain('A rule "a" is already on this sheet');
     expect(message).toContain('updateConditionalRule');
   });

--- a/packages/lib/src/__tests__/sheet-format-request.test.ts
+++ b/packages/lib/src/__tests__/sheet-format-request.test.ts
@@ -212,10 +212,20 @@ describe('planFormatOps — the request envelope', () => {
           ...samples[type as SheetFormatOp['type']],
         };
         delete op[field];
+        if (type === 'setFrozen') {
+          // The one op whose fields are each optional BY DESIGN: an omitted
+          // axis keeps the current freeze (resolved under the lock). Only
+          // both missing is a no-op that must refuse — asserted separately.
+          expect(() => plan([op as never], target)).not.toThrow();
+          continue;
+        }
         const message = refusalOf([op as never], target);
         // Naming the field is what makes the refusal repairable in one step;
         // "invalid op" would satisfy the throw and help nobody.
         expect(message, `${type} without ${field}`).toContain(field);
+      }
+      if (type === 'setFrozen') {
+        expect(refusalOf([{ type } as never], target)).toContain('rows');
       }
     }
   });
@@ -476,6 +486,26 @@ describe('planFormatOps — columns, rows and freezes', () => {
     const result = plan([{ type: 'setFrozen', rows: 1, columns: null }]);
     expect(result.steps).toEqual([{ type: 'setFrozen', rows: 1, columns: undefined }]);
     expect(result.touchesTabFields).toBe(true);
+  });
+
+  it('an omitted freeze axis keeps what the target holds, resolved at plan time', () => {
+    // The caller that means "freeze one row" must not have to send the
+    // columns it read a moment ago: the store plans under its lock, so the
+    // value it keeps is the current one, not a stale snapshot's.
+    const tab = tabWith({ frozenRows: null, frozenColumns: 2 });
+    expect(plan([{ type: 'setFrozen', rows: 1 }], tab).steps).toEqual([{ type: 'setFrozen', rows: 1, columns: 2 }]);
+    expect(plan([{ type: 'setFrozen', columns: null }], tab).steps).toEqual([{ type: 'setFrozen', rows: undefined, columns: undefined }]);
+    // A second freeze in the same plan resolves against the first.
+    expect(plan([{ type: 'setFrozen', rows: 1 }, { type: 'setFrozen', columns: 1 }], tab).steps).toEqual([
+      { type: 'setFrozen', rows: 1, columns: 2 },
+      { type: 'setFrozen', rows: 1, columns: 1 },
+    ]);
+    expect(plan([{ type: 'setFrozen', rows: null, columns: null }, { type: 'setFrozen', columns: 1 }], tab).steps[1]).toEqual({
+      type: 'setFrozen',
+      rows: undefined,
+      columns: 1,
+    });
+    expect(refusalOf([{ type: 'setFrozen' }])).toContain('needs "rows" and/or "columns"');
   });
 
   it('accepts 0 as "unfreeze", which is what setFrozen already means by it', () => {

--- a/packages/lib/src/__tests__/sheet-format-request.test.ts
+++ b/packages/lib/src/__tests__/sheet-format-request.test.ts
@@ -186,6 +186,7 @@ describe('planFormatOps — the request envelope', () => {
       removeConditionalRule: { id: 'a' },
       moveConditionalRule: { id: 'a', direction: 1 },
       clearConditionalRules: {},
+      setConditionalRules: { rules: [rule('cf_new', '99')] },
       setRegions: { regions: [region('r2')] },
       upsertRegion: { region: region('r2') },
       removeRegion: { id: 'r1' },
@@ -692,6 +693,25 @@ describe('planFormatOps — conditional rules', () => {
     // Unlike removing an id that is not there: a clear names no target and so
     // cannot be wrong about one.
     expect(plan([{ type: 'clearConditionalRules' }]).conditionalFormats).toEqual([]);
+  });
+
+  it('setConditionalRules replaces the whole list in the given order', () => {
+    // Order is load-bearing: later rules win. A list that reverses two
+    // existing rules is a real change, not two duplicates.
+    const tab = tabWith({ conditionalFormats: [rule('a'), rule('b', '2')] });
+    const result = plan([{ type: 'setConditionalRules', rules: [rule('b', '2'), rule('a')] }], tab);
+    expect(result.conditionalFormats.map((entry) => entry.id)).toEqual(['b', 'a']);
+    expect(result.touchesTabFields).toBe(true);
+    expect(plan([{ type: 'setConditionalRules', rules: [] }], tab).conditionalFormats).toEqual([]);
+  });
+
+  it('setConditionalRules refuses a duplicate id or duplicate content within the list', () => {
+    expect(refusalOf([{ type: 'setConditionalRules', rules: [rule('a'), rule('a', '2')] }])).toContain(
+      'Two rules share the id "a"'
+    );
+    expect(refusalOf([{ type: 'setConditionalRules', rules: [rule('a'), rule('b')] }])).toContain(
+      'rules[1] is identical to rule "a"'
+    );
   });
 
   it('refuses a resulting rule list that would come back shorter', () => {

--- a/packages/lib/src/__tests__/sheet-format-request.test.ts
+++ b/packages/lib/src/__tests__/sheet-format-request.test.ts
@@ -10,6 +10,7 @@ import {
   SheetDuplicateRuleError,
   SheetFormatError,
   conditionalRuleContentKey,
+  regionContentKey,
   planFormatOps,
   type SheetFormatOp,
   type SheetFormatPlan,
@@ -749,6 +750,25 @@ describe('planFormatOps — conditional rules', () => {
     expect(result.conditionalFormats.map((entry) => entry.id)).toEqual(['b', 'a']);
     expect(result.touchesTabFields).toBe(true);
     expect(plan([{ type: 'setConditionalRules', rules: [] }], tab).conditionalFormats).toEqual([]);
+  });
+
+  it('setConditionalRules refuses a non-array and a list over the limit', () => {
+    expect(refusalOf([{ type: 'setConditionalRules', rules: 'nope' } as never])).toContain('rules must be an array');
+    // A non-object entry is validated as an empty rule and refused by name.
+    expect(() => plan([{ type: 'setConditionalRules', rules: ['nope'] }])).toThrow(SheetFormatError);
+    const tooMany = Array.from({ length: MAX_CONDITIONAL_RULES + 1 }, (_, i) => rule(`cf_${i}`, String(i)));
+    expect(refusalOf([{ type: 'setConditionalRules', rules: tooMany }])).toContain(
+      `at most ${MAX_CONDITIONAL_RULES} rules; got ${MAX_CONDITIONAL_RULES + 1}`
+    );
+  });
+
+  it('regionContentKey identifies a region by everything but its id', () => {
+    // The tool reuses an existing region's id when a new declaration
+    // matches it by content, and derives a stable id from the same key.
+    const base = region('r1');
+    expect(regionContentKey({ ...base, id: 'other' })).toBe(regionContentKey(base));
+    expect(regionContentKey({ ...base, name: undefined })).toBe(regionContentKey(base));
+    expect(regionContentKey({ ...base, theme: 'red' })).not.toBe(regionContentKey(base));
   });
 
   it('setConditionalRules refuses a duplicate id or duplicate content within the list', () => {

--- a/packages/lib/src/commands/command-core.ts
+++ b/packages/lib/src/commands/command-core.ts
@@ -242,7 +242,7 @@ export const BUILTIN_COMMANDS: readonly BuiltinCommandDefinition[] = [
     kind: 'skill',
     description:
       'Creates, reads, edits and formats SHEET (spreadsheet) pages: reading rows by range or column value with read_sheet, cell edits with edit_sheet_cells, formulas and the supported function set, references between sheets, and making a sheet presentable with format_sheet (declared tables with header rows, currency/percent/date columns, totals and a theme) and set_conditional_format (highlight rules, colour scales, data bars). Use when the user asks for a spreadsheet, budget, tracker, dashboard, report or table of computed values, wants a sheet formatted, styled, cleaned up or made presentable, or needs help with formulas.',
-    requiredTools: ['read_sheet', 'edit_sheet_cells', 'format_sheet'],
+    requiredTools: ['read_sheet', 'edit_sheet_cells', 'format_sheet', 'set_conditional_format'],
   },
   {
     trigger: 'task-management',

--- a/packages/lib/src/commands/command-core.ts
+++ b/packages/lib/src/commands/command-core.ts
@@ -241,8 +241,8 @@ export const BUILTIN_COMMANDS: readonly BuiltinCommandDefinition[] = [
     trigger: 'spreadsheets',
     kind: 'skill',
     description:
-      'Creates, reads and edits SHEET (spreadsheet) pages: reading rows by range or column value with read_sheet, cell edits with edit_sheet_cells, formulas and the supported function set, and references between sheets. Use when the user asks for a spreadsheet, budget, tracker, table of computed values, or help with formulas.',
-    requiredTools: ['read_sheet', 'edit_sheet_cells'],
+      'Creates, reads, edits and formats SHEET (spreadsheet) pages: reading rows by range or column value with read_sheet, cell edits with edit_sheet_cells, formulas and the supported function set, references between sheets, and making a sheet presentable with format_sheet (declared tables with header rows, currency/percent/date columns, totals and a theme) and set_conditional_format (highlight rules, colour scales, data bars). Use when the user asks for a spreadsheet, budget, tracker, dashboard, report or table of computed values, wants a sheet formatted, styled, cleaned up or made presentable, or needs help with formulas.',
+    requiredTools: ['read_sheet', 'edit_sheet_cells', 'format_sheet'],
   },
   {
     trigger: 'task-management',

--- a/packages/lib/src/sheets/__tests__/sheet-store.integration.test.ts
+++ b/packages/lib/src/sheets/__tests__/sheet-store.integration.test.ts
@@ -1497,6 +1497,42 @@ describe('sheet store (integration)', () => {
       expect((await db.select({ id: sheetChanges.id }).from(sheetChanges).where(eq(sheetChanges.tabId, tabId))).length).toBe(logged);
     });
 
+    it('setConditionalRules with the list the tab already holds is not a write', async () => {
+      // The AI tool's replaceAll sends the final list on every call, including
+      // a retry, so a rule added concurrently is removed under the lock. That
+      // is only acceptable because an identical list is compared as JSON and
+      // bumps nothing — the case a retry depends on.
+      const { pageId, tabId, ownerId } = await makeSheet({ rowCount: 10 });
+      const second = { ...FORMAT_RULE, id: 'second', ranges: ['B1:B9'] };
+      const first = await applyFormatOps(
+        { pageId },
+        [{ type: 'setConditionalRules', rules: [FORMAT_RULE, second] }],
+        { userId: ownerId }
+      );
+      expect(first.tabFieldsChanged).toEqual(['conditionalFormats']);
+      const before = await revisionOf(pageId);
+      const logged = (await db.select({ id: sheetChanges.id }).from(sheetChanges).where(eq(sheetChanges.tabId, tabId))).length;
+
+      const again = await applyFormatOps(
+        { pageId },
+        [{ type: 'setConditionalRules', rules: [FORMAT_RULE, second] }],
+        { userId: ownerId }
+      );
+      expect(again.tabFieldsChanged).toEqual([]);
+      expect(await revisionOf(pageId)).toEqual(before);
+      expect((await db.select({ id: sheetChanges.id }).from(sheetChanges).where(eq(sheetChanges.tabId, tabId))).length).toBe(logged);
+
+      // Reversed is a change: later rules win.
+      const reversed = await applyFormatOps(
+        { pageId },
+        [{ type: 'setConditionalRules', rules: [second, FORMAT_RULE] }],
+        { userId: ownerId }
+      );
+      expect(reversed.tabFieldsChanged).toEqual(['conditionalFormats']);
+      const tab = (await getTab({ pageId }))!;
+      expect((tab.conditionalFormats as { id: string }[]).map((rule) => rule.id)).toEqual(['second', 'over-100']);
+    });
+
     it('leaves a formula cell’s raw, value and type untouched', async () => {
       // Kills: fabricating a `StoredCell` instead of spreading the loaded one.
       const { pageId, tabId, ownerId } = await makeSheet({ rowCount: 10 });

--- a/packages/lib/src/sheets/__tests__/sheet-store.integration.test.ts
+++ b/packages/lib/src/sheets/__tests__/sheet-store.integration.test.ts
@@ -1659,7 +1659,11 @@ describe('sheet store (integration)', () => {
       // held just before its `UPDATE sheet_tabs`, with the tab lock already
       // taken, until the second call is observed waiting on that lock.
       const { pageId, ownerId } = await makeSheet({ rowCount: 20 });
-      const second = { ...FORMAT_RULE, id: 'second' };
+      // A different RANGE, not just a different id: the store refuses a rule
+      // whose content matches one already on the tab (SheetDuplicateRuleError,
+      // keyed by everything but `id`), and this case is about the lock, not
+      // the dedup — two distinct rules must both land.
+      const second = { ...FORMAT_RULE, id: 'second', ranges: ['B1:B9'] };
 
       let other: Promise<unknown> | null = null;
       await db.transaction(async (tx) =>

--- a/packages/lib/src/sheets/__tests__/sheet-store.integration.test.ts
+++ b/packages/lib/src/sheets/__tests__/sheet-store.integration.test.ts
@@ -1631,6 +1631,8 @@ describe('sheet store (integration)', () => {
         expect(result.tabFieldsChanged.sort()).toEqual(
           ['columnWidths', 'conditionalFormats', 'frozenRows', 'regions'].sort()
         );
+        expect(result.regionIdsAdded).toEqual([REGION.id]);
+        expect(result.regionIdsRemoved).toEqual([]);
         expect(await audit.count()).toBe(1);
       } finally {
         await audit.drop();

--- a/packages/lib/src/sheets/__tests__/sheet-store.integration.test.ts
+++ b/packages/lib/src/sheets/__tests__/sheet-store.integration.test.ts
@@ -1510,6 +1510,9 @@ describe('sheet store (integration)', () => {
         { userId: ownerId }
       );
       expect(first.tabFieldsChanged).toEqual(['conditionalFormats']);
+      // The delta is computed under the lock from what the tab held THEN.
+      expect(first.ruleIdsAdded.sort()).toEqual(['over-100', 'second']);
+      expect(first.ruleIdsRemoved).toEqual([]);
       const before = await revisionOf(pageId);
       const logged = (await db.select({ id: sheetChanges.id }).from(sheetChanges).where(eq(sheetChanges.tabId, tabId))).length;
 
@@ -1519,8 +1522,16 @@ describe('sheet store (integration)', () => {
         { userId: ownerId }
       );
       expect(again.tabFieldsChanged).toEqual([]);
+      expect(again.ruleIdsAdded).toEqual([]);
+      expect(again.ruleIdsRemoved).toEqual([]);
       expect(await revisionOf(pageId)).toEqual(before);
       expect((await db.select({ id: sheetChanges.id }).from(sheetChanges).where(eq(sheetChanges.tabId, tabId))).length).toBe(logged);
+
+      // A list that drops one: the removed id is reported from the locked read.
+      const dropped = await applyFormatOps({ pageId }, [{ type: 'setConditionalRules', rules: [second] }], { userId: ownerId });
+      expect(dropped.ruleIdsRemoved).toEqual(['over-100']);
+      expect(dropped.ruleIdsAdded).toEqual([]);
+      await applyFormatOps({ pageId }, [{ type: 'setConditionalRules', rules: [FORMAT_RULE, second] }], { userId: ownerId });
 
       // Reversed is a change: later rules win.
       const reversed = await applyFormatOps(

--- a/packages/lib/src/sheets/format-request.ts
+++ b/packages/lib/src/sheets/format-request.ts
@@ -393,7 +393,21 @@ export class SheetDuplicateRuleError extends SheetFormatError {
  * retry cannot reproduce. Exported so the planner's content refusal and a
  * caller's pre-flight dedupe are one definition, not two that drift.
  */
+/**
+ * A region's identity by content — everything but `id`, canonicalised the
+ * same way as a rule's — so a caller that declares a region without an id
+ * can recognise the one it already declared and reuse its id instead of
+ * minting a twin. Retries after a timed-out response are routine.
+ */
+export function regionContentKey(region: Omit<SheetRegion, 'id'> | SheetRegion): string {
+  return contentKey(region);
+}
+
 export function conditionalRuleContentKey(rule: Omit<ConditionalRule, 'id'> | ConditionalRule): string {
+  return contentKey(rule);
+}
+
+function contentKey(value: object): string {
   const canonical = (value: unknown): unknown => {
     if (Array.isArray(value)) return value.map(canonical);
     if (typeof value === 'object' && value !== null) {
@@ -407,7 +421,7 @@ export function conditionalRuleContentKey(rule: Omit<ConditionalRule, 'id'> | Co
     }
     return value;
   };
-  return JSON.stringify(canonical(rule));
+  return JSON.stringify(canonical(value));
 }
 
 /**

--- a/packages/lib/src/sheets/format-request.ts
+++ b/packages/lib/src/sheets/format-request.ts
@@ -447,6 +447,7 @@ export type SheetFormatOp =
   | { type: 'removeConditionalRule'; id: string }
   | { type: 'moveConditionalRule'; id: string; direction: -1 | 1 }
   | { type: 'clearConditionalRules' }
+  | { type: 'setConditionalRules'; rules: readonly unknown[] }
   | { type: 'setRegions'; regions: readonly unknown[] }
   | { type: 'upsertRegion'; region: unknown }
   | { type: 'removeRegion'; id: string };
@@ -610,6 +611,7 @@ export const OP_FIELDS: Record<SheetFormatOp['type'], readonly string[]> = {
   removeConditionalRule: ['id'],
   moveConditionalRule: ['id', 'direction'],
   clearConditionalRules: [],
+  setConditionalRules: ['rules'],
   setRegions: ['regions'],
   upsertRegion: ['region'],
   removeRegion: ['id'],
@@ -2197,6 +2199,53 @@ export function planFormatOps(
         // names no target and so cannot be wrong about one, while a remove
         // names an id and is telling us something false about the sheet.
         rules = [];
+        rulesTouched = true;
+        break;
+      }
+
+      case 'setConditionalRules': {
+        // The whole list, in the caller's order, replanned under the lock —
+        // so a "keep only these" holds against a rule another writer added
+        // between the caller's read and this write, and reordering two rules
+        // that both already exist is a real change (later rules win). The
+        // store compares the list it stores as JSON, so sending the list the
+        // tab already holds is not a write.
+        if (!Array.isArray(op.rules)) {
+          refuseOp(index, op.type, 'rules must be an array.');
+        }
+        if (op.rules.length > MAX_CONDITIONAL_RULES) {
+          refuseOp(
+            index,
+            op.type,
+            `A sheet can hold at most ${MAX_CONDITIONAL_RULES} rules; got ${op.rules.length}.`
+          );
+        }
+
+        const next: ConditionalRule[] = [];
+        const seenIds = new Set<string>();
+        const seenContent = new Map<string, string>();
+        op.rules.forEach((value: unknown, position: number) => {
+          const rule = validateRuleInput(
+            value,
+            isObject(value) ? value : {},
+            index,
+            op.type,
+            chargeInspection(index, op.type)
+          );
+          if (seenIds.has(rule.id)) {
+            refuseOp(index, op.type, `Two rules share the id "${rule.id}".`);
+          }
+          const key = conditionalRuleContentKey(rule);
+          const twin = seenContent.get(key);
+          if (twin !== undefined) {
+            refuseOp(index, op.type, `rules[${position}] is identical to rule "${twin}".`);
+          }
+          seenIds.add(rule.id);
+          seenContent.set(key, rule.id);
+          next.push(rule);
+        });
+
+        rules = next;
         rulesTouched = true;
         break;
       }

--- a/packages/lib/src/sheets/format-request.ts
+++ b/packages/lib/src/sheets/format-request.ts
@@ -441,7 +441,11 @@ export type SheetFormatOp =
   | { type: 'setColumnFormat'; column: string; patch: CellFormat }
   | { type: 'setColumnWidth'; column: string; width: number | null }
   | { type: 'setRowHeight'; row: number; height: number | null }
-  | { type: 'setFrozen'; rows: number | null; columns: number | null }
+  // An OMITTED axis keeps what the tab has at plan time — under the store's
+  // lock, so a caller that means "freeze one row" never has to send a value
+  // for the columns it read a moment ago and cannot know still holds.
+  // `null` clears.
+  | { type: 'setFrozen'; rows?: number | null; columns?: number | null }
   | { type: 'addConditionalRule'; rule: unknown }
   | { type: 'updateConditionalRule'; id: string; patch: Record<string, unknown> }
   | { type: 'removeConditionalRule'; id: string }
@@ -486,6 +490,9 @@ export interface SheetFormatTarget {
   columnCount: number;
   conditionalFormats?: readonly ConditionalRule[];
   regions?: readonly SheetRegion[];
+  /** The freeze in force; a `setFrozen` that omits an axis keeps it. */
+  frozenRows?: number | null;
+  frozenColumns?: number | null;
 }
 
 export interface SheetFormatPlan {
@@ -1869,6 +1876,9 @@ export function planFormatOps(
   let regions: SheetRegion[] = [...(tab.regions ?? [])];
   let rulesTouched = false;
   let regionsTouched = false;
+  // Running, so a second freeze op in the same plan resolves its omitted
+  // axis against the first, not the tab.
+  let frozen = { rows: tab.frozenRows ?? null, columns: tab.frozenColumns ?? null };
 
   // How many cells this request has asked us to EXPAND while checking rules,
   // as opposed to how many the resulting sheet covers. Bounded by the same
@@ -2036,20 +2046,24 @@ export function planFormatOps(
       }
 
       case 'setFrozen': {
+        if (op.rows === undefined && op.columns === undefined) {
+          refuseOp(index, op.type, 'setFrozen needs "rows" and/or "columns" (a count, or null to clear).');
+        }
         const frozenRows = validateFreeze(
-          op.rows,
+          op.rows === undefined ? frozen.rows : op.rows,
           tab.rowCount,
           'frozen rows',
           index,
           op.type
         );
         const frozenColumns = validateFreeze(
-          op.columns,
+          op.columns === undefined ? frozen.columns : op.columns,
           tab.columnCount,
           'frozen columns',
           index,
           op.type
         );
+        frozen = { rows: frozenRows ?? null, columns: frozenColumns ?? null };
         steps.push({ type: 'setFrozen', rows: frozenRows, columns: frozenColumns });
         touchesTabFields = true;
         break;

--- a/packages/lib/src/sheets/format-request.ts
+++ b/packages/lib/src/sheets/format-request.ts
@@ -2074,6 +2074,27 @@ export function planFormatOps(
           chargeInspection(index, op.type)
         );
 
+        // Content BEFORE id. A caller that mints ids dedupes by content
+        // before its call, but two overlapping calls (a timeout retry racing
+        // the original) both see no duplicate; the store replans HERE under
+        // its lock, so this is the one check that refuses the second one
+        // atomically — as the duplicate it is, which the caller recovers
+        // from, and not as an id collision, which it cannot. A caller that
+        // derives ids from content sends the SAME id both times, so checking
+        // the id first would turn the retry it was designed for into an
+        // ordinary refusal. Without this the tab holds two rules that paint
+        // the same cells the same way and evaluates the formula twice.
+        const key = conditionalRuleContentKey(rule);
+        const twin = rules.find((existing) => conditionalRuleContentKey(existing) === key);
+        if (twin !== undefined) {
+          throw new SheetDuplicateRuleError(
+            `Op ${index} (${op.type}): An identical rule is already on this sheet as "${twin.id}". ` +
+              'Use updateConditionalRule to change it, or removeConditionalRule if it is no longer wanted.',
+            index,
+            twin.id
+          );
+        }
+
         if (rules.some((existing) => existing.id === rule.id)) {
           // Two rules under one id: `update` and `move` reach the first by
           // `findIndex` while `remove` filters out both, so the new rule is no
@@ -2083,25 +2104,6 @@ export function planFormatOps(
             op.type,
             `A rule "${rule.id}" is already on this sheet. Use updateConditionalRule to change it, ` +
               'or give the new rule its own id.'
-          );
-        }
-
-        // Content, not only id. A caller that mints ids dedupes by content
-        // before its call, but two overlapping calls (a timeout retry racing
-        // the original) both see no duplicate and mint different ids; the
-        // store replans HERE under its lock, so this is the one check that
-        // refuses the second one atomically. Without it the tab holds two
-        // rules that paint the same cells the same way and evaluates the
-        // formula twice per cell, and the "sending the same rules twice adds
-        // them once" promise is broken for precisely the retry it was made for.
-        const key = conditionalRuleContentKey(rule);
-        const twin = rules.find((existing) => conditionalRuleContentKey(existing) === key);
-        if (twin !== undefined) {
-          throw new SheetDuplicateRuleError(
-            `Op ${index} (${op.type}): An identical rule is already on this sheet as "${twin.id}". ` +
-              'Use updateConditionalRule to change it, or removeConditionalRule if it is no longer wanted.',
-            index,
-            twin.id
           );
         }
 

--- a/packages/lib/src/sheets/store.ts
+++ b/packages/lib/src/sheets/store.ts
@@ -1615,6 +1615,8 @@ function formatTarget(tab: StoredTab): SheetFormatTarget {
     columnCount: tab.columnCount,
     conditionalFormats: parseConditionalRules(tab.conditionalFormats ?? undefined) ?? [],
     regions: parseRegions(tab.regions ?? undefined) ?? [],
+    frozenRows: tab.frozenRows ?? null,
+    frozenColumns: tab.frozenColumns ?? null,
   };
 }
 

--- a/packages/lib/src/sheets/store.ts
+++ b/packages/lib/src/sheets/store.ts
@@ -1076,6 +1076,9 @@ export interface ApplyFormatOpsResult {
    */
   ruleIdsAdded: string[];
   ruleIdsRemoved: string[];
+  /** Region ids the write added and removed, computed the same way. */
+  regionIdsAdded: string[];
+  regionIdsRemoved: string[];
   /** Regions on the tab after the write. */
   regions: number;
   rowCount: number;
@@ -1191,6 +1194,8 @@ export async function applyFormatOps(
         ruleIdsAdded: [],
         ruleIdsRemoved: [],
         regions: preview.regions.length,
+        regionIdsAdded: [],
+        regionIdsRemoved: [],
         rowCount: tab.rowCount,
         columnCount: tab.columnCount,
         recomputed: [],
@@ -1251,6 +1256,8 @@ export async function applyFormatOps(
     const plan = planFormatOps(ops, lockedTarget);
     const ruleIdsBefore = new Set((lockedTarget.conditionalFormats ?? []).map((rule) => rule.id));
     const ruleIdsAfter = new Set(plan.conditionalFormats.map((rule) => rule.id));
+    const regionIdsBefore = new Set((lockedTarget.regions ?? []).map((region) => region.id));
+    const regionIdsAfter = new Set(plan.regions.map((region) => region.id));
 
     // Growth is re-derived from the locked extent, and only if the snapshot
     // said so: if it did not, no tab lock is held and the recompute seeds were
@@ -1406,6 +1413,8 @@ export async function applyFormatOps(
       ruleIdsAdded: [...ruleIdsAfter].filter((id) => !ruleIdsBefore.has(id)),
       ruleIdsRemoved: [...ruleIdsBefore].filter((id) => !ruleIdsAfter.has(id)),
       regions: plan.regions.length,
+      regionIdsAdded: [...regionIdsAfter].filter((id) => !regionIdsBefore.has(id)),
+      regionIdsRemoved: [...regionIdsBefore].filter((id) => !regionIdsAfter.has(id)),
       rowCount: extent.rowCount,
       columnCount: extent.columnCount,
       recomputed,

--- a/packages/lib/src/sheets/store.ts
+++ b/packages/lib/src/sheets/store.ts
@@ -1068,6 +1068,14 @@ export interface ApplyFormatOpsResult {
   tabFieldsChanged: string[];
   /** Conditional rules on the tab after the write. */
   conditionalRules: number;
+  /**
+   * Rule ids the write added and removed, computed under the tab lock from
+   * what the tab held THEN — not from any caller's earlier read. A caller
+   * that plans from a snapshot cannot know what another writer landed in
+   * between; these are what actually changed.
+   */
+  ruleIdsAdded: string[];
+  ruleIdsRemoved: string[];
   /** Regions on the tab after the write. */
   regions: number;
   rowCount: number;
@@ -1180,6 +1188,8 @@ export async function applyFormatOps(
         rowsTouched: 0,
         tabFieldsChanged: [],
         conditionalRules: preview.conditionalFormats.length,
+        ruleIdsAdded: [],
+        ruleIdsRemoved: [],
         regions: preview.regions.length,
         rowCount: tab.rowCount,
         columnCount: tab.columnCount,
@@ -1237,7 +1247,10 @@ export async function applyFormatOps(
     // so the two agree on what was locked.
     const current = await getTab(ref, tx);
     if (!current) throw new Error(`Sheet tab not found for page ${ref.pageId}`);
-    const plan = planFormatOps(ops, formatTarget(current));
+    const lockedTarget = formatTarget(current);
+    const plan = planFormatOps(ops, lockedTarget);
+    const ruleIdsBefore = new Set((lockedTarget.conditionalFormats ?? []).map((rule) => rule.id));
+    const ruleIdsAfter = new Set(plan.conditionalFormats.map((rule) => rule.id));
 
     // Growth is re-derived from the locked extent, and only if the snapshot
     // said so: if it did not, no tab lock is held and the recompute seeds were
@@ -1390,6 +1403,8 @@ export async function applyFormatOps(
       rowsTouched,
       tabFieldsChanged,
       conditionalRules: plan.conditionalFormats.length,
+      ruleIdsAdded: [...ruleIdsAfter].filter((id) => !ruleIdsBefore.has(id)),
+      ruleIdsRemoved: [...ruleIdsBefore].filter((id) => !ruleIdsAfter.has(id)),
       regions: plan.regions.length,
       rowCount: extent.rowCount,
       columnCount: extent.columnCount,


### PR DESCRIPTION
## Why

Task 5 of 5 on the sheet-formatting epic. `format_sheet` and `set_conditional_format` (#2571) existed but nothing registered them, no gate knew them, and the spreadsheets skill still said `edit_sheet_cells` was the only write path. Until this lands the whole epic is dead code.

## What

**Registration and gating**
- `TOOL_MODULES.sheetsFormat` in `ai-tools.ts` — `TOOL_REGISTRY`, `WORKSPACE_TOOL_NAMES` and the doc-enforced count follow from it. README and the getting-started doc go 81 → 83 (`tool-registry-docs.test.ts` enforces this; not weakened).
- Both names in `WRITE_TOOLS`, so a read-only agent loses them and `cap-step-tool-payloads` keeps their results intact.
- Labels: `Format Sheet`, `Conditional Formatting`.
- `inline-instructions.ts`: a per-tool-gated SHEET line for `format_sheet`, matching the existing pattern (naming a tool the agent does not hold produces an unknown-tool call).
- `command-core.ts`: the `spreadsheets` description now names formatting, dashboards and "presentable" (the model's only retrieval signal); both `format_sheet` and `set_conditional_format` join the `.some()`-gated `requiredTools`, so an agent holding only the rule tool still discovers the skill (Codex review).

**Two deliberate non-changes**
- `SHEET_WRITE_TOOL_NAMES` in `system-prompt.ts` stays `['edit_sheet_cells']`, with a comment saying why: it answers "can sandbox OUTPUT go into a Sheet", and a formatting tool cannot put data anywhere. A test pins that an agent holding only the formatting tools is not told a Sheet is a destination.
- `cap-step-tool-payloads.ts` untouched — it is generic and keys off `WRITE_TOOLS`.

**Skill body** (`spreadsheets.ts`, 19,795 / 20,000 chars)
- New "Formatting: describe the table, don't paint it" section: regions first, `ops` as the escape hatch, a one-call budget-table example (range, headerRows, currency column, total row, theme), and the lines the schema cannot convey: ops do not cover rows added later / regions do; a region costs nothing per row vs `A2:A5000` = 4,999 cells; precedence `column default < region < cell < conditional rule`; rule values compare the computed, unformatted value.
- Short `set_conditional_format` section: the four rule kinds, `removeRuleIds`, and `replaceAll` requiring a `read_sheet includeFormatting: true` first.
- Pitfall 7 reworded (raw values stay raw, THEN set the display format; `SUM` and `where` still work). "Only write path" claim removed; heading is now "Two write paths". Two new pitfalls (colouring cells instead of a rule; cell-by-cell instead of a region).
- Review corrections: `dataBar` `color` is required (the tool refuses without it); the never-computed-formula exception on `unformatted` reads is restored; MIN/MAX named beside SUM as text-intolerant.
- No taste section, no palette table — `region-format.ts` decides what money and a header band look like.
- Paid for by trimming the function-table Notes column and the longest `read_sheet` bullets. No capability content was cut.

**Renderer**
- `SheetFormatRenderer` — regions, ops, rules, removed rule ids, and one swatch per distinct colour (`#FFF` and `#ffffff` are one swatch). Registered for both tools in `registry.tsx`. Not `SheetEditRenderer`: that is an address → value table and formatting has no values. A refusal falls through to the generic envelope. Rules the result reports in `skippedDuplicates` (a retried or overlapping append) render with an "already present" badge and are excluded from the added count (Codex review). Cell rules are described through the sheet's own `describeCondition`, so the card omits the operands the executor drops and reads "is greater than 1000" like the rule panel (Codex review). The region swatch is the header colour `region-format` actually paints, slate fallback included. Both entries also fall through on the execute_tool `{ error }` envelope, which has no `success` key and arrives with the model's unvalidated input (local review). Input types are the tool's own zod-inferred types, imported type-only.

## Tests

- `sheet-format-registration.test.ts` — registry shape, labels, `WRITE_TOOLS` (direct and via `filterToolsForReadOnly`), the skill's `requiredTools`/description, the gated SHEET line, and the destination-phrase non-change.
  - **Search-mode trap handled**: the read-only assertion is written as `tool_search('select:format_sheet')` on a search-mode set built from the real registry (full agent → found, read-only → empty, with `read_sheet` as the live-probe control), plus an `execute_tool` dispatch probe (full agent reaches the tool's auth guard; read-only gets the unknown-tool envelope). `Object.keys` would have passed vacuously because neither tool is core.
- `spreadsheets-skill-body.test.ts` — no "only write path" line; regions taught before ops; the four schema-invisible lines; worked example; rule kinds, required data-bar colour, replaceAll; pitfall 7; the two new pitfalls; the never-computed-formula clause; MIN/MAX. Pins facts, not wording, so the body can still be trimmed.
- `packages/lib` gains `regionContentKey` (beside the rule key), the `setConditionalRules` op, and `ruleIdsAdded`/`ruleIdsRemoved`/`regionIdsAdded`/`regionIdsRemoved` on the `applyFormatOps` result (computed under the tab lock), and `setFrozen` axes that may be omitted to keep the current freeze; `sheet-format-request.test.ts` covers the op (order, empty list, duplicate id/content) and the store integration suite covers the identical-list no-op end to end.
- Two general guards for the class of bug this epic shipped with: every builtin skill body may only name tools that exist (`skill-bodies.test.ts`), and every `name: tool(` declared in a `*-tools.ts` module must be a key of the full registry (`tool-registry-docs.test.ts`, ledger: `ask_user`). The `ai-tools.test.ts` collision case now derives its keysets from `TOOL_REGISTRY`; the hand list had drifted. The search-mode read-only probe runs over every registered write tool.
- `registry-sheet-format.test.tsx` — both tools render the formatting card, counts/ranges/swatch dedupe, refusal fall-through, empty-state message.

## Mutation probes (by line, all red, restored)

| # | mutation | went red in |
|---|---|---|
| M1 | `sheetsFormat` line removed from `TOOL_MODULES` | registration (4) + tool-registry-docs (2) |
| M2 | `'format_sheet'` removed from `WRITE_TOOLS` | registration |
| M3 | `'set_conditional_format'` removed from `WRITE_TOOLS` | registration |
| M4 | `format_sheet` label removed | registration |
| M5 | gated SHEET line removed | registration |
| M6 | `format_sheet` added to `SHEET_WRITE_TOOL_NAMES` | registration |
| M7 | `format_sheet` removed from `requiredTools` (lib dist rebuilt) | registration |
| M8 | "regions do" line removed from body | skill body |
| M9 | pitfall 11 removed | skill body |
| M10 | "only write path" sentence re-added | skill body |
| M11 | README 83 → 81 | tool-registry-docs |
| M12 | `format_sheet` registry entry renamed | registry-coverage (2) + renderer (3) |
| M13 | swatch `normalizeHex` dedupe removed | renderer |
| M14 | duplicate-rule labelling disabled | renderer |
| M15 | `set_conditional_format` removed from `requiredTools` | registration |
| M16 | execute_tool `{ error }` guard removed from the registry entry | renderer |
| M17 | raw operands printed instead of `describeCondition` | renderer (2) |
| M18 | region swatch uses `hue.mid` instead of the header colour | renderer |
| M19 | data-bar colour described as optional again | skill body |
| M20 | never-computed-formula clause removed | skill body |
| M21 | `sheetsFormat` removed from `TOOL_MODULES` | registration scan (3) |
| M22 | concurrent-rules store test: second rule's range reverted | lib integration (SheetDuplicateRuleError) |
| M23 | empty `replaceAll` no longer exempt from the nothing-given guard | tool tests |
| M24 | replace-all note dropped from the card | renderer |
| M25 | `regionMode` not passed through the registry | renderer |
| M26 | activity/broadcast gate on the store's change indicators removed | tool tests |
| M27 | content-identical new region no longer reuses the existing id | tool tests |
| M28 | `removeRuleIds` dedupe removed | renderer |
| M29 | content-derived region id replaced by a random one | tool tests |
| M30 | `changed` hard-coded true | tool tests |
| M31 | card's unchanged handling disabled | renderer |
| M32 | same-call duplicate region no longer refused | tool tests |
| M33 | conditional `replaceAll` back to clear-and-rebuild | tool tests |
| M34 | rule id random again | tool tests |
| M35 | store `setConditionalRules` content-duplicate refusal removed | lib tests |
| M36 | replaceAll final list order reversed | tool tests |
| M37 | same-call duplicate rule refusal disabled | tool tests |
| M38 | explicit-id region declarations not registered by content | tool tests |
| M39 | absent `removeRuleIds` entry refuses again | tool tests |
| M40 | store checks id collision before content twin again | lib tests |
| M41 | append recovery catches only the duplicate error again | tool tests |
| M42 | replaceAll removed count from the snapshot again | tool tests |
| M43 | unbounded `C:C` example restored | tool tests |
| M44 | "kept" badge dropped | renderer |
| M45 | card reads removals from the input again | renderer |
| M46 | explicit-id twin of an existing region not refused | tool tests |
| M47 | activity metadata counts from the snapshot | tool tests |
| M48 | region-removal note shown regardless of the count | renderer |
| M49 | store clears an omitted freeze axis instead of keeping it | lib + tool tests |
| M50 | tool sends the omitted columns axis as null again | tool tests |

## Verification

- `bun run --filter web test -- sheet-format` → 3 files, 54 passed
- `bun run --filter web test -- skill` → 5 files, 50 passed
- `bun run --filter web test -- tool` → 94 files passed; the 2 failures are `activity-tools.test.ts` and `agent-tool-surface.integration.test.ts`, which fail loud by design without the dockerized test Postgres. Unrelated to this change.
- `bun run --filter web typecheck` → exit 0
- Monorepo build/typecheck not run locally per instructions. `test.yml` only triggers on PRs against master, so the full Test Suite was dispatched by hand on this branch (`gh workflow run test.yml --ref pu/sheet-tool-registry`), the same way the epic base branch got its run.
- **Base-branch fix carried here:** the first dispatched run failed one lib integration test, `sheet-store.integration.test.ts › lands both rules when two calls add different ones concurrently`. It is red on `pu/sheet-agent-regions` itself: #2571's `d31b789` made the store refuse a content-identical rule, and that case added two rules differing only by id (the base branch's last green run, `7ced967`, predates that commit). The second rule now covers a different range. Verified against a migrated local test DB (88/88 in the file; red again with the range removed). Lint/typecheck and E2E passed on the same run.

## Review threads

Codex round 1 (duplicate rules shown as changes; skill eligibility missing `set_conditional_format`) fixed in the second commit. Codex round 2 (data-bar colour is required; card printed operands the executor drops) and the local code-review findings (error-envelope crash, dropped skill clause, MIN/MAX, swatch colour, drifted collision test, unregistered-module guard, changelog) fixed in the third. Codex round 3 (an empty `replaceAll` was refused by the nothing-given guard although the second guard meant to admit it; the card hid the regions a `replaceAll` deleted) fixed in the fifth: an empty `replaceAll` now clears every region like the conditional tool's does, the result carries `regionMode`, and the card names the removal. Codex round 4 (new-region retries minted a twin each time; no-op calls still logged activity and broadcast; repeated `removeRuleIds` rendered twice) fixed in the sixth: a new region content-identical to an existing one reuses its id (`regionContentKey` in lib beside the rule key), side effects are gated on the store's own `rowsTouched`/`tabFieldsChanged`, and removed ids are deduplicated. Codex round 5 (overlapping retries could still mint two ids because each snapshot misses the other's region; a no-op call's card still listed the requested ops) fixed in the seventh: a region declared without an id gets a content-derived id so concurrent executions agree on it and the store's upsert-by-id absorbs the second; the result carries `changed` and the card shows a no-op as unchanged. Codex round 6 (a same-call duplicate region declaration landed a twin; the conditional `replaceAll` re-minted every rule id on retry) fixed in the eighth: the duplicate is refused by name, and `replaceAll` is a diff that keeps content-matched rules under their ids, removes only the rest, and derives new rule ids from content — a retried replaceAll reaches the store zero times. Codex round 7 (the replaceAll diff ignored rule order and could not remove a concurrently added rule; same-call duplicate regions with explicit ids slipped past) fixed in the ninth: a new store op `setConditionalRules` takes the whole list in the caller's order and reconciles it under the tab lock (identical list ⇒ not a write, pinned by a store integration test against Postgres), the tool's replaceAll sends that list, and every region declaration is content-checked. Codex round 8 (an overlapping append retry with content-derived ids hit the store's id check before its twin check and surfaced as an unrecoverable refusal; a replayed append whose `removeRuleIds` had landed was refused) fixed in the tenth: the store compares content before id, and an absent removal id is treated as already removed with a warning. Codex round 9 (overlapping removal retries refused under the lock; replaceAll counted removals from the stale snapshot; unbounded `C:C` examples; the card listed absent ids as removed and reused replaceAll rules as skipped) fixed in the eleventh: `applyFormatOps` now returns `ruleIdsAdded`/`ruleIdsRemoved` computed under the lock, the tool's counts and confirmed removals come from that, the append recovery re-verifies the requested final state after any store refusal, the examples use `C2:C40`, and the card shows confirmed removals, "kept" rows and a reorder. Codex round 10 (an explicit id over an existing region's content landed a twin; the activity entry's counts came from the pre-lock snapshot; the card claimed region removals on every changed replaceAll) fixed in the twelfth: the twin is refused by name, activity metadata is built from the store's locked delta (rules and regions), and the store's new `regionIdsAdded`/`regionIdsRemoved` drive a removal note only when something was removed. That commit also fixes an ESLint break (unused import) the previous commit introduced, which had failed all three CI jobs; the touched files now pass ESLint locally. Codex round 11 (a one-axis freeze filled the other axis from the pre-lock snapshot and could revert a concurrent change) fixed in the thirteenth: `setFrozen` takes each axis optionally and an omitted axis keeps what the tab holds under the lock, tracked across the plan; the tool sends only the axis named. The CI run on the freeze commit failed only `@pagespace/lib#test:coverage`: that package enforces 100% line/branch/function coverage on `format-request.ts`, and the new `setConditionalRules` refusals and `regionContentKey` had no lib test. Covered in the fourteenth commit (file back at 100/100/100/100 locally). All threads replied to and resolved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01X9AGP28YN9qgXonNY3BAZa
