### PR TITLE
fix(tags): repair stale anchors instead of abandoning them forever

### DIFF
--- a/apps/web/src/services/api/__tests__/page-mutation-reanchor.test.ts
+++ b/apps/web/src/services/api/__tests__/page-mutation-reanchor.test.ts
@@ -21,9 +21,10 @@
  */
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 
-const mockReanchor = vi.fn(async () => ({ ok: true as const, data: { considered: 0, updated: 0, orphaned: 0, skippedStaleHash: 0, skippedFormatFlip: 0 } }));
+const mockReanchor = vi.fn(async () => ({ ok: true as const, data: { considered: 0, updated: 0, orphaned: 0, repairedStaleHash: 0, repairedFormatFlip: 0 } }));
 const mockSyncMentions = vi.fn(async () => undefined);
 const mockLogError = vi.fn();
+const mockLogWarn = vi.fn();
 
 /**
  * The row `applyPageMutation` reads before it writes.
@@ -90,7 +91,7 @@ vi.mock('@pagespace/db/operators', () => ({ eq: vi.fn(), and: vi.fn() }));
 vi.mock('@pagespace/db/schema/core', () => ({ pages: { id: 'id', revision: 'revision' } }));
 vi.mock('@pagespace/lib/tags/tag-service', () => ({ reanchorPageTags: (...a: unknown[]) => mockReanchor(...(a as [])) }));
 vi.mock('@/services/api/page-mention-service', () => ({ syncMentions: (...a: unknown[]) => mockSyncMentions(...(a as [])) }));
-vi.mock('@pagespace/lib/logging/logger-config', () => ({ loggers: { api: { error: (...a: unknown[]) => mockLogError(...(a as [])), warn: vi.fn(), info: vi.fn() } } }));
+vi.mock('@pagespace/lib/logging/logger-config', () => ({ loggers: { api: { error: (...a: unknown[]) => mockLogError(...(a as [])), warn: (...a: unknown[]) => mockLogWarn(...(a as [])), info: vi.fn() } } }));
 vi.mock('@pagespace/lib/monitoring/activity-logger', () => ({ logActivityWithTx: vi.fn(async () => undefined) }));
 vi.mock('@pagespace/lib/monitoring/change-group', () => ({ inferChangeGroupType: vi.fn(() => 'edit'), createChangeGroupId: vi.fn(() => 'cg-1') }));
 vi.mock('@pagespace/lib/services/page-version-service', () => ({ computePageStateHash: vi.fn(() => 'hash'), createPageVersion: vi.fn(async () => undefined) }));
@@ -117,6 +118,7 @@ describe('applyPageMutation re-anchors content tags', () => {
   beforeEach(() => {
     mockReanchor.mockClear();
     mockLogError.mockClear();
+    mockLogWarn.mockClear();
     // `transaction.transaction` is a module-level spy, so its call count
     // ACCUMULATES across cases. Without this clear, the savepoint assertion
     // below ("called exactly once") holds only while its test happens to run
@@ -175,5 +177,26 @@ describe('applyPageMutation re-anchors content tags', () => {
 
     expect(savepointRolledBack.value, 'the savepoint must unwind so the outer tx survives').toBe(true);
     expect(mockLogError).toHaveBeenCalled();
+  });
+
+  it('warns when anchors degraded, and stays silent when they did not', async () => {
+    // A sweep can SUCCEED while still failing to forward-port: a stale hash or
+    // a changed projection format both fall back to quote repair, which is a
+    // real result but a weaker one. That outcome used to be computed and then
+    // discarded here, so nothing could tell a degraded page from a healthy one.
+    mockReanchor.mockResolvedValueOnce({
+      ok: true as const,
+      data: { considered: 3, updated: 3, orphaned: 1, repairedStaleHash: 2, repairedFormatFlip: 0 },
+    } as never);
+
+    await applyPageMutation({ ...baseInput, updates: { content: 'degraded edit' } } as never);
+    expect(mockLogWarn).toHaveBeenCalledTimes(1);
+    const [, meta] = mockLogWarn.mock.calls[0] as unknown as [string, Record<string, unknown>];
+    expect(meta.repairedStaleHash).toBe(2);
+    expect(meta.orphaned).toBe(1);
+
+    mockLogWarn.mockClear();
+    await applyPageMutation({ ...baseInput, updates: { content: 'clean edit' } } as never);
+    expect(mockLogWarn, 'an ordinary save must not log').not.toHaveBeenCalled();
   });
 });

--- a/apps/web/src/services/api/__tests__/page-mutation-reanchor.test.ts
+++ b/apps/web/src/services/api/__tests__/page-mutation-reanchor.test.ts
@@ -21,7 +21,7 @@
  */
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 
-const mockReanchor = vi.fn(async () => ({ ok: true as const, data: { considered: 0, updated: 0, orphaned: 0, repairedStaleHash: 0, repairedFormatFlip: 0 } }));
+const mockReanchor = vi.fn(async () => ({ ok: true as const, data: { considered: 0, updated: 0, orphaned: 0, newlyOrphaned: 0, repairedStaleHash: 0, repairedFormatFlip: 0 } }));
 const mockSyncMentions = vi.fn(async () => undefined);
 const mockLogError = vi.fn();
 const mockLogWarn = vi.fn();
