### PR TITLE
fix(dev-preview): a running relay owns 8080 — a stale watch pid no longer turns it into "held by another process"

### DIFF
--- a/packages/lib/src/services/sandbox/preview/__tests__/dev-preview-core.test.ts
+++ b/packages/lib/src/services/sandbox/preview/__tests__/dev-preview-core.test.ts
@@ -4,6 +4,7 @@ import type { SandboxServiceInfo } from '../../sandbox-host';
 import {
   classifyDetectedDevServer,
   isHttpPortSlotFree,
+  describeHttpPortSlot,
   planDevServerService,
   describeServiceState,
   resolveDevPreviewHolder,
@@ -183,10 +184,28 @@ describe('isHttpPortSlotFree — "is 8080 free: no relay, no user process"', () 
       expected: false,
     });
     assert({
-      given: 'a listener on 8080 whose pid differs from the running relay',
-      should: 'not be free',
-      actual: isHttpPortSlotFree({ listeners: [{ port: 8080, pid: 9 }], relay: relayService(5173, { pid: 42 }) }),
+      given: 'a PROBED listener on 8080 whose pid differs from the running relay',
+      should: 'not be free — a fresh pid that is not the relay is a user process',
+      actual: isHttpPortSlotFree({ listeners: [{ port: 8080, pid: 9 }], relay: relayService(5173, { pid: 42 }), listenerSource: 'probe' }),
       expected: false,
+    });
+  });
+
+  it('a running relay owns 8080 whatever a WATCH pid says — that pid can be stale', () => {
+    // Production, first re-pick: the relay restarted as pid 4698, the watch
+    // snapshot still said pid 11264, and the pane read "held by another
+    // process (pid 11264)". The channel never reports a re-bind it missed.
+    assert({
+      given: 'relay running as pid 4698, watch snapshot says pid 11264 on 8080',
+      should: 'attribute the slot to the relay',
+      actual: describeHttpPortSlot({ listeners: [{ port: 8080, pid: 11264 }], relay: relayService(3000, { pid: 4698 }) }),
+      expected: 'relay',
+    });
+    assert({
+      given: 'the same disagreement from a PROBE',
+      should: 'attribute it to a user process',
+      actual: describeHttpPortSlot({ listeners: [{ port: 8080, pid: 11264 }], relay: relayService(3000, { pid: 4698 }), listenerSource: 'probe' }),
+      expected: 'user-process',
     });
   });
 });
@@ -235,12 +254,18 @@ describe('planDevServerService', () => {
     });
   });
 
-  it('refuses when a foreign pid holds 8080 even though the relay claims to be running', () => {
+  it('refuses when a PROBED foreign pid holds 8080 even though the relay claims to be running — but not on a watch pid', () => {
     assert({
-      given: 'relay running as pid 42, but pid 9 listens on 8080',
+      given: 'relay running as pid 42, but a probe says pid 9 listens on 8080',
       should: 'refuse with http-port-busy — the relay is not the one being served',
-      actual: planDevServerService(planInput({ detected: detected(5173), row: relayRow(5173), relay: relayService(5173, { pid: 42 }), listeners: [{ port: 8080, pid: 9 }] })),
+      actual: planDevServerService(planInput({ detected: detected(5173), row: relayRow(5173), relay: relayService(5173, { pid: 42 }), listeners: [{ port: 8080, pid: 9 }], listenerSource: 'probe' })),
       expected: { action: 'refuse', reason: 'http-port-busy', targetPort: 5173 },
+    });
+    assert({
+      given: 'the same disagreement from the watch snapshot',
+      should: 'NOT refuse — the pid may be the relay\'s previous incarnation',
+      actual: planDevServerService(planInput({ detected: detected(5173), row: relayRow(5173), relay: relayService(5173, { pid: 42 }), listeners: [{ port: 8080, pid: 9 }] })).action,
+      expected: 'none',
     });
   });
 
@@ -526,10 +551,16 @@ describe('describeServiceState', () => {
       expected: { status: 'blocked', targetPort: 5173, message: HTTP_PORT_BUSY_MESSAGE },
     });
     assert({
-      given: 'a relay row, relay RUNNING as pid 42, pid 9 on 8080',
-      should: 'still be blocked — a running relay that lost the bind is not serving',
-      actual: describeServiceState({ liveInstanceId: INSTANCE, row: relayRow(5173), relay: relayService(5173, { pid: 42 }), listeners: [{ port: 8080, pid: 9 }] }).status,
+      given: 'a relay row, relay RUNNING as pid 42, a PROBE says pid 9 on 8080',
+      should: 'still be blocked — a fresh pid that is not the relay is a stranger on the slot',
+      actual: describeServiceState({ liveInstanceId: INSTANCE, row: relayRow(5173), relay: relayService(5173, { pid: 42 }), listeners: [{ port: 8080, pid: 9 }], listenerSource: 'probe' }).status,
       expected: 'blocked',
+    });
+    assert({
+      given: 'the same, but the pid comes from the WATCH snapshot',
+      should: 'NOT be blocked — a relay that lost its bind exits and stops being running; a stale watch pid is the relay\'s previous incarnation (production, first re-pick)',
+      actual: describeServiceState({ liveInstanceId: INSTANCE, row: relayRow(5173), relay: relayService(5173, { pid: 42 }), listeners: [{ port: 8080, pid: 9 }] }).status,
+      expected: 'live',
     });
   });
 

