### PR TITLE
Android Phase E: mobile shell configs under CI, allowNavigation guard, and the epic's full story

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -407,6 +407,16 @@ All notable user-facing changes to PageSpace are documented here. Format follows
 
 ### Changed
 
+- **Android app: first internal-testing version identity, and the Android/iOS shell configs are now
+  checked in CI (still not distributed)** — the Android build now identifies itself as version 1.4
+  (build 2), matching the iOS version, instead of the 1.0 (build 1) left over from a debug build in
+  March. Nothing else about the app changes in this release, and **nothing is distributed**: there
+  is still no release signing key, no Play Console listing, and none of the Android work from the
+  last few releases has been run on a real device — the exact checklist for doing so is now in the
+  app's README, alongside what still blocks a public build. Behind the scenes, the two mobile shell
+  configuration files are type-checked on every pull request and a test now guards the rule that
+  the Android shell never hands its native bridge to a third-party site or a wildcard host.
+
 - **Free plan credits are now a one-time starter grant instead of a monthly allowance** — new
   free accounts still get 5 credits to try AI with, granted once on their first AI call, but
   that grant no longer refills or accumulates month over month. Credits you already have never

--- a/apps/android/README.md
+++ b/apps/android/README.md
@@ -1,11 +1,122 @@
-# PageSpace Android
+# PageSpace Android App
 