@@ -186,7 +186,7 @@ describe('applyPageMutation re-anchors content tags', () => {
     // discarded here, so nothing could tell a degraded page from a healthy one.
     mockReanchor.mockResolvedValueOnce({
       ok: true as const,
-      data: { considered: 3, updated: 3, orphaned: 1, repairedStaleHash: 2, repairedFormatFlip: 0 },
+      data: { considered: 3, updated: 3, orphaned: 1, newlyOrphaned: 1, repairedStaleHash: 2, repairedFormatFlip: 0 },
     } as never);
 
     await applyPageMutation({ ...baseInput, updates: { content: 'degraded edit' } } as never);
@@ -198,5 +198,17 @@ describe('applyPageMutation re-anchors content tags', () => {
     mockLogWarn.mockClear();
     await applyPageMutation({ ...baseInput, updates: { content: 'clean edit' } } as never);
     expect(mockLogWarn, 'an ordinary save must not log').not.toHaveBeenCalled();
+  });
+
+  it('does NOT warn for an anchor that was already orphaned', async () => {
+    // The state repeats on every edit; only the transition is new damage.
+    // Warning on the total would fire on every autosave, forever.
+    mockReanchor.mockResolvedValueOnce({
+      ok: true as const,
+      data: { considered: 1, updated: 0, orphaned: 1, newlyOrphaned: 0, repairedStaleHash: 0, repairedFormatFlip: 0 },
+    } as never);
+
+    await applyPageMutation({ ...baseInput, updates: { content: 'another edit' } } as never);
+    expect(mockLogWarn).not.toHaveBeenCalled();
   });
 });

