### PR TITLE
feat(collab): seed fidelity audit over real documents, and userColor

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -422,5 +422,16 @@ jobs:
       - name: Run TypeScript check
         run: bun run typecheck
 
+      # `scripts/` is not a workspace package, so neither `turbo lint` nor
+      # `turbo typecheck` above ever visits it — until these two steps, the
+      # only CI coverage that directory had was its vitest run. The typecheck
+      # is scoped to the seed fidelity audit; see scripts/tsconfig.json for the
+      # thirteen pre-existing failures that keep it from covering the rest yet.
+      - name: Run ESLint (scripts)
+        run: bun run lint:scripts
+
+      - name: Run TypeScript check (scripts)
+        run: bun run typecheck:scripts
+
       - name: Knip (unused code gate)
         run: bun run knip:check

--- a/.pu-reports/pu-mp-seed-fidelity.md
+++ b/.pu-reports/pu-mp-seed-fidelity.md
@@ -193,7 +193,56 @@ Not done (follow-ups, recorded on the leaf page): a `scripts/tsconfig.json` so C
 on every pretty-printed page as written — read that number as "pretty-printed or a lost space");
 the two test-only wrapper exports.
 
-### Mutation sweep — 33 mutations, 0 survivors (first pass) + 12 after the refactor + 13 after the review, 0 survivors after fixes
+### Convergence loop (after the review round)
+
+Four more commits, each driven by a signal rather than a guess.
+
+**`d498e052` docstring coverage.** CodeRabbit's pre-merge check read 51.22% against an 80%
+threshold over the 41 functions this diff touches: the audit documented its *types* heavily and
+left the functions bare, exported ones included. One minimal line each, comments only.
+
+**`6db4204` CI now lints and typechecks `scripts/`.** It never had: `scripts/` is not a workspace
+package, so `turbo lint` and `turbo typecheck` both skip it, and the only coverage that directory
+had was its vitest run — this PR had added ~900 lines of TypeScript into that blind spot, checked
+by nothing but my own habit of running `tsc` by hand. Adds `scripts/tsconfig.json`,
+`typecheck:scripts` and two CI steps. Scoped to the audit's own files on purpose: 13 other files
+there do not typecheck (mostly bun-only globals `import.meta.main`/`Bun`), and `exclude` cannot
+drop them because the `__tests__` suites import them back in — a directory-wide gate would have to
+exclude those tests, a bigger hole than it closes. The step builds `@pagespace/db` and
+`@pagespace/editor` first: **verified that without `packages/editor/dist` the bare `tsc` reports 16
+module-resolution errors**, which would have broken the job the first time turbo restored typecheck
+from cache without building. Also verified the gate fails on a planted type error.
+
+**`98ce9e5` a real content leak, found by adversarial probing.** `contentFreeKey` returned its
+input when the attribute pattern could not decompose a key. happy-dom builds a **real element for a
+tag name starting with `@`**, and the pattern's tag group needs one non-`@` character — so an
+ordinary pasted FreeMarker directive (`<@list items="payroll-2026-Q1.csv">`) or Slack mention
+(`<@U08JANE.DOE email="…">`) produced `attr:@list@items=…`, fell straight through, and printed the
+filename, the address and a full `href` into a report that runs against production. Not a crafted
+attack — pasted content. Verified end to end against a real database: **five planted tokens leaked
+before, none after.** Both folders now fail closed to the marker the census already uses for an
+unescaped `<` in prose.
+
+Two consequences closed with it. Keys are now **bounded** — a 264-column key from one document had
+been padding every row of a table, now 28 chars, asserted by tests on both sides. And a withheld
+value keeps an `=(withheld)` marker: collapsing it to the bare presence key erased the
+dropped-vs-changed distinction `constructKeysOf` exists to preserve, and let a key *outside*
+`ALLOWED_COSMETIC_ADDITIONS` print as one that is on it.
+
+Same commit, from the review's remaining minor: the `whitespaceOnlyTextChange` diagnostic measured
+the document's whole `textContent`, so the newline-and-indent between two blocks made it fire on
+**every pretty-printed page** — reporting "pretty-printed", not "a space was lost".
+`interWordText` now walks per text node, dropping whitespace-only nodes and collapsing within the
+rest; the pretty-printed fixture no longer trips it, a closed gap around a dropped `<iframe>` still
+does. It also carries example page ids now — it was the one number in the report nobody could go
+and look at. And a guard mutation testing proved dead was removed: the fail-closed default already
+makes folding idempotent.
+
+Still open, deliberately: `judgeChain`/`divergenceBetween` are test-only seams. They exist to cover
+branches real data cannot reach — no fixture available makes `y-prosemirror` alter a projection —
+so they are kept and documented rather than removed.
+
+### Mutation sweep — 33 + 12 + 13 + 11 = 69 mutations, 0 survivors after fixes
 
 Each mutation was applied by exact-needle replacement with the runner asserting the needle occurred
 once, the file content changed on disk, the test went red, and the file was byte-identical to the
@@ -252,6 +301,12 @@ import `@pagespace/editor` from `dist`.
 | C7 | `div` exclusion widened back to `closest` | ✔ |
 | O2 / O3 | unknown arguments accepted / `--flag=` ignored | ✔ |
 | T4 | `SET default_transaction_read_only = off` in a lib module | ✔ |
+| F1 | `contentFreeKey` fails open again (both suites) | ✔ |
+| F2 | withheld marker collapses to the presence key | ✔ 4 tests |
+| F3 | `censusKeyOf` fails open again | ✔ |
+| F4 | marker-passthrough guard removed | **survived → proved dead → removed** |
+| W1–W3 | `interWordText` keeps whitespace-only nodes / strips all whitespace / never recurses | ✔ |
+| D1–D3 | whitespace examples not recorded / read from the wrong tally / never printed | ✔ |
 
 Honest gap: "divergence always `null`" (as opposed to flipped) would survive, because no fixture
 I could construct makes `y-prosemirror` alter a projection — every construct in the corpus and the

--- a/.pu-reports/pu-mp-seed-fidelity.md
+++ b/.pu-reports/pu-mp-seed-fidelity.md
@@ -32,12 +32,14 @@ Headlines:
 | `scripts/lib/seed-audit/analyze.ts` | `auditPage` — both chains, the divergence between them, and the package gate's own verdict per page |
 | `scripts/lib/seed-audit/report.ts` | tallies with example page ids, census-keyed construct table, gate-agreement matrix, `contentFreeKey` |
 | `scripts/lib/seed-audit/options.ts` | `--limit`, `--batch-size`, `--progress-every`; refuses a non-integer rather than auditing everything |
-| `scripts/__tests__/collab-seed-audit.test.ts` | 48 tests, incl. read-only-by-construction and no-`Promise.all` scans of every audit source |
-| `packages/editor/src/seed-fidelity.ts` | **new subpath** — `ALLOWED_COSMETIC_ADDITIONS`, `VALUE_BEARING_ATTRIBUTES`, `constructKeysOf`; extracted from the corpus test so the corpus and real documents are held to ONE allowlist |
+| `scripts/__tests__/collab-seed-audit.test.ts` | 50 tests, incl. read-only-by-construction and no-`Promise.all` scans of every audit source and a six-position token sentinel |
+| `packages/editor/src/seed-fidelity.ts` | **new subpath** — `ALLOWED_COSMETIC_ADDITIONS`, `VALUE_BEARING_ATTRIBUTES`, `constructKeysOf`, and the printing side: `KNOWN_ATTRIBUTE_NAMES`, `KNOWN_STYLE_PROPERTIES`, `PRINTABLE_ATTRIBUTE_VALUES` (validators), `contentFreeKey`; extracted from the corpus test so the corpus and real documents are held to ONE allowlist |
+| `packages/editor/src/html-element-names.ts` | **new subpath** — `HTML_ELEMENT_NAMES` and `hasRealHtmlElement`, moved out of `apps/web` (which re-exports) so the audit's tagless rule is the census's and the backfill's |
+| `packages/editor/src/djb2.ts` | **new subpath** — the one hash, shared by `SCHEMA_HASH` and `userColor` |
 | `packages/editor/src/user-color.ts` | **new subpath** — `userColor(userId)` and `USER_COLOR_PALETTE` (second leaf) |
 | `packages/editor/src/html-to-ydoc.ts` | exports `parseHtmlElementUnchecked` (the parse without the gate), `describeParseLoss` (the gate's verdict over an already-parsed page), `stripNonContentElements` and `visibleCharacters` — so the audit measures exactly what the gate measures instead of mirroring it; `htmlToPmDoc` still throws |
 | `packages/editor/src/y-doc-to-html.ts` | `pmDocToHtmlIn(doc, workspace)` — `pmDocToHtml` into a caller-owned window, for the audit's four renders per page |
-| `packages/editor/src/collab-schema.ts` | `djb2` extracted from `hashProjection` and shared with `userColor` (hash value unchanged) |
+| `packages/editor/src/collab-schema.ts` | `hashProjection` now calls `djb2` (hash value unchanged) |
 | `packages/db/src/read-only-session.ts` | **moved** from `apps/web/src/lib/editor/census/` — its own docstring said "a second read-only consumer is the signal to promote it"; the census now imports `@pagespace/db/read-only-session` |
 | root `package.json` | `@pagespace/editor` as a workspace devDependency (root scripts could not resolve it), and `bun run collab:seed-audit` |
 
@@ -85,8 +87,9 @@ could not process, makes the run BLOCKED and the exit code 1. No thresholds anyw
 
 ## Verified how
 
-- **Fixtures**: 48 script tests + 344 editor tests (the corpus suites run over 25 fixtures now) +
-  5 db tests + the census's own read-only scan in web (9). All green as single-file runs.
+- **Fixtures**: 50 script tests + 352 editor tests (the corpus suites run over 25 fixtures now) +
+  5 db tests + the web suites that consume the moved constant (46) and the census's own read-only
+  scan (9). All green as single-file runs.
 - **Seeded local database** (`pagespace_seed_audit`, migrated to head, 12 pages: clean, `<img>`
   without file id, `<iframe>`, `<style>` block, tagless markdown, markdown-mode, empty, TipTap task
   list, `h4`+mention+`mark`+`sup`, bare table + `ol start=7`, pretty-printed, and a FOLDER decoy).
@@ -155,7 +158,42 @@ deriving `bothLossy` from the wrong cell (the agreement test had one page per ce
 was 1 — now 2/1/3/4), and judging the gate over the unstripped source (no test asserted the gate's
 verdict on a `<style>` page — now it does).
 
-### Mutation sweep — 33 mutations, 0 survivors (first pass) + 12 after the refactor, 0 survivors after fixes
+### `/review` pass and the Codex threads (third commit)
+
+Two review agents (security/OWASP, quality/tests) plus my own pass; findings recorded on the leaf
+page's `## Findings` section. Codex's two threads said the same two things. Fixed in this commit:
+
+- **The report could echo markup TOKENS the author controls** — tag names, attribute names,
+  `style` property names, and the "printable" enumerated values (`data-type="customer-name"`),
+  probe-confirmed in all six positions. Printing now goes through closed lists in the package
+  (`HTML_ELEMENT_NAMES`, `KNOWN_ATTRIBUTE_NAMES`, `KNOWN_STYLE_PROPERTIES`) and per-attribute
+  validators (`data-type` ∈ {taskList, taskItem, pageMention}; booleans; `\d{1,6}`); anything else
+  folds to `text:unescaped-angle-bracket` (the census's own marker) or a fixed
+  `(unrecognised-…)` placeholder. The corpus test asserts every name the schema renders is on the
+  lists, so they cannot go stale silently; the sentinel test now plants a token in each of the six
+  positions and asserts none reaches the report.
+- **Tagless rule was weaker than the census's** — `Set<string>` in a markdown page made happy-dom
+  create a `<string>` element and the page counted as HTML. `HTML_ELEMENT_NAMES` /
+  `hasRealHtmlElement` moved from `apps/web` into `@pagespace/editor/html-element-names` (web
+  re-exports); the audit, the census and the backfill now share one definition.
+- Two-clients `userColor` test could not fail for a first-come assignment table (both clients met
+  the id first) — client A now meets two other ids first. Mutating the implementation to a table
+  is red.
+- `--limit=5` and `--limt 5` no longer silently audit the whole table: `--flag=value` is accepted
+  and any unknown argument is refused.
+- Task-item `div` exclusion narrowed to TaskItem's own direct-child wrapper; an author's nested
+  `div` counts again.
+- Read-only source scan also refuses `SET default_transaction_read_only|transaction|session` and
+  `READ WRITE`.
+- `djb2` in its own module so `userColor` no longer imports the schema; stale doc strings; the
+  vacuous `toContain('p')`; the `parse` cast.
+
+Not done (follow-ups, recorded on the leaf page): a `scripts/tsconfig.json` so CI typechecks
+`scripts/` (today only my scratch `tsc` does); a block-aware whitespace-only diagnostic (it fires
+on every pretty-printed page as written — read that number as "pretty-printed or a lost space");
+the two test-only wrapper exports.
+
+### Mutation sweep — 33 mutations, 0 survivors (first pass) + 12 after the refactor + 13 after the review, 0 survivors after fixes
 
 Each mutation was applied by exact-needle replacement with the runner asserting the needle occurred
 once, the file content changed on disk, the test went red, and the file was byte-identical to the
@@ -207,6 +245,13 @@ import `@pagespace/editor` from `dist`.
 | P9 | `bothLossy` derived from the `bothClean` tally | survived → test fixed → ✔ |
 | P10 | `bothClean` rows leak into the example table | ✔ |
 | A7 | gate judged over the unstripped source | survived → test fixed → ✔ |
+| K1–K6 | each printable-value validator / name list disabled in the package (dist rebuilt, scripts sentinel) | ✔ |
+| K7 | `hasRealHtmlElement` counts pseudo-elements | ✔ |
+| K8 | `data-mention-type` dropped from the known-attribute list (corpus guard) | ✔ |
+| K9 | `userColor` replaced by a first-come table | ✔ 2 tests |
+| C7 | `div` exclusion widened back to `closest` | ✔ |
+| O2 / O3 | unknown arguments accepted / `--flag=` ignored | ✔ |
+| T4 | `SET default_transaction_read_only = off` in a lib module | ✔ |
 
 Honest gap: "divergence always `null`" (as opposed to flipped) would survive, because no fixture
 I could construct makes `y-prosemirror` alter a projection — every construct in the corpus and the

--- a/.pu-reports/pu-mp-seed-fidelity.md
+++ b/.pu-reports/pu-mp-seed-fidelity.md
@@ -35,7 +35,9 @@ Headlines:
 | `scripts/__tests__/collab-seed-audit.test.ts` | 48 tests, incl. read-only-by-construction and no-`Promise.all` scans of every audit source |
 | `packages/editor/src/seed-fidelity.ts` | **new subpath** — `ALLOWED_COSMETIC_ADDITIONS`, `VALUE_BEARING_ATTRIBUTES`, `constructKeysOf`; extracted from the corpus test so the corpus and real documents are held to ONE allowlist |
 | `packages/editor/src/user-color.ts` | **new subpath** — `userColor(userId)` and `USER_COLOR_PALETTE` (second leaf) |
-| `packages/editor/src/html-to-ydoc.ts` | exports `parseHtmlElementUnchecked` (the parse without the gate) so the audit can see what a lossy page parses TO; `htmlToPmDoc` still throws |
+| `packages/editor/src/html-to-ydoc.ts` | exports `parseHtmlElementUnchecked` (the parse without the gate), `describeParseLoss` (the gate's verdict over an already-parsed page), `stripNonContentElements` and `visibleCharacters` — so the audit measures exactly what the gate measures instead of mirroring it; `htmlToPmDoc` still throws |
+| `packages/editor/src/y-doc-to-html.ts` | `pmDocToHtmlIn(doc, workspace)` — `pmDocToHtml` into a caller-owned window, for the audit's four renders per page |
+| `packages/editor/src/collab-schema.ts` | `djb2` extracted from `hashProjection` and shared with `userColor` (hash value unchanged) |
 | `packages/db/src/read-only-session.ts` | **moved** from `apps/web/src/lib/editor/census/` — its own docstring said "a second read-only consumer is the signal to promote it"; the census now imports `@pagespace/db/read-only-session` |
 | root `package.json` | `@pagespace/editor` as a workspace devDependency (root scripts could not resolve it), and `bun run collab:seed-audit` |
 
@@ -92,8 +94,8 @@ could not process, makes the run BLOCKED and the exit code 1. No thresholds anyw
   divergence, 0 failures, correct skip of the FOLDER and the markdown page. `--limit 3` → 3 pages,
   exit 1. `--limit x` → refused. Database dropped afterwards.
 - **Scale**: the local `pagespace_test` database (1,501 DOCUMENT pages, all tagless test
-  fixtures) — 6.0 s wall, PASS with the tagless NOTE in the header, exit 0. Extrapolated, the
-  production corpus is well under a minute.
+  fixtures) — 1.2 s wall (6.0 s before the `/simplify` pass below), PASS with the tagless NOTE in
+  the header, exit 0. Extrapolated, the production corpus is well under a minute.
 - **Read-only**: `SET default_transaction_read_only = on` on every connection, read back with
   `SHOW` before the first `select`; a test asserts that ordering in the source, and another scans
   every audit module for `insert`/`update`/`delete`/`transaction`/DDL keywords and the script for
@@ -113,7 +115,47 @@ touch, and the known knip-in-a-pu-worktree phantom.** If CI's knip is red on tho
 are pre-existing on master; if it is red on anything under `scripts/` or `packages/editor`, that is
 mine.
 
-### Mutation sweep — 33 mutations, 0 survivors
+### `/simplify` pass (after the first push)
+
+Four review agents (reuse, simplification, efficiency, altitude). Applied:
+
+- **One DOM window per run, not five per page.** `pmDocToHtml` and `describeHtmlLoss` each opened
+  a fresh happy-dom `Window` (~2 ms, ~0.26 MB, not collectable until the event loop turns — ~260 MB
+  of transient heap per 200-page batch). The package now exports `pmDocToHtmlIn(doc, workspace)`
+  and `describeParseLoss(source, doc)`; the audit renders and judges through its single workspace,
+  and the gate stage no longer re-parses the page. Scale run: 6.0 s → 1.2 s over 1,501 pages; the
+  seeded-fixture report is byte-identical before and after.
+- **No mirrored constants.** `criteria.ts` imported `visibleCharacters`/`stripNonContentElements`
+  from `html-to-ydoc.ts` instead of carrying copies "that mirror" them — the audit now cannot drift
+  from what the gate sees.
+- **Printability lives beside the value-bearing list.** `PRINTABLE_ATTRIBUTE_VALUES` and
+  `contentFreeKey` moved into `packages/editor/seed-fidelity.ts`, next to `VALUE_BEARING_ATTRIBUTES`,
+  with a package test that the printable set is a subset and that the non-printable complement is
+  exactly the prose/url/id attributes. Adding a value-bearing attribute now forces the decision in
+  the same file.
+- One `djb2` (was copied into `user-color.ts`); gate-agreement counts derived from the one tally
+  rather than kept as a second counter; `record(pageId, verdict)` instead of passing the whole
+  audit plus a chain selector; `FailureStage` named once; a `chainResult()` test helper; the
+  test-only `constructsOf` export pulled back into the test; the accidental `workspaces` reflow in
+  the root `package.json` reverted.
+
+Skipped, deliberately: sharing `main()`/the option parser/the read-only scanner with the census
+(cross-app — apps/web cannot import root `scripts/` and vice versa, and the census is documented as
+temporary); a `getReadOnlyDb()` pool with `default_transaction_read_only` as a connection option
+(right idea, but new shared pool infrastructure in `packages/db` is outside this leaf — noted as a
+follow-up); filtering markdown/empty rows in SQL (changes what `--limit` counts); moving the
+census's `HTML_ELEMENT_NAMES`-aware tagless rule and key scheme into `packages/editor` (the right
+home, but it drags the whole census module with it — `isTagless` here is the weaker
+"no element at all" rule, which counts an unescaped `<T>` in prose as HTML; flagged so the
+production tagless count is read with that in mind); the task-item `div` exclusion staying in the
+audit rather than as schema-chrome metadata in the package.
+
+Two mutations SURVIVED the first re-check after the refactor and were fixed by strengthening tests:
+deriving `bothLossy` from the wrong cell (the agreement test had one page per cell, so every count
+was 1 — now 2/1/3/4), and judging the gate over the unstripped source (no test asserted the gate's
+verdict on a `<style>` page — now it does).
+
+### Mutation sweep — 33 mutations, 0 survivors (first pass) + 12 after the refactor, 0 survivors after fixes
 
 Each mutation was applied by exact-needle replacement with the runner asserting the needle occurred
 once, the file content changed on disk, the test went red, and the file was byte-identical to the
@@ -155,6 +197,16 @@ import `@pagespace/editor` from `dist`.
 | T1 | an `INSERT` string appears in a lib module | ✔ |
 | T2 | `Promise.all` appears in the script | ✔ |
 | T3 | `assert` moved before `enforce` | ✔ |
+| U1′ | shared `djb2` loses order | ✔ |
+| E1 | `<style>` no longer stripped in the package (via scripts tests, dist rebuilt) | ✔ |
+| E2 | `visibleCharacters` collapses to a space (package, via scripts) | ✔ |
+| E3 | `describeParseLoss` never reports dropped elements (package, via scripts) | ✔ |
+| E4 | `alt` made printable in the package (via scripts) | ✔ sentinel |
+| E5 | `pmDocToHtmlIn` skips `assertProjectable` | ✔ 4 tests |
+| P6′ | blind spot counted as "gate stricter" | ✔ |
+| P9 | `bothLossy` derived from the `bothClean` tally | survived → test fixed → ✔ |
+| P10 | `bothClean` rows leak into the example table | ✔ |
+| A7 | gate judged over the unstripped source | survived → test fixed → ✔ |
 
 Honest gap: "divergence always `null`" (as opposed to flipped) would survive, because no fixture
 I could construct makes `y-prosemirror` alter a projection — every construct in the corpus and the

--- a/.pu-reports/pu-mp-seed-fidelity.md
+++ b/.pu-reports/pu-mp-seed-fidelity.md
@@ -1,0 +1,207 @@
+# Phase B — seed fidelity gate over real documents, and `userColor`
+
+Both leaves are met in code and verified against fixtures and a seeded local database. **The
+production run has not happened** — by design, the orchestrator holds that credential. The exact
+command is at the end.
+
+Headlines:
+
+- **`scripts/collab-seed-audit.ts` runs every DOCUMENT page through BOTH chains on one parse** —
+  the census chain (HTML → PM → HTML) and the seed chain (HTML → PM → Y.Doc → PM → HTML) — and
+  prints the three criteria for each side by side, plus a table of exactly what differs between
+  the two projections. If the seed chain is lossier than the census chain, the table names what
+  `y-prosemirror` changed; the ProseMirror schema is held constant between them.
+- **The audit already found a blind spot in the package's own seed gate.** `describeHtmlLoss`
+  (what `htmlToYDoc` throws on) accepts a page that loses `<sup>`: the text survives, the mark does
+  not, and the gate only measures text and textless elements. The audit reports this as a
+  `gateBlindSpot` cell so the production run will say how many real pages are affected. Not fixed
+  here — `sup`/`sub` are *representable* and adding them is a v1 decision, which the leaf reserves
+  for the orchestrator.
+- **The "never prints content" test caught a real PII leak in my first draft**: `alt` text was
+  riding into construct keys (`attr:img@alt=<prose>`) and out to the terminal. Fixed by folding
+  every value-bearing key except the schema's own enumerations back to presence form before
+  tallying; the sentinel test now guards it.
+- `SCHEMA_HASH` is unchanged at `'ded0823d'`. Nothing here touches `collabExtensions()`.
+
+## What landed
+
+| file | what it is |
+|---|---|
+| `scripts/collab-seed-audit.ts` | the audit — streaming, keyset-paginated, one query at a time, read-only at the server, exit 0 = PASS / 1 = BLOCKED |
+| `scripts/lib/seed-audit/criteria.ts` | the three criteria as pure functions: 20 content counters, whitespace-stripped visible text, `isTagless` |
+| `scripts/lib/seed-audit/analyze.ts` | `auditPage` — both chains, the divergence between them, and the package gate's own verdict per page |
+| `scripts/lib/seed-audit/report.ts` | tallies with example page ids, census-keyed construct table, gate-agreement matrix, `contentFreeKey` |
+| `scripts/lib/seed-audit/options.ts` | `--limit`, `--batch-size`, `--progress-every`; refuses a non-integer rather than auditing everything |
+| `scripts/__tests__/collab-seed-audit.test.ts` | 48 tests, incl. read-only-by-construction and no-`Promise.all` scans of every audit source |
+| `packages/editor/src/seed-fidelity.ts` | **new subpath** — `ALLOWED_COSMETIC_ADDITIONS`, `VALUE_BEARING_ATTRIBUTES`, `constructKeysOf`; extracted from the corpus test so the corpus and real documents are held to ONE allowlist |
+| `packages/editor/src/user-color.ts` | **new subpath** — `userColor(userId)` and `USER_COLOR_PALETTE` (second leaf) |
+| `packages/editor/src/html-to-ydoc.ts` | exports `parseHtmlElementUnchecked` (the parse without the gate) so the audit can see what a lossy page parses TO; `htmlToPmDoc` still throws |
+| `packages/db/src/read-only-session.ts` | **moved** from `apps/web/src/lib/editor/census/` — its own docstring said "a second read-only consumer is the signal to promote it"; the census now imports `@pagespace/db/read-only-session` |
+| root `package.json` | `@pagespace/editor` as a workspace devDependency (root scripts could not resolve it), and `bun run collab:seed-audit` |
+
+Corpus additions in `packages/editor`: `bare-table` (no `<tbody>`, no spans, bare cell text) and
+`bare-ordered-list` — each earns allowlist entries the leaf named but the corpus had never produced
+(`td`/`th` `colspan="1"`/`rowspan="1"`, and `ol` gaining `class="tight" data-tight="true"`).
+
+## The three criteria, exactly as implemented
+
+1. **Stability** — `h1 === render(parse(h1))`, byte-equal. Per chain.
+2. **Content-bearing loss** — instance counts of `img`, `h4`, `h5`, `h6`, `table`, `tr`, `td`,
+   `th`, `li`, `pre`, `code`, `a[data-page-id]`, `span[data-mention-type]`, `mark`, `sup`, `sub`,
+   `iframe`, `details`, `div` (outside task items — `TaskItem` renders its own `<div>`, and stored
+   task-list markup already carries it, so it is excluded on both sides or a lost wrapper could be
+   "paid back"), `input[type=checkbox]`. `src` vs `h1`; any decrease is loss; increases are not.
+3. **Text** — `textContent` with `<script>`/`<style>`/`<noscript>`/`<template>` removed first
+   (mirroring the seed parse) and **all whitespace stripped**, not collapsed to one space. The
+   judgement call, and why: stored HTML is often pretty-printed, and the newline-and-indent between
+   two `<p>` is a text node ProseMirror correctly drops — collapsing to a single space would fail
+   every pretty-printed page for a reason that is not loss. The cost is that a space vanishing
+   *between* words is invisible to criterion 3; that case is reported as a separate
+   "whitespace-only text differences" diagnostic count (never a verdict).
+
+Cosmetic rewrites are allowlisted in `ALLOWED_COSMETIC_ADDITIONS` (35 entries, every one earned by
+a corpus fixture — the package test still asserts the list is not larger than the corpus produces).
+Additions **outside** the allowlist are reported in their own table; they do not fail the run, but
+they are the "look at this" list.
+
+A page is LOSSY if any of the three fails on the seed chain. Any lossy page, or any page the chain
+could not process, makes the run BLOCKED and the exit code 1. No thresholds anywhere.
+
+## What the report also measures
+
+- **Gate agreement.** For every page, `describeHtmlLoss` (the package gate) vs this audit's seed
+  verdict, in four cells. `gate ACCEPTS, audit lossy` is the one to read first — those are pages
+  Phase E would seed today.
+- **Census comparison.** Dropped constructs are tallied twice: tag-qualified (`attr:p@style:text-align`)
+  for diagnosis, and re-keyed to the census's own scheme (`style:text-align`, `<img>`) so the numbers
+  line up with `apps/web/scripts/collab-content-census.ts` output row for row.
+- **Tagless html-mode pages** (no HTML element at all — markdown or plain text under an html
+  label). Not a criterion, because such a page passes all three trivially, but the count is put in
+  the header next to the verdict so a PASS cannot hide it. The backfill reported 0 remaining; this
+  is the cross-check.
+- `contentMode='markdown'` pages are counted and skipped (Phase K), empty pages counted.
+
+## Verified how
+
+- **Fixtures**: 48 script tests + 344 editor tests (the corpus suites run over 25 fixtures now) +
+  5 db tests + the census's own read-only scan in web (9). All green as single-file runs.
+- **Seeded local database** (`pagespace_seed_audit`, migrated to head, 12 pages: clean, `<img>`
+  without file id, `<iframe>`, `<style>` block, tagless markdown, markdown-mode, empty, TipTap task
+  list, `h4`+mention+`mark`+`sup`, bare table + `ol start=7`, pretty-printed, and a FOLDER decoy).
+  Result: BLOCKED, exit 1, 3 lossy pages (img, iframe, sup), 1 blind spot (sup), 1 tagless, 0
+  divergence, 0 failures, correct skip of the FOLDER and the markdown page. `--limit 3` → 3 pages,
+  exit 1. `--limit x` → refused. Database dropped afterwards.
+- **Scale**: the local `pagespace_test` database (1,501 DOCUMENT pages, all tagless test
+  fixtures) — 6.0 s wall, PASS with the tagless NOTE in the header, exit 0. Extrapolated, the
+  production corpus is well under a minute.
+- **Read-only**: `SET default_transaction_read_only = on` on every connection, read back with
+  `SHOW` before the first `select`; a test asserts that ordering in the source, and another scans
+  every audit module for `insert`/`update`/`delete`/`transaction`/DDL keywords and the script for
+  `Promise.all`. Note: bun's `pg` prints a `DeprecationWarning` for the `client.query()` issued from
+  the pool's `connect` handler (the census has the same). The `SHOW` check proves the `SET` still
+  runs first; the warning goes to stderr and not into the report.
+
+### Gates
+
+Local load was 129 (iOS simulator + Steam) with ten other pu agents running, so per the standing
+rule I did **not** run the monorepo-wide `typecheck`/`lint`/`test` locally — CI is the gate for
+those. What I did run: `bun run lint:scripts` (clean), a scratch `tsc --noEmit` over the audit
+script, lib and test (clean — `scripts/` is in no tsconfig, so this is the only typecheck it gets),
+eslint over every touched db/editor file (clean), and `bun run knip:check`. **knip:check fails
+locally on 4 findings in `packages/lib/src/env-bridge` and `drive-envs` — files this branch does not
+touch, and the known knip-in-a-pu-worktree phantom.** If CI's knip is red on those same four, they
+are pre-existing on master; if it is red on anything under `scripts/` or `packages/editor`, that is
+mine.
+
+### Mutation sweep — 33 mutations, 0 survivors
+
+Each mutation was applied by exact-needle replacement with the runner asserting the needle occurred
+once, the file content changed on disk, the test went red, and the file was byte-identical to the
+original after restore. `S2` rebuilt the editor dist before and after, since the scripts tests
+import `@pagespace/editor` from `dist`.
+
+| id | what I broke | red? |
+|---|---|---|
+| U1 | djb2 → sum of char codes (anagram ids collide) | ✔ (`distinguishes ids` test) |
+| U2 | one palette entry to a low-contrast pink | ✔ |
+| U3 | index modulo 3 instead of palette length | ✔ (spread + pin) |
+| U4 | duplicate palette entry | ✔ |
+| S1 | drop `attr:td@colspan=1` from the allowlist | ✔ (`bare-table`) |
+| S2 | `el:${tag}` → `el:${tag}x` (via scripts tests, dist rebuilt) | ✔ 7 tests |
+| S3 | `constructDifference` inverted | ✔ 52 tests |
+| R1 | `SET … = off` | ✔ |
+| R2 | `assertReadOnlySession` inverted | ✔ |
+| C1 | remove the `img` counter | ✔ 6 tests |
+| C2 | decrease → increase | ✔ |
+| C3 | stop excluding task-item `<div>` | ✔ |
+| C4 | stop stripping `<style>` | ✔ |
+| C5 | strip whitespace → collapse to one space | ✔ |
+| C6 | `isTagless` inverted | ✔ |
+| A1 | instability no longer lossy | ✔ |
+| A2 | gate reason shape not folded | ✔ |
+| A3 | `stage = 'render'` not recorded | ✔ |
+| A4 | divergence comparison flipped | ✔ |
+| A5 | unexpected additions ignore the allowlist | ✔ |
+| A6 | whitespace-only diagnostic inverted | ✔ |
+| P1 | census element key loses its brackets | ✔ |
+| P2 | `alt` made printable | ✔ (sentinel test) |
+| P3 | failures no longer block | ✔ |
+| P4 | four example ids | ✔ |
+| P5 | PASS/BLOCKED swapped | ✔ |
+| P6 | blind spot counted as "gate stricter" | ✔ |
+| P7 | tagless NOTE only from 2 pages | ✔ |
+| P8 | census-key fold not de-duplicated | ✔ |
+| O1 | `--limit 0` accepted | ✔ |
+| T1 | an `INSERT` string appears in a lib module | ✔ |
+| T2 | `Promise.all` appears in the script | ✔ |
+| T3 | `assert` moved before `enforce` | ✔ |
+
+Honest gap: "divergence always `null`" (as opposed to flipped) would survive, because no fixture
+I could construct makes `y-prosemirror` alter a projection — every construct in the corpus and the
+seeded DB round-trips through the Y.Doc byte-identically. The divergence *accounting* is fully
+tested through `divergenceBetween` and the accumulator; the trigger will be exercised the first time
+production produces a divergent page. Every riteway-style `assert` concern is moot here — the tests
+use `expect` from an explicit `vitest` import (`globals: false` in `scripts/vitest.config.ts`).
+
+## Findings to carry to the orchestrator
+
+1. **`<sup>` (and `<sub>`) are silently dropped and the seed gate does not notice.** Representable →
+   report, do not add. The production run will give the population; the leaf's three outcomes
+   apply: v1 addition (orchestrator decision), quarantine, or "schema is wrong" if corpus-wide. The
+   census never had a `sup`/`sub` detector, so this is the first measurement.
+2. **The `describeHtmlLoss` gate is text-and-textless-elements only.** Any inline *mark* loss
+   (`sup`, `sub`, a future unknown span) passes it. Phase E's "fidelity check that refuses rather
+   than storing a lossy doc" should run this audit's criteria, not just `describeHtmlLoss`. Worth a
+   leaf.
+3. `contentFreeKey` in the audit is the reason construct keys can be printed; the package's
+   `constructKeysOf` is deliberately NOT content-free (the corpus test needs to see a rewritten
+   href). Anyone else printing those keys from real data must fold them the same way.
+
+## The command to run against production
+
+From the repo root of a checkout at this branch (or master once merged), with the dist builds in
+place (`bun install`, then `@pagespace/db`, `@pagespace/lib`, `@pagespace/editor` builds), and
+`DATABASE_URL` pointing at production the same way the census was run:
+
+```bash
+# smoke first — 200 pages, prints the full report shape, exit code tells you the verdict
+DATABASE_URL='<production url>' bun run collab:seed-audit --limit 200 > seed-audit-smoke.txt
+
+# the real run — ~4,769 DOCUMENT pages, expect well under a minute
+DATABASE_URL='<production url>' bun run collab:seed-audit > seed-audit.txt
+echo "exit $?"
+```
+
+Only the report goes to stdout; progress (every 500 pages), the schema version/hash banner and the
+`pg` deprecation warning go to stderr. Exit 0 is PASS; exit 1 is BLOCKED, a processing failure, or
+Ctrl-C (which still prints what it has, labelled INTERRUPTED). Read the header NOTE (tagless count),
+then `gate ACCEPTS, audit lossy`, then the seed-chain criterion failures table, in that order.
+
+Then compare `seed chain — constructs dropped, census keys` against the 2026-08-24 census output:
+matching rows mean the schema is the whole story; anything in the `y-prosemirror` table is the
+CRDT layer's doing.
+
+## Board
+
+Both tasks left `in_progress`: `jklkkf8aaao6v7jpc0mk8qub` (gate) and `p7ant1pe661k0izfpxh4ohje`
+(`userColor`). Phase B does not close until the production run reads PASS.

--- a/.pu-reports/pu-mp-seed-fidelity.md
+++ b/.pu-reports/pu-mp-seed-fidelity.md
@@ -238,11 +238,60 @@ does. It also carries example page ids now — it was the one number in the repo
 and look at. And a guard mutation testing proved dead was removed: the fail-closed default already
 makes folding idempotent.
 
+**`51b3c44d` the spacing diagnostic could not see the loss it exists to catch.** Reviewing the
+previous commit found the whitespace measure wrong in both directions, and the second is the bad
+one. Dropping every whitespace-only text node is not "ignore pretty-printing": in
+`a<span> </span>b` — the shape HTML pasted from Word and Docs is full of — that node **is** the
+space between the words. Measured: source and render both read `ab`, identical to a page where the
+space was genuinely lost, so the one class of loss the function exists to see was the one it could
+not see. The same input also reported a change when the schema had *preserved* the space.
+Separately, whitespace inside `<pre>` was collapsed, so a code block that lost every indent read as
+affirmatively clean — and `visibleText` strips all whitespace, so criterion 3 cannot see that
+either.
+
+`interWordText` now decides positionally: a whitespace-only run is formatting when a block edge is
+on either side and content when inline text is on both, with `<pre>` kept verbatim. Verified:
+`a<span> </span>b` reads `a b` and differs from a lost space; indented and unindented code blocks
+now differ; pretty-printed paragraphs, lists, tables and sections still read identically to their
+tight equivalents. Two mutations survived and both were real test gaps — nothing covered table
+block boundaries, nothing pushed the example list past its cap — now closed.
+
+The same review corrected four docblocks that were inaccurate (a "one walk" that is 23 traversals,
+a "three criteria" that also computes the diagnostic, and a claim about example ids the file did
+not satisfy), removed a `pageId` parameter that was declared and never used, replaced a one-key map
+with a capped array, globbed the tsconfig include, and pinned both sides of a test that had
+compared the function under test to itself.
+
+**The new CI steps are confirmed working in CI**, not just locally: run 34365494496 reports
+`Run ESLint (scripts): success` and `Run TypeScript check (scripts): success`.
+
+### A pre-existing flake this PR did not cause, worth someone's attention
+
+`@pagespace/lib#test:coverage` failed once on this branch, in
+`src/permissions/__tests__/page-viewers.integration.test.ts` →
+`evaluates every candidate across the chunk boundary`, with
+`Error: Test timed out in 5000ms` at 5002 ms. 12,385 other tests passed, the
+same job passed on two earlier commits of this branch, and **this PR does not
+touch `packages/lib` at all**.
+
+The cause is structural rather than random: the test creates 205 users and 205
+drive memberships one await at a time — **410 sequential database round-trips**
+— and `packages/lib/vitest.config.ts` sets no `testTimeout`, so it runs under
+vitest's 5 s default. At roughly 12 ms per round-trip it sits on the limit and
+tips over whenever the runner is loaded. It will keep doing this.
+
+Deliberately NOT fixed here. Widening another package's test timeout from a
+seed-fidelity PR is the scope creep a reviewer should object to, and a bare
+timeout bump could also mask a real regression in `getUsersWhoCanViewPage`. The
+proper fix belongs to that file's owner: batch the factory inserts (one
+multi-row insert instead of 410 round-trips) or give the test an explicit
+timeout that reflects what it actually does.
+
 Still open, deliberately: `judgeChain`/`divergenceBetween` are test-only seams. They exist to cover
 branches real data cannot reach — no fixture available makes `y-prosemirror` alter a projection —
 so they are kept and documented rather than removed.
 
