### PR TITLE
fix(sandbox): sprite names fit the URL label — previews never reached a sprite

### DIFF
--- a/docs/sprites/dev-preview-runbook.md
+++ b/docs/sprites/dev-preview-runbook.md
@@ -302,6 +302,35 @@ behaviour before — spike §8), it would remove the in-sprite relay, the 8080
 single slot, and the one-preview-per-sandbox limit entirely. Verify it against
 a real sprite before designing on it.
 
+## 9. Sprite names and the URL label
+
+A sprite's URL is `https://<name>-<org>.sprites.app`. The API accepts names
+up to 63 chars, but the URL puts the name AND `-<org>` in ONE DNS label,
+which RFC 1035 caps at 63 — and the platform never checks the sum. Our
+HMAC-derived names cut to 63 produced 69-char labels (`pgs-env-…-bskrl`);
+`dig` refuses them outright ("label too long"), so **no `pgs-*` sprite URL
+ever resolved** and every preview died at the fetch as `502 fetch failed`.
+
+- Names are now cut to `SPRITE_NAME_MAX` (48: 8-char prefix + 40 hex,
+  leaving 15 for `-<org>`). `spriteNameFor(key)` is the one spelling.
+- The name is not persisted: `getOrCreate` re-derives it on every attach.
+  So it looks up the short name, then the LEGACY 63-char name, and creates
+  (short) only when neither exists. A legacy sprite keeps its disk,
+  services and sessions — and **cannot be previewed**: there is no rename,
+  and its URL is structurally unresolvable. Recreate the env/session.
+- You can tell a legacy sandbox by its `sandboxId` length: 63.
+- The proxy refuses such a URL by name (`sprite-url-unresolvable`, 502)
+  before fetching, and the pane says so before the frame is opened
+  (`down`, not repairable, `SPRITE_URL_UNRESOLVABLE_MESSAGE`).
+- Report to Fly: the API accepts names whose URLs cannot exist.
+
+A related non-issue, verified the same day: Next ≥ 15.2's dev server 403s
+any request carrying an `Origin` header it does not know (even the sprite's
+own origin). The forwarder never sends `Origin` or `Referer` (allowlist in
+`preview-proxy-policy.ts`) and the WS tunnel forwards only the
+`sec-websocket-*` set, so chunks, RSC fetches and HMR all reach Next without
+one. Do not add `Origin` to the allowlist.
+
 ## Runtime behaviour worth knowing
 
 - **A refused reconcile is retried, three times across ~21s.** If the holder's