--- a/apps/web/src/services/api/page-mutation-service.ts
+++ b/apps/web/src/services/api/page-mutation-service.ts
@@ -354,6 +354,24 @@ export async function applyPageMutation({
           if (!reanchored.ok) {
             throw new Error(`reanchorPageTags returned ${reanchored.error}`);
           }
+
+          // SURFACE THE DEGRADED OUTCOMES. The sweep can succeed while still
+          // failing to forward-port: an anchor whose hash did not describe the
+          // predecessor, or a page whose projection format changed underneath
+          // us, both fall back to quote repair — a real result, but a weaker
+          // one than an exact port, and previously invisible. The summary was
+          // computed and then discarded here, so nothing anywhere could tell a
+          // degraded page from a healthy one.
+          //
+          // Logged only when something actually degraded, so an ordinary save
+          // stays silent.
+          const { repairedStaleHash, repairedFormatFlip, orphaned } = reanchored.data;
+          if (repairedStaleHash > 0 || repairedFormatFlip > 0 || orphaned > 0) {
+            loggers.api.warn('Content tag anchors degraded during a page mutation', {
+              pageId,
+              ...reanchored.data,
+            });
+          }
         });
       } catch (error) {
         loggers.api.error(

--- a/apps/web/src/services/api/page-mutation-service.ts
+++ b/apps/web/src/services/api/page-mutation-service.ts
@@ -365,8 +365,12 @@ export async function applyPageMutation({
           //
           // Logged only when something actually degraded, so an ordinary save
           // stays silent.
-          const { repairedStaleHash, repairedFormatFlip, orphaned } = reanchored.data;
-          if (repairedStaleHash > 0 || repairedFormatFlip > 0 || orphaned > 0) {
+          const { repairedStaleHash, repairedFormatFlip, newlyOrphaned } = reanchored.data;
+          // `newlyOrphaned`, NOT `orphaned`. An anchor that is already orphaned
+          // and whose quote is still gone resolves as orphaned again on every
+          // edit, so alerting on the total would warn on every save — every
+          // autosave keystroke — for a page that did not degrade at all.
+          if (repairedStaleHash > 0 || repairedFormatFlip > 0 || newlyOrphaned > 0) {
             loggers.api.warn('Content tag anchors degraded during a page mutation', {
               pageId,
               ...reanchored.data,

--- a/packages/lib/src/content/anchoring/resolve.ts
+++ b/packages/lib/src/content/anchoring/resolve.ts
@@ -216,12 +216,40 @@ export function positionHolds(text: string, anchor: TextAnchor): boolean {
  * Use this only when the predecessor content is unavailable; when both sides of
  * a change are in hand, `portAnchor` is exact and this is not.
  */
-export function resolveAnchor(text: string, anchor: TextAnchor): AnchorResolution {
+export type ResolveAnchorOptions = {
+  /**
+   * Whether the anchor's recorded offsets may be believed.
+   *
+   * Default `true`, which is right for the ordinary case: the offsets came from
+   * a revision of THIS text, so a slice that still matches is strong evidence.
+   *
+   * Pass `false` when the offsets are known to describe a DIFFERENT revision —
+   * a stale `textHash`, or a projection format that changed underneath the
+   * anchor. `positionHolds` accepts a matching slice without consulting prefix
+   * or suffix at all, so with duplicated quote text it will happily accept a
+   * different occurrence that merely happens to sit at the recorded span, and
+   * report it as `exact`. Duplicated text is precisely the case the epic says
+   * search cannot disambiguate, so the one path that KNOWS its offsets are
+   * untrustworthy must not take that shortcut.
+   *
+   * `hint` still uses `anchor.start`, and deliberately: a hint only biases
+   * which of several equally-good context matches is nearest, and never
+   * promotes a match on its own.
+   */
+  trustRecordedOffsets?: boolean;
+};
+
+export function resolveAnchor(
+  text: string,
+  anchor: TextAnchor,
+  options: ResolveAnchorOptions = {}
+): AnchorResolution {
   const { exact, prefix, suffix } = anchor;
   const hint = clamp(anchor.start, 0, text.length);
+  const trustRecordedOffsets = options.trustRecordedOffsets ?? true;
 
   // 1. Position — the recorded offsets still hold.
-  if (positionHolds(text, anchor)) {
+  if (trustRecordedOffsets && positionHolds(text, anchor)) {
     return {
       status: 'exact',
       start: anchor.start,

--- a/packages/lib/src/tags/__tests__/tag-service.integration.test.ts
+++ b/packages/lib/src/tags/__tests__/tag-service.integration.test.ts
@@ -745,4 +745,93 @@ describe('tag-service (integration)', () => {
       expect(row.anchorStatus).toBe('orphaned');
     });
   });
+
+  describe('a stale repair must not trust the offsets it knows are wrong', () => {
+    // DUPLICATED QUOTE TEXT is the case the epic says search cannot
+    // disambiguate and forward-porting can. A stale anchor cannot forward-port
+    // by definition, so the repair path has to lean on prefix/suffix — and
+    // `positionHolds` would skip that entirely, accepting whatever sits at the
+    // recorded span and calling it 'exact'.
+    const DUP_FIRST = 'Intro alpha. REPEATED PHRASE HERE. middle filler words. REPEATED PHRASE HERE. tail.';
+    const QUOTE = 'REPEATED PHRASE HERE.';
+
+    it('reattaches by CONTEXT, not by the stale recorded span', async () => {
+      const owner = await factories.createUser();
+      const drive = await factories.createDrive(owner.id);
+      await factories.createDriveMember(drive.id, owner.id, { role: 'OWNER' });
+      const page = await factories.createPage(drive.id, {
+        type: 'DOCUMENT', title: 'Doc', position: 0, content: DUP_FIRST, contentMode: 'markdown',
+      });
+      const tag = expectOk(await upsertTag(drive.id, owner.id, { name: 'dup' }));
+
+      const projected = projectContent(DUP_FIRST, 'markdown');
+      const secondStart = projected.lastIndexOf(QUOTE);
+      const firstStart = projected.indexOf(QUOTE);
+      expect(secondStart).toBeGreaterThan(firstStart);
+
+      // The anchor belongs to the SECOND occurrence — its context says so — but
+      // its recorded offsets point at the FIRST, and its hash is stale. If the
+      // repair trusts the offsets it will silently claim the wrong occurrence.
+      await db.insert(contentTags).values({
+        tagId: tag.id,
+        pageId: page.id,
+        targetKind: 'text',
+        anchor: {
+          v: 1,
+          exact: QUOTE,
+          prefix: projected.slice(Math.max(0, secondStart - 32), secondStart),
+          suffix: projected.slice(secondStart + QUOTE.length, secondStart + QUOTE.length + 32),
+          start: firstStart,
+          end: firstStart + QUOTE.length,
+          revision: 1,
+          textHash: 'a-hash-from-a-revision-this-page-never-had',
+        },
+        anchorStatus: 'exact',
+        source: 'user',
+        createdBy: owner.id,
+      });
+
+      expectOk(await reanchorPageTags(page.id, DUP_FIRST, DUP_FIRST));
+
+      const [row] = await db.select().from(contentTags).where(eq(contentTags.pageId, page.id));
+      const stored = row.anchor as { start: number; end: number };
+      expect(stored.start, 'context must win over the stale offsets').toBe(secondStart);
+    });
+  });
+
+  describe('orphan reporting counts transitions, not states', () => {
+    const DOC2 = 'Alpha beta gamma. The anchored quote sits here. Delta.';
+    const QUOTE2 = 'The anchored quote sits here.';
+
+    it('reports newlyOrphaned once, then zero on later edits', async () => {
+      // An already-orphaned anchor resolves as orphaned again on EVERY edit. A
+      // caller alerting on the total would warn on every save forever for a
+      // page that did not degrade at all.
+      const owner = await factories.createUser();
+      const drive = await factories.createDrive(owner.id);
+      await factories.createDriveMember(drive.id, owner.id, { role: 'OWNER' });
+      const page = await factories.createPage(drive.id, {
+        type: 'DOCUMENT', title: 'Doc', position: 0, content: DOC2, contentMode: 'markdown',
+      });
+      const tag = expectOk(await upsertTag(drive.id, owner.id, { name: 'orph' }));
+      const projected = projectContent(DOC2, 'markdown');
+      const start = projected.indexOf(QUOTE2);
+      expectOk(await applyTag(owner.id, {
+        pageId: page.id, tagId: tag.id, source: 'user',
+        target: { kind: 'text', anchor: {
+          v: 1, exact: QUOTE2, prefix: '', suffix: '',
+          start, end: start + QUOTE2.length, revision: 1, textHash: hashText(projected),
+        } },
+      }));
+
+      const gone = 'Entirely different prose about shipping containers.';
+      const first = expectOk(await reanchorPageTags(page.id, DOC2, gone));
+      expect(first.newlyOrphaned, 'the anchor degrades on this edit').toBe(1);
+
+      const stillGone = `${gone} And more.`;
+      const second = expectOk(await reanchorPageTags(page.id, gone, stillGone));
+      expect(second.orphaned, 'it is still orphaned').toBe(1);
+      expect(second.newlyOrphaned, 'but it did not degrade AGAIN').toBe(0);
+    });
+  });
 });

--- a/packages/lib/src/tags/__tests__/tag-service.integration.test.ts
+++ b/packages/lib/src/tags/__tests__/tag-service.integration.test.ts
@@ -442,13 +442,13 @@ describe('tag-service (integration)', () => {
       const afterFirst = `${BODY} Appended sentence one.`;
       const first = expectOk(await reanchorPageTags(page.id, BODY, afterFirst));
       expect(first.considered).toBe(1);
-      expect(first.skippedStaleHash).toBe(0);
+      expect(first.repairedStaleHash).toBe(0);
 
       const afterSecond = `${afterFirst} Appended sentence two.`;
       const second = expectOk(await reanchorPageTags(page.id, afterFirst, afterSecond));
 
       expect(second.considered).toBe(1);
-      expect(second.skippedStaleHash, 'the anchor must still be portable after the first edit').toBe(0);
+      expect(second.repairedStaleHash, 'the anchor must still be portable after the first edit').toBe(0);
     });
 
     it('stores the hash of the projection the anchor now describes', async () => {
@@ -570,8 +570,8 @@ describe('tag-service (integration)', () => {
       }));
 
       expect(swept.considered).toBe(1);
-      expect(swept.skippedFormatFlip, 'a declared conversion is not an accidental flip').toBe(0);
-      expect(swept.skippedStaleHash, 'the old mode must project the old content correctly').toBe(0);
+      expect(swept.repairedFormatFlip, 'a declared conversion is not an accidental flip').toBe(0);
+      expect(swept.repairedStaleHash, 'the old mode must project the old content correctly').toBe(0);
 
       const [row] = await db.select().from(contentTags).where(eq(contentTags.pageId, page.id));
       expect(row.anchorStatus).not.toBe('orphaned');
@@ -648,6 +648,101 @@ describe('tag-service (integration)', () => {
 
       expect(result.ok).toBe(false);
       if (!result.ok) expect(result.error).toBe('invalid_target');
+    });
+  });
+
+  describe('a stale anchor is repaired, not abandoned', () => {
+    const DOC = 'Alpha beta gamma. The anchored quote sits here. Delta epsilon.';
+    const QUOTE = 'The anchored quote sits here.';
+
+    async function pageWithStaleAnchor() {
+      const owner = await factories.createUser();
+      const drive = await factories.createDrive(owner.id);
+      await factories.createDriveMember(drive.id, owner.id, { role: 'OWNER' });
+      const page = await factories.createPage(drive.id, {
+        type: 'DOCUMENT', title: 'Doc', position: 0, content: DOC, contentMode: 'markdown',
+      });
+      const tag = expectOk(await upsertTag(drive.id, owner.id, { name: 'stale' }));
+      const projected = projectContent(DOC, 'markdown');
+      const start = projected.indexOf(QUOTE);
+
+      // Inserted directly with a hash from SOME OTHER revision — the shape a
+      // content write that bypassed the hook leaves behind.
+      await db.insert(contentTags).values({
+        tagId: tag.id,
+        pageId: page.id,
+        targetKind: 'text',
+        anchor: {
+          v: 1, exact: QUOTE, prefix: '', suffix: '',
+          start, end: start + QUOTE.length, revision: 1,
+          textHash: 'a-hash-from-a-revision-this-page-never-had',
+        },
+        anchorStatus: 'exact',
+        source: 'user',
+        createdBy: owner.id,
+      });
+      return { page, projected };
+    }
+
+    it('REPAIRS a stale anchor instead of passing over it forever', async () => {
+      // THE PERMANENT-DEATH BUG. Skipping was not a deferral: a hash that does
+      // not describe `oldContent` will not describe any FUTURE oldContent
+      // either, so the anchor was passed over on every later sweep for the rest
+      // of its life — while the row still read anchorStatus 'exact', so nothing
+      // could tell it apart from a healthy one.
+      const { page } = await pageWithStaleAnchor();
+      const edited = `${DOC} Appended.`;
+
+      const swept = expectOk(await reanchorPageTags(page.id, DOC, edited));
+
+      expect(swept.considered).toBe(1);
+      expect(swept.repairedStaleHash, 'the anchor must be repaired, not passed over').toBe(1);
+      expect(swept.updated, 'a repaired anchor must be WRITTEN so it stops being stale').toBe(1);
+
+      const [row] = await db.select().from(contentTags).where(eq(contentTags.pageId, page.id));
+      const stored = row.anchor as { start: number; end: number; textHash: string };
+      // Re-pinned to the revision it now describes — this is what breaks the
+      // permanence: the NEXT sweep finds a hash it can trust.
+      expect(stored.textHash).toBe(hashText(projectContent(edited, 'markdown')));
+      expect(projectContent(edited, 'markdown').slice(stored.start, stored.end)).toBe(QUOTE);
+    });
+
+    it('leaves the anchor portable on the NEXT sweep, which is the whole point', async () => {
+      const { page } = await pageWithStaleAnchor();
+      const first = `${DOC} One.`;
+      expectOk(await reanchorPageTags(page.id, DOC, first));
+
+      const second = `${first} Two.`;
+      const swept = expectOk(await reanchorPageTags(page.id, first, second));
+
+      expect(swept.repairedStaleHash, 'repair must have healed it, so no repair is needed now').toBe(0);
+      expect(swept.considered).toBe(1);
+    });
+
+    it('records an honest status rather than keeping the inherited exact', async () => {
+      // The row said 'exact' while being unusable. After repair the status has
+      // to describe what the repair actually achieved.
+      const { page } = await pageWithStaleAnchor();
+      const moved = `Newly inserted opening sentence. ${DOC}`;
+
+      expectOk(await reanchorPageTags(page.id, DOC, moved));
+
+      const [row] = await db.select().from(contentTags).where(eq(contentTags.pageId, page.id));
+      expect(row.anchorStatus).not.toBe('exact');
+      const stored = row.anchor as { start: number; end: number };
+      expect(projectContent(moved, 'markdown').slice(stored.start, stored.end)).toBe(QUOTE);
+    });
+
+    it('reports an orphan honestly when the quote is genuinely gone', async () => {
+      const { page } = await pageWithStaleAnchor();
+      const rewritten = 'Entirely different prose about shipping containers.';
+
+      const swept = expectOk(await reanchorPageTags(page.id, DOC, rewritten));
+
+      expect(swept.repairedStaleHash).toBe(1);
+      expect(swept.orphaned).toBe(1);
+      const [row] = await db.select().from(contentTags).where(eq(contentTags.pageId, page.id));
+      expect(row.anchorStatus).toBe('orphaned');
     });
   });
 });

--- a/packages/lib/src/tags/tag-service.ts
+++ b/packages/lib/src/tags/tag-service.ts
@@ -521,8 +521,18 @@ export type ReanchorSummary = {
   considered: number;
   /** Anchors whose status or offsets changed and were written back. */
   updated: number;
-  /** Anchors that became 'orphaned' in this sweep. Included in `updated`. */
+  /** Anchors whose status is 'orphaned' after this sweep. */
   orphaned: number;
+  /**
+   * Anchors that became orphaned IN THIS SWEEP — a non-orphaned status going to
+   * 'orphaned'.
+   *
+   * Separate from `orphaned` because an already-orphaned anchor whose quote is
+   * still absent resolves as orphaned again on every subsequent edit. Alerting
+   * on the total would therefore fire on every save, forever, for a page that
+   * did not degrade at all — so callers that log or alert want this one.
+   */
+  newlyOrphaned: number;
   /**
    * Anchors that could not be forward-ported and went through QUOTE REPAIR
    * instead, because their stored hash did not describe `oldContent`.
@@ -616,6 +626,7 @@ export async function reanchorPageTags(
     considered: 0,
     updated: 0,
     orphaned: 0,
+    newlyOrphaned: 0,
     repairedStaleHash: 0,
     repairedFormatFlip: 0,
   };
@@ -706,8 +717,13 @@ export async function reanchorPageTags(
         else summary.repairedStaleHash += 1;
       }
 
+      // `trustRecordedOffsets: false` is the whole point of repairing here. The
+      // hash mismatch is PROOF the offsets describe another revision, and
+      // `positionHolds` would accept a matching slice at those offsets without
+      // consulting prefix or suffix — so with duplicated quote text it would
+      // reattach to the wrong occurrence and store it as 'exact'.
       const resolution = mustRepair
-        ? resolveAnchor(newText, anchor)
+        ? resolveAnchor(newText, anchor, { trustRecordedOffsets: false })
         : portPreparedAnchor(prepared, anchor);
 
       // AnchorResolution is a union: 'orphaned' carries NO offsets, because
@@ -751,7 +767,12 @@ export async function reanchorPageTags(
         .where(eq(contentTags.id, row.id));
 
       summary.updated += 1;
-      if (resolution.status === 'orphaned') summary.orphaned += 1;
+      if (resolution.status === 'orphaned') {
+        summary.orphaned += 1;
+        // A TRANSITION, not a state. `row.anchorStatus` is what this anchor was
+        // before the sweep; only a change into 'orphaned' is new damage.
+        if (row.anchorStatus !== 'orphaned') summary.newlyOrphaned += 1;
+      }
     }
 
     return ok(summary);

--- a/packages/lib/src/tags/tag-service.ts
+++ b/packages/lib/src/tags/tag-service.ts
@@ -32,8 +32,8 @@ import { loggers } from '../logging/logger-config';
 import { normalizeTagName, validateTarget, type TagTarget } from './tag-core';
 import type { TextAnchor } from '../content/anchoring/types';
 import { preparePort, portPreparedAnchor } from '../content/anchoring/reanchor';
-import { projectContent, resolveProjectionFormat } from '../content/anchoring/text-projection';
 import { resolveAnchor } from '../content/anchoring/resolve';
+import { projectContent, resolveProjectionFormat } from '../content/anchoring/text-projection';
 import { hashText } from '../content/anchoring/anchor';
 
 const log = loggers.system;
@@ -523,10 +523,21 @@ export type ReanchorSummary = {
   updated: number;
   /** Anchors that became 'orphaned' in this sweep. Included in `updated`. */
   orphaned: number;
-  /** Skipped because the stored projection hash did not match `oldContent`. */
-  skippedStaleHash: number;
-  /** Skipped because the projection format flipped between the two revisions. */
-  skippedFormatFlip: number;
+  /**
+   * Anchors that could not be forward-ported and went through QUOTE REPAIR
+   * instead, because their stored hash did not describe `oldContent`.
+   *
+   * Not "skipped": skipping was the original behaviour and it was a permanent
+   * death sentence. Once an anchor's `textHash` stops matching, it never
+   * matches any future `oldContent` either, so the anchor was passed over on
+   * every subsequent sweep for the rest of its life — silently, while the row
+   * still read `anchorStatus: 'exact'`. Repair is applicable here precisely
+   * because `resolveAnchor` searches the NEW text by quote and context and
+   * needs no trustworthy predecessor at all.
+   */
+  repairedStaleHash: number;
+  /** Anchors repaired because the projection format changed between revisions. */
+  repairedFormatFlip: number;
 };
 
 /**
@@ -605,8 +616,8 @@ export async function reanchorPageTags(
     considered: 0,
     updated: 0,
     orphaned: 0,
-    skippedStaleHash: 0,
-    skippedFormatFlip: 0,
+    repairedStaleHash: 0,
+    repairedFormatFlip: 0,
   };
 
   try {
@@ -646,13 +657,14 @@ export async function reanchorPageTags(
     // makes that fallback reachable: the old projection still validates each
     // anchor's hash, and the wholesale difference then routes every anchor to
     // `resolveAnchor` against the new text.
-    if (
+    const formatFlipped =
       !conversion &&
-      resolveProjectionFormat(oldContent, oldMode) !== resolveProjectionFormat(newContent, newMode)
-    ) {
-      summary.skippedFormatFlip = rows.length;
-      log.warn('tag-service: projection format flipped between revisions; skipping re-anchor', { pageId, anchors: rows.length });
-      return ok(summary);
+      resolveProjectionFormat(oldContent, oldMode) !== resolveProjectionFormat(newContent, newMode);
+    if (formatFlipped) {
+      log.warn(
+        'tag-service: projection format changed unexpectedly between revisions; repairing anchors instead of porting',
+        { pageId, anchors: rows.length },
+      );
     }
 
     const oldText = projectContent(oldContent, oldMode);
@@ -664,12 +676,39 @@ export async function reanchorPageTags(
 
     for (const row of rows) {
       const anchor = row.anchor as TextAnchor | null;
-      if (!anchor || anchor.textHash !== oldHash) {
-        summary.skippedStaleHash += 1;
-        continue;
+      if (!anchor) continue;
+
+      // WHY THIS REPAIRS RATHER THAN SKIPS.
+      //
+      // Forward-porting needs a trustworthy predecessor: `oldText` must be the
+      // projection the anchor was measured against, which `anchor.textHash`
+      // is what proves. When it does not match — or when the projection format
+      // changed underneath us — porting would map through the wrong coordinate
+      // system and produce a confident wrong answer.
+      //
+      // The original code therefore SKIPPED those anchors. That was a permanent
+      // death sentence, not a deferral: a hash that does not match `oldContent`
+      // will not match any future `oldContent` either, so the anchor was passed
+      // over on every later sweep for the rest of its life. Worse, the row was
+      // left untouched, so it still read `anchorStatus: 'exact'` and nothing
+      // could distinguish it from a healthy one.
+      //
+      // Quote repair does not need a predecessor at all. `resolveAnchor`
+      // searches the NEW text for the quote and its context, using the stored
+      // offset only as a hint — so it is exactly applicable here, and it is the
+      // fallback the epic already designates for changes with no diffable
+      // predecessor. Whatever it finds, the row is WRITTEN, so the anchor
+      // rejoins the normal flow with an honest status instead of freezing.
+      const staleHash = anchor.textHash !== oldHash;
+      const mustRepair = staleHash || formatFlipped;
+      if (mustRepair) {
+        if (formatFlipped) summary.repairedFormatFlip += 1;
+        else summary.repairedStaleHash += 1;
       }
 
-      const resolution = portPreparedAnchor(prepared, anchor);
+      const resolution = mustRepair
+        ? resolveAnchor(newText, anchor)
+        : portPreparedAnchor(prepared, anchor);
 
       // AnchorResolution is a union: 'orphaned' carries NO offsets, because
       // there is nowhere for them to point. Keep the last known start/end on


### PR DESCRIPTION
First of the three blockers found by the pre-scrub audit of the Content Tags epic. This is the one that had to come first: **you cannot verify the other two are fixed while the damage they cause is invisible.**

## The bug: skipping was permanent, not a deferral

`reanchorPageTags` refused to forward-port an anchor whose stored `textHash` did not describe `oldContent`. That refusal is correct — porting through the wrong coordinate system produces a confident wrong answer. But it then did **nothing** and moved on.

A hash that does not describe `oldContent` **will not describe any future `oldContent` either**. So that anchor was passed over on every later sweep for the rest of its life. And the row was left untouched, so it still read `anchorStatus: 'exact'` — a permanently frozen anchor was indistinguishable from a healthy one, and no query could find them.

This is the same permanent-death mode the write-skip fix in #2494 was written to prevent, arriving through a different door.

## The fix uses the mechanism the epic already designates

`resolveAnchor` searches the **new** text by quote and context, using the stored offset only as a hint. It needs no trustworthy predecessor at all — which is exactly the situation a stale hash describes. **The reason forward-porting is unavailable is not a reason quote repair is.**

So a stale anchor is now repaired rather than passed over: the row is written, the hash re-pinned to the revision it now describes, and the anchor rejoins the normal flow on the next sweep instead of freezing. The same applies to an unexpected projection-format flip, which previously abandoned the whole page's anchors and returned early.

Counters renamed to say what they mean — `skippedStaleHash`/`skippedFormatFlip` → `repairedStaleHash`/`repairedFormatFlip`.

## And the outcome is now visible

`applyPageMutation` computed the summary and discarded it. It now warns when something actually degraded (repaired or orphaned) and stays silent on an ordinary save.

## Validation

| Mutation | Result |
|---|---|
| restore the old `continue` on a stale hash | **4 failed** — all the repair tests |
| disable the degraded-outcome warn | **1 failed** — the logging test |

The repair tests deliberately assert the thing that matters rather than the counter: that the **next** sweep finds a hash it can trust. That is what breaks the permanence, and a test that only checked `repairedStaleHash === 1` would pass while the anchor stayed frozen.

Coverage includes an honest-status case (a repaired anchor must not keep the inherited `'exact'`) and a genuine-orphan case.

`tag-service.integration` 33/33 · hook test 5/5. Per the repo's local-build embargo I have not run monorepo typecheck/lint/build — **CI is the gate**.

## What this does NOT do

It does not close the four content writers that bypass the hook entirely — `content-mode-backfill.ts:154`, `rollback/page-mutation.ts:58`, `restore-pages-service.ts:125,161`, `onboarding-memory.ts:104`. That is the next PR.

It makes their damage **recoverable and visible instead of permanent and silent**, which is what has to exist before those paths can be verified fixed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MuVE5VZCUJ1RBqAVXXmQxa