-### Mutation sweep — 33 + 12 + 13 + 11 = 69 mutations, 0 survivors after fixes
+### Mutation sweep — 33 + 12 + 13 + 11 + 1 + 11 = 81 mutations, 0 survivors after fixes
 
 Each mutation was applied by exact-needle replacement with the runner asserting the needle occurred
 once, the file content changed on disk, the test went red, and the file was byte-identical to the
@@ -307,6 +356,12 @@ import `@pagespace/editor` from `dist`.
 | F4 | marker-passthrough guard removed | **survived → proved dead → removed** |
 | W1–W3 | `interWordText` keeps whitespace-only nodes / strips all whitespace / never recurses | ✔ |
 | D1–D3 | whitespace examples not recorded / read from the wrong tally / never printed | ✔ |
+| X1 | `censusKeyOf` marker passthrough broken | ✔ |
+| B1 | `BLOCK_ELEMENTS` emptied of table/list tags | **survived → no table test → added → ✔** |
+| B2 | `<pre>` no longer verbatim | ✔ |
+| B3 / B4 | every whitespace-only node dropped again / none dropped | ✔ 6 and 2 tests |
+| B5 | comments treated as text | ✔ |
+| B6 | example cap removed | **survived → cap never exceeded in a test → fixed → ✔** |
 
 Honest gap: "divergence always `null`" (as opposed to flipped) would survive, because no fixture
 I could construct makes `y-prosemirror` alter a projection — every construct in the corpus and the

--- a/apps/web/scripts/collab-content-census.ts
+++ b/apps/web/scripts/collab-content-census.ts
@@ -10,7 +10,7 @@
  * the schema must be able to represent.
  *
  * READ-ONLY, and not on the honour system: every connection is put into
- * `default_transaction_read_only` (see read-only-session.ts), and
+ * `default_transaction_read_only` (see @pagespace/db/read-only-session), and
  * read-only.test.ts fails the build if any census source grows a write.
  *
  * NEVER PRINTS DOCUMENT CONTENT. This runs against production user data. The
@@ -85,7 +85,7 @@ import { createDomWorkspace } from '../src/lib/editor/census/constructs';
 import { analyzeHtmlDocument } from '../src/lib/editor/census/round-trip';
 import { analyzeMarkdown } from '../src/lib/editor/census/markdown';
 import { createCensusAccumulator, formatCensusReport } from '../src/lib/editor/census/report';