--- a/packages/lib/src/services/sandbox/preview/dev-preview-core.ts
+++ b/packages/lib/src/services/sandbox/preview/dev-preview-core.ts
@@ -304,6 +304,15 @@ export interface HttpPortSlotInput {
   listeners: readonly ListeningPort[];
   /** The relay service as reported now, or null when none is defined. */
   relay: SandboxServiceInfo | null;
+  /**
+   * Where `listeners` came from (see {@link ListenerSource}). Decides whether
+   * a listener's PID may contradict a running relay: a `watch` pid can be
+   * STALE — the relay restarted under a new pid and the channel never said
+   * so (seen in production: the first re-pick rendered a healthy relay as
+   * "held by another process (pid <old relay>)") — so only a fresh `probe`
+   * pid may. Defaults to `'watch'`.
+   */
+  listenerSource?: ListenerSource;
 }
 
 /**
@@ -350,18 +359,23 @@ export type HttpPortSlotHolder = 'none' | 'relay' | 'user-process';
  * `=== 'none'`; the UI asks this fuller form so it can say which of the two
  * holders is in the way and how to release it, instead of surfacing a 409.
  *
- * A listener whose pid matches a live relay — or whose pid is unknown while a
- * relay is live — is the relay; any other listener is a user process. A live
- * relay with no listener in the snapshot still holds the slot (the snapshot
- * may predate its bind). Misattributing a user process to the relay is
- * self-correcting: the planned relay fails to bind, lands in `failed`, and
- * the next call sees a non-live relay beside a listener.
+ * A live relay holds the slot: a `running` relay bound 8080 or it would have
+ * failed, so a listener beside it is the relay itself — even when the
+ * snapshot's pid disagrees, because a `watch` pid may be stale (the relay
+ * restarted; the channel never reported it). Only a fresh `probe` pid that
+ * differs from the relay's names a user process. No live relay and a
+ * listener is a user process; a live relay with no listener in the snapshot
+ * still holds the slot (the snapshot may predate its bind). Misattributing
+ * a user process to the relay is self-correcting: the planned relay fails
+ * to bind, lands in `failed`, and the next call sees a non-live relay beside
+ * a listener.
  */
-export function describeHttpPortSlot({ listeners, relay }: HttpPortSlotInput): HttpPortSlotHolder {
+export function describeHttpPortSlot({ listeners, relay, listenerSource = 'watch' }: HttpPortSlotInput): HttpPortSlotHolder {
   const listener = listeners.find((entry) => entry.port === SPRITE_HTTP_PORT);
   const relayAlive = isRelayAlive(relay);
   if (!listener) return relayAlive ? 'relay' : 'none';
   if (!relayAlive) return 'user-process';
+  if (listenerSource !== 'probe') return 'relay';
   const pidsAgree = listener.pid === undefined || relay.pid === undefined || listener.pid === relay.pid;
   return pidsAgree ? 'relay' : 'user-process';
 }
@@ -632,7 +646,7 @@ export function planDevServerService(input: PlanDevServerServiceInput): DevServe
     };
   }
 