-Capacitor wrapper around the web app, mirroring `apps/ios`.
+Capacitor 7 wrapper around the PageSpace web app, mirroring `apps/ios`. **Not distributed.** There
+is no release build, no Play Console listing, and no release keystore; the last artifact was a
+debug APK on 2026-03-23. What has landed since is the Android Parity Epic (PRs #2500, #2501,
+#2552, #2557, #2558, #2559), and **none of it has been run on a device** — see "Device
+verification" below before trusting any behavioural claim in this file.
 
-> **Scope of this file today:** why the Capacitor config diverges from the iOS one, what deep
-> links ship and what is deferred, the server-side push requirements, and the client-side push
-> permission and registration path. Build and signing belong to the release work and are not
-> documented here yet.
+- **Application ID / namespace:** `ai.pagespace.android` (`android/app/build.gradle`)
+- **Capacitor app ID:** `ai.pagespace.android` (`capacitor.config.ts`)
+- **Firebase project:** `pagespace-f328e` (`android/app/google-services.json`)
+- **SDK levels:** `minSdk 23`, `compileSdk`/`targetSdk 36` (`android/variables.gradle`)
+- **Signing:** debug keystore only. No release signing config exists in `build.gradle`.
+- **Native plugin of our own:** `PageSpaceSecureStoragePlugin.java`, registered in
+  `MainActivity.java` under the name `PageSpaceKeychain` (same name as the iOS Swift plugin, so
+  the web layer's `keychain-plugin.ts` binding serves both)
+
+## Architecture
+
+This is a **remote-loading** app, like iOS. The WebView loads the live site directly:
+
+- `server.url = https://pagespace.ai` with `appStartPath = /dashboard` — the split is deliberate
+  and Android-specific; see "`server.url` must stay an origin" below. iOS carries the path in
+  `server.url` and must not be copied here.
+- `webDir: ./public` is only the offline fallback shell (`errorPath: index.html`, the Retry
+  screen).
+- Because behaviour comes from the live site, most product changes ship without an app update.
+  A new build is needed only when native config changes: version bump, manifest, permissions,
+  plugins, Gradle dependencies, icons/splash, or a Capacitor/plugin upgrade.
+
+Everything the shell *does* natively is driven from the shared web layer through the capability
+table in `apps/web/src/lib/capacitor-bridge.ts` — nothing in `apps/web` asks "is this iOS?" any
+more; it asks `hasNativeCapability('secureStore' | 'nativeAuth' | 'push' | 'badge')`, and Android
+answers yes to all four (Apple sign-in excepted — see below). Adding a capability to Android is a
+one-line table edit, not a call-site sweep.
+
+## Building locally
+
+Prereqs: Android Studio (or the command-line SDK) with an SDK 36 platform, a JDK 17+, and `bun`
+at the repo root. **Run `bun install` first** — the Capacitor packages live under
+`apps/android/node_modules`, not the workspace root.
+
+```bash
+# From the repo root — build the web app, then sync native
+bun run --cwd apps/android build:full   # builds `web`, then `cap sync android`
+# or, if the web build is current:
+bun run --cwd apps/android build        # `cap sync android` only
+
+bun run --cwd apps/android dev          # `cap open android` — opens Android Studio
+bun run --cwd apps/android run          # `cap run android` — build + install on a connected device/emulator
+bun run --cwd apps/android typecheck    # `tsc --noEmit` over capacitor.config.ts (also runs in CI)
+```
+
+`cap sync android` does three things you should know about: it regenerates
+`android/app/src/main/assets/capacitor.config.json` from `capacitor.config.ts` (gitignored — a
+stale copy ships whatever it last held, so **sync immediately before every build**), it rewrites
+`android/capacitor.settings.gradle` and `android/app/capacitor.build.gradle` from the plugin list
+in `package.json` (both are committed and currently **stale** — neither lists
+`@capawesome/capacitor-badge` yet, so a Gradle build without a prior sync compiles no badge plugin
+and `Badge.set()` rejects at runtime), and it copies `public/` into the assets dir.
+
+A plain Gradle build from `android/` (`./gradlew assembleDebug`) works after a sync and produces
+`android/app/build/outputs/apk/debug/app-debug.apk`, signed with `~/.android/debug.keystore`.
+
+### What CI checks — and what it does not
+
+Since Phase E, `apps/android` and `apps/ios` each have a `typecheck` script and a
+package-specific override in the root `turbo.json` (`"@pagespace/android#typecheck": { "dependsOn": [] }`)
+so `bun run typecheck` covers `capacitor.config.ts` **without** dragging web's Next.js build into
+the graph (the app devDepends on `web`, so the default `^build` dependency would). A guard test in
+`apps/web` — `src/lib/__tests__/capacitor-allow-navigation.guard.test.ts` — pins the
+`allowNavigation` and `server.url` invariants described below for both platforms.
+
+That is the whole of it. **Nothing in CI compiles the Java, parses the manifest, runs Gradle, or
+installs an APK.** A change to `MainActivity.java`, `PageSpaceSecureStoragePlugin.java`,
+`AndroidManifest.xml` or any Gradle file is checked by the reviewer's eyes and, later, by a
+device. Validate the manifest as XML at least (`xmllint --noout
+android/app/src/main/AndroidManifest.xml`).
+
+## Versioning
+
+`android/app/build.gradle`, `defaultConfig`:
+
+- `versionCode` — Android's build number, an integer that must strictly increase per upload to
+  Play. Currently **2** (Phase E bumped it from the 2026-03-23 debug APK's `1`).
+- `versionName` — the user-facing version. Currently **`1.4`**, deliberately tracking the iOS
+  `MARKETING_VERSION` so both stores show one product version; bump the two together.
+
+Neither is read from `capacitor.config.ts`; there is no equivalent of iOS's `$(MARKETING_VERSION)`
+indirection.
+
+## Native capabilities — what each phase wired, and how
+
+| Capability | Native side | Web side | Phase / PR |
+|---|---|---|---|
+| Secure storage | `PageSpaceSecureStoragePlugin.java` over `EncryptedSharedPreferences` (`androidx.security:security-crypto:1.1.0-alpha06`, an alpha) | `apps/web/src/lib/auth/platform-storage/android-storage.ts` (`AndroidStorage`), selected by `hasNativeCapability('secureStore')` | A — #2557 |
+| Native Google sign-in | `@capgo/capacitor-social-login`, Android SDK; `androidClientId` in `capacitor.config.ts` | `apps/web/src/lib/native-google-auth.ts`, initialised with `webClientId = NEXT_PUBLIC_GOOGLE_OAUTH_CLIENT_ID` (the ID token's audience is the web client, which `/api/auth/google/native` already accepts) | B — #2559 |
+| Sign in with Apple | **none** — Android has no native Apple SDK | `supportsNativeAuthProvider('apple')` is false on Android; the button falls to web OAuth, which leaves the app for the external browser and drops the session in the wrong cookie jar. **Known broken on Android**, not a regression; tracked on the "Mobile OAuth return-channel hardening" epic in the dev drive | B — #2559 |
+| Bearer auth + CSRF | — | `buildAuthCredentials` in `auth-fetch.ts` mirrors the server's rule: bearer if a token exists, else cookie credentials with `X-CSRF-Token` on mutations. Before #2559 every Android mutation answered 403 `CSRF_TOKEN_MISSING` | B — #2559 |
+| Push registration | `POST_NOTIFICATIONS` in the manifest; Firebase Messaging via the BoM in `build.gradle` | `usePushNotifications.ts`, gated on `capabilities.push`; token POSTs to `/api/notifications/push-tokens` with `platform: 'android'` | D — #2558 |
+| FCM sending | — | `packages/lib/src/notifications/push-notifications.ts`, `case 'android'`: OAuth2 token from `FCM_SERVICE_ACCOUNT_JSON`, FCM HTTP v1 | — #2501 |
+| App-icon badge | `@capawesome/capacitor-badge` (added to `package.json`; Gradle files regenerate on sync) | `useNativeBadgeSync.ts` (formerly `useIosBadgeSync`) | D — #2558 |
+| Deep links | `pagespace://` intent filter (inert); **no** https App Links filter | `DeepLinkHandler.tsx` + `deep-links.ts` (cross-platform, from #2569) | C — #2552 |
+| Error shell | `errorPath: index.html` → `public/index.html` Retry screen | — | C — #2552 |
+
+Details for storage: `AndroidStorage` reports `usesBearer() === true`; a session written by the
+web sign-in flow inside the WebView (before native sign-in existed) lives in `localStorage`, and
+the adapter falls back to it and adopts its device binding rather than stranding it. The plugin
+`call.reject`s if `EncryptedSharedPreferences.create()` threw at load, and `storeSession` /
+`getStoredSession` propagate that as an error instead of silently persisting nothing; every
+bridge read is bounded by a 3-second timeout. The device id is `pagespace_device_id` in
+`@capacitor/preferences`, the same key iOS uses.
+
+Details for native Google: **this is the only route to a Google session in the Android shell**,
+not an optimisation. Google One Tap returns early under Capacitor, the web OAuth handoff cookie
+lands in the external browser, and magic link never mints a device token off desktop. If the
+plugin fails to register on a device there is no working alternative. There is deliberately no
+fall-through from a failed native attempt to web OAuth (`useOAuthSignIn.ts`), because there is no
+working web OAuth inside the shell to fall through to.
 
 ## Why this config is not a copy of the iOS one
 
@@ -183,20 +294,31 @@ not about the mechanism: a debug build can be verified locally against a debug-f
 assetlinks file, and that workflow is documented below. What is missing is the release certificate,
 and with it any possibility of verification on a user's device.
 
-### Prerequisite 2 — link routing in the web app
+### Prerequisite 2 — link routing in the web app (met since PR #2569)
 
-Nothing listens for the `@capacitor/app` plugin's `appUrlOpen` event, on **either** platform, so a
-captured link never reaches the path it names. What the user sees depends on whether the app was
-already running, and the two cases differ:
+When Phase C shipped, nothing listened for the `@capacitor/app` plugin's `appUrlOpen` event on
+either platform, so a captured link never reached the path it named. That is no longer true:
+`apps/web/src/components/DeepLinkHandler.tsx` (mounted in the root layout) handles both halves —
+`App.getLaunchUrl()` for a cold start, where the URL is spent before any listener exists, and the
+`appUrlOpen` listener for a warm one, where `Bridge.onNewIntent` only notifies plugins and never
+calls `loadUrl`. It lives in the shared web layer, so Android gets it for free the moment it
+starts receiving links. Which URLs resolve to which route is
+`apps/web/src/lib/navigation/deep-links.ts` — an allowlist, currently `https://pagespace.ai/invite/<token>`
+only; anything else on the claimed host is handed to the browser rather than swallowed.
 
-| Start | What happens |
+Two things the resolver does **not** do, both on purpose: it ignores the `pagespace://` scheme
+entirely (the exchange-binding precondition above), and it does not route `/auth/callback/*` or
+`/join/*`. Widen the AASA, the Android filter, and the resolver **together** — claiming a path the
+resolver returns `null` for makes the link do nothing in the app, which is strictly worse than
+leaving it to the browser.
+
+The behaviour table below is therefore what a user on Android 6–11 would see **without** the
+routing, and is kept because it is what makes an unverified filter harmful on those versions:
+
+| Start | With no listener (pre-#2569) |
 |---|---|
 | **Cold** | The app launches and loads its start URL (`server.url` + `appStartPath`, so `/dashboard`). The linked path is dropped. |
-| **Warm** (`singleTask`, app already running) | The intent arrives via `onNewIntent`; `Bridge.onNewIntent` only notifies plugins — it never calls `loadUrl` — so `AppPlugin` fires `appUrlOpen` into a void and **the WebView stays exactly where it was.** Nothing visible happens at all. |
-
-Either way the invite token or auth callback code is silently dropped. Do not rely on a
-reset-to-`/dashboard` guarantee: it holds only on a cold launch, which matters both for device
-verification and for whoever implements the routing.
+| **Warm** (`singleTask`, app already running) | The intent arrives via `onNewIntent`; `Bridge.onNewIntent` only notifies plugins — it never calls `loadUrl` — so `AppPlugin` fires `appUrlOpen` into a void and **the WebView stays exactly where it was.** |
 
 ### Why `autoVerify` alone is not enough here
 
@@ -232,11 +354,9 @@ succeed — which is prerequisite 1.
 
 ### The filter to add, once both prerequisites are met
 
-**Prerequisite 2 is now met** — `apps/web/src/components/DeepLinkHandler.tsx` consumes
-`appUrlOpen` and `getLaunchUrl`, and it lives in the shared web layer, so the routing is
-already there for Android the moment it starts receiving links. What remains for Android is
-prerequisite 1: the release signing certificate and a real `assetlinks.json`. Until those
-exist **Android captures nothing** — no https intent-filter is registered.
+Prerequisite 2 is met (above). What remains for Android is prerequisite 1: the release signing
+certificate and a real `assetlinks.json`. Until those exist **Android captures nothing** — no
+https intent-filter is registered.
 
 When it does, mirror `apps/marketing/public/.well-known/apple-app-site-association` (the copy
 Caddy actually serves), currently `/invite/*` only, so both platforms capture the same links. Widening beyond these paths should still wait on prerequisite 2 — whole-host
@@ -393,3 +513,101 @@ Gradle directly without syncing first.
 **Not verified on a device.** Nothing here has been exercised on real hardware — there is no
 release build yet. The permission dialog, the FCM token round trip and badge behaviour across
 launchers are all the device-verification task's to confirm.
+
+## Device verification — the checklist nothing has run yet
+
+Every behavioural claim in PRs #2552, #2557, #2558 and #2559 was read off source (Capacitor 7.6.5
+Java, the plugin's Java, this repo) and **not observed on hardware**. This is the list of what a
+person with an Android device or emulator needs to confirm, in the order the failures would
+cascade. The board task "Device verification" on the Android Parity Epic is `blocked` until this
+is done; mark each line with the device, API level and build you used.
+
+**Setup**
+
+- [ ] `bun install`, then `bun run --cwd apps/android build:full`, then `./gradlew assembleDebug`
+      from `android/`. Confirm `android/app/src/main/assets/capacitor.config.json` contains
+      `"url": "https://pagespace.ai"`, `"appStartPath": "/dashboard"`, `"allowNavigation": ["pagespace.ai"]`,
+      `"errorPath": "index.html"` — that is what the shell actually reads.
+- [ ] Confirm `capacitor.settings.gradle` and `app/capacitor.build.gradle` now list
+      `capawesome-capacitor-badge` after the sync (they are stale in git).
+- [ ] Install on **one API 33+ device** (permission dialog path) and, if possible, **one API 23–30
+      device or emulator** (the App Links chooser row in the table above; also the
+      `POST_NOTIFICATIONS`-is-ignored path).
+
+**Shell (Phase C, #2552)**
+
+- [ ] Cold launch lands on `https://pagespace.ai/dashboard` (or the signin redirect), inside the
+      WebView, not the browser. This is the `appStartPath` split working.
+- [ ] **The bridge origin allowlist is live, not the fallback.** Two checks, from `chrome://inspect`
+      on the connected device: (1) on the app's own page, `window.androidBridge` exists and
+      `Capacitor.Plugins.PageSpaceKeychain` calls resolve; (2) open a page on a **non-listed**
+      origin in the same WebView (e.g. navigate via an in-app link that is not intercepted, or
+      load one through DevTools) and confirm `androidBridge.postMessage` is **absent or refused**
+      there. If it works on a foreign origin, `MessageHandler` took its
+      `addJavascriptInterface` catch — that is the finding-3 fallback, and it means the
+      allowlist protects nothing. Report upstream to Capacitor if so.
+- [ ] Airplane mode, cold launch: the bundled Retry screen renders (not Chrome's error page).
+      Restore connectivity, tap Retry: the app loads `/dashboard`.
+- [ ] Tap a `https://pagespace.ai/...` link from another app: it opens in the **browser**, with no
+      disambiguation chooser, on both API rows. (No https filter is registered; this confirms it.)
+- [ ] `adb shell am start -a android.intent.action.VIEW -d "pagespace://anything"` with the app
+      **running**: the app comes to the foreground, stays on its current route, and nothing else
+      happens (the resolver ignores the scheme). Cold: the app launches to `/dashboard`.
+
+**Secure storage (Phase A, #2557) and auth (Phase B, #2559)**
+
+- [ ] Native Google sign-in end to end: the native account picker appears (not a web consent
+      page), the app lands authenticated, and `adb logcat` shows no `PageSpaceKeychain` rejection.
+- [ ] A **mutation** after native sign-in — create a page, send a message — returns 2xx, not
+      403 `CSRF_TOKEN_MISSING`.
+- [ ] Force-stop and relaunch: the session survives (read from `EncryptedSharedPreferences`), with
+      no visit to `/auth/signin`.
+- [ ] Background the app for **more than five minutes**, foreground it: still signed in (the
+      proactive refresh must not sign a live session out — the Phase B round-3/4 defect).
+- [ ] Sign out: relaunch lands on `/auth/signin`, and the keychain holds no session
+      (`adb shell run-as ai.pagespace.android ls shared_prefs` shows the file; its contents are
+      encrypted, so judge by the relaunch).
+- [ ] Sign in with **Apple**: expected to **fail** (leaves for the external browser; app stays
+      signed out). Confirm that is what happens and that it fails cleanly, not with a crash.
+- [ ] Magic link from an email on the device: opens in the browser, not the app (no App Links),
+      and the app stays signed out — known, not a regression.
+
+**Push and badge (Phase D, #2558)**
+
+- [ ] API 33+: first launch after sign-in shows the notification permission dialog **once**. Deny,
+      relaunch: no dialog. Enable in system settings, relaunch: registration proceeds (the
+      `push_permission_denied` record is dropped when the OS reports `granted`).
+- [ ] With `FCM_SERVICE_ACCOUNT_JSON` set on the server: a row for this device appears with
+      `platform = 'android'`, and a mention from another account **arrives in the tray** with the
+      app in the background. Note the small icon and channel name — both are Firebase defaults
+      today (no `default_notification_icon` / `default_notification_channel_id` meta-data).
+- [ ] Tap the notification: the app opens the referenced page (`PushActionHandler`).
+- [ ] With the app in the **foreground**, a push does nothing visible — by design.
+- [ ] Badge: an unread count shows on the launcher icon on a launcher that supports badges
+      (Pixel Launcher, Samsung One UI); on one that does not, nothing happens and nothing errors.
+- [ ] Uninstall, send again: the server marks the token inactive (`UNREGISTERED`).
+
+**Not verifiable here and not expected to pass**: anything needing a release-signed build (App
+Links verification against a real `assetlinks.json`, Play internal testing) — see below.
+
+## What blocks a distributable build
+
+All deliberately outside the Android Parity Epic's scope, all still outstanding:
+
+- **Release keystore.** `build.gradle` has no `signingConfigs.release`; nothing in the repo or in
+  Fly secrets holds an upload key. Until it exists every build is debug-signed, `assetlinks.json`
+  cannot name a shipped certificate, and Play will not accept an upload.
+- **Play Console.** No app record, no internal-testing track, no store listing, no privacy
+  declarations (the data-safety form needs the same answers `PrivacyInfo.xcprivacy` gives on iOS).
+- **`assetlinks.json`** at `https://pagespace.ai/.well-known/assetlinks.json`, served by the
+  marketing app like the AASA is, carrying the release certificate's SHA-256 — and only then the
+  https intent filter above.
+- **Release automation.** iOS has a fastlane `beta` lane; Android has nothing. A Gradle
+  `bundleRelease` + Play upload lane (fastlane `supply`, or the Gradle Play Publisher plugin) is
+  the equivalent.
+- **Notification icon.** A monochrome `ic_notification` and the two Firebase meta-data entries in
+  the manifest, or the tray shows Firebase's default glyph.
+- **Dependency disclosure.** `@capgo/capacitor-social-login`'s Android target pulls the Facebook
+  SDK the same way its iOS target does. `OSS-COMPLIANCE.md` at the repo root carries the mobile
+  native-dependency inventory (the per-platform files were folded into it in #1029); re-check it
+  against `capacitor.settings.gradle` after a sync before any listing.

--- a/apps/android/README.md
+++ b/apps/android/README.md
@@ -29,9 +29,12 @@ This is a **remote-loading** app, like iOS. The WebView loads the live site dire
   plugins, Gradle dependencies, icons/splash, or a Capacitor/plugin upgrade.
 
 Everything the shell *does* natively is driven from the shared web layer through the capability
-table in `apps/web/src/lib/capacitor-bridge.ts` — nothing in `apps/web` asks "is this iOS?" any
-more; it asks `hasNativeCapability('secureStore' | 'nativeAuth' | 'push' | 'badge')`, and Android
-answers yes to all four (Apple sign-in excepted — see below). Adding a capability to Android is a
+table in `apps/web/src/lib/capacitor-bridge.ts`: the storage, auth, push and badge paths ask
+`hasNativeCapability('secureStore' | 'nativeAuth' | 'push' | 'badge')` rather than comparing the
+platform to `'ios'`, and Android answers yes to all four (Apple sign-in excepted — see below).
+`isIOS()` still exists and is still used where behaviour genuinely is iOS-only — the badge hook's
+authorization-option gate, iPad layout heuristics — so a remaining `=== 'ios'` is not automatically
+a parity bug; ask whether Android would want the same branch. Adding a capability to Android is a
 one-line table edit, not a call-site sweep.
 
 ## Building locally
@@ -594,8 +597,8 @@ Links verification against a real `assetlinks.json`, Play internal testing) — 
 
 All deliberately outside the Android Parity Epic's scope, all still outstanding:
 
-- **Release keystore.** `build.gradle` has no `signingConfigs.release`; nothing in the repo or in
-  Fly secrets holds an upload key. Until it exists every build is debug-signed, `assetlinks.json`
+- **Release keystore.** `build.gradle` has no `signingConfigs.release` and nothing in the repo
+  references an upload key. Until it exists every build is debug-signed, `assetlinks.json`
   cannot name a shipped certificate, and Play will not accept an upload.
 - **Play Console.** No app record, no internal-testing track, no store listing, no privacy
   declarations (the data-safety form needs the same answers `PrivacyInfo.xcprivacy` gives on iOS).
@@ -607,7 +610,11 @@ All deliberately outside the Android Parity Epic's scope, all still outstanding:
   the equivalent.
 - **Notification icon.** A monochrome `ic_notification` and the two Firebase meta-data entries in
   the manifest, or the tray shows Firebase's default glyph.
-- **Dependency disclosure.** `@capgo/capacitor-social-login`'s Android target pulls the Facebook
-  SDK the same way its iOS target does. `OSS-COMPLIANCE.md` at the repo root carries the mobile
-  native-dependency inventory (the per-platform files were folded into it in #1029); re-check it
-  against `capacitor.settings.gradle` after a sync before any listing.
+- **Dependency disclosure.** `@capgo/capacitor-social-login`'s Android `build.gradle` pulls the
+  Facebook SDK by default, as its iOS target does — but unlike iOS it is **excludable**: the plugin
+  reads the Gradle property `socialLogin.facebook.include` (default `'true'`), so
+  `socialLogin.facebook.include=false` in `android/gradle.properties` drops it from the APK. We
+  never initialise Facebook, so set that before the first listing rather than disclosing an SDK
+  that does nothing. `OSS-COMPLIANCE.md` at the repo root carries the mobile native-dependency
+  inventory (the per-platform files were folded into it in #1029); re-check it against
+  `capacitor.settings.gradle` after a sync before any listing.

--- a/apps/android/android/app/build.gradle
+++ b/apps/android/android/app/build.gradle
@@ -7,8 +7,8 @@ android {
         applicationId "ai.pagespace.android"
         minSdkVersion rootProject.ext.minSdkVersion
         targetSdkVersion rootProject.ext.targetSdkVersion
-        versionCode 1
-        versionName "1.0"
+        versionCode 2
+        versionName "1.4"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         aaptOptions {
              // Files and dirs to omit from the packaged assets dir, modified to accommodate modern web apps.

--- a/apps/android/android/app/src/main/AndroidManifest.xml
+++ b/apps/android/android/app/src/main/AndroidManifest.xml
@@ -30,11 +30,12 @@
                 API 23-30 the filter would put PageSpace in the disambiguation
                 chooser. No assetlinks.json can match a SHIPPED build (there is
                 no release signing certificate; a debug one can be verified
-                locally, which does not help a user's device) and nothing routes
-                appUrlOpen, so picking it there drops the invite or auth token —
-                landing on /dashboard from a cold start, or doing nothing visible
-                at all if the app is already running, since Bridge.onNewIntent
-                notifies plugins without reloading the WebView.
+                locally, which does not help a user's device). Link routing itself
+                now exists — apps/web/src/components/DeepLinkHandler.tsx (PR #2569)
+                consumes appUrlOpen and getLaunchUrl in the shared web layer, and
+                its resolver accepts /invite/* on pagespace.ai — so once a release
+                certificate and a matching assetlinks.json exist, the filter in
+                the README is the only remaining step for invite links.
             -->
 
             <!--
@@ -77,8 +78,11 @@
 
                 Note what that does NOT do: Bridge.onNewIntent only notifies
                 plugins, never loadUrl. So on a warm start the WebView stays on
-                whatever route it was showing — the event fires into a void while
-                no listener exists. Only a cold launch loads the start URL.
+                whatever route it was showing unless a listener acts. Since PR
+                #2569 one does — DeepLinkHandler in the web layer — but its
+                resolver ignores the pagespace:// scheme on purpose, for the
+                exchange-binding reason above. Nothing routes this scheme until
+                that binding lands.
             -->
             <intent-filter>
                 <action android:name="android.intent.action.VIEW" />

--- a/apps/android/package.json
+++ b/apps/android/package.json
@@ -11,7 +11,8 @@
     "sync": "bun x cap sync android",
     "update": "bun x cap update android",
     "add-platform": "bun x cap add android",
-    "run": "bun x cap run android"
+    "run": "bun x cap run android",
+    "typecheck": "tsc --noEmit"
   },
   "dependencies": {
     "@capawesome/capacitor-badge": "^7.0.0",

--- a/apps/ios/package.json
+++ b/apps/ios/package.json
@@ -10,7 +10,8 @@
     "dev": "bun x cap open ios",
     "sync": "bun x cap sync ios",
     "update": "bun x cap update ios",
-    "add-platform": "bun x cap add ios"
+    "add-platform": "bun x cap add ios",
+    "typecheck": "tsc --noEmit"
   },
   "dependencies": {
     "@capawesome/capacitor-badge": "^7.0.0",

--- a/apps/web/src/lib/__tests__/capacitor-allow-navigation.guard.test.ts
+++ b/apps/web/src/lib/__tests__/capacitor-allow-navigation.guard.test.ts
@@ -47,8 +47,16 @@ const CONFIGS = {
   ios: readFileSync(resolve(APPS, 'ios/capacitor.config.ts'), 'utf-8'),
 } as const;
 
-/** The app's own apex; a subdomain of it is "own origin", anything else is third party. */
+/** The app's own apex — the one host that must always be listed on both platforms. */
 const OWN_APEX = 'pagespace.ai';
+
+/**
+ * The COMPLETE Android list, asserted exactly. Not "own-origin hosts are fine":
+ * a subdomain entry is still a bridge grant to a host the shell never
+ * navigates to at top level, so adding one (a tenant host, `app.`, `*.`) must
+ * mean editing this constant in the same diff, where review sees the grant.
+ */
+const ANDROID_EXACT_ENTRIES = [OWN_APEX];
 
 /**
  * What the SHIPPED iOS app lists today. This is a ratchet, not an endorsement:
@@ -72,23 +80,47 @@ function stripLineComments(source: string): string {
   return source.replace(/^\s*\/\/[^\n]*/gm, '');
 }
 
-/** The string entries of `allowNavigation: [...]`, or null if the key is absent. */
+/**
+ * The entries of `allowNavigation: [...]`, or null if the key is absent.
+ *
+ * Every element must be a single-quoted string LITERAL. An identifier
+ * (`tenantHost`), a template, a spread, or a call would have been silently
+ * skipped by a literal-only regex and the list would look shorter than it is —
+ * so anything that is not a literal fails here rather than being dropped.
+ */
 function allowNavigationEntries(source: string): string[] | null {
   const match = /allowNavigation:\s*\[([^\]]*)\]/.exec(stripLineComments(source));
   if (!match) return null;
-  return [...match[1].matchAll(/'([^']*)'/g)].map((m) => m[1]);
+  const elements = match[1].split(',').map((e) => e.trim()).filter((e) => e.length > 0);
+  return elements.map((element) => {
+    const literal = /^'([^']*)'$/.exec(element);
+    if (!literal) {
+      throw new Error(`allowNavigation entry is not a string literal: ${element}`);
+    }
+    return literal[1];
+  });
 }
 
-/** The value of `<key>: '<value>'` inside the `server: { ... }` block, or null. */
-function serverString(source: string, key: string): string | null {
+/** The body of the `server: { ... }` block, or null. */
+function serverBlock(source: string): string | null {
   const server = /server:\s*\{([\s\S]*?)\n {2}\},/.exec(stripLineComments(source));
-  if (!server) return null;
-  const match = new RegExp(`\\b${key}:\\s*'([^']*)'`).exec(server[1]);
+  return server ? server[1] : null;
+}
+
+/** The value of `<key>: '<value>'` inside the `server` block, or null. */
+function serverString(source: string, key: string): string | null {
+  const block = serverBlock(source);
+  if (block === null) return null;
+  const match = new RegExp(`\\b${key}:\\s*'([^']*)'`).exec(block);
   return match ? match[1] : null;
 }
 
-function isOwnOrigin(host: string): boolean {
-  return host === OWN_APEX || host.endsWith(`.${OWN_APEX}`);
+/** The raw (unquoted) value of `<key>: <value>,` inside the `server` block, or null. */
+function serverRaw(source: string, key: string): string | null {
+  const block = serverBlock(source);
+  if (block === null) return null;
+  const match = new RegExp(`\\b${key}:\\s*([^,\\n]+)`).exec(block);
+  return match ? match[1].trim() : null;
 }
 
 describe('Android capacitor.config.ts — allowNavigation grants the native bridge', () => {
@@ -99,13 +131,13 @@ describe('Android capacitor.config.ts — allowNavigation grants the native brid
     expect(entries!.length).toBeGreaterThan(0);
   });
 
-  it('lists no third-party host', () => {
+  it('is exactly the app\'s own apex and nothing else', () => {
     // Every entry is handed the native plugin bridge, PageSpaceKeychain
-    // included. A provider consent page must never be one of them; provider
-    // pages belong in a Custom Tab with a bound callback.
-    for (const host of entries ?? []) {
-      expect(isOwnOrigin(host), `${host} is not an own-origin host`).toBe(true);
-    }
+    // included. A provider consent page must never be one of them (provider
+    // pages belong in a Custom Tab with a bound callback), and a subdomain is
+    // a grant the shell has no top-level navigation to justify. Exact match,
+    // so any addition is a deliberate edit to ANDROID_EXACT_ENTRIES.
+    expect(entries).toEqual(ANDROID_EXACT_ENTRIES);
   });
 
   it('contains no wildcard', () => {
@@ -136,9 +168,23 @@ describe('Android capacitor.config.ts — server.url is an origin, the path is a
   const url = serverString(CONFIGS.android, 'url');
   const appStartPath = serverString(CONFIGS.android, 'appStartPath');
   const errorPath = serverString(CONFIGS.android, 'errorPath');
+  const cleartext = serverRaw(CONFIGS.android, 'cleartext');
 
   it('found server.url', () => {
     expect(url).not.toBeNull();
+  });
+
+  it('server.url is https', () => {
+    // The origin below becomes an addWebMessageListener rule and the cookie
+    // domain; an http origin would put the bridge and the session on a
+    // cleartext channel.
+    expect(new URL(url!).protocol).toBe('https:');
+  });
+
+  it('cleartext traffic stays disabled', () => {
+    // `cleartext: false` is what keeps usesCleartextTraffic off in the shell.
+    // Asserted on the literal, so `true` or a removed key both fail.
+    expect(cleartext).toBe('false');
   });
 
   it('server.url carries no path, query, or fragment', () => {
@@ -179,12 +225,14 @@ describe('iOS capacitor.config.ts — allowNavigation is ratcheted, not endorsed
     }
   });
 
-  it('the apex stays listed whenever the wildcard is', () => {
-    // doesHost() compares dot-component counts, so '*.pagespace.ai' (3) never
-    // matches 'pagespace.ai' (2). Dropping the apex while keeping the wildcard
-    // re-creates the PR #2010 brick for every apex navigation.
-    if (entries?.includes(`*.${OWN_APEX}`)) {
-      expect(entries).toContain(OWN_APEX);
-    }
+  it('the apex is always listed', () => {
+    // Unconditional. With the apex absent, shouldAllowNavigation() is false
+    // for pagespace.ai itself and WebViewDelegationHandler falls back to a
+    // string-prefix test against server.url — which carries `/dashboard` — so
+    // the signin redirect leaves for Safari and the WebView is left with no
+    // document (PR #2010). The wildcard does not cover it: doesHost() compares
+    // dot-component counts, and '*.pagespace.ai' (3) never matches
+    // 'pagespace.ai' (2).
+    expect(entries).toContain(OWN_APEX);
   });
 });

--- a/apps/web/src/lib/__tests__/capacitor-allow-navigation.guard.test.ts
+++ b/apps/web/src/lib/__tests__/capacitor-allow-navigation.guard.test.ts
@@ -1,0 +1,190 @@
+/**
+ * Capacitor `allowNavigation` is a grant of the NATIVE PLUGIN BRIDGE, not a
+ * navigation allowlist. Asserted structurally against the config source.
+ *
+ * On Android every entry is folded into `allowedOriginRules`
+ * (`Bridge.setAllowedOriginRules()`), which `MessageHandler` passes to
+ * `WebViewCompat.addWebMessageListener(webView, "androidBridge", ...)`; from
+ * there `postMessage` reaches `Bridge.callPluginMethod()` and every registered
+ * plugin — `PageSpaceKeychain` over EncryptedSharedPreferences included. A
+ * third-party host in that list hands a provider's consent page the user's
+ * session store; a wildcard hands it to every subdomain that exists or ever
+ * will, tenant hosts included. Two separate reviewers caught two separate
+ * versions of exactly that regression in PR #2552. This file is what stops a
+ * third.
+ *
+ * `server.url` is guarded for a related reason: `Bridge.setAllowedOriginRules()`
+ * also puts `getServerUrl()` VERBATIM into the same rule set, and the rule
+ * grammar (`SCHEME "://" [ HOSTNAME_PATTERN [ ":" PORT ] ]`) has no path
+ * production. A `url` carrying `/dashboard` is not a rule; `MessageHandler`'s
+ * catch for a rejected rule is `webView.addJavascriptInterface(this,
+ * "androidBridge")`, which enforces no origin at all. So a path in `server.url`
+ * may silently disable the allowlist this test protects. The landing path
+ * belongs in `appStartPath`.
+ *
+ * This lives in `apps/web` rather than beside the configs because neither
+ * mobile app is in the turbo test graph, and the web layer is the other half of
+ * the same bridge (`@/lib/capacitor-bridge`). `deploy-order.guard.test.ts` in
+ * `apps/realtime` is the precedent for guarding a file outside the package.
+ *
+ * Both files are read as TEXT, not imported: the configs import
+ * `@capacitor/keyboard` at runtime, which is installed under each app's own
+ * `node_modules`, not the workspace root, and a guard that depended on that
+ * resolving would fail for reasons unrelated to the invariant. A regex over the
+ * source is exactly as brittle as the idiom in `sheet-read-is-read-only.guard`
+ * and no more.
+ */
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { resolve, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const APPS = resolve(HERE, '../../../..');
+
+const CONFIGS = {
+  android: readFileSync(resolve(APPS, 'android/capacitor.config.ts'), 'utf-8'),
+  ios: readFileSync(resolve(APPS, 'ios/capacitor.config.ts'), 'utf-8'),
+} as const;
+
+/** The app's own apex; a subdomain of it is "own origin", anything else is third party. */
+const OWN_APEX = 'pagespace.ai';
+
+/**
+ * What the SHIPPED iOS app lists today. This is a ratchet, not an endorsement:
+ * the two provider hosts are a deliberate, imperfect tradeoff recorded in the
+ * config's own comment (omitting them hands the consent screen to Safari, where
+ * a successful sign-in lands the cookie in the wrong jar), and the bridge on iOS
+ * is a `WKUserScript(forMainFrameOnly: true)` with no origin scoping at all
+ * (`JSExport.swift:20`), so every entry here is a bridge grant just as on
+ * Android. Additions fail this test. Removals pass — that is the direction the
+ * open finding on the Android parity epic points, and when it lands, shrink
+ * this constant to match.
+ */
+const IOS_KNOWN_ENTRIES = ['pagespace.ai', '*.pagespace.ai', 'accounts.google.com', 'appleid.apple.com'];
+
+/**
+ * Strip full-line `//` comments so a commented-out entry inside the array is
+ * not read as live. Whole-line only: `https://` inside a string literal must
+ * survive, and both configs are written with full-line comments.
+ */
+function stripLineComments(source: string): string {
+  return source.replace(/^\s*\/\/[^\n]*/gm, '');
+}
+
+/** The string entries of `allowNavigation: [...]`, or null if the key is absent. */
+function allowNavigationEntries(source: string): string[] | null {
+  const match = /allowNavigation:\s*\[([^\]]*)\]/.exec(stripLineComments(source));
+  if (!match) return null;
+  return [...match[1].matchAll(/'([^']*)'/g)].map((m) => m[1]);
+}
+
+/** The value of `<key>: '<value>'` inside the `server: { ... }` block, or null. */
+function serverString(source: string, key: string): string | null {
+  const server = /server:\s*\{([\s\S]*?)\n {2}\},/.exec(stripLineComments(source));
+  if (!server) return null;
+  const match = new RegExp(`\\b${key}:\\s*'([^']*)'`).exec(server[1]);
+  return match ? match[1] : null;
+}
+
+function isOwnOrigin(host: string): boolean {
+  return host === OWN_APEX || host.endsWith(`.${OWN_APEX}`);
+}
+
+describe('Android capacitor.config.ts — allowNavigation grants the native bridge', () => {
+  const entries = allowNavigationEntries(CONFIGS.android);
+
+  it('found the allowNavigation list (guard is actually scanning something)', () => {
+    expect(entries).not.toBeNull();
+    expect(entries!.length).toBeGreaterThan(0);
+  });
+
+  it('lists no third-party host', () => {
+    // Every entry is handed the native plugin bridge, PageSpaceKeychain
+    // included. A provider consent page must never be one of them; provider
+    // pages belong in a Custom Tab with a bound callback.
+    for (const host of entries ?? []) {
+      expect(isOwnOrigin(host), `${host} is not an own-origin host`).toBe(true);
+    }
+  });
+
+  it('contains no wildcard', () => {
+    // '*.pagespace.ai' is a bridge grant to every subdomain that exists or
+    // ever will, tenant hosts included, and top-level navigation to a
+    // subdomain is not something the shell does (it loads /dashboard and
+    // stays). If one is ever genuinely needed, the apex must stay beside it —
+    // HostMask.Simple.matches() never matches a 2-component host against a
+    // 3-component mask — and this assertion must be replaced by one naming
+    // the specific subdomain.
+    for (const host of entries ?? []) {
+      expect(host.includes('*'), `${host} is a wildcard`).toBe(false);
+    }
+  });
+
+  it('entries are bare hostnames — no scheme, port, or path', () => {
+    // Bridge.setAllowedOriginRules() prefixes a bare host with `https://` and
+    // takes anything containing `://` verbatim. Only the bare form is what the
+    // comment on the list describes, and anything else is a rule someone
+    // should have to justify in review.
+    for (const host of entries ?? []) {
+      expect(host, `${host} is not a bare hostname`).toMatch(/^[a-z0-9.-]+$/);
+    }
+  });
+});
+
+describe('Android capacitor.config.ts — server.url is an origin, the path is appStartPath', () => {
+  const url = serverString(CONFIGS.android, 'url');
+  const appStartPath = serverString(CONFIGS.android, 'appStartPath');
+  const errorPath = serverString(CONFIGS.android, 'errorPath');
+
+  it('found server.url', () => {
+    expect(url).not.toBeNull();
+  });
+
+  it('server.url carries no path, query, or fragment', () => {
+    // A path here is not expressible as an addWebMessageListener origin rule,
+    // and the fallback for a rejected rule is an unscoped
+    // addJavascriptInterface — see the file header.
+    expect(url).toBe(new URL(url!).origin);
+  });
+
+  it('the landing path is appStartPath, and it is absolute', () => {
+    // Bridge appends appStartPath after the server.url branch, so the app
+    // still lands on /dashboard without a path ever entering the rule set.
+    expect(appStartPath).not.toBeNull();
+    expect(appStartPath!.startsWith('/')).toBe(true);
+  });
+
+  it('errorPath names the bundled retry shell', () => {
+    // Without it BridgeWebViewClient.onReceivedError has no URL to load and a
+    // failed load leaves the WebView on Chrome's own error page.
+    expect(errorPath).toBe('index.html');
+  });
+});
+
+describe('iOS capacitor.config.ts — allowNavigation is ratcheted, not endorsed', () => {
+  const entries = allowNavigationEntries(CONFIGS.ios);
+
+  it('found the allowNavigation list (guard is actually scanning something)', () => {
+    expect(entries).not.toBeNull();
+    expect(entries!.length).toBeGreaterThan(0);
+  });
+
+  it('adds no entry beyond the recorded shipped set', () => {
+    // A new host here is a new bridge grant on the shipped app. Removing one
+    // is allowed and expected; adding one needs the tradeoff in the config
+    // comment re-argued for that host, and this constant updated with it.
+    for (const host of entries ?? []) {
+      expect(IOS_KNOWN_ENTRIES, `${host} is not in the recorded iOS set`).toContain(host);
+    }
+  });
+
+  it('the apex stays listed whenever the wildcard is', () => {
+    // doesHost() compares dot-component counts, so '*.pagespace.ai' (3) never
+    // matches 'pagespace.ai' (2). Dropping the apex while keeping the wildcard
+    // re-creates the PR #2010 brick for every apex navigation.
+    if (entries?.includes(`*.${OWN_APEX}`)) {
+      expect(entries).toContain(OWN_APEX);
+    }
+  });
+});

--- a/turbo.json
+++ b/turbo.json
@@ -34,6 +34,8 @@
       "dependsOn": ["^build"],
       "inputs": ["$TURBO_DEFAULT$", "tsconfig*.json"]
     },
+    "@pagespace/android#typecheck": { "dependsOn": [] },
+    "@pagespace/ios#typecheck": { "dependsOn": [] },
     "test": {
       "dependsOn": ["^build"],
       "inputs": ["$TURBO_DEFAULT$", "vitest.config.*", "src/**/*.test.{ts,tsx}"],


### PR DESCRIPTION
Phase E of the Android Parity Epic (`yqkxh0e9wdt730dqdro8xf6o`, dev drive): the last phase. Scoped wider than its two board tasks on purpose — Jono asked for the full story, i.e. every loose end Phases A–D logged and left. **Nothing here ran on an Android device**, and the PR does not pretend otherwise; that is the phase's main job.

## What changed, in the order it matters

### 1. The mobile shell configs are under CI for the first time

`apps/android` and `apps/ios` declared no `lint`/`typecheck`/`test` script, so turbo skipped both. **Green CI said nothing about #2552 or #2558** — every behavioural claim in three merged PRs rested on hand-inspection, including whether the config keys were even valid.

Each app now has `"typecheck": "tsc --noEmit"` over its existing strict single-file tsconfig (`include: ["capacitor.config.ts"]`). The naive version drags **web's full Next.js build** into the typecheck graph because both apps devDepend on `web` and the root `typecheck` task is `dependsOn: ["^build"]`. Two package-task overrides in `turbo.json` cut that edge:

```json
"@pagespace/android#typecheck": { "dependsOn": [] },
"@pagespace/ios#typecheck": { "dependsOn": [] },
```

Verified rather than trusted (turbo 2.7.6, `--dry=json`):

| | `@pagespace/android#typecheck` dependencies |
|---|---|
| without the override | `["web#build"]` |
| with the override | `[]` |

Two details worth knowing: the package name is `@pagespace/android`, not the directory `apps/android` the Phase C summary guessed; and an override does **not** inherit the base task's `inputs` — the resolved definition is `inputs: []`, i.e. turbo's default of every tracked file in the package, which is fine and keeps the diff to two lines. Both scoped typechecks pass locally (`exit=0`).

### 2. The `allowNavigation` guard test #2552 designed and could not land

`apps/web/src/lib/__tests__/capacitor-allow-navigation.guard.test.ts`. On Android an `allowNavigation` entry grants the **native plugin bridge** (`Bridge.setAllowedOriginRules()` → `MessageHandler` → `addWebMessageListener` → `callPluginMethod`, reaching `PageSpaceKeychain` over EncryptedSharedPreferences), and two reviewers caught two separate versions of that regression in #2552. The guard is what stops a third.

It reads both configs as **text** (importing them would need `@capacitor/keyboard`, which lives under each app's own `node_modules`) and asserts:

- **Android**: the list is **exactly** `['pagespace.ai']` (a subdomain or tenant host is an edit to the constant, where review sees the grant); every element must be a string literal (an identifier or spread throws rather than being skipped); no wildcard; bare hostnames only; `server.url` is an **https** origin (`url === new URL(url).origin` — a path there may silently disable the allowlist via `MessageHandler`'s `addJavascriptInterface` catch, finding 3 on the epic); `cleartext: false` pinned on the literal; `appStartPath` is absolute; `errorPath` is `index.html`.
- **iOS**: a **ratchet**, not an endorsement — entries must be a subset of the recorded shipped four (additions fail CI, removals pass), and the apex must **always** be listed (with it absent the shell falls back to the `/dashboard` prefix test that bricked it in PR #2010; the wildcard never covers the apex because `doesHost()` compares dot-component counts).

**14/14 mutants killed**, each by editing the real config, running the single file, and reverting: `+accounts.google.com`, `+*.pagespace.ai`, `+app.pagespace.ai`, `+tenantHost` (identifier), path in `server.url`, `http://` in `server.url`, `cleartext: true`, `cleartext` removed, `errorPath` removed, relative `appStartPath`, iOS `+example.com`, iOS apex dropped with the wildcard kept, iOS apex and wildcard both dropped. Baseline 13/13 green; eslint clean; the test file typechecks under a tsconfig scoped to it.

Review (CodeRabbit, three Major findings on the guard — exact allowlist + literal-only parsing, https + cleartext, unconditional iOS apex) — all three valid, fixed in `3d5e95d72`, replied in-thread.

Why it lives in `apps/web`: neither mobile app is in the turbo test graph, putting it there would need vitest plus `test`/`test:coverage` scripts plus four more turbo overrides for one file, and the web layer is the other half of the same bridge (`@/lib/capacitor-bridge`). `apps/realtime`'s `deploy-order.guard.test.ts` guards a file outside its package already; the "no precedent for cross-app source guards" objection in #2552 was not quite right.

### 3. Device verification — blocked, not done

No Android hardware, no emulator. **The board task is `blocked`**, and the epic page and the Phase E page both say so and why.

What was done instead:

- `versionCode 1 → 2`, `versionName "1.0" → "1.4"` (`build.gradle`). `versionName` tracks the iOS `MARKETING_VERSION` so both stores show one product version; the README records the convention.
- The full verification checklist is in `apps/android/README.md` → "Device verification — the checklist nothing has run yet": every claim the four PRs left unverified, grouped by phase, in the order the failures would cascade. The single highest-value item is whether the bridge allowlist is live on a real WebView or `MessageHandler` took its unscoped `addJavascriptInterface` fallback — testable from `chrome://inspect` on a foreign origin.
- "What blocks a distributable build" lists the deliberately-out-of-scope items with what each unblocks: release keystore, Play Console, `assetlinks.json` + the https filter, release automation, a notification icon, dependency disclosure.

### 4. Android README to iOS parity

Extended, not rewritten — everything #2552/#2558 put there stands. Added: a real header (app id, Firebase project, SDK levels, signing status, our own plugin), Architecture, Building locally (with what `cap sync` regenerates and why the committed Gradle files are stale), **what CI checks and what it does not** (nothing compiles the Java, parses the manifest, or runs Gradle), Versioning, and a per-phase capability table covering Phases A/B/D (secure storage, native Google, Apple-on-Android known broken, bearer/CSRF, push, FCM, badge, deep links, error shell).

Self-review after the first CI run tightened three claims (`261abcdcc`): "nothing in apps/web asks is-this-iOS any more" overclaimed (17 `=== 'ios'`/`isIOS()` sites remain, some correctly) and now says what the capability table replaced and how to read a remaining equality; the keystore bullet no longer asserts what Fly secrets hold; and the Facebook SDK the social-login plugin pulls is noted as **excludable on Android** via the plugin's `socialLogin.facebook.include` Gradle property, a lever iOS lacks.

**Corrected**: the "Prerequisite 2 — link routing" section said nothing listens for `appUrlOpen` on either platform. That was true when written and false since #2569 shipped `DeepLinkHandler`; the README contradicted itself two sections later. Rewritten as "met since PR #2569", with what the resolver deliberately does not route. The same stale claim in the `AndroidManifest.xml` comments is fixed. It is **still** in `google/callback/route.ts` (~L380-410) and `useOAuthSignIn.ts` (~L211) — left alone as web auth files outside this PR, and recorded on the follow-up epic.

### 5. The epic page's own drift — fixed

Finding 1 said "Android now lists only `pagespace.ai` and `*.pagespace.ai`". Wrong: the merged config is `['pagespace.ai']`; the wildcard was removed in review for the same bridge-grant reason. Fixed, along with: status `📋 PLANNED` → closed; the Phase C deep-link finding marked resolved by #2569 with what remains for Android; a "Phase E outcome" section — shipped, deferred, unverified, the three acceptance criteria deliberately not met and why, and follow-ups.

### 6. The two iOS security findings — assessed, not changed

Both are live on the **shipped iOS app**. Neither is touched. Written up on a new dev-drive epic, **Mobile OAuth return-channel hardening** (`wopcjlb7femjjt96krgcnlzp`, Epics folder), linked from the Android epic, with four tasks:

- **Finding 1** (`accounts.google.com` / `appleid.apple.com` hold the bridge): verified against `@capacitor/ios` 7.6.5 — `JSExport.swift:20/107/212` inject via `WKUserScript(forMainFrameOnly: true)` with no origin scoping, and `WebViewDelegationHandler.swift:98` is what keeps a listed host in the WebView. **Not a safe copy of the Android change**: `useOAuthSignIn` has deliberately no fall-through from native to web OAuth (Phase B), so the fallback fires on iOS only when the plugin is unavailable; with the entries that path fails visibly (`disallowed_useragent`), without them it fails silently in Safari with the cookie in the wrong jar. Threat: needs hostile script on a provider auth origin inside our WebView — low likelihood, high impact, defense-in-depth. Options costed (remove / keep / `ASWebAuthenticationSession` + bound return); recommendation is the real fix sequenced after Finding 2, and **not** removal alone.
- **Finding 2** (`/api/auth/desktop/exchange` is bearer-only): **Option A**, PKCE-bind the exchange (challenge rides in the HMAC-signed OAuth state, stored in the JSONB payload, verifier required on redeem; ~6 server files, ~3 desktop, ~2 web; no migration; enforce-when-present then flip to required) vs **Option B**, verified App/Universal Link transport (blocked on Android by the missing release keystore, not applicable to desktop, and the code stays bearer). Recommendation A first, B later as transport. **Jono's call — recorded, not made.** The two findings share a fix: getting provider pages out of the privileged WebView needs a return channel, which is exactly what Finding 2 says is unsafe.

### 7. Board

Phase E container → `completed`; Android documentation → `completed`; Device verification → `blocked`. Children before container.

## Changelog

One `Changed` entry. The only thing a user could ever observe is the version identity, and it says plainly that nothing is distributed and nothing has run on a device. The CI and guard work is mentioned in one sentence as "behind the scenes".

## What I did not do, and one thing I did that I should not have

- No device, no emulator, no APK build. Nothing behavioural is claimed as observed.
- No repo-wide build/typecheck/test. The two scoped typechecks and the single guard file are the only things run — **except** that I ran `tsc --noEmit` over all of `apps/web` once, to typecheck the new test file, before catching myself. It passed and I did not repeat it; noting it because the ground rules said not to.
- `turbo.json` diff is two lines; rebased-clean on `origin/master` at push (0 behind).
- Web auth files (`google/callback/route.ts`, `useOAuthSignIn.ts`, `oauth-state.ts`, `desktop/exchange/route.ts`) are read, cited, and untouched.

**Do not merge — Jono merges.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Fx9qo1XussQn6HEy8yYWMT