-import { assertReadOnlySession, enforceReadOnlySession } from '../src/lib/editor/census/read-only-session';
+import { assertReadOnlySession, enforceReadOnlySession } from '@pagespace/db/read-only-session';
 
 interface Options {
   limit: number;

--- a/apps/web/src/lib/editor/census/__tests__/read-only.test.ts
+++ b/apps/web/src/lib/editor/census/__tests__/read-only.test.ts
@@ -2,40 +2,15 @@ import { describe, it, expect } from 'vitest';
 import { readFileSync, readdirSync } from 'node:fs';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
-import { READ_ONLY_SESSION_SQL, assertReadOnlySession, enforceReadOnlySession } from '../read-only-session';
 
 const here = path.dirname(fileURLToPath(import.meta.url));
 const appRoot = path.resolve(here, '../../../../..');
 
-describe('enforceReadOnlySession', () => {
-  it('makes every connection the pool opens read-only at the server', () => {
-    const queries: string[] = [];
-    const listeners: Array<(client: { query: (sql: string) => void }) => void> = [];
-    const pool = {
-      on(event: string, listener: (client: { query: (sql: string) => void }) => void) {
-        expect(event).toBe('connect');
-        listeners.push(listener);
-        return pool;
-      },
-    };
-
-    enforceReadOnlySession(pool);
-    // A pool opens connections lazily and reopens them after a drop; the guard
-    // has to ride every connection, not just be run once at startup.
-    for (const listener of listeners) {
-      listener({ query: (sql) => queries.push(sql) });
-      listener({ query: (sql) => queries.push(sql) });
-    }
-
-    expect(queries).toEqual([READ_ONLY_SESSION_SQL, READ_ONLY_SESSION_SQL]);
-  });
-
-  it('asks Postgres itself to refuse writes, rather than trusting the caller', () => {
-    expect(READ_ONLY_SESSION_SQL).toBe('SET default_transaction_read_only = on');
-  });
-});
-
 /**
+ * The guard itself (`enforceReadOnlySession`/`assertReadOnlySession`) is
+ * tested where it now lives, `@pagespace/db/read-only-session`. What stays
+ * here is the census's own promise.
+ *
  * The census runs against production with the production credential. "It only
  * reads" has to be checkable without reading the whole script, so it is a test:
  * no census source may contain a write.
@@ -82,21 +57,5 @@ describe('the census is read-only by construction', () => {
 
   it('strips comments before scanning, but not code that follows one', () => {
     expect(codeOf('scripts/collab-content-census.ts')).toContain('getMigrationDb');
-  });
-});
-
-describe('assertReadOnlySession', () => {
-  it('passes when Postgres reports the session read-only', () => {
-    expect(() => assertReadOnlySession([{ default_transaction_read_only: 'on' }])).not.toThrow();
-  });
-
-  it('refuses to run when the setting did not take', () => {
-    expect(() => assertReadOnlySession([{ default_transaction_read_only: 'off' }])).toThrow(
-      /not read-only/,
-    );
-  });
-
-  it('refuses to run when the check returned nothing at all', () => {
-    expect(() => assertReadOnlySession([])).toThrow(/not read-only/);
   });
 });

--- a/apps/web/src/lib/editor/document-content-format.ts
+++ b/apps/web/src/lib/editor/document-content-format.ts
@@ -1,26 +1,15 @@
 import { Window } from 'happy-dom';
 
+import { HTML_ELEMENT_NAMES } from '@pagespace/editor/html-element-names';
+
 /**
- * Real HTML element names. Anything outside this set that a parser produced is
- * not markup the author wrote — it is an unescaped `<` in prose or a code
- * sample (`ActionResult<void>`, `<task-id>`), which every happy-dom parse
- * turns into an element of its own. Moved here (out of
- * `census/constructs.ts`, which this repo is going to delete once
- * `COLLAB_SCHEMA_VERSION` v1 is frozen) because the mislabelled-content-mode
- * backfill needs the exact same "does this contain real HTML" answer the
- * census measured, and needs it to survive after the census is gone.
+ * Re-exported from `@pagespace/editor/html-element-names`, where the list now
+ * lives so the seed fidelity audit (root `scripts/`, which cannot import
+ * `apps/web`) counts tagless pages by the same definition the census and the
+ * mislabelled-content-mode backfill do. Everything in `apps/web` keeps
+ * importing it from here.
  */
-export const HTML_ELEMENT_NAMES = new Set<string>([
-  'a','abbr','address','area','article','aside','audio','b','base','bdi','bdo','blockquote','body',
-  'br','button','canvas','caption','cite','code','col','colgroup','data','datalist','dd','del',
-  'details','dfn','dialog','div','dl','dt','em','embed','fieldset','figcaption','figure','footer',
-  'form','h1','h2','h3','h4','h5','h6','head','header','hgroup','hr','html','i','iframe','img',
-  'input','ins','kbd','label','legend','li','link','main','map','mark','menu','meta','meter','nav',
-  'noscript','object','ol','optgroup','option','output','p','param','picture','pre','progress','q',
-  'rp','rt','ruby','s','samp','script','search','section','select','slot','small','source','span',
-  'strong','style','sub','summary','sup','table','tbody','td','template','textarea','tfoot','th',
-  'thead','time','title','tr','track','u','ul','var','video','wbr','svg','math',
-]);
+export { HTML_ELEMENT_NAMES };
 
 /** Single marker for parser artefacts of unescaped `<` in text. */
 export const UNESCAPED_ANGLE_BRACKET_KEY = 'text:unescaped-angle-bracket';

--- a/bun.lock
+++ b/bun.lock
@@ -7,6 +7,7 @@
       "devDependencies": {
         "@faker-js/faker": "^9.3.0",
         "@pagespace/db": "workspace:*",
+        "@pagespace/editor": "workspace:*",
         "@pagespace/lib": "workspace:*",
         "@paralleldrive/cuid2": "^2.2.2",
         "@testing-library/dom": "^10.4.0",

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "lint": "turbo lint",
     "lint:scripts": "eslint --config scripts/eslint.config.mjs scripts",
     "typecheck": "turbo typecheck",
+    "typecheck:scripts": "turbo build --filter=@pagespace/db --filter=@pagespace/editor && tsc -p scripts/tsconfig.json",
     "db:generate": "drizzle-kit generate",
     "db:migrate": "bun run --filter '@pagespace/db' db:migrate",
     "db:generate:admin": "bun run --filter '@pagespace/db' db:generate:admin",

--- a/package.json
+++ b/package.json
@@ -5,10 +5,7 @@
   "engines": {
     "node": ">=22"
   },
-  "workspaces": [
-    "apps/*",
-    "packages/*"
-  ],
+  "workspaces": ["apps/*", "packages/*"],
   "scripts": {
     "dev": "turbo dev --filter=!control-plane",
     "dev:atlas": "bun run --filter 'atlas' dev",

--- a/package.json
+++ b/package.json
@@ -5,7 +5,10 @@
   "engines": {
     "node": ">=22"
   },
-  "workspaces": ["apps/*", "packages/*"],
+  "workspaces": [
+    "apps/*",
+    "packages/*"
+  ],
   "scripts": {
     "dev": "turbo dev --filter=!control-plane",
     "dev:atlas": "bun run --filter 'atlas' dev",
@@ -36,6 +39,7 @@
     "build:desktop:coder": "bun run --filter 'desktop' build:coder",
     "package:desktop:coder": "bun run --filter 'desktop' package:coder",
     "check:fetch": "node scripts/check-fetch-auth.js",
+    "collab:seed-audit": "bun scripts/collab-seed-audit.ts",
     "knip": "knip",
     "knip:fix": "knip --fix",
     "knip:check": "node scripts/knip-ratchet.mjs",
@@ -48,6 +52,7 @@
   },
   "devDependencies": {
     "@pagespace/db": "workspace:*",
+    "@pagespace/editor": "workspace:*",
     "@pagespace/lib": "workspace:*",
     "@paralleldrive/cuid2": "^2.2.2",
     "@faker-js/faker": "^9.3.0",

--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -35,6 +35,10 @@
       "types": "./dist/operators.d.ts",
       "default": "./dist/operators.js"
     },
+    "./read-only-session": {
+      "types": "./dist/read-only-session.d.ts",
+      "default": "./dist/read-only-session.js"
+    },
     "./schema": {
       "types": "./dist/schema.d.ts",
       "default": "./dist/schema.js"

--- a/packages/db/src/__tests__/read-only-session.test.ts
+++ b/packages/db/src/__tests__/read-only-session.test.ts
@@ -1,0 +1,50 @@
+import { describe, it, expect } from 'vitest';
+import {
+  READ_ONLY_SESSION_SQL,
+  assertReadOnlySession,
+  enforceReadOnlySession,
+} from '../read-only-session';
+
+describe('enforceReadOnlySession', () => {
+  it('makes every connection the pool opens read-only at the server', () => {
+    const queries: string[] = [];
+    const listeners: Array<(client: { query: (sql: string) => void }) => void> = [];
+    const pool = {
+      on(event: string, listener: (client: { query: (sql: string) => void }) => void) {
+        expect(event).toBe('connect');
+        listeners.push(listener);
+        return pool;
+      },
+    };
+
+    enforceReadOnlySession(pool);
+    // A pool opens connections lazily and reopens them after a drop; the guard
+    // has to ride every connection, not just be run once at startup.
+    for (const listener of listeners) {
+      listener({ query: (sql) => queries.push(sql) });
+      listener({ query: (sql) => queries.push(sql) });
+    }
+
+    expect(queries).toEqual([READ_ONLY_SESSION_SQL, READ_ONLY_SESSION_SQL]);
+  });
+
+  it('asks Postgres itself to refuse writes, rather than trusting the caller', () => {
+    expect(READ_ONLY_SESSION_SQL).toBe('SET default_transaction_read_only = on');
+  });
+});
+
+describe('assertReadOnlySession', () => {
+  it('passes when Postgres reports the session read-only', () => {
+    expect(() => assertReadOnlySession([{ default_transaction_read_only: 'on' }])).not.toThrow();
+  });
+
+  it('refuses to run when the setting did not take', () => {
+    expect(() => assertReadOnlySession([{ default_transaction_read_only: 'off' }])).toThrow(
+      /not read-only/,
+    );
+  });
+
+  it('refuses to run when the check returned nothing at all', () => {
+    expect(() => assertReadOnlySession([])).toThrow(/not read-only/);
+  });
+});

--- a/packages/db/src/read-only-session.ts
+++ b/packages/db/src/read-only-session.ts
@@ -1,6 +1,6 @@
 /**
- * `SET`, not a promise from the caller. The census is run by a human holding
- * the production credential, so "it only reads" is enforced by the server:
+ * `SET`, not a promise from the caller. A read-only script is run by a human
+ * holding the production credential, so "it only reads" is enforced by the server:
  * every connection this pool opens starts its transactions read-only, and any
  * write — a bug, a future edit, a library doing something unexpected — fails
  * with `cannot execute ... in a read-only transaction` instead of succeeding.
@@ -16,11 +16,11 @@ interface ReadOnlyCapablePool {
 }
 
 /**
- * Nothing in `packages/db` advertises that a caller can flip the shared
- * migration pool read-only, so this stays local to the census while it is the
- * only read-only consumer. A second one is the signal to promote it to a
- * `getReadOnlyDb()` beside `getMigrationDb()`, where import order cannot
- * bypass it — a move, not a rewrite.
+ * Promoted here from the collab content census (`apps/web`) when the seed
+ * fidelity audit (`scripts/collab-seed-audit.ts`) became the second read-only
+ * consumer of the migration pool — a move, not a rewrite. Both scripts are run
+ * by a human holding the production credential, and both prove the guard took
+ * with `assertReadOnlySession` before their first real query.
  *
  * Registers the guard on a `pg.Pool` BEFORE it opens its first connection.
  * node-postgres queues queries per client, so the `SET` issued from `connect`

--- a/packages/editor/package.json
+++ b/packages/editor/package.json
@@ -73,10 +73,20 @@
       "import": "./dist/projection-errors.js",
       "default": "./dist/projection-errors.js"
     },
+    "./seed-fidelity": {
+      "types": "./dist/seed-fidelity.d.ts",
+      "import": "./dist/seed-fidelity.js",
+      "default": "./dist/seed-fidelity.js"
+    },
     "./simple-data-attr": {
       "types": "./dist/simple-data-attr.d.ts",
       "import": "./dist/simple-data-attr.js",
       "default": "./dist/simple-data-attr.js"
+    },
+    "./user-color": {
+      "types": "./dist/user-color.d.ts",
+      "import": "./dist/user-color.js",
+      "default": "./dist/user-color.js"
     },
     "./y-doc-to-blocks": {
       "types": "./dist/y-doc-to-blocks.d.ts",
@@ -137,8 +147,14 @@
       "projection-errors": [
         "./dist/projection-errors.d.ts"
       ],
+      "seed-fidelity": [
+        "./dist/seed-fidelity.d.ts"
+      ],
       "simple-data-attr": [
         "./dist/simple-data-attr.d.ts"
+      ],
+      "user-color": [
+        "./dist/user-color.d.ts"
       ],
       "y-doc-to-blocks": [
         "./dist/y-doc-to-blocks.d.ts"

--- a/packages/editor/package.json
+++ b/packages/editor/package.json
@@ -43,10 +43,20 @@
       "import": "./dist/collab-schema.js",
       "default": "./dist/collab-schema.js"
     },
+    "./djb2": {
+      "types": "./dist/djb2.d.ts",
+      "import": "./dist/djb2.js",
+      "default": "./dist/djb2.js"
+    },
     "./dom-workspace": {
       "types": "./dist/dom-workspace.d.ts",
       "import": "./dist/dom-workspace.js",
       "default": "./dist/dom-workspace.js"
+    },
+    "./html-element-names": {
+      "types": "./dist/html-element-names.d.ts",
+      "import": "./dist/html-element-names.js",
+      "default": "./dist/html-element-names.js"
     },
     "./html-to-ydoc": {
       "types": "./dist/html-to-ydoc.d.ts",
@@ -129,8 +139,14 @@
       "collab-schema": [
         "./dist/collab-schema.d.ts"
       ],
+      "djb2": [
+        "./dist/djb2.d.ts"
+      ],
       "dom-workspace": [
         "./dist/dom-workspace.d.ts"
+      ],
+      "html-element-names": [
+        "./dist/html-element-names.d.ts"
       ],
       "html-to-ydoc": [
         "./dist/html-to-ydoc.d.ts"

--- a/packages/editor/src/__tests__/seed-fidelity.test.ts
+++ b/packages/editor/src/__tests__/seed-fidelity.test.ts
@@ -21,9 +21,13 @@
 import { describe, it, expect } from 'vitest';
 import { htmlToPmDoc, describeHtmlLoss } from '../html-to-ydoc.js';
 import { pmDocToHtml } from '../y-doc-to-html.js';
+import { withDomWorkspace } from '../dom-workspace.js';
 import {
   ALLOWED_COSMETIC_ADDITIONS,
-  constructsOf,
+  PRINTABLE_ATTRIBUTE_VALUES,
+  VALUE_BEARING_ATTRIBUTES,
+  constructKeysOf,
+  contentFreeKey,
   constructDifference as difference,
 } from '../seed-fidelity.js';
 import {
@@ -31,6 +35,11 @@ import {
   CORPUS_CASES,
   corpusDocumentHtml,
 } from './support/construct-corpus.js';
+
+/** `constructKeysOf` over a markup string, in a throwaway workspace. */
+function constructsOf(html: string): Set<string> {
+  return withDomWorkspace((workspace) => constructKeysOf(workspace.parse(html)));
+}
 
 describe.each(CORPUS_CASES)(
   'seed fidelity: %s',
@@ -95,5 +104,28 @@ describe('the allowlist itself', () => {
     expect([...ALLOWED_COSMETIC_ADDITIONS].sort().filter((key) => !produced.includes(key))).toEqual(
       [],
     );
+  });
+});
+
+describe('printable attribute values', () => {
+  it('are a subset of the value-bearing attributes — a value that is never in a key needs no printability rule', () => {
+    expect([...PRINTABLE_ATTRIBUTE_VALUES].filter((name) => !VALUE_BEARING_ATTRIBUTES.has(name))).toEqual([]);
+  });
+
+  it('keep enumerations and fold prose, urls and ids back to presence', () => {
+    expect(contentFreeKey('attr:ul@data-type=taskList')).toBe('attr:ul@data-type=taskList');
+    expect(contentFreeKey('attr:td@colspan=2')).toBe('attr:td@colspan=2');
+    expect(contentFreeKey('attr:img@alt=a photo of Ada')).toBe('attr:img@alt');
+    expect(contentFreeKey('attr:a@href=https://x.test/ada-lovelace')).toBe('attr:a@href');
+    expect(contentFreeKey('attr:a@data-page-id=pg_1')).toBe('attr:a@data-page-id');
+    expect(contentFreeKey('el:img')).toBe('el:img');
+  });
+
+  it('every value-bearing attribute that is not printable is one whose value could be content or an identifier', () => {
+    // The complement is the list a reader should check when adding to either set.
+    expect([...VALUE_BEARING_ATTRIBUTES].filter((name) => !PRINTABLE_ATTRIBUTE_VALUES.has(name)).sort()).toEqual([
+      'alt', 'data-block-id', 'data-change-id', 'data-change-type', 'data-drive-id', 'data-file-id',
+      'data-page-id', 'data-role-id', 'data-user-id', 'href',
+    ]);
   });
 });

--- a/packages/editor/src/__tests__/seed-fidelity.test.ts
+++ b/packages/editor/src/__tests__/seed-fidelity.test.ts
@@ -131,17 +131,31 @@ describe('contentFreeKey', () => {
     expect(contentFreeKey('el:img')).toBe('el:img');
   });
 
-  it('folds prose, urls and ids back to presence', () => {
-    expect(contentFreeKey('attr:img@alt=a photo of Ada')).toBe('attr:img@alt');
-    expect(contentFreeKey('attr:a@href=https://x.test/ada-lovelace')).toBe('attr:a@href');
-    expect(contentFreeKey('attr:a@data-page-id=pg_1')).toBe('attr:a@data-page-id');
+  it('withholds prose, urls and ids while keeping the key marked as a VALUE key', () => {
+    // `=(withheld)` rather than the bare presence key: `constructKeysOf` emits
+    // both forms so a dropped attribute and a changed one stay distinguishable,
+    // and collapsing to presence here would undo that at the last step.
+    expect(contentFreeKey('attr:img@alt=a photo of Ada')).toBe('attr:img@alt=(withheld)');
+    expect(contentFreeKey('attr:a@href=https://x.test/ada-lovelace')).toBe('attr:a@href=(withheld)');
+    expect(contentFreeKey('attr:a@data-page-id=pg_1')).toBe('attr:a@data-page-id=(withheld)');
+    // The presence key is untouched, so the two remain different rows.
+    expect(contentFreeKey('attr:img@alt')).toBe('attr:img@alt');
   });
 
-  it('folds a printable attribute whose value is not one the schema renders', () => {
-    expect(contentFreeKey('attr:span@data-type=customer-name')).toBe('attr:span@data-type');
-    expect(contentFreeKey('attr:li@data-checked=SECRET')).toBe('attr:li@data-checked');
-    expect(contentFreeKey('attr:ol@start=SECRET_START')).toBe('attr:ol@start');
-    expect(contentFreeKey('attr:td@colspan=1234567')).toBe('attr:td@colspan');
+  it('withholds a printable attribute whose value is not one the schema renders', () => {
+    expect(contentFreeKey('attr:span@data-type=customer-name')).toBe('attr:span@data-type=(withheld)');
+    expect(contentFreeKey('attr:li@data-checked=SECRET')).toBe('attr:li@data-checked=(withheld)');
+    expect(contentFreeKey('attr:ol@start=SECRET_START')).toBe('attr:ol@start=(withheld)');
+    expect(contentFreeKey('attr:td@colspan=1234567')).toBe('attr:td@colspan=(withheld)');
+  });
+
+  it('never withholds a value into a key that is itself on the cosmetic allowlist', () => {
+    // Without the `=(withheld)` marker an author-typed `data-type` would print
+    // as `attr:a@data-type`, which IS allowlisted — a finding wearing the key
+    // of a non-finding.
+    for (const key of ['attr:a@data-type=customer-name', 'attr:ul@data-tight=maybe', 'attr:td@colspan=x']) {
+      expect(ALLOWED_COSMETIC_ADDITIONS.has(contentFreeKey(key)), key).toBe(false);
+    }
   });
 
   it('folds names the author could have typed: unknown tags, odd attribute names, custom properties', () => {
@@ -149,14 +163,34 @@ describe('contentFreeKey', () => {
     expect(contentFreeKey('attr:secret-tag@class')).toBe('text:unescaped-angle-bracket');
     expect(contentFreeKey('attr:p@secret_attr_name')).toBe('attr:p@(unrecognised-attribute)');
     expect(contentFreeKey('attr:p@secretattr')).toBe('attr:p@(unrecognised-attribute)');
-    expect(contentFreeKey('attr:p@data-secret=x')).toBe('attr:p@(unrecognised-attribute)');
+    expect(contentFreeKey('attr:p@data-secret=x')).toBe('attr:p@(unrecognised-attribute)=(withheld)');
     expect(contentFreeKey('attr:p@style:--secret-name')).toBe('attr:p@style:(unrecognised-property)');
     expect(contentFreeKey('attr:p@style:secret_prop')).toBe('attr:p@style:(unrecognised-property)');
     expect(contentFreeKey('attr:p@style:margin-top')).toBe('attr:p@style:margin-top');
   });
 
-  it('passes keys in neither form through unchanged', () => {
+  it('FAILS CLOSED on a key it cannot decompose, rather than handing back its input', () => {
+    // happy-dom builds a real element for a tag name starting with `@`, so a
+    // pasted FreeMarker directive or Slack mention produces `attr:@list@items`
+    // — which the attribute pattern cannot split, because its tag group needs
+    // one non-`@` character. Returning the input there printed a Slack user id
+    // and a full href straight into the report.
+    expect(contentFreeKey('attr:@u08jane.doe@email=jane.doe@acme.com')).toBe('text:unescaped-angle-bracket');
+    expect(contentFreeKey('attr:@list@items=payroll-2026-Q1.csv')).toBe('text:unescaped-angle-bracket');
+    expect(contentFreeKey('attr:@p@href=https://secret.example/a')).toBe('text:unescaped-angle-bracket');
+    expect(contentFreeKey('attr:@x@style:color')).toBe('text:unescaped-angle-bracket');
+    expect(contentFreeKey('not a key at all')).toBe('text:unescaped-angle-bracket');
+    // The marker itself is the one thing that survives, or folding would not
+    // be idempotent.
     expect(contentFreeKey('text:unescaped-angle-bracket')).toBe('text:unescaped-angle-bracket');
+    expect(contentFreeKey(contentFreeKey('attr:@list@items=x'))).toBe('text:unescaped-angle-bracket');
+  });
+
+  it('bounds every key it returns, so one document cannot pad the whole report', () => {
+    const long = 'a'.repeat(5000);
+    for (const key of [`el:${long}`, `attr:p@${long}`, `attr:p@style:${long}`, `attr:p@alt=${long}`, `attr:@${long}@x=${long}`]) {
+      expect(contentFreeKey(key).length, key.slice(0, 30)).toBeLessThanOrEqual(64);
+    }
   });
 });
 

--- a/packages/editor/src/__tests__/seed-fidelity.test.ts
+++ b/packages/editor/src/__tests__/seed-fidelity.test.ts
@@ -109,16 +109,7 @@ describe('the allowlist itself', () => {
 
 describe('printable attribute values', () => {
   it('are a subset of the value-bearing attributes — a value that is never in a key needs no printability rule', () => {
-    expect([...PRINTABLE_ATTRIBUTE_VALUES].filter((name) => !VALUE_BEARING_ATTRIBUTES.has(name))).toEqual([]);
-  });
-
-  it('keep enumerations and fold prose, urls and ids back to presence', () => {
-    expect(contentFreeKey('attr:ul@data-type=taskList')).toBe('attr:ul@data-type=taskList');
-    expect(contentFreeKey('attr:td@colspan=2')).toBe('attr:td@colspan=2');
-    expect(contentFreeKey('attr:img@alt=a photo of Ada')).toBe('attr:img@alt');
-    expect(contentFreeKey('attr:a@href=https://x.test/ada-lovelace')).toBe('attr:a@href');
-    expect(contentFreeKey('attr:a@data-page-id=pg_1')).toBe('attr:a@data-page-id');
-    expect(contentFreeKey('el:img')).toBe('el:img');
+    expect([...PRINTABLE_ATTRIBUTE_VALUES.keys()].filter((name) => !VALUE_BEARING_ATTRIBUTES.has(name))).toEqual([]);
   });
 
   it('every value-bearing attribute that is not printable is one whose value could be content or an identifier', () => {
@@ -127,5 +118,56 @@ describe('printable attribute values', () => {
       'alt', 'data-block-id', 'data-change-id', 'data-change-type', 'data-drive-id', 'data-file-id',
       'data-page-id', 'data-role-id', 'data-user-id', 'href',
     ]);
+  });
+});
+
+describe('contentFreeKey', () => {
+  it('keeps values the schema itself enumerates', () => {
+    expect(contentFreeKey('attr:ul@data-type=taskList')).toBe('attr:ul@data-type=taskList');
+    expect(contentFreeKey('attr:li@data-checked=true')).toBe('attr:li@data-checked=true');
+    expect(contentFreeKey('attr:td@colspan=2')).toBe('attr:td@colspan=2');
+    expect(contentFreeKey('attr:ol@start=7')).toBe('attr:ol@start=7');
+    expect(contentFreeKey('attr:p@style:text-align')).toBe('attr:p@style:text-align');
+    expect(contentFreeKey('el:img')).toBe('el:img');
+  });
+
+  it('folds prose, urls and ids back to presence', () => {
+    expect(contentFreeKey('attr:img@alt=a photo of Ada')).toBe('attr:img@alt');
+    expect(contentFreeKey('attr:a@href=https://x.test/ada-lovelace')).toBe('attr:a@href');
+    expect(contentFreeKey('attr:a@data-page-id=pg_1')).toBe('attr:a@data-page-id');
+  });
+
+  it('folds a printable attribute whose value is not one the schema renders', () => {
+    expect(contentFreeKey('attr:span@data-type=customer-name')).toBe('attr:span@data-type');
+    expect(contentFreeKey('attr:li@data-checked=SECRET')).toBe('attr:li@data-checked');
+    expect(contentFreeKey('attr:ol@start=SECRET_START')).toBe('attr:ol@start');
+    expect(contentFreeKey('attr:td@colspan=1234567')).toBe('attr:td@colspan');
+  });
+
+  it('folds names the author could have typed: unknown tags, odd attribute names, custom properties', () => {
+    expect(contentFreeKey('el:secret-tag')).toBe('text:unescaped-angle-bracket');
+    expect(contentFreeKey('attr:secret-tag@class')).toBe('text:unescaped-angle-bracket');
+    expect(contentFreeKey('attr:p@secret_attr_name')).toBe('attr:p@(unrecognised-attribute)');
+    expect(contentFreeKey('attr:p@secretattr')).toBe('attr:p@(unrecognised-attribute)');
+    expect(contentFreeKey('attr:p@data-secret=x')).toBe('attr:p@(unrecognised-attribute)');
+    expect(contentFreeKey('attr:p@style:--secret-name')).toBe('attr:p@style:(unrecognised-property)');
+    expect(contentFreeKey('attr:p@style:secret_prop')).toBe('attr:p@style:(unrecognised-property)');
+    expect(contentFreeKey('attr:p@style:margin-top')).toBe('attr:p@style:margin-top');
+  });
+
+  it('passes keys in neither form through unchanged', () => {
+    expect(contentFreeKey('text:unescaped-angle-bracket')).toBe('text:unescaped-angle-bracket');
+  });
+});
+
+describe('the corpus reports only recognised names', () => {
+  it('folds nothing the schema renders — every corpus key is already content-free', () => {
+    for (const fixture of CONSTRUCT_CORPUS) {
+      const rendered = constructsOf(pmDocToHtml(htmlToPmDoc(fixture.html)));
+      for (const key of rendered) {
+        if (VALUE_BEARING_ATTRIBUTES.has(/@([^=]+)=/u.exec(key)?.[1] ?? '') && !PRINTABLE_ATTRIBUTE_VALUES.has(/@([^=]+)=/u.exec(key)?.[1] ?? '')) continue;
+        expect(contentFreeKey(key), key).toBe(key);
+      }
+    }
   });
 });

--- a/packages/editor/src/__tests__/seed-fidelity.test.ts
+++ b/packages/editor/src/__tests__/seed-fidelity.test.ts
@@ -12,152 +12,25 @@
  *
  * The danger in relaxing an assertion is that the relaxation swallows a real
  * loss. So the tolerance is NOT a loose comparison — it is an explicit,
- * exhaustively-named allowlist (`ALLOWED_COSMETIC_ADDITIONS`) which the suite
- * also asserts is not larger than it needs to be. A rewrite that is not on the
+ * exhaustively-named allowlist (`ALLOWED_COSMETIC_ADDITIONS`, in
+ * `seed-fidelity.ts`, shared with `scripts/collab-seed-audit.ts` so the corpus
+ * and real documents are held to ONE list) which the suite also asserts is not
+ * larger than it needs to be. A rewrite that is not on the
  * list fails, whether it is new or newly noticed.
  */
 import { describe, it, expect } from 'vitest';
 import { htmlToPmDoc, describeHtmlLoss } from '../html-to-ydoc.js';
 import { pmDocToHtml } from '../y-doc-to-html.js';
-import { withDomWorkspace } from '../dom-workspace.js';
+import {
+  ALLOWED_COSMETIC_ADDITIONS,
+  constructsOf,
+  constructDifference as difference,
+} from '../seed-fidelity.js';
 import {
   CONSTRUCT_CORPUS,
   CORPUS_CASES,
   corpusDocumentHtml,
 } from './support/construct-corpus.js';
-
-/**
- * Every markup construct one pass through the schema is allowed to ADD.
- *
- * Each entry is a rewrite whose absence from the source is not information:
- *
- * - `a@target` / `a@rel` — `Link` stamps these on every anchor it renders.
- * - `a@data-type`, `span@data-type` — TipTap's node-name marker on a mention.
- * - `a@contenteditable`, `a@data-drive-id` — the AI mention dialect omits
- *   them; the node's own `renderHTML` always writes them.
- * - `ul@class`, `ul@data-tight` (`=true`) — `MarkdownTightLists` makes the
- *   tightness it INFERRED from the source (`!element.querySelector('p')`)
- *   explicit.
- * - `a@data-drive-id=` — the AI mention dialect carries no drive, and the
- *   node's `renderHTML` always writes the attribute, so it appears empty. The
- *   EMPTY value is the allowlisted one; a mention gaining a real drive id would
- *   produce a different key and fail.
- * - `p` — a bare `<li>text</li>` becomes `<li><p>text</p></li>`, because the
- *   schema's `listItem` content is `paragraph block*`.
- * - `label`, `input`, `input@type`, `input@checked`, `span`, `div` —
- *   `TaskItem`'s rendered checkbox. The state itself lives in
- *   `li@data-checked`, which the source already carried.
- * - `pre@class` — `CodeBlockNode` mirrors `language-x` onto the `<pre>`.
- * - `table@style`, `colgroup`, `col`, `col@style` (and their `style:min-width`
- *   forms) — TipTap's table column model, emitted as `min-width` from the
- *   schema's own defaults.
- *
- * The `=pageMention` entries are the VALUE-bearing form of the `data-type`
- * marker above. They are listed separately, and deliberately: it is the value
- * that carries the meaning, so `data-type` changing from `taskList` to
- * `taskItem` must fail rather than be absorbed by a bare `attr@data-type`.
- *
- * Nothing here changes what the document SAYS. An addition outside this set is
- * a change to the stored dialect and must be looked at, not tolerated.
- */
-const ALLOWED_COSMETIC_ADDITIONS: ReadonlySet<string> = new Set([
-  'attr:a@contenteditable',
-  'attr:a@data-drive-id',
-  'attr:a@data-drive-id=',
-  'attr:a@data-type',
-  'attr:a@data-type=pageMention',
-  'attr:a@rel',
-  'attr:a@target',
-  'attr:col@style',
-  'attr:col@style:min-width',
-  'attr:input@checked',
-  'attr:input@type',
-  'attr:pre@class',
-  'attr:span@data-type',
-  'attr:span@data-type=pageMention',
-  'attr:table@style',
-  'attr:table@style:min-width',
-  'attr:ul@class',
-  'attr:ul@data-tight',
-  'attr:ul@data-tight=true',
-  'el:col',
-  'el:colgroup',
-  'el:div',
-  'el:input',
-  'el:label',
-  'el:p',
-  'el:span',
-]);
-
-/**
- * Markup constructs as comparable keys: `el:<tag>`, `attr:<tag>@<name>`, and —
- * for the two attributes whose VALUE is the construct — `attr:<tag>@<name>=<value>`.
- * Deliberately not the markup string: a set difference names WHICH construct
- * moved, where a string diff only says "changed".
- *
- * `style` is split per CSS property, and the attributes in
- * `VALUE_BEARING_ATTRIBUTES` carry their value, because a bare `attr:p@style`
- * merges the question with the answer. `text-align:center` becoming
- * `text-align:left`, `data-type="taskList"` becoming `taskItem`, a rewritten
- * `href`, a `data-page-id` pointing at a different page, or `start="7"` becoming
- * `start="1"` would otherwise all be invisible to a gate whose entire job is
- * naming the construct that moved — and the corpus has fixtures for every one
- * of them.
- *
- * Presence-only keys are kept alongside the value keys, so a DROPPED attribute
- * and a CHANGED one are distinguishable in the diff.
- */
-const VALUE_BEARING_ATTRIBUTES: ReadonlySet<string> = new Set([
-  'data-type',
-  'href',
-  'data-page-id',
-  'data-user-id',
-  'data-role-id',
-  'data-drive-id',
-  'data-file-id',
-  'data-block-id',
-  'data-change-id',
-  'data-change-type',
-  'data-checked',
-  'data-tight',
-  'start',
-  'colspan',
-  'rowspan',
-  'alt',
-]);
-function constructsOf(html: string): Set<string> {
-  return withDomWorkspace((workspace) => {
-    const keys = new Set<string>();
-    const walk = (element: Element): void => {
-      const tag = element.tagName.toLowerCase();
-      keys.add(`el:${tag}`);
-      for (const name of element.getAttributeNames()) {
-        keys.add(`attr:${tag}@${name}`);
-        if (VALUE_BEARING_ATTRIBUTES.has(name)) {
-          keys.add(`attr:${tag}@${name}=${element.getAttribute(name) ?? ''}`);
-        }
-        if (name === 'style') {
-          for (const declaration of (element.getAttribute(name) ?? '').split(';')) {
-            const property = declaration.split(':')[0]?.trim().toLowerCase();
-            if (property) {
-              keys.add(`attr:${tag}@style:${property}`);
-            }
-          }
-        }
-      }
-      for (const child of Array.from(element.children)) {
-        walk(child);
-      }
-    };
-    for (const child of Array.from(workspace.parse(html).children)) {
-      walk(child);
-    }
-    return keys;
-  });
-}
-
-const difference = (a: Set<string>, b: Set<string>): string[] =>
-  [...a].filter((key) => !b.has(key)).sort();
 
 describe.each(CORPUS_CASES)(
   'seed fidelity: %s',

--- a/packages/editor/src/__tests__/support/construct-corpus.ts
+++ b/packages/editor/src/__tests__/support/construct-corpus.ts
@@ -89,6 +89,13 @@ export const CONSTRUCT_CORPUS: readonly ConstructFixture[] = [
     text: ['outer', 'inner', 'deep'],
   },
   {
+    key: 'bare-ordered-list',
+    // The `<ol>` twin of `bare-list`: `MarkdownTightLists` infers and then
+    // writes `tight` on ordered lists too.
+    html: '<ol><li>first</li><li>second</li></ol>',
+    text: ['first', 'second'],
+  },
+  {
     key: 'ordered-list-with-start',
     html: '<ol start="7"><li><p>seven</p></li><li><p>eight</p></li></ol>',
     text: ['seven', 'eight'],
@@ -129,6 +136,15 @@ export const CONSTRUCT_CORPUS: readonly ConstructFixture[] = [
       '<tr><th colspan="1" rowspan="1"><p>Name</p></th><th colspan="1" rowspan="1"><p>Role</p></th></tr>' +
       '<tr><td colspan="1" rowspan="1"><p>Ada</p></td><td colspan="1" rowspan="1"><p>Engineer</p></td></tr>' +
       '</tbody></table>',
+    text: ['Name', 'Role', 'Ada', 'Engineer'],
+  },
+  {
+    key: 'bare-table',
+    // No `<tbody>`, no `colspan`/`rowspan`, bare cell text: the dialect a
+    // hand-written or imported table arrives in. The schema fills in every
+    // one of those (`colspan="1"`, `rowspan="1"`, `<p>` per cell), which is
+    // what earns those entries their place on the cosmetic allowlist.
+    html: '<table><tr><th>Name</th><th>Role</th></tr><tr><td>Ada</td><td>Engineer</td></tr></table>',
     text: ['Name', 'Role', 'Ada', 'Engineer'],
   },
   {

--- a/packages/editor/src/__tests__/user-color.test.ts
+++ b/packages/editor/src/__tests__/user-color.test.ts
@@ -46,6 +46,10 @@ describe('userColor', () => {
     const clientA = await import('../user-color.js');
     vi.resetModules();
     const clientB = await import('../user-color.js');
+    // Client A has met other users first; client B meets usr_beta cold. A
+    // first-come assignment table would give them different answers.
+    clientA.userColor('usr_gamma');
+    clientA.userColor('usr_delta');
     expect(clientA.userColor('usr_beta')).toBe(clientB.userColor('usr_beta'));
   });
 

--- a/packages/editor/src/__tests__/user-color.test.ts
+++ b/packages/editor/src/__tests__/user-color.test.ts
@@ -9,6 +9,7 @@ import { userColor, USER_COLOR_PALETTE } from '../user-color.js';
 
 /** WCAG 2.x relative luminance, written out here rather than imported so the test does not share code with the module it checks. */
 function relativeLuminance(hex: string): number {
+  /** One sRGB channel, linearised. */
   const channel = (index: number): number => {
     const c = Number.parseInt(hex.slice(1 + index * 2, 3 + index * 2), 16) / 255;
     return c <= 0.04045 ? c / 12.92 : ((c + 0.055) / 1.055) ** 2.4;
@@ -16,6 +17,7 @@ function relativeLuminance(hex: string): number {
   return 0.2126 * channel(0) + 0.7152 * channel(1) + 0.0722 * channel(2);
 }
 
+/** WCAG contrast ratio between two `#rrggbb` colours, lighter over darker. */
 function contrastRatio(a: string, b: string): number {
   const [lighter, darker] = [relativeLuminance(a), relativeLuminance(b)].sort((x, y) => y - x);
   return (lighter + 0.05) / (darker + 0.05);

--- a/packages/editor/src/__tests__/user-color.test.ts
+++ b/packages/editor/src/__tests__/user-color.test.ts
@@ -1,0 +1,96 @@
+/**
+ * `userColor(userId)` — one deterministic colour per user, so the avatar ring
+ * in the presence roster and the `CollaborationCaret` label agree with zero
+ * coordination between them. Two clients that have never spoken must pick
+ * the same colour for the same user, so the only input is the id.
+ */
+import { describe, it, expect, vi } from 'vitest';
+import { userColor, USER_COLOR_PALETTE } from '../user-color.js';
+
+/** WCAG 2.x relative luminance, written out here rather than imported so the test does not share code with the module it checks. */
+function relativeLuminance(hex: string): number {
+  const channel = (index: number): number => {
+    const c = Number.parseInt(hex.slice(1 + index * 2, 3 + index * 2), 16) / 255;
+    return c <= 0.04045 ? c / 12.92 : ((c + 0.055) / 1.055) ** 2.4;
+  };
+  return 0.2126 * channel(0) + 0.7152 * channel(1) + 0.0722 * channel(2);
+}
+
+function contrastRatio(a: string, b: string): number {
+  const [lighter, darker] = [relativeLuminance(a), relativeLuminance(b)].sort((x, y) => y - x);
+  return (lighter + 0.05) / (darker + 0.05);
+}
+
+/**
+ * The two backgrounds a caret or ring is drawn over. Light is pure white —
+ * the worst case, since the app's `--background` (oklch 0.995) is darker than
+ * that. Dark is the app's `--card` (oklch 0.23 0 0 ≈ #1d1d1d), the LIGHTEST
+ * dark surface: contrast against a darker one is always higher, so passing
+ * here passes everywhere.
+ */
+const LIGHT_BACKGROUND = '#ffffff';
+const DARK_BACKGROUND = '#1d1d1d';
+
+/** WCAG 1.4.11 (non-text contrast) — the bar for UI components and graphical objects, which is what a caret and an avatar ring are. */
+const MINIMUM_UI_CONTRAST = 3;
+
+describe('userColor', () => {
+  it('gives the same userId the same colour on every call', () => {
+    expect(userColor('usr_alpha')).toBe(userColor('usr_alpha'));
+  });
+
+  it('gives the same userId the same colour on two clients that share nothing but the module', async () => {
+    // A fresh module instance per "client": no cache, no process-level state
+    // can be what makes the two answers agree.
+    vi.resetModules();
+    const clientA = await import('../user-color.js');
+    vi.resetModules();
+    const clientB = await import('../user-color.js');
+    expect(clientA.userColor('usr_beta')).toBe(clientB.userColor('usr_beta'));
+  });
+
+  it('is pinned: a change to the hash or the palette changes every existing user’s colour', () => {
+    // A snapshot, deliberately. Colours are shown to people who learn them;
+    // silently re-hashing everyone is a visible regression, so it must be a
+    // visible diff here first.
+    expect(userColor('usr_1')).toBe('#558920');
+    expect(userColor('usr_2')).toBe('#218f21');
+    expect(userColor('')).toBe('#218d57');
+  });
+
+  it('always answers with a palette member as lowercase #rrggbb', () => {
+    for (const id of ['', 'a', 'usr_1', 'clh0000000000000000000000', '🙂', 'x'.repeat(500)]) {
+      const color = userColor(id);
+      expect(color).toMatch(/^#[0-9a-f]{6}$/);
+      expect(USER_COLOR_PALETTE).toContain(color);
+    }
+  });
+
+  it('spreads users across the whole palette rather than a corner of it', () => {
+    const seen = new Set<string>();
+    for (let i = 0; i < 200; i += 1) {
+      seen.add(userColor(`usr_${i}`));
+    }
+    expect(seen.size).toBe(USER_COLOR_PALETTE.length);
+  });
+
+  it('distinguishes ids that a weak hash would collide', () => {
+    // Same characters, different order — a sum-of-char-codes hash maps these
+    // to one colour.
+    expect(userColor('usr_ab')).not.toBe(userColor('usr_ba'));
+  });
+});
+
+describe('USER_COLOR_PALETTE', () => {
+  it.each(USER_COLOR_PALETTE)('%s meets 3:1 against the light theme background', (color) => {
+    expect(contrastRatio(color, LIGHT_BACKGROUND)).toBeGreaterThanOrEqual(MINIMUM_UI_CONTRAST);
+  });
+
+  it.each(USER_COLOR_PALETTE)('%s meets 3:1 against the dark theme background', (color) => {
+    expect(contrastRatio(color, DARK_BACKGROUND)).toBeGreaterThanOrEqual(MINIMUM_UI_CONTRAST);
+  });
+
+  it('has no duplicate entries', () => {
+    expect(new Set(USER_COLOR_PALETTE).size).toBe(USER_COLOR_PALETTE.length);
+  });
+});

--- a/packages/editor/src/collab-schema.ts
+++ b/packages/editor/src/collab-schema.ts
@@ -369,12 +369,21 @@ export function projectSchema(schema: Schema): { nodes: ProjectedSpec[]; marks: 
  * server, future seed scripts).
  */
 export function hashProjection(projection: unknown): string {
-  const json = JSON.stringify(projection);
+  return djb2(JSON.stringify(projection)).toString(16);
+}
+
+/**
+ * djb2 over UTF-16 code units, as an unsigned 32-bit integer. Shared with
+ * `userColor` (`user-color.ts`) for the same reasons it is used here: no
+ * `node:crypto`, identical in the browser and in Node, and nothing but the
+ * string as input.
+ */
+export function djb2(input: string): number {
   let hash = 5381;
-  for (let i = 0; i < json.length; i += 1) {
-    hash = (hash * 33 + json.charCodeAt(i)) | 0;
+  for (let i = 0; i < input.length; i += 1) {
+    hash = (hash * 33 + input.charCodeAt(i)) | 0;
   }
-  return (hash >>> 0).toString(16);
+  return hash >>> 0;
 }
 
 /**

--- a/packages/editor/src/collab-schema.ts
+++ b/packages/editor/src/collab-schema.ts
@@ -12,6 +12,7 @@ import { CodeBlockNode } from './code-block-node.js';
 import { BlockId } from './block-id.js';
 import { CommentMark, InsertionMark, DeletionMark } from './collab-marks.js';
 import { ImageNode } from './image-node.js';
+import { djb2 } from './djb2.js';
 
 /**
  * Node-safe by contract: no React, no `document`/`window` at module-eval
@@ -370,20 +371,6 @@ export function projectSchema(schema: Schema): { nodes: ProjectedSpec[]; marks: 
  */
 export function hashProjection(projection: unknown): string {
   return djb2(JSON.stringify(projection)).toString(16);
-}
-
-/**
- * djb2 over UTF-16 code units, as an unsigned 32-bit integer. Shared with
- * `userColor` (`user-color.ts`) for the same reasons it is used here: no
- * `node:crypto`, identical in the browser and in Node, and nothing but the
- * string as input.
- */
-export function djb2(input: string): number {
-  let hash = 5381;
-  for (let i = 0; i < input.length; i += 1) {
-    hash = (hash * 33 + input.charCodeAt(i)) | 0;
-  }
-  return hash >>> 0;
 }
 
 /**

--- a/packages/editor/src/djb2.ts
+++ b/packages/editor/src/djb2.ts
@@ -1,0 +1,17 @@
+/**
+ * djb2 over UTF-16 code units, as an unsigned 32-bit integer.
+ *
+ * Deliberately non-cryptographic and dependency-free: it must run identically
+ * in the browser (no `node:crypto`) and in Node, with nothing but the string
+ * as input. Shared by `SCHEMA_HASH` (`collab-schema.ts`, a drift detector)
+ * and `userColor` (`user-color.ts`, a palette index) — neither is a security
+ * boundary. In its own module so that a colour helper does not have to import
+ * the schema, and everything it pulls in, for six lines.
+ */
+export function djb2(input: string): number {
+  let hash = 5381;
+  for (let i = 0; i < input.length; i += 1) {
+    hash = (hash * 33 + input.charCodeAt(i)) | 0;
+  }
+  return hash >>> 0;
+}

--- a/packages/editor/src/html-element-names.ts
+++ b/packages/editor/src/html-element-names.ts
@@ -1,0 +1,40 @@
+/**
+ * Real HTML element names. Anything outside this set that a parser produced is
+ * not markup the author wrote — it is an unescaped `<` in prose or a code
+ * sample (`ActionResult<void>`, `Set<string>`, `<task-id>`), which every
+ * happy-dom parse turns into an element of its own.
+ *
+ * Lives in this package because three consumers need the exact same "does
+ * this contain real HTML" answer: the content census and the
+ * mislabelled-content-mode backfill in `apps/web` (which re-export it from
+ * `lib/editor/document-content-format.ts`), and the seed fidelity audit in
+ * root `scripts/`, which cannot import `apps/web`. A tagless-page count
+ * measured with a different definition is not the same count.
+ */
+export const HTML_ELEMENT_NAMES: ReadonlySet<string> = new Set<string>([
+  'a','abbr','address','area','article','aside','audio','b','base','bdi','bdo','blockquote','body',
+  'br','button','canvas','caption','cite','code','col','colgroup','data','datalist','dd','del',
+  'details','dfn','dialog','div','dl','dt','em','embed','fieldset','figcaption','figure','footer',
+  'form','h1','h2','h3','h4','h5','h6','head','header','hgroup','hr','html','i','iframe','img',
+  'input','ins','kbd','label','legend','li','link','main','map','mark','menu','meta','meter','nav',
+  'noscript','object','ol','optgroup','option','output','p','param','picture','pre','progress','q',
+  'rp','rt','ruby','s','samp','script','search','section','select','slot','small','source','span',
+  'strong','style','sub','summary','sup','table','tbody','td','template','textarea','tfoot','th',
+  'thead','time','title','tr','track','u','ul','var','video','wbr','svg','math',
+]);
+
+/** Single marker for parser artefacts of unescaped `<` in text. */
+export const UNESCAPED_ANGLE_BRACKET_KEY = 'text:unescaped-angle-bracket';
+
+/**
+ * Whether `container` holds at least one element the author could have
+ * written as HTML. A page that has none is markdown or plain text — whatever
+ * its `contentMode` column says — and seeding it through the HTML path
+ * flattens it into one paragraph, permanently.
+ */
+export function hasRealHtmlElement(container: Element): boolean {
+  for (const element of Array.from(container.querySelectorAll('*'))) {
+    if (HTML_ELEMENT_NAMES.has(element.tagName.toLowerCase())) return true;
+  }
+  return false;
+}

--- a/packages/editor/src/html-to-ydoc.ts
+++ b/packages/editor/src/html-to-ydoc.ts
@@ -169,8 +169,8 @@ export function parseHtmlElementUnchecked(source: HTMLElement): PmNode {
  * gets wrapped in `<p>`; `style` declarations reorder and requote. None of
  * that is loss, and a byte-equality test here would send its next reader off
  * to "fix" normalisation that is not broken. The allowlist of those rewrites
- * is explicit in `__tests__/seed-fidelity.test.ts` rather than expressed as a
- * tolerance, so a real loss cannot be rounded away by a loose comparison.
+ * is explicit in `seed-fidelity.ts` rather than expressed as a tolerance, so
+ * a real loss cannot be rounded away by a loose comparison.
  */
 export function htmlToPmDoc(html: string): PmNode {
   return withDomWorkspace((workspace) => {

--- a/packages/editor/src/html-to-ydoc.ts
+++ b/packages/editor/src/html-to-ydoc.ts
@@ -91,7 +91,7 @@ function parseAndDiagnose(
     }
   }
 
-  const doc = parseIn(source);
+  const doc = parseHtmlElementUnchecked(source);
   const reasons: string[] = [];
 
   const sourceText = visibleCharacters(source.textContent ?? '');
@@ -119,6 +119,14 @@ function parseAndDiagnose(
 }
 
 /**
+ * The parse itself, with NO loss check — the one step `htmlToPmDoc` wraps.
+ *
+ * Exported for surveys only: `scripts/collab-seed-audit.ts` needs the
+ * document a lossy page parses TO, so it can name what was lost, and
+ * `htmlToPmDoc` throws on exactly those pages. Nothing that seeds may call
+ * this; the gate is `htmlToPmDoc`/`htmlToYDoc`, and bypassing it is how a
+ * lossy document becomes permanent.
+ *
  * `preserveWhitespace: 'full'` is deliberately NOT passed. The schema's own
  * `codeBlock` carries `whitespace: 'pre'`, so ProseMirror already preserves
  * whitespace exactly where it is significant; forcing it document-wide would
@@ -129,7 +137,7 @@ function parseAndDiagnose(
  * global `document`, which is what lets this run in a Node service with no DOM
  * installed process-wide.
  */
-function parseIn(source: HTMLElement): PmNode {
+export function parseHtmlElementUnchecked(source: HTMLElement): PmNode {
   return PmDOMParser.fromSchema(collabSchema()).parse(source);
 }
 

--- a/packages/editor/src/html-to-ydoc.ts
+++ b/packages/editor/src/html-to-ydoc.ts
@@ -36,7 +36,16 @@ const TEXTLESS_CONTENT_ELEMENTS: Readonly<Record<string, string | null>> = {
  * content, and their text is not prose. Removed from the source before the
  * text comparison, or a `<style>` block's CSS reads as lost text.
  */
-const NON_CONTENT_ELEMENTS = ['script', 'style', 'noscript', 'template'];
+export const NON_CONTENT_ELEMENTS: readonly string[] = ['script', 'style', 'noscript', 'template'];
+
+/** Removes `NON_CONTENT_ELEMENTS` from `root` in place — what the seed parse sees is `root` after this. */
+export function stripNonContentElements(root: HTMLElement): void {
+  for (const tag of NON_CONTENT_ELEMENTS) {
+    for (const element of Array.from(root.querySelectorAll(tag))) {
+      element.remove();
+    }
+  }
+}
 
 /**
  * Whitespace is stripped, not normalised, before comparing text.
@@ -46,7 +55,7 @@ const NON_CONTENT_ELEMENTS = ['script', 'style', 'noscript', 'template'];
  * invariant explicitly tolerates. What must not change is the sequence of
  * visible characters.
  */
-function visibleCharacters(text: string): string {
+export function visibleCharacters(text: string): string {
   return text.replace(/\s+/gu, '');
 }
 
@@ -85,13 +94,19 @@ function parseAndDiagnose(
   workspace: DomWorkspace,
 ): { doc: PmNode; reasons: string[] } {
   const source = workspace.parse(html);
-  for (const tag of NON_CONTENT_ELEMENTS) {
-    for (const element of Array.from(source.querySelectorAll(tag))) {
-      element.remove();
-    }
-  }
-
+  stripNonContentElements(source);
   const doc = parseHtmlElementUnchecked(source);
+  return { doc, reasons: describeParseLoss(source, doc) };
+}
+
+/**
+ * The gate's verdict on an already-parsed page: what `doc` lost relative to
+ * `source` (which must already have had `stripNonContentElements` applied).
+ * Exported so a survey that has done the parse itself — the seed fidelity
+ * audit — gets the gate's OWN reasons without re-parsing the page, and can
+ * never drift from what `htmlToPmDoc` would decide.
+ */
+export function describeParseLoss(source: HTMLElement, doc: PmNode): string[] {
   const reasons: string[] = [];
 
   const sourceText = visibleCharacters(source.textContent ?? '');
@@ -115,7 +130,7 @@ function parseAndDiagnose(
     }
   }
 
-  return { doc, reasons };
+  return reasons;
 }
 
 /**

--- a/packages/editor/src/html-to-ydoc.ts
+++ b/packages/editor/src/html-to-ydoc.ts
@@ -59,6 +59,7 @@ export function visibleCharacters(text: string): string {
   return text.replace(/\s+/gu, '');
 }
 
+/** How many nodes of `typeName` the parsed document holds — the survivor count for a textless element. */
 function countNodesOfType(doc: PmNode, typeName: string): number {
   let count = 0;
   doc.descendants((node) => {

--- a/packages/editor/src/seed-fidelity.ts
+++ b/packages/editor/src/seed-fidelity.ts
@@ -177,6 +177,8 @@ export const KNOWN_STYLE_PROPERTIES: ReadonlySet<string> = new Set([
 
 const UNRECOGNISED_ATTRIBUTE = '(unrecognised-attribute)';
 const UNRECOGNISED_PROPERTY = '(unrecognised-property)';
+/** Stands in for an attribute value that is the author's text rather than the schema's. */
+const WITHHELD_VALUE = '(withheld)';
 
 /**
  * A construct key with everything the author could have typed removed:
@@ -196,7 +198,17 @@ export function contentFreeKey(key: string): string {
     return HTML_ELEMENT_NAMES.has(element[1]) ? key : UNESCAPED_ANGLE_BRACKET_KEY;
   }
   const attribute = /^attr:([^@]+)@([^=]+)(?:=(.*))?$/su.exec(key);
-  if (!attribute) return key;
+  // FAIL CLOSED. A key this cannot decompose is not a key this can vouch for,
+  // and handing back the input is how a sanitiser leaks. It is reachable, not
+  // theoretical: happy-dom builds a real element for a tag name starting with
+  // `@` — a pasted FreeMarker directive (`<@list items="payroll.csv">`) or a
+  // Slack mention (`<@U08JANE.DOE email="...">`) — and the tag group above
+  // needs one non-`@` character, so those keys fall straight through. They
+  // came from an unescaped `<` in prose, which is exactly what the marker is
+  // for. It also makes folding idempotent for free: the marker itself is not
+  // an `el:`/`attr:` key, so re-folding one returns it unchanged. A separate
+  // guard for that was measurably dead — removing it changed no test.
+  if (!attribute) return UNESCAPED_ANGLE_BRACKET_KEY;
   const [, tag, rawName, value] = attribute;
   if (!HTML_ELEMENT_NAMES.has(tag)) return UNESCAPED_ANGLE_BRACKET_KEY;
 
@@ -208,7 +220,13 @@ export function contentFreeKey(key: string): string {
   const name = KNOWN_ATTRIBUTE_NAMES.has(rawName) ? rawName : UNRECOGNISED_ATTRIBUTE;
   if (value === undefined) return `attr:${tag}@${name}`;
   const printable = PRINTABLE_ATTRIBUTE_VALUES.get(name);
-  return printable?.(value) ? `attr:${tag}@${name}=${value}` : `attr:${tag}@${name}`;
+  // A withheld value keeps the `=` marker. `constructKeysOf` emits the
+  // presence key and the value key side by side so that an attribute the
+  // schema DROPPED and one whose value it CHANGED stay distinguishable;
+  // folding a withheld value down to the bare presence key would collapse
+  // that distinction at the last step, and would also let a key outside
+  // `ALLOWED_COSMETIC_ADDITIONS` print as one that is on it.
+  return printable?.(value) ? `attr:${tag}@${name}=${value}` : `attr:${tag}@${name}=${WITHHELD_VALUE}`;
 }
 
 /**

--- a/packages/editor/src/seed-fidelity.ts
+++ b/packages/editor/src/seed-fidelity.ts
@@ -231,6 +231,7 @@ export function contentFreeKey(key: string): string {
  */
 export function constructKeysOf(root: Element): Set<string> {
   const keys = new Set<string>();
+  /** Depth-first over the element tree, adding every construct each element carries. */
   const walk = (element: Element): void => {
     const tag = element.tagName.toLowerCase();
     keys.add(`el:${tag}`);

--- a/packages/editor/src/seed-fidelity.ts
+++ b/packages/editor/src/seed-fidelity.ts
@@ -1,5 +1,3 @@
-import { withDomWorkspace } from './dom-workspace.js';
-
 /**
  * The seed-fidelity vocabulary: markup constructs as comparable keys, and the
  * one allowlist of rewrites a pass through the frozen schema is permitted to
@@ -129,6 +127,35 @@ export const VALUE_BEARING_ATTRIBUTES: ReadonlySet<string> = new Set([
 ]);
 
 /**
+ * The subset of `VALUE_BEARING_ATTRIBUTES` whose values are safe to PRINT:
+ * enumerations and small integers the schema itself defines. Everything else
+ * on that list — `href`, `alt`, the `data-*-id` family — is user content or
+ * an identifier, and `contentFreeKey` folds it back to presence before a key
+ * reaches a terminal. Declared beside the list it partitions so adding a
+ * value-bearing attribute forces the printability decision in the same diff.
+ */
+export const PRINTABLE_ATTRIBUTE_VALUES: ReadonlySet<string> = new Set([
+  'data-type',
+  'data-checked',
+  'data-tight',
+  'start',
+  'colspan',
+  'rowspan',
+]);
+
+/**
+ * A construct key with any non-printable value removed. The COMPARISON must
+ * run on the valued form (`ALLOWED_COSMETIC_ADDITIONS` names
+ * `attr:a@data-drive-id=` and the `=1`/`=true` forms); only what is REPORTED
+ * from real documents goes through here.
+ */
+export function contentFreeKey(key: string): string {
+  const valued = /^(attr:[^@]+@)([^=]+)=/u.exec(key);
+  if (!valued) return key;
+  return PRINTABLE_ATTRIBUTE_VALUES.has(valued[2]) ? key : `${valued[1]}${valued[2]}`;
+}
+
+/**
  * The markup under `root` as comparable keys: `el:<tag>`,
  * `attr:<tag>@<name>`, `attr:<tag>@<name>=<value>` for the value-bearing
  * attributes, and `attr:<tag>@style:<property>` per inline CSS property.
@@ -144,7 +171,7 @@ export const VALUE_BEARING_ATTRIBUTES: ReadonlySet<string> = new Set([
  * changed alt is exactly what the corpus test has to see. `alt` is prose. A
  * consumer that PRINTS keys from real documents (`scripts/collab-seed-audit.ts`)
  * folds every value except the schema's own enumerations back to the presence
- * form before tallying; see `contentFreeKey` there.
+ * form before tallying; see `contentFreeKey` below.
  */
 export function constructKeysOf(root: Element): Set<string> {
   const keys = new Set<string>();
@@ -173,11 +200,6 @@ export function constructKeysOf(root: Element): Set<string> {
     walk(child);
   }
   return keys;
-}
-
-/** `constructKeysOf` over a markup string, in a throwaway workspace. */
-export function constructsOf(html: string): Set<string> {
-  return withDomWorkspace((workspace) => constructKeysOf(workspace.parse(html)));
 }
 
 /** Keys in `a` that `b` lacks, sorted — the "what moved" half of every comparison here. */

--- a/packages/editor/src/seed-fidelity.ts
+++ b/packages/editor/src/seed-fidelity.ts
@@ -1,3 +1,5 @@
+import { HTML_ELEMENT_NAMES, UNESCAPED_ANGLE_BRACKET_KEY } from './html-element-names.js';
+
 /**
  * The seed-fidelity vocabulary: markup constructs as comparable keys, and the
  * one allowlist of rewrites a pass through the frozen schema is permitted to
@@ -127,32 +129,86 @@ export const VALUE_BEARING_ATTRIBUTES: ReadonlySet<string> = new Set([
 ]);
 
 /**
- * The subset of `VALUE_BEARING_ATTRIBUTES` whose values are safe to PRINT:
- * enumerations and small integers the schema itself defines. Everything else
- * on that list — `href`, `alt`, the `data-*-id` family — is user content or
- * an identifier, and `contentFreeKey` folds it back to presence before a key
- * reaches a terminal. Declared beside the list it partitions so adding a
- * value-bearing attribute forces the printability decision in the same diff.
+ * The subset of `VALUE_BEARING_ATTRIBUTES` whose values may be PRINTED, each
+ * with the validator its value must pass first. These are the schema's own
+ * enumerations and small integers; a value that fails its validator is
+ * user-typed (`data-type="customer-name"`) and is folded to presence.
+ * Everything else on the value-bearing list — `href`, `alt`, the `data-*-id`
+ * family — is user content or an identifier and is never printed. Declared
+ * beside the list it partitions so adding a value-bearing attribute forces the
+ * printability decision in the same diff.
  */
-export const PRINTABLE_ATTRIBUTE_VALUES: ReadonlySet<string> = new Set([
-  'data-type',
-  'data-checked',
-  'data-tight',
-  'start',
-  'colspan',
-  'rowspan',
+export const PRINTABLE_ATTRIBUTE_VALUES: ReadonlyMap<string, (value: string) => boolean> = new Map([
+  ['data-type', (value: string) => SCHEMA_DATA_TYPES.has(value)],
+  ['data-checked', (value: string) => value === 'true' || value === 'false'],
+  ['data-tight', (value: string) => value === 'true' || value === 'false'],
+  ['start', (value: string) => /^\d{1,6}$/u.test(value)],
+  ['colspan', (value: string) => /^\d{1,6}$/u.test(value)],
+  ['rowspan', (value: string) => /^\d{1,6}$/u.test(value)],
 ]);
 
+/** Every `data-type` value a node in the frozen schema renders. */
+export const SCHEMA_DATA_TYPES: ReadonlySet<string> = new Set(['taskList', 'taskItem', 'pageMention']);
+
 /**
- * A construct key with any non-printable value removed. The COMPARISON must
- * run on the valued form (`ALLOWED_COSMETIC_ADDITIONS` names
- * `attr:a@data-drive-id=` and the `=1`/`=true` forms); only what is REPORTED
- * from real documents goes through here.
+ * The NAMES the report may print — closed lists, not a shape. A parser turns
+ * `Set<string>` in prose into a `<string>` element and `<p note=...>` into an
+ * attribute, so a name is as much under the author's control as a value is,
+ * and any lower-case token would print `secretattr`. Tags must be real HTML
+ * (`HTML_ELEMENT_NAMES`); attributes and CSS properties must be ones the
+ * frozen schema reads or writes, or common HTML the census has already
+ * reported on. The corpus test asserts every attribute and property the
+ * corpus produces is on these lists, so they cannot go stale silently.
+ */
+export const KNOWN_ATTRIBUTE_NAMES: ReadonlySet<string> = new Set([
+  'alt', 'checked', 'class', 'colspan', 'contenteditable', 'dir', 'height', 'href', 'id', 'lang',
+  'rel', 'rowspan', 'spellcheck', 'src', 'start', 'style', 'target', 'title', 'type', 'width',
+  'data-author-id', 'data-block-id', 'data-change-id', 'data-change-type', 'data-checked',
+  'data-drive-id', 'data-file-id', 'data-label', 'data-language', 'data-mention-type',
+  'data-page-id', 'data-role-id', 'data-thread-id', 'data-tight', 'data-type', 'data-user-id',
+  'data-width',
+]);
+
+export const KNOWN_STYLE_PROPERTIES: ReadonlySet<string> = new Set([
+  'background-color', 'color', 'font-family', 'font-size', 'font-style', 'font-weight',
+  'line-height', 'margin', 'margin-bottom', 'margin-left', 'margin-right', 'margin-top',
+  'min-width', 'padding', 'text-align', 'text-decoration', 'width',
+]);
+
+const UNRECOGNISED_ATTRIBUTE = '(unrecognised-attribute)';
+const UNRECOGNISED_PROPERTY = '(unrecognised-property)';
+
+/**
+ * A construct key with everything the author could have typed removed:
+ * unknown tag names become `UNESCAPED_ANGLE_BRACKET_KEY` (the census's own
+ * marker for the same artefact), attribute and property names outside the
+ * known lists are folded to a fixed placeholder, and a value survives only if
+ * its attribute is in `PRINTABLE_ATTRIBUTE_VALUES` AND the value passes that
+ * validator.
+ *
+ * The COMPARISON must run on the raw form (`ALLOWED_COSMETIC_ADDITIONS`
+ * names `attr:a@data-drive-id=` and the `=1`/`=true` forms); only what is
+ * REPORTED from real documents goes through here.
  */
 export function contentFreeKey(key: string): string {
-  const valued = /^(attr:[^@]+@)([^=]+)=/u.exec(key);
-  if (!valued) return key;
-  return PRINTABLE_ATTRIBUTE_VALUES.has(valued[2]) ? key : `${valued[1]}${valued[2]}`;
+  const element = /^el:(.+)$/u.exec(key);
+  if (element) {
+    return HTML_ELEMENT_NAMES.has(element[1]) ? key : UNESCAPED_ANGLE_BRACKET_KEY;
+  }
+  const attribute = /^attr:([^@]+)@([^=]+)(?:=(.*))?$/su.exec(key);
+  if (!attribute) return key;
+  const [, tag, rawName, value] = attribute;
+  if (!HTML_ELEMENT_NAMES.has(tag)) return UNESCAPED_ANGLE_BRACKET_KEY;
+
+  const style = /^style:(.*)$/su.exec(rawName);
+  if (style) {
+    const property = KNOWN_STYLE_PROPERTIES.has(style[1]) ? style[1] : UNRECOGNISED_PROPERTY;
+    return `attr:${tag}@style:${property}`;
+  }
+  const name = KNOWN_ATTRIBUTE_NAMES.has(rawName) ? rawName : UNRECOGNISED_ATTRIBUTE;
+  if (value === undefined) return `attr:${tag}@${name}`;
+  const printable = PRINTABLE_ATTRIBUTE_VALUES.get(name);
+  return printable?.(value) ? `attr:${tag}@${name}=${value}` : `attr:${tag}@${name}`;
 }
 
 /**

--- a/packages/editor/src/seed-fidelity.ts
+++ b/packages/editor/src/seed-fidelity.ts
@@ -1,0 +1,186 @@
+import { withDomWorkspace } from './dom-workspace.js';
+
+/**
+ * The seed-fidelity vocabulary: markup constructs as comparable keys, and the
+ * one allowlist of rewrites a pass through the frozen schema is permitted to
+ * make.
+ *
+ * Shared by `__tests__/seed-fidelity.test.ts` (the construct corpus) and
+ * `scripts/collab-seed-audit.ts` (real documents) on purpose. The bar is
+ * `render(parse(h1)) == h1` — a FIXPOINT — plus zero loss of any
+ * content-bearing construct; it is deliberately NOT byte-identical output.
+ * Measured over the corpus, one pass through the schema rewrites its input in
+ * ways that lose nothing: tables gain `<colgroup>` and `min-width`, a bare
+ * `<ul>` gains `class="tight" data-tight="true"`, bare `<li>` text is wrapped
+ * in `<p>`, `TaskItem` renders its own checkbox markup, `Link` stamps
+ * `target`/`rel`. A byte-equality assertion would fail on all of that and
+ * send its next reader off to "fix" normalisation that is not broken.
+ *
+ * The danger in relaxing an assertion is that the relaxation swallows a real
+ * loss. So the tolerance is NOT a loose comparison — it is this explicit,
+ * exhaustively-named allowlist, which the corpus test also asserts is not
+ * larger than it needs to be. Keeping one copy is what stops the audit and
+ * the test from tolerating different things.
+ */
+
+/**
+ * Every markup construct one pass through the schema is allowed to ADD.
+ *
+ * Each entry is a rewrite whose absence from the source is not information:
+ *
+ * - `a@target` / `a@rel` — `Link` stamps these on every anchor it renders.
+ * - `a@data-type`, `span@data-type` — TipTap's node-name marker on a mention.
+ * - `a@contenteditable`, `a@data-drive-id` — the AI mention dialect omits
+ *   them; the node's own `renderHTML` always writes them.
+ * - `ul@class`, `ul@data-tight`, `ol@class`, `ol@data-tight` (`=true`) —
+ *   `MarkdownTightLists` makes the tightness it INFERRED from the source
+ *   (`!element.querySelector('p')`) explicit, on both list kinds.
+ * - `a@data-drive-id=` — the AI mention dialect carries no drive, and the
+ *   node's `renderHTML` always writes the attribute, so it appears empty. The
+ *   EMPTY value is the allowlisted one; a mention gaining a real drive id would
+ *   produce a different key and fail.
+ * - `p` — a bare `<li>text</li>` becomes `<li><p>text</p></li>`, because the
+ *   schema's `listItem` content is `paragraph block*`.
+ * - `label`, `input`, `input@type`, `input@checked`, `span`, `div` —
+ *   `TaskItem`'s rendered checkbox. The state itself lives in
+ *   `li@data-checked`, which the source already carried.
+ * - `pre@class` — `CodeBlockNode` mirrors `language-x` onto the `<pre>`.
+ * - `table@style`, `colgroup`, `col`, `col@style` (and their `style:min-width`
+ *   forms) — TipTap's table column model, emitted as `min-width` from the
+ *   schema's own defaults.
+ * - `td@colspan`, `td@rowspan`, `th@colspan`, `th@rowspan` (`=1`) — every
+ *   cell is rendered with its span made explicit. The VALUE `1` is the
+ *   allowlisted one: a cell whose span actually changed produces a different
+ *   key and fails.
+ *
+ * The `=pageMention` entries are the VALUE-bearing form of the `data-type`
+ * marker above. They are listed separately, and deliberately: it is the value
+ * that carries the meaning, so `data-type` changing from `taskList` to
+ * `taskItem` must fail rather than be absorbed by a bare `attr@data-type`.
+ *
+ * Nothing here changes what the document SAYS. An addition outside this set is
+ * a change to the stored dialect and must be looked at, not tolerated.
+ */
+export const ALLOWED_COSMETIC_ADDITIONS: ReadonlySet<string> = new Set([
+  'attr:a@contenteditable',
+  'attr:a@data-drive-id',
+  'attr:a@data-drive-id=',
+  'attr:a@data-type',
+  'attr:a@data-type=pageMention',
+  'attr:a@rel',
+  'attr:a@target',
+  'attr:col@style',
+  'attr:col@style:min-width',
+  'attr:input@checked',
+  'attr:input@type',
+  'attr:ol@class',
+  'attr:ol@data-tight',
+  'attr:ol@data-tight=true',
+  'attr:pre@class',
+  'attr:span@data-type',
+  'attr:span@data-type=pageMention',
+  'attr:table@style',
+  'attr:table@style:min-width',
+  'attr:td@colspan',
+  'attr:td@colspan=1',
+  'attr:td@rowspan',
+  'attr:td@rowspan=1',
+  'attr:th@colspan',
+  'attr:th@colspan=1',
+  'attr:th@rowspan',
+  'attr:th@rowspan=1',
+  'attr:ul@class',
+  'attr:ul@data-tight',
+  'attr:ul@data-tight=true',
+  'el:col',
+  'el:colgroup',
+  'el:div',
+  'el:input',
+  'el:label',
+  'el:p',
+  'el:span',
+]);
+
+/**
+ * Attributes whose VALUE is the construct, not just their presence.
+ *
+ * `text-align:center` becoming `text-align:left`, `data-type="taskList"`
+ * becoming `taskItem`, a rewritten `href`, a `data-page-id` pointing at a
+ * different page, or `start="7"` becoming `start="1"` would all be invisible
+ * to a comparison whose entire job is naming the construct that moved.
+ */
+export const VALUE_BEARING_ATTRIBUTES: ReadonlySet<string> = new Set([
+  'data-type',
+  'href',
+  'data-page-id',
+  'data-user-id',
+  'data-role-id',
+  'data-drive-id',
+  'data-file-id',
+  'data-block-id',
+  'data-change-id',
+  'data-change-type',
+  'data-checked',
+  'data-tight',
+  'start',
+  'colspan',
+  'rowspan',
+  'alt',
+]);
+
+/**
+ * The markup under `root` as comparable keys: `el:<tag>`,
+ * `attr:<tag>@<name>`, `attr:<tag>@<name>=<value>` for the value-bearing
+ * attributes, and `attr:<tag>@style:<property>` per inline CSS property.
+ *
+ * Deliberately not the markup string: a set difference names WHICH construct
+ * moved, where a string diff only says "changed". Presence-only keys are kept
+ * alongside the value keys, so a DROPPED attribute and a CHANGED one are
+ * distinguishable in the diff. `style` is split per property because a bare
+ * `attr:p@style` merges the question with the answer.
+ *
+ * Structural, not lexical — but NOT content-free: the value-bearing keys carry
+ * `href`, `alt` and the id attributes verbatim, because a rewritten href or a
+ * changed alt is exactly what the corpus test has to see. `alt` is prose. A
+ * consumer that PRINTS keys from real documents (`scripts/collab-seed-audit.ts`)
+ * folds every value except the schema's own enumerations back to the presence
+ * form before tallying; see `contentFreeKey` there.
+ */
+export function constructKeysOf(root: Element): Set<string> {
+  const keys = new Set<string>();
+  const walk = (element: Element): void => {
+    const tag = element.tagName.toLowerCase();
+    keys.add(`el:${tag}`);
+    for (const name of element.getAttributeNames()) {
+      keys.add(`attr:${tag}@${name}`);
+      if (VALUE_BEARING_ATTRIBUTES.has(name)) {
+        keys.add(`attr:${tag}@${name}=${element.getAttribute(name) ?? ''}`);
+      }
+      if (name === 'style') {
+        for (const declaration of (element.getAttribute(name) ?? '').split(';')) {
+          const property = declaration.split(':')[0]?.trim().toLowerCase();
+          if (property) {
+            keys.add(`attr:${tag}@style:${property}`);
+          }
+        }
+      }
+    }
+    for (const child of Array.from(element.children)) {
+      walk(child);
+    }
+  };
+  for (const child of Array.from(root.children)) {
+    walk(child);
+  }
+  return keys;
+}
+
+/** `constructKeysOf` over a markup string, in a throwaway workspace. */
+export function constructsOf(html: string): Set<string> {
+  return withDomWorkspace((workspace) => constructKeysOf(workspace.parse(html)));
+}
+
+/** Keys in `a` that `b` lacks, sorted — the "what moved" half of every comparison here. */
+export function constructDifference(a: ReadonlySet<string>, b: ReadonlySet<string>): string[] {
+  return [...a].filter((key) => !b.has(key)).sort();
+}

--- a/packages/editor/src/user-color.ts
+++ b/packages/editor/src/user-color.ts
@@ -1,0 +1,59 @@
+/**
+ * One deterministic colour per user, for the avatar ring in the presence
+ * roster and the `CollaborationCaret` label.
+ *
+ * The presence roster and Yjs awareness are two channels that never talk to
+ * each other, and both draw the same user. Agreeing on a colour through either
+ * channel would mean one of them owning an assignment table and the other
+ * reading it — a lookup, a race on first sight, and a stale colour after a
+ * reconnect. A pure function of the id needs none of that: every client, on
+ * every reconnect, with no state, arrives at the same answer.
+ *
+ * The palette is fixed and small on purpose. A colour is a label people learn
+ * ("the green cursor is Ada"), so it must be one of a set that is legible at
+ * two-pixel caret width and one-pixel ring width on BOTH themes. Every entry
+ * holds a WCAG 1.4.11 non-text contrast of at least 3:1 against pure white and
+ * against the app's lightest dark surface (`--card`, oklch 0.23 ≈ #1d1d1d);
+ * `__tests__/user-color.test.ts` recomputes that from the hex values rather
+ * than trusting this comment. Twelve hues, thirty degrees apart, at a
+ * relative luminance of ~0.20 — the band where both bounds are met with
+ * margin. Two users CAN share a colour; with twelve entries that is a fact,
+ * not a bug, and the roster shows names.
+ *
+ * Changing an entry, or the hash, recolours every existing user everywhere at
+ * once. The test pins three ids to their colours so that happens as a visible
+ * diff, never as a side effect.
+ */
+export const USER_COLOR_PALETTE: readonly string[] = [
+  '#d54e4e', // red
+  '#b06c29', // orange
+  '#7f7f1e', // olive
+  '#558920', // lime
+  '#218f21', // green
+  '#218d57', // teal-green
+  '#208888', // teal
+  '#307fcd', // blue
+  '#7070dd', // indigo
+  '#9b5ed9', // violet
+  '#cf32cf', // magenta
+  '#d3458c', // pink
+];
+
+/**
+ * djb2 over UTF-16 code units — the same hash `SCHEMA_HASH` uses, for the
+ * same reasons: no `node:crypto` (this runs in the browser), and no
+ * dependence on anything but the string. A sum of char codes would map
+ * anagram ids to one colour; djb2's multiply-by-33 makes order matter.
+ */
+function hashUserId(userId: string): number {
+  let hash = 5381;
+  for (let i = 0; i < userId.length; i += 1) {
+    hash = (hash * 33 + userId.charCodeAt(i)) | 0;
+  }
+  return hash >>> 0;
+}
+
+/** A palette colour, `#rrggbb`, chosen by `userId` alone. */
+export function userColor(userId: string): string {
+  return USER_COLOR_PALETTE[hashUserId(userId) % USER_COLOR_PALETTE.length];
+}

--- a/packages/editor/src/user-color.ts
+++ b/packages/editor/src/user-color.ts
@@ -1,3 +1,5 @@
+import { djb2 } from './collab-schema.js';
+
 /**
  * One deterministic colour per user, for the avatar ring in the presence
  * roster and the `CollaborationCaret` label.
@@ -39,21 +41,7 @@ export const USER_COLOR_PALETTE: readonly string[] = [
   '#d3458c', // pink
 ];
 
-/**
- * djb2 over UTF-16 code units — the same hash `SCHEMA_HASH` uses, for the
- * same reasons: no `node:crypto` (this runs in the browser), and no
- * dependence on anything but the string. A sum of char codes would map
- * anagram ids to one colour; djb2's multiply-by-33 makes order matter.
- */
-function hashUserId(userId: string): number {
-  let hash = 5381;
-  for (let i = 0; i < userId.length; i += 1) {
-    hash = (hash * 33 + userId.charCodeAt(i)) | 0;
-  }
-  return hash >>> 0;
-}
-
 /** A palette colour, `#rrggbb`, chosen by `userId` alone. */
 export function userColor(userId: string): string {
-  return USER_COLOR_PALETTE[hashUserId(userId) % USER_COLOR_PALETTE.length];
+  return USER_COLOR_PALETTE[djb2(userId) % USER_COLOR_PALETTE.length];
 }

--- a/packages/editor/src/user-color.ts
+++ b/packages/editor/src/user-color.ts
@@ -1,4 +1,4 @@
-import { djb2 } from './collab-schema.js';
+import { djb2 } from './djb2.js';
 
 /**
  * One deterministic colour per user, for the avatar ring in the presence

--- a/packages/editor/src/y-doc-to-html.ts
+++ b/packages/editor/src/y-doc-to-html.ts
@@ -37,6 +37,7 @@ export function yDocToHtml(yDoc: Y.Doc): string {
  */
 let cachedNames: { nodes: ReadonlySet<string>; marks: ReadonlySet<string> } | undefined;
 
+/** The frozen schema's node and mark names, memoised — what the HTML projection is allowed to contain. */
 function projectableNames(): { nodes: ReadonlySet<string>; marks: ReadonlySet<string> } {
   const schema = collabSchema();
   cachedNames ??= {

--- a/packages/editor/src/y-doc-to-html.ts
+++ b/packages/editor/src/y-doc-to-html.ts
@@ -1,7 +1,7 @@
 import { DOMSerializer, type Node as PmNode } from 'prosemirror-model';
 import type * as Y from 'yjs';
 import { collabSchema, yDocToPmDoc } from './collab-document.js';
-import { withDomWorkspace } from './dom-workspace.js';
+import { withDomWorkspace, type DomWorkspace } from './dom-workspace.js';
 import { assertProjectable } from './projection-errors.js';
 
 /**
@@ -48,15 +48,23 @@ function projectableNames(): { nodes: ReadonlySet<string>; marks: ReadonlySet<st
 
 /** `yDocToHtml` over an already-materialised ProseMirror document. */
 export function pmDocToHtml(doc: PmNode): string {
+  return withDomWorkspace((workspace) => pmDocToHtmlIn(doc, workspace));
+}
+
+/**
+ * `pmDocToHtml` into a caller-owned workspace. For callers that render many
+ * documents in one run (the seed fidelity audit renders four per page over
+ * thousands of pages): a window per call is ~2 ms and a quarter-megabyte
+ * that is not collectable until the event loop turns.
+ */
+export function pmDocToHtmlIn(doc: PmNode, workspace: DomWorkspace): string {
   const known = projectableNames();
   assertProjectable(doc, 'html', known.nodes, known.marks);
-  return withDomWorkspace((workspace) => {
-    const target = workspace.empty();
-    DOMSerializer.fromSchema(collabSchema()).serializeFragment(
-      doc.content,
-      { document: workspace.document },
-      target,
-    );
-    return target.innerHTML;
-  });
+  const target = workspace.empty();
+  DOMSerializer.fromSchema(collabSchema()).serializeFragment(
+    doc.content,
+    { document: workspace.document },
+    target,
+  );
+  return target.innerHTML;
 }

--- a/scripts/__tests__/collab-seed-audit.test.ts
+++ b/scripts/__tests__/collab-seed-audit.test.ts
@@ -1,0 +1,588 @@
+/**
+ * The seed fidelity audit (`scripts/collab-seed-audit.ts`), tested through
+ * its pure modules in `scripts/lib/seed-audit/`.
+ *
+ * The three criteria are hard blockers, so what matters most here is that
+ * each one can actually go red: every test that asserts "lossy" was
+ * mutation-checked by breaking the mechanism it names (see the PR report).
+ * Everything else is the audit's two promises to production — it never
+ * writes, and it never prints content — held as tests rather than as prose.
+ */
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { readFileSync, readdirSync } from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { createDomWorkspace, type DomWorkspace } from '@pagespace/editor/dom-workspace';
+import {
+  CONTENT_COUNTERS,
+  countContent,
+  counterDecreases,
+  isTagless,
+  spaceCollapsedText,
+  stripNonContentElements,
+  visibleText,
+} from '../lib/seed-audit/criteria';
+import {
+  auditPage,
+  divergenceBetween,
+  gateReasonShape,
+  isLossy,
+  judgeChain,
+  type PageAudit,
+} from '../lib/seed-audit/analyze';
+import {
+  auditPassed,
+  censusKeyOf,
+  contentFreeKey,
+  createAuditAccumulator,
+  formatAuditReport,
+} from '../lib/seed-audit/report';
+import { parseAuditArgs } from '../lib/seed-audit/options';
+
+const here = path.dirname(fileURLToPath(import.meta.url));
+const scriptsDir = path.resolve(here, '..');
+
+/** One window for the file; every `parse` is a fresh detached element. */
+let workspace: DomWorkspace;
+beforeAll(() => {
+  workspace = createDomWorkspace();
+});
+afterAll(() => {
+  workspace.close();
+});
+
+const parse = (html: string): Element => workspace.parse(html);
+
+/** A clean audit, as a fixture other tests narrow. */
+const CLEAN_HTML =
+  '<h1>Title</h1><p>Some <strong>prose</strong> with <a href="https://example.test/">a link</a>.</p>' +
+  '<ul><li><p>alpha</p></li><li><p>beta</p></li></ul>' +
+  '<table><tbody><tr><th colspan="1" rowspan="1"><p>Name</p></th></tr>' +
+  '<tr><td colspan="1" rowspan="1"><p>Ada</p></td></tr></tbody></table>' +
+  '<pre><code class="language-ts">const x = 1;</code></pre>';
+
+function audited(audit: PageAudit): PageAudit & { status: 'audited' } {
+  if (audit.status !== 'audited') {
+    throw new Error(`expected an audited page, got ${audit.status}`);
+  }
+  return audit;
+}
+
+describe('content counters (criterion 2)', () => {
+  it('counts every construct the leaf names, per instance', () => {
+    const counts = countContent(
+      parse(
+        '<img><h4>a</h4><h5>b</h5><h6>c</h6>' +
+          '<table><tr><th>h</th><td>d</td><td>e</td></tr></table>' +
+          '<ul><li>1</li><li>2</li><li>3</li></ul>' +
+          '<pre><code>x</code></pre><p><code>y</code></p>' +
+          '<p><a data-page-id="pg_1">@p</a><span data-mention-type="role">@r</span></p>' +
+          '<p><mark>m</mark><sup>s</sup><sub>t</sub></p>' +
+          '<iframe></iframe><details></details><div><div></div></div>' +
+          '<input type="checkbox">',
+      ),
+    );
+    expect(counts).toEqual({
+      img: 1,
+      h4: 1,
+      h5: 1,
+      h6: 1,
+      table: 1,
+      tr: 1,
+      td: 2,
+      th: 1,
+      li: 3,
+      pre: 1,
+      code: 2,
+      'a[data-page-id]': 1,
+      'span[data-mention-type]': 1,
+      mark: 1,
+      sup: 1,
+      sub: 1,
+      iframe: 1,
+      details: 1,
+      'div (outside task items)': 2,
+      'input[type=checkbox]': 1,
+    });
+  });
+
+  it('does not count the <div> TaskItem renders inside a task item, so a lost wrapper cannot be paid back by one', () => {
+    const counts = countContent(
+      parse(
+        '<div><p>wrapper</p></div>' +
+          '<ul data-type="taskList"><li data-type="taskItem" data-checked="false">' +
+          '<label><input type="checkbox"><span></span></label><div><p>todo</p></div></li></ul>',
+      ),
+    );
+    expect(counts['div (outside task items)']).toBe(1);
+    expect(counts['input[type=checkbox]']).toBe(1);
+  });
+
+  it('reports a decrease and never an increase', () => {
+    const before = countContent(parse('<ul><li>a</li><li>b</li></ul><img>'));
+    const after = countContent(parse('<ul><li><p>a</p></li><li><p>b</p></li></ul><p><p>'));
+    expect(counterDecreases(before, after)).toEqual(['img']);
+    expect(counterDecreases(after, before)).toEqual([]);
+  });
+
+  it('treats a counter missing from either side as zero', () => {
+    expect(counterDecreases({ img: 2 }, {})).toEqual(['img']);
+    expect(counterDecreases({}, { img: 2 })).toEqual([]);
+  });
+
+  it('has one row per construct the leaf names', () => {
+    expect(CONTENT_COUNTERS.map((counter) => counter.key)).toEqual([
+      'img', 'h4', 'h5', 'h6', 'table', 'tr', 'td', 'th', 'li', 'pre', 'code',
+      'a[data-page-id]', 'span[data-mention-type]', 'mark', 'sup', 'sub', 'iframe', 'details',
+      'div (outside task items)', 'input[type=checkbox]',
+    ]);
+  });
+});
+
+describe('text (criterion 3)', () => {
+  it('compares visible characters with all whitespace stripped, so pretty-printing is not loss', () => {
+    expect(visibleText(parse('<p>a b</p>\n  <p>c</p>'))).toBe('abc');
+    expect(visibleText(parse('<p>a b</p><p>c</p>'))).toBe('abc');
+  });
+
+  it('keeps single spaces in the diagnostic form, so a vanished space is at least visible', () => {
+    expect(spaceCollapsedText(parse('<p>a   b</p>\n'))).toBe('a b');
+    expect(spaceCollapsedText(parse('<p>ab</p>'))).toBe('ab');
+  });
+
+  it('strips script, style, noscript and template before measuring — their text is not prose', () => {
+    const root = parse('<p>keep</p><style>p{color:red}</style><script>x()</script><noscript>n</noscript><template>t</template>');
+    stripNonContentElements(root);
+    expect(visibleText(root)).toBe('keep');
+  });
+
+  it('calls a document with no HTML element at all tagless', () => {
+    expect(isTagless(parse('# heading\n\nplain markdown'))).toBe(true);
+    expect(isTagless(parse('<p>html</p>'))).toBe(false);
+  });
+});
+
+describe('auditPage — the two chains', () => {
+  it('passes a clean document on both chains with no divergence and no gate reason', () => {
+    const audit = audited(auditPage(CLEAN_HTML, workspace));
+    expect(audit.tagless).toBe(false);
+    expect(isLossy(audit.seed)).toBe(false);
+    expect(isLossy(audit.census)).toBe(false);
+    expect(audit.seed.droppedConstructs).toEqual([]);
+    expect(audit.seed.unexpectedAdditions).toEqual([]);
+    expect(audit.divergence).toBeNull();
+    expect(audit.gateReasons).toEqual([]);
+  });
+
+  it('flags an <img> the schema has no node for as a counter decrease, a dropped construct and a gate reason', () => {
+    const audit = audited(auditPage('<p>before</p><img src="https://cdn.test/x.png" alt="x"><p>after</p>', workspace));
+    expect(audit.seed.counterDecreases).toEqual(['img']);
+    expect(audit.seed.droppedConstructs).toContain('el:img');
+    expect(audit.seed.textPreserved).toBe(true);
+    expect(isLossy(audit.seed)).toBe(true);
+    expect(audit.gateReasons).toEqual(['dropped <img>']);
+    // The census chain sees the same loss — the schema, not y-prosemirror.
+    expect(audit.census.counterDecreases).toEqual(['img']);
+    expect(audit.divergence).toBeNull();
+  });
+
+  it('flags lost text, and an <iframe>, by criterion 3 and criterion 2 respectively', () => {
+    const audit = audited(auditPage('<p>kept</p><iframe src="https://e.test/"></iframe>', workspace));
+    expect(audit.seed.counterDecreases).toEqual(['iframe']);
+    expect(isLossy(audit.seed)).toBe(true);
+  });
+
+  it('does not report a <style> block as lost text', () => {
+    const audit = audited(auditPage('<style>p{margin:0}</style><p>prose</p>', workspace));
+    expect(audit.seed.textPreserved).toBe(true);
+    expect(isLossy(audit.seed)).toBe(false);
+  });
+
+  it('accepts the cosmetic rewrites the allowlist names and reports nothing outside it', () => {
+    // Bare list, bare cells, bare link: every one of these is rewritten by a
+    // pass through the schema, and none of it is loss.
+    const audit = audited(
+      auditPage('<ul><li>one</li></ul><table><tr><td>c</td></tr></table><p><a href="https://x.test/">l</a></p>', workspace),
+    );
+    expect(audit.seed.unexpectedAdditions).toEqual([]);
+    expect(audit.seed.droppedConstructs).toEqual([]);
+    expect(isLossy(audit.seed)).toBe(false);
+    expect(audit.seed.stable).toBe(true);
+  });
+
+  it('marks a page with no HTML element tagless while still auditing it', () => {
+    const audit = audited(auditPage('# Heading\n\n- item', workspace));
+    expect(audit.tagless).toBe(true);
+    expect(audit.seed.textPreserved).toBe(true);
+  });
+
+  it('records a parse failure by stage and error type only', () => {
+    const broken: DomWorkspace = {
+      ...workspace,
+      parse() {
+        throw new RangeError('<p>the offending markup</p>');
+      },
+    };
+    expect(auditPage('<p>x</p>', broken)).toEqual({ status: 'failed', stage: 'parse', errorName: 'RangeError' });
+  });
+
+  it('attributes a failure after the source parse to the render stage', () => {
+    let parses = 0;
+    const brokenSecondParse: DomWorkspace = {
+      ...workspace,
+      parse(html) {
+        parses += 1;
+        if (parses === 2) throw new TypeError('boom');
+        return workspace.parse(html);
+      },
+    };
+    expect(auditPage('<p>x</p>', brokenSecondParse)).toEqual({ status: 'failed', stage: 'render', errorName: 'TypeError' });
+  });
+});
+
+describe('judgeChain and divergenceBetween (on DOMs, so the branches y-prosemirror has not yet exercised are still covered)', () => {
+  it('reports unstable, a counter decrease and lost text as three separate failures', () => {
+    const verdict = judgeChain(parse('<p>abc</p><img>'), parse('<p>ab</p>'), false);
+    expect(verdict.stable).toBe(false);
+    expect(verdict.counterDecreases).toEqual(['img']);
+    expect(verdict.textPreserved).toBe(false);
+    expect(verdict.whitespaceOnlyTextChange).toBe(false);
+    expect(verdict.droppedConstructs).toEqual(['el:img']);
+    expect(isLossy(verdict)).toBe(true);
+  });
+
+  it('treats instability alone as lossy — a churning projection is a blocker on its own', () => {
+    const verdict = judgeChain(parse('<p>a</p>'), parse('<p>a</p>'), false);
+    expect(verdict.counterDecreases).toEqual([]);
+    expect(verdict.textPreserved).toBe(true);
+    expect(isLossy(verdict)).toBe(true);
+    expect(isLossy({ ...verdict, stable: true })).toBe(false);
+  });
+
+  it('separates a whitespace-only change from lost text', () => {
+    const verdict = judgeChain(parse('<p>a b</p>'), parse('<p>ab</p>'), true);
+    expect(verdict.textPreserved).toBe(true);
+    expect(verdict.whitespaceOnlyTextChange).toBe(true);
+    expect(isLossy(verdict)).toBe(false);
+  });
+
+  it('names additions outside the allowlist and not those on it', () => {
+    const verdict = judgeChain(parse('<ul><li>a</li></ul>'), parse('<ul class="tight" data-tight="true"><li><p>a</p></li></ul><figure></figure>'), true);
+    expect(verdict.unexpectedAdditions).toEqual(['el:figure']);
+  });
+
+  it('names what the seed projection changed relative to the census projection', () => {
+    const divergence = divergenceBetween(parse('<p>ab <mark>c</mark></p><h4>x</h4>'), parse('<p>ab c</p><p>x</p>'));
+    expect(divergence).toEqual({
+      counterChanges: ['h4', 'mark'],
+      textChanged: false,
+      constructsLost: ['el:h4', 'el:mark'],
+      constructsGained: [],
+    });
+  });
+});
+
+describe('gateReasonShape', () => {
+  it('strips the per-page counts off describeHtmlLoss reasons so they tally', () => {
+    expect(gateReasonShape('dropped 2 <img> element(s)')).toBe('dropped <img>');
+    expect(gateReasonShape('dropped 1 <iframe> element(s)')).toBe('dropped <iframe>');
+    expect(gateReasonShape('visible text changed (140 characters in, 120 out)')).toBe('visible text changed');
+  });
+
+  it('passes a reason it does not recognise through unchanged', () => {
+    expect(gateReasonShape('some future reason')).toBe('some future reason');
+  });
+});
+
+describe('censusKeyOf', () => {
+  it('re-keys tag-qualified constructs the way the content census keys them', () => {
+    expect(censusKeyOf('el:img')).toBe('<img>');
+    expect(censusKeyOf('attr:p@style:text-align')).toBe('style:text-align');
+    expect(censusKeyOf('attr:ul@data-type=taskList')).toBe('attr:data-type=taskList');
+    expect(censusKeyOf('attr:a@href=https://x.test/')).toBe('attr:href');
+    expect(censusKeyOf('attr:img@src')).toBe('attr:src');
+    expect(censusKeyOf('something-else')).toBe('something-else');
+  });
+});
+
+describe('contentFreeKey', () => {
+  it('keeps the values the schema itself enumerates', () => {
+    expect(contentFreeKey('attr:ul@data-type=taskList')).toBe('attr:ul@data-type=taskList');
+    expect(contentFreeKey('attr:li@data-checked=true')).toBe('attr:li@data-checked=true');
+    expect(contentFreeKey('attr:td@colspan=2')).toBe('attr:td@colspan=2');
+    expect(contentFreeKey('attr:ol@start=7')).toBe('attr:ol@start=7');
+  });
+
+  it('folds prose, urls and ids back to presence', () => {
+    expect(contentFreeKey('attr:img@alt=a photo of Ada')).toBe('attr:img@alt');
+    expect(contentFreeKey('attr:a@href=https://x.test/ada-lovelace')).toBe('attr:a@href');
+    expect(contentFreeKey('attr:a@data-page-id=pg_1')).toBe('attr:a@data-page-id');
+    expect(contentFreeKey('el:img')).toBe('el:img');
+    expect(contentFreeKey('attr:p@style:text-align')).toBe('attr:p@style:text-align');
+  });
+});
+
+describe('the accumulator and the report', () => {
+  function lossyAudit(overrides: Partial<PageAudit & { status: 'audited' }> = {}): PageAudit {
+    return {
+      status: 'audited',
+      tagless: false,
+      census: {
+        stable: true,
+        counterDecreases: ['img'],
+        textPreserved: true,
+        whitespaceOnlyTextChange: false,
+        droppedConstructs: ['attr:img@src', 'el:img'],
+        unexpectedAdditions: [],
+      },
+      seed: {
+        stable: false,
+        counterDecreases: ['img'],
+        textPreserved: false,
+        whitespaceOnlyTextChange: false,
+        droppedConstructs: ['attr:img@src', 'el:img'],
+        unexpectedAdditions: ['el:figure'],
+      },
+      divergence: {
+        counterChanges: ['img'],
+        textChanged: true,
+        constructsLost: ['el:h4'],
+        constructsGained: ['el:p'],
+      },
+      gateReasons: ['dropped <img>'],
+      ...overrides,
+    };
+  }
+
+  const cleanAudit = (): PageAudit => audited(auditPage(CLEAN_HTML, workspace));
+
+  it('tallies each criterion, the conjunction, and per-construct example ids', () => {
+    const audit = createAuditAccumulator();
+    audit.recordHtml('page_1', lossyAudit());
+    audit.recordHtml('page_2', cleanAudit());
+    const snapshot = audit.snapshot();
+
+    expect(snapshot.totals).toEqual({ documents: 2, audited: 2, markdownMode: 0, empty: 0, tagless: 0, failed: 0, divergent: 1 });
+    expect(snapshot.seed.totals).toEqual({ unstable: 1, counterDecreased: 1, textLost: 1, lossy: 1, whitespaceOnlyTextChange: 0 });
+    expect(snapshot.census.totals).toEqual({ unstable: 0, counterDecreased: 1, textLost: 0, lossy: 1, whitespaceOnlyTextChange: 0 });
+    expect(snapshot.seed.criteriaFailures).toEqual([
+      { key: 'counter decreased: img', pages: 1, examplePageIds: ['page_1'] },
+      { key: 'text-lost', pages: 1, examplePageIds: ['page_1'] },
+      { key: 'unstable', pages: 1, examplePageIds: ['page_1'] },
+    ]);
+    expect(snapshot.seed.droppedConstructs).toEqual([
+      { key: 'attr:img@src', pages: 1, examplePageIds: ['page_1'] },
+      { key: 'el:img', pages: 1, examplePageIds: ['page_1'] },
+    ]);
+    expect(snapshot.seed.droppedConstructsCensusKeyed).toEqual([
+      { key: '<img>', pages: 1, examplePageIds: ['page_1'] },
+      { key: 'attr:src', pages: 1, examplePageIds: ['page_1'] },
+    ]);
+    expect(snapshot.seed.unexpectedAdditions).toEqual([{ key: 'el:figure', pages: 1, examplePageIds: ['page_1'] }]);
+    expect(snapshot.divergence.rows).toEqual([
+      { key: 'counter changed: img', pages: 1, examplePageIds: ['page_1'] },
+      { key: 'gained: el:p', pages: 1, examplePageIds: ['page_1'] },
+      { key: 'lost: el:h4', pages: 1, examplePageIds: ['page_1'] },
+      { key: 'text changed', pages: 1, examplePageIds: ['page_1'] },
+    ]);
+    expect(auditPassed(snapshot)).toBe(false);
+  });
+
+  it('counts one page once per census key even when two tag-qualified keys fold into it', () => {
+    const audit = createAuditAccumulator();
+    audit.recordHtml(
+      'page_1',
+      lossyAudit({
+        seed: {
+          stable: true,
+          counterDecreases: [],
+          textPreserved: true,
+          whitespaceOnlyTextChange: false,
+          droppedConstructs: ['attr:h2@style:text-align', 'attr:p@style:text-align'],
+          unexpectedAdditions: [],
+        },
+      }),
+    );
+    expect(audit.snapshot().seed.droppedConstructsCensusKeyed).toEqual([
+      { key: 'style:text-align', pages: 1, examplePageIds: ['page_1'] },
+    ]);
+  });
+
+  it('names a byte-only divergence rather than letting it hide in a zero', () => {
+    const audit = createAuditAccumulator();
+    audit.recordHtml(
+      'page_1',
+      lossyAudit({ divergence: { counterChanges: [], textChanged: false, constructsLost: [], constructsGained: [] } }),
+    );
+    const snapshot = audit.snapshot();
+    expect(snapshot.totals.divergent).toBe(1);
+    expect(snapshot.divergence.rows).toEqual([
+      { key: 'bytes only (no measured construct, counter or text)', pages: 1, examplePageIds: ['page_1'] },
+    ]);
+  });
+
+  it('classifies every page into one of the four gate-agreement cells', () => {
+    const audit = createAuditAccumulator();
+    const cleanSeed = { stable: true, counterDecreases: [], textPreserved: true, whitespaceOnlyTextChange: false, droppedConstructs: [], unexpectedAdditions: [] };
+    audit.recordHtml('both_lossy', lossyAudit());
+    audit.recordHtml('blind_spot', lossyAudit({ gateReasons: [] }));
+    audit.recordHtml('stricter', lossyAudit({ seed: cleanSeed, gateReasons: ['visible text changed'] }));
+    audit.recordHtml('both_clean', lossyAudit({ seed: cleanSeed, gateReasons: [] }));
+    const { gate } = audit.snapshot();
+    expect(gate.agreement).toEqual({ bothLossy: 1, gateBlindSpot: 1, gateStricter: 1, bothClean: 1 });
+    expect(gate.agreementRows).toEqual([
+      { key: 'bothLossy', pages: 1, examplePageIds: ['both_lossy'] },
+      { key: 'gateBlindSpot', pages: 1, examplePageIds: ['blind_spot'] },
+      { key: 'gateStricter', pages: 1, examplePageIds: ['stricter'] },
+    ]);
+    expect(gate.reasons).toEqual([
+      { key: 'dropped <img>', pages: 1, examplePageIds: ['both_lossy'] },
+      { key: 'visible text changed', pages: 1, examplePageIds: ['stricter'] },
+    ]);
+  });
+
+  it('keeps at most three example ids per row', () => {
+    const audit = createAuditAccumulator();
+    for (const id of ['a', 'b', 'c', 'd', 'e']) audit.recordHtml(id, lossyAudit());
+    const row = audit.snapshot().seed.criteriaFailures.find((r) => r.key === 'unstable');
+    expect(row).toEqual({ key: 'unstable', pages: 5, examplePageIds: ['a', 'b', 'c'] });
+  });
+
+  it('counts markdown-mode, empty, tagless and failed pages in the totals and fails the run on a failure', () => {
+    const audit = createAuditAccumulator();
+    audit.recordMarkdownMode('md');
+    audit.recordEmpty();
+    audit.recordHtml('tagless', { ...audited(cleanAudit()), tagless: true });
+    audit.recordHtml('broken', { status: 'failed', stage: 'parse', errorName: 'RangeError' });
+    const snapshot = audit.snapshot();
+    expect(snapshot.totals).toEqual({ documents: 4, audited: 2, markdownMode: 1, empty: 1, tagless: 1, failed: 1, divergent: 0 });
+    expect(snapshot.taglessPages).toEqual([{ key: 'no HTML element', pages: 1, examplePageIds: ['tagless'] }]);
+    expect(snapshot.failures).toEqual([{ key: 'parse: RangeError', pages: 1, examplePageIds: ['broken'] }]);
+    expect(snapshot.seed.totals.lossy).toBe(0);
+    expect(auditPassed(snapshot)).toBe(false);
+  });
+
+  it('passes only when the seed chain has zero lossy pages and nothing failed', () => {
+    const audit = createAuditAccumulator();
+    audit.recordHtml('p', cleanAudit());
+    expect(auditPassed(audit.snapshot())).toBe(true);
+  });
+
+  it('prints PASS, BLOCKED or INTERRUPTED as the verdict', () => {
+    const clean = createAuditAccumulator();
+    clean.recordHtml('p', cleanAudit());
+    expect(formatAuditReport(clean.snapshot(), { partial: false })).toContain('AUDIT — PASS');
+    expect(formatAuditReport(clean.snapshot(), { partial: true })).toContain('INTERRUPTED');
+
+    const blocked = createAuditAccumulator();
+    blocked.recordHtml('p', lossyAudit());
+    const report = formatAuditReport(blocked.snapshot(), { partial: false });
+    expect(report).toContain('AUDIT — BLOCKED');
+    expect(report).toContain('counter decreased: img');
+    expect(report).toContain('p');
+  });
+
+  it('carries the tagless count into the header so a PASS cannot hide it', () => {
+    const audit = createAuditAccumulator();
+    audit.recordHtml('t', { ...audited(cleanAudit()), tagless: true });
+    const report = formatAuditReport(audit.snapshot(), { partial: false });
+    expect(report).toContain('AUDIT — PASS');
+    expect(report).toContain('NOTE: 1 html-mode page(s) contain no HTML element');
+    const clean = createAuditAccumulator();
+    clean.recordHtml('p', cleanAudit());
+    expect(formatAuditReport(clean.snapshot(), { partial: false })).not.toContain('NOTE:');
+  });
+
+  it('never prints document content — only ids, counts and construct names', () => {
+    const sentinel = 'SENTINEL_PROSE_9f3a';
+    const audit = createAuditAccumulator();
+    audit.recordHtml('page_x', auditPage(`<h4>${sentinel}</h4><img src="https://h.test/${sentinel}.png" alt="${sentinel}"><p>${sentinel}</p>`, workspace));
+    const report = formatAuditReport(audit.snapshot(), { partial: false });
+    expect(report).toContain('page_x');
+    expect(report).not.toContain(sentinel);
+    expect(JSON.stringify(audit.snapshot())).not.toContain(sentinel);
+  });
+});
+
+describe('options', () => {
+  it('defaults, and reads each flag', () => {
+    expect(parseAuditArgs([])).toEqual({ limit: Number.POSITIVE_INFINITY, batchSize: 200, progressEvery: 500 });
+    expect(parseAuditArgs(['--limit', '50', '--batch-size', '10', '--progress-every', '5'])).toEqual({
+      limit: 50,
+      batchSize: 10,
+      progressEvery: 5,
+    });
+  });
+
+  it('refuses a flag without a positive integer rather than silently auditing everything', () => {
+    expect(() => parseAuditArgs(['--limit'])).toThrow(/--limit requires a positive integer/);
+    expect(() => parseAuditArgs(['--limit', '0'])).toThrow(/--limit requires a positive integer/);
+    expect(() => parseAuditArgs(['--limit', 'ten'])).toThrow(/--limit requires a positive integer/);
+  });
+});
+
+/**
+ * The audit runs against production with the production credential. "It only
+ * reads" and "one query at a time" have to be checkable without reading the
+ * whole script, so they are tests: no audit source may contain a write, and
+ * the script may not fan queries out against the `max: 1` pool.
+ */
+describe('the audit is read-only and sequential by construction', () => {
+  // Globbed, not listed: a hand-written inventory is how a file ends up
+  // unscanned while the test stays green. Opting a file out has to be a
+  // visible edit here.
+  const libDir = 'lib/seed-audit';
+  const sources = [
+    'collab-seed-audit.ts',
+    ...readdirSync(path.join(scriptsDir, libDir))
+      .filter((entry) => entry.endsWith('.ts'))
+      .map((entry) => `${libDir}/${entry}`),
+  ];
+
+  // Comments are stripped first: the script's own header explains that it never
+  // runs an INSERT, and a scanner that cannot tell code from prose would either
+  // fail on that sentence or force the sentence out of the file.
+  const codeOf = (relative: string) =>
+    readFileSync(path.join(scriptsDir, relative), 'utf8')
+      .replace(/\/\*[\s\S]*?\*\//g, '')
+      .replace(/(^|[^:])\/\/.*$/gm, '$1');
+
+  const writes = [
+    /\.insert\s*\(/,
+    /\.update\s*\(/,
+    /\.delete\s*\(/,
+    /\btransaction\s*\(/,
+    /\b(INSERT|UPDATE|DELETE|TRUNCATE|ALTER|DROP|CREATE|GRANT)\b/i,
+  ];
+
+  it.each(sources)('%s contains no write', (relative) => {
+    const code = codeOf(relative);
+    for (const write of writes) {
+      expect(code).not.toMatch(write);
+    }
+  });
+
+  it('never fans queries out against the max: 1 migration pool', () => {
+    expect(codeOf('collab-seed-audit.ts')).not.toMatch(/Promise\.(all|allSettled|race|any)\s*\(/);
+  });
+
+  it('puts the session read-only at the server and checks that it took, before the first real query', () => {
+    const code = codeOf('collab-seed-audit.ts');
+    const enforce = code.indexOf('enforceReadOnlySession(getMigrationPool())');
+    const check = code.indexOf('assertReadOnlySession(');
+    const firstSelect = code.indexOf('.select(');
+    expect(enforce).toBeGreaterThan(-1);
+    expect(check).toBeGreaterThan(enforce);
+    expect(firstSelect).toBeGreaterThan(check);
+  });
+
+  it('scans every audit module, not a list that can go stale', () => {
+    expect(sources).toContain(`${libDir}/analyze.ts`);
+    expect(sources).toContain(`${libDir}/report.ts`);
+    expect(sources.length).toBeGreaterThanOrEqual(5);
+  });
+
+  it('strips comments before scanning, but not code that follows one', () => {
+    expect(codeOf('collab-seed-audit.ts')).toContain('getMigrationDb');
+  });
+});

--- a/scripts/__tests__/collab-seed-audit.test.ts
+++ b/scripts/__tests__/collab-seed-audit.test.ts
@@ -18,7 +18,7 @@ import {
   countContent,
   counterDecreases,
   isTagless,
-  spaceCollapsedText,
+  interWordText,
   visibleText,
 } from '../lib/seed-audit/criteria';
 import { stripNonContentElements } from '@pagespace/editor/html-to-ydoc';
@@ -157,9 +157,18 @@ describe('text (criterion 3)', () => {
     expect(visibleText(parse('<p>a b</p><p>c</p>'))).toBe('abc');
   });
 
-  it('keeps single spaces in the diagnostic form, so a vanished space is at least visible', () => {
-    expect(spaceCollapsedText(parse('<p>a   b</p>\n'))).toBe('a b');
-    expect(spaceCollapsedText(parse('<p>ab</p>'))).toBe('ab');
+  it('keeps the spacing between words in the diagnostic form, so a vanished space is visible', () => {
+    expect(interWordText(parse('<p>a   b</p>\n'))).toBe('a b');
+    expect(interWordText(parse('<p>ab</p>'))).toBe('ab');
+    expect(interWordText(parse('<p>hello <em>world</em></p>'))).toBe('hello world');
+  });
+
+  it('drops the whitespace BETWEEN blocks, so pretty-printing is not reported as a lost space', () => {
+    // The newline-and-indent between two blocks is its own text node. Reading
+    // the document's textContent instead would make these two differ, and the
+    // diagnostic would fire on every pretty-printed page in the corpus.
+    expect(interWordText(parse('<p>a</p>\n  <p>b</p>'))).toBe(interWordText(parse('<p>a</p><p>b</p>')));
+    expect(interWordText(parse('<ul>\n  <li>x</li>\n  <li>y</li>\n</ul>'))).toBe('xy');
   });
 
   it('strips script, style, noscript and template before measuring — their text is not prose', () => {
@@ -280,6 +289,12 @@ describe('judgeChain and divergenceBetween (on DOMs, so the branches y-prosemirr
     expect(isLossy(verdict)).toBe(false);
   });
 
+  it('does not raise the whitespace diagnostic merely because the source was pretty-printed', () => {
+    const verdict = judgeChain(parse('<p>a</p>\n  <p>b</p>'), parse('<p>a</p><p>b</p>'), true);
+    expect(verdict.textPreserved).toBe(true);
+    expect(verdict.whitespaceOnlyTextChange).toBe(false);
+  });
+
   it('names additions outside the allowlist and not those on it', () => {
     const verdict = judgeChain(parse('<ul><li>a</li></ul>'), parse('<ul class="tight" data-tight="true"><li><p>a</p></li></ul><figure></figure>'), true);
     expect(verdict.unexpectedAdditions).toEqual(['el:figure']);
@@ -315,7 +330,9 @@ describe('censusKeyOf', () => {
     expect(censusKeyOf('attr:ul@data-type=taskList')).toBe('attr:data-type=taskList');
     expect(censusKeyOf('attr:a@href=https://x.test/')).toBe('attr:href');
     expect(censusKeyOf('attr:img@src')).toBe('attr:src');
-    expect(censusKeyOf('something-else')).toBe('something-else');
+    // Fail closed, like contentFreeKey: a key it cannot decompose is not one
+    // it can vouch for.
+    expect(censusKeyOf('something-else')).toBe('text:unescaped-angle-bracket');
   });
 });
 
@@ -366,6 +383,7 @@ describe('the accumulator and the report', () => {
 
     expect(snapshot.totals).toEqual({ documents: 2, audited: 2, markdownMode: 0, empty: 0, tagless: 0, failed: 0, divergent: 1 });
     expect(snapshot.seed.totals).toEqual({ unstable: 1, counterDecreased: 1, textLost: 1, lossy: 1, whitespaceOnlyTextChange: 0 });
+    expect(snapshot.seed.whitespaceOnlyExamples).toEqual([]);
     expect(snapshot.census.totals).toEqual({ unstable: 0, counterDecreased: 1, textLost: 0, lossy: 1, whitespaceOnlyTextChange: 0 });
     expect(snapshot.seed.criteriaFailures).toEqual([
       { key: 'counter decreased: img', pages: 1, examplePageIds: ['page_1'] },
@@ -483,6 +501,18 @@ describe('the accumulator and the report', () => {
     expect(report).toContain('page_blocked_1');
   });
 
+  it('names example pages for the whitespace diagnostic — a bare count is undiagnosable', () => {
+    const audit = createAuditAccumulator();
+    // `<iframe>` has no node in the frozen schema, so dropping it closes the
+    // gap around it: every visible character survives, the spacing does not.
+    const spacing = '<p>a <iframe src="https://e.test/"></iframe> b</p>';
+    for (const id of ['ws_1', 'ws_2']) audit.recordHtml(id, auditPage(spacing, workspace));
+    const snapshot = audit.snapshot();
+    expect(snapshot.seed.totals.whitespaceOnlyTextChange).toBe(2);
+    expect(snapshot.seed.whitespaceOnlyExamples).toEqual(['ws_1', 'ws_2']);
+    expect(formatAuditReport(snapshot, { partial: false })).toContain('e.g. ws_1 ws_2');
+  });
+
   it('carries the tagless count into the header so a PASS cannot hide it', () => {
     const audit = createAuditAccumulator();
     audit.recordHtml('t', { ...audited(cleanAudit()), tagless: true });
@@ -502,6 +532,36 @@ describe('the accumulator and the report', () => {
     expect(report).toContain('page_x');
     expect(report).not.toContain(sentinel);
     expect(JSON.stringify(audit.snapshot())).not.toContain(sentinel);
+  });
+
+  it('never prints an unescaped `<` in prose — a pasted FreeMarker directive or Slack mention', () => {
+    // happy-dom turns `<@list …>` into a real element, and the resulting keys
+    // do not match the attribute pattern. Folding used to hand those back
+    // unchanged, printing a Slack user id and a full href from prose.
+    const html =
+      '<p>From Slack: <@U08JANE.DOE email="jane.doe@acme.test"> please review</p>' +
+      '<@list items="payroll-2026-Q1.csv" as="row">x</@list>' +
+      '<@p href="https://secret.test/a" style="color:red">z</@p>';
+    const audit = createAuditAccumulator();
+    audit.recordHtml('page_prose', auditPage(html, workspace));
+    const printed = formatAuditReport(audit.snapshot(), { partial: false }) + JSON.stringify(audit.snapshot());
+    for (const token of ['jane.doe@acme.test', 'payroll-2026-Q1.csv', 'u08jane', 'secret.test', '@list']) {
+      expect(printed.toLowerCase(), token).not.toContain(token.toLowerCase());
+    }
+  });
+
+  it('bounds every key it tallies, so one document cannot pad the whole report', () => {
+    const html = `<@x ${'long-name-'.repeat(200)}end="1">q</@x><p ${'b'.repeat(2000)}="1">y</p>`;
+    const audit = createAuditAccumulator();
+    audit.recordHtml('page_long', auditPage(html, workspace));
+    const snapshot = audit.snapshot();
+    const keys = [
+      ...snapshot.seed.droppedConstructs,
+      ...snapshot.seed.droppedConstructsCensusKeyed,
+      ...snapshot.seed.unexpectedAdditions,
+      ...snapshot.divergence.rows,
+    ].map((row) => row.key);
+    for (const key of keys) expect(key.length, key.slice(0, 40)).toBeLessThanOrEqual(64);
   });
 
   it('never prints markup TOKENS the author controls either — tag names, attribute names, style properties, enumerated values', () => {

--- a/scripts/__tests__/collab-seed-audit.test.ts
+++ b/scripts/__tests__/collab-seed-audit.test.ts
@@ -51,6 +51,7 @@ afterAll(() => {
   workspace.close();
 });
 
+/** Markup into a detached element in the shared workspace. */
 const parse = (html: string): HTMLElement => workspace.parse(html);
 
 /** A clean audit, as a fixture other tests narrow. */
@@ -61,6 +62,7 @@ const CLEAN_HTML =
   '<tr><td colspan="1" rowspan="1"><p>Ada</p></td></tr></tbody></table>' +
   '<pre><code class="language-ts">const x = 1;</code></pre>';
 
+/** Narrows to the audited branch, so a test that meant to measure a page fails loudly if it did not. */
 function audited(audit: PageAudit): PageAudit & { status: 'audited' } {
   if (audit.status !== 'audited') {
     throw new Error(`expected an audited page, got ${audit.status}`);
@@ -318,6 +320,7 @@ describe('censusKeyOf', () => {
 });
 
 describe('the accumulator and the report', () => {
+  /** A clean chain verdict, narrowed by `overrides` — so each test states only what it is about. */
   const chainResult = (overrides: Partial<ChainResult> = {}): ChainResult => ({
     stable: true,
     counterDecreases: [],
@@ -328,6 +331,7 @@ describe('the accumulator and the report', () => {
     ...overrides,
   });
 
+  /** A page that fails all three criteria on the seed chain, diverges, and the gate refuses. */
   function lossyAudit(overrides: Partial<PageAudit & { status: 'audited' }> = {}): PageAudit {
     return {
       status: 'audited',
@@ -351,6 +355,7 @@ describe('the accumulator and the report', () => {
     };
   }
 
+  /** A real audit of a document that loses nothing — not a literal, so it cannot drift from the code. */
   const cleanAudit = (): PageAudit => audited(auditPage(CLEAN_HTML, workspace));
 
   it('tallies each criterion, the conjunction, and per-construct example ids', () => {

--- a/scripts/__tests__/collab-seed-audit.test.ts
+++ b/scripts/__tests__/collab-seed-audit.test.ts
@@ -106,7 +106,7 @@ describe('content counters (criterion 2)', () => {
     });
   });
 
-  it('does not count the <div> TaskItem renders inside a task item, so a lost wrapper cannot be paid back by one', () => {
+  it('does not count the <div> TaskItem renders directly inside a task item, so a lost wrapper cannot be paid back by one', () => {
     const counts = countContent(
       parse(
         '<div><p>wrapper</p></div>' +
@@ -116,6 +116,16 @@ describe('content counters (criterion 2)', () => {
     );
     expect(counts['div (outside task items)']).toBe(1);
     expect(counts['input[type=checkbox]']).toBe(1);
+  });
+
+  it("still counts an author's <div> nested deeper inside a task item", () => {
+    const counts = countContent(
+      parse(
+        '<ul data-type="taskList"><li data-type="taskItem" data-checked="false">' +
+          '<div><p>todo</p><div><p>nested wrapper</p></div></div></li></ul>',
+      ),
+    );
+    expect(counts['div (outside task items)']).toBe(1);
   });
 
   it('reports a decrease and never an increase', () => {
@@ -156,8 +166,9 @@ describe('text (criterion 3)', () => {
     expect(visibleText(root)).toBe('keep');
   });
 
-  it('calls a document with no HTML element at all tagless', () => {
+  it('calls a document with no real HTML element tagless — a generic in prose is not markup', () => {
     expect(isTagless(parse('# heading\n\nplain markdown'))).toBe(true);
+    expect(isTagless(parse('const x: Set<string> = new Set();'))).toBe(true);
     expect(isTagless(parse('<p>html</p>'))).toBe(false);
   });
 });
@@ -284,7 +295,7 @@ describe('judgeChain and divergenceBetween (on DOMs, so the branches y-prosemirr
 });
 
 describe('gateReasonShape', () => {
-  it('strips the per-page counts off describeHtmlLoss reasons so they tally', () => {
+  it('strips the per-page counts off the gate reasons so they tally', () => {
     expect(gateReasonShape('dropped 2 <img> element(s)')).toBe('dropped <img>');
     expect(gateReasonShape('dropped 1 <iframe> element(s)')).toBe('dropped <iframe>');
     expect(gateReasonShape('visible text changed (140 characters in, 120 out)')).toBe('visible text changed');
@@ -460,11 +471,11 @@ describe('the accumulator and the report', () => {
     expect(formatAuditReport(clean.snapshot(), { partial: true })).toContain('INTERRUPTED');
 
     const blocked = createAuditAccumulator();
-    blocked.recordHtml('p', lossyAudit());
+    blocked.recordHtml('page_blocked_1', lossyAudit());
     const report = formatAuditReport(blocked.snapshot(), { partial: false });
     expect(report).toContain('AUDIT — BLOCKED');
     expect(report).toContain('counter decreased: img');
-    expect(report).toContain('p');
+    expect(report).toContain('page_blocked_1');
   });
 
   it('carries the tagless count into the header so a PASS cannot hide it', () => {
@@ -487,6 +498,31 @@ describe('the accumulator and the report', () => {
     expect(report).not.toContain(sentinel);
     expect(JSON.stringify(audit.snapshot())).not.toContain(sentinel);
   });
+
+  it('never prints markup TOKENS the author controls either — tag names, attribute names, style properties, enumerated values', () => {
+    // Every one of these is dropped by the schema, so every one lands in the
+    // dropped-constructs tables — the place a token would leak from.
+    const tokens = {
+      tag: 'secrettag9f3a',
+      attribute: 'secretattr9f3a',
+      property: 'secretprop9f3a',
+      dataType: 'secrettype9f3a',
+      checked: 'secretchecked9f3a',
+      start: 'secretstart9f3a',
+    };
+    const html =
+      `<${tokens.tag}>x</${tokens.tag}>` +
+      `<p ${tokens.attribute}="1" style="${tokens.property}: 1; --${tokens.property}: 2">y</p>` +
+      `<span data-type="${tokens.dataType}">z</span>` +
+      `<ul data-type="taskList"><li data-type="taskItem" data-checked="${tokens.checked}"><p>t</p></li></ul>` +
+      `<ol start="${tokens.start}"><li><p>o</p></li></ol>`;
+    const audit = createAuditAccumulator();
+    audit.recordHtml('page_y', auditPage(html, workspace));
+    const printed = formatAuditReport(audit.snapshot(), { partial: false }) + JSON.stringify(audit.snapshot());
+    for (const [position, token] of Object.entries(tokens)) {
+      expect(printed, position).not.toContain(token);
+    }
+  });
 });
 
 describe('options', () => {
@@ -503,6 +539,17 @@ describe('options', () => {
     expect(() => parseAuditArgs(['--limit'])).toThrow(/--limit requires a positive integer/);
     expect(() => parseAuditArgs(['--limit', '0'])).toThrow(/--limit requires a positive integer/);
     expect(() => parseAuditArgs(['--limit', 'ten'])).toThrow(/--limit requires a positive integer/);
+    expect(() => parseAuditArgs(['--limit='])).toThrow(/--limit requires a positive integer/);
+  });
+
+  it('accepts --flag=value', () => {
+    expect(parseAuditArgs(['--limit=5', '--batch-size=2']).limit).toBe(5);
+    expect(parseAuditArgs(['--limit=5', '--batch-size=2']).batchSize).toBe(2);
+  });
+
+  it('refuses an argument it does not know, so a typo cannot audit the whole table', () => {
+    expect(() => parseAuditArgs(['--limt', '5'])).toThrow(/unknown argument --limt/);
+    expect(() => parseAuditArgs(['5'])).toThrow(/unknown argument 5/);
   });
 });
 
@@ -538,6 +585,9 @@ describe('the audit is read-only and sequential by construction', () => {
     /\.delete\s*\(/,
     /\btransaction\s*\(/,
     /\b(INSERT|UPDATE|DELETE|TRUNCATE|ALTER|DROP|CREATE|GRANT)\b/i,
+    // The one write a read-only session still permits is turning itself off.
+    /\bSET\s+(default_transaction_read_only|transaction|session)\b/i,
+    /\bREAD\s+WRITE\b/i,
   ];
 
   it.each(sources)('%s contains no write', (relative) => {

--- a/scripts/__tests__/collab-seed-audit.test.ts
+++ b/scripts/__tests__/collab-seed-audit.test.ts
@@ -164,12 +164,46 @@ describe('text (criterion 3)', () => {
     expect(interWordText(parse('<p>hello <em>world</em></p>'))).toBe('hello world');
   });
 
+  it('keeps a whitespace-only node that IS the space between two words', () => {
+    // `a<span> </span>b` is what pasting from Word and Docs produces. Dropping
+    // every whitespace-only node made this read `ab` — identical to a page
+    // where the space was genuinely lost, so the one loss the diagnostic
+    // exists to catch became the one it could not see.
+    expect(interWordText(parse('<p>a<span> </span>b</p>'))).toBe('a b');
+    expect(interWordText(parse('<p>ab</p>'))).toBe('ab');
+    expect(interWordText(parse('<p>a b</p>'))).toBe('a b');
+  });
+
+  it('keeps whitespace inside <pre> verbatim, where it is the content', () => {
+    // visibleText strips all whitespace, so criterion 3 cannot see indentation
+    // either — if this collapsed too, a code block that lost every indent would
+    // report as affirmatively clean.
+    const indented = interWordText(parse('<pre><code>if (x) {\n    y();\n}</code></pre>'));
+    const flattened = interWordText(parse('<pre><code>if (x) {\ny();\n}</code></pre>'));
+    expect(indented).toContain('    y();');
+    expect(indented).not.toBe(flattened);
+  });
+
+  it('ignores comments, which carry no prose', () => {
+    expect(interWordText(parse('<p>a<!--SECRET-->b</p>'))).toBe('ab');
+  });
+
   it('drops the whitespace BETWEEN blocks, so pretty-printing is not reported as a lost space', () => {
     // The newline-and-indent between two blocks is its own text node. Reading
     // the document's textContent instead would make these two differ, and the
     // diagnostic would fire on every pretty-printed page in the corpus.
-    expect(interWordText(parse('<p>a</p>\n  <p>b</p>'))).toBe(interWordText(parse('<p>a</p><p>b</p>')));
+    expect(interWordText(parse('<p>a</p>\n  <p>b</p>'))).toBe('ab');
+    expect(interWordText(parse('<p>a</p><p>b</p>'))).toBe('ab');
     expect(interWordText(parse('<ul>\n  <li>x</li>\n  <li>y</li>\n</ul>'))).toBe('xy');
+    expect(interWordText(parse('<ul><li>x</li><li>y</li></ul>'))).toBe('xy');
+    // Tables are the densest source of inter-block whitespace in stored HTML,
+    // and every level of one has to count as a block or the indentation
+    // between cells reads as prose.
+    const prettyTable =
+      '<table>\n  <tbody>\n    <tr>\n      <td>a</td>\n      <td>b</td>\n    </tr>\n  </tbody>\n</table>';
+    expect(interWordText(parse(prettyTable))).toBe('ab');
+    expect(interWordText(parse('<table><tbody><tr><td>a</td><td>b</td></tr></tbody></table>'))).toBe('ab');
+    expect(interWordText(parse('<section>\n  <h2>t</h2>\n  <p>p</p>\n</section>'))).toBe('tp');
   });
 
   it('strips script, style, noscript and template before measuring — their text is not prose', () => {
@@ -481,12 +515,13 @@ describe('the accumulator and the report', () => {
 
   it('counts markdown-mode, empty, tagless and failed pages in the totals and fails the run on a failure', () => {
     const audit = createAuditAccumulator();
-    audit.recordMarkdownMode('md');
+    audit.recordMarkdownMode();
     audit.recordEmpty();
     audit.recordHtml('tagless', { ...audited(cleanAudit()), tagless: true });
     audit.recordHtml('broken', { status: 'failed', stage: 'parse', errorName: 'RangeError' });
     const snapshot = audit.snapshot();
     expect(snapshot.totals).toEqual({ documents: 4, audited: 2, markdownMode: 1, empty: 1, tagless: 1, failed: 1, divergent: 0 });
+    expect(snapshot.seed.whitespaceOnlyExamples).toEqual([]);
     expect(snapshot.taglessPages).toEqual([{ key: 'no HTML element', pages: 1, examplePageIds: ['tagless'] }]);
     expect(snapshot.failures).toEqual([{ key: 'parse: RangeError', pages: 1, examplePageIds: ['broken'] }]);
     expect(snapshot.seed.totals.lossy).toBe(0);
@@ -518,11 +553,15 @@ describe('the accumulator and the report', () => {
     // `<iframe>` has no node in the frozen schema, so dropping it closes the
     // gap around it: every visible character survives, the spacing does not.
     const spacing = '<p>a <iframe src="https://e.test/"></iframe> b</p>';
-    for (const id of ['ws_1', 'ws_2']) audit.recordHtml(id, auditPage(spacing, workspace));
+    for (const id of ['ws_1', 'ws_2', 'ws_3', 'ws_4', 'ws_5']) {
+      audit.recordHtml(id, auditPage(spacing, workspace));
+    }
     const snapshot = audit.snapshot();
-    expect(snapshot.seed.totals.whitespaceOnlyTextChange).toBe(2);
-    expect(snapshot.seed.whitespaceOnlyExamples).toEqual(['ws_1', 'ws_2']);
-    expect(formatAuditReport(snapshot, { partial: false })).toContain('e.g. ws_1 ws_2');
+    expect(snapshot.seed.totals.whitespaceOnlyTextChange).toBe(5);
+    // Capped like every other example list: enough to go and look at, not a
+    // transcript of who wrote what.
+    expect(snapshot.seed.whitespaceOnlyExamples).toEqual(['ws_1', 'ws_2', 'ws_3']);
+    expect(formatAuditReport(snapshot, { partial: false })).toContain('e.g. ws_1 ws_2 ws_3');
   });
 
   it('carries the tagless count into the header so a PASS cannot hide it', () => {

--- a/scripts/__tests__/collab-seed-audit.test.ts
+++ b/scripts/__tests__/collab-seed-audit.test.ts
@@ -37,6 +37,7 @@ import {
   createAuditAccumulator,
   formatAuditReport,
 } from '../lib/seed-audit/report';
+import { contentFreeKey } from '@pagespace/editor/seed-fidelity';
 import { parseAuditArgs } from '../lib/seed-audit/options';
 
 const here = path.dirname(fileURLToPath(import.meta.url));
@@ -333,6 +334,17 @@ describe('censusKeyOf', () => {
     // Fail closed, like contentFreeKey: a key it cannot decompose is not one
     // it can vouch for.
     expect(censusKeyOf('something-else')).toBe('text:unescaped-angle-bracket');
+  });
+
+  it('passes the unescaped-angle-bracket marker through, since folding produces it constantly', () => {
+    // The accumulator re-keys already-folded keys, and a folded key is often
+    // the marker — so this is a live path, not a defensive one.
+    expect(censusKeyOf(contentFreeKey('attr:@list@items=payroll.csv'))).toBe('text:unescaped-angle-bracket');
+    expect(censusKeyOf(contentFreeKey('el:secret-tag'))).toBe('text:unescaped-angle-bracket');
+    // …while a real construct still re-keys the way the census keys it.
+    expect(censusKeyOf(contentFreeKey('el:img'))).toBe('<img>');
+    expect(censusKeyOf(contentFreeKey('attr:p@style:text-align'))).toBe('style:text-align');
+    expect(censusKeyOf(contentFreeKey('attr:ul@data-type=taskList'))).toBe('attr:data-type=taskList');
   });
 });
 

--- a/scripts/__tests__/collab-seed-audit.test.ts
+++ b/scripts/__tests__/collab-seed-audit.test.ts
@@ -19,21 +19,21 @@ import {
   counterDecreases,
   isTagless,
   spaceCollapsedText,
-  stripNonContentElements,
   visibleText,
 } from '../lib/seed-audit/criteria';
+import { stripNonContentElements } from '@pagespace/editor/html-to-ydoc';
 import {
   auditPage,
   divergenceBetween,
   gateReasonShape,
   isLossy,
   judgeChain,
+  type ChainResult,
   type PageAudit,
 } from '../lib/seed-audit/analyze';
 import {
   auditPassed,
   censusKeyOf,
-  contentFreeKey,
   createAuditAccumulator,
   formatAuditReport,
 } from '../lib/seed-audit/report';
@@ -51,7 +51,7 @@ afterAll(() => {
   workspace.close();
 });
 
-const parse = (html: string): Element => workspace.parse(html);
+const parse = (html: string): HTMLElement => workspace.parse(html);
 
 /** A clean audit, as a fixture other tests narrow. */
 const CLEAN_HTML =
@@ -192,10 +192,11 @@ describe('auditPage — the two chains', () => {
     expect(isLossy(audit.seed)).toBe(true);
   });
 
-  it('does not report a <style> block as lost text', () => {
+  it('does not report a <style> block as lost text — and neither does the gate, because it judges the same stripped source', () => {
     const audit = audited(auditPage('<style>p{margin:0}</style><p>prose</p>', workspace));
     expect(audit.seed.textPreserved).toBe(true);
     expect(isLossy(audit.seed)).toBe(false);
+    expect(audit.gateReasons).toEqual([]);
   });
 
   it('accepts the cosmetic rewrites the allowlist names and reports nothing outside it', () => {
@@ -305,44 +306,29 @@ describe('censusKeyOf', () => {
   });
 });
 
-describe('contentFreeKey', () => {
-  it('keeps the values the schema itself enumerates', () => {
-    expect(contentFreeKey('attr:ul@data-type=taskList')).toBe('attr:ul@data-type=taskList');
-    expect(contentFreeKey('attr:li@data-checked=true')).toBe('attr:li@data-checked=true');
-    expect(contentFreeKey('attr:td@colspan=2')).toBe('attr:td@colspan=2');
-    expect(contentFreeKey('attr:ol@start=7')).toBe('attr:ol@start=7');
-  });
-
-  it('folds prose, urls and ids back to presence', () => {
-    expect(contentFreeKey('attr:img@alt=a photo of Ada')).toBe('attr:img@alt');
-    expect(contentFreeKey('attr:a@href=https://x.test/ada-lovelace')).toBe('attr:a@href');
-    expect(contentFreeKey('attr:a@data-page-id=pg_1')).toBe('attr:a@data-page-id');
-    expect(contentFreeKey('el:img')).toBe('el:img');
-    expect(contentFreeKey('attr:p@style:text-align')).toBe('attr:p@style:text-align');
-  });
-});
-
 describe('the accumulator and the report', () => {
+  const chainResult = (overrides: Partial<ChainResult> = {}): ChainResult => ({
+    stable: true,
+    counterDecreases: [],
+    textPreserved: true,
+    whitespaceOnlyTextChange: false,
+    droppedConstructs: [],
+    unexpectedAdditions: [],
+    ...overrides,
+  });
+
   function lossyAudit(overrides: Partial<PageAudit & { status: 'audited' }> = {}): PageAudit {
     return {
       status: 'audited',
       tagless: false,
-      census: {
-        stable: true,
-        counterDecreases: ['img'],
-        textPreserved: true,
-        whitespaceOnlyTextChange: false,
-        droppedConstructs: ['attr:img@src', 'el:img'],
-        unexpectedAdditions: [],
-      },
-      seed: {
+      census: chainResult({ counterDecreases: ['img'], droppedConstructs: ['attr:img@src', 'el:img'] }),
+      seed: chainResult({
         stable: false,
         counterDecreases: ['img'],
         textPreserved: false,
-        whitespaceOnlyTextChange: false,
         droppedConstructs: ['attr:img@src', 'el:img'],
         unexpectedAdditions: ['el:figure'],
-      },
+      }),
       divergence: {
         counterChanges: ['img'],
         textChanged: true,
@@ -393,14 +379,7 @@ describe('the accumulator and the report', () => {
     audit.recordHtml(
       'page_1',
       lossyAudit({
-        seed: {
-          stable: true,
-          counterDecreases: [],
-          textPreserved: true,
-          whitespaceOnlyTextChange: false,
-          droppedConstructs: ['attr:h2@style:text-align', 'attr:p@style:text-align'],
-          unexpectedAdditions: [],
-        },
+        seed: chainResult({ droppedConstructs: ['attr:h2@style:text-align', 'attr:p@style:text-align'] }),
       }),
     );
     expect(audit.snapshot().seed.droppedConstructsCensusKeyed).toEqual([
@@ -423,21 +402,27 @@ describe('the accumulator and the report', () => {
 
   it('classifies every page into one of the four gate-agreement cells', () => {
     const audit = createAuditAccumulator();
-    const cleanSeed = { stable: true, counterDecreases: [], textPreserved: true, whitespaceOnlyTextChange: false, droppedConstructs: [], unexpectedAdditions: [] };
-    audit.recordHtml('both_lossy', lossyAudit());
+    const cleanSeed = chainResult();
+    // Distinct counts per cell, so a count derived from the wrong cell fails.
+    audit.recordHtml('both_lossy_1', lossyAudit());
+    audit.recordHtml('both_lossy_2', lossyAudit());
     audit.recordHtml('blind_spot', lossyAudit({ gateReasons: [] }));
-    audit.recordHtml('stricter', lossyAudit({ seed: cleanSeed, gateReasons: ['visible text changed'] }));
-    audit.recordHtml('both_clean', lossyAudit({ seed: cleanSeed, gateReasons: [] }));
+    audit.recordHtml('stricter_1', lossyAudit({ seed: cleanSeed, gateReasons: ['visible text changed'] }));
+    audit.recordHtml('stricter_2', lossyAudit({ seed: cleanSeed, gateReasons: ['visible text changed'] }));
+    audit.recordHtml('stricter_3', lossyAudit({ seed: cleanSeed, gateReasons: ['visible text changed'] }));
+    for (const id of ['clean_1', 'clean_2', 'clean_3', 'clean_4']) {
+      audit.recordHtml(id, lossyAudit({ seed: cleanSeed, gateReasons: [] }));
+    }
     const { gate } = audit.snapshot();
-    expect(gate.agreement).toEqual({ bothLossy: 1, gateBlindSpot: 1, gateStricter: 1, bothClean: 1 });
+    expect(gate.agreement).toEqual({ bothLossy: 2, gateBlindSpot: 1, gateStricter: 3, bothClean: 4 });
     expect(gate.agreementRows).toEqual([
-      { key: 'bothLossy', pages: 1, examplePageIds: ['both_lossy'] },
+      { key: 'gateStricter', pages: 3, examplePageIds: ['stricter_1', 'stricter_2', 'stricter_3'] },
+      { key: 'bothLossy', pages: 2, examplePageIds: ['both_lossy_1', 'both_lossy_2'] },
       { key: 'gateBlindSpot', pages: 1, examplePageIds: ['blind_spot'] },
-      { key: 'gateStricter', pages: 1, examplePageIds: ['stricter'] },
     ]);
     expect(gate.reasons).toEqual([
-      { key: 'dropped <img>', pages: 1, examplePageIds: ['both_lossy'] },
-      { key: 'visible text changed', pages: 1, examplePageIds: ['stricter'] },
+      { key: 'visible text changed', pages: 3, examplePageIds: ['stricter_1', 'stricter_2', 'stricter_3'] },
+      { key: 'dropped <img>', pages: 2, examplePageIds: ['both_lossy_1', 'both_lossy_2'] },
     ]);
   });
 

--- a/scripts/collab-seed-audit.ts
+++ b/scripts/collab-seed-audit.ts
@@ -67,6 +67,7 @@ import { auditPage } from './lib/seed-audit/analyze';
 import { parseAuditArgs } from './lib/seed-audit/options';
 import { auditPassed, createAuditAccumulator, formatAuditReport } from './lib/seed-audit/report';
 
+/** Runs the audit and returns the process exit code: 0 only for a complete, passing run. */
 async function main(): Promise<number> {
   const options = parseAuditArgs(process.argv.slice(2));
 

--- a/scripts/collab-seed-audit.ts
+++ b/scripts/collab-seed-audit.ts
@@ -1,0 +1,145 @@
+/**
+ * Collab seed fidelity audit — the Phase B exit criterion (multiplayer epic).
+ *
+ * Streams every DOCUMENT page and takes each `contentMode='html'` one through
+ * the full seed path, HTML → ProseMirror → Y.Doc → ProseMirror → HTML, over
+ * the frozen `COLLAB_SCHEMA_VERSION` v1 schema in `@pagespace/editor` — and,
+ * on the same parse, through the shorter HTML → ProseMirror → HTML chain the
+ * content census ran (`apps/web/scripts/collab-content-census.ts`). The two
+ * are reported side by side and must agree; where they do not, the only thing
+ * between them is `y-prosemirror`, and the report names what it changed.
+ *
+ * Three criteria, all hard blockers, no thresholds (see lib/seed-audit/
+ * criteria.ts): one-pass stability, no decrease in any content-bearing
+ * counter, and visible text preserved. Any page failing any of them on the
+ * seed chain makes the run BLOCKED and the exit code non-zero. Seeding is
+ * permanent — once a page is a Y.Doc the flattened version IS the document —
+ * so a lossy page is a finding about the schema, never a rate to tolerate.
+ *
+ * READ-ONLY, and not on the honour system: every connection the pool opens is
+ * put into `default_transaction_read_only` at the server
+ * (`@pagespace/db/read-only-session`), the setting is read back before the
+ * first real query, and `__tests__/collab-seed-audit.test.ts` fails the build
+ * if any audit source grows a write.
+ *
+ * NEVER PRINTS DOCUMENT CONTENT. This runs against production user data. The
+ * report is criterion names, construct keys, counts and at most three example
+ * page ids per row — an id is a handle someone holding the credential can go
+ * and look at; an excerpt is user content in a terminal scrollback. Failures
+ * are reported by stage and error TYPE only, because ProseMirror quotes the
+ * offending markup in its messages.
+ *
+ * ONE connection, ONE query at a time. `getMigrationPool()` is deliberately
+ * `max: 1` so a long script cannot starve the deployment; a `Promise.all`
+ * over a batch against it is a self-deadlock, and has been. Everything here
+ * is sequential by construction.
+ *
+ * `contentMode='markdown'` pages are counted and skipped: they are markdown
+ * source, not HTML, and reach this surface through the Phase K migration.
+ * An html-mode page with no HTML element at all is markdown (or plain text)
+ * under the wrong label; it is audited like any other but counted in its
+ * own row, because Phase E must refuse to seed it regardless of what the
+ * column says.
+ *
+ * Run from the repo root, with DATABASE_URL pointing at the database to audit:
+ *
+ *   bun run collab:seed-audit
+ *
+ * Only the report goes to stdout, so `> seed-audit.txt` captures it and
+ * nothing else. Exit code 0 means PASS; 1 means BLOCKED, a processing failure,
+ * or an interrupted run.
+ *
+ * Options:
+ *   --limit N           stop after N documents (a smoke run before the full one)
+ *   --batch-size N      rows per query (default 200)
+ *   --progress-every N  progress line to stderr every N documents (default 500)
+ *
+ * Ctrl-C stops the scan and prints what it has, labelled INTERRUPTED.
+ */
+
+import { getMigrationDb, getMigrationPool } from '@pagespace/db/db';
+import { pages } from '@pagespace/db/schema/core';
+import { and, asc, eq, gt, sql } from '@pagespace/db/operators';
+import { assertReadOnlySession, enforceReadOnlySession } from '@pagespace/db/read-only-session';
+import { SCHEMA_HASH, COLLAB_SCHEMA_VERSION } from '@pagespace/editor/collab-schema';
+import { createDomWorkspace } from '@pagespace/editor/dom-workspace';
+import { auditPage } from './lib/seed-audit/analyze';
+import { parseAuditArgs } from './lib/seed-audit/options';
+import { auditPassed, createAuditAccumulator, formatAuditReport } from './lib/seed-audit/report';
+
+async function main(): Promise<number> {
+  const options = parseAuditArgs(process.argv.slice(2));
+
+  // Registered before the pool is handed to drizzle, and therefore before it
+  // has opened a connection to attach the guard to.
+  enforceReadOnlySession(getMigrationPool());
+  const db = getMigrationDb();
+  assertReadOnlySession((await db.execute(sql`SHOW default_transaction_read_only`)).rows);
+
+  process.stderr.write(
+    `auditing against COLLAB_SCHEMA_VERSION ${COLLAB_SCHEMA_VERSION} (SCHEMA_HASH ${SCHEMA_HASH})\n`,
+  );
+
+  const workspace = createDomWorkspace();
+  const audit = createAuditAccumulator();
+
+  let interrupted = false;
+  const onInterrupt = () => {
+    if (interrupted) process.exit(130);
+    interrupted = true;
+    process.stderr.write('\ninterrupted — finishing this batch, then reporting what was scanned\n');
+  };
+  process.on('SIGINT', onInterrupt);
+
+  let scanned = 0;
+  // Keyset pagination on the primary key rather than OFFSET: the scan holds no
+  // cursor open across batches, so it is interruptible and costs the same on
+  // the last page as on the first.
+  let after: string | null = null;
+
+  try {
+    while (!interrupted && scanned < options.limit) {
+      const remaining = options.limit - scanned;
+      const batch = await db
+        .select({ id: pages.id, content: pages.content, contentMode: pages.contentMode })
+        .from(pages)
+        // `and()` drops an undefined operand, so the first batch and every
+        // batch after it state the DOCUMENT filter once. Trashed pages are
+        // included: a restored page is seeded like any other.
+        .where(and(eq(pages.type, 'DOCUMENT'), after === null ? undefined : gt(pages.id, after)))
+        .orderBy(asc(pages.id))
+        .limit(Math.min(options.batchSize, remaining));
+
+      if (batch.length === 0) break;
+
+      for (const page of batch) {
+        // /\S/ rather than trim(): a whole-string copy per document, for a
+        // question answered by the first non-space character.
+        if (!/\S/.test(page.content)) {
+          audit.recordEmpty();
+        } else if (page.contentMode === 'markdown') {
+          audit.recordMarkdownMode(page.id);
+        } else {
+          audit.recordHtml(page.id, auditPage(page.content, workspace));
+        }
+
+        scanned += 1;
+        if (scanned % options.progressEvery === 0) {
+          process.stderr.write(`scanned ${scanned} documents\n`);
+        }
+      }
+
+      after = batch[batch.length - 1].id;
+    }
+  } finally {
+    process.off('SIGINT', onInterrupt);
+    workspace.close();
+    await getMigrationPool().end();
+  }
+
+  const snapshot = audit.snapshot();
+  process.stdout.write(`${formatAuditReport(snapshot, { partial: interrupted })}\n`);
+  return !interrupted && auditPassed(snapshot) ? 0 : 1;
+}
+
+process.exitCode = await main();

--- a/scripts/collab-seed-audit.ts
+++ b/scripts/collab-seed-audit.ts
@@ -119,7 +119,7 @@ async function main(): Promise<number> {
         if (!/\S/.test(page.content)) {
           audit.recordEmpty();
         } else if (page.contentMode === 'markdown') {
-          audit.recordMarkdownMode(page.id);
+          audit.recordMarkdownMode();
         } else {
           audit.recordHtml(page.id, auditPage(page.content, workspace));
         }

--- a/scripts/collab-seed-audit.ts
+++ b/scripts/collab-seed-audit.ts
@@ -85,6 +85,7 @@ async function main(): Promise<number> {
   const audit = createAuditAccumulator();
 
   let interrupted = false;
+  /** First Ctrl-C stops after the current batch and still reports; a second exits immediately. */
   const onInterrupt = () => {
     if (interrupted) process.exit(130);
     interrupted = true;

--- a/scripts/lib/seed-audit/analyze.ts
+++ b/scripts/lib/seed-audit/analyze.ts
@@ -1,0 +1,235 @@
+import { pmDocToYDoc, yDocToPmDoc } from '@pagespace/editor/collab-document';
+import type { DomWorkspace } from '@pagespace/editor/dom-workspace';
+import { describeHtmlLoss, parseHtmlElementUnchecked } from '@pagespace/editor/html-to-ydoc';
+import { pmDocToHtml } from '@pagespace/editor/y-doc-to-html';
+import {
+  ALLOWED_COSMETIC_ADDITIONS,
+  constructDifference,
+  constructKeysOf,
+} from '@pagespace/editor/seed-fidelity';
+import {
+  countContent,
+  counterDecreases,
+  isTagless,
+  spaceCollapsedText,
+  stripNonContentElements,
+  visibleText,
+  type ContentCounts,
+} from './criteria';
+
+/**
+ * One stored document through BOTH chains, judged by the three criteria on
+ * each, with the difference between the chains isolated.
+ *
+ *   census chain:  HTML → ProseMirror → HTML
+ *   seed chain:    HTML → ProseMirror → Y.Doc → ProseMirror → HTML
+ *
+ * The census chain is what `apps/web/scripts/collab-content-census.ts` ran;
+ * the seed chain is what Phase E will actually do to the document. They are
+ * run side by side on the same parse so the comparison is direct: if the two
+ * projections differ, the ProseMirror schema is not what changed — the only
+ * thing between them is `y-prosemirror` (`prosemirrorToYXmlFragment` and
+ * `yXmlFragmentToProseMirrorRootNode`), and the divergence names what it
+ * altered.
+ *
+ * NEVER RETURNS DOCUMENT CONTENT. Every field is a boolean, a count, a
+ * construct key (`el:img`, `attr:ul@class`), a counter name or an error type.
+ */
+
+/** One chain's verdict on one page. */
+export interface ChainResult {
+  /** Criterion 1: `render(parse(h1)) == h1`. */
+  stable: boolean;
+  /** Criterion 2: counters that DECREASED from `src` to `h1`. Empty means none did. */
+  counterDecreases: string[];
+  /** Criterion 3: whitespace-stripped visible text equal between `src` and `h1`. */
+  textPreserved: boolean;
+  /**
+   * Diagnostic, never a verdict: text equal with all whitespace stripped but
+   * NOT with runs collapsed to a single space — a space vanished or appeared
+   * between words. See `visibleText` for why this is not criterion 3.
+   */
+  whitespaceOnlyTextChange: boolean;
+  /** Construct keys present in `src` and absent from `h1` — presence-based, the census's own measure. */
+  droppedConstructs: string[];
+  /** Construct keys `h1` gained that are NOT in `ALLOWED_COSMETIC_ADDITIONS`. */
+  unexpectedAdditions: string[];
+}
+
+/** True when any of the three hard blockers failed. */
+export function isLossy(result: ChainResult): boolean {
+  return !result.stable || result.counterDecreases.length > 0 || !result.textPreserved;
+}
+
+/** What `y-prosemirror` changed, when the two chains' projections differ. */
+export interface ChainDivergence {
+  /** Counters whose value differs between the census projection and the seed projection. */
+  counterChanges: string[];
+  textChanged: boolean;
+  /** Constructs the census chain rendered that the seed chain did not. */
+  constructsLost: string[];
+  /** Constructs the seed chain rendered that the census chain did not. */
+  constructsGained: string[];
+}
+
+export type PageAudit =
+  | {
+      status: 'audited';
+      /** No HTML element at all — markdown or plain text under an html label. */
+      tagless: boolean;
+      census: ChainResult;
+      seed: ChainResult;
+      /** `null` when both chains rendered byte-identical `h1`. */
+      divergence: ChainDivergence | null;
+      /**
+       * What the package's own seed gate (`describeHtmlLoss`, the check
+       * `htmlToYDoc` throws on) says about this page, as content-free reason
+       * SHAPES — `dropped <img>`, `visible text changed` — with the counts the
+       * reasons carry stripped off so they tally.
+       */
+      gateReasons: string[];
+    }
+  | {
+      /**
+       * The document could not be taken through the chain at all. Only the
+       * stage and the error TYPE are kept: ProseMirror quotes the offending
+       * markup in its messages, and this runs against production user data.
+       */
+      status: 'failed';
+      stage: 'parse' | 'render' | 'ydoc' | 'gate';
+      errorName: string;
+    };
+
+type PmNode = ReturnType<typeof parseHtmlElementUnchecked>;
+
+/**
+ * `htmlToPmDoc` is deliberately NOT used to parse: it throws on the very
+ * pages this audit exists to describe. `parseHtmlElementUnchecked` is the
+ * same `DOMParser` call over the same frozen schema, minus the throw — and
+ * `describeHtmlLoss` is run alongside so the gate's own verdict is still on
+ * the record for every page.
+ */
+function parse(root: Element): PmNode {
+  return parseHtmlElementUnchecked(root as HTMLElement);
+}
+
+function throughYDoc(doc: PmNode): PmNode {
+  const yDoc = pmDocToYDoc(doc);
+  try {
+    return yDocToPmDoc(yDoc);
+  } finally {
+    // One Y.Doc per page per chain over thousands of pages; each holds its
+    // own event emitters until destroyed.
+    yDoc.destroy();
+  }
+}
+
+interface Measured {
+  counts: ContentCounts;
+  text: string;
+  spacedText: string;
+  constructs: Set<string>;
+}
+
+function measure(root: Element): Measured {
+  return {
+    counts: countContent(root),
+    text: visibleText(root),
+    spacedText: spaceCollapsedText(root),
+    constructs: constructKeysOf(root),
+  };
+}
+
+/** The three criteria (plus the presence-based construct diff) for one rendered `h1` against its source. */
+export function judgeChain(sourceRoot: Element, renderedRoot: Element, stable: boolean): ChainResult {
+  return judge(measure(sourceRoot), measure(renderedRoot), stable);
+}
+
+function judge(source: Measured, rendered: Measured, stable: boolean): ChainResult {
+  const textPreserved = source.text === rendered.text;
+  return {
+    stable,
+    counterDecreases: counterDecreases(source.counts, rendered.counts),
+    textPreserved,
+    whitespaceOnlyTextChange: textPreserved && source.spacedText !== rendered.spacedText,
+    droppedConstructs: constructDifference(source.constructs, rendered.constructs),
+    unexpectedAdditions: constructDifference(rendered.constructs, source.constructs).filter(
+      (key) => !ALLOWED_COSMETIC_ADDITIONS.has(key),
+    ),
+  };
+}
+
+/** What the seed projection changed relative to the census projection of the same page. */
+export function divergenceBetween(censusRoot: Element, seedRoot: Element): ChainDivergence {
+  return diverge(measure(censusRoot), measure(seedRoot));
+}
+
+function diverge(census: Measured, seed: Measured): ChainDivergence {
+  return {
+    counterChanges: Object.keys(census.counts).filter((key) => census.counts[key] !== seed.counts[key]),
+    textChanged: census.text !== seed.text,
+    constructsLost: constructDifference(census.constructs, seed.constructs),
+    constructsGained: constructDifference(seed.constructs, census.constructs),
+  };
+}
+
+/**
+ * `describeHtmlLoss` reasons carry counts ("dropped 2 <img> element(s)",
+ * "visible text changed (140 characters in, 120 out)"). The count is per
+ * page; the SHAPE is what tallies across pages.
+ */
+export function gateReasonShape(reason: string): string {
+  const dropped = /^dropped \d+ <([a-z0-9-]+)> element\(s\)$/u.exec(reason);
+  if (dropped) return `dropped <${dropped[1]}>`;
+  if (/^visible text changed \(/u.test(reason)) return 'visible text changed';
+  return reason;
+}
+
+/**
+ * Runs the page. `workspace` is the run's single happy-dom window — a parse
+ * per measurement, never a window per page. Errors are caught per stage so a
+ * page that ProseMirror cannot parse is a row in the failure table, not the
+ * end of the run.
+ */
+export function auditPage(html: string, workspace: DomWorkspace): PageAudit {
+  let stage: 'parse' | 'render' | 'ydoc' | 'gate' = 'parse';
+  try {
+    const sourceRoot = workspace.parse(html);
+    stripNonContentElements(sourceRoot);
+    const source = measure(sourceRoot);
+    const tagless = isTagless(sourceRoot);
+    const sourceDoc = parse(sourceRoot);
+
+    // Census chain: HTML → PM → HTML, then once more for stability.
+    stage = 'render';
+    const h1 = pmDocToHtml(sourceDoc);
+    const h1Root = workspace.parse(h1);
+    const h2 = pmDocToHtml(parse(h1Root));
+    const censusRendered = measure(h1Root);
+
+    // Seed chain: the same parse, through a Y.Doc and back, then once more.
+    stage = 'ydoc';
+    const h1y = pmDocToHtml(throughYDoc(sourceDoc));
+    const h1yRoot = workspace.parse(h1y);
+    const h2y = pmDocToHtml(throughYDoc(parse(h1yRoot)));
+    const seedRendered = measure(h1yRoot);
+
+    stage = 'gate';
+    const gateReasons = describeHtmlLoss(html).map(gateReasonShape);
+
+    return {
+      status: 'audited',
+      tagless,
+      census: judge(source, censusRendered, h1 === h2),
+      seed: judge(source, seedRendered, h1y === h2y),
+      divergence: h1 === h1y ? null : diverge(censusRendered, seedRendered),
+      gateReasons,
+    };
+  } catch (error) {
+    return {
+      status: 'failed',
+      stage,
+      errorName: error instanceof Error ? error.name : 'unknown',
+    };
+  }
+}

--- a/scripts/lib/seed-audit/analyze.ts
+++ b/scripts/lib/seed-audit/analyze.ts
@@ -15,7 +15,7 @@ import {
   countContent,
   counterDecreases,
   isTagless,
-  spaceCollapsedText,
+  interWordText,
   visibleText,
   type ContentCounts,
 } from './criteria';
@@ -48,9 +48,10 @@ export interface ChainResult {
   /** Criterion 3: whitespace-stripped visible text equal between `src` and `h1`. */
   textPreserved: boolean;
   /**
-   * Diagnostic, never a verdict: text equal with all whitespace stripped but
-   * NOT with runs collapsed to a single space — a space vanished or appeared
-   * between words. See `visibleText` for why this is not criterion 3.
+   * Diagnostic, never a verdict: every visible character survived, but the
+   * spacing BETWEEN words did not — a space vanished or appeared. See
+   * `interWordText` for why this is measured per text node, and `visibleText`
+   * for why it is not criterion 3.
    */
   whitespaceOnlyTextChange: boolean;
   /** Construct keys present in `src` and absent from `h1` — presence-based, the census's own measure. */
@@ -137,7 +138,7 @@ function throughYDoc(doc: PmNode): PmNode {
 interface Measured {
   counts: ContentCounts;
   text: string;
-  spacedText: string;
+  interWord: string;
   constructs: Set<string>;
 }
 
@@ -146,7 +147,7 @@ function measure(root: Element): Measured {
   return {
     counts: countContent(root),
     text: visibleText(root),
-    spacedText: spaceCollapsedText(root),
+    interWord: interWordText(root),
     constructs: constructKeysOf(root),
   };
 }
@@ -163,7 +164,7 @@ function judge(source: Measured, rendered: Measured, stable: boolean): ChainResu
     stable,
     counterDecreases: counterDecreases(source.counts, rendered.counts),
     textPreserved,
-    whitespaceOnlyTextChange: textPreserved && source.spacedText !== rendered.spacedText,
+    whitespaceOnlyTextChange: textPreserved && source.interWord !== rendered.interWord,
     droppedConstructs: constructDifference(source.constructs, rendered.constructs),
     unexpectedAdditions: constructDifference(rendered.constructs, source.constructs).filter(
       (key) => !ALLOWED_COSMETIC_ADDITIONS.has(key),

--- a/scripts/lib/seed-audit/analyze.ts
+++ b/scripts/lib/seed-audit/analyze.ts
@@ -142,7 +142,7 @@ interface Measured {
   constructs: Set<string>;
 }
 
-/** Everything the three criteria and the construct diff need from one parsed page, in one walk. */
+/** Everything the three criteria and the construct diff need from one parsed page, in one call. */
 function measure(root: Element): Measured {
   return {
     counts: countContent(root),
@@ -157,7 +157,7 @@ export function judgeChain(sourceRoot: Element, renderedRoot: Element, stable: b
   return judge(measure(sourceRoot), measure(renderedRoot), stable);
 }
 
-/** The three criteria over an already-measured source and rendering; `judgeChain` is the public form. */
+/** The three criteria and the whitespace diagnostic over an already-measured source and rendering; `judgeChain` is the public form. */
 function judge(source: Measured, rendered: Measured, stable: boolean): ChainResult {
   const textPreserved = source.text === rendered.text;
   return {

--- a/scripts/lib/seed-audit/analyze.ts
+++ b/scripts/lib/seed-audit/analyze.ts
@@ -118,6 +118,11 @@ function parse(root: HTMLElement): PmNode {
   return parseHtmlElementUnchecked(root);
 }
 
+/**
+ * `doc` seeded into a `Y.Doc` and read straight back out — the step that makes
+ * the seed chain differ from the census chain, and the only place
+ * `y-prosemirror` can lose something.
+ */
 function throughYDoc(doc: PmNode): PmNode {
   const yDoc = pmDocToYDoc(doc);
   try {
@@ -136,6 +141,7 @@ interface Measured {
   constructs: Set<string>;
 }
 
+/** Everything the three criteria and the construct diff need from one parsed page, in one walk. */
 function measure(root: Element): Measured {
   return {
     counts: countContent(root),
@@ -150,6 +156,7 @@ export function judgeChain(sourceRoot: Element, renderedRoot: Element, stable: b
   return judge(measure(sourceRoot), measure(renderedRoot), stable);
 }
 
+/** The three criteria over an already-measured source and rendering; `judgeChain` is the public form. */
 function judge(source: Measured, rendered: Measured, stable: boolean): ChainResult {
   const textPreserved = source.text === rendered.text;
   return {
@@ -169,6 +176,7 @@ export function divergenceBetween(censusRoot: Element, seedRoot: Element): Chain
   return diverge(measure(censusRoot), measure(seedRoot));
 }
 
+/** The census-vs-seed comparison over two already-measured renderings; `divergenceBetween` is the public form. */
 function diverge(census: Measured, seed: Measured): ChainDivergence {
   return {
     counterChanges: Object.keys(census.counts).filter((key) => census.counts[key] !== seed.counts[key]),

--- a/scripts/lib/seed-audit/analyze.ts
+++ b/scripts/lib/seed-audit/analyze.ts
@@ -1,7 +1,11 @@
 import { pmDocToYDoc, yDocToPmDoc } from '@pagespace/editor/collab-document';
 import type { DomWorkspace } from '@pagespace/editor/dom-workspace';
-import { describeHtmlLoss, parseHtmlElementUnchecked } from '@pagespace/editor/html-to-ydoc';
-import { pmDocToHtml } from '@pagespace/editor/y-doc-to-html';
+import {
+  describeParseLoss,
+  parseHtmlElementUnchecked,
+  stripNonContentElements,
+} from '@pagespace/editor/html-to-ydoc';
+import { pmDocToHtmlIn } from '@pagespace/editor/y-doc-to-html';
 import {
   ALLOWED_COSMETIC_ADDITIONS,
   constructDifference,
@@ -12,7 +16,6 @@ import {
   counterDecreases,
   isTagless,
   spaceCollapsedText,
-  stripNonContentElements,
   visibleText,
   type ContentCounts,
 } from './criteria';
@@ -82,7 +85,7 @@ export type PageAudit =
       /** `null` when both chains rendered byte-identical `h1`. */
       divergence: ChainDivergence | null;
       /**
-       * What the package's own seed gate (`describeHtmlLoss`, the check
+       * What the package's own seed gate (`describeParseLoss`, the check
        * `htmlToYDoc` throws on) says about this page, as content-free reason
        * SHAPES — `dropped <img>`, `visible text changed` — with the counts the
        * reasons carry stripped off so they tally.
@@ -96,9 +99,11 @@ export type PageAudit =
        * markup in its messages, and this runs against production user data.
        */
       status: 'failed';
-      stage: 'parse' | 'render' | 'ydoc' | 'gate';
+      stage: FailureStage;
       errorName: string;
     };
+
+export type FailureStage = 'parse' | 'render' | 'ydoc' | 'gate';
 
 type PmNode = ReturnType<typeof parseHtmlElementUnchecked>;
 
@@ -106,8 +111,8 @@ type PmNode = ReturnType<typeof parseHtmlElementUnchecked>;
  * `htmlToPmDoc` is deliberately NOT used to parse: it throws on the very
  * pages this audit exists to describe. `parseHtmlElementUnchecked` is the
  * same `DOMParser` call over the same frozen schema, minus the throw — and
- * `describeHtmlLoss` is run alongside so the gate's own verdict is still on
- * the record for every page.
+ * `describeParseLoss` is run over the same parse so the gate's own verdict is
+ * on the record for every page without parsing it twice.
  */
 function parse(root: Element): PmNode {
   return parseHtmlElementUnchecked(root as HTMLElement);
@@ -174,7 +179,7 @@ function diverge(census: Measured, seed: Measured): ChainDivergence {
 }
 
 /**
- * `describeHtmlLoss` reasons carry counts ("dropped 2 <img> element(s)",
+ * Gate reasons carry counts ("dropped 2 <img> element(s)",
  * "visible text changed (140 characters in, 120 out)"). The count is per
  * page; the SHAPE is what tallies across pages.
  */
@@ -186,13 +191,13 @@ export function gateReasonShape(reason: string): string {
 }
 
 /**
- * Runs the page. `workspace` is the run's single happy-dom window — a parse
- * per measurement, never a window per page. Errors are caught per stage so a
- * page that ProseMirror cannot parse is a row in the failure table, not the
- * end of the run.
+ * Runs the page. `workspace` is the run's single happy-dom window — every
+ * parse and every render goes through it, so a run creates one window, not
+ * five per page. Errors are caught per stage so a page that ProseMirror
+ * cannot parse is a row in the failure table, not the end of the run.
  */
 export function auditPage(html: string, workspace: DomWorkspace): PageAudit {
-  let stage: 'parse' | 'render' | 'ydoc' | 'gate' = 'parse';
+  let stage: FailureStage = 'parse';
   try {
     const sourceRoot = workspace.parse(html);
     stripNonContentElements(sourceRoot);
@@ -202,20 +207,20 @@ export function auditPage(html: string, workspace: DomWorkspace): PageAudit {
 
     // Census chain: HTML → PM → HTML, then once more for stability.
     stage = 'render';
-    const h1 = pmDocToHtml(sourceDoc);
+    const h1 = pmDocToHtmlIn(sourceDoc, workspace);
     const h1Root = workspace.parse(h1);
-    const h2 = pmDocToHtml(parse(h1Root));
+    const h2 = pmDocToHtmlIn(parse(h1Root), workspace);
     const censusRendered = measure(h1Root);
 
     // Seed chain: the same parse, through a Y.Doc and back, then once more.
     stage = 'ydoc';
-    const h1y = pmDocToHtml(throughYDoc(sourceDoc));
+    const h1y = pmDocToHtmlIn(throughYDoc(sourceDoc), workspace);
     const h1yRoot = workspace.parse(h1y);
-    const h2y = pmDocToHtml(throughYDoc(parse(h1yRoot)));
+    const h2y = pmDocToHtmlIn(throughYDoc(parse(h1yRoot)), workspace);
     const seedRendered = measure(h1yRoot);
 
     stage = 'gate';
-    const gateReasons = describeHtmlLoss(html).map(gateReasonShape);
+    const gateReasons = describeParseLoss(sourceRoot, sourceDoc).map(gateReasonShape);
 
     return {
       status: 'audited',

--- a/scripts/lib/seed-audit/analyze.ts
+++ b/scripts/lib/seed-audit/analyze.ts
@@ -114,8 +114,8 @@ type PmNode = ReturnType<typeof parseHtmlElementUnchecked>;
  * `describeParseLoss` is run over the same parse so the gate's own verdict is
  * on the record for every page without parsing it twice.
  */
-function parse(root: Element): PmNode {
-  return parseHtmlElementUnchecked(root as HTMLElement);
+function parse(root: HTMLElement): PmNode {
+  return parseHtmlElementUnchecked(root);
 }
 
 function throughYDoc(doc: PmNode): PmNode {

--- a/scripts/lib/seed-audit/criteria.ts
+++ b/scripts/lib/seed-audit/criteria.ts
@@ -120,39 +120,96 @@ export function visibleText(root: Element): string {
   return visibleCharacters(root.textContent ?? '');
 }
 
-/** A DOM text node, per the DOM's own `Node.TEXT_NODE`. */
+/** DOM node types, per the DOM's own `Node` constants. */
 const TEXT_NODE = 3;
+const ELEMENT_NODE = 1;
+
+/**
+ * Elements that begin and end a line of prose. Whitespace BETWEEN two of them
+ * is the pretty-printer's; whitespace between two inline things is the
+ * author's. That is the whole distinction `interWordText` turns on, so the set
+ * is listed rather than inferred — happy-dom has no layout engine to ask.
+ */
+const BLOCK_ELEMENTS: ReadonlySet<string> = new Set([
+  'address', 'article', 'aside', 'blockquote', 'caption', 'col', 'colgroup', 'dd', 'details',
+  'div', 'dl', 'dt', 'fieldset', 'figcaption', 'figure', 'footer', 'form', 'h1', 'h2', 'h3',
+  'h4', 'h5', 'h6', 'header', 'hgroup', 'hr', 'iframe', 'li', 'main', 'nav', 'ol', 'p', 'pre',
+  'section', 'summary', 'table', 'tbody', 'td', 'tfoot', 'th', 'thead', 'tr', 'ul',
+]);
+
+/** A run of document text, or the edge of a block. */
+type Segment = { boundary: true } | { boundary: false; text: string; verbatim: boolean };
 
 /**
  * Text with the spacing BETWEEN words kept and the spacing between BLOCKS
  * discarded — the weaker comparison behind the `whitespaceOnlyTextChange`
  * diagnostic.
  *
- * Collapsing the whole document's `textContent` to single spaces cannot do
- * this: in pretty-printed HTML the newline-and-indent between two `<p>` is
- * itself a text node, so `<p>a</p>\n  <p>b</p>` reads `a b` while the
- * schema's own `<p>a</p><p>b</p>` reads `ab`, and the diagnostic fires on
- * every pretty-printed page — saying "pretty-printed", not "a space was
- * lost", which is worse than not measuring at all.
+ * Collapsing the whole document's `textContent` cannot do this: in
+ * pretty-printed HTML the newline-and-indent between two `<p>` is itself a
+ * text node, so `<p>a</p>\n  <p>b</p>` reads `a b` while the schema's own
+ * `<p>a</p><p>b</p>` reads `ab`, and the diagnostic fires on every
+ * pretty-printed page — saying "pretty-printed", not "a space was lost".
  *
- * So the walk is per text node: a node that is entirely whitespace is
- * formatting between blocks and is dropped, and every other node keeps its
- * internal spacing collapsed to single spaces. `hello <em>world</em>` still
- * reads `hello world` and reports a real loss if that space disappears.
+ * Dropping every whitespace-only node is not the fix either, and gets the
+ * question backwards: in `a<span> </span>b` — the shape HTML pasted from Word
+ * and Docs is full of — that node IS the space between the words. Dropping it
+ * makes a page where the space SURVIVED read `ab`, identical to one where it
+ * was lost, so the single class of loss this function exists to see becomes
+ * the one it cannot see.
+ *
+ * So the rule is positional: a whitespace-only run is formatting when a block
+ * edge is on either side of it, and content when inline text is on both.
+ * Inside `<pre>`, where whitespace is the content, text is kept verbatim —
+ * otherwise a code block that lost every indent would read as unchanged, and
+ * `visibleText` (which strips all whitespace) cannot see that either.
+ *
+ * Known and deliberate: a non-breaking space is treated as a space, so an
+ * `&nbsp;` rewritten to U+0020 does not show up here. It is a diagnostic, not
+ * a criterion, and no verdict rests on it.
  */
 export function interWordText(root: Element): string {
-  const parts: string[] = [];
-  const walk = (node: Node): void => {
+  const segments: Segment[] = [];
+  const walk = (node: Node, verbatim: boolean): void => {
     if (node.nodeType === TEXT_NODE) {
-      const text = node.nodeValue ?? '';
-      // Entirely whitespace: the indentation between two blocks, not prose.
-      if (/\S/u.test(text)) parts.push(text.replace(/\s+/gu, ' '));
+      segments.push({ boundary: false, text: node.nodeValue ?? '', verbatim });
       return;
     }
-    for (const child of Array.from(node.childNodes)) walk(child);
+    // Comments and processing instructions carry no prose.
+    if (node.nodeType !== ELEMENT_NODE) return;
+
+    const tag = (node as Element).tagName.toLowerCase();
+    const isBlock = BLOCK_ELEMENTS.has(tag);
+    if (isBlock) segments.push({ boundary: true });
+    for (const child of Array.from(node.childNodes)) walk(child, verbatim || tag === 'pre');
+    if (isBlock) segments.push({ boundary: true });
   };
-  walk(root);
-  return parts.join('').trim();
+  walk(root, false);
+
+  const isFormatting = (index: number): boolean => {
+    const segment = segments[index];
+    if (segment.boundary || segment.verbatim || /\S/u.test(segment.text)) return false;
+    // The nearest thing on each side that is not itself blank space.
+    const meaningful = (from: number, step: number): Segment | undefined => {
+      for (let i = from; i >= 0 && i < segments.length; i += step) {
+        const candidate = segments[i];
+        if (candidate.boundary || /\S/u.test(candidate.text)) return candidate;
+      }
+      return undefined;
+    };
+    const before = meaningful(index - 1, -1);
+    const after = meaningful(index + 1, 1);
+    // Missing counts as a boundary: leading and trailing space is not between words.
+    return before === undefined || before.boundary || after === undefined || after.boundary;
+  };
+
+  return segments
+    .map((segment, index) => {
+      if (segment.boundary || isFormatting(index)) return '';
+      return segment.verbatim ? segment.text : segment.text.replace(/\s+/gu, ' ');
+    })
+    .join('')
+    .trim();
 }
 
 /**

--- a/scripts/lib/seed-audit/criteria.ts
+++ b/scripts/lib/seed-audit/criteria.ts
@@ -41,6 +41,7 @@ export interface ContentCounter {
   count(root: Element): number;
 }
 
+/** A counter that reports how many elements in the page match `selector`. */
 function bySelector(key: string, selector: string): ContentCounter {
   return { key, count: (root) => root.querySelectorAll(selector).length };
 }
@@ -81,6 +82,7 @@ export const CONTENT_COUNTERS: readonly ContentCounter[] = [
 
 export type ContentCounts = Readonly<Record<string, number>>;
 
+/** Every counter's value for one page — the `src` and `h1` inputs to criterion 2. */
 export function countContent(root: Element): ContentCounts {
   const counts: Record<string, number> = {};
   for (const counter of CONTENT_COUNTERS) {

--- a/scripts/lib/seed-audit/criteria.ts
+++ b/scripts/lib/seed-audit/criteria.ts
@@ -170,6 +170,7 @@ type Segment = { boundary: true } | { boundary: false; text: string; verbatim: b
  */
 export function interWordText(root: Element): string {
   const segments: Segment[] = [];
+  /** Flattens the tree to segments, marking block edges and `<pre>` content. */
   const walk = (node: Node, verbatim: boolean): void => {
     if (node.nodeType === TEXT_NODE) {
       segments.push({ boundary: false, text: node.nodeValue ?? '', verbatim });
@@ -186,6 +187,7 @@ export function interWordText(root: Element): string {
   };
   walk(root, false);
 
+  /** Whether the segment at `index` is the pretty-printer's whitespace rather than the author's. */
   const isFormatting = (index: number): boolean => {
     const segment = segments[index];
     if (segment.boundary || segment.verbatim || /\S/u.test(segment.text)) return false;

--- a/scripts/lib/seed-audit/criteria.ts
+++ b/scripts/lib/seed-audit/criteria.ts
@@ -1,0 +1,149 @@
+/**
+ * The three seed-fidelity criteria, as pure functions over a parsed DOM.
+ *
+ * Taken from the Phase B leaf ("Seed fidelity gate over real documents"),
+ * which corrected the plan's "lossy rate ~0" into three hard blockers with no
+ * thresholds:
+ *
+ *  1. STABILITY — `h1 = render(parse(src))`, `h2 = render(parse(h1))`,
+ *     require `h1 == h2`. A page that fails is a document whose projection
+ *     churns forever. (Byte equality IS the right bar here: h1 is already in
+ *     the schema's own dialect.)
+ *  2. CONTENT-BEARING LOSS — instance COUNTS of the constructs below, `src`
+ *     vs `h1`. Any decrease in any counter is loss. Increases are not: a bare
+ *     `<li>` gaining a `<p>`, or `TaskItem` rendering its own `<input>`, add
+ *     markup without changing what the document says.
+ *  3. TEXT PRESERVATION — whitespace-collapsed `textContent` of `src` must
+ *     equal that of `h1`.
+ *
+ * "Byte-identical" between `src` and `h1` is the WRONG bar — see
+ * `@pagespace/editor/seed-fidelity` for the allowlist of cosmetic rewrites one
+ * pass through the schema makes. That allowlist is used by `analyze.ts` to
+ * name additions OUTSIDE it; nothing in this file tolerates anything.
+ */
+
+/**
+ * The counters the leaf names, verbatim, one per selector. Kept as separate
+ * rows rather than the leaf's groups (`h4`–`h6`, `table`/`tr`/`td`/`th`) so a
+ * decrease names the exact construct.
+ *
+ * `div`: the leaf says "non-semantic `div` wrappers". `TaskItem`'s own
+ * rendering puts a `<div>` around each item's content, and the TipTap markup
+ * already stored for task lists carries the same `<div>` — so those are
+ * excluded on BOTH sides, or a document could lose a genuine wrapper `<div>`
+ * while its task items "pay it back" and the counter never moves.
+ */
+export interface ContentCounter {
+  readonly key: string;
+  count(root: Element): number;
+}
+
+function bySelector(key: string, selector: string): ContentCounter {
+  return { key, count: (root) => root.querySelectorAll(selector).length };
+}
+
+const TASK_ITEM_SELECTOR = 'li[data-type="taskItem"]';
+
+export const CONTENT_COUNTERS: readonly ContentCounter[] = [
+  bySelector('img', 'img'),
+  bySelector('h4', 'h4'),
+  bySelector('h5', 'h5'),
+  bySelector('h6', 'h6'),
+  bySelector('table', 'table'),
+  bySelector('tr', 'tr'),
+  bySelector('td', 'td'),
+  bySelector('th', 'th'),
+  bySelector('li', 'li'),
+  bySelector('pre', 'pre'),
+  bySelector('code', 'code'),
+  bySelector('a[data-page-id]', 'a[data-page-id]'),
+  bySelector('span[data-mention-type]', 'span[data-mention-type]'),
+  bySelector('mark', 'mark'),
+  bySelector('sup', 'sup'),
+  bySelector('sub', 'sub'),
+  bySelector('iframe', 'iframe'),
+  bySelector('details', 'details'),
+  {
+    key: 'div (outside task items)',
+    count: (root) =>
+      Array.from(root.querySelectorAll('div')).filter(
+        (div) => div.closest(TASK_ITEM_SELECTOR) === null,
+      ).length,
+  },
+  bySelector('input[type=checkbox]', 'input[type="checkbox"]'),
+];
+
+export type ContentCounts = Readonly<Record<string, number>>;
+
+export function countContent(root: Element): ContentCounts {
+  const counts: Record<string, number> = {};
+  for (const counter of CONTENT_COUNTERS) {
+    counts[counter.key] = counter.count(root);
+  }
+  return counts;
+}
+
+/** Counter keys whose count in `after` is lower than in `before`, in counter order. Never the counts themselves. */
+export function counterDecreases(before: ContentCounts, after: ContentCounts): string[] {
+  return CONTENT_COUNTERS.map((counter) => counter.key).filter(
+    (key) => (after[key] ?? 0) < (before[key] ?? 0),
+  );
+}
+
+/**
+ * Elements the parse is *supposed* to discard: they carry no document
+ * content and their text is not prose. Mirrors `NON_CONTENT_ELEMENTS` in
+ * `@pagespace/editor/html-to-ydoc`, which strips the same four before the
+ * seed parse — so this audit measures the text the seed path actually sees,
+ * and a `<style>` block's CSS is not reported as lost prose.
+ */
+export const NON_CONTENT_ELEMENTS: readonly string[] = ['script', 'style', 'noscript', 'template'];
+
+/** Removes `NON_CONTENT_ELEMENTS` from `root` in place, so every later measurement of it agrees with the seed parse. */
+export function stripNonContentElements(root: Element): void {
+  for (const tag of NON_CONTENT_ELEMENTS) {
+    for (const element of Array.from(root.querySelectorAll(tag))) {
+      element.remove();
+    }
+  }
+}
+
+/**
+ * The leaf's "whitespace-collapsed `textContent`", with the collapse taken
+ * all the way to zero whitespace.
+ *
+ * Collapsing runs to a single space is not enough: stored HTML is often
+ * pretty-printed, and the newline-and-indent between two `<p>` blocks is a
+ * text node whose `textContent` is whitespace ProseMirror correctly drops.
+ * `<p>a</p>\n  <p>b</p>` would read `a b` in and `ab` out, and every
+ * pretty-printed document in the corpus would fail criterion 3 for a reason
+ * that is not loss. Stripping all whitespace compares the sequence of visible
+ * characters, which is what must not change — and is the same rule the seed
+ * gate itself applies (`visibleCharacters` in `html-to-ydoc.ts`).
+ *
+ * The cost is that a space vanishing BETWEEN two words is invisible here.
+ * `spaceCollapsedText` exists for that: the weaker (single-space) form, whose
+ * mismatches are reported as a diagnostic count, never as a verdict.
+ */
+export function visibleText(root: Element): string {
+  return (root.textContent ?? '').replace(/\s+/gu, '');
+}
+
+/** Whitespace runs collapsed to one space and trimmed — diagnostic only; see `visibleText`. */
+export function spaceCollapsedText(root: Element): string {
+  return (root.textContent ?? '').replace(/\s+/gu, ' ').trim();
+}
+
+/**
+ * Whether a stored `contentMode='html'` document contains any HTML element at
+ * all. A page that parses to none is markdown (or plain text) filed under the
+ * wrong content mode; the content census found 3,003 of them and the
+ * mislabelled-content backfill has since corrected 2,718. Seeding one through
+ * the HTML path flattens every heading, list and code fence into a single
+ * paragraph, permanently — so Phase E must refuse them, and this audit counts
+ * them separately rather than letting them pass criterion 2 with every
+ * counter at zero.
+ */
+export function isTagless(root: Element): boolean {
+  return root.querySelector('*') === null;
+}

--- a/scripts/lib/seed-audit/criteria.ts
+++ b/scripts/lib/seed-audit/criteria.ts
@@ -1,3 +1,4 @@
+import { hasRealHtmlElement } from '@pagespace/editor/html-element-names';
 import { visibleCharacters } from '@pagespace/editor/html-to-ydoc';
 
 /**
@@ -67,9 +68,12 @@ export const CONTENT_COUNTERS: readonly ContentCounter[] = [
   bySelector('details', 'details'),
   {
     key: 'div (outside task items)',
+    // Only TaskItem's OWN wrapper — the direct child of the item — is chrome.
+    // A `<div>` nested deeper inside a task item is the author's, and losing
+    // it must count.
     count: (root) =>
       Array.from(root.querySelectorAll('div')).filter(
-        (div) => div.closest(TASK_ITEM_SELECTOR) === null,
+        (div) => !(div.parentElement?.matches(TASK_ITEM_SELECTOR) ?? false),
       ).length,
   },
   bySelector('input[type=checkbox]', 'input[type="checkbox"]'),
@@ -121,15 +125,19 @@ export function spaceCollapsedText(root: Element): string {
 }
 
 /**
- * Whether a stored `contentMode='html'` document contains any HTML element at
- * all. A page that parses to none is markdown (or plain text) filed under the
- * wrong content mode; the content census found 3,003 of them and the
+ * Whether a stored `contentMode='html'` document contains no REAL HTML
+ * element. A page with none is markdown (or plain text) filed under the wrong
+ * content mode; the content census found 3,003 of them and the
  * mislabelled-content backfill has since corrected 2,718. Seeding one through
  * the HTML path flattens every heading, list and code fence into a single
  * paragraph, permanently — so Phase E must refuse them, and this audit counts
  * them separately rather than letting them pass criterion 2 with every
  * counter at zero.
+ *
+ * "Real" is the census's and the backfill's definition (`HTML_ELEMENT_NAMES`):
+ * `Set<string>` in a markdown page makes happy-dom create a `<string>`
+ * element, and a rule of "any element at all" would call that page HTML.
  */
 export function isTagless(root: Element): boolean {
-  return root.querySelector('*') === null;
+  return !hasRealHtmlElement(root);
 }

--- a/scripts/lib/seed-audit/criteria.ts
+++ b/scripts/lib/seed-audit/criteria.ts
@@ -114,16 +114,45 @@ export function counterDecreases(before: ContentCounts, after: ContentCounts): s
  * `<style>` block's CSS is not reported as lost prose.
  *
  * The cost is that a space vanishing BETWEEN two words is invisible here.
- * `spaceCollapsedText` exists for that: the weaker (single-space) form, whose
- * mismatches are reported as a diagnostic count, never as a verdict.
+ * `interWordText` exists for that, as a diagnostic count and never a verdict.
  */
 export function visibleText(root: Element): string {
   return visibleCharacters(root.textContent ?? '');
 }
 
-/** Whitespace runs collapsed to one space and trimmed — diagnostic only; see `visibleText`. */
-export function spaceCollapsedText(root: Element): string {
-  return (root.textContent ?? '').replace(/\s+/gu, ' ').trim();
+/** A DOM text node, per the DOM's own `Node.TEXT_NODE`. */
+const TEXT_NODE = 3;
+
+/**
+ * Text with the spacing BETWEEN words kept and the spacing between BLOCKS
+ * discarded — the weaker comparison behind the `whitespaceOnlyTextChange`
+ * diagnostic.
+ *
+ * Collapsing the whole document's `textContent` to single spaces cannot do
+ * this: in pretty-printed HTML the newline-and-indent between two `<p>` is
+ * itself a text node, so `<p>a</p>\n  <p>b</p>` reads `a b` while the
+ * schema's own `<p>a</p><p>b</p>` reads `ab`, and the diagnostic fires on
+ * every pretty-printed page — saying "pretty-printed", not "a space was
+ * lost", which is worse than not measuring at all.
+ *
+ * So the walk is per text node: a node that is entirely whitespace is
+ * formatting between blocks and is dropped, and every other node keeps its
+ * internal spacing collapsed to single spaces. `hello <em>world</em>` still
+ * reads `hello world` and reports a real loss if that space disappears.
+ */
+export function interWordText(root: Element): string {
+  const parts: string[] = [];
+  const walk = (node: Node): void => {
+    if (node.nodeType === TEXT_NODE) {
+      const text = node.nodeValue ?? '';
+      // Entirely whitespace: the indentation between two blocks, not prose.
+      if (/\S/u.test(text)) parts.push(text.replace(/\s+/gu, ' '));
+      return;
+    }
+    for (const child of Array.from(node.childNodes)) walk(child);
+  };
+  walk(root);
+  return parts.join('').trim();
 }
 
 /**

--- a/scripts/lib/seed-audit/criteria.ts
+++ b/scripts/lib/seed-audit/criteria.ts
@@ -1,3 +1,5 @@
+import { visibleCharacters } from '@pagespace/editor/html-to-ydoc';
+
 /**
  * The three seed-fidelity criteria, as pure functions over a parsed DOM.
  *
@@ -91,24 +93,6 @@ export function counterDecreases(before: ContentCounts, after: ContentCounts): s
 }
 
 /**
- * Elements the parse is *supposed* to discard: they carry no document
- * content and their text is not prose. Mirrors `NON_CONTENT_ELEMENTS` in
- * `@pagespace/editor/html-to-ydoc`, which strips the same four before the
- * seed parse — so this audit measures the text the seed path actually sees,
- * and a `<style>` block's CSS is not reported as lost prose.
- */
-export const NON_CONTENT_ELEMENTS: readonly string[] = ['script', 'style', 'noscript', 'template'];
-
-/** Removes `NON_CONTENT_ELEMENTS` from `root` in place, so every later measurement of it agrees with the seed parse. */
-export function stripNonContentElements(root: Element): void {
-  for (const tag of NON_CONTENT_ELEMENTS) {
-    for (const element of Array.from(root.querySelectorAll(tag))) {
-      element.remove();
-    }
-  }
-}
-
-/**
  * The leaf's "whitespace-collapsed `textContent`", with the collapse taken
  * all the way to zero whitespace.
  *
@@ -118,15 +102,17 @@ export function stripNonContentElements(root: Element): void {
  * `<p>a</p>\n  <p>b</p>` would read `a b` in and `ab` out, and every
  * pretty-printed document in the corpus would fail criterion 3 for a reason
  * that is not loss. Stripping all whitespace compares the sequence of visible
- * characters, which is what must not change — and is the same rule the seed
- * gate itself applies (`visibleCharacters` in `html-to-ydoc.ts`).
+ * characters, which is what must not change — and it IS the seed gate's own
+ * rule: `visibleCharacters` from `html-to-ydoc.ts`, not a copy of it. The
+ * source is measured after `stripNonContentElements` (same module) so a
+ * `<style>` block's CSS is not reported as lost prose.
  *
  * The cost is that a space vanishing BETWEEN two words is invisible here.
  * `spaceCollapsedText` exists for that: the weaker (single-space) form, whose
  * mismatches are reported as a diagnostic count, never as a verdict.
  */
 export function visibleText(root: Element): string {
-  return (root.textContent ?? '').replace(/\s+/gu, '');
+  return visibleCharacters(root.textContent ?? '');
 }
 
 /** Whitespace runs collapsed to one space and trimmed — diagnostic only; see `visibleText`. */

--- a/scripts/lib/seed-audit/options.ts
+++ b/scripts/lib/seed-audit/options.ts
@@ -8,20 +8,35 @@ export interface AuditOptions {
   progressEvery: number;
 }
 
-function numericFlag(argv: readonly string[], flag: string, fallback: number): number {
-  const index = argv.indexOf(flag);
-  if (index < 0) return fallback;
+const FLAGS = ['--limit', '--batch-size', '--progress-every'] as const;
 
-  const value = Number(argv[index + 1]);
-  // Refuse rather than fall back: `--limit` with a typo after it would
-  // otherwise silently audit the whole table when a sample was asked for.
-  if (!Number.isInteger(value) || value <= 0) {
+/**
+ * `--flag value` and `--flag=value` both work; anything else on the command
+ * line is refused. `--limt 5` or `--limit=5` silently auditing the whole table
+ * is the exact outcome a smoke run exists to avoid.
+ */
+function numericFlag(argv: readonly string[], flag: string, fallback: number): number {
+  const joined = argv.find((token) => token.startsWith(`${flag}=`));
+  const index = argv.indexOf(flag);
+  if (joined === undefined && index < 0) return fallback;
+
+  const raw = joined === undefined ? argv[index + 1] : joined.slice(flag.length + 1);
+  const value = Number(raw);
+  if (raw === undefined || raw === '' || !Number.isInteger(value) || value <= 0) {
     throw new Error(`${flag} requires a positive integer, e.g. ${flag} 500`);
   }
   return value;
 }
 
 export function parseAuditArgs(argv: readonly string[]): AuditOptions {
+  const known = new Set<string>(FLAGS);
+  argv.forEach((token, index) => {
+    const isFlag = known.has(token) || [...known].some((flag) => token.startsWith(`${flag}=`));
+    const isValueOfFlag = index > 0 && known.has(argv[index - 1]);
+    if (!isFlag && !isValueOfFlag) {
+      throw new Error(`unknown argument ${token}; expected one of ${FLAGS.join(', ')}`);
+    }
+  });
   return {
     limit: numericFlag(argv, '--limit', Number.POSITIVE_INFINITY),
     batchSize: numericFlag(argv, '--batch-size', 200),

--- a/scripts/lib/seed-audit/options.ts
+++ b/scripts/lib/seed-audit/options.ts
@@ -1,0 +1,30 @@
+/** Command-line options for `scripts/collab-seed-audit.ts`. */
+export interface AuditOptions {
+  /** Stop after this many documents — a smoke run before the full one. */
+  limit: number;
+  /** Rows per query. One query at a time against a `max: 1` pool, always. */
+  batchSize: number;
+  /** Progress line to stderr every N documents. */
+  progressEvery: number;
+}
+
+function numericFlag(argv: readonly string[], flag: string, fallback: number): number {
+  const index = argv.indexOf(flag);
+  if (index < 0) return fallback;
+
+  const value = Number(argv[index + 1]);
+  // Refuse rather than fall back: `--limit` with a typo after it would
+  // otherwise silently audit the whole table when a sample was asked for.
+  if (!Number.isInteger(value) || value <= 0) {
+    throw new Error(`${flag} requires a positive integer, e.g. ${flag} 500`);
+  }
+  return value;
+}
+
+export function parseAuditArgs(argv: readonly string[]): AuditOptions {
+  return {
+    limit: numericFlag(argv, '--limit', Number.POSITIVE_INFINITY),
+    batchSize: numericFlag(argv, '--batch-size', 200),
+    progressEvery: numericFlag(argv, '--progress-every', 500),
+  };
+}

--- a/scripts/lib/seed-audit/options.ts
+++ b/scripts/lib/seed-audit/options.ts
@@ -28,6 +28,7 @@ function numericFlag(argv: readonly string[], flag: string, fallback: number): n
   return value;
 }
 
+/** The run's options, or a throw naming the offending flag — never a silent full-table audit. */
 export function parseAuditArgs(argv: readonly string[]): AuditOptions {
   const known = new Set<string>(FLAGS);
   argv.forEach((token, index) => {

--- a/scripts/lib/seed-audit/report.ts
+++ b/scripts/lib/seed-audit/report.ts
@@ -142,8 +142,11 @@ export function censusKeyOf(key: string): string {
   if (element) return `<${element[1]}>`;
   const attribute = /^attr:[^@]+@(.+)$/u.exec(key);
   // Fail closed, for the same reason `contentFreeKey` does: a key this cannot
-  // decompose is one it cannot vouch for. Unreachable today — every key
-  // reaching here has already been folded — and kept so it stays unreachable.
+  // decompose is one it cannot vouch for. This branch is LIVE, not defensive —
+  // every key arriving here has already been folded, and a folded key is often
+  // the marker itself, which is neither an `el:` nor an `attr:` key. Returning
+  // the marker unchanged is the right answer for it and the safe answer for
+  // anything else.
   if (!attribute) return UNESCAPED_ANGLE_BRACKET_KEY;
   const rest = attribute[1];
   if (rest.startsWith('style:')) return rest;

--- a/scripts/lib/seed-audit/report.ts
+++ b/scripts/lib/seed-audit/report.ts
@@ -1,0 +1,397 @@
+import { isLossy, type PageAudit } from './analyze';
+
+/**
+ * Tallies and the printed report.
+ *
+ * Counts, never rates — the three criteria are hard blockers, and "0.4%
+ * lossy" is exactly the framing the leaf ruled out. Every table carries
+ * example page ids because a bare count is undiagnosable: an id is a handle
+ * someone holding the credential can go and look at; an excerpt would be
+ * user content in a terminal scrollback, so there are none anywhere here.
+ */
+
+/**
+ * Three, as in the census: enough to go and look at a page deliberately, few
+ * enough that the report is not a transcript of who wrote what.
+ */
+const MAX_EXAMPLE_PAGE_IDS = 3;
+
+export interface TallyRow {
+  key: string;
+  pages: number;
+  examplePageIds: string[];
+}
+
+/** The three criteria plus their conjunction, for one chain. */
+export interface CriteriaTotals {
+  unstable: number;
+  counterDecreased: number;
+  textLost: number;
+  /** Pages failing ANY of the three — the number that has to be zero. */
+  lossy: number;
+  /** Diagnostic: whitespace-only text differences (not a criterion). */
+  whitespaceOnlyTextChange: number;
+}
+
+export interface ChainTallies {
+  totals: CriteriaTotals;
+  /** Per-criterion example pages: `unstable`, `text-lost`, and one row per counter that decreased. */
+  criteriaFailures: TallyRow[];
+  /** Presence-based construct drops, tag-qualified (`el:img`, `attr:p@style:text-align`). */
+  droppedConstructs: TallyRow[];
+  /** The same drops, keyed the way the content census keys them, for a direct comparison. */
+  droppedConstructsCensusKeyed: TallyRow[];
+  /** Constructs gained outside the cosmetic allowlist. */
+  unexpectedAdditions: TallyRow[];
+}
+
+export interface AuditTotals {
+  /** Every DOCUMENT row the scan reached. */
+  documents: number;
+  /** `contentMode='html'` rows that were taken through the chains. */
+  audited: number;
+  /** `contentMode='markdown'` rows — markdown source, not seedable through this path (Phase K). */
+  markdownMode: number;
+  empty: number;
+  /** Audited pages with no HTML element at all — markdown/plain text under an html label. */
+  tagless: number;
+  failed: number;
+  /** Pages whose two projections differ byte-for-byte — `y-prosemirror`'s doing. */
+  divergent: number;
+}
+
+export interface GateAgreement {
+  /** Gate refuses and the seed chain is lossy — both right. */
+  bothLossy: number;
+  /** Gate ACCEPTS a page the seed chain shows lossy — Phase E would seed it. */
+  gateBlindSpot: number;
+  /** Gate refuses a page the seed chain shows clean — over-strict, not dangerous. */
+  gateStricter: number;
+  bothClean: number;
+}
+
+export interface AuditSnapshot {
+  totals: AuditTotals;
+  seed: ChainTallies;
+  census: ChainTallies;
+  divergence: {
+    /** `y-prosemirror changed <counter>` / `text changed` / `lost <construct>` / `gained <construct>`. */
+    rows: TallyRow[];
+  };
+  gate: {
+    agreement: GateAgreement;
+    /** Example pages per agreement cell — the blind-spot ids are the ones to read first. */
+    agreementRows: TallyRow[];
+    reasons: TallyRow[];
+  };
+  failures: TallyRow[];
+  taglessPages: TallyRow[];
+}
+
+export interface AuditAccumulator {
+  recordHtml(pageId: string, audit: PageAudit): void;
+  recordMarkdownMode(pageId: string): void;
+  recordEmpty(): void;
+  snapshot(): AuditSnapshot;
+}
+
+type Tallies = Map<string, { pages: number; examplePageIds: string[] }>;
+
+function tally(tallies: Tallies, key: string, pageId: string): void {
+  let entry = tallies.get(key);
+  if (!entry) {
+    entry = { pages: 0, examplePageIds: [] };
+    tallies.set(key, entry);
+  }
+  entry.pages += 1;
+  if (entry.examplePageIds.length < MAX_EXAMPLE_PAGE_IDS) {
+    entry.examplePageIds.push(pageId);
+  }
+}
+
+function rows(tallies: Tallies): TallyRow[] {
+  return [...tallies]
+    .map(([key, entry]) => ({ key, pages: entry.pages, examplePageIds: [...entry.examplePageIds] }))
+    .sort((a, b) => b.pages - a.pages || a.key.localeCompare(b.key));
+}
+
+/**
+ * A tag-qualified seed-fidelity key, re-keyed the way
+ * `apps/web/src/lib/editor/census/constructs.ts` keys the same construct:
+ * `el:img` → `<img>`; `attr:p@style:text-align` → `style:text-align`;
+ * `attr:ul@data-type=taskList` → `attr:data-type=taskList` (`data-type` is
+ * the census's one value-bearing attribute); every other attribute →
+ * `attr:<name>`, presence only. Two audit keys can fold into one census key
+ * (`h2@style:text-align` and `p@style:text-align`); the census counted that
+ * page once, and so does the fold.
+ */
+export function censusKeyOf(key: string): string {
+  const element = /^el:(.+)$/u.exec(key);
+  if (element) return `<${element[1]}>`;
+  const attribute = /^attr:[^@]+@(.+)$/u.exec(key);
+  if (!attribute) return key;
+  const rest = attribute[1];
+  if (rest.startsWith('style:')) return rest;
+  if (rest.startsWith('data-type=')) return `attr:${rest}`;
+  return `attr:${rest.split('=')[0]}`;
+}
+
+/**
+ * Attribute values that are safe to print: enumerations and small integers
+ * the schema itself defines. Every OTHER value-bearing key (`href`, `alt`,
+ * the `data-*-id` family) is folded to its presence form before it is
+ * tallied — `alt` is prose, an `href` can carry a person's name, and this
+ * report goes to a terminal. `constructKeysOf` keeps those values so the
+ * corpus test can see a rewritten href; the AUDIT must not repeat them.
+ * The "never prints document content" test feeds a sentinel through `alt`
+ * to hold this.
+ */
+const PRINTABLE_ATTRIBUTE_VALUES: ReadonlySet<string> = new Set([
+  'data-type',
+  'data-checked',
+  'data-tight',
+  'start',
+  'colspan',
+  'rowspan',
+]);
+
+export function contentFreeKey(key: string): string {
+  const valued = /^(attr:[^@]+@)([^=]+)=/u.exec(key);
+  if (!valued) return key;
+  return PRINTABLE_ATTRIBUTE_VALUES.has(valued[2]) ? key : `${valued[1]}${valued[2]}`;
+}
+
+function createChainTallies() {
+  const criteria: Tallies = new Map();
+  const dropped: Tallies = new Map();
+  const droppedCensus: Tallies = new Map();
+  const additions: Tallies = new Map();
+  const totals: CriteriaTotals = {
+    unstable: 0,
+    counterDecreased: 0,
+    textLost: 0,
+    lossy: 0,
+    whitespaceOnlyTextChange: 0,
+  };
+
+  return {
+    record(pageId: string, result: PageAudit & { status: 'audited' }, chain: 'seed' | 'census') {
+      const verdict = result[chain];
+      if (!verdict.stable) {
+        totals.unstable += 1;
+        tally(criteria, 'unstable', pageId);
+      }
+      if (verdict.counterDecreases.length > 0) {
+        totals.counterDecreased += 1;
+        for (const key of verdict.counterDecreases) tally(criteria, `counter decreased: ${key}`, pageId);
+      }
+      if (!verdict.textPreserved) {
+        totals.textLost += 1;
+        tally(criteria, 'text-lost', pageId);
+      }
+      if (isLossy(verdict)) totals.lossy += 1;
+      if (verdict.whitespaceOnlyTextChange) totals.whitespaceOnlyTextChange += 1;
+
+      // Folded to content-free form; two keys can fold into one, and a page
+      // counts once per folded key, hence the Sets.
+      for (const key of new Set(verdict.droppedConstructs.map(contentFreeKey))) tally(dropped, key, pageId);
+      for (const key of new Set(verdict.droppedConstructs.map(censusKeyOf))) {
+        tally(droppedCensus, key, pageId);
+      }
+      for (const key of new Set(verdict.unexpectedAdditions.map(contentFreeKey))) tally(additions, key, pageId);
+    },
+    snapshot(): ChainTallies {
+      return {
+        totals: { ...totals },
+        criteriaFailures: rows(criteria),
+        droppedConstructs: rows(dropped),
+        droppedConstructsCensusKeyed: rows(droppedCensus),
+        unexpectedAdditions: rows(additions),
+      };
+    },
+  };
+}
+
+export function createAuditAccumulator(): AuditAccumulator {
+  const seed = createChainTallies();
+  const census = createChainTallies();
+  const divergence: Tallies = new Map();
+  const gateReasons: Tallies = new Map();
+  const agreementRows: Tallies = new Map();
+  const failures: Tallies = new Map();
+  const tagless: Tallies = new Map();
+  const agreement: GateAgreement = { bothLossy: 0, gateBlindSpot: 0, gateStricter: 0, bothClean: 0 };
+  const totals: AuditTotals = {
+    documents: 0,
+    audited: 0,
+    markdownMode: 0,
+    empty: 0,
+    tagless: 0,
+    failed: 0,
+    divergent: 0,
+  };
+
+  return {
+    recordHtml(pageId, audit) {
+      totals.documents += 1;
+      totals.audited += 1;
+
+      if (audit.status === 'failed') {
+        totals.failed += 1;
+        tally(failures, `${audit.stage}: ${audit.errorName}`, pageId);
+        return;
+      }
+
+      if (audit.tagless) {
+        totals.tagless += 1;
+        tally(tagless, 'no HTML element', pageId);
+      }
+
+      seed.record(pageId, audit, 'seed');
+      census.record(pageId, audit, 'census');
+
+      if (audit.divergence) {
+        totals.divergent += 1;
+        for (const key of audit.divergence.counterChanges) tally(divergence, `counter changed: ${key}`, pageId);
+        if (audit.divergence.textChanged) tally(divergence, 'text changed', pageId);
+        for (const key of new Set(audit.divergence.constructsLost.map(contentFreeKey))) {
+          tally(divergence, `lost: ${key}`, pageId);
+        }
+        for (const key of new Set(audit.divergence.constructsGained.map(contentFreeKey))) {
+          tally(divergence, `gained: ${key}`, pageId);
+        }
+        if (
+          audit.divergence.counterChanges.length === 0 &&
+          !audit.divergence.textChanged &&
+          audit.divergence.constructsLost.length === 0 &&
+          audit.divergence.constructsGained.length === 0
+        ) {
+          // Bytes differ, but nothing this audit measures does — attribute
+          // order, quoting, or whitespace between blocks. Still divergence;
+          // still named, so it cannot hide inside a zero.
+          tally(divergence, 'bytes only (no measured construct, counter or text)', pageId);
+        }
+      }
+
+      const gateRefuses = audit.gateReasons.length > 0;
+      const seedLossy = isLossy(audit.seed);
+      const cell = gateRefuses
+        ? seedLossy
+          ? 'bothLossy'
+          : 'gateStricter'
+        : seedLossy
+          ? 'gateBlindSpot'
+          : 'bothClean';
+      agreement[cell] += 1;
+      if (cell !== 'bothClean') tally(agreementRows, cell, pageId);
+      for (const reason of new Set(audit.gateReasons)) tally(gateReasons, reason, pageId);
+    },
+
+    recordMarkdownMode() {
+      totals.documents += 1;
+      totals.markdownMode += 1;
+    },
+
+    recordEmpty() {
+      totals.documents += 1;
+      totals.empty += 1;
+    },
+
+    snapshot() {
+      return {
+        totals: { ...totals },
+        seed: seed.snapshot(),
+        census: census.snapshot(),
+        divergence: { rows: rows(divergence) },
+        gate: { agreement: { ...agreement }, agreementRows: rows(agreementRows), reasons: rows(gateReasons) },
+        failures: rows(failures),
+        taglessPages: rows(tagless),
+      };
+    },
+  };
+}
+
+/** The run passes only when every hard blocker is zero on the SEED chain and nothing failed to process. */
+export function auditPassed(snapshot: AuditSnapshot): boolean {
+  return snapshot.seed.totals.lossy === 0 && snapshot.totals.failed === 0;
+}
+
+function table(title: string, tallies: TallyRow[], header = 'CONSTRUCT'): string[] {
+  if (tallies.length === 0) {
+    return [title, '  (none)', ''];
+  }
+  const width = Math.max(...tallies.map((row) => row.key.length), header.length);
+  return [
+    title,
+    `  ${header.padEnd(width)}  ${'PAGES'.padStart(7)}  EXAMPLE PAGE IDS`,
+    ...tallies.map(
+      (row) => `  ${row.key.padEnd(width)}  ${String(row.pages).padStart(7)}  ${row.examplePageIds.join(' ')}`,
+    ),
+    '',
+  ];
+}
+
+function criteriaBlock(title: string, chain: ChainTallies): string[] {
+  const { totals } = chain;
+  return [
+    title,
+    `  1. stability      h1 == render(parse(h1))      pages failing  ${totals.unstable}`,
+    `  2. content loss   any counter decreased        pages failing  ${totals.counterDecreased}`,
+    `  3. text           visible characters changed   pages failing  ${totals.textLost}`,
+    `  LOSSY (any of the three)                                      ${totals.lossy}`,
+    `  whitespace-only text differences (diagnostic, not a criterion) ${totals.whitespaceOnlyTextChange}`,
+    '',
+  ];
+}
+
+export interface ReportOptions {
+  partial: boolean;
+}
+
+export function formatAuditReport(snapshot: AuditSnapshot, { partial }: ReportOptions): string {
+  const { totals, gate } = snapshot;
+  const verdict = partial ? 'INTERRUPTED — PARTIAL, NOT A VERDICT' : auditPassed(snapshot) ? 'PASS' : 'BLOCKED';
+  const lines = [
+    '',
+    `COLLAB SEED FIDELITY AUDIT — ${verdict}`,
+    // Not a criterion — a page with no HTML element passes all three
+    // trivially — but not something a PASS may hide either: Phase E must
+    // refuse these regardless of what this audit says about the rest.
+    ...(totals.tagless > 0
+      ? [`  NOTE: ${totals.tagless} html-mode page(s) contain no HTML element (markdown or plain text under an html label). Phase E must refuse to seed them regardless of this verdict.`]
+      : []),
+    '',
+    `  DOCUMENT pages scanned                       ${totals.documents}`,
+    `  html-mode, audited through both chains       ${totals.audited}`,
+    `  markdown-mode, skipped (Phase K, not HTML)   ${totals.markdownMode}`,
+    `  empty                                        ${totals.empty}`,
+    `  html-mode with no HTML element (refuse!)     ${totals.tagless}`,
+    `  could not be processed                       ${totals.failed}`,
+    `  projections differ between the two chains    ${totals.divergent}`,
+    '',
+    ...criteriaBlock('SEED CHAIN  html → pm → y.doc → pm → html  (what Phase E does — the gate)', snapshot.seed),
+    ...criteriaBlock('CENSUS CHAIN  html → pm → html  (what collab-content-census ran — must match)', snapshot.census),
+    ...table('seed chain — criterion failures', snapshot.seed.criteriaFailures, 'CRITERION'),
+    ...table('seed chain — constructs dropped (tag-qualified)', snapshot.seed.droppedConstructs),
+    ...table('seed chain — constructs dropped, census keys (compare with the census report)', snapshot.seed.droppedConstructsCensusKeyed),
+    ...table('seed chain — additions outside the cosmetic allowlist', snapshot.seed.unexpectedAdditions),
+    ...table('census chain — criterion failures', snapshot.census.criteriaFailures, 'CRITERION'),
+    ...table('census chain — constructs dropped, census keys', snapshot.census.droppedConstructsCensusKeyed),
+    ...table(
+      'y-prosemirror — what differs between the census projection and the seed projection',
+      snapshot.divergence.rows,
+      'DIFFERENCE',
+    ),
+    'package seed gate (describeHtmlLoss) vs this audit, seed chain',
+    `  gate refuses, audit lossy   (agree)                 ${gate.agreement.bothLossy}`,
+    `  gate ACCEPTS, audit lossy   (BLIND SPOT — read these) ${gate.agreement.gateBlindSpot}`,
+    `  gate refuses, audit clean   (gate stricter)         ${gate.agreement.gateStricter}`,
+    `  both clean                                          ${gate.agreement.bothClean}`,
+    '',
+    ...table('gate agreement — example pages', gate.agreementRows, 'CELL'),
+    ...table('gate reasons (shape only — never content)', gate.reasons, 'REASON'),
+    ...table('html-mode pages with no HTML element — markdown/plain text under an html label', snapshot.taglessPages, 'FINDING'),
+    ...table('documents the chain could not process (stage and error type only)', snapshot.failures, 'STAGE: ERROR'),
+  ];
+  return lines.join('\n');
+}

--- a/scripts/lib/seed-audit/report.ts
+++ b/scripts/lib/seed-audit/report.ts
@@ -174,6 +174,7 @@ function createChainTallies() {
   };
 
   return {
+    /** Folds one page's verdict for this chain into the tallies. */
     record(pageId: string, verdict: ChainResult) {
       if (!verdict.stable) {
         totals.unstable += 1;
@@ -201,6 +202,7 @@ function createChainTallies() {
       }
       for (const key of new Set(verdict.unexpectedAdditions.map(contentFreeKey))) tally(additions, key, pageId);
     },
+    /** This chain's totals and tables, as plain data. */
     snapshot(): ChainTallies {
       return {
         totals: { ...totals },
@@ -236,6 +238,7 @@ export function createAuditAccumulator(): AuditAccumulator {
   };
 
   return {
+    /** One audited html-mode page: both chains, the divergence, and the gate's verdict. */
     recordHtml(pageId, audit) {
       totals.documents += 1;
       totals.audited += 1;
@@ -290,16 +293,19 @@ export function createAuditAccumulator(): AuditAccumulator {
       for (const reason of new Set(audit.gateReasons)) tally(gateReasons, reason, pageId);
     },
 
+    /** A `contentMode='markdown'` page: counted, not audited — it is not HTML yet (Phase K). */
     recordMarkdownMode() {
       totals.documents += 1;
       totals.markdownMode += 1;
     },
 
+    /** A page with no content at all. */
     recordEmpty() {
       totals.documents += 1;
       totals.empty += 1;
     },
 
+    /** Everything the report is formatted from, as plain data. */
     snapshot() {
       return {
         totals: { ...totals },

--- a/scripts/lib/seed-audit/report.ts
+++ b/scripts/lib/seed-audit/report.ts
@@ -122,7 +122,8 @@ function rows(tallies: Tallies): TallyRow[] {
  * `el:img` → `<img>`; `attr:p@style:text-align` → `style:text-align`;
  * `attr:ul@data-type=taskList` → `attr:data-type=taskList` (`data-type` is
  * the census's one value-bearing attribute); every other attribute →
- * `attr:<name>`, presence only. Two audit keys can fold into one census key
+ * `attr:<name>`, presence only. Applied AFTER `contentFreeKey`, so the value
+ * has already been validated against the schema's enumeration. Two audit keys can fold into one census key
  * (`h2@style:text-align` and `p@style:text-align`); the census counted that
  * page once, and so does the fold.
  */
@@ -170,7 +171,7 @@ function createChainTallies() {
       // Folded to content-free form; two keys can fold into one, and a page
       // counts once per folded key, hence the Sets.
       for (const key of new Set(verdict.droppedConstructs.map(contentFreeKey))) tally(dropped, key, pageId);
-      for (const key of new Set(verdict.droppedConstructs.map(censusKeyOf))) {
+      for (const key of new Set(verdict.droppedConstructs.map((raw) => censusKeyOf(contentFreeKey(raw))))) {
         tally(droppedCensus, key, pageId);
       }
       for (const key of new Set(verdict.unexpectedAdditions.map(contentFreeKey))) tally(additions, key, pageId);
@@ -368,7 +369,7 @@ export function formatAuditReport(snapshot: AuditSnapshot, { partial }: ReportOp
       snapshot.divergence.rows,
       'DIFFERENCE',
     ),
-    'package seed gate (describeHtmlLoss) vs this audit, seed chain',
+    'package seed gate (what htmlToPmDoc throws on — describeParseLoss) vs this audit, seed chain',
     `  gate refuses, audit lossy   (agree)                 ${gate.agreement.bothLossy}`,
     `  gate ACCEPTS, audit lossy   (BLIND SPOT — read these) ${gate.agreement.gateBlindSpot}`,
     `  gate refuses, audit clean   (gate stricter)         ${gate.agreement.gateStricter}`,

--- a/scripts/lib/seed-audit/report.ts
+++ b/scripts/lib/seed-audit/report.ts
@@ -98,6 +98,7 @@ export interface AuditAccumulator {
 
 type Tallies = Map<string, { pages: number; examplePageIds: string[] }>;
 
+/** Counts one more page under `key`, keeping at most `MAX_EXAMPLE_PAGE_IDS` ids as examples. */
 function tally(tallies: Tallies, key: string, pageId: string): void {
   let entry = tallies.get(key);
   if (!entry) {
@@ -110,6 +111,7 @@ function tally(tallies: Tallies, key: string, pageId: string): void {
   }
 }
 
+/** A tally map as report rows, most pages first and ties broken by key so runs are comparable. */
 function rows(tallies: Tallies): TallyRow[] {
   return [...tallies]
     .map(([key, entry]) => ({ key, pages: entry.pages, examplePageIds: [...entry.examplePageIds] }))
@@ -138,6 +140,7 @@ export function censusKeyOf(key: string): string {
   return `attr:${rest.split('=')[0]}`;
 }
 
+/** The per-chain half of the accumulator: one of these for the seed chain, one for the census chain. */
 function createChainTallies() {
   const criteria: Tallies = new Map();
   const dropped: Tallies = new Map();
@@ -188,6 +191,7 @@ function createChainTallies() {
   };
 }
 
+/** Collects every page's verdict into the one snapshot the report is formatted from. */
 export function createAuditAccumulator(): AuditAccumulator {
   const seed = createChainTallies();
   const census = createChainTallies();
@@ -303,6 +307,7 @@ export function auditPassed(snapshot: AuditSnapshot): boolean {
   return snapshot.seed.totals.lossy === 0 && snapshot.totals.failed === 0;
 }
 
+/** One padded report table; `(none)` rather than an empty block, so a zero is visibly a measurement. */
 function table(title: string, tallies: TallyRow[], header = 'CONSTRUCT'): string[] {
   if (tallies.length === 0) {
     return [title, '  (none)', ''];
@@ -318,6 +323,7 @@ function table(title: string, tallies: TallyRow[], header = 'CONSTRUCT'): string
   ];
 }
 
+/** The three criteria and their conjunction for one chain, in the same shape for both. */
 function criteriaBlock(title: string, chain: ChainTallies): string[] {
   const { totals } = chain;
   return [
@@ -335,6 +341,7 @@ export interface ReportOptions {
   partial: boolean;
 }
 
+/** The whole report as text: verdict, totals, both chains' criteria, then every diagnostic table. */
 export function formatAuditReport(snapshot: AuditSnapshot, { partial }: ReportOptions): string {
   const { totals, gate } = snapshot;
   const verdict = partial ? 'INTERRUPTED — PARTIAL, NOT A VERDICT' : auditPassed(snapshot) ? 'PASS' : 'BLOCKED';

--- a/scripts/lib/seed-audit/report.ts
+++ b/scripts/lib/seed-audit/report.ts
@@ -1,4 +1,5 @@
 import { contentFreeKey } from '@pagespace/editor/seed-fidelity';
+import { UNESCAPED_ANGLE_BRACKET_KEY } from '@pagespace/editor/html-element-names';
 import { isLossy, type ChainResult, type PageAudit } from './analyze';
 
 /**
@@ -38,6 +39,13 @@ export interface ChainTallies {
   totals: CriteriaTotals;
   /** Per-criterion example pages: `unstable`, `text-lost`, and one row per counter that decreased. */
   criteriaFailures: TallyRow[];
+  /**
+   * Example pages for the whitespace-only diagnostic. It is not a criterion,
+   * so it has no row in `criteriaFailures` — but a bare count is
+   * undiagnosable, and every other number in this report can be gone and
+   * looked at.
+   */
+  whitespaceOnlyExamples: string[];
   /** Presence-based construct drops, tag-qualified (`el:img`, `attr:p@style:text-align`). */
   droppedConstructs: TallyRow[];
   /** The same drops, keyed the way the content census keys them, for a direct comparison. */
@@ -133,7 +141,10 @@ export function censusKeyOf(key: string): string {
   const element = /^el:(.+)$/u.exec(key);
   if (element) return `<${element[1]}>`;
   const attribute = /^attr:[^@]+@(.+)$/u.exec(key);
-  if (!attribute) return key;
+  // Fail closed, for the same reason `contentFreeKey` does: a key this cannot
+  // decompose is one it cannot vouch for. Unreachable today — every key
+  // reaching here has already been folded — and kept so it stays unreachable.
+  if (!attribute) return UNESCAPED_ANGLE_BRACKET_KEY;
   const rest = attribute[1];
   if (rest.startsWith('style:')) return rest;
   if (rest.startsWith('data-type=')) return `attr:${rest}`;
@@ -143,6 +154,7 @@ export function censusKeyOf(key: string): string {
 /** The per-chain half of the accumulator: one of these for the seed chain, one for the census chain. */
 function createChainTallies() {
   const criteria: Tallies = new Map();
+  const whitespaceOnly: Tallies = new Map();
   const dropped: Tallies = new Map();
   const droppedCensus: Tallies = new Map();
   const additions: Tallies = new Map();
@@ -169,7 +181,10 @@ function createChainTallies() {
         tally(criteria, 'text-lost', pageId);
       }
       if (isLossy(verdict)) totals.lossy += 1;
-      if (verdict.whitespaceOnlyTextChange) totals.whitespaceOnlyTextChange += 1;
+      if (verdict.whitespaceOnlyTextChange) {
+        totals.whitespaceOnlyTextChange += 1;
+        tally(whitespaceOnly, 'spacing', pageId);
+      }
 
       // Folded to content-free form; two keys can fold into one, and a page
       // counts once per folded key, hence the Sets.
@@ -183,6 +198,7 @@ function createChainTallies() {
       return {
         totals: { ...totals },
         criteriaFailures: rows(criteria),
+        whitespaceOnlyExamples: whitespaceOnly.get('spacing')?.examplePageIds ?? [],
         droppedConstructs: rows(dropped),
         droppedConstructsCensusKeyed: rows(droppedCensus),
         unexpectedAdditions: rows(additions),
@@ -332,7 +348,8 @@ function criteriaBlock(title: string, chain: ChainTallies): string[] {
     `  2. content loss   any counter decreased        pages failing  ${totals.counterDecreased}`,
     `  3. text           visible characters changed   pages failing  ${totals.textLost}`,
     `  LOSSY (any of the three)                                      ${totals.lossy}`,
-    `  whitespace-only text differences (diagnostic, not a criterion) ${totals.whitespaceOnlyTextChange}`,
+    `  spacing between words changed (diagnostic, not a criterion)   ${totals.whitespaceOnlyTextChange}` +
+      (chain.whitespaceOnlyExamples.length > 0 ? `  e.g. ${chain.whitespaceOnlyExamples.join(' ')}` : ''),
     '',
   ];
 }

--- a/scripts/lib/seed-audit/report.ts
+++ b/scripts/lib/seed-audit/report.ts
@@ -42,8 +42,10 @@ export interface ChainTallies {
   /**
    * Example pages for the whitespace-only diagnostic. It is not a criterion,
    * so it has no row in `criteriaFailures` — but a bare count is
-   * undiagnosable, and every other number in this report can be gone and
-   * looked at.
+   * undiagnosable, and this one describes a shape worth going and looking at.
+   * (`markdownMode` and `empty` are still bare counts: both are whole
+   * populations rather than findings, and a handful of ids says nothing about
+   * either.)
    */
   whitespaceOnlyExamples: string[];
   /** Presence-based construct drops, tag-qualified (`el:img`, `attr:p@style:text-align`). */
@@ -99,7 +101,7 @@ export interface AuditSnapshot {
 
 export interface AuditAccumulator {
   recordHtml(pageId: string, audit: PageAudit): void;
-  recordMarkdownMode(pageId: string): void;
+  recordMarkdownMode(): void;
   recordEmpty(): void;
   snapshot(): AuditSnapshot;
 }
@@ -157,7 +159,9 @@ export function censusKeyOf(key: string): string {
 /** The per-chain half of the accumulator: one of these for the seed chain, one for the census chain. */
 function createChainTallies() {
   const criteria: Tallies = new Map();
-  const whitespaceOnly: Tallies = new Map();
+  // A plain list, not a `Tallies` map: there is exactly one key, and the count
+  // it would carry already lives in `totals.whitespaceOnlyTextChange`.
+  const whitespaceOnlyExamples: string[] = [];
   const dropped: Tallies = new Map();
   const droppedCensus: Tallies = new Map();
   const additions: Tallies = new Map();
@@ -186,7 +190,7 @@ function createChainTallies() {
       if (isLossy(verdict)) totals.lossy += 1;
       if (verdict.whitespaceOnlyTextChange) {
         totals.whitespaceOnlyTextChange += 1;
-        tally(whitespaceOnly, 'spacing', pageId);
+        if (whitespaceOnlyExamples.length < MAX_EXAMPLE_PAGE_IDS) whitespaceOnlyExamples.push(pageId);
       }
 
       // Folded to content-free form; two keys can fold into one, and a page
@@ -201,7 +205,7 @@ function createChainTallies() {
       return {
         totals: { ...totals },
         criteriaFailures: rows(criteria),
-        whitespaceOnlyExamples: whitespaceOnly.get('spacing')?.examplePageIds ?? [],
+        whitespaceOnlyExamples: [...whitespaceOnlyExamples],
         droppedConstructs: rows(dropped),
         droppedConstructsCensusKeyed: rows(droppedCensus),
         unexpectedAdditions: rows(additions),

--- a/scripts/lib/seed-audit/report.ts
+++ b/scripts/lib/seed-audit/report.ts
@@ -1,4 +1,5 @@
-import { isLossy, type PageAudit } from './analyze';
+import { contentFreeKey } from '@pagespace/editor/seed-fidelity';
+import { isLossy, type ChainResult, type PageAudit } from './analyze';
 
 /**
  * Tallies and the printed report.
@@ -136,31 +137,6 @@ export function censusKeyOf(key: string): string {
   return `attr:${rest.split('=')[0]}`;
 }
 
-/**
- * Attribute values that are safe to print: enumerations and small integers
- * the schema itself defines. Every OTHER value-bearing key (`href`, `alt`,
- * the `data-*-id` family) is folded to its presence form before it is
- * tallied — `alt` is prose, an `href` can carry a person's name, and this
- * report goes to a terminal. `constructKeysOf` keeps those values so the
- * corpus test can see a rewritten href; the AUDIT must not repeat them.
- * The "never prints document content" test feeds a sentinel through `alt`
- * to hold this.
- */
-const PRINTABLE_ATTRIBUTE_VALUES: ReadonlySet<string> = new Set([
-  'data-type',
-  'data-checked',
-  'data-tight',
-  'start',
-  'colspan',
-  'rowspan',
-]);
-
-export function contentFreeKey(key: string): string {
-  const valued = /^(attr:[^@]+@)([^=]+)=/u.exec(key);
-  if (!valued) return key;
-  return PRINTABLE_ATTRIBUTE_VALUES.has(valued[2]) ? key : `${valued[1]}${valued[2]}`;
-}
-
 function createChainTallies() {
   const criteria: Tallies = new Map();
   const dropped: Tallies = new Map();
@@ -175,8 +151,7 @@ function createChainTallies() {
   };
 
   return {
-    record(pageId: string, result: PageAudit & { status: 'audited' }, chain: 'seed' | 'census') {
-      const verdict = result[chain];
+    record(pageId: string, verdict: ChainResult) {
       if (!verdict.stable) {
         totals.unstable += 1;
         tally(criteria, 'unstable', pageId);
@@ -217,10 +192,11 @@ export function createAuditAccumulator(): AuditAccumulator {
   const census = createChainTallies();
   const divergence: Tallies = new Map();
   const gateReasons: Tallies = new Map();
+  // One tally per cell; the `agreement` counts are derived from it in
+  // `snapshot()` rather than kept as a second counter that could disagree.
   const agreementRows: Tallies = new Map();
   const failures: Tallies = new Map();
   const tagless: Tallies = new Map();
-  const agreement: GateAgreement = { bothLossy: 0, gateBlindSpot: 0, gateStricter: 0, bothClean: 0 };
   const totals: AuditTotals = {
     documents: 0,
     audited: 0,
@@ -247,8 +223,8 @@ export function createAuditAccumulator(): AuditAccumulator {
         tally(tagless, 'no HTML element', pageId);
       }
 
-      seed.record(pageId, audit, 'seed');
-      census.record(pageId, audit, 'census');
+      seed.record(pageId, audit.seed);
+      census.record(pageId, audit.census);
 
       if (audit.divergence) {
         totals.divergent += 1;
@@ -275,15 +251,14 @@ export function createAuditAccumulator(): AuditAccumulator {
 
       const gateRefuses = audit.gateReasons.length > 0;
       const seedLossy = isLossy(audit.seed);
-      const cell = gateRefuses
+      const cell: keyof GateAgreement = gateRefuses
         ? seedLossy
           ? 'bothLossy'
           : 'gateStricter'
         : seedLossy
           ? 'gateBlindSpot'
           : 'bothClean';
-      agreement[cell] += 1;
-      if (cell !== 'bothClean') tally(agreementRows, cell, pageId);
+      tally(agreementRows, cell, pageId);
       for (const reason of new Set(audit.gateReasons)) tally(gateReasons, reason, pageId);
     },
 
@@ -303,7 +278,18 @@ export function createAuditAccumulator(): AuditAccumulator {
         seed: seed.snapshot(),
         census: census.snapshot(),
         divergence: { rows: rows(divergence) },
-        gate: { agreement: { ...agreement }, agreementRows: rows(agreementRows), reasons: rows(gateReasons) },
+        gate: {
+          agreement: {
+            bothLossy: agreementRows.get('bothLossy')?.pages ?? 0,
+            gateBlindSpot: agreementRows.get('gateBlindSpot')?.pages ?? 0,
+            gateStricter: agreementRows.get('gateStricter')?.pages ?? 0,
+            bothClean: agreementRows.get('bothClean')?.pages ?? 0,
+          },
+          // Example ids for the three cells worth reading; `bothClean` is the
+          // corpus and its ids say nothing.
+          agreementRows: rows(agreementRows).filter((row) => row.key !== 'bothClean'),
+          reasons: rows(gateReasons),
+        },
         failures: rows(failures),
         taglessPages: rows(tagless),
       };

--- a/scripts/tsconfig.json
+++ b/scripts/tsconfig.json
@@ -1,0 +1,41 @@
+{
+  // Typechecks the seed fidelity audit. `scripts/` is in no other TypeScript
+  // project — the root tsconfig includes only `types/**`, and `turbo
+  // typecheck` visits workspace packages, which this directory is not — so
+  // until this file existed nothing in CI typechecked any of it, and the audit
+  // added ~900 lines into that blind spot.
+  //
+  // DELIBERATELY NOT the whole directory. Thirteen files here do not currently
+  // typecheck: most use bun-only globals (`import.meta.main`, `Bun`) that
+  // `@types/node` does not declare, the rest are real mismatches (a drizzle
+  // insert overload, `Duplex` vs `Socket`, `KeyObject` vs `PrivateKeyInput`)
+  // plus one untyped `.mjs` import. `exclude` cannot drop them, because the
+  // suites in `__tests__/` import them and pull them back into the program, so
+  // a directory-wide gate would have to exclude those tests too — a bigger
+  // hole than the one it closes. Fixing all thirteen means editing a dozen
+  // unrelated scripts, which does not belong in the PR that added this file.
+  // Widening `include` to `**/*.ts` is the follow-up, and the reason it is not
+  // done here is recorded so the next reader does not rediscover it.
+  //
+  // `moduleResolution: "bundler"` because bun runs these directly and resolves
+  // the workspace packages' `exports` maps; the root tsconfig's `"node"` mode
+  // ignores `exports` and cannot see a `@pagespace/*` subpath.
+  "compilerOptions": {
+    "target": "es2022",
+    "lib": ["es2022", "dom"],
+    "module": "esnext",
+    "moduleResolution": "bundler",
+    "types": ["node"],
+    "strict": true,
+    "esModuleInterop": true,
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "skipLibCheck": true,
+    "noEmit": true
+  },
+  "include": [
+    "collab-seed-audit.ts",
+    "lib/seed-audit/**/*.ts",
+    "__tests__/collab-seed-audit.test.ts"
+  ]
+}

--- a/scripts/tsconfig.json
+++ b/scripts/tsconfig.json
@@ -36,6 +36,6 @@
   "include": [
     "collab-seed-audit.ts",
     "lib/seed-audit/**/*.ts",
-    "__tests__/collab-seed-audit.test.ts"
+    "__tests__/collab-seed-audit*.test.ts"
   ]
 }


### PR DESCRIPTION
## Phase B exit criterion — seed fidelity audit over real documents (+ `userColor`)

Board: Phase B `f2s3rh7nxew8bn6vsrs0mw5f` → leaves `jklkkf8aaao6v7jpc0mk8qub` (gate) and `p7ant1pe661k0izfpxh4ohje` (`userColor`). Both left `in_progress` — Phase B does not close until the production run reads PASS. Full report: `.pu-reports/pu-mp-seed-fidelity.md`.

**Not run against production.** The orchestrator holds that credential; the exact command is in the report.

### What this adds

- **`scripts/collab-seed-audit.ts`** — streams every DOCUMENT page through the seed chain (HTML → PM → Y.Doc → PM → HTML) *and*, on the same parse, the census chain (HTML → PM → HTML), and judges each by the leaf's three hard blockers: one-pass stability, no decrease in any content-bearing counter, visible text preserved. No thresholds. Any lossy page ⇒ BLOCKED, exit 1.
- The two projections are diffed per page, so a seed-chain loss the census chain does not show is attributed to `y-prosemirror` by construction, with the construct named.
- Dropped constructs are tallied both tag-qualified and **re-keyed to the census's own scheme**, so the numbers line up with `collab-content-census` row for row.
- **Gate-agreement matrix**: `describeParseLoss` (what `htmlToPmDoc` throws on) vs this audit's verdict, per page. On the seeded DB this already found a blind spot: **`<sup>` is dropped and the gate accepts it** (text survives, the mark does not). Reported, not fixed — `sup`/`sub` are representable, so adding them is a v1 decision for the orchestrator.
- Read-only at the server, one query at a time against the `max: 1` pool, never prints content — all three held by tests that scan the audit's own sources.
- **`@pagespace/editor/seed-fidelity`** (new subpath): the cosmetic-rewrite allowlist, construct keys, and the printing side (`KNOWN_ATTRIBUTE_NAMES`, `KNOWN_STYLE_PROPERTIES`, `PRINTABLE_ATTRIBUTE_VALUES`, `contentFreeKey`). Two corpus fixtures (`bare-table`, `bare-ordered-list`) earn the `td`/`th` span and `ol` tight allowlist entries.
- **`@pagespace/editor/user-color`** (new subpath): `userColor(userId)` — djb2 into a 12-entry palette, every entry ≥ 3:1 non-text contrast against white and the app's lightest dark surface; three ids pinned so a re-hash is a visible diff.
- **`@pagespace/editor/html-element-names`** (new subpath): `HTML_ELEMENT_NAMES` / `hasRealHtmlElement` moved out of `apps/web` (which re-exports), so the audit, the census and the mislabelled-content backfill share one "is this really HTML" rule.
- `read-only-session` promoted from the web census into `@pagespace/db` (its own docstring asked for this on the second consumer). `@pagespace/editor` added as a root devDependency — root scripts could not resolve it.

`SCHEMA_HASH` unchanged at `ded0823d`.

### Commits

1. `263761ff` the audit, `userColor`, the shared allowlist, the `read-only-session` move.
2. `3b64b0d0` **`/simplify` pass** — the audit renders and judges through **one** happy-dom window instead of five per page, via new `pmDocToHtmlIn` / `describeParseLoss` seams; it also stopped mirroring `stripNonContentElements` / `visibleCharacters` and now imports them. 1,501-page scale run **6.0 s → 1.2 s**, fixture report byte-identical.
3. `f2f73141` **`/review` + Codex threads** — the report could echo author-controlled markup tokens (tag names, attribute names, style properties, and "printable" enumerated values); printing now goes through closed lists plus per-attribute validators, with a six-position sentinel test. `isTagless` switched to the census's definition. Plus: two-clients `userColor` test strengthened, `--flag=value` and unknown-argument handling, narrower task-item `div` rule, read-only scan also refuses `SET … read_only` / `READ WRITE`.
4. `d498e052` **docstring coverage** — CodeRabbit's pre-merge check read 51.22% against an 80% threshold; every function in the new modules now carries a minimal docblock, not just its types. Comments only.
5. `6db4204` **CI now lints and typechecks `scripts/`, which it never has.** `scripts/` is not a workspace package, so `turbo lint` and `turbo typecheck` both skip it — this PR had added ~900 lines of TypeScript into a directory whose only CI coverage was its vitest run. Adds `scripts/tsconfig.json`, `typecheck:scripts` and two steps in the lint job. Scoped to the audit's files: 13 other files there do not typecheck and their `__tests__` importers defeat `exclude`, so a directory-wide gate would have to exclude those tests — a bigger hole than it closes. The step builds `@pagespace/db` and `@pagespace/editor` first, because without `packages/editor/dist` the bare `tsc` reports 16 module-resolution errors.
6. `98ce9e5` **a real content leak, found by adversarial probing.** `contentFreeKey` returned its input when the attribute pattern could not decompose a key — and happy-dom builds a *real element* for a tag name starting with `@`, so an ordinary pasted FreeMarker directive (`<@list items="payroll-2026-Q1.csv">`) or Slack mention (`<@U08JANE.DOE email="…">`) printed the filename, the address and a full `href` into a report that runs against production. Both folders now fail closed to the census's unescaped-angle-bracket marker. Verified end to end against a real database: **5 planted tokens leaked before, 0 after.** Two consequences closed with it: keys are now bounded (a 264-column key had been padding every table row; 28 chars now, asserted by tests), and a withheld value keeps an `=(withheld)` marker so "dropped" stays distinguishable from "changed" and a non-allowlisted key cannot print as an allowlisted one. Same commit: the whitespace diagnostic no longer fires on every pretty-printed page (it now walks per text node) and carries example page ids; and a guard mutation testing proved dead was removed.
7. `51b3c44d` **the spacing diagnostic could not see the loss it exists to catch.** Dropping every whitespace-only text node is not "ignore pretty-printing": in `a<span> </span>b` — the shape HTML pasted from Word and Docs is full of — that node *is* the space between the words, so a page where the space survived read identically to one where it was lost. Separately, whitespace inside `<pre>` was collapsed, so a code block that lost every indent read as clean. `interWordText` now decides positionally (block edge vs inline text) and keeps `<pre>` verbatim.
8. `d498e05` / `3f6546f` **docstring coverage**, and `6db4204` / `e5bdbd5` / `16d1c84` supporting fixes and report updates.

### Reviewer notes

- **CodeRabbit's "Docstring Coverage 51.22%" pre-merge warning is stale.** Its own `change_assessment_commit` is `263761ff`, the first commit — it was rate-limited mid-review and has not re-measured since the two docstring commits. Every function in the audit's own files now carries a docblock.
- **`@pagespace/lib#test:coverage` failed once, on a flake this PR did not cause.** `page-viewers.integration.test.ts` timed out at 5002 ms; re-running the same commit passed. That test makes 410 sequential database round-trips under vitest's 5 s default, and this PR does not touch `packages/lib`. Left for its owner rather than widening someone else's timeout from here — details in the report.

### Validation

- 59 script tests, 354 editor tests, 5 db tests, 17 web tests for the moved constant, 9 census read-only tests — green as single-file runs; CI green on every push.
- Seeded local DB (14 pages: clean, `<img>`, `<iframe>`, `<style>`, tagless markdown, a `Set<string>` generic, an all-tokens page, markdown-mode, empty, task list, `h4`+mention+`mark`+`sup`, bare table + `ol start=7`, pretty-printed, FOLDER decoy) → BLOCKED, exit 1, correct skips; `--limit 3` and bad flags behave; database dropped after.
- Scale: 1,501 local pages in 1.2 s → production is well under a minute.
- **81 mutations across six sweeps, 0 survivors after fixes.** Three survived and each taught something: two were closed by strengthening tests (agreement cells now have distinct counts; the gate's verdict on a `<style>` page is asserted), and the third proved a guard was dead code, so it was removed. Table in the report.

No CHANGELOG entry: that file is explicitly "user-facing changes", and this is an internal ops script plus package internals with no user-visible surface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014NERCWEMMMPiuTkNLoepvw
