### PR TITLE
fix(desktop): judge will-redirect for the main frame only — the preview frame's redirect opened a browser tab

### DIFF
--- a/apps/desktop/src/main/window.ts
+++ b/apps/desktop/src/main/window.ts
@@ -5,7 +5,7 @@ import { getAppOrigin, getStartUrl } from './app-url';
 import { mainWindow, setMainWindow, isQuitting } from './state';
 import { injectDesktopStyles, injectDoubleClickHandler } from './window-injections';
 import { setupAutoUpdater } from './updater';
-import { classifyNavigation } from '../shared/navigation-guard';
+import { classifyNavigation, guardsRedirect } from '../shared/navigation-guard';
 import { APP_IDENTITY } from '../shared/current-app-identity';
 
 const storeAny = store as any;
@@ -127,7 +127,14 @@ export function createWindow(): void {
   };
 
   window.webContents.on('will-navigate', guardNavigation);
-  window.webContents.on('will-redirect', guardNavigation);
+  // `will-redirect` fires for subframes too (unlike `will-navigate`), and a
+  // subframe holds no preload bridge — see `guardsRedirect`. Without this the
+  // preview iframe's own redirect to its preview host was cancelled and
+  // opened as a system-browser tab on every Refresh.
+  window.webContents.on('will-redirect', (event, url, _isInPlace, isMainFrame) => {
+    if (!guardsRedirect(isMainFrame)) return;
+    guardNavigation(event, url);
+  });
 
   window.webContents.setWindowOpenHandler(({ url }) => {
     if (url.startsWith('http://') || url.startsWith('https://')) {

--- a/apps/desktop/src/shared/__tests__/navigation-guard.test.ts
+++ b/apps/desktop/src/shared/__tests__/navigation-guard.test.ts
@@ -5,6 +5,7 @@ import {
   isAllowedAppUrl,
   isTrustedSenderUrl,
   classifyNavigation,
+  guardsRedirect,
 } from '../navigation-guard';
 
 describe('isAllowedNavigation', () => {
@@ -160,5 +161,16 @@ describe('isTrustedSenderUrl', () => {
     expect(isTrustedSenderUrl('https://evil.com', appOrigin)).toBe(false);
     expect(isTrustedSenderUrl('http://pagespace.ai', appOrigin)).toBe(false);
     expect(isTrustedSenderUrl('file:///offline.html', appOrigin)).toBe(false);
+  });
+});
+
+describe('guardsRedirect', () => {
+  it('judges the main frame, and an event that does not say (fail closed)', () => {
+    expect(guardsRedirect(true)).toBe(true);
+    expect(guardsRedirect(undefined)).toBe(true);
+  });
+
+  it('exempts a subframe — it holds no preload bridge, and the preview frame must follow its own redirect', () => {
+    expect(guardsRedirect(false)).toBe(false);
   });
 });

--- a/apps/desktop/src/shared/navigation-guard.ts
+++ b/apps/desktop/src/shared/navigation-guard.ts
@@ -117,3 +117,21 @@ export function classifyNavigation(
   if (protocol === 'http:' || protocol === 'https:') return 'open-external';
   return 'block';
 }
+
+/**
+ * PURE. Whether a `will-redirect` event is one the H5 guard should judge.
+ *
+ * `will-navigate` is main-frame only by Electron's definition, but
+ * `will-redirect` fires for EVERY frame and carries `isMainFrame`. The guard
+ * exists for the privileged main frame — the one holding the preload bridge
+ * (session token, MCP exec). Subframes never receive that bridge (no
+ * `nodeIntegrationInSubFrames`), and the one subframe this app renders — the
+ * dev-server preview — is sandboxed by the web app and MUST follow its own
+ * redirect: `/preview/open` on the app origin 302s to the preview host, and
+ * judging that as an off-origin navigation cancelled the frame and threw the
+ * URL into the system browser on every Refresh. An absent value is judged
+ * (fail closed): only an explicit `false` exempts.
+ */
+export function guardsRedirect(isMainFrame: boolean | undefined): boolean {
+  return isMainFrame !== false;
+}


### PR DESCRIPTION
## What you saw

In the desktop app, **Refresh** on the preview pane and the sidebar's **Preview** opened a browser tab on `https://env-<id>.preview.pagespace.io/` while the pane stayed blank.

## Cause — `apps/desktop/src/main/window.ts`

```ts
window.webContents.on('will-navigate', guardNavigation);
window.webContents.on('will-redirect', guardNavigation);   // fires for subframes too
```

`will-navigate` is main-frame only; `will-redirect` fires for **every frame** and carries `isMainFrame`, which `guardNavigation(event, url)` never read. The preview iframe loads `/preview/open` (app origin) → 302 to the preview host → the guard classified that as `open-external`, `preventDefault()`ed the frame's navigation and `shell.openExternal`ed the URL. Refresh re-navigates the frame (fires again); Preview opens the pane whose frame then navigates (fires again).

## Why exempting subframes keeps H5 intact

The guard exists so an XSS can't point the **privileged main frame** — the one with the preload bridge (session token, MCP exec) — at an attacker origin. Subframes never receive the preload (`webPreferences` has no `nodeIntegrationInSubFrames`), and the preview frame is additionally sandboxed by the web app. Nothing H5 guards changes.

## Fix

- `guardsRedirect(isMainFrame)` in `navigation-guard.ts`: exempts an explicit `false`, judges `true` and `undefined` (fail closed).
- `will-redirect` gets its own listener that consults it before delegating to `guardNavigation`. `will-navigate` and `setWindowOpenHandler` are unchanged — a subframe's `window.open`/`target=_blank` still goes to the system browser, which is what the ⧉ link and a dev app's own links should do.

## Tests

`navigation-guard.test.ts`: `true`/`undefined` judged, `false` exempt (30/30 desktop tests green; lint clean). No harness exists for `webContents.on`, so the listener wiring is verified manually: desktop → open a session with a running preview → Refresh reloads in place, no external tab; sidebar Preview opens the pane, no tab; Help → pagespace.ai (top-level off-origin) still opens externally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01P8A8KLYCoViP7ouH5QzbnB