-  if (describeHttpPortSlot({ listeners, relay }) === 'user-process') {
+  if (describeHttpPortSlot({ listeners, relay, listenerSource: input.listenerSource }) === 'user-process') {
     return { action: 'refuse', reason: 'http-port-busy', targetPort };
   }
 
@@ -788,7 +802,7 @@ export function describeServiceState({ liveInstanceId, row, relay, listeners, li
 
   const targetListening = isPortListening(listeners, row.targetPort, listenerSource);
 
-  const holder = describeHttpPortSlot({ listeners: listeners ?? [], relay });
+  const holder = describeHttpPortSlot({ listeners: listeners ?? [], relay, listenerSource });
 
   // Detected, recorded, and serving NOTHING — no relay for a non-8080 target
   // means the sprite URL (which routes to 8080 alone) reaches nothing. Three

--- a/packages/lib/src/services/sandbox/preview/dev-preview-status.ts
+++ b/packages/lib/src/services/sandbox/preview/dev-preview-status.ts
@@ -223,7 +223,7 @@ export function buildDevPreviewStatus({ holder, sandbox, liveInstanceId, row, re
 
   let slot: DevPreviewSlotReport = { known: false };
   if (sandbox === 'attached' && listeners !== null) {
-    const slotHolder = describeHttpPortSlot({ listeners, relay });
+    const slotHolder = describeHttpPortSlot({ listeners, relay, listenerSource });
     const listener = listeners.find((entry) => entry.port === SPRITE_HTTP_PORT);
     const pid = slotHolder === 'user-process' && listener?.pid !== undefined ? listener.pid : null;
     slot = {


### PR DESCRIPTION
## What you saw

> Port 8080 is already in use by something that is not the preview relay. … Port 8080 is held by another process in the sandbox (pid 11264).

## What was actually true (read from the sandbox)

`ss -ltnp` on the env sprite: 8080 is held by **our own relay** (`node -e … 8080 3000`, pid **4698**, `running`, started 20:45 by the re-pick); `:3000` is `next-server`. Pid 11264 no longer exists — it was the *previous* relay incarnation (created 17:48 by the first pick). The realtime `ports/watch` snapshot still carried pid 11264 because the channel never reported the re-bind.

`describeHttpPortSlot` compared the snapshot's pid with the relay's, saw a mismatch, and called the relay a stranger — so the status read `blocked`, `canOpen` was false, and the planner refused the pick with `http-port-busy`.

## Fix

A `running` relay bound 8080 or it would have exited (`server.on('error') → process.exit(1)`) and stopped being running. So a listener beside a live relay **is** the relay, whatever a `watch` pid says; only a fresh **`probe`** pid that differs may name a user process. `HttpPortSlotInput` gains `listenerSource` (default `'watch'`), threaded through `buildDevPreviewStatus`, the planner's `http-port-busy` check and `describeServiceState`. The select path already re-probes and plans with `'probe'`, so a genuine stranger on 8080 is still refused there.

Realtime's fold already replaces a same-port entry on `port_opened`; the channel just never sent one — no realtime change.

## Tests

Stale watch pid → `relay`; same disagreement from a probe → `user-process`; planner does not refuse on a watch pid but does on a probe pid; `describeServiceState` is `live` on a watch pid, `blocked` on a probe pid. The two existing assertions that expected refusal on any pid mismatch now say `probe`. Mutation-checked: removing the source check fails exactly the new assertions.

## After deploy

The pane for the pinned `:3000` shows **Live** and the frame renders (given #2572 is live too). No re-pick needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01P8A8KLYCoViP7ouH5QzbnB


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved development preview status reporting when listener information is outdated, preventing valid previews from being incorrectly marked as blocked.
  * Development previews now continue when a stale process identifier conflicts with an active preview relay.
  * Preserved safeguards for confirmed port conflicts, which continue to be reported as blocked when an unrelated process is using the port.
  * Improved HTTP port status descriptions for more accurate ownership reporting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->