--- a/packages/lib/src/services/sandbox/preview/__tests__/dev-preview-core.test.ts
+++ b/packages/lib/src/services/sandbox/preview/__tests__/dev-preview-core.test.ts
@@ -7,6 +7,7 @@ import {
   describeHttpPortSlot,
   planDevServerService,
   describeServiceState,
+  SPRITE_URL_UNRESOLVABLE_MESSAGE,
   resolveDevPreviewHolder,
   HTTP_PORT_BUSY_MESSAGE,
   requiresPreviewApproval,
@@ -460,6 +461,21 @@ describe('planDevServerService — thrash guard', () => {
 });
 
 describe('describeServiceState', () => {
+  it('a sandbox whose URL cannot resolve is down, NOT repairable, and says so — whatever the relay and listeners say', () => {
+    assert({
+      given: 'a live relay row and a listening target, but urlRoutable: false',
+      should: 'be down with the unresolvable-URL sentence and repairable: false',
+      actual: describeServiceState({ liveInstanceId: INSTANCE, row: relayRow(5173), relay: relayService(5173), listeners: [{ port: 5173, pid: 7 }, { port: 8080, pid: 42 }], urlRoutable: false }),
+      expected: { status: 'down', targetPort: 5173, via: 'relay', error: 'sprite-url-unresolvable', repairable: false, message: SPRITE_URL_UNRESOLVABLE_MESSAGE },
+    });
+    assert({
+      given: 'the same with urlRoutable omitted',
+      should: 'be live — the default has nothing to say',
+      actual: describeServiceState({ liveInstanceId: INSTANCE, row: relayRow(5173), relay: relayService(5173), listeners: [{ port: 5173, pid: 7 }, { port: 8080, pid: 42 }] }).status,
+      expected: 'live',
+    });
+  });
+
   it('reports none / instance-unknown / stale before anything live is consulted', () => {
     assert({ given: 'no row', should: 'be none', actual: describeServiceState({ liveInstanceId: INSTANCE, row: null, relay: null, listeners: null }).status, expected: 'none' });
     assert({

--- a/packages/lib/src/services/sandbox/preview/__tests__/dev-preview-status.test.ts
+++ b/packages/lib/src/services/sandbox/preview/__tests__/dev-preview-status.test.ts
@@ -6,7 +6,7 @@ import { describe, it, expect } from 'vitest';
 import { assert } from '../../__tests__/riteway';
 import { SPRITE_SANDBOX_CAPABILITIES, type SandboxHandle, type SandboxServiceInfo } from '../../sandbox-host';
 import type { DevPreviewHolderRef, DevPreviewRow } from '../dev-preview-core';
-import { HTTP_PORT_BUSY_MESSAGE, describeServiceState } from '../dev-preview-core';
+import { HTTP_PORT_BUSY_MESSAGE, describeServiceState, SPRITE_URL_UNRESOLVABLE_MESSAGE } from '../dev-preview-core';
 import type { DevPreviewRecord, DevPreviewStore } from '../dev-preview-store';
 import {
   SANDBOX_ABSENT_MESSAGE,
@@ -274,6 +274,18 @@ describe('gatherDevPreviewStatus — authorize, attach, fold; never a probe', ()
     assert({ given: 'member + live relay + snapshot', should: 'be live with a known relay-held slot', actual: [result.status.state.status, result.status.slot.known && result.status.slot.holder, result.status.sandbox, result.status.openPath], expected: ['live', 'relay', 'attached', '/api/drives/d1/envs/env1/preview/open'] });
     assert({ given: 'the gather', should: 'never exec', actual: d.calls.includes('exec'), expected: false });
     assert({ given: 'the gather', should: 'read the services API once', actual: d.calls.filter((c) => c === 'services.get').length, expected: 1 });
+  });
+
+  it('a sprite whose URL cannot resolve reads as down/unrepairable BEFORE the frame is opened; a holder with no URL surface is unaffected', async () => {
+    const long = statusDeps({ attach: async () => ({ ...fakeHandle({ relay: relayService(5173) }), urlInfo: async () => ({ url: `https://pgs-env-${'a'.repeat(55)}-bskrl.sprites.app`, auth: 'sprite' as const }) }) });
+    const r1 = await gatherDevPreviewStatus({ authorizeAs: ENV, holder: ENV, userId: 'u1', deps: long });
+    if (!r1.ok) throw new Error('expected ok');
+    assert({ given: 'a 69-char URL label', should: 'be down, unrepairable, with the sentence', actual: [r1.status.state.status, 'repairable' in r1.status.state ? r1.status.state.repairable : null, r1.status.state.message], expected: ['down', false, SPRITE_URL_UNRESOLVABLE_MESSAGE] });
+    // A local env's handle rejects urlInfo (no URL surface at all): nothing to say, so the state is what the row and relay say.
+    const local = statusDeps({ attach: async () => ({ ...fakeHandle({ relay: relayService(5173) }), urlInfo: async () => { throw new Error('unsupported'); } }) });
+    const r2 = await gatherDevPreviewStatus({ authorizeAs: ENV, holder: ENV, userId: 'u1', deps: local });
+    if (!r2.ok) throw new Error('expected ok');
+    assert({ given: 'urlInfo rejects', should: 'stay live', actual: r2.status.state.status, expected: 'live' });
   });
 
   it('a refused user gets the decider reason and NO control-plane read', async () => {

--- a/packages/lib/src/services/sandbox/preview/__tests__/dev-preview-status.test.ts
+++ b/packages/lib/src/services/sandbox/preview/__tests__/dev-preview-status.test.ts
@@ -276,16 +276,15 @@ describe('gatherDevPreviewStatus — authorize, attach, fold; never a probe', ()
     assert({ given: 'the gather', should: 'read the services API once', actual: d.calls.filter((c) => c === 'services.get').length, expected: 1 });
   });
 
-  it('a sprite whose URL cannot resolve reads as down/unrepairable BEFORE the frame is opened; a holder with no URL surface is unaffected', async () => {
-    const long = statusDeps({ attach: async () => ({ ...fakeHandle({ relay: relayService(5173) }), urlInfo: async () => ({ url: `https://pgs-env-${'a'.repeat(55)}-bskrl.sprites.app`, auth: 'sprite' as const }) }) });
-    const r1 = await gatherDevPreviewStatus({ authorizeAs: ENV, holder: ENV, userId: 'u1', deps: long });
+  it('a LEGACY sprite (name over the budget, so its URL cannot resolve) reads as down/unrepairable BEFORE the frame is opened — from the name alone, no control-plane read', async () => {
+    const legacy = statusDeps({ attach: async () => ({ ...fakeHandle({ relay: relayService(5173) }), sandboxId: `pgs-env-${'a'.repeat(55)}` }) });
+    const r1 = await gatherDevPreviewStatus({ authorizeAs: ENV, holder: ENV, userId: 'u1', deps: legacy });
     if (!r1.ok) throw new Error('expected ok');
-    assert({ given: 'a 69-char URL label', should: 'be down, unrepairable, with the sentence', actual: [r1.status.state.status, 'repairable' in r1.status.state ? r1.status.state.repairable : null, r1.status.state.message], expected: ['down', false, SPRITE_URL_UNRESOLVABLE_MESSAGE] });
-    // A local env's handle rejects urlInfo (no URL surface at all): nothing to say, so the state is what the row and relay say.
-    const local = statusDeps({ attach: async () => ({ ...fakeHandle({ relay: relayService(5173) }), urlInfo: async () => { throw new Error('unsupported'); } }) });
-    const r2 = await gatherDevPreviewStatus({ authorizeAs: ENV, holder: ENV, userId: 'u1', deps: local });
+    assert({ given: 'a 63-char sprite name', should: 'be down, unrepairable, with the sentence', actual: [r1.status.state.status, 'repairable' in r1.status.state ? r1.status.state.repairable : null, r1.status.state.message], expected: ['down', false, SPRITE_URL_UNRESOLVABLE_MESSAGE] });
+    const current = statusDeps({ attach: async () => ({ ...fakeHandle({ relay: relayService(5173) }), sandboxId: `pgs-env-${'a'.repeat(40)}` }) });
+    const r2 = await gatherDevPreviewStatus({ authorizeAs: ENV, holder: ENV, userId: 'u1', deps: current });
     if (!r2.ok) throw new Error('expected ok');
-    assert({ given: 'urlInfo rejects', should: 'stay live', actual: r2.status.state.status, expected: 'live' });
+    assert({ given: 'a 48-char sprite name', should: 'stay live', actual: r2.status.state.status, expected: 'live' });
   });
 
   it('a refused user gets the decider reason and NO control-plane read', async () => {

--- a/packages/lib/src/services/sandbox/preview/__tests__/preview-access.test.ts
+++ b/packages/lib/src/services/sandbox/preview/__tests__/preview-access.test.ts
@@ -134,10 +134,15 @@ describe('resolvePreviewTarget — the gather, in order', () => {
 
   it('a sprite whose URL cannot exist in DNS is refused BY NAME before any fetch — not surfaced later as "fetch failed"', async () => {
     // Production: 63-char names + the org suffix made a 69-char label; every forward died at the fetch.
-    const d = deps({ attach: async () => fakeHandle({ relay: runningRelay(), url: `https://pgs-env-${'a'.repeat(55)}-bskrl.sprites.app` }) });
+    const LONG_URL = `https://pgs-env-${'a'.repeat(55)}-bskrl.sprites.app`;
+    const d = deps({ attach: async () => fakeHandle({ relay: runningRelay(), url: LONG_URL }) });
     const target = await resolvePreviewTarget({ holder, userId: USER, sessionId: SESSION, deps: d });
     assert({ given: 'live + running, 69-char URL label', should: 'refuse as sprite-url-unresolvable, 502', actual: [target.decision.kind, 'reason' in target.decision ? target.decision.reason : null, 'status' in target.decision ? target.decision.status : null], expected: ['refuse', 'sprite-url-unresolvable', 502] });
     assert({ given: 'the refusal', should: 'carry no sprite URL to forward', actual: 'spriteUrl' in target, expected: false });
+    // Structural: refused by the state machine, so a PAUSED legacy sprite never reaches the wake gate either.
+    const paused = deps({ attach: async () => fakeHandle({ relay: runningRelay(), url: LONG_URL, power: 'paused' }) });
+    const t2 = await resolvePreviewTarget({ holder, userId: USER, sessionId: SESSION, deps: paused });
+    assert({ given: 'paused + unroutable', should: 'refuse without consulting canRunCode', actual: [t2.decision.kind, paused.calls.includes('canRunCode')], expected: ['refuse', false] });
   });
 
   it('a paused sprite consults the wake gate on the PAYER and forwards as a wake when allowed', async () => {

--- a/packages/lib/src/services/sandbox/preview/__tests__/preview-access.test.ts
+++ b/packages/lib/src/services/sandbox/preview/__tests__/preview-access.test.ts
@@ -132,6 +132,14 @@ describe('resolvePreviewTarget — the gather, in order', () => {
     assert({ given: 'dark', should: 'not attach', actual: d.calls.includes('attach'), expected: false });
   });
 
+  it('a sprite whose URL cannot exist in DNS is refused BY NAME before any fetch — not surfaced later as "fetch failed"', async () => {
+    // Production: 63-char names + the org suffix made a 69-char label; every forward died at the fetch.
+    const d = deps({ attach: async () => fakeHandle({ relay: runningRelay(), url: `https://pgs-env-${'a'.repeat(55)}-bskrl.sprites.app` }) });
+    const target = await resolvePreviewTarget({ holder, userId: USER, sessionId: SESSION, deps: d });
+    assert({ given: 'live + running, 69-char URL label', should: 'refuse as sprite-url-unresolvable, 502', actual: [target.decision.kind, 'reason' in target.decision ? target.decision.reason : null, 'status' in target.decision ? target.decision.status : null], expected: ['refuse', 'sprite-url-unresolvable', 502] });
+    assert({ given: 'the refusal', should: 'carry no sprite URL to forward', actual: 'spriteUrl' in target, expected: false });
+  });
+
   it('a paused sprite consults the wake gate on the PAYER and forwards as a wake when allowed', async () => {
     let seen: unknown;
     const d = deps({ attach: async () => fakeHandle({ relay: runningRelay(), power: 'paused' }), canRunCode: async (input) => { seen = input; return { ok: true }; } });

--- a/packages/lib/src/services/sandbox/preview/__tests__/preview-forward-gate.test.ts
+++ b/packages/lib/src/services/sandbox/preview/__tests__/preview-forward-gate.test.ts
@@ -75,6 +75,8 @@ describe('decidePreviewForward — order of refusal', () => {
     [{ status: 'stopped', targetPort: 3000, stoppedAt: new Date(0), message: 'off' }, 'stopped-by-user', 409],
     [{ status: 'blocked', targetPort: 3000, message: 'busy' }, 'http-port-busy', 409],
     [{ status: 'down', targetPort: 3000, via: 'relay', error: null, repairable: true, message: 'down' }, 'preview-down', 502],
+    // Structural: a URL DNS cannot answer is named, so a client never retries or wakes for it.
+    [{ status: 'down', targetPort: 3000, via: 'relay', error: 'sprite-url-unresolvable', repairable: false, message: 'too long' }, 'sprite-url-unresolvable', 502],
     [{ status: 'starting', targetPort: 3000, via: 'relay', message: 'starting' }, 'preview-starting', 503],
   ] as const)('refuses a %o preview and never routes it (the stale-instance rule)', (state, reason, status) => {
     const decision = decidePreviewForward(input({ state: state as DevPreviewServiceState, power: 'paused' }));

--- a/packages/lib/src/services/sandbox/preview/__tests__/preview-proxy-policy.test.ts
+++ b/packages/lib/src/services/sandbox/preview/__tests__/preview-proxy-policy.test.ts
@@ -2,6 +2,8 @@ import { describe, it, expect } from 'vitest';
 import { assert } from '../../__tests__/riteway';
 import {
   assertTrustedPreviewUpstream,
+  isRoutableSpriteUrl,
+  isRoutableSpriteUrlString,
   buildPreviewUpstreamUrl,
   buildPreviewAccessLog,
   buildPreviewResponseHeaders,
@@ -172,5 +174,25 @@ describe('attributable access log', () => {
       actual: buildPreviewAccessLog({ userId: 'u', holder: { kind: 'workspace', id: 'w' }, method: 'GET', path: '/', outcome: 'refused', reason: 'stale-instance', transport: 'websocket' }),
       expected: { userId: 'u', holderKind: 'workspace', holderId: 'w', transport: 'websocket', method: 'GET', path: '/', outcome: 'refused', reason: 'stale-instance' },
     });
+  });
+});
+
+describe('a sprite URL must be a hostname DNS can answer', () => {
+  const LONG = `https://pgs-env-${'a'.repeat(55)}-bskrl.sprites.app`; // 69-char first label — what production had
+  const OK = `https://pgs-env-${'a'.repeat(40)}-bskrl.sprites.app`;   // 54
+
+  it('refuses a first label longer than 63 chars, in the assertion and in the pure check', () => {
+    expect(new URL(LONG).hostname.split('.')[0]).toHaveLength(69);
+    expect(isRoutableSpriteUrl(new URL(LONG))).toBe(false);
+    expect(() => assertTrustedPreviewUpstream(new URL(LONG))).toThrow(/label longer/);
+    expect(isRoutableSpriteUrl(new URL(OK))).toBe(true);
+    expect(() => assertTrustedPreviewUpstream(new URL(OK))).not.toThrow();
+  });
+
+  it('the string form has nothing to say about null or garbage — only a parsable URL can be unroutable', () => {
+    expect(isRoutableSpriteUrlString(null)).toBe(true);
+    expect(isRoutableSpriteUrlString('not a url')).toBe(true);
+    expect(isRoutableSpriteUrlString(LONG)).toBe(false);
+    expect(isRoutableSpriteUrlString(OK)).toBe(true);
   });
 });

--- a/packages/lib/src/services/sandbox/preview/__tests__/preview-proxy-policy.test.ts
+++ b/packages/lib/src/services/sandbox/preview/__tests__/preview-proxy-policy.test.ts
@@ -3,7 +3,6 @@ import { assert } from '../../__tests__/riteway';
 import {
   assertTrustedPreviewUpstream,
   isRoutableSpriteUrl,
-  isRoutableSpriteUrlString,
   buildPreviewUpstreamUrl,
   buildPreviewAccessLog,
   buildPreviewResponseHeaders,
@@ -182,17 +181,17 @@ describe('a sprite URL must be a hostname DNS can answer', () => {
   const OK = `https://pgs-env-${'a'.repeat(40)}-bskrl.sprites.app`;   // 54
 
   it('refuses a first label longer than 63 chars, in the assertion and in the pure check', () => {
-    expect(new URL(LONG).hostname.split('.')[0]).toHaveLength(69);
-    expect(isRoutableSpriteUrl(new URL(LONG))).toBe(false);
+    assert({ given: 'the production shape', should: 'have a 69-char first label', actual: new URL(LONG).hostname.split('.')[0].length, expected: 69 });
+    assert({ given: 'a 69-char label', should: 'not be routable', actual: isRoutableSpriteUrl(new URL(LONG)), expected: false });
     expect(() => assertTrustedPreviewUpstream(new URL(LONG))).toThrow(/label longer/);
-    expect(isRoutableSpriteUrl(new URL(OK))).toBe(true);
+    assert({ given: 'a 54-char label', should: 'be routable', actual: isRoutableSpriteUrl(new URL(OK)), expected: true });
     expect(() => assertTrustedPreviewUpstream(new URL(OK))).not.toThrow();
   });
 
-  it('the string form has nothing to say about null or garbage — only a parsable URL can be unroutable', () => {
-    expect(isRoutableSpriteUrlString(null)).toBe(true);
-    expect(isRoutableSpriteUrlString('not a url')).toBe(true);
-    expect(isRoutableSpriteUrlString(LONG)).toBe(false);
-    expect(isRoutableSpriteUrlString(OK)).toBe(true);
+  it('a string is judged the same way; null and garbage have nothing to say', () => {
+    assert({ given: 'null (no URL yet)', should: 'be treated as routable', actual: isRoutableSpriteUrl(null), expected: true });
+    assert({ given: 'an unparsable string', should: 'be treated as routable', actual: isRoutableSpriteUrl('not a url'), expected: true });
+    assert({ given: 'the long string', should: 'not be routable', actual: isRoutableSpriteUrl(LONG), expected: false });
+    assert({ given: 'the ok string', should: 'be routable', actual: isRoutableSpriteUrl(OK), expected: true });
   });
 });

--- a/packages/lib/src/services/sandbox/preview/dev-preview-core.ts
+++ b/packages/lib/src/services/sandbox/preview/dev-preview-core.ts
@@ -713,9 +713,10 @@ export interface DescribeServiceStateInput {
    */
   listenerSource?: ListenerSource;
   /**
-   * Whether the sprite's URL can exist in DNS (`isRoutableSpriteUrlString`).
-   * Defaults to true — "nothing to say" — because most readers hold no URL;
-   * only the status gather, which reads `urlInfo`, can answer false.
+   * Whether the sprite's URL can exist in DNS — its name plus the org suffix
+   * must fit one label (`SPRITE_NAME_MAX`). Defaults to true, "nothing to
+   * say"; the status gather answers from the name, the access gather from
+   * the URL itself.
    */
   urlRoutable?: boolean;
 }

--- a/packages/lib/src/services/sandbox/preview/dev-preview-core.ts
+++ b/packages/lib/src/services/sandbox/preview/dev-preview-core.ts
@@ -712,6 +712,12 @@ export interface DescribeServiceStateInput {
    * perfectly well, for every framework the channel cannot see.
    */
   listenerSource?: ListenerSource;
+  /**
+   * Whether the sprite's URL can exist in DNS (`isRoutableSpriteUrlString`).
+   * Defaults to true — "nothing to say" — because most readers hold no URL;
+   * only the status gather, which reads `urlInfo`, can answer false.
+   */
+  urlRoutable?: boolean;
 }
 
 export type DevPreviewServiceState =
@@ -778,8 +784,12 @@ export const DETECTION_UNAVAILABLE_MESSAGE = 'Dev-server detection is not runnin
 export const HTTP_PORT_BUSY_MESSAGE =
   `Port ${SPRITE_HTTP_PORT} is already in use by something that is not the preview relay. Run your dev server on port ${SPRITE_HTTP_PORT} to preview it, or free the port.`;
 
+/** A sandbox whose URL cannot exist in DNS — the ONE place it is worded (the pane, the proxy and the status all say this). */
+export const SPRITE_URL_UNRESOLVABLE_MESSAGE =
+  'This sandbox was created with a name too long for a preview URL. Create a new environment or session to preview it.';
+
 /** Pure: the row folded with the live service read, as one UI-consumable status. */
-export function describeServiceState({ liveInstanceId, row, relay, listeners, listenerSource = 'watch' }: DescribeServiceStateInput): DevPreviewServiceState {
+export function describeServiceState({ liveInstanceId, row, relay, listeners, listenerSource = 'watch', urlRoutable = true }: DescribeServiceStateInput): DevPreviewServiceState {
   if (row === null) return { status: 'none', message: 'No dev server has been detected in this sandbox yet.' };
   if (liveInstanceId === null) {
     return { status: 'instance-unknown', message: 'The sandbox could not be identified, so its preview state cannot be shown.' };
@@ -797,6 +807,21 @@ export function describeServiceState({ liveInstanceId, row, relay, listeners, li
       targetPort: row.targetPort,
       stoppedAt: row.stoppedByUserAt,
       message: `Preview of port ${row.targetPort} is switched off.`,
+    };
+  }
+
+  // Nothing below can help a sandbox whose URL no resolver will answer: the
+  // relay may be up and the server serving, and the proxy still cannot reach
+  // them. Said here, before the frame is ever opened, and NOT repairable —
+  // the fix is a new sandbox, which no button on this pane performs.
+  if (!urlRoutable) {
+    return {
+      status: 'down',
+      targetPort: row.targetPort,
+      via: row.relayServiceName === null ? 'direct' : 'relay',
+      error: 'sprite-url-unresolvable',
+      repairable: false,
+      message: SPRITE_URL_UNRESOLVABLE_MESSAGE,
     };
   }
 

--- a/packages/lib/src/services/sandbox/preview/dev-preview-status.ts
+++ b/packages/lib/src/services/sandbox/preview/dev-preview-status.ts
@@ -55,6 +55,7 @@ import type { DevPreviewStore } from './dev-preview-store';
 import { authorizePreviewHolder, type PreviewAccessDeps, type PreviewAuthorization } from './preview-access';
 import { buildPreviewOpenPath } from './preview-grant';
 import { PREVIEW_RELAY_SERVICE_NAME, SPRITE_HTTP_PORT } from './preview-relay';
+import { isRoutableSpriteUrlString } from './preview-proxy-policy';
 
 // -----------------------------------------------------------------------------
 // The read model
@@ -207,19 +208,21 @@ export interface BuildDevPreviewStatusInput {
    * say `'probe'` and let a missing target render as `down`.
    */
   listenerSource?: ListenerSource;
+  /** Whether the sprite's URL can exist in DNS — see `DescribeServiceStateInput.urlRoutable`. Defaults to true. */
+  urlRoutable?: boolean;
   detection: DevPreviewDetection;
   openPath: string | null;
 }
 
 /** Pure: the whole read model from what the gather collected. */
-export function buildDevPreviewStatus({ holder, sandbox, liveInstanceId, row, relay, listeners, listenerSource, detection, openPath }: BuildDevPreviewStatusInput): DevPreviewStatus {
+export function buildDevPreviewStatus({ holder, sandbox, liveInstanceId, row, relay, listeners, listenerSource, urlRoutable, detection, openPath }: BuildDevPreviewStatusInput): DevPreviewStatus {
   // Absent is the one reach the core cannot describe (it is asked about a
   // sprite); unreachable IS the core's `instance-unknown` (no live instance
   // id can be proven), so it is worded there and nowhere else.
   const state: DevPreviewServiceState =
     sandbox === 'absent'
       ? { status: 'none', message: SANDBOX_ABSENT_MESSAGE }
-      : describeServiceState({ liveInstanceId: sandbox === 'attached' ? liveInstanceId : null, row, relay, listeners, listenerSource });
+      : describeServiceState({ liveInstanceId: sandbox === 'attached' ? liveInstanceId : null, row, relay, listeners, listenerSource, urlRoutable });
 
   let slot: DevPreviewSlotReport = { known: false };
   if (sandbox === 'attached' && listeners !== null) {
@@ -313,10 +316,16 @@ export async function gatherDevPreviewStatus({
   if (handle === null) {
     return { ok: true, status: buildDevPreviewStatus({ holder, sandbox: 'unreachable', liveInstanceId: null, row, relay: null, listeners: null, detection: read.detection, openPath }) };
   }
-  const relay = await handle.services.get(PREVIEW_RELAY_SERVICE_NAME);
+  // `urlInfo` is a control-plane read (no wake). A holder with no URL
+  // surface at all (a local env) rejects it — that is "nothing to say", not
+  // "unroutable", so the answer stays `true`.
+  const [relay, urlRoutable] = await Promise.all([
+    handle.services.get(PREVIEW_RELAY_SERVICE_NAME),
+    handle.urlInfo().then((info) => isRoutableSpriteUrlString(info.url), () => true),
+  ]);
   return {
     ok: true,
-    status: buildDevPreviewStatus({ holder, sandbox: 'attached', liveInstanceId: handle.spriteInstanceId, row, relay, listeners: read.listeners, detection: read.detection, openPath }),
+    status: buildDevPreviewStatus({ holder, sandbox: 'attached', liveInstanceId: handle.spriteInstanceId, row, relay, listeners: read.listeners, detection: read.detection, openPath, urlRoutable }),
   };
 }
 

--- a/packages/lib/src/services/sandbox/preview/dev-preview-status.ts
+++ b/packages/lib/src/services/sandbox/preview/dev-preview-status.ts
@@ -55,7 +55,7 @@ import type { DevPreviewStore } from './dev-preview-store';
 import { authorizePreviewHolder, type PreviewAccessDeps, type PreviewAuthorization } from './preview-access';
 import { buildPreviewOpenPath } from './preview-grant';
 import { PREVIEW_RELAY_SERVICE_NAME, SPRITE_HTTP_PORT } from './preview-relay';
-import { isRoutableSpriteUrlString } from './preview-proxy-policy';
+import { SPRITE_NAME_MAX } from '../sandbox-client/sprites';
 
 // -----------------------------------------------------------------------------
 // The read model
@@ -208,7 +208,7 @@ export interface BuildDevPreviewStatusInput {
    * say `'probe'` and let a missing target render as `down`.
    */
   listenerSource?: ListenerSource;
-  /** Whether the sprite's URL can exist in DNS — see `DescribeServiceStateInput.urlRoutable`. Defaults to true. */
+  /** See `DescribeServiceStateInput.urlRoutable`. */
   urlRoutable?: boolean;
   detection: DevPreviewDetection;
   openPath: string | null;
@@ -316,13 +316,13 @@ export async function gatherDevPreviewStatus({
   if (handle === null) {
     return { ok: true, status: buildDevPreviewStatus({ holder, sandbox: 'unreachable', liveInstanceId: null, row, relay: null, listeners: null, detection: read.detection, openPath }) };
   }
-  // `urlInfo` is a control-plane read (no wake). A holder with no URL
-  // surface at all (a local env) rejects it — that is "nothing to say", not
-  // "unroutable", so the answer stays `true`.
-  const [relay, urlRoutable] = await Promise.all([
-    handle.services.get(PREVIEW_RELAY_SERVICE_NAME),
-    handle.urlInfo().then((info) => isRoutableSpriteUrlString(info.url), () => true),
-  ]);
+  const relay = await handle.services.get(PREVIEW_RELAY_SERVICE_NAME);
+  // A sprite's URL label is its NAME plus the org suffix, so whether it can
+  // resolve is a fact about the name already in hand — no control-plane read
+  // per poll. A name over the budget is a legacy sprite (created under the
+  // API's own 63-char limit); a local env's id is short and never trips it.
+  // The proxy judges the real URL before forwarding (`preview-access`).
+  const urlRoutable = handle.sandboxId.length <= SPRITE_NAME_MAX;
   return {
     ok: true,
     status: buildDevPreviewStatus({ holder, sandbox: 'attached', liveInstanceId: handle.spriteInstanceId, row, relay, listeners: read.listeners, detection: read.detection, openPath, urlRoutable }),

--- a/packages/lib/src/services/sandbox/preview/preview-access.ts
+++ b/packages/lib/src/services/sandbox/preview/preview-access.ts
@@ -32,11 +32,11 @@ import {
 import type { CanRunCodeResult } from '../can-run-code';
 import type { SandboxHandle } from '../sandbox-host';
 import { resolveLiveSandboxId } from '../../agent-workspaces/workspace-status';
-import { describeServiceState, type DevPreviewHolderRef, SPRITE_URL_UNRESOLVABLE_MESSAGE } from './dev-preview-core';
+import { describeServiceState, type DevPreviewHolderRef } from './dev-preview-core';
 import type { DevPreviewStore } from './dev-preview-store';
 import { decidePreviewForward, type PreviewAuthz, type PreviewForwardDecision } from './preview-forward-gate';
 import { PREVIEW_RELAY_SERVICE_NAME } from './preview-relay';
-import { isRoutableSpriteUrlString } from './preview-proxy-policy';
+import { isRoutableSpriteUrl } from './preview-proxy-policy';
 
 /** The session row slice the access gather reads. */
 export interface PreviewSessionRow {
@@ -245,7 +245,11 @@ export async function resolvePreviewTarget({
     handle.powerState(),
     handle.urlInfo(),
   ]);
-  const state = describeServiceState({ liveInstanceId: handle.spriteInstanceId, row, relay, listeners: null });
+  // The URL the control plane hands back decides routability here (the
+  // status gather judges it from the name); an unroutable one reads as
+  // `down`/`sprite-url-unresolvable`, which the gate refuses BEFORE the wake
+  // gate is consulted — nothing about it is transient or wakeable.
+  const state = describeServiceState({ liveInstanceId: handle.spriteInstanceId, row, relay, listeners: null, urlRoutable: isRoutableSpriteUrl(urlInfo.url) });
 
   let decision = decidePreviewForward({ featureEnabled, authz, state, power, wakeAuthorization: 'not-consulted' });
   if (decision.kind === 'needs-wake-gate') {
@@ -263,11 +267,6 @@ export async function resolvePreviewTarget({
   // is safer than proxying to a URL whose auth posture we cannot vouch for.
   if (urlInfo.auth !== 'sprite') {
     return { decision: { kind: 'refuse', reason: 'preview-down', status: 502, message: 'The sandbox URL is not in the expected private mode.' }, authorization };
-  }
-  // A URL DNS cannot answer is refused HERE, by name, rather than surfacing
-  // downstream as an opaque `fetch failed`: nothing about it is transient.
-  if (!isRoutableSpriteUrlString(urlInfo.url)) {
-    return { decision: { kind: 'refuse', reason: 'sprite-url-unresolvable', status: 502, message: SPRITE_URL_UNRESOLVABLE_MESSAGE }, authorization };
   }
   return { decision, authorization, spriteUrl: urlInfo.url, handle };
 }

--- a/packages/lib/src/services/sandbox/preview/preview-access.ts
+++ b/packages/lib/src/services/sandbox/preview/preview-access.ts
@@ -32,10 +32,11 @@ import {
 import type { CanRunCodeResult } from '../can-run-code';
 import type { SandboxHandle } from '../sandbox-host';
 import { resolveLiveSandboxId } from '../../agent-workspaces/workspace-status';
-import { describeServiceState, type DevPreviewHolderRef } from './dev-preview-core';
+import { describeServiceState, type DevPreviewHolderRef, SPRITE_URL_UNRESOLVABLE_MESSAGE } from './dev-preview-core';
 import type { DevPreviewStore } from './dev-preview-store';
 import { decidePreviewForward, type PreviewAuthz, type PreviewForwardDecision } from './preview-forward-gate';
 import { PREVIEW_RELAY_SERVICE_NAME } from './preview-relay';
+import { isRoutableSpriteUrlString } from './preview-proxy-policy';
 
 /** The session row slice the access gather reads. */
 export interface PreviewSessionRow {
@@ -262,6 +263,11 @@ export async function resolvePreviewTarget({
   // is safer than proxying to a URL whose auth posture we cannot vouch for.
   if (urlInfo.auth !== 'sprite') {
     return { decision: { kind: 'refuse', reason: 'preview-down', status: 502, message: 'The sandbox URL is not in the expected private mode.' }, authorization };
+  }
+  // A URL DNS cannot answer is refused HERE, by name, rather than surfacing
+  // downstream as an opaque `fetch failed`: nothing about it is transient.
+  if (!isRoutableSpriteUrlString(urlInfo.url)) {
+    return { decision: { kind: 'refuse', reason: 'sprite-url-unresolvable', status: 502, message: SPRITE_URL_UNRESOLVABLE_MESSAGE }, authorization };
   }
   return { decision, authorization, spriteUrl: urlInfo.url, handle };
 }

--- a/packages/lib/src/services/sandbox/preview/preview-forward-gate.ts
+++ b/packages/lib/src/services/sandbox/preview/preview-forward-gate.ts
@@ -143,7 +143,9 @@ export function decidePreviewForward(input: PreviewForwardInput): PreviewForward
     case 'blocked':
       return { kind: 'refuse', reason: 'http-port-busy', status: 409, message: state.message };
     case 'down':
-      return { kind: 'refuse', reason: 'preview-down', status: 502, message: state.message };
+      // A URL DNS cannot answer is structural, not a relay that is down:
+      // named so a client never retries or wakes for it.
+      return { kind: 'refuse', reason: state.error === 'sprite-url-unresolvable' ? 'sprite-url-unresolvable' : 'preview-down', status: 502, message: state.message };
     case 'starting':
       return { kind: 'refuse', reason: 'preview-starting', status: 503, message: state.message };
     case 'live':

--- a/packages/lib/src/services/sandbox/preview/preview-forward-gate.ts
+++ b/packages/lib/src/services/sandbox/preview/preview-forward-gate.ts
@@ -99,7 +99,14 @@ export type PreviewForwardDecision =
          * that HAS the surface is not serving on it: this one will never
          * become available, so a client must not retry.
          */
-        | 'preview-unsupported';
+        | 'preview-unsupported'
+        /**
+         * The sprite exists and may be serving, but its URL cannot resolve:
+         * the name it was created under, plus the platform's org suffix,
+         * exceeds a DNS label. Structural — no retry, no wake, no repair
+         * short of recreating the sandbox under the current name budget.
+         */
+        | 'sprite-url-unresolvable';
       /** Suggested HTTP status; the caller's not-found/denied policy may collapse it. */
       status: 403 | 404 | 409 | 502 | 503;
       /** Human copy for the response body — never a sprite name, URL or token. */

--- a/packages/lib/src/services/sandbox/preview/preview-proxy-policy.ts
+++ b/packages/lib/src/services/sandbox/preview/preview-proxy-policy.ts
@@ -83,6 +83,34 @@ export function assertTrustedPreviewUpstream(url: URL): void {
   if (url.protocol !== 'https:' || !url.hostname.endsWith(SPRITE_URL_HOST_SUFFIX) || url.hostname === SPRITE_URL_HOST_SUFFIX.slice(1)) {
     throw new Error('preview upstream is not a sprite URL — refusing to forward');
   }
+  if (!isRoutableSpriteUrl(url)) {
+    throw new Error('preview upstream host has a label longer than a DNS label allows — refusing to forward');
+  }
+}
+
+/** RFC 1035 §2.3.4: one hostname label is at most 63 octets. */
+const MAX_HOSTNAME_LABEL = 63;
+
+/**
+ * Pure: can this sprite URL exist in DNS at all? The platform builds a
+ * sprite's URL as `<name>-<org>.sprites.app` without checking that the first
+ * label fits; a sprite named to the API's own 63-char limit gets a 69-char
+ * label that no resolver will answer (`dig`: "label too long"). A request
+ * to such a URL fails as `fetch failed` — the one failure that must be named
+ * before the fetch, because nothing downstream can recover it.
+ */
+export function isRoutableSpriteUrl(url: URL): boolean {
+  return url.hostname.split('.').every((label) => label.length >= 1 && label.length <= MAX_HOSTNAME_LABEL);
+}
+
+/** {@link isRoutableSpriteUrl} over the string the control plane hands back; `null`/unparsable ⇒ nothing to say (true). */
+export function isRoutableSpriteUrlString(url: string | null): boolean {
+  if (url === null) return true;
+  try {
+    return isRoutableSpriteUrl(new URL(url));
+  } catch {
+    return true;
+  }
 }
 
 /**

--- a/packages/lib/src/services/sandbox/preview/preview-proxy-policy.ts
+++ b/packages/lib/src/services/sandbox/preview/preview-proxy-policy.ts
@@ -46,6 +46,8 @@
  * Public exposure is a separate task with its own containment ruling.
  */
 
+import { MAX_LABEL_LENGTH } from '../../../validators/custom-domain';
+
 export interface PreviewProxyLimits {
   maxRequestBodyBytes: number;
   maxResponseBodyBytes: number;
@@ -88,29 +90,27 @@ export function assertTrustedPreviewUpstream(url: URL): void {
   }
 }
 
-/** RFC 1035 §2.3.4: one hostname label is at most 63 octets. */
-const MAX_HOSTNAME_LABEL = 63;
-
 /**
  * Pure: can this sprite URL exist in DNS at all? The platform builds a
  * sprite's URL as `<name>-<org>.sprites.app` without checking that the first
  * label fits; a sprite named to the API's own 63-char limit gets a 69-char
  * label that no resolver will answer (`dig`: "label too long"). A request
  * to such a URL fails as `fetch failed` — the one failure that must be named
- * before the fetch, because nothing downstream can recover it.
+ * before the fetch, because nothing downstream can recover it. `null` (no
+ * URL yet) and an unparsable string are "nothing to say", not unroutable.
  */
-export function isRoutableSpriteUrl(url: URL): boolean {
-  return url.hostname.split('.').every((label) => label.length >= 1 && label.length <= MAX_HOSTNAME_LABEL);
-}
-
-/** {@link isRoutableSpriteUrl} over the string the control plane hands back; `null`/unparsable ⇒ nothing to say (true). */
-export function isRoutableSpriteUrlString(url: string | null): boolean {
-  if (url === null) return true;
-  try {
-    return isRoutableSpriteUrl(new URL(url));
-  } catch {
-    return true;
+export function isRoutableSpriteUrl(url: URL | string | null): boolean {
+  let parsed: URL | null = null;
+  if (url instanceof URL) parsed = url;
+  else if (url !== null) {
+    try {
+      parsed = new URL(url);
+    } catch {
+      parsed = null;
+    }
   }
+  if (parsed === null) return true;
+  return parsed.hostname.split('.').every((label) => label.length >= 1 && label.length <= MAX_LABEL_LENGTH);
 }
 
 /**

--- a/packages/lib/src/services/sandbox/sandbox-client/__tests__/sprites.test.ts
+++ b/packages/lib/src/services/sandbox/sandbox-client/__tests__/sprites.test.ts
@@ -456,7 +456,7 @@ describe('sprite names fit the URL label', () => {
     const ok = { name: 'x', url: `https://${'a'.repeat(48)}-bskrl.sprites.app` };
     expect(checkSpriteUrlLabelFits(long)).toBe(false);
     expect(checkSpriteUrlLabelFits(ok)).toBe(true);
-    expect(checkSpriteUrlLabelFits({ name: 'x', url: null })).toBe(true);
+    expect(checkSpriteUrlLabelFits({ name: 'x' })).toBe(true);
     expect(checkSpriteUrlLabelFits({ name: 'x', url: 'not a url' })).toBe(true);
   });
 

--- a/packages/lib/src/services/sandbox/sandbox-client/__tests__/sprites.test.ts
+++ b/packages/lib/src/services/sandbox/sandbox-client/__tests__/sprites.test.ts
@@ -5,8 +5,9 @@ import {
   isSpriteGoneStatus,
   isSpriteNotFoundError,
   spriteNameFor,
-  legacySpriteNameFor,
   SPRITE_NAME_MAX,
+  LEGACY_SPRITE_NAME_MAX,
+  checkSpriteUrlLabelFits,
   classifyProvisionError,
   planProvisionFailure,
   readSessionInfoId,
@@ -413,10 +414,10 @@ describe('sprite names fit the URL label', () => {
     expect(SPRITE_NAME_MAX).toBe(48);
     expect(spriteNameFor(KEY)).toHaveLength(48);
     expect(spriteNameFor(KEY)).toBe(spriteNameFor(KEY));
-    expect(legacySpriteNameFor(KEY)).toHaveLength(63);
+    expect(spriteNameFor(KEY, LEGACY_SPRITE_NAME_MAX)).toHaveLength(63);
     // Room for a `-` plus an org suffix of up to 14 chars inside 63.
     expect(`${spriteNameFor(KEY)}-bskrl`.length).toBeLessThanOrEqual(63);
-    expect(`${legacySpriteNameFor(KEY)}-bskrl`.length).toBeGreaterThan(63);
+    expect(`${spriteNameFor(KEY, LEGACY_SPRITE_NAME_MAX)}-bskrl`.length).toBeGreaterThan(63);
   });
 
   function sdkWith(existing: string[]) {
@@ -437,9 +438,9 @@ describe('sprite names fit the URL label', () => {
   });
 
   it('resumes a sprite created under the LEGACY 63-char name — its disk and sessions, not a fresh VM — and creates nothing', async () => {
-    const { sdk, calls } = sdkWith([legacySpriteNameFor(KEY)]);
+    const { sdk, calls } = sdkWith([spriteNameFor(KEY, LEGACY_SPRITE_NAME_MAX)]);
     const handle = await createSpritesSandboxClient({ sdk }).getOrCreate({ name: KEY, options });
-    expect(handle.sandboxId).toBe(legacySpriteNameFor(KEY));
+    expect(handle.sandboxId).toBe(spriteNameFor(KEY, LEGACY_SPRITE_NAME_MAX));
     expect(calls.created).toEqual([]);
   });
 
@@ -448,6 +449,15 @@ describe('sprite names fit the URL label', () => {
     const handle = await createSpritesSandboxClient({ sdk }).getOrCreate({ name: KEY, options });
     expect(calls.created).toEqual([spriteNameFor(KEY)]);
     expect(handle.sandboxId).toBe('session-key'); // makeSdk's fake returns its fixed sprite on create
+  });
+
+  it('checks the URL the platform returns for a FRESH sprite: a label over 63 is reported (the reserve is too small), a fitting one is not', () => {
+    const long = { name: 'x', url: `https://${'a'.repeat(64)}.sprites.app` };
+    const ok = { name: 'x', url: `https://${'a'.repeat(48)}-bskrl.sprites.app` };
+    expect(checkSpriteUrlLabelFits(long)).toBe(false);
+    expect(checkSpriteUrlLabelFits(ok)).toBe(true);
+    expect(checkSpriteUrlLabelFits({ name: 'x', url: null })).toBe(true);
+    expect(checkSpriteUrlLabelFits({ name: 'x', url: 'not a url' })).toBe(true);
   });
 
   it('a non-not-found error from the legacy lookup surfaces instead of creating a duplicate', async () => {

--- a/packages/lib/src/services/sandbox/sandbox-client/__tests__/sprites.test.ts
+++ b/packages/lib/src/services/sandbox/sandbox-client/__tests__/sprites.test.ts
@@ -4,6 +4,9 @@ import {
   createSpritesSandboxClient,
   isSpriteGoneStatus,
   isSpriteNotFoundError,
+  spriteNameFor,
+  legacySpriteNameFor,
+  SPRITE_NAME_MAX,
   classifyProvisionError,
   planProvisionFailure,
   readSessionInfoId,
@@ -400,6 +403,61 @@ describe('spawnWithSelfHealingCwd (pure)', () => {
     should: 'keep it a positional arg (the arg-array no-injection invariant holds)',
     actual: spawnWithSelfHealingCwd({ command: 'bash', args: [], cwd: '/workspace; rm -rf /' })[1].slice(2),
     expected: ['sh', '/workspace; rm -rf /', 'bash'],
+  });
+});
+
+describe('sprite names fit the URL label', () => {
+  const KEY = `pgs-env-${'a'.repeat(64)}`; // a real key: 8-char prefix + 64 hex
+
+  it('cuts the key to SPRITE_NAME_MAX so `<name>-<org>.sprites.app` stays a legal DNS label; the legacy name is the old 63', () => {
+    expect(SPRITE_NAME_MAX).toBe(48);
+    expect(spriteNameFor(KEY)).toHaveLength(48);
+    expect(spriteNameFor(KEY)).toBe(spriteNameFor(KEY));
+    expect(legacySpriteNameFor(KEY)).toHaveLength(63);
+    // Room for a `-` plus an org suffix of up to 14 chars inside 63.
+    expect(`${spriteNameFor(KEY)}-bskrl`.length).toBeLessThanOrEqual(63);
+    expect(`${legacySpriteNameFor(KEY)}-bskrl`.length).toBeGreaterThan(63);
+  });
+
+  function sdkWith(existing: string[]) {
+    const { sdk, calls, sprite } = makeSdk({
+      getSprite: async (name) => {
+        if (!existing.includes(name)) throw Object.assign(new Error('sprite not found'), { status: 404 });
+        return { ...sprite, name };
+      },
+    });
+    return { sdk, calls };
+  }
+
+  it('resumes by the short name when it exists — no legacy lookup, no create', async () => {
+    const { sdk, calls } = sdkWith([spriteNameFor(KEY)]);
+    const handle = await createSpritesSandboxClient({ sdk }).getOrCreate({ name: KEY, options });
+    expect(handle.sandboxId).toBe(spriteNameFor(KEY));
+    expect(calls.created).toEqual([]);
+  });
+
+  it('resumes a sprite created under the LEGACY 63-char name — its disk and sessions, not a fresh VM — and creates nothing', async () => {
+    const { sdk, calls } = sdkWith([legacySpriteNameFor(KEY)]);
+    const handle = await createSpritesSandboxClient({ sdk }).getOrCreate({ name: KEY, options });
+    expect(handle.sandboxId).toBe(legacySpriteNameFor(KEY));
+    expect(calls.created).toEqual([]);
+  });
+
+  it('creates under the SHORT name when neither exists', async () => {
+    const { sdk, calls } = sdkWith([]);
+    const handle = await createSpritesSandboxClient({ sdk }).getOrCreate({ name: KEY, options });
+    expect(calls.created).toEqual([spriteNameFor(KEY)]);
+    expect(handle.sandboxId).toBe('session-key'); // makeSdk's fake returns its fixed sprite on create
+  });
+
+  it('a non-not-found error from the legacy lookup surfaces instead of creating a duplicate', async () => {
+    const { sdk } = makeSdk({
+      getSprite: async (name) => {
+        if (name === spriteNameFor(KEY)) throw Object.assign(new Error('sprite not found'), { status: 404 });
+        throw Object.assign(new Error('rate limited'), { status: 429 });
+      },
+    });
+    await expect(createSpritesSandboxClient({ sdk }).getOrCreate({ name: KEY, options })).rejects.toThrow();
   });
 });
 

--- a/packages/lib/src/services/sandbox/sandbox-client/sprites.ts
+++ b/packages/lib/src/services/sandbox/sandbox-client/sprites.ts
@@ -75,6 +75,7 @@ import type {
   WriteFileEntry,
 } from './types';
 import { SandboxProvisionError, type SandboxCreateOptions } from '../sandbox-options';
+import { loggers } from '../../../logging/logger-config';
 
 /** Thrown when a command exceeds the policy's per-run wall-clock cap. */
 export class SandboxCommandTimeoutError extends Error {
@@ -1204,6 +1205,32 @@ export function withKillSession<T extends { name: string; client: { baseURL: str
   });
 }
 
+/**
+ * The longest Sprite NAME that still yields a URL DNS can resolve.
+ *
+ * The API accepts names up to 63 chars (a DNS label), but the sprite's URL is
+ * `<name>-<org>.sprites.app` — the platform appends the org suffix to the
+ * SAME label and never checks the sum. Our keys are 72-char HMAC hex; sliced
+ * to 63 they produced 69-char labels (`pgs-env-…-bskrl`) that `dig` refuses
+ * outright ("label too long"), so no preview ever reached a sprite. 48 =
+ * 63 − 15: the observed org suffix is `-` + 5 chars, and 15 is headroom for
+ * a longer one, not a guess about its format. 48 chars is the 8-char prefix
+ * plus 40 hex — 160 bits of the digest, still collision-free for our keys.
+ */
+export const SPRITE_NAME_MAX = 48;
+/** The budget before {@link SPRITE_NAME_MAX} — kept ONLY to resume sprites created under it. */
+const LEGACY_SPRITE_NAME_MAX = 63;
+
+/** Pure: the Sprite name for a session/env key. Deterministic, so the same key always resumes the same sprite. */
+export function spriteNameFor(key: string): string {
+  return key.slice(0, SPRITE_NAME_MAX);
+}
+
+/** Pure: the name a sprite created before the 48-char budget was given — resumed by `getOrCreate`, never created. */
+export function legacySpriteNameFor(key: string): string {
+  return key.slice(0, LEGACY_SPRITE_NAME_MAX);
+}
+
 function wrap(sprite: SpriteInstanceLike, egressPolicyToken?: string): ExecutableSandbox {
   return {
     sandboxId: sprite.name,
@@ -1332,6 +1359,16 @@ function wrap(sprite: SpriteInstanceLike, egressPolicyToken?: string): Executabl
  * and fall back to a conservative message match; a KNOWN non-404 status is never
  * a cache miss.
  */
+/** `getSprite`, with a genuine not-found folded to `null`; every other error (auth, rate limit, outage) surfaces. */
+async function getSpriteIfExists(sdk: SpritesSdk, name: string): Promise<SpriteInstanceLike | null> {
+  try {
+    return await sdk.getSprite(name);
+  } catch (error) {
+    if (isSpriteNotFoundError(error)) return null;
+    throw error;
+  }
+}
+
 export function isSpriteNotFoundError(error: unknown): boolean {
   if (typeof error !== 'object' || error === null) return false;
   const e = error as {
@@ -1706,10 +1743,17 @@ export function createSpritesSandboxClient({
       // genuine not-found. Auth/rate-limit/outage errors from getSprite surface
       // rather than spawning a duplicate Sprite under a name that may still be live.
       //
-      // The Sprites API enforces a 63-char name limit (DNS label). Our session
-      // keys are 72-char HMAC hex strings; truncate to 63 before hitting the API.
-      // The full key stays as the DB session key — only the Sprites name is short.
-      const spriteName = name.slice(0, 63);
+      // Our session keys are 72-char HMAC hex strings; the Sprite NAME is the
+      // key cut to `SPRITE_NAME_MAX` so the sprite's URL stays a legal DNS
+      // label (see the constant). The full key stays as the DB session key.
+      //
+      // The name is not persisted anywhere — every attach re-derives it — so
+      // a sprite created under the old 63-char budget must still be found by
+      // THAT name, or every existing env and session would silently land on
+      // a fresh, empty VM. Hence the second lookup: short name, then legacy
+      // name, and only when neither exists a create — under the short name.
+      const spriteName = spriteNameFor(name);
+      const legacyName = legacySpriteNameFor(name);
       try {
         let sprite: SpriteInstanceLike;
         let fresh = false;
@@ -1717,10 +1761,19 @@ export function createSpritesSandboxClient({
           sprite = await sdk.getSprite(spriteName);
         } catch (error) {
           if (!isSpriteNotFoundError(error)) throw error;
-          // Caps (RAM / vCPUs / storage / region) come from the resolved policy and
-          // are set explicitly per Sprite rather than relying on the quota defaults.
-          sprite = await sdk.createSprite(spriteName, options.caps);
-          fresh = true;
+          const legacy = legacyName === spriteName ? null : await getSpriteIfExists(sdk, legacyName);
+          if (legacy !== null) {
+            // Resumed on a name whose URL cannot resolve: the sandbox works
+            // (shell, files, services) but cannot be previewed until it is
+            // recreated. Logged so the legacy population can be watched.
+            loggers.ai.info('sprite resumed by legacy name — its URL is not resolvable', { spriteName, legacyName });
+            sprite = legacy;
+          } else {
+            // Caps (RAM / vCPUs / storage / region) come from the resolved policy and
+            // are set explicitly per Sprite rather than relying on the quota defaults.
+            sprite = await sdk.createSprite(spriteName, options.caps);
+            fresh = true;
+          }
         }
         // Lock down egress only when THIS VM is not already proven to be running
         // THIS policy — see the file header and `../egress-lockdown.ts`. The proof
@@ -1749,7 +1802,8 @@ export function createSpritesSandboxClient({
             sleep,
           });
         }
-        // wrap sets sandboxId = sprite.name = spriteName (truncated). The token is
+        // wrap sets sandboxId = sprite.name (the short name, or the legacy one it
+        // resumed on — `get` reconnects by whichever was recorded). The token is
         // now CONFIRMED for this VM (freshly applied, or already proven) — the
         // caller records it, and it is what lets the next hand-back skip the push.
         return wrap(sprite, desiredToken);

--- a/packages/lib/src/services/sandbox/sandbox-client/sprites.ts
+++ b/packages/lib/src/services/sandbox/sandbox-client/sprites.ts
@@ -76,6 +76,7 @@ import type {
 } from './types';
 import { SandboxProvisionError, type SandboxCreateOptions } from '../sandbox-options';
 import { loggers } from '../../../logging/logger-config';
+import { MAX_LABEL_LENGTH } from '../../../validators/custom-domain';
 
 /** Thrown when a command exceeds the policy's per-run wall-clock cap. */
 export class SandboxCommandTimeoutError extends Error {
@@ -465,6 +466,8 @@ export function drainServiceLogStream(
 /** The Sprite instance subset the driver consumes. */
 export interface SpriteInstanceLike {
   readonly name: string;
+  /** The sprite's URL as the platform reports it (`<name>-<org>.sprites.app`); absent on a fake. */
+  readonly url?: string | null;
   /**
    * The platform's id for this Sprite INSTANCE, hydrated from the API response by
    * both `getSprite` and `createSprite` (the SDK `Object.assign`s the parsed body
@@ -1208,27 +1211,50 @@ export function withKillSession<T extends { name: string; client: { baseURL: str
 /**
  * The longest Sprite NAME that still yields a URL DNS can resolve.
  *
- * The API accepts names up to 63 chars (a DNS label), but the sprite's URL is
+ * The API accepts names up to a full DNS label (63), but the sprite's URL is
  * `<name>-<org>.sprites.app` — the platform appends the org suffix to the
  * SAME label and never checks the sum. Our keys are 72-char HMAC hex; sliced
  * to 63 they produced 69-char labels (`pgs-env-…-bskrl`) that `dig` refuses
- * outright ("label too long"), so no preview ever reached a sprite. 48 =
- * 63 − 15: the observed org suffix is `-` + 5 chars, and 15 is headroom for
- * a longer one, not a guess about its format. 48 chars is the 8-char prefix
- * plus 40 hex — 160 bits of the digest, still collision-free for our keys.
+ * outright ("label too long"), so no preview ever reached a sprite. 15 is
+ * reserved for `-<org>`: the observed suffix is `-` + 5 chars, and the rest
+ * is headroom for a longer one, not a guess about its format. 48 chars is
+ * the 8-char prefix plus 40 hex — 160 bits of the digest, still
+ * collision-free for our keys.
  */
-export const SPRITE_NAME_MAX = 48;
-/** The budget before {@link SPRITE_NAME_MAX} — kept ONLY to resume sprites created under it. */
-const LEGACY_SPRITE_NAME_MAX = 63;
+export const SPRITE_NAME_MAX = MAX_LABEL_LENGTH - 15;
+/** The budget before {@link SPRITE_NAME_MAX} — the API's own limit; kept ONLY to resume sprites created under it. */
+export const LEGACY_SPRITE_NAME_MAX = MAX_LABEL_LENGTH;
 
-/** Pure: the Sprite name for a session/env key. Deterministic, so the same key always resumes the same sprite. */
-export function spriteNameFor(key: string): string {
-  return key.slice(0, SPRITE_NAME_MAX);
+/**
+ * Pure: the Sprite name for a session/env key — deterministic, so the same
+ * key always resumes the same sprite. `max` is the legacy budget only where
+ * `getOrCreate` looks for a sprite created before the current one.
+ */
+export function spriteNameFor(key: string, max: number = SPRITE_NAME_MAX): string {
+  return key.slice(0, max);
 }
 
-/** Pure: the name a sprite created before the 48-char budget was given — resumed by `getOrCreate`, never created. */
-export function legacySpriteNameFor(key: string): string {
-  return key.slice(0, LEGACY_SPRITE_NAME_MAX);
+/** Legacy names already reported this process — one line per sprite, not per attach. */
+const legacyResumesLogged = new Set<string>();
+
+/**
+ * The budget above is an assumption about the org suffix; this is where it
+ * is CHECKED, on the one path that sees the platform's answer — the URL it
+ * hands back for a sprite just created. An overflow is logged as an error
+ * for the operator (raise the reserve), never thrown at the user: the
+ * sandbox itself works, and the proxy refuses its URL by name anyway.
+ */
+export function checkSpriteUrlLabelFits(sprite: Pick<SpriteInstanceLike, 'name' | 'url'>): boolean {
+  if (!sprite.url) return true;
+  let label: string;
+  try {
+    label = new URL(sprite.url).hostname.split('.')[0] ?? '';
+  } catch {
+    return true;
+  }
+  if (label.length <= MAX_LABEL_LENGTH) return true;
+  loggers.ai.error('sprite URL label exceeds a DNS label — SPRITE_NAME_MAX reserves too little for the org suffix', undefined, { spriteName: sprite.name, labelLength: label.length });
+  return false;
 }
 
 function wrap(sprite: SpriteInstanceLike, egressPolicyToken?: string): ExecutableSandbox {
@@ -1743,38 +1769,31 @@ export function createSpritesSandboxClient({
       // genuine not-found. Auth/rate-limit/outage errors from getSprite surface
       // rather than spawning a duplicate Sprite under a name that may still be live.
       //
-      // Our session keys are 72-char HMAC hex strings; the Sprite NAME is the
-      // key cut to `SPRITE_NAME_MAX` so the sprite's URL stays a legal DNS
-      // label (see the constant). The full key stays as the DB session key.
-      //
-      // The name is not persisted anywhere — every attach re-derives it — so
-      // a sprite created under the old 63-char budget must still be found by
-      // THAT name, or every existing env and session would silently land on
-      // a fresh, empty VM. Hence the second lookup: short name, then legacy
-      // name, and only when neither exists a create — under the short name.
+      // The Sprite NAME is the key cut to `SPRITE_NAME_MAX` (see the constant);
+      // the full key stays as the DB session key. The name is not persisted
+      // anywhere — every attach re-derives it — so a sprite created under the
+      // old, longer budget must still be found by THAT name, or every existing
+      // env and session would silently land on a fresh, empty VM. Hence two
+      // lookups, and a create only when neither exists — under the short name.
       const spriteName = spriteNameFor(name);
-      const legacyName = legacySpriteNameFor(name);
+      const legacyName = spriteNameFor(name, LEGACY_SPRITE_NAME_MAX);
       try {
-        let sprite: SpriteInstanceLike;
-        let fresh = false;
-        try {
-          sprite = await sdk.getSprite(spriteName);
-        } catch (error) {
-          if (!isSpriteNotFoundError(error)) throw error;
-          const legacy = legacyName === spriteName ? null : await getSpriteIfExists(sdk, legacyName);
-          if (legacy !== null) {
-            // Resumed on a name whose URL cannot resolve: the sandbox works
-            // (shell, files, services) but cannot be previewed until it is
-            // recreated. Logged so the legacy population can be watched.
-            loggers.ai.info('sprite resumed by legacy name — its URL is not resolvable', { spriteName, legacyName });
-            sprite = legacy;
-          } else {
-            // Caps (RAM / vCPUs / storage / region) come from the resolved policy and
-            // are set explicitly per Sprite rather than relying on the quota defaults.
-            sprite = await sdk.createSprite(spriteName, options.caps);
-            fresh = true;
-          }
+        const existing =
+          (await getSpriteIfExists(sdk, spriteName))
+          ?? (name.length > SPRITE_NAME_MAX ? await getSpriteIfExists(sdk, legacyName) : null);
+        if (existing !== null && existing.name === legacyName && legacyName !== spriteName && !legacyResumesLogged.has(legacyName)) {
+          // Resumed on a name whose URL cannot resolve: the sandbox works
+          // (shell, files, services) but cannot be previewed until it is
+          // recreated. Logged once per name per process, so the legacy
+          // population can be watched without a line per attach.
+          legacyResumesLogged.add(legacyName);
+          loggers.ai.info('sprite resumed by legacy name — its URL is not resolvable', { spriteName, legacyName });
         }
+        const fresh = existing === null;
+        // Caps (RAM / vCPUs / storage / region) come from the resolved policy and
+        // are set explicitly per Sprite rather than relying on the quota defaults.
+        const sprite: SpriteInstanceLike = existing ?? (await sdk.createSprite(spriteName, options.caps));
+        if (fresh) checkSpriteUrlLabelFits(sprite);
         // Lock down egress only when THIS VM is not already proven to be running
         // THIS policy — see the file header and `../egress-lockdown.ts`. The proof
         // is a token over (Sprite instance id, policy hash): a warm resume of the
@@ -1822,12 +1841,8 @@ export function createSpritesSandboxClient({
       // We do NOT reapply egress here: the policy persists across hibernation
       // (the platform's configure-once model), and a dropped first wake is
       // recovered by runCommand's cold-start retry.
-      try {
-        return wrap(await sdk.getSprite(sandboxId));
-      } catch (error) {
-        if (isSpriteNotFoundError(error)) return null;
-        throw error;
-      }
+      const sprite = await getSpriteIfExists(sdk, sandboxId);
+      return sprite === null ? null : wrap(sprite);
     },
 
     async stop({ sandboxId }) {

--- a/packages/lib/src/services/sandbox/sandbox-client/sprites.ts
+++ b/packages/lib/src/services/sandbox/sandbox-client/sprites.ts
@@ -1348,6 +1348,16 @@ function wrap(sprite: SpriteInstanceLike, egressPolicyToken?: string): Executabl
   };
 }
 
+/** `getSprite`, with a genuine not-found folded to `null`; every other error (auth, rate limit, outage) surfaces. */
+async function getSpriteIfExists(sdk: SpritesSdk, name: string): Promise<SpriteInstanceLike | null> {
+  try {
+    return await sdk.getSprite(name);
+  } catch (error) {
+    if (isSpriteNotFoundError(error)) return null;
+    throw error;
+  }
+}
+
 /**
  * Whether an error from `sdk.getSprite` means the named Sprite does not exist —
  * a cache miss that should create-fresh (`getOrCreate`) or reconnect-null
@@ -1359,16 +1369,6 @@ function wrap(sprite: SpriteInstanceLike, egressPolicyToken?: string): Executabl
  * and fall back to a conservative message match; a KNOWN non-404 status is never
  * a cache miss.
  */
-/** `getSprite`, with a genuine not-found folded to `null`; every other error (auth, rate limit, outage) surfaces. */
-async function getSpriteIfExists(sdk: SpritesSdk, name: string): Promise<SpriteInstanceLike | null> {
-  try {
-    return await sdk.getSprite(name);
-  } catch (error) {
-    if (isSpriteNotFoundError(error)) return null;
-    throw error;
-  }
-}
-
 export function isSpriteNotFoundError(error: unknown): boolean {
   if (typeof error !== 'object' || error === null) return false;
   const e = error as {

--- a/packages/lib/src/services/sandbox/sandbox-client/sprites.ts
+++ b/packages/lib/src/services/sandbox/sandbox-client/sprites.ts
@@ -466,8 +466,6 @@ export function drainServiceLogStream(
 /** The Sprite instance subset the driver consumes. */
 export interface SpriteInstanceLike {
   readonly name: string;
-  /** The sprite's URL as the platform reports it (`<name>-<org>.sprites.app`); absent on a fake. */
-  readonly url?: string | null;
   /**
    * The platform's id for this Sprite INSTANCE, hydrated from the API response by
    * both `getSprite` and `createSprite` (the SDK `Object.assign`s the parsed body

--- a/packages/lib/src/validators/custom-domain.ts
+++ b/packages/lib/src/validators/custom-domain.ts
@@ -7,8 +7,8 @@
  * and is a documented limitation for multi-segment TLDs like .co.uk.
  */
 
-/** Max length of a single DNS label (RFC 1035 §2.3.4). */
-const MAX_LABEL_LENGTH = 63;
+/** Max length of a single DNS label (RFC 1035 §2.3.4). Exported: the sprite-URL policy and the sprite name budget are sized from it. */
+export const MAX_LABEL_LENGTH = 63;
 
 /** Max total length of a fully-qualified domain name (RFC 1035 §3.1). */
 const MAX_HOSTNAME_LENGTH = 253;


### PR DESCRIPTION
## What you saw

`dev-preview.access … outcome:"upstream-error" reason:"fetch failed" status:502` on every open, with the relay up and Next serving inside the sandbox.

## Root cause (read from the sandbox and from DNS)

A sprite's URL is `https://<name>-<org>.sprites.app`. The Sprites API accepts names up to 63 chars, but the URL puts the name **and** the org suffix in one DNS label — RFC 1035 caps a label at 63 — and the platform never checks the sum. Our HMAC-derived names (`pgs-env-<64 hex>`) cut to 63 produced 69-char labels:

```
$ dig pgs-env-10226de…e30e3e-bskrl.sprites.app
dig: '…' is not a legal name (label too long)
```

So **no `pgs-*` sprite URL has ever resolved**. Every preview on every env and session was doomed before its first request; the short-named scratch sprite used for yesterday's token canary is why that passed.

## Fix

- `SPRITE_NAME_MAX = MAX_LABEL_LENGTH − 15` (= 48: 8-char prefix + 40 hex, 15 reserved for `-<org>`), sized from the one exported RFC label cap in `validators/custom-domain.ts`; `spriteNameFor(key, max?)` is the single spelling.
- **The reserve is checked, not assumed:** on the create path the URL the platform returns is inspected (`checkSpriteUrlLabelFits`) and an overflow is logged as an operator error — the failure lands on whoever can raise the reserve, not on a user with a dead preview.
- The name is **not persisted** — every attach re-derives it and calls `getSprite(name)` ("same name, same filesystem"). So `getOrCreate` looks up the short name, then the **legacy** 63-char name (`getSpriteIfExists`, now also used by `get`), and creates (short) only when neither exists. Existing sandboxes keep their disk, services and sessions; a legacy resume is logged once per name per process.
- **Unroutable is a state, not a special case:** `describeServiceState` takes `urlRoutable` and answers `down` / `error: 'sprite-url-unresolvable'` / not repairable with one sentence. The access gather feeds it from the real URL (`isRoutableSpriteUrl`, one predicate over `URL | string | null`), so the gate refuses **before the wake gate** — a paused legacy sprite is never woken for a preview that cannot be reached; the status gather feeds it from the sprite's *name* (no control-plane read per poll), so the pane says it before the frame is opened. `assertTrustedPreviewUpstream` carries the same check as a backstop.
- Runbook §9. Also records a verified non-issue from the same sweep: Next 16's dev server 403s any request carrying `Origin`; the forwarder never sends `Origin`/`Referer` and the WS tunnel forwards only `sec-websocket-*`, so chunks, RSC and HMR reach Next without one.

## What this means for existing sandboxes

They cannot be previewed — no rename exists and their URL is structurally unresolvable. **Create a new env or session** to preview; the old one keeps working for everything else. (Decision taken with Jono: keep them rather than re-home onto empty sprites.)

## Tests

Name budget and legacy budget; resume by short name / by legacy name without creating / create short when neither exists; a non-not-found error on the legacy lookup surfaces instead of creating a duplicate; the create-path URL check; the 69-char label refused in the policy (URL and string forms), by the access decision (running **and** paused — no wake gate consulted), by the state, and by the status gather from the name (a 48-char name stays live). Mutation-checked: removing the legacy lookup, the unroutable answer, and the gate's reason mapping each fail exactly their tests. Simplify pass (reuse/simplification/efficiency/altitude) applied.

## Verify after deploy

1. Create a **new** env, start a dev server, split → Ports → pick: `dig +short <new-sprite>-bskrl.sprites.app` resolves and the frame renders.
2. Open the **old** env's preview: the pane says "created with a name too long for a preview URL", the web log shows `sprite-url-unresolvable`, no `fetch failed`.
3. Logs show `sprite resumed by legacy name` for old holders and no `createSprite` for a name that already existed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01P8A8KLYCoViP7ouH5QzbnB


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Sprite names now use a shorter limit to keep preview URLs routable.
  - Existing sprites with legacy names can still be resumed when supported.
  - Preview URLs that cannot resolve are detected before forwarding or waking a preview.

- **Bug Fixes**
  - Unresolvable preview URLs now show clear error messaging and return a 502 response instead of failing ambiguously.
  - Preview forwarding validates DNS label limits and applies appropriate WebSocket and request-header handling.

- **Documentation**
  - Added guidance on sprite naming limits, legacy previews, URL errors, and forwarded request headers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->