### PR TITLE
feat(env-bridge): durable scoped approvals + the exec click in chat (GA wave 2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ All notable user-facing changes to PageSpace are documented here. Format follows
 
 ### Added
 
+- **Local Environments: commands need your click in the chat; file work runs on its own
+  (opt-in).** Two tiers now. **Reading and writing files** inside the folders you allowed runs
+  without asking from the moment you enrol — no terminal to babysit. **Running a command** always
+  asks: the first time an agent wants to run a program on your computer, a card appears in the
+  chat showing the exact command, working directory, environment and limits the machine froze,
+  and only you — the person who enrolled it, never a drive admin — can click Allow or Deny. Your
+  click is checked by the machine itself against what it froze, so a click can never run something
+  other than what you saw. Choose how long to remember an approval: this once, until the daemon
+  stops, 30 days, or until you revoke it — remembered per program (approving `git status` covers
+  `git push` from a new chat tomorrow, and never covers `rm`). Approvals live on your machine; a
+  drive admin or you can revoke one from PageSpace, and PageSpace can never add one.
+
 - **Local Environments: PageSpace now has a say in what runs on your computer — and only you
   can drive it (opt-in).** When you create a local Environment you now choose what PageSpace may
   ask that computer to do: **Read files** and **Write files** are on by default; **Run commands**

--- a/apps/web/src/app/api/drives/[driveId]/envs/[envId]/approvals/[approvalId]/route.ts
+++ b/apps/web/src/app/api/drives/[driveId]/envs/[envId]/approvals/[approvalId]/route.ts
@@ -14,10 +14,10 @@
  * drive admins. Nobody can ADD an approval through PageSpace: the machine file
  * is authoritative for allow; the server may only revoke.
  *
- * **Honest about reach.** The frame goes over the env's live socket on this
- * replica. Without one the machine still holds the approval; the answer says
- * so (`machine: 'no_live_socket'`, 409) rather than claiming a revoke that
- * was never delivered. Every attempt is audited on the env with the id.
+ * **Honest about reach.** 200 ONLY on the machine's SIGNED acknowledgement
+ * (`approval_revoke_result { approvalId, removed }`). Sent but not acked in
+ * time ⇒ 202 `unacknowledged`; no live socket ⇒ 409. The server never claims
+ * a revoke it cannot prove. Every attempt is audited on the env with the id.
  */
 import { NextResponse } from 'next/server';
 import { authenticateRequestWithOptions, isAuthError, checkMCPDriveScope, isPrincipalDriveMember, isPrincipalDriveOwnerOrAdmin } from '@/lib/auth';
@@ -62,11 +62,14 @@ export async function DELETE(request: Request, context: { params: Promise<{ driv
       if (result.reason === 'not_found') return NextResponse.json({ error: 'Environment not found' }, { status: 404 });
       return NextResponse.json({ error: 'This environment has been revoked', reason: 'revoked' }, { status: 409 });
     }
-    auditRequest(request, { eventType: 'data.write', userId: auth.userId, resourceType: 'drive_env', resourceId: envId, details: { route: 'drive-env-approvals', operation: 'revoke', approvalId, machine: result.machine } });
-    if (result.machine !== 'sent') {
-      return NextResponse.json({ revoked: false, machine: result.machine, error: 'The machine is not connected right now, so it still holds this approval. Connect it and try again.' }, { status: 409 });
+    const machine = result.machine;
+    auditRequest(request, { eventType: 'data.write', userId: auth.userId, resourceType: 'drive_env', resourceId: envId, details: { route: 'drive-env-approvals', operation: 'revoke', approvalId, machine: machine.kind, ...(machine.kind === 'acknowledged' && { removed: machine.removed }) } });
+    // 200 ONLY on the machine's signed ack (Codex P2 on #2583): the server never claims a revoke it cannot prove.
+    if (machine.kind === 'acknowledged') return NextResponse.json({ revoked: true, machine: 'acknowledged', approvalId, removed: machine.removed });
+    if (machine.kind === 'unacknowledged') {
+      return NextResponse.json({ revoked: false, reason: 'unacknowledged', machine: machine.reason, error: 'The revoke was sent, but the machine did not acknowledge it in time; it may still hold this approval. Try again once it is connected.' }, { status: 202 });
     }
-    return NextResponse.json({ revoked: true, machine: result.machine, approvalId });
+    return NextResponse.json({ revoked: false, reason: machine.kind, machine: machine.kind, error: 'The machine is not connected right now, so it still holds this approval. Connect it and try again.' }, { status: 409 });
   } catch (error) {
     loggers.api.error('Failed to revoke an environment approval', error instanceof Error ? error : new Error(String(error)));
     return NextResponse.json({ error: 'Failed to revoke the approval' }, { status: 500 });

--- a/apps/web/src/app/api/drives/[driveId]/envs/[envId]/approvals/[approvalId]/route.ts
+++ b/apps/web/src/app/api/drives/[driveId]/envs/[envId]/approvals/[approvalId]/route.ts
@@ -1,0 +1,74 @@
+/**
+ * Revoke ONE remembered approval on a local environment's machine —
+ * `DELETE /api/drives/[driveId]/envs/[envId]/approvals/[approvalId]`
+ * (GA wave 2, leaf 8).
+ *
+ * The machine remembers an owner's approval under the challenge id it was
+ * answered with (`~/.pagespace/env-approvals.json`). This route asks the
+ * machine to delete exactly that entry, over the existing signed `revoke`
+ * frame with `approvalId` set — signed under its own domain by the key the
+ * enrollment pinned, so it can never be turned into an enrollment revoke.
+ *
+ * **Who may:** the environment OWNER (the human who enrolled it), or a drive
+ * owner/admin — revoking narrows and only narrows, and [D-6] keeps Revoke with
+ * drive admins. Nobody can ADD an approval through PageSpace: the machine file
+ * is authoritative for allow; the server may only revoke.
+ *
+ * **Honest about reach.** The frame goes over the env's live socket on this
+ * replica. Without one the machine still holds the approval; the answer says
+ * so (`machine: 'no_live_socket'`, 409) rather than claiming a revoke that
+ * was never delivered. Every attempt is audited on the env with the id.
+ */
+import { NextResponse } from 'next/server';
+import { authenticateRequestWithOptions, isAuthError, checkMCPDriveScope, isPrincipalDriveMember, isPrincipalDriveOwnerOrAdmin } from '@/lib/auth';
+import { auditRequest } from '@pagespace/lib/audit/audit-log';
+import { loggers } from '@pagespace/lib/logging/logger-config';
+import { resolveEnvInDrive } from '@/lib/drive-envs/drive-envs-runtime';
+import { getDriveEnvStore } from '@/lib/drive-envs/drive-envs-runtime';
+import { revokeLocalEnvApproval } from '@/lib/env-bridge/revoke';
+
+const AUTH_OPTIONS_WRITE = { allow: ['session', 'mcp'] as const, requireCSRF: true };
+
+export async function DELETE(request: Request, context: { params: Promise<{ driveId: string; envId: string; approvalId: string }> }) {
+  try {
+    const { driveId, envId, approvalId } = await context.params;
+    const auth = await authenticateRequestWithOptions(request, AUTH_OPTIONS_WRITE);
+    if (isAuthError(auth)) return auth.error;
+
+    const scopeError = checkMCPDriveScope(auth, driveId);
+    if (scopeError) return scopeError;
+
+    if (!(await isPrincipalDriveMember(auth, driveId))) {
+      auditRequest(request, { eventType: 'authz.access.denied', userId: auth.userId, resourceType: 'drive', resourceId: driveId, details: { route: 'drive-env-approvals', operation: 'revoke', envId, approvalId } });
+      return NextResponse.json({ error: 'Not a member of this drive' }, { status: 403 });
+    }
+
+    const env = await resolveEnvInDrive(envId, driveId);
+    if (!env) return NextResponse.json({ error: 'Environment not found' }, { status: 404 });
+    if (env.substrate !== 'local') return NextResponse.json({ error: 'Only a local environment remembers approvals', reason: 'not_local' }, { status: 409 });
+
+    const sibling = await (await getDriveEnvStore()).findLocalByEnvId(envId);
+    if (!sibling) return NextResponse.json({ error: 'Environment not found' }, { status: 404 });
+
+    // The env OWNER, or drive administration (Revoke stays with admins under D-6).
+    const allowed = sibling.ownerId === auth.userId || (await isPrincipalDriveOwnerOrAdmin(auth, driveId));
+    if (!allowed) {
+      auditRequest(request, { eventType: 'authz.access.denied', userId: auth.userId, resourceType: 'drive_env', resourceId: envId, details: { route: 'drive-env-approvals', operation: 'revoke', approvalId, ownerId: sibling.ownerId }, riskScore: 0.3 });
+      return NextResponse.json({ error: "Only this machine's owner or a drive admin can revoke an approval on it", reason: 'not_owner' }, { status: 403 });
+    }
+
+    const result = await revokeLocalEnvApproval({ envId, approvalId, reason: `revoked_by_${auth.userId}` });
+    if (!result.ok) {
+      if (result.reason === 'not_found') return NextResponse.json({ error: 'Environment not found' }, { status: 404 });
+      return NextResponse.json({ error: 'This environment has been revoked', reason: 'revoked' }, { status: 409 });
+    }
+    auditRequest(request, { eventType: 'data.write', userId: auth.userId, resourceType: 'drive_env', resourceId: envId, details: { route: 'drive-env-approvals', operation: 'revoke', approvalId, machine: result.machine } });
+    if (result.machine !== 'sent') {
+      return NextResponse.json({ revoked: false, machine: result.machine, error: 'The machine is not connected right now, so it still holds this approval. Connect it and try again.' }, { status: 409 });
+    }
+    return NextResponse.json({ revoked: true, machine: result.machine, approvalId });
+  } catch (error) {
+    loggers.api.error('Failed to revoke an environment approval', error instanceof Error ? error : new Error(String(error)));
+    return NextResponse.json({ error: 'Failed to revoke the approval' }, { status: 500 });
+  }
+}

--- a/apps/web/src/app/api/drives/[driveId]/envs/[envId]/approvals/__tests__/route.test.ts
+++ b/apps/web/src/app/api/drives/[driveId]/envs/[envId]/approvals/__tests__/route.test.ts
@@ -1,0 +1,88 @@
+/**
+ * GA wave 2, leaf 8 — DELETE one remembered approval: env owner or drive
+ * admin, over the signed revoke frame, honest when the machine is not there.
+ */
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+
+vi.mock('@pagespace/lib/audit/audit-log', () => ({ audit: vi.fn(), auditRequest: vi.fn() }));
+vi.mock('@pagespace/lib/logging/logger-config', () => ({ loggers: { api: { error: vi.fn(), warn: vi.fn(), info: vi.fn(), debug: vi.fn() } }, logger: { child: () => ({ info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() }) } }));
+vi.mock('@/lib/auth', () => ({
+  authenticateRequestWithOptions: vi.fn(),
+  isAuthError: vi.fn(() => false),
+  checkMCPDriveScope: vi.fn(() => null),
+  isPrincipalDriveMember: vi.fn(async () => true),
+  isPrincipalDriveOwnerOrAdmin: vi.fn(async () => false),
+}));
+vi.mock('@/lib/drive-envs/drive-envs-runtime', () => ({ resolveEnvInDrive: vi.fn(), getDriveEnvStore: vi.fn() }));
+vi.mock('@/lib/env-bridge/revoke', () => ({ revokeLocalEnvApproval: vi.fn() }));
+
+import { DELETE } from '../[approvalId]/route';
+import { auditRequest } from '@pagespace/lib/audit/audit-log';
+import { authenticateRequestWithOptions, isPrincipalDriveMember, isPrincipalDriveOwnerOrAdmin } from '@/lib/auth';
+import { getDriveEnvStore, resolveEnvInDrive } from '@/lib/drive-envs/drive-envs-runtime';
+import { revokeLocalEnvApproval } from '@/lib/env-bridge/revoke';
+
+const DRIVE = 'drive_1';
+const ENV = 'env_1';
+const OWNER = 'user_owner';
+const ADMIN = 'user_admin';
+const MEMBER = 'user_member';
+
+const call = (approvalId = 'ch_1') => DELETE(new Request(`http://localhost/api/drives/${DRIVE}/envs/${ENV}/approvals/${approvalId}`, { method: 'DELETE' }), { params: Promise.resolve({ driveId: DRIVE, envId: ENV, approvalId }) });
+const json = async (r: Response) => (await r.json()) as Record<string, unknown>;
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  vi.mocked(isPrincipalDriveMember).mockResolvedValue(true);
+  vi.mocked(isPrincipalDriveOwnerOrAdmin).mockResolvedValue(false);
+  vi.mocked(authenticateRequestWithOptions).mockResolvedValue({ userId: OWNER } as never);
+  vi.mocked(resolveEnvInDrive).mockResolvedValue({ id: ENV, driveId: DRIVE, substrate: 'local' } as never);
+  vi.mocked(getDriveEnvStore).mockResolvedValue({ findLocalByEnvId: vi.fn(async () => ({ envId: ENV, ownerId: OWNER, revokedAt: null })) } as never);
+  vi.mocked(revokeLocalEnvApproval).mockResolvedValue({ ok: true, machine: 'sent' });
+});
+
+describe('DELETE /api/drives/[driveId]/envs/[envId]/approvals/[approvalId]', () => {
+  it('given the env OWNER (a plain member), should send the signed approval revoke and answer revoked', async () => {
+    const r = await call();
+    expect(r.status).toBe(200);
+    expect(await json(r)).toEqual({ revoked: true, machine: 'sent', approvalId: 'ch_1' });
+    expect(revokeLocalEnvApproval).toHaveBeenCalledWith({ envId: ENV, approvalId: 'ch_1', reason: `revoked_by_${OWNER}` });
+    expect(auditRequest).toHaveBeenCalledWith(expect.anything(), expect.objectContaining({ eventType: 'data.write', details: expect.objectContaining({ operation: 'revoke', approvalId: 'ch_1', machine: 'sent' }) }));
+  });
+
+  it('given a drive ADMIN who is not the owner, should ALSO revoke (Revoke stays with admins, D-6)', async () => {
+    vi.mocked(authenticateRequestWithOptions).mockResolvedValue({ userId: ADMIN } as never);
+    vi.mocked(isPrincipalDriveOwnerOrAdmin).mockResolvedValue(true);
+    expect((await call()).status).toBe(200);
+  });
+
+  it('given a plain member who is neither, should refuse 403, send nothing, and audit', async () => {
+    vi.mocked(authenticateRequestWithOptions).mockResolvedValue({ userId: MEMBER } as never);
+    const r = await call();
+    expect(r.status).toBe(403);
+    expect(revokeLocalEnvApproval).not.toHaveBeenCalled();
+    expect(auditRequest).toHaveBeenCalledWith(expect.anything(), expect.objectContaining({ eventType: 'authz.access.denied', userId: MEMBER }));
+  });
+
+  it('given a non-member, should 403 before any lookup', async () => {
+    vi.mocked(isPrincipalDriveMember).mockResolvedValue(false);
+    expect((await call()).status).toBe(403);
+    expect(resolveEnvInDrive).not.toHaveBeenCalled();
+  });
+
+  it('given the machine is not connected, should answer 409 revoked:false with the reach outcome — never a claimed revoke', async () => {
+    vi.mocked(revokeLocalEnvApproval).mockResolvedValue({ ok: true, machine: 'no_live_socket' });
+    const r = await call();
+    expect(r.status).toBe(409);
+    expect(await json(r)).toMatchObject({ revoked: false, machine: 'no_live_socket' });
+  });
+
+  it('given an env outside the drive, a Sprite env, or a revoked env, should answer 404 / 409 / 409', async () => {
+    vi.mocked(resolveEnvInDrive).mockResolvedValueOnce(null);
+    expect((await call()).status).toBe(404);
+    vi.mocked(resolveEnvInDrive).mockResolvedValueOnce({ id: ENV, driveId: DRIVE, substrate: 'sprite' } as never);
+    expect((await call()).status).toBe(409);
+    vi.mocked(revokeLocalEnvApproval).mockResolvedValueOnce({ ok: false, reason: 'revoked' });
+    expect((await call()).status).toBe(409);
+  });
+});

--- a/apps/web/src/app/api/drives/[driveId]/envs/[envId]/approvals/__tests__/route.test.ts
+++ b/apps/web/src/app/api/drives/[driveId]/envs/[envId]/approvals/__tests__/route.test.ts
@@ -38,16 +38,23 @@ beforeEach(() => {
   vi.mocked(authenticateRequestWithOptions).mockResolvedValue({ userId: OWNER } as never);
   vi.mocked(resolveEnvInDrive).mockResolvedValue({ id: ENV, driveId: DRIVE, substrate: 'local' } as never);
   vi.mocked(getDriveEnvStore).mockResolvedValue({ findLocalByEnvId: vi.fn(async () => ({ envId: ENV, ownerId: OWNER, revokedAt: null })) } as never);
-  vi.mocked(revokeLocalEnvApproval).mockResolvedValue({ ok: true, machine: 'sent' });
+  vi.mocked(revokeLocalEnvApproval).mockResolvedValue({ ok: true, machine: { kind: 'acknowledged', removed: 2 } });
 });
 
 describe('DELETE /api/drives/[driveId]/envs/[envId]/approvals/[approvalId]', () => {
-  it('given the env OWNER (a plain member), should send the signed approval revoke and answer revoked', async () => {
+  it('given the env OWNER (a plain member) and the machine\'s signed ACK, should answer 200 revoked with the count the machine signed', async () => {
     const r = await call();
     expect(r.status).toBe(200);
-    expect(await json(r)).toEqual({ revoked: true, machine: 'sent', approvalId: 'ch_1' });
+    expect(await json(r)).toEqual({ revoked: true, machine: 'acknowledged', approvalId: 'ch_1', removed: 2 });
     expect(revokeLocalEnvApproval).toHaveBeenCalledWith({ envId: ENV, approvalId: 'ch_1', reason: `revoked_by_${OWNER}` });
-    expect(auditRequest).toHaveBeenCalledWith(expect.anything(), expect.objectContaining({ eventType: 'data.write', details: expect.objectContaining({ operation: 'revoke', approvalId: 'ch_1', machine: 'sent' }) }));
+    expect(auditRequest).toHaveBeenCalledWith(expect.anything(), expect.objectContaining({ eventType: 'data.write', details: expect.objectContaining({ operation: 'revoke', approvalId: 'ch_1', machine: 'acknowledged', removed: 2 }) }));
+  });
+
+  it('Codex P2 on #2583: sent but NOT acknowledged ⇒ 202 { revoked: false, reason: unacknowledged } — never a success it cannot prove', async () => {
+    vi.mocked(revokeLocalEnvApproval).mockResolvedValue({ ok: true, machine: { kind: 'unacknowledged', reason: 'timeout' } });
+    const r = await call();
+    expect(r.status).toBe(202);
+    expect(await json(r)).toMatchObject({ revoked: false, reason: 'unacknowledged', machine: 'timeout' });
   });
 
   it('given a drive ADMIN who is not the owner, should ALSO revoke (Revoke stays with admins, D-6)', async () => {
@@ -71,10 +78,10 @@ describe('DELETE /api/drives/[driveId]/envs/[envId]/approvals/[approvalId]', () 
   });
 
   it('given the machine is not connected, should answer 409 revoked:false with the reach outcome — never a claimed revoke', async () => {
-    vi.mocked(revokeLocalEnvApproval).mockResolvedValue({ ok: true, machine: 'no_live_socket' });
+    vi.mocked(revokeLocalEnvApproval).mockResolvedValue({ ok: true, machine: { kind: 'no_live_socket' } });
     const r = await call();
     expect(r.status).toBe(409);
-    expect(await json(r)).toMatchObject({ revoked: false, machine: 'no_live_socket' });
+    expect(await json(r)).toMatchObject({ revoked: false, reason: 'no_live_socket', machine: 'no_live_socket' });
   });
 
   it('given an env outside the drive, a Sprite env, or a revoked env, should answer 404 / 409 / 409', async () => {

--- a/apps/web/src/app/api/env-bridge/__tests__/routes.test.ts
+++ b/apps/web/src/app/api/env-bridge/__tests__/routes.test.ts
@@ -61,11 +61,12 @@ describe('the cloud opt-in (invariant 11)', () => {
 
 describe('POST /api/env-bridge/enroll', () => {
   it('given a valid code and key, should pin and answer 200 with the server key to pin, auditing the pin', async () => {
-    vi.mocked(enrollLocalEnv).mockResolvedValue({ ok: true, envId: 'env_1', enrollmentId: ENROLLMENT, serverKeyId: 'k1', serverPublicKey: 'U0VSVkVS', ownerId: 'user_owner' });
+    vi.mocked(enrollLocalEnv).mockResolvedValue({ ok: true, envId: 'env_1', enrollmentId: ENROLLMENT, serverKeyId: 'k1', serverPublicKey: 'U0VSVkVS', ownerId: 'user_owner', serverPolicy: { ops: ['fs_read', 'exec'], checkpoint: false } });
     const response = await enroll(enrollReq());
     expect(response.status).toBe(200);
     // `ownerId` rides the answer so the enroller can scaffold `principals: [owner]` (D-6).
-    expect(await json(response)).toEqual({ enrollmentId: ENROLLMENT, envId: 'env_1', serverKeyId: 'k1', serverPublicKey: 'U0VSVkVS', ownerId: 'user_owner' });
+    // `serverPolicy` rides too (GA wave 2): the enroller scaffolds the FILE ops it allows into the machine policy — and never `exec`, whatever it says.
+    expect(await json(response)).toEqual({ enrollmentId: ENROLLMENT, envId: 'env_1', serverKeyId: 'k1', serverPublicKey: 'U0VSVkVS', ownerId: 'user_owner', serverPolicy: { ops: ['fs_read', 'exec'], checkpoint: false } });
     expect(enrollLocalEnv).toHaveBeenCalledWith(enrollBody);
     expect(auditRequest).toHaveBeenCalledWith(expect.anything(), expect.objectContaining({ eventType: 'auth.token.created', resourceId: 'env_1' }));
   });

--- a/apps/web/src/app/api/env-bridge/approvals/[challengeId]/route.ts
+++ b/apps/web/src/app/api/env-bridge/approvals/[challengeId]/route.ts
@@ -21,7 +21,8 @@
  * grant carrying a server-signed `approvalIntent { challengeId, scope,
  * expiresAt }`. The MACHINE looks the frozen request up by that id,
  * byte-compares the re-issued request against it, and runs only on a match
- * (`approval_mismatch` otherwise). This route can only ask the machine to
+ * (`approval_mismatch` otherwise — including for a challenge the machine
+ * never froze). This route can only ask the machine to
  * honour a question the machine itself framed; it cannot introduce a request.
  *
  * **After the challenge TTL ⇒ `approval_expired`** (410): the frozen request
@@ -131,7 +132,6 @@ function outcomeOf(challengeId: string, scope: RequestEnvApprovalOutput['scope']
     case 'grant_denied':
       if (reply.reason === 'approval_mismatch') return { challengeId, outcome: 'mismatch', error: reply.reason };
       if (reply.reason === 'approval_expired') return { challengeId, outcome: 'expired', error: reply.reason };
-      if (reply.reason === 'approval_unknown') return { challengeId, outcome: 'unknown', error: reply.reason };
       return { challengeId, outcome: 'failed', error: reply.reason };
   }
 }

--- a/apps/web/src/app/api/env-bridge/approvals/[challengeId]/route.ts
+++ b/apps/web/src/app/api/env-bridge/approvals/[challengeId]/route.ts
@@ -137,6 +137,9 @@ function outcomeOf(challengeId: string, scope: RequestEnvApprovalOutput['scope']
       return reply.ok ? { challengeId, outcome: 'allowed', scope } : { challengeId, outcome: 'failed', scope, error: reply.error ?? 'write failed' };
     case 'fs_read_result':
       return { challengeId, outcome: 'allowed', scope };
+    case 'approval_revoke_result':
+      // Not an answer to a grant; a click can never be answered by a revoke ack.
+      return { challengeId, outcome: 'failed', error: 'unexpected_frame' };
     case 'grant_denied':
       if (reply.reason === 'approval_mismatch') return { challengeId, outcome: 'mismatch', error: reply.reason };
       if (reply.reason === 'approval_expired') return { challengeId, outcome: 'expired', error: reply.reason };

--- a/apps/web/src/app/api/env-bridge/approvals/[challengeId]/route.ts
+++ b/apps/web/src/app/api/env-bridge/approvals/[challengeId]/route.ts
@@ -1,0 +1,193 @@
+/**
+ * The owner's click on a pending local-environment approval — `/api/env-bridge/approvals/[challengeId]`
+ * (GA wave 2, leaves 5–6; Tier B).
+ *
+ * GET   → { challengeId, envId, principal, expiresAt, request }   — the ENV OWNER only
+ * POST  { decision: 'allow' | 'deny', scope? } → { outcome, … }   — the ENV OWNER only
+ *
+ * A machine that reached the `ask` verdict froze the exact normalised request
+ * under a challenge id and answered `ask_pending:<id>`; the bridge client
+ * remembered what re-issuing it needs (`pending-approvals.ts`). This route
+ * lets the environment's OWNER — and nobody else — see that frozen request
+ * (the card renders it verbatim, as the machine signed it) and answer it.
+ *
+ * **Owner only, by the row ([D-6]).** The clicker must be
+ * `drive_env_local.ownerId`. A drive admin who did not enrol the machine is
+ * 403 (`not_owner`), audited. No drive role is consulted: approving a command
+ * on someone else's laptop is not drive administration.
+ *
+ * **Allow re-issues, it does not run.** On Allow the server sends the machine
+ * the SAME unsigned frame it sent before, under the same principal, as a fresh
+ * grant carrying a server-signed `approvalIntent { challengeId, scope,
+ * expiresAt }`. The MACHINE looks the frozen request up by that id,
+ * byte-compares the re-issued request against it, and runs only on a match
+ * (`approval_mismatch` otherwise). This route can only ask the machine to
+ * honour a question the machine itself framed; it cannot introduce a request.
+ *
+ * **After the challenge TTL ⇒ `approval_expired`** (410): the frozen request
+ * dies with the grant that framed it, on the machine and here.
+ *
+ * Every answer is audited on the env with the challenge id.
+ */
+import { NextResponse } from 'next/server';
+import { z } from 'zod';
+import { authenticateRequestWithOptions, isAuthError } from '@/lib/auth';
+import { auditRequest } from '@pagespace/lib/audit/audit-log';
+import { loggers } from '@pagespace/lib/logging/logger-config';
+import { isLocalEnvsEnabled } from '@pagespace/lib/services/drive-envs/local-envs-enabled';
+import type { MachineResultFrame } from '@pagespace/lib/env-bridge/machine-signatures';
+import { ENV_APPROVAL_SCOPES, type RequestEnvApprovalOutput } from '@/lib/ai/tools/env-approval-tools';
+import { EnvBridgeError, getEnvBridgeClient } from '@/lib/env-bridge/bridge-client';
+import { getPendingApprovalStore, type PendingEnvApproval } from '@/lib/env-bridge/pending-approvals';
+import { getDriveEnvStore } from '@/lib/drive-envs/drive-envs-runtime';
+
+const AUTH_OPTIONS_READ = { allow: ['session'] as const, requireCSRF: false };
+const AUTH_OPTIONS_WRITE = { allow: ['session'] as const, requireCSRF: true };
+
+const bodySchema = z
+  .object({
+    decision: z.enum(['allow', 'deny']),
+    scope: z.enum(ENV_APPROVAL_SCOPES).optional(),
+  })
+  .strict();
+
+type Params = { params: Promise<{ challengeId: string }> };
+
+/** The pending entry and the sibling it belongs to, or the response that ends the request. */
+async function loadForOwner(request: Request, challengeId: string, userId: string, now: number): Promise<{ ok: true; pending: PendingEnvApproval; ownerId: string } | { ok: false; response: Response }> {
+  const pending = getPendingApprovalStore().get(challengeId, now);
+  if (!pending) {
+    auditRequest(request, { eventType: 'authz.access.denied', userId, resourceType: 'drive_env_approval', resourceId: challengeId, details: { route: 'env-bridge/approvals', reason: 'unknown_or_expired' } });
+    return { ok: false, response: NextResponse.json({ error: 'No pending approval with this id — it was answered, or the request it froze has expired', outcome: 'expired', reason: 'approval_expired' }, { status: 410 }) };
+  }
+  const sibling = await (await getDriveEnvStore()).findLocalByEnvId(pending.envId);
+  if (!sibling || sibling.revokedAt !== null) {
+    getPendingApprovalStore().take(challengeId, now);
+    return { ok: false, response: NextResponse.json({ error: 'Environment not found', outcome: 'unknown' }, { status: 404 }) };
+  }
+  // The env OWNER only (D-6): the human who enrolled the machine, never a drive role.
+  if (sibling.ownerId !== userId) {
+    auditRequest(request, {
+      eventType: 'authz.access.denied',
+      userId,
+      resourceType: 'drive_env',
+      resourceId: pending.envId,
+      details: { route: 'env-bridge/approvals', operation: 'approve', challengeId, ownerId: sibling.ownerId },
+      riskScore: 0.5,
+    });
+    return {
+      ok: false,
+      response: NextResponse.json(
+        { error: `Only this machine's owner (the user who enrolled it, ${sibling.ownerId}) can approve what runs on it — drive admins can delete or revoke it, but not drive it`, outcome: 'not_owner', reason: 'not_owner', ownerId: sibling.ownerId },
+        { status: 403 },
+      ),
+    };
+  }
+  return { ok: true, pending, ownerId: sibling.ownerId };
+}
+
+export async function GET(request: Request, context: Params) {
+  if (!isLocalEnvsEnabled()) return NextResponse.json({ error: 'Not found' }, { status: 404 });
+  try {
+    const { challengeId } = await context.params;
+    const auth = await authenticateRequestWithOptions(request, AUTH_OPTIONS_READ);
+    if (isAuthError(auth)) return auth.error;
+    const loaded = await loadForOwner(request, challengeId, auth.userId, Date.now());
+    if (!loaded.ok) return loaded.response;
+    const { pending } = loaded;
+    auditRequest(request, { eventType: 'data.read', userId: auth.userId, resourceType: 'drive_env', resourceId: pending.envId, details: { route: 'env-bridge/approvals', operation: 'read', challengeId } });
+    return NextResponse.json({
+      challengeId,
+      envId: pending.envId,
+      principal: pending.principal,
+      expiresAt: pending.expiresAt,
+      // Verbatim: the frozen request as the MACHINE signed it.
+      request: pending.pending.request,
+      scopes: ENV_APPROVAL_SCOPES,
+    });
+  } catch (error) {
+    loggers.api.error('Failed to read a pending environment approval', error instanceof Error ? error : new Error(String(error)));
+    return NextResponse.json({ error: 'Failed to read the pending approval' }, { status: 500 });
+  }
+}
+
+/** The tool result for a machine reply to the re-issued grant. */
+function outcomeOf(challengeId: string, scope: RequestEnvApprovalOutput['scope'], reply: MachineResultFrame): RequestEnvApprovalOutput {
+  switch (reply.type) {
+    case 'exec_result':
+      return {
+        challengeId,
+        outcome: 'allowed',
+        scope,
+        exitCode: reply.exitCode,
+        stdout: Buffer.from(reply.stdoutB64, 'base64').toString('utf8'),
+        stderr: Buffer.from(reply.stderrB64, 'base64').toString('utf8'),
+        truncated: reply.truncated,
+      };
+    case 'fs_write_result':
+      return reply.ok ? { challengeId, outcome: 'allowed', scope } : { challengeId, outcome: 'failed', scope, error: reply.error ?? 'write failed' };
+    case 'fs_read_result':
+      return { challengeId, outcome: 'allowed', scope };
+    case 'grant_denied':
+      if (reply.reason === 'approval_mismatch') return { challengeId, outcome: 'mismatch', error: reply.reason };
+      if (reply.reason === 'approval_expired') return { challengeId, outcome: 'expired', error: reply.reason };
+      if (reply.reason === 'approval_unknown') return { challengeId, outcome: 'unknown', error: reply.reason };
+      return { challengeId, outcome: 'failed', error: reply.reason };
+  }
+}
+
+export async function POST(request: Request, context: Params) {
+  if (!isLocalEnvsEnabled()) return NextResponse.json({ error: 'Not found' }, { status: 404 });
+  try {
+    const { challengeId } = await context.params;
+    const auth = await authenticateRequestWithOptions(request, AUTH_OPTIONS_WRITE);
+    if (isAuthError(auth)) return auth.error;
+
+    const body = await request.json().catch(() => null);
+    const parsed = bodySchema.safeParse(body);
+    if (!parsed.success) return NextResponse.json({ error: 'decision (allow | deny) is required; scope is one of once | session | 30d | until_revoked' }, { status: 400 });
+
+    const now = Date.now();
+    const loaded = await loadForOwner(request, challengeId, auth.userId, now);
+    if (!loaded.ok) return loaded.response;
+    const { pending } = loaded;
+    const store = getPendingApprovalStore();
+
+    if (parsed.data.decision === 'deny') {
+      store.take(challengeId, now);
+      auditRequest(request, { eventType: 'data.write', userId: auth.userId, resourceType: 'drive_env', resourceId: pending.envId, details: { route: 'env-bridge/approvals', operation: 'deny', challengeId } });
+      const output: RequestEnvApprovalOutput = { challengeId, outcome: 'denied' };
+      return NextResponse.json(output);
+    }
+
+    const scope = parsed.data.scope ?? '30d';
+    // Spent before the re-issue: one click answers one question, whatever the machine says next.
+    store.take(challengeId, now);
+    let reply: MachineResultFrame;
+    try {
+      reply = await getEnvBridgeClient().sendGrant({
+        envId: pending.envId,
+        frame: pending.frame,
+        principal: pending.principal,
+        approvalIntent: { challengeId, scope, expiresAt: pending.expiresAt },
+      });
+    } catch (error) {
+      const kind = error instanceof EnvBridgeError ? error.kind : 'error';
+      auditRequest(request, { eventType: 'data.write', userId: auth.userId, resourceType: 'drive_env', resourceId: pending.envId, details: { route: 'env-bridge/approvals', operation: 'allow', challengeId, scope, outcome: 'failed', error: kind } });
+      const output: RequestEnvApprovalOutput = { challengeId, outcome: 'failed', scope, error: kind };
+      return NextResponse.json(output, { status: 502 });
+    }
+    const output = outcomeOf(challengeId, scope, reply);
+    auditRequest(request, {
+      eventType: 'data.write',
+      userId: auth.userId,
+      resourceType: 'drive_env',
+      resourceId: pending.envId,
+      details: { route: 'env-bridge/approvals', operation: 'allow', challengeId, scope, outcome: output.outcome, ...(output.exitCode !== undefined && { exitCode: output.exitCode }) },
+    });
+    return NextResponse.json(output, { status: output.outcome === 'allowed' ? 200 : output.outcome === 'expired' ? 410 : 409 });
+  } catch (error) {
+    loggers.api.error('Failed to answer a pending environment approval', error instanceof Error ? error : new Error(String(error)));
+    return NextResponse.json({ error: 'Failed to answer the pending approval' }, { status: 500 });
+  }
+}

--- a/apps/web/src/app/api/env-bridge/approvals/[challengeId]/route.ts
+++ b/apps/web/src/app/api/env-bridge/approvals/[challengeId]/route.ts
@@ -37,7 +37,7 @@ import { auditRequest } from '@pagespace/lib/audit/audit-log';
 import { loggers } from '@pagespace/lib/logging/logger-config';
 import { isLocalEnvsEnabled } from '@pagespace/lib/services/drive-envs/local-envs-enabled';
 import type { MachineResultFrame } from '@pagespace/lib/env-bridge/machine-signatures';
-import { ENV_APPROVAL_SCOPES, type RequestEnvApprovalOutput } from '@/lib/ai/tools/env-approval-tools';
+import { ENV_APPROVAL_SCOPES, ENV_APPROVAL_STDERR_MAX_CHARS, ENV_APPROVAL_STDOUT_MAX_CHARS, type RequestEnvApprovalOutput } from '@/lib/ai/tools/env-approval-tools';
 import { EnvBridgeError, getEnvBridgeClient } from '@/lib/env-bridge/bridge-client';
 import { getPendingApprovalStore, type PendingEnvApproval } from '@/lib/env-bridge/pending-approvals';
 import { getDriveEnvStore } from '@/lib/drive-envs/drive-envs-runtime';
@@ -112,19 +112,27 @@ export async function GET(request: Request, context: Params) {
   }
 }
 
-/** The tool result for a machine reply to the re-issued grant. */
+/** Cut a stream to the tool output bound (UTF-16 length, the unit zod measures); says whether it cut. */
+function bounded(text: string, maxChars: number): { text: string; cut: boolean } {
+  return text.length > maxChars ? { text: text.slice(0, maxChars), cut: true } : { text, cut: false };
+}
+
+/** The tool result for a machine reply to the re-issued grant. Output is truncated to the schema's bounds so the result always merges. */
 function outcomeOf(challengeId: string, scope: RequestEnvApprovalOutput['scope'], reply: MachineResultFrame): RequestEnvApprovalOutput {
   switch (reply.type) {
-    case 'exec_result':
+    case 'exec_result': {
+      const stdout = bounded(Buffer.from(reply.stdoutB64, 'base64').toString('utf8'), ENV_APPROVAL_STDOUT_MAX_CHARS);
+      const stderr = bounded(Buffer.from(reply.stderrB64, 'base64').toString('utf8'), ENV_APPROVAL_STDERR_MAX_CHARS);
       return {
         challengeId,
         outcome: 'allowed',
         scope,
         exitCode: reply.exitCode,
-        stdout: Buffer.from(reply.stdoutB64, 'base64').toString('utf8'),
-        stderr: Buffer.from(reply.stderrB64, 'base64').toString('utf8'),
-        truncated: reply.truncated,
+        stdout: stdout.text,
+        stderr: stderr.text,
+        truncated: reply.truncated || stdout.cut || stderr.cut,
       };
+    }
     case 'fs_write_result':
       return reply.ok ? { challengeId, outcome: 'allowed', scope } : { challengeId, outcome: 'failed', scope, error: reply.error ?? 'write failed' };
     case 'fs_read_result':

--- a/apps/web/src/app/api/env-bridge/approvals/__tests__/route.test.ts
+++ b/apps/web/src/app/api/env-bridge/approvals/__tests__/route.test.ts
@@ -17,6 +17,7 @@ vi.mock('@/lib/env-bridge/bridge-client', async (importOriginal) => {
 });
 
 import { GET, POST } from '../[challengeId]/route';
+import { ENV_APPROVAL_STDERR_MAX_CHARS, ENV_APPROVAL_STDOUT_MAX_CHARS, requestEnvApprovalOutputSchema } from '@/lib/ai/tools/env-approval-tools';
 import { auditRequest } from '@pagespace/lib/audit/audit-log';
 import { isLocalEnvsEnabled } from '@pagespace/lib/services/drive-envs/local-envs-enabled';
 import { authenticateRequestWithOptions } from '@/lib/auth';
@@ -95,6 +96,25 @@ describe('POST allow — the click re-issues a grant over IDENTICAL args carryin
     // Spent: a second click on the same id is gone.
     expect((await post({ decision: 'allow' })).status).toBe(410);
     expect(sendGrant).toHaveBeenCalledTimes(1);
+  });
+
+  it('Codex P1 on #2583: a LARGE successful output (300 KiB stdout) is truncated to the tool output bounds so the result still validates against requestEnvApprovalOutputSchema, with truncated: true', async () => {
+    const big = 'x'.repeat(300 * 1024);
+    sendGrant.mockResolvedValueOnce({ type: 'exec_result', grantId: 'g', exitCode: 0, stdoutB64: Buffer.from(big).toString('base64'), stderrB64: Buffer.from('e'.repeat(60 * 1024)).toString('base64'), truncated: false, sig: 'c2ln' });
+    const r = await post({ decision: 'allow' });
+    expect(r.status).toBe(200);
+    const body = await json(r);
+    const parsed = requestEnvApprovalOutputSchema.safeParse(body);
+    expect(parsed.success, JSON.stringify(parsed.success ? null : parsed.error.issues[0])).toBe(true);
+    expect((body.stdout as string).length).toBe(ENV_APPROVAL_STDOUT_MAX_CHARS);
+    expect((body.stderr as string).length).toBe(ENV_APPROVAL_STDERR_MAX_CHARS);
+    expect(body.truncated).toBe(true);
+    // Under the bound: untouched, and truncated stays what the machine said.
+    sendGrant.mockResolvedValueOnce({ type: 'exec_result', grantId: 'g', exitCode: 0, stdoutB64: Buffer.from('small').toString('base64'), stderrB64: '', truncated: false, sig: 'c2ln' });
+    resetPendingApprovalStoreForTesting();
+    getPendingApprovalStore().remember(pendingEntry(), NOW);
+    const small = await json(await post({ decision: 'allow' }));
+    expect(small).toMatchObject({ stdout: 'small', truncated: false });
   });
 
   it('given no scope, should default to 30d', async () => {

--- a/apps/web/src/app/api/env-bridge/approvals/__tests__/route.test.ts
+++ b/apps/web/src/app/api/env-bridge/approvals/__tests__/route.test.ts
@@ -1,0 +1,163 @@
+/**
+ * GA wave 2, leaf 6 — the owner's click. Contract tests at the runtime seam:
+ * Allow re-issues the IDENTICAL frame under the same principal with a
+ * server-signed approvalIntent; the clicker must be the env's owner (a drive
+ * admin is 403); after the challenge TTL the answer is approval_expired.
+ */
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+
+vi.mock('@pagespace/lib/audit/audit-log', () => ({ audit: vi.fn(), auditRequest: vi.fn() }));
+vi.mock('@pagespace/lib/logging/logger-config', () => ({ loggers: { api: { error: vi.fn(), warn: vi.fn(), info: vi.fn(), debug: vi.fn() } }, logger: { child: () => ({ info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() }) } }));
+vi.mock('@pagespace/lib/services/drive-envs/local-envs-enabled', () => ({ isLocalEnvsEnabled: vi.fn(() => true) }));
+vi.mock('@/lib/auth', () => ({ authenticateRequestWithOptions: vi.fn(), isAuthError: vi.fn(() => false) }));
+vi.mock('@/lib/drive-envs/drive-envs-runtime', () => ({ getDriveEnvStore: vi.fn() }));
+vi.mock('@/lib/env-bridge/bridge-client', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@/lib/env-bridge/bridge-client')>();
+  return { ...actual, getEnvBridgeClient: vi.fn() };
+});
+
+import { GET, POST } from '../[challengeId]/route';
+import { auditRequest } from '@pagespace/lib/audit/audit-log';
+import { isLocalEnvsEnabled } from '@pagespace/lib/services/drive-envs/local-envs-enabled';
+import { authenticateRequestWithOptions } from '@/lib/auth';
+import { getDriveEnvStore } from '@/lib/drive-envs/drive-envs-runtime';
+import { EnvBridgeError, getEnvBridgeClient } from '@/lib/env-bridge/bridge-client';
+import { getPendingApprovalStore, resetPendingApprovalStoreForTesting, type PendingEnvApproval } from '@/lib/env-bridge/pending-approvals';
+
+const OWNER = 'user_owner';
+const ADMIN = 'user_admin';
+const ENV = 'env_1';
+const NOW = Date.parse('2026-09-09T12:00:00.000Z');
+
+const FRAME = { type: 'grant_exec' as const, cmd: 'sh', args: ['-c', 'git status'], cwd: '/home/o/proj', env: { CI: '1' } };
+const PRINCIPAL = { userId: OWNER, sessionId: 'sess_1', conversationId: 'conv_1' };
+const REQUEST = { op: 'exec' as const, cmd: 'sh', args: ['-c', 'git status'], cwd: '/home/o/proj', paths: [], env: { CI: '1' }, timeoutMs: 120_000, maxBytes: 1_048_576, clamped: false };
+
+function pendingEntry(over: Partial<PendingEnvApproval> = {}): PendingEnvApproval {
+  return { challengeId: 'ch_1', envId: ENV, frame: FRAME, principal: PRINCIPAL, expiresAt: NOW + 30_000, pending: { challengeId: 'ch_1', expiresAt: NOW + 30_000, request: REQUEST }, createdAt: NOW, ...over };
+}
+
+const ctx = (challengeId = 'ch_1') => ({ params: Promise.resolve({ challengeId }) });
+const post = (body: unknown, challengeId = 'ch_1') => POST(new Request(`http://localhost/api/env-bridge/approvals/${challengeId}`, { method: 'POST', body: JSON.stringify(body), headers: { 'content-type': 'application/json' } }), ctx(challengeId));
+const get = (challengeId = 'ch_1') => GET(new Request(`http://localhost/api/env-bridge/approvals/${challengeId}`), ctx(challengeId));
+const json = async (r: Response) => (await r.json()) as Record<string, unknown>;
+
+let sendGrant: ReturnType<typeof vi.fn>;
+let sibling: { envId: string; ownerId: string; revokedAt: Date | null } | null;
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  vi.mocked(isLocalEnvsEnabled).mockReturnValue(true);
+  vi.useFakeTimers();
+  vi.setSystemTime(NOW);
+  resetPendingApprovalStoreForTesting();
+  sibling = { envId: ENV, ownerId: OWNER, revokedAt: null };
+  vi.mocked(getDriveEnvStore).mockResolvedValue({ findLocalByEnvId: vi.fn(async () => sibling) } as never);
+  vi.mocked(authenticateRequestWithOptions).mockResolvedValue({ userId: OWNER } as never);
+  sendGrant = vi.fn(async () => ({ type: 'exec_result', grantId: 'g_click', exitCode: 0, stdoutB64: Buffer.from('On branch main').toString('base64'), stderrB64: '', truncated: false, sig: 'c2ln' }));
+  vi.mocked(getEnvBridgeClient).mockReturnValue({ sendGrant } as never);
+  getPendingApprovalStore().remember(pendingEntry(), NOW);
+});
+
+describe('GET — the owner sees the frozen request verbatim', () => {
+  it('given the owner, should answer the frozen request, principal and expiry exactly as the machine signed them', async () => {
+    const r = await get();
+    expect(r.status).toBe(200);
+    expect(await json(r)).toEqual({ challengeId: 'ch_1', envId: ENV, principal: PRINCIPAL, expiresAt: NOW + 30_000, request: REQUEST, scopes: ['once', 'session', '30d', 'until_revoked'] });
+  });
+
+  it('given a drive ADMIN who is not the env owner, should refuse 403 not_owner and audit (D-6)', async () => {
+    vi.mocked(authenticateRequestWithOptions).mockResolvedValue({ userId: ADMIN } as never);
+    const r = await get();
+    expect(r.status).toBe(403);
+    expect(await json(r)).toMatchObject({ outcome: 'not_owner', ownerId: OWNER });
+    expect(auditRequest).toHaveBeenCalledWith(expect.anything(), expect.objectContaining({ eventType: 'authz.access.denied', userId: ADMIN, resourceId: ENV }));
+  });
+
+  it('given an unknown id, should answer 410 approval_expired', async () => {
+    expect((await get('ch_nope')).status).toBe(410);
+  });
+
+  it('given LOCAL_ENVS_ENABLED off, should 404 and touch nothing', async () => {
+    vi.mocked(isLocalEnvsEnabled).mockReturnValue(false);
+    expect((await get()).status).toBe(404);
+    expect(authenticateRequestWithOptions).not.toHaveBeenCalled();
+  });
+});
+
+describe('POST allow — the click re-issues a grant over IDENTICAL args carrying a server-signed approvalIntent', () => {
+  it('given the owner clicks Allow with a scope, should send the SAME frame under the SAME principal with approvalIntent { challengeId, scope, expiresAt } and answer the command\'s outcome', async () => {
+    const r = await post({ decision: 'allow', scope: 'until_revoked' });
+    expect(r.status).toBe(200);
+    expect(sendGrant).toHaveBeenCalledTimes(1);
+    expect(sendGrant).toHaveBeenCalledWith({ envId: ENV, frame: FRAME, principal: PRINCIPAL, approvalIntent: { challengeId: 'ch_1', scope: 'until_revoked', expiresAt: NOW + 30_000 } });
+    expect(await json(r)).toEqual({ challengeId: 'ch_1', outcome: 'allowed', scope: 'until_revoked', exitCode: 0, stdout: 'On branch main', stderr: '', truncated: false });
+    // Spent: a second click on the same id is gone.
+    expect((await post({ decision: 'allow' })).status).toBe(410);
+    expect(sendGrant).toHaveBeenCalledTimes(1);
+  });
+
+  it('given no scope, should default to 30d', async () => {
+    await post({ decision: 'allow' });
+    expect(sendGrant).toHaveBeenCalledWith(expect.objectContaining({ approvalIntent: expect.objectContaining({ scope: '30d' }) }));
+  });
+
+  it('given the clicker is NOT drive_env_local.ownerId (a drive admin), should refuse 403, send NOTHING to the machine, keep the question pending, and audit', async () => {
+    vi.mocked(authenticateRequestWithOptions).mockResolvedValue({ userId: ADMIN } as never);
+    const r = await post({ decision: 'allow' });
+    expect(r.status).toBe(403);
+    expect(await json(r)).toMatchObject({ outcome: 'not_owner', reason: 'not_owner' });
+    expect(sendGrant).not.toHaveBeenCalled();
+    expect(getPendingApprovalStore().size()).toBe(1);
+    expect(auditRequest).toHaveBeenCalledWith(expect.anything(), expect.objectContaining({ eventType: 'authz.access.denied', userId: ADMIN }));
+  });
+
+  it('given the click arrives after the challenge TTL, should answer 410 approval_expired and send nothing — the agent must request again', async () => {
+    vi.setSystemTime(NOW + 30_001);
+    const r = await post({ decision: 'allow' });
+    expect(r.status).toBe(410);
+    expect(await json(r)).toMatchObject({ outcome: 'expired', reason: 'approval_expired' });
+    expect(sendGrant).not.toHaveBeenCalled();
+  });
+
+  it('given the MACHINE answers approval_mismatch / approval_expired / approval_unknown, should relay the typed outcome (never 200 allowed)', async () => {
+    for (const [reason, outcome, status] of [['approval_mismatch', 'mismatch', 409], ['approval_expired', 'expired', 410], ['approval_unknown', 'unknown', 409]] as const) {
+      resetPendingApprovalStoreForTesting();
+      getPendingApprovalStore().remember(pendingEntry(), NOW);
+      sendGrant.mockResolvedValueOnce({ type: 'grant_denied', grantId: 'g', reason, sig: 'c2ln' });
+      const r = await post({ decision: 'allow' });
+      expect(r.status, reason).toBe(status);
+      expect(await json(r)).toMatchObject({ outcome, error: reason });
+    }
+  });
+
+  it('given the bridge throws (no socket, refused to sign), should answer 502 failed with the typed kind', async () => {
+    sendGrant.mockRejectedValueOnce(new EnvBridgeError('not_connected', 'gone'));
+    const r = await post({ decision: 'allow' });
+    expect(r.status).toBe(502);
+    expect(await json(r)).toMatchObject({ outcome: 'failed', error: 'not_connected' });
+  });
+
+  it('given a revoked env, should 404 and drop the pending question', async () => {
+    sibling = { envId: ENV, ownerId: OWNER, revokedAt: new Date(NOW) };
+    expect((await post({ decision: 'allow' })).status).toBe(404);
+    expect(getPendingApprovalStore().size()).toBe(0);
+  });
+
+  it('given a malformed body, should 400 without touching the store', async () => {
+    expect((await post({ decision: 'maybe' })).status).toBe(400);
+    expect((await post({ decision: 'allow', scope: 'forever' })).status).toBe(400);
+    expect(getPendingApprovalStore().size()).toBe(1);
+  });
+});
+
+describe('POST deny', () => {
+  it('given the owner clicks Deny, should spend the question, send nothing, audit, and answer denied', async () => {
+    const r = await post({ decision: 'deny' });
+    expect(r.status).toBe(200);
+    expect(await json(r)).toEqual({ challengeId: 'ch_1', outcome: 'denied' });
+    expect(sendGrant).not.toHaveBeenCalled();
+    expect(getPendingApprovalStore().size()).toBe(0);
+    expect(auditRequest).toHaveBeenCalledWith(expect.anything(), expect.objectContaining({ eventType: 'data.write', details: expect.objectContaining({ operation: 'deny', challengeId: 'ch_1' }) }));
+  });
+});

--- a/apps/web/src/app/api/env-bridge/approvals/__tests__/route.test.ts
+++ b/apps/web/src/app/api/env-bridge/approvals/__tests__/route.test.ts
@@ -120,8 +120,8 @@ describe('POST allow — the click re-issues a grant over IDENTICAL args carryin
     expect(sendGrant).not.toHaveBeenCalled();
   });
 
-  it('given the MACHINE answers approval_mismatch / approval_expired / approval_unknown, should relay the typed outcome (never 200 allowed)', async () => {
-    for (const [reason, outcome, status] of [['approval_mismatch', 'mismatch', 409], ['approval_expired', 'expired', 410], ['approval_unknown', 'unknown', 409]] as const) {
+  it('given the MACHINE answers approval_mismatch / approval_expired / any other refusal, should relay the typed outcome (never 200 allowed)', async () => {
+    for (const [reason, outcome, status] of [['approval_mismatch', 'mismatch', 409], ['approval_expired', 'expired', 410], ['declined', 'failed', 409]] as const) {
       resetPendingApprovalStoreForTesting();
       getPendingApprovalStore().remember(pendingEntry(), NOW);
       sendGrant.mockResolvedValueOnce({ type: 'grant_denied', grantId: 'g', reason, sig: 'c2ln' });

--- a/apps/web/src/app/api/env-bridge/enroll/route.ts
+++ b/apps/web/src/app/api/env-bridge/enroll/route.ts
@@ -16,7 +16,7 @@
  * for every refusal.
  *
  *   body   { enrollmentId, code, machinePublicKey (base64 SPKI DER) }
- *   200    { enrollmentId, envId, serverKeyId, serverPublicKey (base64 SPKI DER) }
+ *   200    { enrollmentId, envId, serverKeyId, serverPublicKey (base64 SPKI DER), ownerId, serverPolicy }
  */
 import { NextResponse } from 'next/server';
 import { z } from 'zod';
@@ -92,5 +92,8 @@ export async function POST(request: Request) {
   });
   // `ownerId` is the enrolling user's id — no secret, and exactly what the
   // machine needs to scaffold `principals: [owner]` in its own policy (D-6).
-  return NextResponse.json({ enrollmentId: result.enrollmentId, envId: result.envId, serverKeyId: result.serverKeyId, serverPublicKey: result.serverPublicKey, ownerId: result.ownerId });
+  // `serverPolicy` is the env's allow-set — no secret either (the owner chose
+  // it in the dialog), and what the machine needs to scaffold the file ops it
+  // may run headless (GA wave 2, Tier A). The enroller never scaffolds `exec`.
+  return NextResponse.json({ enrollmentId: result.enrollmentId, envId: result.envId, serverKeyId: result.serverKeyId, serverPublicKey: result.serverPublicKey, ownerId: result.ownerId, serverPolicy: result.serverPolicy });
 }

--- a/apps/web/src/app/api/env-bridge/ws/__tests__/route.security.test.ts
+++ b/apps/web/src/app/api/env-bridge/ws/__tests__/route.security.test.ts
@@ -35,7 +35,7 @@ import { getDriveEnvStore } from '@/lib/drive-envs/drive-envs-runtime';
 import { loadServerSigningKeyring } from '@pagespace/lib/auth/env-bridge-signing-key';
 import { LOCAL_ENV_HEARTBEAT_WINDOW_MS } from '@pagespace/lib/services/drive-envs/drive-envs';
 import { decodeFrame, encodeFrame, type Frame } from '@pagespace/lib/env-bridge/frame-codec';
-import { encodeHelloForSigning, encodeResultForSigning, resultHashForFrame, type MachineResultFrame } from '@pagespace/lib/env-bridge/machine-signatures';
+import { encodeHelloForSigning, encodeResultForSigning, machineResultBindingId, resultHashForFrame, type MachineResultFrame } from '@pagespace/lib/env-bridge/machine-signatures';
 import { parseServerSigningKeyring, type SigningKeyPrimitives } from '@pagespace/lib/env-bridge/server-signing-key';
 import { clearAllEnvConnectionsForTesting, getEnvConnection, readEnvLiveConnection, ENV_SUPERSEDED_CLOSE_CODE, ENV_SUPERSEDED_CLOSE_REASON } from '@/lib/websocket/ws-env-connections';
 import { getEnvBridgeClient } from '@/lib/env-bridge/bridge-client';
@@ -113,7 +113,7 @@ type UnsignedResult<T = MachineResultFrame> = T extends unknown ? Omit<T, 'sig'>
 
 function signedResult(body: UnsignedResult, key = machine): string {
   const resultHash = resultHashForFrame({ ...body, sig: '' } as MachineResultFrame, envBridgeHash);
-  return encodeFrame({ ...body, sig: Buffer.from(nodeSign(null, encodeResultForSigning({ grantId: body.grantId, resultHash }), key.privateKey)).toString('base64') } as MachineResultFrame);
+  return encodeFrame({ ...body, sig: Buffer.from(nodeSign(null, encodeResultForSigning({ grantId: machineResultBindingId({ ...body, sig: '' } as MachineResultFrame), resultHash }), key.privateKey)).toString('base64') } as MachineResultFrame);
 }
 
 const events = () => vi.mocked(auditRequest).mock.calls.map((call) => (call[1] as { details?: { originalEvent?: string } }).details?.originalEvent);

--- a/apps/web/src/app/api/env-bridge/ws/route.ts
+++ b/apps/web/src/app/api/env-bridge/ws/route.ts
@@ -21,7 +21,7 @@ import { isLocalEnvsEnabled } from '@pagespace/lib/services/drive-envs/local-env
 import { LOCAL_ENV_HEARTBEAT_WINDOW_MS } from '@pagespace/lib/services/drive-envs/drive-envs';
 import type { DriveEnvLocalRecord } from '@pagespace/lib/services/drive-envs/drive-envs-store';
 import { initialBridgeSession, reduceBridgeSession, type BridgeSessionState } from '@pagespace/lib/env-bridge/bridge-session';
-import { verifyHello, isMachineResultFrame } from '@pagespace/lib/env-bridge/machine-signatures';
+import { verifyHello, isMachineResultFrame, machineResultBindingId } from '@pagespace/lib/env-bridge/machine-signatures';
 import { getDriveEnvStore } from '@/lib/drive-envs/drive-envs-runtime';
 import { getEnvBridgeClient } from '@/lib/env-bridge/bridge-client';
 import { decodePinnedPublicKey, ed25519Verify } from '@/lib/env-bridge/crypto';
@@ -397,19 +397,20 @@ export async function UPGRADE(client: WebSocket, server: WebSocketServer, reques
       return;
     }
     if (isMachineResultFrame(frame)) {
+      const grantId = machineResultBindingId(frame);
       // SECURITY CHECK 7: Connection health check before a result is accepted
       const health = checkEnvConnectionHealth(client);
       if (!health.isHealthy) {
-        dropFrame('ws_unhealthy_connection_result', { reason: health.reason, readyState: health.readyState, grantId: frame.grantId }, 0.5);
+        dropFrame('ws_unhealthy_connection_result', { reason: health.reason, readyState: health.readyState, grantId }, 0.5);
         return;
       }
       const disposition = getEnvBridgeClient().handleMachineResult(client, frame);
       if (disposition === 'unverified') {
-        dropFrame('env_bridge_result_unverified', { grantId: frame.grantId, frameType: frame.type }, 0.8);
+        dropFrame('env_bridge_result_unverified', { grantId, frameType: frame.type }, 0.8);
       } else if (disposition === 'dropped_wrong_env') {
-        dropFrame('env_bridge_result_wrong_env', { grantId: frame.grantId, frameType: frame.type }, 0.8);
+        dropFrame('env_bridge_result_wrong_env', { grantId, frameType: frame.type }, 0.8);
       } else if (disposition !== 'delivered') {
-        dropFrame('env_bridge_result_dropped', { grantId: frame.grantId, frameType: frame.type, disposition }, 0.3);
+        dropFrame('env_bridge_result_dropped', { grantId, frameType: frame.type, disposition }, 0.3);
       }
       return;
     }

--- a/apps/web/src/components/ai/shared/chat/__tests__/EnvApprovalCard.test.tsx
+++ b/apps/web/src/components/ai/shared/chat/__tests__/EnvApprovalCard.test.tsx
@@ -1,0 +1,111 @@
+/**
+ * GA wave 2, leaf 5 — the approval card renders the FROZEN request the server
+ * hands it (as the machine signed it), and a click posts the owner's decision
+ * then submits the route's answer as the tool result under the tool's own
+ * name — never as an ask_user answer.
+ */
+import React from 'react';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { AskUserAnswerProvider } from '../ask-user/AskUserAnswerContext';
+import { EnvApprovalCard, frozenRequestRows } from '../env-approval/EnvApprovalCard';
+
+const PENDING = {
+  challengeId: 'ch_1',
+  envId: 'env_1',
+  principal: { userId: 'user_owner', sessionId: 'sess_1', conversationId: 'conv_1' },
+  expiresAt: 1_800_000_030_000,
+  request: { op: 'exec', cmd: 'sh', args: ['-c', 'git status'], cwd: '/home/o/proj', paths: [], env: { CI: '1' }, timeoutMs: 120_000, maxBytes: 1_048_576, clamped: true },
+};
+
+function jsonResponse(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), { status, headers: { 'content-type': 'application/json' } });
+}
+
+const part = (over: Record<string, unknown> = {}) => ({ type: 'tool-request_env_approval', toolCallId: 'call_1', state: 'input-available' as const, input: { challengeId: 'ch_1' }, ...over });
+
+describe('EnvApprovalCard', () => {
+  let fetchMock: ReturnType<typeof vi.fn>;
+  beforeEach(() => {
+    fetchMock = vi.fn();
+    vi.stubGlobal('fetch', fetchMock);
+  });
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('frozenRequestRows prints the same fields the daemon prompt does: principal, op, command, cwd, paths, env, limits', () => {
+    const rows = frozenRequestRows(PENDING);
+    expect(rows.map(([label]) => label)).toEqual(['principal', 'op', 'command', 'cwd', 'env', 'limits']);
+    expect(rows).toContainEqual(['command', 'sh -c git status']);
+    expect(rows).toContainEqual(['env', 'CI=1']);
+    expect(rows).toContainEqual(['limits', 'timeout 120000 ms, output 1048576 bytes (clamped to the machine policy)']);
+    expect(frozenRequestRows({ ...PENDING, request: { ...PENDING.request, paths: ['/a', '/b'], env: {} } })).toContainEqual(['paths', '/a, /b']);
+  });
+
+  it('fetches the frozen request from the approvals route and renders it verbatim; Allow posts the chosen scope and submits the route\'s answer under request_env_approval', async () => {
+    fetchMock.mockImplementation(async (url: string, init?: RequestInit) => {
+      if (!init || init.method === undefined) return jsonResponse(PENDING);
+      expect(url).toBe('/api/env-bridge/approvals/ch_1');
+      expect(JSON.parse(String(init.body))).toEqual({ decision: 'allow', scope: 'until_revoked' });
+      return jsonResponse({ challengeId: 'ch_1', outcome: 'allowed', scope: 'until_revoked', exitCode: 0, stdout: 'On branch main', stderr: '', truncated: false });
+    });
+    const submitAnswers = vi.fn();
+    render(
+      <AskUserAnswerProvider value={{ answerableToolCallIds: new Set(['call_1']), submitAnswers }}>
+        <EnvApprovalCard part={part()} />
+      </AskUserAnswerProvider>,
+    );
+    await waitFor(() => expect(screen.getByTestId('env-approval-request')).toBeTruthy());
+    expect(screen.getByTestId('env-approval-request').textContent).toContain('sh -c git status');
+    expect(screen.getByTestId('env-approval-request').textContent).toContain('/home/o/proj');
+    expect(screen.getByTestId('env-approval-request').textContent).toContain('user user_owner, session sess_1, conversation conv_1');
+    fireEvent.change(screen.getByLabelText('Remember for'), { target: { value: 'until_revoked' } });
+    fireEvent.click(screen.getByTestId('env-approval-allow'));
+    await waitFor(() => expect(submitAnswers).toHaveBeenCalledTimes(1));
+    expect(submitAnswers).toHaveBeenCalledWith('call_1', expect.objectContaining({ challengeId: 'ch_1', outcome: 'allowed', exitCode: 0 }), 'request_env_approval');
+  });
+
+  it('Deny posts a deny and submits denied', async () => {
+    fetchMock.mockImplementation(async (_url: string, init?: RequestInit) => {
+      if (!init || init.method === undefined) return jsonResponse(PENDING);
+      expect(JSON.parse(String(init.body))).toEqual({ decision: 'deny' });
+      return jsonResponse({ challengeId: 'ch_1', outcome: 'denied' });
+    });
+    const submitAnswers = vi.fn();
+    render(
+      <AskUserAnswerProvider value={{ answerableToolCallIds: new Set(['call_1']), submitAnswers }}>
+        <EnvApprovalCard part={part()} />
+      </AskUserAnswerProvider>,
+    );
+    await waitFor(() => expect(screen.getByTestId('env-approval-deny')).toBeTruthy());
+    fireEvent.click(screen.getByTestId('env-approval-deny'));
+    await waitFor(() => expect(submitAnswers).toHaveBeenCalledWith('call_1', { challengeId: 'ch_1', outcome: 'denied' }, 'request_env_approval'));
+  });
+
+  it('given the viewer is not the owner (403), shows the refusal and offers no Allow button', async () => {
+    fetchMock.mockResolvedValue(jsonResponse({ error: 'Only this machine\'s owner can approve', outcome: 'not_owner' }, 403));
+    render(
+      <AskUserAnswerProvider value={{ answerableToolCallIds: new Set(['call_1']), submitAnswers: vi.fn() }}>
+        <EnvApprovalCard part={part()} />
+      </AskUserAnswerProvider>,
+    );
+    await waitFor(() => expect(screen.getByTestId('env-approval-gone')).toBeTruthy());
+    expect(screen.getByTestId('env-approval-gone').textContent).toContain('owner');
+    expect(screen.queryByTestId('env-approval-allow')).toBeNull();
+  });
+
+  it('outside a live chat surface (no context) or when not answerable, renders read-only — no buttons, no fetch of the decision', async () => {
+    fetchMock.mockResolvedValue(jsonResponse(PENDING));
+    render(<EnvApprovalCard part={part()} />);
+    await waitFor(() => expect(screen.getByTestId('env-approval-request')).toBeTruthy());
+    expect(screen.queryByTestId('env-approval-allow')).toBeNull();
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('an answered part renders the outcome and never fetches', () => {
+    render(<EnvApprovalCard part={part({ state: 'output-available', output: { challengeId: 'ch_1', outcome: 'allowed', scope: '30d', exitCode: 0 } })} />);
+    expect(screen.getByTestId('env-approval-answered').textContent).toContain('Approved and run on your machine');
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/src/components/ai/shared/chat/__tests__/EnvApprovalCard.test.tsx
+++ b/apps/web/src/components/ai/shared/chat/__tests__/EnvApprovalCard.test.tsx
@@ -7,6 +7,9 @@
 import React from 'react';
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+const fetchWithAuthMock = vi.hoisted(() => vi.fn());
+vi.mock('@/lib/auth/auth-fetch', () => ({ fetchWithAuth: (...args: unknown[]) => fetchWithAuthMock(...args) }));
+
 import { AskUserAnswerProvider } from '../ask-user/AskUserAnswerContext';
 import { EnvApprovalCard, frozenRequestRows } from '../env-approval/EnvApprovalCard';
 
@@ -25,13 +28,18 @@ function jsonResponse(body: unknown, status = 200): Response {
 const part = (over: Record<string, unknown> = {}) => ({ type: 'tool-request_env_approval', toolCallId: 'call_1', state: 'input-available' as const, input: { challengeId: 'ch_1' }, ...over });
 
 describe('EnvApprovalCard', () => {
+  /** Every request goes through the auth fetch helper (session + CSRF); a raw window.fetch would be a regression. */
   let fetchMock: ReturnType<typeof vi.fn>;
+  let rawFetch: ReturnType<typeof vi.fn>;
   beforeEach(() => {
-    fetchMock = vi.fn();
-    vi.stubGlobal('fetch', fetchMock);
+    fetchMock = fetchWithAuthMock;
+    fetchMock.mockReset();
+    rawFetch = vi.fn(async () => { throw new Error('raw fetch must not be used — it carries no CSRF token'); });
+    vi.stubGlobal('fetch', rawFetch);
   });
   afterEach(() => {
     vi.unstubAllGlobals();
+    expect(rawFetch).not.toHaveBeenCalled();
   });
 
   it('frozenRequestRows prints the same fields the daemon prompt does: principal, op, command, cwd, paths, env, limits', () => {
@@ -45,7 +53,7 @@ describe('EnvApprovalCard', () => {
 
   it('fetches the frozen request from the approvals route and renders it verbatim; Allow posts the chosen scope and submits the route\'s answer under request_env_approval', async () => {
     fetchMock.mockImplementation(async (url: string, init?: RequestInit) => {
-      if (!init || init.method === undefined) return jsonResponse(PENDING);
+      if (!init || init.method !== 'POST') return jsonResponse(PENDING);
       expect(url).toBe('/api/env-bridge/approvals/ch_1');
       expect(JSON.parse(String(init.body))).toEqual({ decision: 'allow', scope: 'until_revoked' });
       return jsonResponse({ challengeId: 'ch_1', outcome: 'allowed', scope: 'until_revoked', exitCode: 0, stdout: 'On branch main', stderr: '', truncated: false });
@@ -64,11 +72,15 @@ describe('EnvApprovalCard', () => {
     fireEvent.click(screen.getByTestId('env-approval-allow'));
     await waitFor(() => expect(submitAnswers).toHaveBeenCalledTimes(1));
     expect(submitAnswers).toHaveBeenCalledWith('call_1', expect.objectContaining({ challengeId: 'ch_1', outcome: 'allowed', exitCode: 0 }), 'request_env_approval');
+    // Codex P1 on #2583: BOTH the GET and the POST go through fetchWithAuth (the helper that attaches the CSRF token the requireCSRF route demands).
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(fetchMock.mock.calls[0]![1]).toMatchObject({ method: 'GET' });
+    expect(fetchMock.mock.calls[1]![1]).toMatchObject({ method: 'POST' });
   });
 
   it('Deny posts a deny and submits denied', async () => {
     fetchMock.mockImplementation(async (_url: string, init?: RequestInit) => {
-      if (!init || init.method === undefined) return jsonResponse(PENDING);
+      if (!init || init.method !== 'POST') return jsonResponse(PENDING);
       expect(JSON.parse(String(init.body))).toEqual({ decision: 'deny' });
       return jsonResponse({ challengeId: 'ch_1', outcome: 'denied' });
     });

--- a/apps/web/src/components/ai/shared/chat/ask-user/AskUserAnswerContext.tsx
+++ b/apps/web/src/components/ai/shared/chat/ask-user/AskUserAnswerContext.tsx
@@ -1,10 +1,11 @@
 import { createContext, useContext } from 'react';
-import type { AskUserOutput } from '@/lib/ai/tools/ask-user-tools';
+import type { PausingToolName } from '@/lib/ai/tools/pausing-tools';
 
 export interface AskUserAnswerContextValue {
-  /** toolCallIds currently answerable in THIS chat instance (last message, chat idle). */
+  /** toolCallIds currently answerable in THIS chat instance (last message, chat idle) — ask_user AND request_env_approval parts. */
   answerableToolCallIds: ReadonlySet<string>;
-  submitAnswers: (toolCallId: string, output: AskUserOutput) => void;
+  /** Submit a pausing tool's client result; `tool` defaults to ask_user. */
+  submitAnswers: (toolCallId: string, output: unknown, tool?: PausingToolName) => void;
 }
 
 /**

--- a/apps/web/src/components/ai/shared/chat/ask-user/AskUserQuestionCard.tsx
+++ b/apps/web/src/components/ai/shared/chat/ask-user/AskUserQuestionCard.tsx
@@ -5,7 +5,7 @@ import { Badge } from '@/components/ui/badge';
 import { Textarea } from '@/components/ui/textarea';
 import { cn } from '@/lib/utils';
 import { useAskUserAnswerContext } from './AskUserAnswerContext';
-import type { AskUserInput, AskUserAnswer } from '@/lib/ai/tools/ask-user-tools';
+import type { AskUserInput, AskUserAnswer, AskUserOutput } from '@/lib/ai/tools/ask-user-tools';
 
 interface ToolPart {
   type: string;
@@ -33,9 +33,7 @@ const tryJson = (value: string): unknown => {
   }
 };
 
-type AskUserOutputShape =
-  | { answers: AskUserAnswer[] }
-  | { dismissed: true; reason: string };
+type AskUserOutputShape = AskUserOutput;
 
 const safeParseOutput = (value: unknown): AskUserOutputShape | null => {
   const parsed = typeof value === 'string' ? tryJson(value) : value;

--- a/apps/web/src/components/ai/shared/chat/env-approval/EnvApprovalCard.tsx
+++ b/apps/web/src/components/ai/shared/chat/env-approval/EnvApprovalCard.tsx
@@ -1,0 +1,268 @@
+import React, { useEffect, useMemo, useState } from 'react';
+import { ShieldAlert, ShieldCheck, ShieldX } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import { Badge } from '@/components/ui/badge';
+import { cn } from '@/lib/utils';
+import { useAskUserAnswerContext } from '../ask-user/AskUserAnswerContext';
+import {
+  ENV_APPROVAL_SCOPES,
+  REQUEST_ENV_APPROVAL_TOOL_NAME,
+  type EnvApprovalScope,
+  type RequestEnvApprovalOutput,
+} from '@/lib/ai/tools/env-approval-tools';
+
+/**
+ * The Tier B approval card (GA wave 2, leaf 5): the environment owner's
+ * click on a request the MACHINE froze.
+ *
+ * What it shows is fetched from `GET /api/env-bridge/approvals/<challengeId>`
+ * — the frozen request as the machine signed it (principal, op, argv, cwd,
+ * paths, env, limits: the same fields the daemon's terminal prompt renders),
+ * never the model's paraphrase and never the tool input. Allow / Deny call
+ * `POST` on the same route; the server re-issues the identical request with
+ * the owner's signed intent and the machine byte-compares before it runs.
+ * The route's answer is submitted as the tool result so the turn resumes.
+ *
+ * This card never reuses `ask_user`: the click is an authenticated request
+ * to the server, not text the model reads. A test asserts this file does not
+ * import the ask_user module.
+ */
+
+interface ToolPart {
+  type: string;
+  toolCallId?: string;
+  state?: 'input-streaming' | 'input-available' | 'output-available' | 'output-error' | 'done' | 'streaming';
+  input?: unknown;
+  output?: unknown;
+}
+
+interface EnvApprovalCardProps {
+  part: ToolPart;
+}
+
+interface FrozenRequest {
+  op: string;
+  cmd?: string;
+  args?: string[];
+  cwd: string;
+  paths: string[];
+  env: Record<string, string>;
+  timeoutMs: number;
+  maxBytes: number;
+  clamped: boolean;
+}
+
+interface PendingApprovalView {
+  challengeId: string;
+  envId: string;
+  principal: { userId: string; sessionId: string; conversationId: string };
+  expiresAt: number;
+  request: FrozenRequest;
+}
+
+type LoadState =
+  | { kind: 'loading' }
+  | { kind: 'loaded'; pending: PendingApprovalView }
+  | { kind: 'gone'; outcome: 'expired' | 'not_owner' | 'unknown'; message: string };
+
+const tryJson = (value: string): unknown => {
+  try {
+    return JSON.parse(value);
+  } catch {
+    return null;
+  }
+};
+
+const challengeIdOf = (input: unknown): string | null => {
+  const parsed = typeof input === 'string' ? tryJson(input) : input;
+  const id = parsed && typeof parsed === 'object' ? (parsed as { challengeId?: unknown }).challengeId : undefined;
+  return typeof id === 'string' && id.length > 0 ? id : null;
+};
+
+const outputOf = (value: unknown): RequestEnvApprovalOutput | null => {
+  const parsed = typeof value === 'string' ? tryJson(value) : value;
+  if (!parsed || typeof parsed !== 'object' || typeof (parsed as { outcome?: unknown }).outcome !== 'string') return null;
+  return parsed as RequestEnvApprovalOutput;
+};
+
+export const SCOPE_LABELS: Record<EnvApprovalScope, string> = {
+  once: 'This once',
+  session: 'Until the daemon stops',
+  '30d': 'For 30 days',
+  until_revoked: 'Until I revoke it',
+};
+
+/** Exactly the lines `renderAskPrompt` prints on the daemon, as rows. */
+export function frozenRequestRows(pending: PendingApprovalView): Array<[string, string]> {
+  const { request, principal } = pending;
+  const rows: Array<[string, string]> = [
+    ['principal', `user ${principal.userId}, session ${principal.sessionId}, conversation ${principal.conversationId}`],
+    ['op', request.op],
+  ];
+  if (request.cmd !== undefined) rows.push(['command', [request.cmd, ...(request.args ?? [])].join(' ')]);
+  rows.push(['cwd', request.cwd]);
+  if (request.paths.length > 0) rows.push(['paths', request.paths.join(', ')]);
+  const env = Object.entries(request.env).map(([name, value]) => `${name}=${value}`);
+  rows.push(['env', env.length > 0 ? env.join(' ') : '(none)']);
+  rows.push(['limits', `timeout ${request.timeoutMs} ms, output ${request.maxBytes} bytes${request.clamped ? ' (clamped to the machine policy)' : ''}`]);
+  return rows;
+}
+
+async function fetchPending(challengeId: string): Promise<LoadState> {
+  const response = await fetch(`/api/env-bridge/approvals/${encodeURIComponent(challengeId)}`, { credentials: 'include' });
+  if (response.ok) {
+    const pending = (await response.json()) as PendingApprovalView;
+    return { kind: 'loaded', pending };
+  }
+  const body = (await response.json().catch(() => ({}))) as { outcome?: string; error?: string };
+  const outcome = body.outcome === 'not_owner' ? 'not_owner' : body.outcome === 'unknown' ? 'unknown' : 'expired';
+  return { kind: 'gone', outcome, message: body.error ?? `The pending approval could not be loaded (${response.status}).` };
+}
+
+export function EnvApprovalCard({ part }: EnvApprovalCardProps) {
+  const answerContext = useAskUserAnswerContext();
+  const challengeId = useMemo(() => challengeIdOf(part.input), [part.input]);
+  const answered = useMemo(() => outputOf(part.output), [part.output]);
+  const answerable = Boolean(answerContext && part.toolCallId && answerContext.answerableToolCallIds.has(part.toolCallId)) && part.state === 'input-available';
+
+  const [load, setLoad] = useState<LoadState>({ kind: 'loading' });
+  const [scope, setScope] = useState<EnvApprovalScope>('30d');
+  const [busy, setBusy] = useState<'allow' | 'deny' | null>(null);
+  const [failure, setFailure] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (answered !== null || challengeId === null) return;
+    let cancelled = false;
+    fetchPending(challengeId)
+      .then((state) => {
+        if (!cancelled) setLoad(state);
+      })
+      .catch((error: unknown) => {
+        if (!cancelled) setLoad({ kind: 'gone', outcome: 'unknown', message: error instanceof Error ? error.message : String(error) });
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [challengeId, answered]);
+
+  const submit = (output: RequestEnvApprovalOutput) => {
+    if (!answerContext || !part.toolCallId) return;
+    answerContext.submitAnswers(part.toolCallId, output, REQUEST_ENV_APPROVAL_TOOL_NAME);
+  };
+
+  const decide = async (decision: 'allow' | 'deny') => {
+    if (challengeId === null || busy !== null) return;
+    setBusy(decision);
+    setFailure(null);
+    try {
+      const response = await fetch(`/api/env-bridge/approvals/${encodeURIComponent(challengeId)}`, {
+        method: 'POST',
+        credentials: 'include',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify(decision === 'allow' ? { decision, scope } : { decision }),
+      });
+      const body = (await response.json().catch(() => null)) as RequestEnvApprovalOutput | { error?: string; outcome?: string } | null;
+      const outcome = body && typeof body === 'object' && typeof (body as { outcome?: unknown }).outcome === 'string' ? (body as RequestEnvApprovalOutput).outcome : 'failed';
+      const output: RequestEnvApprovalOutput = body && 'challengeId' in body && typeof body.challengeId === 'string' ? (body as RequestEnvApprovalOutput) : { challengeId, outcome, error: (body as { error?: string } | null)?.error ?? `HTTP ${response.status}` };
+      submit(output);
+    } catch (error: unknown) {
+      setFailure(error instanceof Error ? error.message : String(error));
+    } finally {
+      setBusy(null);
+    }
+  };
+
+  if (challengeId === null) {
+    return (
+      <div className="my-2 rounded-lg border border-destructive/40 bg-destructive/5 p-3 text-sm">
+        <span className="font-medium">Approval request without a challenge id.</span> Nothing was sent to the machine.
+      </div>
+    );
+  }
+
+  if (answered !== null) {
+    const ok = answered.outcome === 'allowed';
+    const Icon = ok ? ShieldCheck : answered.outcome === 'denied' ? ShieldX : ShieldAlert;
+    return (
+      <div className={cn('my-2 rounded-lg border p-3 text-sm', ok ? 'border-emerald-500/40 bg-emerald-500/5' : 'border-muted bg-muted/30')} data-testid="env-approval-answered">
+        <div className="flex items-center gap-2">
+          <Icon className="h-4 w-4" aria-hidden />
+          <span className="font-medium">
+            {ok ? 'Approved and run on your machine' : answered.outcome === 'denied' ? 'Denied' : `Not run (${answered.outcome})`}
+          </span>
+          {answered.scope && ok ? <Badge variant="secondary">{SCOPE_LABELS[answered.scope]}</Badge> : null}
+        </div>
+        {ok && answered.exitCode !== undefined ? <div className="mt-1 text-xs text-muted-foreground">exit code {answered.exitCode}{answered.truncated ? ' · output truncated' : ''}</div> : null}
+        {answered.error ? <div className="mt-1 text-xs text-muted-foreground">{answered.error}</div> : null}
+      </div>
+    );
+  }
+
+  return (
+    <div className="my-2 rounded-lg border border-amber-500/40 bg-amber-500/5 p-3 text-sm" data-testid="env-approval-card">
+      <div className="flex items-center gap-2">
+        <ShieldAlert className="h-4 w-4 text-amber-600" aria-hidden />
+        <span className="font-medium">Your machine is asking for your approval</span>
+        <Badge variant="outline">local environment</Badge>
+      </div>
+      <p className="mt-1 text-xs text-muted-foreground">
+        The machine froze this exact request. Allowing runs it as you, on your computer, with whatever it does once started; nothing else runs.
+      </p>
+
+      {load.kind === 'loading' ? <div className="mt-2 text-xs text-muted-foreground">Loading the frozen request…</div> : null}
+      {load.kind === 'gone' ? (
+        <div className="mt-2 text-xs" data-testid="env-approval-gone">
+          {load.message}
+          {answerable ? (
+            <div className="mt-2">
+              <Button size="sm" variant="secondary" onClick={() => submit({ challengeId, outcome: load.outcome, error: load.message })}>
+                Tell the agent
+              </Button>
+            </div>
+          ) : null}
+        </div>
+      ) : null}
+      {load.kind === 'loaded' ? (
+        <>
+          <dl className="mt-2 grid grid-cols-[auto_1fr] gap-x-3 gap-y-1 font-mono text-xs" data-testid="env-approval-request">
+            {frozenRequestRows(load.pending).map(([label, value]) => (
+              <React.Fragment key={label}>
+                <dt className="text-muted-foreground">{label}</dt>
+                <dd className="break-all whitespace-pre-wrap">{value}</dd>
+              </React.Fragment>
+            ))}
+          </dl>
+          {answerable ? (
+            <div className="mt-3 flex flex-wrap items-center gap-2">
+              <label className="text-xs text-muted-foreground" htmlFor={`env-approval-scope-${part.toolCallId}`}>
+                Remember for
+              </label>
+              <select
+                id={`env-approval-scope-${part.toolCallId}`}
+                className="rounded border bg-background px-2 py-1 text-xs"
+                value={scope}
+                onChange={(event) => setScope(event.target.value as EnvApprovalScope)}
+                disabled={busy !== null}
+              >
+                {ENV_APPROVAL_SCOPES.map((value) => (
+                  <option key={value} value={value}>
+                    {SCOPE_LABELS[value]}
+                  </option>
+                ))}
+              </select>
+              <Button size="sm" onClick={() => void decide('allow')} disabled={busy !== null} data-testid="env-approval-allow">
+                {busy === 'allow' ? 'Sending…' : 'Allow'}
+              </Button>
+              <Button size="sm" variant="outline" onClick={() => void decide('deny')} disabled={busy !== null} data-testid="env-approval-deny">
+                {busy === 'deny' ? 'Sending…' : 'Deny'}
+              </Button>
+            </div>
+          ) : (
+            <div className="mt-2 text-xs text-muted-foreground">Waiting for the machine owner.</div>
+          )}
+          {failure ? <div className="mt-2 text-xs text-destructive">{failure}</div> : null}
+        </>
+      ) : null}
+    </div>
+  );
+}

--- a/apps/web/src/components/ai/shared/chat/env-approval/EnvApprovalCard.tsx
+++ b/apps/web/src/components/ai/shared/chat/env-approval/EnvApprovalCard.tsx
@@ -4,6 +4,7 @@ import { Button } from '@/components/ui/button';
 import { Badge } from '@/components/ui/badge';
 import { cn } from '@/lib/utils';
 import { useAskUserAnswerContext } from '../ask-user/AskUserAnswerContext';
+import { fetchWithAuth } from '@/lib/auth/auth-fetch';
 import {
   ENV_APPROVAL_SCOPES,
   REQUEST_ENV_APPROVAL_TOOL_NAME,
@@ -109,7 +110,8 @@ export function frozenRequestRows(pending: PendingApprovalView): Array<[string, 
 }
 
 async function fetchPending(challengeId: string): Promise<LoadState> {
-  const response = await fetch(`/api/env-bridge/approvals/${encodeURIComponent(challengeId)}`, { credentials: 'include' });
+  // Through the auth fetch helper (Codex P1 on #2583): it carries the session and the CSRF token the POST route requires; a raw fetch answered 403 CSRF_TOKEN_MISSING.
+  const response = await fetchWithAuth(`/api/env-bridge/approvals/${encodeURIComponent(challengeId)}`, { method: 'GET' });
   if (response.ok) {
     const pending = (await response.json()) as PendingApprovalView;
     return { kind: 'loaded', pending };
@@ -155,9 +157,8 @@ export function EnvApprovalCard({ part }: EnvApprovalCardProps) {
     setBusy(decision);
     setFailure(null);
     try {
-      const response = await fetch(`/api/env-bridge/approvals/${encodeURIComponent(challengeId)}`, {
+      const response = await fetchWithAuth(`/api/env-bridge/approvals/${encodeURIComponent(challengeId)}`, {
         method: 'POST',
-        credentials: 'include',
         headers: { 'content-type': 'application/json' },
         body: JSON.stringify(decision === 'allow' ? { decision, scope } : { decision }),
       });

--- a/apps/web/src/components/ai/shared/chat/tool-calls/CompactToolCallRenderer.tsx
+++ b/apps/web/src/components/ai/shared/chat/tool-calls/CompactToolCallRenderer.tsx
@@ -27,6 +27,7 @@ import { GeneratedImageRenderer } from './GeneratedImageRenderer';
 import { TASK_TOOL_NAMES } from '../useAggregatedTasks';
 import { PageAgentConversationRenderer } from '@/components/ai/page-agents';
 import { AskUserQuestionCard } from '../ask-user/AskUserQuestionCard';
+import { EnvApprovalCard } from '../env-approval/EnvApprovalCard';
 import { renderToolContent } from './registry';
 import { dispatchToolCall, resolveIntegrationToolLabel } from './tool-call-dispatch';
 
@@ -90,6 +91,7 @@ const getSendChannelMessagePreview = (
 export const TOOL_NAME_MAP: Record<string, string> = {
   'ask_agent': 'Ask Agent',
   'ask_user': 'Question',
+  'request_env_approval': 'Approval',
   'list_drives': 'List Drives',
   'list_pages': 'List Pages',
   'read_page': 'Read',
@@ -384,6 +386,8 @@ export const CompactToolCallRenderer: React.FC<CompactToolCallRendererProps> = m
       return <PageAgentConversationRenderer part={dispatch.part} />;
     case 'question':
       return <AskUserQuestionCard part={dispatch.part} />;
+    case 'env_approval':
+      return <EnvApprovalCard part={dispatch.part} />;
     case 'image':
       return <GeneratedImageRenderer part={dispatch.part} />;
     case 'generic':

--- a/apps/web/src/components/ai/shared/chat/tool-calls/ToolCallRenderer.tsx
+++ b/apps/web/src/components/ai/shared/chat/tool-calls/ToolCallRenderer.tsx
@@ -7,6 +7,7 @@ import {
 } from '@/components/ai/ui/tool';
 import { PageAgentConversationRenderer } from '@/components/ai/page-agents';
 import { AskUserQuestionCard } from '../ask-user/AskUserQuestionCard';
+import { EnvApprovalCard } from '../env-approval/EnvApprovalCard';
 import { TaskRenderer } from './TaskRenderer';
 import { GeneratedImageRenderer } from './GeneratedImageRenderer';
 import { TASK_TOOL_NAMES } from '../useAggregatedTasks';
@@ -166,6 +167,8 @@ export const ToolCallRenderer: React.FC<ToolCallRendererProps> = memo(function T
       return <PageAgentConversationRenderer part={dispatch.part} />;
     case 'question':
       return <AskUserQuestionCard part={dispatch.part} />;
+    case 'env_approval':
+      return <EnvApprovalCard part={dispatch.part} />;
     case 'image':
       return <GeneratedImageRenderer part={dispatch.part} />;
     case 'generic':

--- a/apps/web/src/components/ai/shared/chat/tool-calls/registry.tsx
+++ b/apps/web/src/components/ai/shared/chat/tool-calls/registry.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 
 import { TASK_TOOL_NAMES } from '../useAggregatedTasks';
 import { ASK_USER_TOOL_NAME } from '@/lib/ai/tools/ask-user-tools';
+import { REQUEST_ENV_APPROVAL_TOOL_NAME } from '@/lib/ai/tools/env-approval-tools';
 import { RichContentRenderer } from './RichContentRenderer';
 import { RichDiffRenderer } from './RichDiffRenderer';
 import { PageTreeRenderer, type TreeItem } from './PageTreeRenderer';
@@ -218,6 +219,7 @@ export const SPECIAL_HANDLED_TOOLS: Set<string> = new Set<string>([
   ...TASK_TOOL_NAMES,
   'ask_agent',
   ASK_USER_TOOL_NAME,
+  REQUEST_ENV_APPROVAL_TOOL_NAME,
   'generate_image',
 ]);
 

--- a/apps/web/src/components/ai/shared/chat/tool-calls/tool-call-dispatch.ts
+++ b/apps/web/src/components/ai/shared/chat/tool-calls/tool-call-dispatch.ts
@@ -9,6 +9,7 @@ import { isHiddenTool } from './tool-significance';
 import { isIntegrationTool, parseIntegrationToolName } from '@pagespace/lib/integrations/converter/ai-sdk';
 import { getBuiltinProvider } from '@pagespace/lib/integrations/providers/builtin-providers';
 import { ASK_USER_TOOL_NAME } from '@/lib/ai/tools/ask-user-tools';
+import { REQUEST_ENV_APPROVAL_TOOL_NAME } from '@/lib/ai/tools/env-approval-tools';
 
 // Not imported from image-generation-tools.ts: that module pulls in the DB
 // client and billing services (server-only) and must never reach the client
@@ -30,6 +31,8 @@ export type ToolCallDispatchResult<TPart extends DispatchToolPart> =
   | { kind: 'task'; part: TPart }
   | { kind: 'agent'; part: TPart }
   | { kind: 'question'; part: TPart }
+  /** The Tier B approval click for a local environment (GA wave 2) — a full-width card like a question. */
+  | { kind: 'env_approval'; part: TPart }
   | { kind: 'image'; part: TPart }
   | { kind: 'generic'; part: TPart; toolName: string };
 
@@ -77,6 +80,7 @@ export function dispatchToolCall<TPart extends DispatchToolPart>(
   if (taskToolNames.has(toolName)) return { kind: 'task', part: resolvedPart };
   if (toolName === 'ask_agent') return { kind: 'agent', part: resolvedPart };
   if (toolName === ASK_USER_TOOL_NAME) return { kind: 'question', part: resolvedPart };
+  if (toolName === REQUEST_ENV_APPROVAL_TOOL_NAME) return { kind: 'env_approval', part: resolvedPart };
   if (toolName === GENERATE_IMAGE_TOOL_NAME) return { kind: 'image', part: resolvedPart };
   return { kind: 'generic', part: resolvedPart, toolName };
 }

--- a/apps/web/src/lib/ai/chat-pipeline/global-chat-turn.ts
+++ b/apps/web/src/lib/ai/chat-pipeline/global-chat-turn.ts
@@ -17,6 +17,8 @@ import { streamText, stepCountIs, hasToolCall, UIMessage, createUIMessageStream,
 import type { convertToModelMessages } from 'ai';
 import { finishTool, FINISH_TOOL_NAME } from '@/lib/ai/tools/finish-tool';
 import { askUserTools, ASK_USER_TOOL_NAME } from '@/lib/ai/tools/ask-user-tools';
+import { envApprovalTools, REQUEST_ENV_APPROVAL_TOOL_NAME } from '@/lib/ai/tools/env-approval-tools';
+import { resolveLocalEnvBindingForConversation } from '@/lib/ai/core/local-env-binding';
 import { resolveMessageId } from '@/lib/ai/streams/resolveMessageId';
 import { readAgentDispatchDepth } from '@/lib/ai/core/agent-dispatch-depth';
 import { buildLocationTurnPrompt } from '@/lib/ai/core/location-prompt';
@@ -1136,6 +1138,14 @@ export async function runGlobalChatTurn(ctx: GlobalChatTurnContext): Promise<Res
     // so it never enters the tool_search catalog or the execute_tool dispatch map
     // (execute_tool would crash on an execute-less tool).
     finalTools = { ...finalTools, ...askUserTools } as ToolSet;
+    // The Tier B approval click (GA wave 2): same discipline as ask_user, ONLY
+    // when the bound session is on a LOCAL environment.
+    const localEnvBinding = await resolveLocalEnvBindingForConversation(conversation.id);
+    const pauseToolNames = [ASK_USER_TOOL_NAME];
+    if (localEnvBinding !== null) {
+      finalTools = { ...finalTools, ...envApprovalTools } as ToolSet;
+      pauseToolNames.push(REQUEST_ENV_APPROVAL_TOOL_NAME);
+    }
 
     // Sanitize, compact, and elide via the unified seam.
     // finalSystemPrompt + finalTools are now known — pass for accurate token budgeting.
@@ -1311,7 +1321,7 @@ export async function runGlobalChatTurn(ctx: GlobalChatTurnContext): Promise<Res
           abortSignal: generationAbortSignal,
           baseMessages: modelMessages,
           finishToolName: FINISH_TOOL_NAME,
-          pauseToolNames: [ASK_USER_TOOL_NAME],
+          pauseToolNames,
           maxSteps: AGENT_MAX_STEPS,
           startTimeMs: startTime,
           logger: loggers.api,
@@ -1339,7 +1349,7 @@ export async function runGlobalChatTurn(ctx: GlobalChatTurnContext): Promise<Res
             tools: finalTools,
             // hasToolCall(ASK_USER_TOOL_NAME) is documentation: ask_user has no
             // execute, so v6 halts the loop on it anyway (finishReason 'tool-calls').
-            stopWhen: [hasToolCall(FINISH_TOOL_NAME), hasToolCall(ASK_USER_TOOL_NAME), stepCountIs(AGENT_MAX_STEPS)],
+            stopWhen: [hasToolCall(FINISH_TOOL_NAME), ...pauseToolNames.map((name) => hasToolCall(name)), stepCountIs(AGENT_MAX_STEPS)],
             // The user's Stop composed with the mid-stream credit ceiling —
             // the registry signal alone only fires on an explicit user stop.
             abortSignal: generationAbortSignal,

--- a/apps/web/src/lib/ai/chat-pipeline/global-chat-turn.ts
+++ b/apps/web/src/lib/ai/chat-pipeline/global-chat-turn.ts
@@ -16,9 +16,8 @@ import { NextResponse } from 'next/server';
 import { streamText, stepCountIs, hasToolCall, UIMessage, createUIMessageStream, type ToolSet } from 'ai';
 import type { convertToModelMessages } from 'ai';
 import { finishTool, FINISH_TOOL_NAME } from '@/lib/ai/tools/finish-tool';
-import { askUserTools, ASK_USER_TOOL_NAME } from '@/lib/ai/tools/ask-user-tools';
-import { envApprovalTools, REQUEST_ENV_APPROVAL_TOOL_NAME } from '@/lib/ai/tools/env-approval-tools';
-import { resolveLocalEnvBindingForConversation } from '@/lib/ai/core/local-env-binding';
+import { askUserTools } from '@/lib/ai/tools/ask-user-tools';
+import { withEnvApprovalTool } from '@/lib/ai/core/local-env-binding';
 import { resolveMessageId } from '@/lib/ai/streams/resolveMessageId';
 import { readAgentDispatchDepth } from '@/lib/ai/core/agent-dispatch-depth';
 import { buildLocationTurnPrompt } from '@/lib/ai/core/location-prompt';
@@ -1138,14 +1137,11 @@ export async function runGlobalChatTurn(ctx: GlobalChatTurnContext): Promise<Res
     // so it never enters the tool_search catalog or the execute_tool dispatch map
     // (execute_tool would crash on an execute-less tool).
     finalTools = { ...finalTools, ...askUserTools } as ToolSet;
-    // The Tier B approval click (GA wave 2): same discipline as ask_user, ONLY
+    // The Tier B approval click (GA wave 2), injected by the shared helper ONLY
     // when the bound session is on a LOCAL environment.
-    const localEnvBinding = await resolveLocalEnvBindingForConversation(conversation.id);
-    const pauseToolNames = [ASK_USER_TOOL_NAME];
-    if (localEnvBinding !== null) {
-      finalTools = { ...finalTools, ...envApprovalTools } as ToolSet;
-      pauseToolNames.push(REQUEST_ENV_APPROVAL_TOOL_NAME);
-    }
+    const envApproval = await withEnvApprovalTool(finalTools, conversation.id);
+    finalTools = envApproval.tools as ToolSet;
+    const { pauseToolNames } = envApproval;
 
     // Sanitize, compact, and elide via the unified seam.
     // finalSystemPrompt + finalTools are now known — pass for accurate token budgeting.
@@ -1347,7 +1343,7 @@ export async function runGlobalChatTurn(ctx: GlobalChatTurnContext): Promise<Res
             system: finalSystemPrompt,
             messages: cachedMessages,
             tools: finalTools,
-            // hasToolCall(ASK_USER_TOOL_NAME) is documentation: ask_user has no
+            // hasToolCall on the pause tools is documentation: ask_user has no
             // execute, so v6 halts the loop on it anyway (finishReason 'tool-calls').
             stopWhen: [hasToolCall(FINISH_TOOL_NAME), ...pauseToolNames.map((name) => hasToolCall(name)), stepCountIs(AGENT_MAX_STEPS)],
             // The user's Stop composed with the mid-stream credit ceiling —

--- a/apps/web/src/lib/ai/chat-pipeline/page-chat-turn.ts
+++ b/apps/web/src/lib/ai/chat-pipeline/page-chat-turn.ts
@@ -32,8 +32,8 @@ import { resolveGenerationAdmission } from '@/lib/ai/core/generation-admission';
 import { mergeToolSets } from '@/lib/ai/core/tool-utils';
 import { finishTool, FINISH_TOOL_NAME } from '@/lib/ai/tools/finish-tool';
 import { askUserTools, ASK_USER_TOOL_NAME } from '@/lib/ai/tools/ask-user-tools';
-import { envApprovalTools, REQUEST_ENV_APPROVAL_TOOL_NAME } from '@/lib/ai/tools/env-approval-tools';
-import { resolveLocalEnvBindingForConversation } from '@/lib/ai/core/local-env-binding';
+import { REQUEST_ENV_APPROVAL_TOOL_NAME } from '@/lib/ai/tools/env-approval-tools';
+import { withEnvApprovalTool } from '@/lib/ai/core/local-env-binding';
 import {
   extractClientAskUserResults,
   applyAskUserResultsToPageMessage,
@@ -1493,17 +1493,13 @@ export async function runPageChatTurn(ctx: PageChatTurnContext): Promise<Respons
     filteredTools = { ...filteredTools, ...askUserTools } as ToolSet;
     allowedToolNames.push(ASK_USER_TOOL_NAME);
 
-    // The Tier B approval click (GA wave 2): injected with the SAME discipline
-    // as ask_user (execute-less, after every transform, never in tool_search /
-    // execute_tool) — but ONLY when the session is bound to a LOCAL environment,
-    // the one substrate whose machine can freeze a request for its owner's click.
-    const localEnvBinding = sandboxEnabled ? await resolveLocalEnvBindingForConversation(conversationId) : null;
-    const pauseToolNames = [ASK_USER_TOOL_NAME];
-    if (localEnvBinding !== null) {
-      filteredTools = { ...filteredTools, ...envApprovalTools } as ToolSet;
-      allowedToolNames.push(REQUEST_ENV_APPROVAL_TOOL_NAME);
-      pauseToolNames.push(REQUEST_ENV_APPROVAL_TOOL_NAME);
-    }
+    // The Tier B approval click (GA wave 2), injected by the shared helper ONLY
+    // when the session is bound to a LOCAL environment (never for a page agent
+    // with the sandbox off).
+    const envApproval = await withEnvApprovalTool(filteredTools, sandboxEnabled ? conversationId : undefined);
+    filteredTools = envApproval.tools as ToolSet;
+    if (envApproval.injected) allowedToolNames.push(REQUEST_ENV_APPROVAL_TOOL_NAME);
+    const { pauseToolNames } = envApproval;
 
     // Guard against a stale read_page tool-result (image bytes delivered on an
     // earlier turn when the model had vision) being re-embedded as an image when

--- a/apps/web/src/lib/ai/chat-pipeline/page-chat-turn.ts
+++ b/apps/web/src/lib/ai/chat-pipeline/page-chat-turn.ts
@@ -32,6 +32,8 @@ import { resolveGenerationAdmission } from '@/lib/ai/core/generation-admission';
 import { mergeToolSets } from '@/lib/ai/core/tool-utils';
 import { finishTool, FINISH_TOOL_NAME } from '@/lib/ai/tools/finish-tool';
 import { askUserTools, ASK_USER_TOOL_NAME } from '@/lib/ai/tools/ask-user-tools';
+import { envApprovalTools, REQUEST_ENV_APPROVAL_TOOL_NAME } from '@/lib/ai/tools/env-approval-tools';
+import { resolveLocalEnvBindingForConversation } from '@/lib/ai/core/local-env-binding';
 import {
   extractClientAskUserResults,
   applyAskUserResultsToPageMessage,
@@ -1491,6 +1493,18 @@ export async function runPageChatTurn(ctx: PageChatTurnContext): Promise<Respons
     filteredTools = { ...filteredTools, ...askUserTools } as ToolSet;
     allowedToolNames.push(ASK_USER_TOOL_NAME);
 
+    // The Tier B approval click (GA wave 2): injected with the SAME discipline
+    // as ask_user (execute-less, after every transform, never in tool_search /
+    // execute_tool) — but ONLY when the session is bound to a LOCAL environment,
+    // the one substrate whose machine can freeze a request for its owner's click.
+    const localEnvBinding = sandboxEnabled ? await resolveLocalEnvBindingForConversation(conversationId) : null;
+    const pauseToolNames = [ASK_USER_TOOL_NAME];
+    if (localEnvBinding !== null) {
+      filteredTools = { ...filteredTools, ...envApprovalTools } as ToolSet;
+      allowedToolNames.push(REQUEST_ENV_APPROVAL_TOOL_NAME);
+      pauseToolNames.push(REQUEST_ENV_APPROVAL_TOOL_NAME);
+    }
+
     // Guard against a stale read_page tool-result (image bytes delivered on an
     // earlier turn when the model had vision) being re-embedded as an image when
     // convertToModelMessages re-converts history for a model that no longer has
@@ -1795,7 +1809,7 @@ export async function runPageChatTurn(ctx: PageChatTurnContext): Promise<Respons
               : abortSignal,
             baseMessages: modelMessages,
             finishToolName: FINISH_TOOL_NAME,
-            pauseToolNames: [ASK_USER_TOOL_NAME],
+            pauseToolNames,
             maxSteps: AGENT_MAX_STEPS,
             startTimeMs: startTime,
             logger: loggers.ai,
@@ -1828,7 +1842,7 @@ export async function runPageChatTurn(ctx: PageChatTurnContext): Promise<Respons
               tools: filteredTools,
               // hasToolCall(ASK_USER_TOOL_NAME) is documentation: ask_user has no
               // execute, so v6 halts the loop on it anyway (finishReason 'tool-calls').
-              stopWhen: [hasToolCall(FINISH_TOOL_NAME), hasToolCall(ASK_USER_TOOL_NAME), stepCountIs(AGENT_MAX_STEPS)],
+              stopWhen: [hasToolCall(FINISH_TOOL_NAME), ...pauseToolNames.map((name) => hasToolCall(name)), stepCountIs(AGENT_MAX_STEPS)],
               // abortSignal from the abort registry — only fires on explicit user stop, never on client disconnect
               // creditAbortController fires when mid-stream credit check determines balance is exhausted
               abortSignal: creditAbortController

--- a/apps/web/src/lib/ai/core/__tests__/ask-user-resume.test.ts
+++ b/apps/web/src/lib/ai/core/__tests__/ask-user-resume.test.ts
@@ -141,6 +141,40 @@ beforeEach(() => {
   saveGlobalAssistantMessageToDatabase.mockClear();
 });
 
+const pendingApprovalPart = (toolCallId: string): UIMessage['parts'][number] => ({
+  type: 'tool-request_env_approval',
+  toolCallId,
+  state: 'input-available',
+  input: { challengeId: 'ch_1' },
+} as UIMessage['parts'][number]);
+
+describe('GA wave 2 — the request_env_approval click resumes through the same merge, validated by ITS schema', () => {
+  it('merges a well-formed outcome into the pending approval part and persists it', async () => {
+    selectRows = [dbRow([pendingApprovalPart('a1')])];
+    const output = { challengeId: 'ch_1', outcome: 'allowed', scope: '30d', exitCode: 0, stdout: 'ok', stderr: '', truncated: false };
+    const result = await applyAskUserResultsToPageMessage({ messageId: 'msg-1', pageId: 'page-1', conversationId: 'conv-1', results: [{ toolCallId: 'a1', output }] });
+    expect(result).toEqual({ merged: true });
+    const saved = saveMessageToDatabase.mock.calls[0]![0] as { toolResults: Array<{ toolCallId: string; output: unknown; state: string }> };
+    expect(saved.toolResults).toEqual([expect.objectContaining({ toolCallId: 'a1', output, state: 'output-available' })]);
+  });
+
+  it('rejects an output that is an ask_user answer shape, or an unknown outcome, and persists nothing', async () => {
+    for (const output of [{ answers: [{ header: 'A', question: 'Q', selectedLabel: 'x' }] }, { challengeId: 'ch_1', outcome: 'sure' }, { dismissed: true, reason: 'x' }]) {
+      selectRows = [dbRow([pendingApprovalPart('a1')])];
+      const result = await applyAskUserResultsToPageMessage({ messageId: 'msg-1', pageId: 'page-1', conversationId: 'conv-1', results: [{ toolCallId: 'a1', output }] });
+      expect(result).toEqual({ merged: false });
+    }
+    expect(saveMessageToDatabase).not.toHaveBeenCalled();
+  });
+
+  it('a new chat message DISMISSES pending ask_user questions but never a pending approval click (that is not a question prose can answer)', async () => {
+    selectRows = [dbRow([pendingPart('q1'), pendingApprovalPart('a1')])];
+    await dismissPendingAskUserForPageConversation({ pageId: 'page-1', conversationId: 'conv-1' });
+    const saved = saveMessageToDatabase.mock.calls[0]![0] as { toolResults: Array<{ toolCallId: string }> };
+    expect(saved.toolResults.map((r) => r.toolCallId)).toEqual(['q1']);
+  });
+});
+
 describe('extractClientAskUserResults', () => {
   it('extracts output-available ask_user parts from a trailing assistant message', () => {
     const results = extractClientAskUserResults({

--- a/apps/web/src/lib/ai/core/__tests__/local-env-binding.test.ts
+++ b/apps/web/src/lib/ai/core/__tests__/local-env-binding.test.ts
@@ -3,7 +3,7 @@
  * Only then is `request_env_approval` offered. Every failure is "not local".
  */
 import { describe, it, expect } from 'vitest';
-import { resolveLocalEnvBinding, type LocalEnvBindingDeps } from '../local-env-binding';
+import { resolveLocalEnvBinding, withEnvApprovalTool, type LocalEnvBindingDeps } from '../local-env-binding';
 
 function deps(over: Partial<LocalEnvBindingDeps> = {}): LocalEnvBindingDeps {
   return {
@@ -27,5 +27,12 @@ describe('resolveLocalEnvBinding', () => {
     ['a lookup that throws', 'conv_1', deps({ findSessionForConversation: async () => { throw new Error('db down'); } })],
   ])('given %s, should answer null (the tool is not offered)', async (_label, conversationId, d) => {
     expect(await resolveLocalEnvBinding(conversationId, d)).toBeNull();
+  });
+});
+
+describe('withEnvApprovalTool', () => {
+  it('given no conversation id (the production lookup answers null), should return the tools untouched and pause only on ask_user', async () => {
+    const tools = { finish: {} };
+    expect(await withEnvApprovalTool(tools, undefined)).toEqual({ tools, pauseToolNames: ['ask_user'], injected: false });
   });
 });

--- a/apps/web/src/lib/ai/core/__tests__/local-env-binding.test.ts
+++ b/apps/web/src/lib/ai/core/__tests__/local-env-binding.test.ts
@@ -1,0 +1,31 @@
+/**
+ * GA wave 2 — is the conversation's bound session on a LOCAL environment?
+ * Only then is `request_env_approval` offered. Every failure is "not local".
+ */
+import { describe, it, expect } from 'vitest';
+import { resolveLocalEnvBinding, type LocalEnvBindingDeps } from '../local-env-binding';
+
+function deps(over: Partial<LocalEnvBindingDeps> = {}): LocalEnvBindingDeps {
+  return {
+    findSessionForConversation: async () => ({ envId: 'env_1' }),
+    findEnv: async () => ({ substrate: 'local' }),
+    ...over,
+  };
+}
+
+describe('resolveLocalEnvBinding', () => {
+  it('given a bound session on a local env, should answer the envId', async () => {
+    expect(await resolveLocalEnvBinding('conv_1', deps())).toEqual({ envId: 'env_1' });
+  });
+
+  it.each([
+    ['no conversation id', undefined, deps()],
+    ['no session', 'conv_1', deps({ findSessionForConversation: async () => null })],
+    ['a session with no env (ephemeral)', 'conv_1', deps({ findSessionForConversation: async () => ({ envId: null }) })],
+    ['a Sprite env', 'conv_1', deps({ findEnv: async () => ({ substrate: 'sprite' }) })],
+    ['a missing env row', 'conv_1', deps({ findEnv: async () => null })],
+    ['a lookup that throws', 'conv_1', deps({ findSessionForConversation: async () => { throw new Error('db down'); } })],
+  ])('given %s, should answer null (the tool is not offered)', async (_label, conversationId, d) => {
+    expect(await resolveLocalEnvBinding(conversationId, d)).toBeNull();
+  });
+});

--- a/apps/web/src/lib/ai/core/ask-user-resume.ts
+++ b/apps/web/src/lib/ai/core/ask-user-resume.ts
@@ -13,15 +13,17 @@ import {
   buildAssistantPersistencePayload,
   type AssistantPersistencePayload,
 } from '@/lib/ai/core/persistAssistantParts';
-import { ASK_USER_TOOL_NAME, askUserOutputSchema } from '@/lib/ai/tools/ask-user-tools';
+import { ASK_USER_TOOL_NAME } from '@/lib/ai/tools/ask-user-tools';
+import { isPausingToolPartType, pausingToolOutputSchema, pausingToolPartType } from '@/lib/ai/tools/pausing-tools';
 
-const ASK_USER_PART_TYPE = `tool-${ASK_USER_TOOL_NAME}`;
+const ASK_USER_PART_TYPE = pausingToolPartType(ASK_USER_TOOL_NAME);
 const DISMISSED_REASON = 'User replied in chat instead of selecting an option.';
 
 type AskUserToolPart = { type: string; toolCallId: string; state?: string; output?: unknown };
 
+/** Every PAUSING tool part: ask_user, and the Tier B approval click (GA wave 2). */
 function isAskUserPart(part: { type: string }): part is AskUserToolPart {
-  return part.type === ASK_USER_PART_TYPE;
+  return isPausingToolPartType(part.type);
 }
 
 export interface ClientAskUserResult {
@@ -68,7 +70,9 @@ function mergeResultsIntoParts(
     if (!result) return part;
     if (part.state !== 'input-available') return part;
 
-    const parsed = askUserOutputSchema.safeParse(result.output);
+    // Each pausing tool validates its own client-supplied result before it is persisted.
+    const schema = pausingToolOutputSchema(part.type);
+    const parsed = schema === null ? { success: false as const, error: { issues: [{ message: `no output schema for ${part.type}` }] } } : schema.safeParse(result.output);
     if (!parsed.success) {
       loggers.ai.warn('ask_user resume: rejected invalid client output', {
         toolCallId: part.toolCallId,
@@ -84,10 +88,15 @@ function mergeResultsIntoParts(
   return { parts: nextParts as UIMessage['parts'], changed };
 }
 
+/**
+ * Only ask_user questions are dismissed by a new chat message: a pending
+ * approval click is not a question the user can answer in prose, and a
+ * dismissal would read to the model as a decision nobody made.
+ */
 function pendingAskUserToolCallIds(parts: UIMessage['parts']): string[] {
   const ids: string[] = [];
   for (const part of parts) {
-    if (isAskUserPart(part) && part.state === 'input-available') ids.push(part.toolCallId);
+    if (part.type === ASK_USER_PART_TYPE && isAskUserPart(part) && part.state === 'input-available') ids.push(part.toolCallId);
   }
   return ids;
 }

--- a/apps/web/src/lib/ai/core/local-env-binding.ts
+++ b/apps/web/src/lib/ai/core/local-env-binding.ts
@@ -44,3 +44,23 @@ export async function resolveLocalEnvBindingForConversation(conversationId: stri
     },
   });
 }
+
+/**
+ * The Tier B tool, injected ONCE for both chat turns (the turn-duplication
+ * ratchet forbids copying it). With the same discipline as `ask_user`: after
+ * every transform, never in `tool_search` / `execute_tool` — and ONLY when the
+ * bound session is on a local environment. Returns the tools to use and the
+ * names the turn must pause on (ask_user always; the approval tool when injected).
+ */
+export async function withEnvApprovalTool<T extends Record<string, unknown>>(
+  tools: T,
+  conversationId: string | undefined,
+): Promise<{ tools: T; pauseToolNames: string[]; injected: boolean }> {
+  const { ASK_USER_TOOL_NAME } = await import('@/lib/ai/tools/ask-user-tools');
+  const pauseToolNames = [ASK_USER_TOOL_NAME];
+  const binding = await resolveLocalEnvBindingForConversation(conversationId);
+  if (binding === null) return { tools, pauseToolNames, injected: false };
+  const { envApprovalTools, REQUEST_ENV_APPROVAL_TOOL_NAME } = await import('@/lib/ai/tools/env-approval-tools');
+  pauseToolNames.push(REQUEST_ENV_APPROVAL_TOOL_NAME);
+  return { tools: { ...tools, ...envApprovalTools } as T, pauseToolNames, injected: true };
+}

--- a/apps/web/src/lib/ai/core/local-env-binding.ts
+++ b/apps/web/src/lib/ai/core/local-env-binding.ts
@@ -1,0 +1,46 @@
+/**
+ * Is this conversation's bound session on a LOCAL environment? (GA wave 2)
+ *
+ * The `request_env_approval` tool is injected at route level ONLY when the
+ * answer is yes: a Sprite session can never produce a `local_approval_required`
+ * result, so advertising the tool there would only invite a call that has
+ * nothing to answer. The lookup is the same one the sandbox eligibility gate
+ * makes (the session a conversation is bound to), then the env row's
+ * substrate. Any failure — no session, no env, a Sprite env, a lookup error —
+ * is "not local": the tool is simply not offered, never offered by default.
+ */
+export interface LocalEnvBinding {
+  readonly envId: string;
+}
+
+export interface LocalEnvBindingDeps {
+  readonly findSessionForConversation: (conversationId: string) => Promise<{ envId: string | null } | null>;
+  readonly findEnv: (envId: string) => Promise<{ substrate: string } | null>;
+}
+
+export async function resolveLocalEnvBinding(conversationId: string | undefined, deps: LocalEnvBindingDeps): Promise<LocalEnvBinding | null> {
+  if (!conversationId) return null;
+  try {
+    const session = await deps.findSessionForConversation(conversationId);
+    if (!session || session.envId === null) return null;
+    const env = await deps.findEnv(session.envId);
+    if (!env || env.substrate !== 'local') return null;
+    return { envId: session.envId };
+  } catch {
+    return null;
+  }
+}
+
+/** The production binding: the agent-session store and the drive-env store, both loaded lazily (the chat pipeline must not import them at module load). */
+export async function resolveLocalEnvBindingForConversation(conversationId: string | undefined): Promise<LocalEnvBinding | null> {
+  return resolveLocalEnvBinding(conversationId, {
+    findSessionForConversation: async (id) => {
+      const { findSessionForConversation } = await import('@/lib/agent-workspaces/agent-workspaces-runtime');
+      return findSessionForConversation(id);
+    },
+    findEnv: async (envId) => {
+      const { getDriveEnvStore } = await import('@/lib/drive-envs/drive-envs-runtime');
+      return (await getDriveEnvStore()).findById(envId);
+    },
+  });
+}

--- a/apps/web/src/lib/ai/shared/ask-user-client.ts
+++ b/apps/web/src/lib/ai/shared/ask-user-client.ts
@@ -1,7 +1,5 @@
 import type { UIMessage } from 'ai';
-import { ASK_USER_TOOL_NAME } from '@/lib/ai/tools/ask-user-tools';
-
-const ASK_USER_PART_TYPE = `tool-${ASK_USER_TOOL_NAME}`;
+import { isPausingToolPartType } from '@/lib/ai/tools/pausing-tools';
 
 /**
  * sendAutomaticallyWhen predicate: auto-resubmit ONLY once every ask_user
@@ -17,7 +15,8 @@ export function askUserAnswersComplete({ messages }: { messages: UIMessage[] }):
   const last = messages[messages.length - 1];
   if (!last || last.role !== 'assistant' || !last.parts) return false;
 
-  const askParts = last.parts.filter((part) => part.type === ASK_USER_PART_TYPE);
+  // Every PAUSING tool part (ask_user, request_env_approval) must be answered before the turn resumes.
+  const askParts = last.parts.filter((part) => isPausingToolPartType(part.type));
   if (askParts.length === 0) return false;
 
   return askParts.every((part) => {

--- a/apps/web/src/lib/ai/shared/hooks/useAnswerAskUser.ts
+++ b/apps/web/src/lib/ai/shared/hooks/useAnswerAskUser.ts
@@ -1,5 +1,6 @@
 import { useCallback, useMemo } from 'react';
-import { ASK_USER_TOOL_NAME, type AskUserOutput } from '@/lib/ai/tools/ask-user-tools';
+import { ASK_USER_TOOL_NAME } from '@/lib/ai/tools/ask-user-tools';
+import type { PausingToolName } from '@/lib/ai/tools/pausing-tools';
 import { selectAnswerableAskUserToolCallIds } from '@/lib/ai/streams/selectAnswerableAskUserToolCallIds';
 import type { RenderedMessage } from '@/lib/ai/streams/selectRenderedMessages';
 import { useAskUserAnsweringStore } from '@/stores/useAskUserAnsweringStore';
@@ -47,9 +48,10 @@ export interface UseAnswerAskUserOptions {
  */
 
 export interface UseAnswerAskUserResult {
-  /** toolCallIds of ask_user parts currently answerable on THIS surface. */
+  /** toolCallIds of pausing-tool parts (ask_user, request_env_approval) currently answerable on THIS surface. */
   answerableToolCallIds: ReadonlySet<string>;
-  submitAnswers: (toolCallId: string, output: AskUserOutput) => void;
+  /** Submit a client result for a pausing tool; `tool` defaults to ask_user (the original caller). */
+  submitAnswers: (toolCallId: string, output: unknown, tool?: PausingToolName) => void;
 }
 
 /**
@@ -90,7 +92,7 @@ export function useAnswerAskUser(options: UseAnswerAskUserOptions): UseAnswerAsk
   );
 
   const submitAnswers = useCallback(
-    (toolCallId: string, output: AskUserOutput) => {
+    (toolCallId: string, output: unknown, tool: PausingToolName = ASK_USER_TOOL_NAME) => {
       // Guard: still answerable on THIS render. Cheap and correct for the ordinary
       // single-surface case; claimAnswering below is what actually arbitrates a race.
       if (!answerableToolCallIds.has(toolCallId)) return;
@@ -121,7 +123,7 @@ export function useAnswerAskUser(options: UseAnswerAskUserOptions): UseAnswerAsk
           // to copy the snapshot in before every re-invocation.
           const body = await buildBody();
           const { dispatched } = await addToolResult({
-            tool: ASK_USER_TOOL_NAME,
+            tool,
             toolCallId,
             output,
             conversationId: conversationId!,

--- a/apps/web/src/lib/ai/shared/hooks/useChatSession.ts
+++ b/apps/web/src/lib/ai/shared/hooks/useChatSession.ts
@@ -81,7 +81,7 @@ import {
   readAdmissionEnvelope,
 } from '@/lib/ai/core/detached-stream-mode';
 import { openStreamSession } from '@/lib/ai/streams/streamSessionRegistry';
-import { ASK_USER_TOOL_NAME } from '@/lib/ai/tools/ask-user-tools';
+import { isPausingToolPartType } from '@/lib/ai/tools/pausing-tools';
 
 /** The status vocabulary the surfaces already speak, kept so their branches do not churn. */
 export type ChatSessionStatus = 'ready' | 'submitted' | 'streaming' | 'error';
@@ -215,7 +215,7 @@ export const useChatSession = ({
       if (message.role !== 'assistant') return message;
       let changed = false;
       const parts = message.parts.map((part) => {
-        if (part.type !== `tool-${ASK_USER_TOOL_NAME}`) return part;
+        if (!isPausingToolPartType(part.type)) return part;
         const toolCallId = (part as { toolCallId?: unknown }).toolCallId;
         const patch = patches.find((candidate) => candidate.toolCallId === toolCallId);
         if (!patch) return part;

--- a/apps/web/src/lib/ai/streams/applyAskUserAnswer.ts
+++ b/apps/web/src/lib/ai/streams/applyAskUserAnswer.ts
@@ -1,7 +1,5 @@
 import type { UIMessage } from 'ai';
-import { ASK_USER_TOOL_NAME, type AskUserOutput } from '@/lib/ai/tools/ask-user-tools';
-
-const ASK_USER_PART_TYPE = `tool-${ASK_USER_TOOL_NAME}`;
+import { isPausingToolPartType } from '@/lib/ai/tools/pausing-tools';
 
 type AskUserPart = { type: string; toolCallId?: string; state?: string; output?: unknown };
 
@@ -16,7 +14,7 @@ const patchAskUserPart = <T extends UIMessage>(
 
   const message = messages[idx];
   const parts = (message.parts ?? []) as AskUserPart[];
-  const partIdx = parts.findIndex((p) => p.type === ASK_USER_PART_TYPE && p.toolCallId === toolCallId);
+  const partIdx = parts.findIndex((p) => isPausingToolPartType(p.type) && p.toolCallId === toolCallId);
   if (partIdx < 0) return messages;
 
   const nextParts = parts.slice();
@@ -30,7 +28,8 @@ const patchAskUserPart = <T extends UIMessage>(
 export interface AskUserAnswerPayload {
   messageId: string;
   toolCallId: string;
-  output: AskUserOutput;
+  /** The tool's client result: an ask_user answer, or a request_env_approval outcome. */
+  output: unknown;
 }
 
 /**

--- a/apps/web/src/lib/ai/streams/selectAnswerableAskUserToolCallIds.ts
+++ b/apps/web/src/lib/ai/streams/selectAnswerableAskUserToolCallIds.ts
@@ -1,7 +1,5 @@
 import type { RenderedMessage } from './selectRenderedMessages';
-import { ASK_USER_TOOL_NAME } from '@/lib/ai/tools/ask-user-tools';
-
-const ASK_USER_PART_TYPE = `tool-${ASK_USER_TOOL_NAME}`;
+import { isPausingToolPartType } from '@/lib/ai/tools/pausing-tools';
 
 export interface AskUserAnswerabilityInput {
   /** Selector output (selectRenderedMessages) — the rendered list, never useChat's local array. */
@@ -13,7 +11,8 @@ export interface AskUserAnswerabilityInput {
 }
 
 /**
- * Pure answerability predicate (epic leaf 6.3): a `tool-ask_user` part is
+ * Pure answerability predicate (epic leaf 6.3): a pausing-tool part (`tool-ask_user`,
+ * `tool-request_env_approval`) is
  * answerable iff it sits on the LAST message, that message is a settled
  * (non-streaming) assistant reply, its state is `input-available`, no other
  * surface already claimed it (answeringToolCallIds), and nothing is busy for
@@ -30,7 +29,7 @@ export const selectAnswerableAskUserToolCallIds = (
   if (!last || last.role !== 'assistant') return ids;
 
   for (const part of last.parts ?? []) {
-    if (part.type !== ASK_USER_PART_TYPE) continue;
+    if (!isPausingToolPartType(part.type)) continue;
     const p = part as { toolCallId: string; state?: string };
     if (p.state !== 'input-available') continue;
     if (input.answeringToolCallIds.has(p.toolCallId)) continue;

--- a/apps/web/src/lib/ai/tools/__tests__/env-approval-tools.test.ts
+++ b/apps/web/src/lib/ai/tools/__tests__/env-approval-tools.test.ts
@@ -1,0 +1,80 @@
+/**
+ * GA wave 2, leaf 5 — `request_env_approval`: client-side (no execute),
+ * injected only when the session is bound to a local env, kept out of
+ * baseTools / tool_search / execute_tool with the same discipline as
+ * ask_user — and never a reuse of ask_user, whose answers are model-visible
+ * text rather than an authorization artefact.
+ */
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { envApprovalTools, REQUEST_ENV_APPROVAL_TOOL_NAME, requestEnvApprovalInputSchema, requestEnvApprovalOutputSchema } from '../env-approval-tools';
+import { buildPageSpaceTools } from '@/lib/ai/core/ai-tools';
+
+const read = (relative: string) => readFileSync(join(__dirname, '..', '..', '..', '..', relative), 'utf8');
+
+describe('the tool definition', () => {
+  it('has no execute — the turn pauses and resumes on the owner\'s click', () => {
+    expect('execute' in envApprovalTools[REQUEST_ENV_APPROVAL_TOOL_NAME]).toBe(false);
+    expect(REQUEST_ENV_APPROVAL_TOOL_NAME).toBe('request_env_approval');
+  });
+
+  it('tells the model to STOP after calling it and to pass the challengeId verbatim', () => {
+    const description = envApprovalTools[REQUEST_ENV_APPROVAL_TOOL_NAME].description ?? '';
+    expect(description).toMatch(/STOP/);
+    expect(description).toMatch(/challengeId/);
+    expect(description).toMatch(/local_approval_required/);
+  });
+
+  it('is NOT in the base registry (never in tool_search or execute_tool), for every registry shape', () => {
+    for (const codeExecutionEnabled of [true, false]) {
+      expect(Object.keys(buildPageSpaceTools({ codeExecutionEnabled }))).not.toContain(REQUEST_ENV_APPROVAL_TOOL_NAME);
+    }
+  });
+
+  it('input is a single challengeId; output is the closed outcome set with capped strings', () => {
+    expect(requestEnvApprovalInputSchema.safeParse({ challengeId: 'ch_1' }).success).toBe(true);
+    expect(requestEnvApprovalInputSchema.safeParse({ challengeId: '' }).success).toBe(false);
+    expect(requestEnvApprovalInputSchema.safeParse({}).success).toBe(false);
+    expect(requestEnvApprovalOutputSchema.safeParse({ challengeId: 'ch_1', outcome: 'allowed', exitCode: 0, stdout: 'ok', stderr: '', truncated: false }).success).toBe(true);
+    expect(requestEnvApprovalOutputSchema.safeParse({ challengeId: 'ch_1', outcome: 'denied' }).success).toBe(true);
+    expect(requestEnvApprovalOutputSchema.safeParse({ challengeId: 'ch_1', outcome: 'maybe' }).success).toBe(false);
+    expect(requestEnvApprovalOutputSchema.safeParse({ challengeId: 'ch_1', outcome: 'allowed', isAdmin: true }).success).toBe(false);
+    expect(requestEnvApprovalOutputSchema.safeParse({ challengeId: 'ch_1', outcome: 'allowed', stdout: 'x'.repeat(200_001) }).success).toBe(false);
+  });
+});
+
+describe('not ask_user — pinned by reading the source', () => {
+  it('env-approval-tools.ts and the card never import the ask_user tool module', () => {
+    expect(read('lib/ai/tools/env-approval-tools.ts')).not.toMatch(/ask-user-tools/);
+    expect(read('components/ai/shared/chat/env-approval/EnvApprovalCard.tsx')).not.toMatch(/ask-user-tools|ASK_USER_TOOL_NAME|askUser/);
+  });
+
+  it('the card renders the FROZEN request fetched from the approvals route, never the tool input', () => {
+    const card = read('components/ai/shared/chat/env-approval/EnvApprovalCard.tsx');
+    expect(card).toMatch(/\/api\/env-bridge\/approvals\//);
+    for (const field of ['principal', 'op', 'command', 'cwd', 'paths', 'env', 'limits']) expect(card, field).toContain(`'${field}'`);
+  });
+});
+
+describe('route-level injection — the same discipline as ask_user, gated on a LOCAL env binding', () => {
+  it.each(['lib/ai/chat-pipeline/page-chat-turn.ts', 'lib/ai/chat-pipeline/global-chat-turn.ts'])('%s spreads envApprovalTools ONLY inside the local-env guard, after the ask_user injection, and pauses on it', (file) => {
+    const source = read(file);
+    expect(source).toMatch(/resolveLocalEnvBindingForConversation\(/);
+    const guard = source.indexOf('if (localEnvBinding !== null) {');
+    const spread = source.indexOf('...envApprovalTools');
+    const askUser = source.indexOf('...askUserTools');
+    expect(guard).toBeGreaterThan(-1);
+    expect(spread).toBeGreaterThan(guard);
+    expect(spread - guard).toBeLessThan(400);
+    expect(askUser).toBeLessThan(spread);
+    // Exactly one spread: never a second, unguarded one.
+    expect(source.split('...envApprovalTools').length).toBe(2);
+    expect(source).toMatch(/pauseToolNames\.push\(REQUEST_ENV_APPROVAL_TOOL_NAME\)/);
+    expect(source).toMatch(/\.\.\.pauseToolNames\.map\(\(name\) => hasToolCall\(name\)\)/);
+  });
+
+  it('the base registry builder never mentions it (no accidental catalog entry)', () => {
+    expect(read('lib/ai/core/ai-tools.ts')).not.toMatch(/env-approval-tools|request_env_approval/);
+  });
+});

--- a/apps/web/src/lib/ai/tools/__tests__/env-approval-tools.test.ts
+++ b/apps/web/src/lib/ai/tools/__tests__/env-approval-tools.test.ts
@@ -58,20 +58,29 @@ describe('not ask_user — pinned by reading the source', () => {
 });
 
 describe('route-level injection — the same discipline as ask_user, gated on a LOCAL env binding', () => {
-  it.each(['lib/ai/chat-pipeline/page-chat-turn.ts', 'lib/ai/chat-pipeline/global-chat-turn.ts'])('%s spreads envApprovalTools ONLY inside the local-env guard, after the ask_user injection, and pauses on it', (file) => {
-    const source = read(file);
-    expect(source).toMatch(/resolveLocalEnvBindingForConversation\(/);
-    const guard = source.indexOf('if (localEnvBinding !== null) {');
+  it('the ONE injection lives in withEnvApprovalTool: the spread sits after the local-env guard, and the pause list gains the tool only then', () => {
+    const source = read('lib/ai/core/local-env-binding.ts');
+    const guard = source.indexOf("if (binding === null) return { tools, pauseToolNames, injected: false };");
     const spread = source.indexOf('...envApprovalTools');
-    const askUser = source.indexOf('...askUserTools');
     expect(guard).toBeGreaterThan(-1);
     expect(spread).toBeGreaterThan(guard);
-    expect(spread - guard).toBeLessThan(400);
-    expect(askUser).toBeLessThan(spread);
-    // Exactly one spread: never a second, unguarded one.
     expect(source.split('...envApprovalTools').length).toBe(2);
     expect(source).toMatch(/pauseToolNames\.push\(REQUEST_ENV_APPROVAL_TOOL_NAME\)/);
+  });
+
+  it.each(['lib/ai/chat-pipeline/page-chat-turn.ts', 'lib/ai/chat-pipeline/global-chat-turn.ts'])('%s calls the helper AFTER the ask_user injection, never spreads envApprovalTools itself, and pauses on what the helper returned', (file) => {
+    const source = read(file);
+    const askUser = source.indexOf('...askUserTools');
+    const helper = source.indexOf('await withEnvApprovalTool(');
+    expect(askUser).toBeGreaterThan(-1);
+    expect(helper).toBeGreaterThan(askUser);
+    expect(source).not.toMatch(/\.\.\.envApprovalTools|resolveLocalEnvBindingForConversation/);
+    expect(source).toMatch(/const \{ pauseToolNames \} = envApproval;/);
     expect(source).toMatch(/\.\.\.pauseToolNames\.map\(\(name\) => hasToolCall\(name\)\)/);
+  });
+
+  it('the page turn only offers the tool with the sandbox on (the helper gets no conversation otherwise); a helper given no binding injects nothing', () => {
+    expect(read('lib/ai/chat-pipeline/page-chat-turn.ts')).toMatch(/withEnvApprovalTool\(filteredTools, sandboxEnabled \? conversationId : undefined\)/);
   });
 
   it('the base registry builder never mentions it (no accidental catalog entry)', () => {

--- a/apps/web/src/lib/ai/tools/__tests__/pausing-tools.test.ts
+++ b/apps/web/src/lib/ai/tools/__tests__/pausing-tools.test.ts
@@ -1,0 +1,26 @@
+import { describe, it, expect } from 'vitest';
+import { isPausingToolName, isPausingToolPartType, PAUSING_TOOL_NAMES, pausingToolOutputSchema, pausingToolPartType } from '../pausing-tools';
+
+describe('pausing tools — the set defined once', () => {
+  it('is exactly ask_user and request_env_approval', () => {
+    expect([...PAUSING_TOOL_NAMES]).toEqual(['ask_user', 'request_env_approval']);
+    expect(isPausingToolName('ask_user')).toBe(true);
+    expect(isPausingToolName('request_env_approval')).toBe(true);
+    expect(isPausingToolName('finish')).toBe(false);
+  });
+
+  it('recognises both part types and nothing else', () => {
+    expect(isPausingToolPartType(pausingToolPartType('ask_user'))).toBe(true);
+    expect(isPausingToolPartType('tool-request_env_approval')).toBe(true);
+    expect(isPausingToolPartType('tool-execute_tool')).toBe(false);
+    expect(isPausingToolPartType('text')).toBe(false);
+  });
+
+  it('gives each its own output schema, and none for anything else', () => {
+    expect(pausingToolOutputSchema('tool-ask_user')?.safeParse({ dismissed: true, reason: 'x' }).success).toBe(true);
+    expect(pausingToolOutputSchema('tool-ask_user')?.safeParse({ challengeId: 'c', outcome: 'allowed' }).success).toBe(false);
+    expect(pausingToolOutputSchema('tool-request_env_approval')?.safeParse({ challengeId: 'c', outcome: 'allowed' }).success).toBe(true);
+    expect(pausingToolOutputSchema('tool-request_env_approval')?.safeParse({ dismissed: true, reason: 'x' }).success).toBe(false);
+    expect(pausingToolOutputSchema('tool-bash')).toBeNull();
+  });
+});

--- a/apps/web/src/lib/ai/tools/__tests__/tool-labels.test.ts
+++ b/apps/web/src/lib/ai/tools/__tests__/tool-labels.test.ts
@@ -106,6 +106,7 @@ describe('the label table against the real registry', () => {
     const registry = new Set(Object.keys(buildPageSpaceTools({ codeExecutionEnabled: true })));
     const outsideRegistry = Object.keys(TOOL_NAME_MAP).filter((name) => !registry.has(name));
 
-    expect(outsideRegistry.sort()).toEqual(['ask_agent', 'ask_user']);
+    // `request_env_approval` is merged in per-route too (GA wave 2), only when the session is bound to a local env.
+    expect(outsideRegistry.sort()).toEqual(['ask_agent', 'ask_user', 'request_env_approval']);
   });
 });

--- a/apps/web/src/lib/ai/tools/env-approval-tools.ts
+++ b/apps/web/src/lib/ai/tools/env-approval-tools.ts
@@ -1,0 +1,79 @@
+import { tool } from 'ai';
+import { z } from 'zod';
+
+/**
+ * `request_env_approval` — the Tier B click, as a tool (GA wave 2, leaf 5).
+ *
+ * When a request reaches a LOCAL environment whose machine froze it under a
+ * challenge (`local_approval_required` from the sandbox tool runners), the
+ * agent calls this tool with the challenge id and STOPS. The chat renders an
+ * approval card that fetches the frozen request from the server — the exact
+ * normalised command, working directory, environment and limits the MACHINE
+ * signed — and the environment's OWNER clicks Allow or Deny. The click
+ * re-issues the request to the machine as a fresh grant carrying a
+ * server-signed approval intent; the machine byte-compares it against what it
+ * froze and runs it only on a match. The outcome comes back as this tool's
+ * result and the turn resumes.
+ *
+ * **Deliberately NOT `ask_user`.** An `ask_user` answer is model-visible free
+ * text; it is not an authorization artefact and nothing may treat it as one.
+ * Here the authorization never passes through the model or the tool output at
+ * all: it is the owner's authenticated click at `POST /api/env-bridge/approvals/
+ * <challengeId>`, checked against `drive_env_local.ownerId`, then signed by
+ * the server and verified by the machine. The tool output only REPORTS what
+ * happened. A test asserts this module never imports the ask_user module.
+ *
+ * Client-side: no `execute`. Injected at route level ONLY when the session is
+ * bound to a local environment, and — exactly as `ask_user` — kept out of
+ * `baseTools`, the `tool_search` catalog and the `execute_tool` dispatch map.
+ */
+export const REQUEST_ENV_APPROVAL_TOOL_NAME = 'request_env_approval';
+
+export const requestEnvApprovalInputSchema = z.object({
+  challengeId: z
+    .string()
+    .min(1)
+    .max(128)
+    .describe('The challengeId from the local_approval_required tool result, verbatim.'),
+});
+
+export type RequestEnvApprovalInput = z.infer<typeof requestEnvApprovalInputSchema>;
+
+/** The scopes the owner may choose on the card; mirrors `APPROVAL_SCOPES` in the pure core. */
+export const ENV_APPROVAL_SCOPES = ['once', 'session', '30d', 'until_revoked'] as const;
+export type EnvApprovalScope = (typeof ENV_APPROVAL_SCOPES)[number];
+
+/**
+ * The output the CLIENT submits when the owner has answered (validated on the
+ * server before it is merged into the persisted assistant message, exactly
+ * like an ask_user answer; the length caps bound what a client can inject
+ * into model context). `outcome` is what the SERVER answered the click with;
+ * `exitCode`/`stdout`/`stderr` are the command's own output when it ran.
+ */
+export const requestEnvApprovalOutputSchema = z
+  .object({
+    challengeId: z.string().min(1).max(128),
+    outcome: z.enum(['allowed', 'denied', 'expired', 'mismatch', 'unknown', 'not_owner', 'failed']),
+    scope: z.enum(ENV_APPROVAL_SCOPES).optional(),
+    exitCode: z.number().int().optional(),
+    stdout: z.string().max(200_000).optional(),
+    stderr: z.string().max(50_000).optional(),
+    truncated: z.boolean().optional(),
+    error: z.string().max(2_000).optional(),
+  })
+  .strict();
+
+export type RequestEnvApprovalOutput = z.infer<typeof requestEnvApprovalOutputSchema>;
+
+export const envApprovalTools = {
+  [REQUEST_ENV_APPROVAL_TOOL_NAME]: tool({
+    description:
+      'Ask the local environment\'s owner to approve a request the machine has frozen. Use it ONLY when a sandbox tool ' +
+      'answered reason local_approval_required with a challengeId; pass that challengeId verbatim. The owner sees the exact ' +
+      'command the machine froze and clicks Allow or Deny in the chat; the machine then runs exactly that request, or nothing. ' +
+      'After calling this tool, STOP — do not call finish or any other tool; your turn ends and resumes when the owner answers. ' +
+      'The result reports the outcome (allowed | denied | expired | mismatch | unknown | not_owner | failed) and, when it ran, ' +
+      'the command\'s exit code and output. Do not retry or rephrase the original command while an approval is pending.',
+    inputSchema: requestEnvApprovalInputSchema,
+  }),
+};

--- a/apps/web/src/lib/ai/tools/env-approval-tools.ts
+++ b/apps/web/src/lib/ai/tools/env-approval-tools.ts
@@ -37,8 +37,6 @@ export const requestEnvApprovalInputSchema = z.object({
     .describe('The challengeId from the local_approval_required tool result, verbatim.'),
 });
 
-export type RequestEnvApprovalInput = z.infer<typeof requestEnvApprovalInputSchema>;
-
 /** The scopes the owner may choose on the card; mirrors `APPROVAL_SCOPES` in the pure core. */
 export const ENV_APPROVAL_SCOPES = ['once', 'session', '30d', 'until_revoked'] as const;
 export type EnvApprovalScope = (typeof ENV_APPROVAL_SCOPES)[number];

--- a/apps/web/src/lib/ai/tools/env-approval-tools.ts
+++ b/apps/web/src/lib/ai/tools/env-approval-tools.ts
@@ -48,14 +48,24 @@ export type EnvApprovalScope = (typeof ENV_APPROVAL_SCOPES)[number];
  * into model context). `outcome` is what the SERVER answered the click with;
  * `exitCode`/`stdout`/`stderr` are the command's own output when it ran.
  */
+/**
+ * The output bounds, in UTF-16 code units (what zod's `.max` measures). The
+ * approvals route truncates a machine reply to EXACTLY these before it
+ * answers the click (Codex P1 on #2583: a ~786 KiB exec_result used to fail
+ * the merge and leave the tool call pending, so the turn never resumed).
+ * Defined once here so the schema and the route cannot drift.
+ */
+export const ENV_APPROVAL_STDOUT_MAX_CHARS = 200_000;
+export const ENV_APPROVAL_STDERR_MAX_CHARS = 50_000;
+
 export const requestEnvApprovalOutputSchema = z
   .object({
     challengeId: z.string().min(1).max(128),
     outcome: z.enum(['allowed', 'denied', 'expired', 'mismatch', 'unknown', 'not_owner', 'failed']),
     scope: z.enum(ENV_APPROVAL_SCOPES).optional(),
     exitCode: z.number().int().optional(),
-    stdout: z.string().max(200_000).optional(),
-    stderr: z.string().max(50_000).optional(),
+    stdout: z.string().max(ENV_APPROVAL_STDOUT_MAX_CHARS).optional(),
+    stderr: z.string().max(ENV_APPROVAL_STDERR_MAX_CHARS).optional(),
     truncated: z.boolean().optional(),
     error: z.string().max(2_000).optional(),
   })

--- a/apps/web/src/lib/ai/tools/pausing-tools.ts
+++ b/apps/web/src/lib/ai/tools/pausing-tools.ts
@@ -1,0 +1,43 @@
+import type { z } from 'zod';
+import { ASK_USER_TOOL_NAME, askUserOutputSchema } from './ask-user-tools';
+import { REQUEST_ENV_APPROVAL_TOOL_NAME, requestEnvApprovalOutputSchema } from './env-approval-tools';
+
+/**
+ * The client-side tools that PAUSE a turn awaiting a person: execute-less,
+ * answered in the chat UI, resumed by merging the client's result into the
+ * persisted assistant message. `ask_user` (a question) and
+ * `request_env_approval` (the Tier B click, GA wave 2) share every piece of
+ * that plumbing — answerability, the optimistic patch, the resume merge, the
+ * "resume only once every pending part is answered" predicate — and this
+ * module is where the set is defined ONCE, so adding a third never means
+ * finding six string comparisons.
+ *
+ * The two are still different things: an `ask_user` answer is model-visible
+ * text; a `request_env_approval` result only REPORTS an authorization that
+ * happened elsewhere (the owner's authenticated click, server-signed and
+ * machine-verified). Sharing the transport does not make them the same.
+ */
+export const PAUSING_TOOL_NAMES = [ASK_USER_TOOL_NAME, REQUEST_ENV_APPROVAL_TOOL_NAME] as const;
+export type PausingToolName = (typeof PAUSING_TOOL_NAMES)[number];
+
+const PART_TYPES = new Set<string>(PAUSING_TOOL_NAMES.map((name) => `tool-${name}`));
+
+/** `tool-<name>` for a pausing tool; the UIMessage part type. */
+export function pausingToolPartType(name: PausingToolName): string {
+  return `tool-${name}`;
+}
+
+export function isPausingToolPartType(type: string): boolean {
+  return PART_TYPES.has(type);
+}
+
+export function isPausingToolName(name: string): name is PausingToolName {
+  return (PAUSING_TOOL_NAMES as readonly string[]).includes(name);
+}
+
+/** The schema the SERVER validates a client-supplied result against before persisting it. */
+export function pausingToolOutputSchema(partType: string): z.ZodTypeAny | null {
+  if (partType === pausingToolPartType(ASK_USER_TOOL_NAME)) return askUserOutputSchema;
+  if (partType === pausingToolPartType(REQUEST_ENV_APPROVAL_TOOL_NAME)) return requestEnvApprovalOutputSchema;
+  return null;
+}

--- a/apps/web/src/lib/ai/tools/tool-labels.ts
+++ b/apps/web/src/lib/ai/tools/tool-labels.ts
@@ -72,6 +72,7 @@ export const TOOL_NAME_MAP: Record<string, string> = {
   'multi_drive_list_agents': 'All Agents',
   'ask_agent': 'Ask Agent',
   'ask_user': 'Question',
+  'request_env_approval': 'Approval',
   // Web
   'web_search': 'Web Search',
   'web_fetch': 'Fetch Page',

--- a/apps/web/src/lib/env-bridge/__tests__/bridge-client.test.ts
+++ b/apps/web/src/lib/env-bridge/__tests__/bridge-client.test.ts
@@ -15,6 +15,9 @@ vi.mock('@pagespace/lib/audit/audit-log', () => ({ audit: vi.fn(), auditRequest:
 vi.mock('@/lib/drive-envs/drive-envs-runtime', () => ({ getDriveEnvStore: vi.fn() }));
 
 import { decodeFrame, type Frame } from '@pagespace/lib/env-bridge/frame-codec';
+import { createMemoryNonceStore, verifyGrant } from '@pagespace/lib/env-bridge/grant';
+import { grantRequestForFrame } from '@pagespace/lib/env-bridge/grant-args';
+import { ed25519Verify } from '../crypto';
 import { encodeResultForSigning, resultHashForFrame, type MachineResultFrame } from '@pagespace/lib/env-bridge/machine-signatures';
 import { parseServerSigningKeyring, type SigningKeyPrimitives } from '@pagespace/lib/env-bridge/server-signing-key';
 import { DEFAULT_TIMEOUT_DEFAULTS } from '@pagespace/lib/env-bridge/resolve-timeout';
@@ -135,6 +138,53 @@ describe('EnvBridgeClient', () => {
     expect(client.handleMachineResult(ws, result)).toBe('delivered');
     await expect(pending).resolves.toEqual(result);
     expect(unverified).toEqual([]);
+  });
+
+  describe('GA wave 2 — the pending click', () => {
+    const PENDING = { challengeId: 'ch_1', expiresAt: 1_760_000_030_000, request: { op: 'exec' as const, cmd: 'ls', args: [], cwd: '/p', paths: [], env: {}, timeoutMs: 1000, maxBytes: 1024, clamped: false } };
+
+    it('given the machine answers ask_pending:<id> with a signed frozen request, should deliver it AND remember what re-issuing needs under that id, for the grant\'s exp', async () => {
+      const store = { entries: [] as unknown[], remember: vi.fn((entry: unknown) => { store.entries.push(entry); return true; }), get: vi.fn(), take: vi.fn(), evictExpired: vi.fn(), size: () => store.entries.length };
+      const c = new EnvBridgeClient({ ...(client as unknown as { deps: EnvBridgeClientDeps }).deps, pendingApprovals: store });
+      const ws = connect('env-1');
+      const frame = { type: 'grant_exec' as const, cmd: 'ls', cwd: '/p' };
+      const pending = c.sendGrant({ envId: 'env-1', frame, principal });
+      await flushPromises();
+      const denied = signedResult({ type: 'grant_denied', grantId: 'g-1', reason: 'ask_pending:ch_1', pending: PENDING });
+      expect(c.handleMachineResult(ws, denied)).toBe('delivered');
+      await expect(pending).resolves.toEqual(denied);
+      expect(store.remember).toHaveBeenCalledTimes(1);
+      expect(store.entries[0]).toMatchObject({ challengeId: 'ch_1', envId: 'env-1', frame, principal, expiresAt: 1_760_000_060_000, pending: PENDING });
+    });
+
+    it('given an ask_pending whose reason id and pending id disagree, or with no pending body, should deliver but remember NOTHING', async () => {
+      const store = { remember: vi.fn(() => true), get: vi.fn(), take: vi.fn(), evictExpired: vi.fn(), size: () => 0 };
+      const c = new EnvBridgeClient({ ...(client as unknown as { deps: EnvBridgeClientDeps }).deps, pendingApprovals: store });
+      const ws = connect('env-1');
+      const p1 = c.sendGrant({ envId: 'env-1', frame: { type: 'grant_exec', cmd: 'ls' }, principal });
+      await flushPromises();
+      c.handleMachineResult(ws, signedResult({ type: 'grant_denied', grantId: 'g-1', reason: 'ask_pending:ch_other', pending: PENDING }));
+      await p1;
+      const p2 = c.sendGrant({ envId: 'env-1', frame: { type: 'grant_exec', cmd: 'ls' }, principal });
+      await flushPromises();
+      c.handleMachineResult(ws, signedResult({ type: 'grant_denied', grantId: 'g-2', reason: 'ask_pending:ch_1' }));
+      await p2;
+      expect(store.remember).not.toHaveBeenCalled();
+    });
+
+    it('given an approvalIntent, should sign it INTO the grant on the wire (the daemon verifies it with the pinned key)', async () => {
+      const ws = connect('env-1');
+      const intent = { challengeId: 'ch_1', scope: '30d' as const, expiresAt: 1_760_000_030_000 };
+      const pending = client.sendGrant({ envId: 'env-1', frame: { type: 'grant_exec', cmd: 'ls' }, principal, approvalIntent: intent });
+      await flushPromises();
+      pending.catch(() => {});
+      const frame = sentFrame(ws);
+      if (frame.type !== 'grant_exec') throw new Error('type');
+      expect(frame.grant).toMatchObject({ approvalIntent: intent });
+      // Under the pinned key: the daemon's own gate accepts it.
+      const verdict = verifyGrant({ grant: frame.grant, signature: frame.sig, serverPublicKey: ring.current.publicKey, now: 1_760_000_001_000, nonces: createMemoryNonceStore(), expectedEnvId: 'env-1', request: grantRequestForFrame(frame), verify: ed25519Verify, hash: envBridgeHash });
+      expect(verdict).toMatchObject({ ok: true, grant: { approvalIntent: intent } });
+    });
   });
 
   it('EXIT CRITERION — given an exec_result whose machine signature does not verify, should NOT deliver it: the request fails with typed unverified_result and the event is surfaced', async () => {

--- a/apps/web/src/lib/env-bridge/__tests__/bridge-client.test.ts
+++ b/apps/web/src/lib/env-bridge/__tests__/bridge-client.test.ts
@@ -18,7 +18,7 @@ import { decodeFrame, type Frame } from '@pagespace/lib/env-bridge/frame-codec';
 import { createMemoryNonceStore, verifyGrant } from '@pagespace/lib/env-bridge/grant';
 import { grantRequestForFrame } from '@pagespace/lib/env-bridge/grant-args';
 import { ed25519Verify } from '../crypto';
-import { encodeResultForSigning, resultHashForFrame, type MachineResultFrame } from '@pagespace/lib/env-bridge/machine-signatures';
+import { encodeResultForSigning, machineResultBindingId, resultHashForFrame, type MachineResultFrame } from '@pagespace/lib/env-bridge/machine-signatures';
 import { parseServerSigningKeyring, type SigningKeyPrimitives } from '@pagespace/lib/env-bridge/server-signing-key';
 import { DEFAULT_TIMEOUT_DEFAULTS } from '@pagespace/lib/env-bridge/resolve-timeout';
 import { RequestCorrelator } from '../correlator';
@@ -57,7 +57,7 @@ type UnsignedResult<T = MachineResultFrame> = T extends unknown ? Omit<T, 'sig'>
 
 function signedResult(body: UnsignedResult, key = machine): MachineResultFrame {
   const resultHash = resultHashForFrame({ ...body, sig: '' } as MachineResultFrame, envBridgeHash);
-  return { ...body, sig: Buffer.from(nodeSign(null, encodeResultForSigning({ grantId: body.grantId, resultHash }), key.privateKey)).toString('base64') } as MachineResultFrame;
+  return { ...body, sig: Buffer.from(nodeSign(null, encodeResultForSigning({ grantId: machineResultBindingId({ ...body, sig: '' } as MachineResultFrame), resultHash }), key.privateKey)).toString('base64') } as MachineResultFrame;
 }
 
 describe('EnvBridgeClient', () => {

--- a/apps/web/src/lib/env-bridge/__tests__/grant-signer.test.ts
+++ b/apps/web/src/lib/env-bridge/__tests__/grant-signer.test.ts
@@ -155,3 +155,16 @@ describe('signGrantFrame — window and identity', () => {
     expect(Object.keys(a.frame.grant).sort()).toEqual(['argsHash', 'envId', 'exp', 'grantId', 'iat', 'nonce', 'op', 'principal']);
   });
 });
+
+describe('GA wave 2 — approvalIntent is signed into the grant', () => {
+  it('given an approvalIntent, the wire grant carries it and the daemon gate verifies it under the pinned key; without one, no key is added', () => {
+    const intent = { challengeId: 'ch_1', scope: 'until_revoked' as const, expiresAt: NOW + 30_000 };
+    const signed = signGrantFrame({ frame: frames.grant_exec, envId: 'env-1', principal, serverKeyId: currentId, keyring: ring, now: NOW, ids, approvalIntent: intent });
+    if (!signed.ok) throw new Error(signed.reason);
+    expect(signed.frame.grant).toMatchObject({ approvalIntent: intent });
+    expect(gate(signed.frame)).toMatchObject({ ok: true, grant: { approvalIntent: intent } });
+    const plain = signGrantFrame({ frame: frames.grant_exec, envId: 'env-1', principal, serverKeyId: currentId, keyring: ring, now: NOW, ids });
+    if (!plain.ok) throw new Error(plain.reason);
+    expect('approvalIntent' in plain.frame.grant).toBe(false);
+  });
+});

--- a/apps/web/src/lib/env-bridge/__tests__/pending-approvals.test.ts
+++ b/apps/web/src/lib/env-bridge/__tests__/pending-approvals.test.ts
@@ -1,0 +1,49 @@
+/**
+ * GA wave 2 — the server-side memory of a machine's `ask_pending` answer:
+ * what re-issuing the identical request needs, under the machine's id, for as
+ * long as the machine itself holds it. Bounded, TTL'd, consumed once.
+ */
+import { describe, it, expect } from 'vitest';
+import { createPendingApprovalStore, type PendingEnvApproval } from '../pending-approvals';
+
+const NOW = 1_800_000_000_000;
+const entry = (over: Partial<PendingEnvApproval> = {}): PendingEnvApproval => ({
+  challengeId: 'ch_1',
+  envId: 'env_1',
+  frame: { type: 'grant_exec', cmd: 'sh', args: ['-c', 'git status'] },
+  principal: { userId: 'u1', sessionId: 's1', conversationId: 'c1' },
+  expiresAt: NOW + 30_000,
+  pending: { challengeId: 'ch_1', expiresAt: NOW + 30_000, request: { op: 'exec', cmd: 'sh', args: ['-c', 'git status'], cwd: '/p', paths: [], env: {}, timeoutMs: 1000, maxBytes: 1024, clamped: false } },
+  createdAt: NOW,
+  ...over,
+});
+
+describe('pending approvals (server side)', () => {
+  it('remembers under the machine\'s id, hands it back until taken, then forgets', () => {
+    const s = createPendingApprovalStore();
+    expect(s.remember(entry(), NOW)).toBe(true);
+    expect(s.get('ch_1', NOW)).toMatchObject({ envId: 'env_1' });
+    expect(s.take('ch_1', NOW)).toMatchObject({ envId: 'env_1' });
+    expect(s.get('ch_1', NOW)).toBeUndefined();
+    expect(s.size()).toBe(0);
+  });
+
+  it('refuses an already-expired entry and evicts on the machine\'s TTL (the grant exp)', () => {
+    const s = createPendingApprovalStore();
+    expect(s.remember(entry({ expiresAt: NOW - 1 }), NOW)).toBe(false);
+    s.remember(entry(), NOW);
+    expect(s.get('ch_1', NOW + 30_000)).toBeDefined();
+    expect(s.get('ch_1', NOW + 30_001)).toBeUndefined();
+    expect(s.size()).toBe(0);
+  });
+
+  it('is bounded: a full store refuses to remember rather than evicting a live question; a repeat of a remembered id is a no-op', () => {
+    const s = createPendingApprovalStore(2);
+    expect(s.remember(entry({ challengeId: 'a' }), NOW)).toBe(true);
+    expect(s.remember(entry({ challengeId: 'b' }), NOW)).toBe(true);
+    expect(s.remember(entry({ challengeId: 'c' }), NOW)).toBe(false);
+    expect(s.remember(entry({ challengeId: 'a', envId: 'env_other' }), NOW)).toBe(true);
+    expect(s.get('a', NOW)?.envId).toBe('env_1');
+    expect(s.size()).toBe(2);
+  });
+});

--- a/apps/web/src/lib/env-bridge/__tests__/revoke.test.ts
+++ b/apps/web/src/lib/env-bridge/__tests__/revoke.test.ts
@@ -20,12 +20,13 @@ import { sessionService } from '@pagespace/lib/auth/session-service';
 import { loadServerSigningKeyring } from '@pagespace/lib/auth/env-bridge-signing-key';
 import { getDriveEnvStore } from '@/lib/drive-envs/drive-envs-runtime';
 import { decodeFrame } from '@pagespace/lib/env-bridge/frame-codec';
-import { verifyRevoke } from '@pagespace/lib/env-bridge/machine-signatures';
+import { encodeResultForSigning, machineResultBindingId, resultHashForFrame, verifyRevoke, type MachineResultFrame } from '@pagespace/lib/env-bridge/machine-signatures';
+import { envBridgeHash } from '@/lib/env-bridge/crypto';
 import { parseServerSigningKeyring, type SigningKeyPrimitives } from '@pagespace/lib/env-bridge/server-signing-key';
 import { clearAllEnvConnectionsForTesting, getEnvConnection, markEnvAuthorized, registerEnvConnection } from '@/lib/websocket/ws-env-connections';
 import { getEnvBridgeClient } from '@/lib/env-bridge/bridge-client';
 import { ed25519Verify } from '@/lib/env-bridge/crypto';
-import { revokeLocalEnv, buildRevokeFrame, ENV_REVOKED_CLOSE_CODE, ENV_REVOKED_CLOSE_REASON, revokeLocalEnvApproval } from '../revoke';
+import { revokeLocalEnv, buildRevokeFrame, ENV_REVOKED_CLOSE_CODE, ENV_REVOKED_CLOSE_REASON, revokeLocalEnvApproval, APPROVAL_REVOKE_ACK_TIMEOUT_MS } from '../revoke';
 
 const primitives: SigningKeyPrimitives = {
   importPrivateKey: (pkcs8) => {
@@ -35,6 +36,10 @@ const primitives: SigningKeyPrimitives = {
   hash: (bytes) => createHash('sha256').update(bytes).digest('hex'),
 };
 const pkcs8 = () => generateKeyPairSync('ed25519').privateKey.export({ type: 'pkcs8', format: 'der' }).toString('base64');
+/** The machine key an ack must be signed with (pinned on the socket), and a rogue one. */
+const machine = generateKeyPairSync('ed25519');
+const rogue = generateKeyPairSync('ed25519');
+const machinePublicKeyB64 = machine.publicKey.export({ type: 'spki', format: 'der' }).toString('base64');
 const ringVerdict = parseServerSigningKeyring({ single: undefined, multi: `${pkcs8()},${pkcs8()}` }, primitives);
 if (!ringVerdict.ok) throw new Error('ring');
 const ring = ringVerdict.keyring;
@@ -183,14 +188,57 @@ describe('GA wave 2 · leaf 8 — revoking ONE approval rides the signed revoke 
 
   function liveSocket(serverKeyId: string | null = currentId, authorized = true): FakeSocket {
     const ws = socket();
-    registerEnvConnection(ENV, ws, { userId: 'u', sessionId: 's', enrollmentId: 'enr_a', machinePublicKey: 'pk', serverKeyId, sessionExpiresAt: new Date(NOW.getTime() + 3600_000) });
+    registerEnvConnection(ENV, ws, { userId: 'u', sessionId: 's', enrollmentId: 'enr_a', machinePublicKey: machinePublicKeyB64, serverKeyId, sessionExpiresAt: new Date(NOW.getTime() + 3600_000) });
     if (authorized) markEnvAuthorized(ws);
     return ws;
   }
 
+  /** The daemon's signed ack, as the machine would produce it (or forge, with `key`). */
+  const ack = (approvalId: string, removed: number, key = machine): MachineResultFrame => {
+    const body = { type: 'approval_revoke_result' as const, approvalId, removed };
+    const frame = { ...body, sig: '' } as MachineResultFrame;
+    const resultHash = resultHashForFrame(frame, envBridgeHash);
+    return { ...body, sig: Buffer.from(nodeSign(null, encodeResultForSigning({ grantId: machineResultBindingId(frame), resultHash }), key.privateKey)).toString('base64') } as MachineResultFrame;
+  };
+  const settle = async () => { for (let i = 0; i < 8; i += 1) await Promise.resolve(); };
+
+  it('Codex P2 on #2583: given the machine answers with its SIGNED ack, should report acknowledged with the count the machine signed — the socket stays open, the row is not stamped', async () => {
+    const ws = liveSocket();
+    const pending = revokeLocalEnvApproval({ envId: ENV, approvalId: 'ch_1', reason: 'owner' });
+    await settle();
+    expect(ws.sent).toHaveLength(1);
+    expect(getEnvBridgeClient().handleMachineResult(ws, ack('ch_1', 2))).toBe('delivered');
+    expect(await pending).toEqual({ ok: true, machine: { kind: 'acknowledged', removed: 2 } });
+    expect(ws.close).not.toHaveBeenCalled();
+    expect(getEnvConnection(ENV)).toBe(ws);
+  });
+
+  it('Codex P2 on #2583: given the socket drops after the send (no ack), should report unacknowledged — never a revoke it cannot prove', async () => {
+    const ws = liveSocket();
+    const pending = revokeLocalEnvApproval({ envId: ENV, approvalId: 'ch_1', reason: 'owner' });
+    await settle();
+    expect(ws.sent).toHaveLength(1);
+    await vi.advanceTimersByTimeAsync(APPROVAL_REVOKE_ACK_TIMEOUT_MS + 1);
+    expect(await pending).toEqual({ ok: true, machine: { kind: 'unacknowledged', reason: 'timeout' } });
+  });
+
+  it('Codex P2 on #2583: given only a FORGED ack (wrong key, or the count edited), it is ignored and the revoke is still unacknowledged', async () => {
+    const ws = liveSocket();
+    const pending = revokeLocalEnvApproval({ envId: ENV, approvalId: 'ch_1', reason: 'owner' });
+    await settle();
+    expect(getEnvBridgeClient().handleMachineResult(ws, ack('ch_1', 2, rogue))).toBe('unverified');
+    const genuine = ack('ch_1', 2);
+    expect(getEnvBridgeClient().handleMachineResult(ws, { ...genuine, removed: 99 } as MachineResultFrame)).toBe('unverified');
+    await vi.advanceTimersByTimeAsync(APPROVAL_REVOKE_ACK_TIMEOUT_MS + 1);
+    expect(await pending).toEqual({ ok: true, machine: { kind: 'unacknowledged', reason: 'timeout' } });
+  });
+
   it('given an authorized socket, should send a revoke frame carrying approvalId that the daemon verifies under the approval domain, and NOT close the socket or stamp the row', async () => {
     const ws = liveSocket();
-    expect(await revokeLocalEnvApproval({ envId: ENV, approvalId: 'ch_1', reason: 'owner' })).toEqual({ ok: true, machine: 'sent' });
+    const pending = revokeLocalEnvApproval({ envId: ENV, approvalId: 'ch_1', reason: 'owner' });
+    await settle();
+    getEnvBridgeClient().handleMachineResult(ws, ack('ch_1', 1));
+    expect(await pending).toEqual({ ok: true, machine: { kind: 'acknowledged', removed: 1 } });
     const decoded = decodeFrame(ws.sent[0]!, { maxFrameBytes: 65536 });
     if (!decoded.ok || decoded.frame.type !== 'revoke') throw new Error('no revoke frame');
     expect(decoded.frame.approvalId).toBe('ch_1');
@@ -205,19 +253,19 @@ describe('GA wave 2 · leaf 8 — revoking ONE approval rides the signed revoke 
   });
 
   it('given no live socket, should say so (no_live_socket) rather than claim a revoke the machine never received', async () => {
-    expect(await revokeLocalEnvApproval({ envId: ENV, approvalId: 'ch_1', reason: 'owner' })).toEqual({ ok: true, machine: 'no_live_socket' });
+    expect(await revokeLocalEnvApproval({ envId: ENV, approvalId: 'ch_1', reason: 'owner' })).toEqual({ ok: true, machine: { kind: 'no_live_socket' } });
   });
 
   it('given an unauthorized socket, should send NOTHING to it', async () => {
     const ws = liveSocket(currentId, false);
-    expect(await revokeLocalEnvApproval({ envId: ENV, approvalId: 'ch_1', reason: 'owner' })).toEqual({ ok: true, machine: 'unauthorized_socket' });
+    expect(await revokeLocalEnvApproval({ envId: ENV, approvalId: 'ch_1', reason: 'owner' })).toEqual({ ok: true, machine: { kind: 'unauthorized_socket' } });
     expect(ws.sent).toHaveLength(0);
   });
 
   it('given the pinned key (the ROW\'s serverKeyId) is not loaded, should not sign under another key', async () => {
     row = { envId: ENV, enrollmentId: 'enr_a', serverKeyId: 'gone-key', revokedAt: null };
     const ws = liveSocket('gone-key');
-    expect(await revokeLocalEnvApproval({ envId: ENV, approvalId: 'ch_1', reason: 'owner' })).toEqual({ ok: true, machine: 'signing_key_unavailable' });
+    expect(await revokeLocalEnvApproval({ envId: ENV, approvalId: 'ch_1', reason: 'owner' })).toEqual({ ok: true, machine: { kind: 'signing_key_unavailable' } });
     expect(ws.sent).toHaveLength(0);
   });
 

--- a/apps/web/src/lib/env-bridge/__tests__/revoke.test.ts
+++ b/apps/web/src/lib/env-bridge/__tests__/revoke.test.ts
@@ -25,7 +25,7 @@ import { parseServerSigningKeyring, type SigningKeyPrimitives } from '@pagespace
 import { clearAllEnvConnectionsForTesting, getEnvConnection, markEnvAuthorized, registerEnvConnection } from '@/lib/websocket/ws-env-connections';
 import { getEnvBridgeClient } from '@/lib/env-bridge/bridge-client';
 import { ed25519Verify } from '@/lib/env-bridge/crypto';
-import { revokeLocalEnv, buildRevokeFrame, ENV_REVOKED_CLOSE_CODE, ENV_REVOKED_CLOSE_REASON } from '../revoke';
+import { revokeLocalEnv, buildRevokeFrame, ENV_REVOKED_CLOSE_CODE, ENV_REVOKED_CLOSE_REASON, revokeLocalEnvApproval } from '../revoke';
 
 const primitives: SigningKeyPrimitives = {
   importPrivateKey: (pkcs8) => {
@@ -164,5 +164,67 @@ describe('revokeLocalEnv — all three legs through the production seams', () =>
 
   it('buildRevokeFrame: given a null serverKeyId (never enrolled), should answer signing_key_unavailable', () => {
     expect(buildRevokeFrame({ envId: ENV, enrollmentId: 'e', serverKeyId: null, issuedAt: 1, reason: 'r' }, ring)).toEqual({ ok: false, reason: 'signing_key_unavailable' });
+  });
+});
+
+describe('GA wave 2 · leaf 8 — revoking ONE approval rides the signed revoke frame; the socket stays open, the key stays', () => {
+  let row: { envId: string; enrollmentId: string; serverKeyId: string | null; revokedAt: Date | null } | null;
+  let store: { findLocalByEnvId: ReturnType<typeof vi.fn> };
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(NOW);
+    clearAllEnvConnectionsForTesting();
+    row = { envId: ENV, enrollmentId: 'enr_a', serverKeyId: currentId, revokedAt: null };
+    store = { findLocalByEnvId: vi.fn(async () => row) };
+    vi.mocked(getDriveEnvStore).mockResolvedValue(store as never);
+    vi.mocked(loadServerSigningKeyring).mockReturnValue(ring);
+  });
+  afterEach(() => vi.useRealTimers());
+
+  function liveSocket(serverKeyId: string | null = currentId, authorized = true): FakeSocket {
+    const ws = socket();
+    registerEnvConnection(ENV, ws, { userId: 'u', sessionId: 's', enrollmentId: 'enr_a', machinePublicKey: 'pk', serverKeyId, sessionExpiresAt: new Date(NOW.getTime() + 3600_000) });
+    if (authorized) markEnvAuthorized(ws);
+    return ws;
+  }
+
+  it('given an authorized socket, should send a revoke frame carrying approvalId that the daemon verifies under the approval domain, and NOT close the socket or stamp the row', async () => {
+    const ws = liveSocket();
+    expect(await revokeLocalEnvApproval({ envId: ENV, approvalId: 'ch_1', reason: 'owner' })).toEqual({ ok: true, machine: 'sent' });
+    const decoded = decodeFrame(ws.sent[0]!, { maxFrameBytes: 65536 });
+    if (!decoded.ok || decoded.frame.type !== 'revoke') throw new Error('no revoke frame');
+    expect(decoded.frame.approvalId).toBe('ch_1');
+    const binding = { envId: ENV, enrollmentId: 'enr_a', keyId: currentId, issuedAt: NOW.getTime(), serverPublicKey: ring.get(currentId)!.publicKey, verify: ed25519Verify };
+    expect(verifyRevoke({ frame: decoded.frame, ...binding })).toEqual({ ok: true });
+    // Stripping the id does NOT yield a valid enrollment revoke; another id does not verify either.
+    const { approvalId: _dropped, ...stripped } = decoded.frame;
+    expect(verifyRevoke({ frame: stripped as typeof decoded.frame, ...binding })).toEqual({ ok: false, reason: 'bad_signature' });
+    expect(verifyRevoke({ frame: { ...decoded.frame, approvalId: 'ch_2' }, ...binding })).toEqual({ ok: false, reason: 'bad_signature' });
+    expect(ws.close).not.toHaveBeenCalled();
+    expect(getEnvConnection(ENV)).toBe(ws);
+  });
+
+  it('given no live socket, should say so (no_live_socket) rather than claim a revoke the machine never received', async () => {
+    expect(await revokeLocalEnvApproval({ envId: ENV, approvalId: 'ch_1', reason: 'owner' })).toEqual({ ok: true, machine: 'no_live_socket' });
+  });
+
+  it('given an unauthorized socket, should send NOTHING to it', async () => {
+    const ws = liveSocket(currentId, false);
+    expect(await revokeLocalEnvApproval({ envId: ENV, approvalId: 'ch_1', reason: 'owner' })).toEqual({ ok: true, machine: 'unauthorized_socket' });
+    expect(ws.sent).toHaveLength(0);
+  });
+
+  it('given the pinned key (the ROW\'s serverKeyId) is not loaded, should not sign under another key', async () => {
+    row = { envId: ENV, enrollmentId: 'enr_a', serverKeyId: 'gone-key', revokedAt: null };
+    const ws = liveSocket('gone-key');
+    expect(await revokeLocalEnvApproval({ envId: ENV, approvalId: 'ch_1', reason: 'owner' })).toEqual({ ok: true, machine: 'signing_key_unavailable' });
+    expect(ws.sent).toHaveLength(0);
+  });
+
+  it('given a missing or revoked env, should answer the typed refusal', async () => {
+    row = null;
+    expect(await revokeLocalEnvApproval({ envId: ENV, approvalId: 'ch_1', reason: 'owner' })).toEqual({ ok: false, reason: 'not_found' });
+    row = { envId: ENV, enrollmentId: 'enr_a', serverKeyId: currentId, revokedAt: NOW };
+    expect(await revokeLocalEnvApproval({ envId: ENV, approvalId: 'ch_1', reason: 'owner' })).toEqual({ ok: false, reason: 'revoked' });
   });
 });

--- a/apps/web/src/lib/env-bridge/bridge-client.ts
+++ b/apps/web/src/lib/env-bridge/bridge-client.ts
@@ -17,7 +17,7 @@ import type { ApprovalIntent, GrantPrincipal } from '@pagespace/lib/env-bridge/g
 import { grantRequestForFrame, type GrantFrame, type UnsignedGrantFrame } from '@pagespace/lib/env-bridge/grant-args';
 import { decideSign, type SignDenyReason } from '@pagespace/lib/env-bridge/decide-sign';
 import { parseServerPolicy } from '@pagespace/lib/env-bridge/policy-types';
-import type { MachineResultFrame } from '@pagespace/lib/env-bridge/machine-signatures';
+import { approvalRevokeBindingId, machineResultBindingId, type MachineResultFrame, type RevokeFrame } from '@pagespace/lib/env-bridge/machine-signatures';
 import type { ServerSigningKeyring } from '@pagespace/lib/env-bridge/server-signing-key';
 import { logger } from '@pagespace/lib/logging/logger-config';
 import { loadServerSigningKeyring } from '@pagespace/lib/auth/env-bridge-signing-key';
@@ -178,30 +178,59 @@ export class EnvBridgeClient {
    * request with `unverified_result` — the agent never sees its contents.
    */
   handleMachineResult(ws: WebSocket, frame: MachineResultFrame): MachineResultDisposition {
+    // The grant a result answers — or, for an approval-revoke ack, the namespaced approval id.
+    const grantId = machineResultBindingId(frame);
     const facts = this.deps.getSocketFacts(ws);
     if (!facts) {
-      log().warn('Result frame from an unregistered socket dropped', { grantId: frame.grantId, frameType: frame.type, action: 'result_dropped' });
+      log().warn('Result frame from an unregistered socket dropped', { grantId, frameType: frame.type, action: 'result_dropped' });
       return 'dropped_unregistered_socket';
     }
-    const owner = this.deps.correlator.groupOf(frame.grantId);
+    const owner = this.deps.correlator.groupOf(grantId);
     if (owner === undefined) {
-      log().warn('Result frame for an unknown grant dropped', { envId: facts.envId, grantId: frame.grantId, frameType: frame.type, action: 'result_dropped' });
+      log().warn('Result frame for an unknown grant dropped', { envId: facts.envId, grantId, frameType: frame.type, action: 'result_dropped' });
       return 'dropped_unknown_grant';
     }
     if (owner !== facts.envId) {
-      log().error('Result frame from an env that does not own the grant refused — request stays pending for its owner', { envId: facts.envId, ownerEnvId: owner, grantId: frame.grantId, frameType: frame.type, action: 'result_wrong_env' });
-      this.deps.onUnverified?.({ envId: facts.envId, grantId: frame.grantId, frameType: frame.type, reason: 'wrong_env' });
+      log().error('Result frame from an env that does not own the grant refused — request stays pending for its owner', { envId: facts.envId, ownerEnvId: owner, grantId, frameType: frame.type, action: 'result_wrong_env' });
+      this.deps.onUnverified?.({ envId: facts.envId, grantId, frameType: frame.type, reason: 'wrong_env' });
       return 'dropped_wrong_env';
     }
     const verified = verifyResultFromMachine({ frame, machinePublicKey: facts.machinePublicKey });
     if (!verified.ok) {
-      log().error('Result frame failed machine-signature verification — NOT delivered', { envId: facts.envId, grantId: frame.grantId, frameType: frame.type, reason: verified.reason, action: 'result_unverified' });
-      this.deps.onUnverified?.({ envId: facts.envId, grantId: frame.grantId, frameType: frame.type, reason: verified.reason });
-      this.deps.correlator.reject(frame.grantId, new EnvBridgeError('unverified_result', `Result for grant ${frame.grantId} failed machine-signature verification (${verified.reason})`, { envId: facts.envId, grantId: frame.grantId, reason: verified.reason }));
+      log().error('Result frame failed machine-signature verification — NOT delivered', { envId: facts.envId, grantId, frameType: frame.type, reason: verified.reason, action: 'result_unverified' });
+      this.deps.onUnverified?.({ envId: facts.envId, grantId, frameType: frame.type, reason: verified.reason });
+      // A forged ACK is ignored, not fatal: the revoke stays pending for the genuine ack until its deadline (Codex P2 on #2583).
+      if (frame.type !== 'approval_revoke_result') {
+        this.deps.correlator.reject(grantId, new EnvBridgeError('unverified_result', `Result for grant ${grantId} failed machine-signature verification (${verified.reason})`, { envId: facts.envId, grantId, reason: verified.reason }));
+      }
       return 'unverified';
     }
-    this.deps.correlator.resolve(frame.grantId, frame);
+    this.deps.correlator.resolve(grantId, frame);
     return 'delivered';
+  }
+
+  /**
+   * Send a signed approval revoke over `ws` and await the machine's SIGNED ack
+   * (`approval_revoke_result`, correlated on the namespaced approval id) with
+   * a bounded deadline. Resolves with the verified ack; rejects with a typed
+   * `timeout` / `disconnected` when no genuine ack arrives — the caller must
+   * report that as unacknowledged, never as a revoke it cannot prove.
+   */
+  async awaitApprovalRevokeAck(input: { envId: string; approvalId: string; ws: WebSocket; frame: RevokeFrame; timeoutMs: number }): Promise<Extract<MachineResultFrame, { type: 'approval_revoke_result' }>> {
+    let reply: MachineResultFrame;
+    try {
+      reply = await this.deps.correlator.open({
+        id: approvalRevokeBindingId(input.approvalId),
+        group: input.envId,
+        timeoutMs: input.timeoutMs,
+        send: () => input.ws.send(encodeFrame(input.frame)),
+      });
+    } catch (error) {
+      if (error instanceof CorrelationError) throw new EnvBridgeError(error.kind, error.message, { ...error.detail, envId: input.envId, approvalId: input.approvalId });
+      throw error;
+    }
+    if (reply.type !== 'approval_revoke_result') throw new EnvBridgeError('unverified_result', `Expected an approval_revoke_result for ${input.approvalId}, got ${reply.type}`, { envId: input.envId, approvalId: input.approvalId });
+    return reply;
   }
 
   /** The env's live socket is gone: fail its in-flight requests with a typed `disconnected`. */

--- a/apps/web/src/lib/env-bridge/bridge-client.ts
+++ b/apps/web/src/lib/env-bridge/bridge-client.ts
@@ -13,7 +13,7 @@
  */
 import type { WebSocket } from 'ws';
 import { encodeFrame } from '@pagespace/lib/env-bridge/frame-codec';
-import type { GrantPrincipal } from '@pagespace/lib/env-bridge/grant';
+import type { ApprovalIntent, GrantPrincipal } from '@pagespace/lib/env-bridge/grant';
 import { grantRequestForFrame, type GrantFrame, type UnsignedGrantFrame } from '@pagespace/lib/env-bridge/grant-args';
 import { decideSign, type SignDenyReason } from '@pagespace/lib/env-bridge/decide-sign';
 import { parseServerPolicy } from '@pagespace/lib/env-bridge/policy-types';
@@ -27,6 +27,10 @@ import { getAuthorizedEnvConnection, getEnvConnectionMetadata, onEnvConnectionLo
 import { RequestCorrelator, CorrelationError, grantCorrelatorTimeoutMs, type CorrelationFailureKind } from './correlator';
 import { signGrantFrame, type GrantIdSource } from './grant-signer';
 import { verifyResultFromMachine } from './result-verifier';
+import { getPendingApprovalStore, type PendingApprovalStore } from './pending-approvals';
+
+/** The reason prefix a daemon answers with while a request waits for its owner's click. */
+export const ASK_PENDING_PREFIX = 'ask_pending:';
 
 export type EnvBridgeFailureKind = CorrelationFailureKind | 'not_connected' | 'signing_key_unavailable' | 'ttl_too_long' | 'server_denied';
 
@@ -68,6 +72,8 @@ export interface EnvBridgeClientDeps {
   readonly ids: GrantIdSource;
   /** Observability hook for a result that failed verification (audit/log). */
   readonly onUnverified?: (info: { envId: string; grantId: string; frameType: MachineResultFrame['type']; reason: string }) => void;
+  /** Where a daemon's `ask_pending` answer is remembered for the owner's click (GA wave 2). Omitted = the process-wide store. */
+  readonly pendingApprovals?: PendingApprovalStore;
 }
 
 export type MachineResultDisposition = 'delivered' | 'unverified' | 'dropped_unknown_grant' | 'dropped_unregistered_socket' | 'dropped_wrong_env';
@@ -93,7 +99,7 @@ export class EnvBridgeClient {
    * chokepoint because the grant IS the capability — refusing to mint beats
    * asking a daemon we do not control to refuse what we minted.
    */
-  async sendGrant(input: { envId: string; frame: UnsignedGrantFrame; principal: GrantPrincipal }): Promise<MachineResultFrame> {
+  async sendGrant(input: { envId: string; frame: UnsignedGrantFrame; principal: GrantPrincipal; approvalIntent?: ApprovalIntent }): Promise<MachineResultFrame> {
     // The op is the same projection the signer and the daemon's gate use on
     // the frame as sent (grant/sig are envelope, so placeholders change nothing).
     const op = grantRequestForFrame({ ...input.frame, grant: {}, sig: '' } as GrantFrame).op;
@@ -125,18 +131,33 @@ export class EnvBridgeClient {
       keyring: this.deps.keyring(),
       now: this.deps.now(),
       ids: this.deps.ids,
+      ...(input.approvalIntent !== undefined && { approvalIntent: input.approvalIntent }),
     });
     if (!signed.ok) throw new EnvBridgeError(signed.reason, `Cannot sign grant for ${input.envId}: ${signed.reason}`, { envId: input.envId, serverKeyId: facts.serverKeyId });
 
     const timeoutMs = grantCorrelatorTimeoutMs(signed.frame);
     log().info('Sending grant to local environment', { envId: input.envId, grantId: signed.grant.grantId, op: signed.grant.op, keyId: signed.keyId, timeoutMs, action: 'send_grant' });
     try {
-      return await this.deps.correlator.open({
+      const result = await this.deps.correlator.open({
         id: signed.grant.grantId,
         group: input.envId,
         timeoutMs,
         send: () => ws.send(encodeFrame(signed.frame)),
       });
+      // The machine froze the request for its owner's click (GA wave 2):
+      // remember what re-issuing it needs, under the id the machine chose,
+      // for as long as the machine itself will hold it (the grant's exp).
+      // Only a VERIFIED reply reaches here, so `pending` is what the machine
+      // signed. A reply whose id and reason disagree is not remembered.
+      if (result.type === 'grant_denied' && result.reason.startsWith(ASK_PENDING_PREFIX) && result.pending !== undefined) {
+        const challengeId = result.reason.slice(ASK_PENDING_PREFIX.length);
+        if (challengeId.length > 0 && challengeId === result.pending.challengeId) {
+          const store = this.deps.pendingApprovals ?? getPendingApprovalStore();
+          const remembered = store.remember({ challengeId, envId: input.envId, frame: input.frame, principal: signed.grant.principal, expiresAt: signed.grant.exp, pending: result.pending, createdAt: this.deps.now() }, this.deps.now());
+          log().info('Local environment is waiting for its owner\'s approval', { envId: input.envId, grantId: signed.grant.grantId, challengeId, remembered, action: 'approval_pending' });
+        }
+      }
+      return result;
     } catch (error) {
       if (error instanceof CorrelationError) throw new EnvBridgeError(error.kind, error.message, { ...error.detail, envId: input.envId });
       throw error;

--- a/apps/web/src/lib/env-bridge/grant-signer.ts
+++ b/apps/web/src/lib/env-bridge/grant-signer.ts
@@ -20,7 +20,7 @@
  * Pure apart from the injected id source: the byte layout comes from
  * `encodeGrant` (never re-implemented here), the clock is a parameter.
  */
-import { canonicalizeArgs, encodeGrant, GRANT_MAX_TTL_MS, type Grant, type GrantPrincipal, type HashBytes } from '@pagespace/lib/env-bridge/grant';
+import { canonicalizeArgs, encodeGrant, GRANT_MAX_TTL_MS, type ApprovalIntent, type Grant, type GrantPrincipal, type HashBytes } from '@pagespace/lib/env-bridge/grant';
 import { grantRequestForFrame, type GrantFrame, type UnsignedGrantFrame } from '@pagespace/lib/env-bridge/grant-args';
 import type { ServerSigningKeyring } from '@pagespace/lib/env-bridge/server-signing-key';
 import { envBridgeHash } from './crypto';
@@ -44,6 +44,13 @@ export interface SignGrantFrameInput {
   readonly ids: GrantIdSource;
   /** Defaults to the bridge's SHA-256; injectable for tests that pair the signer with a differently-hashing gate. */
   readonly hash?: HashBytes;
+  /**
+   * The owner's click (GA wave 2): signed INTO the grant under the same pinned
+   * key, so the daemon verifies it with the key it already holds and it can
+   * neither be forged nor moved onto another grant. Present only on the grant
+   * a click re-issues.
+   */
+  readonly approvalIntent?: ApprovalIntent;
 }
 
 export type SignGrantFrameResult =
@@ -78,6 +85,9 @@ export function signGrantFrame(input: SignGrantFrameInput): SignGrantFrameResult
     iat: input.now,
     exp: input.now + ttlMs,
     nonce: input.ids.nonce(),
+    ...(input.approvalIntent !== undefined && {
+      approvalIntent: { challengeId: input.approvalIntent.challengeId, scope: input.approvalIntent.scope, expiresAt: input.approvalIntent.expiresAt },
+    }),
   };
   const sig = Buffer.from(key.sign(encodeGrant(grant))).toString('base64');
 
@@ -92,6 +102,7 @@ export function signGrantFrame(input: SignGrantFrameInput): SignGrantFrameResult
     iat: grant.iat,
     exp: grant.exp,
     nonce: grant.nonce,
+    ...(grant.approvalIntent !== undefined && { approvalIntent: { ...grant.approvalIntent } }),
   };
   return { ok: true, frame: { ...input.frame, grant: wireGrant, sig } as GrantFrame, grant, keyId: key.keyId };
 }

--- a/apps/web/src/lib/env-bridge/pending-approvals.ts
+++ b/apps/web/src/lib/env-bridge/pending-approvals.ts
@@ -1,0 +1,88 @@
+/**
+ * Pending chat approvals, server side (GA wave 2, leaves 5–6).
+ *
+ * When a daemon answers a grant with `grant_denied ask_pending:<challengeId>`
+ * it has FROZEN the request on the machine and is waiting for the owner's
+ * click. The server remembers, under that id, what it would need to re-issue
+ * the identical request when the click comes: the unsigned frame exactly as
+ * it was sent, the principal it was sent for, the env, and the frozen request
+ * the machine signed (for the card). Nothing here is an authorization: the
+ * click is checked against `drive_env_local.ownerId` by the route, signed as
+ * an `approvalIntent` on a fresh grant, and byte-compared by the MACHINE
+ * against what IT froze. This map only lets the server ask the same question
+ * again with the owner's answer attached.
+ *
+ * Bounded and TTL'd like the daemon's own challenge store: the TTL is the
+ * grant's `exp` (the frozen request dies with it on the machine, so nothing
+ * older could ever be honoured), eviction is synchronous on every access, and
+ * a full map refuses to remember rather than evicting a live question.
+ */
+import type { GrantPrincipal } from '@pagespace/lib/env-bridge/grant';
+import type { UnsignedGrantFrame } from '@pagespace/lib/env-bridge/grant-args';
+import type { PendingApproval } from '@pagespace/lib/env-bridge/frame-codec';
+
+export const MAX_PENDING_APPROVALS = 1024;
+
+export interface PendingEnvApproval {
+  readonly challengeId: string;
+  readonly envId: string;
+  /** The frame exactly as the server sent it; the click re-issues THIS. */
+  readonly frame: UnsignedGrantFrame;
+  /** The principal the request was made for; the click re-issues under the same one. */
+  readonly principal: GrantPrincipal;
+  /** The grant's exp — the machine's own TTL for the frozen request. */
+  readonly expiresAt: number;
+  /** The frozen request as the MACHINE signed it — what the card renders. */
+  readonly pending: PendingApproval;
+  readonly createdAt: number;
+}
+
+export interface PendingApprovalStore {
+  remember(entry: PendingEnvApproval, now: number): boolean;
+  get(challengeId: string, now: number): PendingEnvApproval | undefined;
+  /** Consume: the click (or the deny) answers the question once. */
+  take(challengeId: string, now: number): PendingEnvApproval | undefined;
+  evictExpired(now: number): void;
+  size(): number;
+}
+
+export function createPendingApprovalStore(max = MAX_PENDING_APPROVALS): PendingApprovalStore {
+  const byId = new Map<string, PendingEnvApproval>();
+  const evictExpired = (now: number) => {
+    for (const [id, entry] of byId) if (entry.expiresAt < now) byId.delete(id);
+  };
+  return {
+    remember(entry, now) {
+      evictExpired(now);
+      if (entry.expiresAt < now) return false;
+      if (byId.has(entry.challengeId)) return true;
+      if (byId.size >= max) return false;
+      byId.set(entry.challengeId, entry);
+      return true;
+    },
+    get(id, now) {
+      evictExpired(now);
+      return byId.get(id);
+    },
+    take(id, now) {
+      evictExpired(now);
+      const entry = byId.get(id);
+      if (entry !== undefined) byId.delete(id);
+      return entry;
+    },
+    evictExpired,
+    size: () => byId.size,
+  };
+}
+
+let singleton: PendingApprovalStore | null = null;
+
+/** The process-wide store the bridge client writes and the approvals route reads. */
+export function getPendingApprovalStore(): PendingApprovalStore {
+  singleton ??= createPendingApprovalStore();
+  return singleton;
+}
+
+export function resetPendingApprovalStoreForTesting(): void {
+  singleton = null;
+}

--- a/apps/web/src/lib/env-bridge/revoke.ts
+++ b/apps/web/src/lib/env-bridge/revoke.ts
@@ -21,7 +21,7 @@
  */
 import type { WebSocket } from 'ws';
 import { encodeFrame } from '@pagespace/lib/env-bridge/frame-codec';
-import { encodeRevokeForSigning, type RevokeFrame } from '@pagespace/lib/env-bridge/machine-signatures';
+import { encodeApprovalRevokeForSigning, encodeRevokeForSigning, type RevokeFrame } from '@pagespace/lib/env-bridge/machine-signatures';
 import type { ServerSigningKeyring } from '@pagespace/lib/env-bridge/server-signing-key';
 import { loadServerSigningKeyring } from '@pagespace/lib/auth/env-bridge-signing-key';
 import { sessionService } from '@pagespace/lib/auth/session-service';
@@ -129,4 +129,78 @@ export async function revokeLocalEnv(input: { envId: string; reason: string }): 
         }),
     },
   });
+}
+
+// ---- revoking ONE approval (GA wave 2, leaf 8) ---------------------------------
+
+export interface ApprovalRevokeFrameInput extends RevokeFrameInput {
+  /** The durable approval to delete on the machine — the challenge id the click was answered under. */
+  approvalId: string;
+}
+
+/**
+ * The signed frame that deletes ONE approval on the machine: signed under the
+ * approval-revoke domain over `{envId, enrollmentId, keyId, issuedAt,
+ * approvalId}` by the key this enrollment pinned. The daemon deletes exactly
+ * that entry and stays connected; nothing on this path touches the key. This
+ * is the ONLY thing the server can do to an approval — it can never add one:
+ * the machine file is authoritative for allow.
+ */
+export function buildApprovalRevokeFrame(input: ApprovalRevokeFrameInput, keyring: Pick<ServerSigningKeyring, 'get'>): { ok: true; frame: RevokeFrame; keyId: string } | { ok: false; reason: 'signing_key_unavailable' } {
+  const key = input.serverKeyId === null ? null : keyring.get(input.serverKeyId);
+  if (!key) return { ok: false, reason: 'signing_key_unavailable' };
+  const sig = Buffer.from(key.sign(encodeApprovalRevokeForSigning({ envId: input.envId, enrollmentId: input.enrollmentId, keyId: key.keyId, issuedAt: input.issuedAt, approvalId: input.approvalId }))).toString('base64');
+  return { ok: true, frame: { type: 'revoke', sig, issuedAt: input.issuedAt, reason: input.reason, approvalId: input.approvalId }, keyId: key.keyId };
+}
+
+export type ApprovalRevokeOutcome = 'sent' | 'no_live_socket' | 'unauthorized_socket' | 'signing_key_unavailable' | 'send_failed';
+
+/**
+ * Push a signed approval revoke over the env's live, AUTHORIZED socket on this
+ * replica. The socket stays open. Honest about reach: without a live socket the
+ * machine still holds the approval — the caller must say so, not claim a
+ * revoke it could not deliver (a queued retry is a follow-up; see the PR).
+ */
+export function notifyMachineOfApprovalRevoke(input: ApprovalRevokeFrameInput, deps: Pick<NotifyMachineDeps, 'getConnection' | 'isAuthorized' | 'keyring'>): ApprovalRevokeOutcome {
+  const ws = deps.getConnection(input.envId);
+  if (!ws || (ws.readyState !== 0 && ws.readyState !== 1)) return 'no_live_socket';
+  if (!deps.isAuthorized(ws)) return 'unauthorized_socket';
+  const built = buildApprovalRevokeFrame(input, deps.keyring());
+  if (!built.ok) {
+    log().error('Enrollment pinned a signing key that is no longer loaded; approval revoke not sent', { envId: input.envId, approvalId: input.approvalId, serverKeyId: input.serverKeyId, action: 'approval_revoke_key_unavailable' });
+    return 'signing_key_unavailable';
+  }
+  try {
+    ws.send(encodeFrame(built.frame));
+    return 'sent';
+  } catch (error) {
+    log().warn('Approval revoke frame send failed', { envId: input.envId, approvalId: input.approvalId, error: error instanceof Error ? error.message : String(error), action: 'approval_revoke_send_failed' });
+    return 'send_failed';
+  }
+}
+
+export type RevokeLocalEnvApprovalResult = { ok: true; machine: ApprovalRevokeOutcome } | { ok: false; reason: 'not_found' | 'revoked' };
+
+/** Revoke ONE approval on a local env's machine through the production seams. */
+export async function revokeLocalEnvApproval(input: { envId: string; approvalId: string; reason: string }): Promise<RevokeLocalEnvApprovalResult> {
+  const store = await getDriveEnvStore();
+  const row = await store.findLocalByEnvId(input.envId);
+  if (!row) return { ok: false, reason: 'not_found' };
+  if (row.revokedAt !== null) return { ok: false, reason: 'revoked' };
+  const machine = notifyMachineOfApprovalRevoke(
+    { envId: input.envId, enrollmentId: row.enrollmentId, serverKeyId: row.serverKeyId, issuedAt: Date.now(), reason: input.reason, approvalId: input.approvalId },
+    {
+      getConnection: getEnvConnection,
+      isAuthorized: isEnvAuthorized,
+      keyring: () => {
+        try {
+          return loadKeyring();
+        } catch (error) {
+          log().error('Signing key ring unavailable during approval revoke', { envId: input.envId, error: error instanceof Error ? error.message : String(error), action: 'approval_revoke_keyring_error' });
+          return { get: () => null };
+        }
+      },
+    },
+  );
+  return { ok: true, machine };
 }

--- a/apps/web/src/lib/env-bridge/revoke.ts
+++ b/apps/web/src/lib/env-bridge/revoke.ts
@@ -28,6 +28,7 @@ import { sessionService } from '@pagespace/lib/auth/session-service';
 import { revokeLocalDriveEnv, type RevokeLocalDriveEnvResult, type RevokeMachineNotifyOutcome } from '@pagespace/lib/services/drive-envs/local-env-revoke';
 import { logger } from '@pagespace/lib/logging/logger-config';
 import { getEnvConnection, isEnvAuthorized, unregisterEnvConnection } from '@/lib/websocket/ws-env-connections';
+import { EnvBridgeError, getEnvBridgeClient } from '@/lib/env-bridge/bridge-client';
 import { getDriveEnvStore } from '@/lib/drive-envs/drive-envs-runtime';
 
 export const ENV_REVOKED_CLOSE_CODE = 1008;
@@ -153,29 +154,50 @@ export function buildApprovalRevokeFrame(input: ApprovalRevokeFrameInput, keyrin
   return { ok: true, frame: { type: 'revoke', sig, issuedAt: input.issuedAt, reason: input.reason, approvalId: input.approvalId }, keyId: key.keyId };
 }
 
-export type ApprovalRevokeOutcome = 'sent' | 'no_live_socket' | 'unauthorized_socket' | 'signing_key_unavailable' | 'send_failed';
+export type ApprovalRevokeOutcome =
+  /** The machine's SIGNED ack arrived: it deleted `removed` rows. The only outcome that proves a revoke. */
+  | { kind: 'acknowledged'; removed: number }
+  /** Sent, but no genuine ack within the deadline (or the socket dropped, or only a forged ack arrived): the machine may still hold it. */
+  | { kind: 'unacknowledged'; reason: string }
+  | { kind: 'no_live_socket' }
+  | { kind: 'unauthorized_socket' }
+  | { kind: 'signing_key_unavailable' }
+  | { kind: 'send_failed' };
+
+/** How long the server waits for the machine's ack before reporting `unacknowledged`. */
+export const APPROVAL_REVOKE_ACK_TIMEOUT_MS = 5_000;
+
+export interface ApprovalRevokeNotifyDeps extends Pick<NotifyMachineDeps, 'getConnection' | 'isAuthorized' | 'keyring'> {
+  /** Send the frame and await the machine's verified ack (production: `EnvBridgeClient.awaitApprovalRevokeAck`). */
+  awaitAck: (input: { envId: string; approvalId: string; ws: WebSocket; frame: RevokeFrame; timeoutMs: number }) => Promise<{ removed: number }>;
+  timeoutMs?: number;
+}
 
 /**
  * Push a signed approval revoke over the env's live, AUTHORIZED socket on this
- * replica. The socket stays open. Honest about reach: without a live socket the
- * machine still holds the approval — the caller must say so, not claim a
- * revoke it could not deliver (a queued retry is a follow-up; see the PR).
+ * replica and wait for the machine's SIGNED acknowledgement (Codex P2 on
+ * #2583). The socket stays open. Honest about reach: without a live socket,
+ * or without a genuine ack before the deadline, the machine may still hold
+ * the approval — the caller says so, never claiming a revoke it cannot prove.
+ * (Wave 3 mirrors approvals server-side and replays unacknowledged revokes on
+ * reconnect; this ack is what it keys on.)
  */
-export function notifyMachineOfApprovalRevoke(input: ApprovalRevokeFrameInput, deps: Pick<NotifyMachineDeps, 'getConnection' | 'isAuthorized' | 'keyring'>): ApprovalRevokeOutcome {
+export async function notifyMachineOfApprovalRevoke(input: ApprovalRevokeFrameInput, deps: ApprovalRevokeNotifyDeps): Promise<ApprovalRevokeOutcome> {
   const ws = deps.getConnection(input.envId);
-  if (!ws || (ws.readyState !== 0 && ws.readyState !== 1)) return 'no_live_socket';
-  if (!deps.isAuthorized(ws)) return 'unauthorized_socket';
+  if (!ws || (ws.readyState !== 0 && ws.readyState !== 1)) return { kind: 'no_live_socket' };
+  if (!deps.isAuthorized(ws)) return { kind: 'unauthorized_socket' };
   const built = buildApprovalRevokeFrame(input, deps.keyring());
   if (!built.ok) {
     log().error('Enrollment pinned a signing key that is no longer loaded; approval revoke not sent', { envId: input.envId, approvalId: input.approvalId, serverKeyId: input.serverKeyId, action: 'approval_revoke_key_unavailable' });
-    return 'signing_key_unavailable';
+    return { kind: 'signing_key_unavailable' };
   }
   try {
-    ws.send(encodeFrame(built.frame));
-    return 'sent';
+    const ack = await deps.awaitAck({ envId: input.envId, approvalId: input.approvalId, ws, frame: built.frame, timeoutMs: deps.timeoutMs ?? APPROVAL_REVOKE_ACK_TIMEOUT_MS });
+    return { kind: 'acknowledged', removed: ack.removed };
   } catch (error) {
-    log().warn('Approval revoke frame send failed', { envId: input.envId, approvalId: input.approvalId, error: error instanceof Error ? error.message : String(error), action: 'approval_revoke_send_failed' });
-    return 'send_failed';
+    const reason = error instanceof EnvBridgeError ? error.kind : error instanceof Error ? error.message : String(error);
+    log().warn('Approval revoke not acknowledged by the machine', { envId: input.envId, approvalId: input.approvalId, reason, action: 'approval_revoke_unacknowledged' });
+    return { kind: 'unacknowledged', reason };
   }
 }
 
@@ -187,11 +209,12 @@ export async function revokeLocalEnvApproval(input: { envId: string; approvalId:
   const row = await store.findLocalByEnvId(input.envId);
   if (!row) return { ok: false, reason: 'not_found' };
   if (row.revokedAt !== null) return { ok: false, reason: 'revoked' };
-  const machine = notifyMachineOfApprovalRevoke(
+  const machine = await notifyMachineOfApprovalRevoke(
     { envId: input.envId, enrollmentId: row.enrollmentId, serverKeyId: row.serverKeyId, issuedAt: Date.now(), reason: input.reason, approvalId: input.approvalId },
     {
       getConnection: getEnvConnection,
       isAuthorized: isEnvAuthorized,
+      awaitAck: (ack) => getEnvBridgeClient().awaitApprovalRevokeAck(ack),
       keyring: () => {
         try {
           return loadKeyring();

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -6,6 +6,19 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Added
 
+- **PageSpace can revoke one remembered approval on your machine — and can never add one.** A
+  revoke of a single approval rides the existing signed `revoke` frame with an `approvalId`,
+  signed under its own domain by the key this machine pinned at enrolment, so it can never be
+  turned into an enrolment revoke (your key stays). The daemon deletes exactly that approval's
+  rows from `~/.pagespace/env-approvals.json` and stays connected. Nothing on the wire can write
+  an approval: the file on this machine is the only source of allow.
+- **Chat approvals.** A request the machine froze for your click arrives as a card in the
+  PageSpace chat; your Allow re-issues the identical request with a server-signed intent that
+  the daemon verifies with the key it already holds, byte-compares against what it froze, and
+  only then remembers (under the scope you picked) and runs. A click can only ever unblock a
+  request this machine framed itself; anything else is refused as `approval_mismatch`,
+  `approval_expired` or `approval_unknown` and written to the audit log with the grant id.
+
 - **`ask` mode works without a terminal: the question goes to the PageSpace chat.** A request that
   is not pre-approved and not covered by a remembered approval is frozen under a challenge and
   answered `ask_pending:<id>` together with the exact normalised request (signed by the machine),

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -16,8 +16,8 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   PageSpace chat; your Allow re-issues the identical request with a server-signed intent that
   the daemon verifies with the key it already holds, byte-compares against what it froze, and
   only then remembers (under the scope you picked) and runs. A click can only ever unblock a
-  request this machine framed itself; anything else is refused as `approval_mismatch`,
-  `approval_expired` or `approval_unknown` and written to the audit log with the grant id.
+  request this machine framed itself; anything else is refused as `approval_mismatch` or
+  `approval_expired` and written to the audit log with the grant id.
 
 - **`ask` mode works without a terminal: the question goes to the PageSpace chat.** A request that
   is not pre-approved and not covered by a remembered approval is frozen under a challenge and

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -6,6 +6,13 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Added
 
+- **`pagespace env enroll` pre-approves the file operations the environment allows — and never
+  `exec`.** The starter policy's `ops` is now the server policy's file operations (`fs_read`,
+  `fs_write`), so file work inside the root runs without asking from the start; `exec` is never
+  written into it, whatever the environment allows, so every command reaches the prompt and each
+  program needs your approval the first time. When a policy file already exists, `enroll` keeps
+  it and prints the diff of what it would have written.
+
 - **Approvals are remembered per program, with a scope you choose, in
   `~/.pagespace/env-approvals.json`.** An `ask`-mode approval used to live in the daemon's memory
   under (you, session, operation): a new chat asked again, and approving `git status` silently

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -6,6 +6,14 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Added
 
+- **`ask` mode works without a terminal: the question goes to the PageSpace chat.** A request that
+  is not pre-approved and not covered by a remembered approval is frozen under a challenge and
+  answered `ask_pending:<id>` together with the exact normalised request (signed by the machine),
+  so the chat can show precisely what would run. The challenge lives as long as the request's
+  grant (at most a minute), the daemon holds at most 64 at once, and a repeat of the same program
+  while one is pending reuses it. `PAGESPACE_ENV_ASK=chat` sends questions to the chat even when a
+  terminal is attached. `env connect` no longer refuses to start in `ask` mode without a TTY.
+
 - **`pagespace env enroll` pre-approves the file operations the environment allows — and never
   `exec`.** The starter policy's `ops` is now the server policy's file operations (`fs_read`,
   `fs_write`), so file work inside the root runs without asking from the start; `exec` is never

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -6,6 +6,17 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Added
 
+- **Approvals are remembered per program, with a scope you choose, in
+  `~/.pagespace/env-approvals.json`.** An `ask`-mode approval used to live in the daemon's memory
+  under (you, session, operation): a new chat asked again, and approving `git status` silently
+  covered every later `exec` in that session. It is now keyed on (environment, you, operation,
+  program) — for a shell command line, every program it names — for `once`, until the daemon
+  stops, `30 days` (the default) or `until revoked`. Approving `git status` covers `git push` from
+  a new chat tomorrow and never covers `rm`. A command line whose programs cannot be pinned down
+  (`$(…)`, `eval`, a nested `sh -c`, `find -exec`, `sudo`) is never remembered. The file follows the
+  policy file's trust rules (yours, not writable by others, read through one descriptor) and any
+  defect in it makes the daemon ask more, never less. `PAGESPACE_ENV_APPROVALS` overrides the path.
+
 - **`pagespace env enroll` writes a starter policy naming you as the only principal.** If
   `~/.pagespace/env-policy.json` (or `PAGESPACE_ENV_POLICY`) does not exist, enrolling creates it:
   `mode: ask`, no pre-approved operations, the directory you ran `enroll` in as the only root, and

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -241,7 +241,8 @@ second surprises people:
   line whose programs cannot be pinned down (`$(…)`, `eval`, a nested `sh -c`, `find -exec`,
   `sudo`) is never remembered and asks every time. Approvals live in
   `~/.pagespace/env-approvals.json` (yours, 0600; a file anybody else can write is ignored), and
-  PageSpace can revoke one but never add one.
+  PageSpace can revoke one (from the environment's settings, over a signed frame the daemon checks
+  against its pinned key) but never add one.
 
 The `roots` in your policy file confine the paths an agent can **name** — the working directory it
 asks for, and the files it asks to read or write. They do **not** confine what a program does once

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -291,7 +291,11 @@ know what actually ran.
   directory, paths, environment and limits — and which programs an approval would cover. Approving
   remembers those programs (for you, on this environment) for the scope you pick; later commands
   that run only remembered programs are never shown to you, others ask. Declining refuses that
-  request and asks again next time. `ask` needs a terminal: a headless machine cannot use it.
+  request and asks again next time. Without a terminal (or with `PAGESPACE_ENV_ASK=chat`), the
+  daemon does not deny: it freezes the exact request under a challenge and the question is put to
+  you **in the PageSpace chat**, on a card showing that exact command, directory, environment and
+  limits; the machine compares your click against what it froze before anything runs, and the
+  challenge dies with the request's one-minute grant.
 - **`allowlist`** — only the operations in `ops` run; everything else is denied with no prompt.
 
 **`allowlist` allowlists operations, not executables.** `ops` holds `exec`, `fs_read` and

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -367,12 +367,15 @@ or one that is unreadable, invalid, wrongly owned or writable by others, means e
 denied** (`no_policy`); the daemon still connects so you can see the Environment and fix the file.
 `pagespace env policy` prints what is in force, or why the file is being ignored.
 
-**`env enroll` writes a starter policy for you** if none exists: `mode: ask`, no pre-approved ops,
-the directory you ran `enroll` in as the only root, and — the part that matters — `principals`
+**`env enroll` writes a starter policy for you** if none exists: `mode: ask`, the **file**
+operations the environment's server policy allows (`fs_read`, `fs_write`) pre-approved so file
+work inside the root runs without asking — **never `exec`**, however the environment is
+configured: every command reaches the prompt, and each program needs your approval the first time
+— the directory you ran `enroll` in as the only root, and — the part that matters — `principals`
 set to **your user id and nobody else's**. A machine is driven by its owner only: PageSpace will
 only ever bind the environment owner's sessions to it, and this file makes the machine refuse
 everyone else on its own, even if the server were wrong. An existing policy is never overwritten;
-if it does not name you, `enroll` says so. Naming other users in `principals` is honoured (it is
+`enroll` prints the diff of what it would have written, and if the file does not name you it says so. Naming other users in `principals` is honoured (it is
 your file), but `env policy` and `env connect` warn about it, because each user listed there can
 run commands as you.
 

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -233,10 +233,15 @@ second surprises people:
   read any file you can read, change any file you can change, reach anything on your network that
   you can reach, and use any credential sitting in your home directory. There is no sandbox
   around it.
-- You see the **first** command of each kind, and approving it covers **every later command of
-  that kind for the rest of that session, unseen**. The approval is remembered per user, session
-  and operation — not per command — so after you approve one `exec`, the next `exec` from that
-  same user and session runs with no prompt at all, whatever it is.
+- Approving a command is remembered **per program, not per session**. The approval is keyed on
+  you, this environment, the operation, and the *program* that ran (`/usr/bin/git` — for a shell
+  command line, every program it names), for the time you choose: once, until the daemon stops,
+  30 days (the default), or until you revoke it. So approving `git status` lets `git push` run
+  from a new chat tomorrow with no prompt, and does **not** let `rm` run: `rm` asks. A command
+  line whose programs cannot be pinned down (`$(…)`, `eval`, a nested `sh -c`, `find -exec`,
+  `sudo`) is never remembered and asks every time. Approvals live in
+  `~/.pagespace/env-approvals.json` (yours, 0600; a file anybody else can write is ignored), and
+  PageSpace can revoke one but never add one.
 
 The `roots` in your policy file confine the paths an agent can **name** — the working directory it
 asks for, and the files it asks to read or write. They do **not** confine what a program does once
@@ -245,9 +250,9 @@ it has started. A command approved with a working directory inside a root can st
 daemon to open them. Actually confining a running process needs operating-system sandboxing,
 which this daemon does not do.
 
-So the question at the prompt is not "may this touch that folder". It is "may this, and everything
-like it for the rest of this session, run as me". Answer it the way you would answer a stranger
-asking for your shell for the afternoon. Two practical consequences:
+So the question at the prompt is not "may this touch that folder". It is "may this program, run
+with any arguments, from any of my chats, run as me for the time I pick". Answer it the way you
+would answer a stranger asking for your shell for the afternoon. Two practical consequences:
 
 - Run the daemon as an ordinary user, never as root, and prefer a machine — or a separate account —
   that does not hold secrets you would not hand to whoever is driving the agent.
@@ -270,21 +275,23 @@ What the daemon does guarantee is narrower than "safe", and worth knowing exactl
 One consequence of the two facts above, worth seeing once before you pick a mode: an agent that
 reads a file on this machine can be *steered* by what that file says — a README, a dependency's
 source, a downloaded document can all contain text aimed at the agent rather than at you. If the
-agent then runs a command, and you have already approved an `exec` in that session, **that command
-runs without a prompt**. This is inherent to agents reading content nobody vetted, not a defect in
-this daemon; the defences that apply here are the ordinary ones — keep `principals` short, keep
-`ops` narrow, stop the daemon when you are not using it, and read
-`~/.pagespace/env-audit.jsonl` when you want to know what actually ran.
+agent then runs a command whose program you have already approved, **that command runs without a
+prompt** — with whatever arguments the steered agent chose. This is inherent to agents reading
+content nobody vetted, not a defect in this daemon; the defences that apply here are the ordinary
+ones — approve programs, not shells or interpreters, when you can; pick the shortest scope that
+does the job; keep `principals` short and `ops` narrow; stop the daemon when you are not using it;
+revoke approvals you no longer need; and read `~/.pagespace/env-audit.jsonl` when you want to
+know what actually ran.
 
 ### The three modes, in practice
 
 - **`deny`** — nothing runs, ever. The daemon still connects, so the Environment shows as connected.
 - **`ask`** — the safe default to start with. An operation listed in `ops` runs without asking;
   anything else stops and prompts you in this terminal, showing the exact command, working
-  directory, paths, environment and limits. As above, approving covers further requests for that
-  same operation from the same user and session while the daemon runs — those later commands are
-  never shown to you — but not forever, and not for other people. Declining refuses that request
-  and asks again next time. `ask` needs a terminal: a headless machine cannot use it.
+  directory, paths, environment and limits — and which programs an approval would cover. Approving
+  remembers those programs (for you, on this environment) for the scope you pick; later commands
+  that run only remembered programs are never shown to you, others ask. Declining refuses that
+  request and asks again next time. `ask` needs a terminal: a headless machine cannot use it.
 - **`allowlist`** — only the operations in `ops` run; everything else is denied with no prompt.
 
 **`allowlist` allowlists operations, not executables.** `ops` holds `exec`, `fs_read` and

--- a/packages/cli/src/commands/__tests__/env-connect.test.ts
+++ b/packages/cli/src/commands/__tests__/env-connect.test.ts
@@ -3,11 +3,12 @@ import { EventEmitter } from 'node:events';
 import { createHash, generateKeyPairSync, sign as nodeSign } from 'node:crypto';
 import { encodeFrame, decodeFrame, type Frame } from '@pagespace/lib/env-bridge/frame-codec';
 import { encodeRevokeForSigning, verifyHello } from '@pagespace/lib/env-bridge/machine-signatures';
-import { decodeBase64 } from '@pagespace/lib/env-bridge/grant';
+import { canonicalizeArgs, decodeBase64, encodeGrant, type Grant } from '@pagespace/lib/env-bridge/grant';
+import { grantRequestForFrame, type GrantFrame } from '@pagespace/lib/env-bridge/grant-args';
 import { createEnvConnectHandler, PID_HEARTBEAT_MS, pidFilePath, type EnvConnectHandlerDeps, type PidRecord } from '../env/connect.js';
 import { bridgeSocketUrl } from '../../env-bridge/secure-host.js';
 import { generateMachineKeypair, signWithMachineKey } from '../../env-bridge/keypair.js';
-import { ed25519Verify } from '../../env-bridge/crypto.js';
+import { ed25519Verify, envBridgeHash } from '../../env-bridge/crypto.js';
 import type { BridgeSocket } from '../../env-bridge/ws-client.js';
 import type { ExecRunner } from '../../env-bridge/exec-runner.js';
 import { machineProfileName, type HostCredential, type MachineHostCredential } from '../../credentials/serialize.js';
@@ -109,6 +110,7 @@ function harness(overrides: Partial<EnvConnectHandlerDeps> & { policy?: string |
   const pidWrites: Array<{ path: string; record: PidRecord }> = [];
   const pidRemoves: string[] = [];
   const auditLines: string[] = [];
+  const approvalWrites: Array<{ path: string; content: string }> = [];
   const signals: Array<(signal: string) => void> = [];
   const exit = vi.fn<(code: number) => void>();
   const execRunner: ExecRunner & { killed: number } = { killed: 0, run: async () => ({ exitCode: 0, stdout: Buffer.alloc(0), stderr: Buffer.alloc(0), truncated: false, timedOut: false }), killAll() { this.killed += 1; }, liveCount: () => 0 };
@@ -123,7 +125,8 @@ function harness(overrides: Partial<EnvConnectHandlerDeps> & { policy?: string |
     pid: 4242,
     argv0: 'pagespace',
     platform: 'darwin',
-    openPolicy: () => {
+    openPolicy: (path) => {
+      if (path.endsWith('env-approvals.json')) return null;
       if (policyStat === null || policy === null) return null;
       return { uid: policyStat.uid, mode: policyStat.mode, content: policy };
     },
@@ -134,11 +137,13 @@ function harness(overrides: Partial<EnvConnectHandlerDeps> & { policy?: string |
     createFsRunner: () => ({ read: async () => ({ kind: 'read', found: false }), write: async () => ({ kind: 'write', ok: true }) }),
     createSocket: (url, headers) => { const s = new FakeSocket(url, headers); sockets.push(s); return s; },
     confirm: async () => false,
+    writeApprovals: async (path, content) => void approvalWrites.push({ path, content }),
+    approvalId: () => 'ap_test',
     onSignal: (handler) => void signals.push(handler),
     exit,
     ...rest,
   };
-  return { deps, store, sockets, pidWrites, pidRemoves, auditLines, signals, exit, execRunner, handler: createEnvConnectHandler(deps), socket: () => sockets[sockets.length - 1]! };
+  return { deps, store, sockets, pidWrites, pidRemoves, auditLines, approvalWrites, signals, exit, execRunner, handler: createEnvConnectHandler(deps), socket: () => sockets[sockets.length - 1]! };
 }
 
 const flush = () => vi.advanceTimersByTimeAsync(0);
@@ -184,6 +189,48 @@ describe('pagespace env connect <enrollmentId>', () => {
     expect(await h.handler(c.ctx, intent(['env', 'connect', 'enr_1']))).toBe(EXIT_RUNTIME_ERROR);
     expect(c.err.text()).toMatch(/"ask" needs an interactive terminal/);
     expect(h.sockets).toHaveLength(0);
+  });
+
+  it('GA wave 2 · leaf 1: at start the daemon names the approvals file and how many approvals are in force (none ⇒ 0)', async () => {
+    const h = harness();
+    const c = ctx(false);
+    await h.handler(c.ctx, intent(['env', 'connect', 'enr_1']));
+    expect(c.err.text()).toMatch(/Approvals \/home\/me\/\.pagespace\/env-approvals\.json: 0 in force/);
+  });
+
+  it('GA wave 2 · leaf 1: in ask mode, a durable approval in ~/.pagespace/env-approvals.json runs a covered command from a NEW session with NO terminal prompt; an uncovered one prompts', async () => {
+    const ASK = JSON.stringify({ mode: 'ask', principals: ['u1'], ops: [], roots: ['/home/me/proj'], envAllowlist: [] });
+    const APPROVALS = JSON.stringify({ version: 1, approvals: [{ approvalId: 'old', envId: 'env_1', userId: 'u1', op: 'exec', subject: 'exec:/usr/bin/true', scope: 'until_revoked', createdAt: 1, expiresAt: null }] });
+    const confirm = vi.fn(async () => false);
+    const runs: string[] = [];
+    const h = harness({
+      policy: ASK,
+      confirm,
+      openPolicy: (path) => ({ uid: UID, mode: 0o100600, content: path.endsWith('env-approvals.json') ? APPROVALS : ASK }),
+      createExecRunner: () => ({ run: async (request) => { runs.push(request.cmd ?? ''); return { exitCode: 0, stdout: Buffer.alloc(0), stderr: Buffer.alloc(0), truncated: false, timedOut: false }; }, killAll: () => undefined, liveCount: () => 0 }),
+    });
+    const c = ctx(true);
+    await h.handler(c.ctx, intent(['env', 'connect', 'enr_1']));
+    expect(c.err.text()).toMatch(/Approvals .*: 1 in force/);
+    await flush();
+    h.socket().open();
+    await flush();
+    h.socket().receive({ type: 'ping', ts: 1 }); // the ack
+    await flush();
+    const grantFor = (cmd: string, n: number) => {
+      const unsigned = { type: 'grant_exec' as const, cmd, args: [], cwd: '/home/me/proj', env: {} };
+      const request = grantRequestForFrame({ ...unsigned, grant: {}, sig: '' } as GrantFrame);
+      const grant: Grant = { grantId: `g${n}`, envId: 'env_1', principal: { userId: 'u1', sessionId: `brand-new-session-${n}`, conversationId: `new-chat-${n}` }, op: 'exec', argsHash: envBridgeHash(canonicalizeArgs(request.args)), iat: NOW - 1000, exp: NOW + 30_000, nonce: `n${n}` };
+      return { ...unsigned, grant: { ...grant, principal: { ...grant.principal } }, sig: Buffer.from(nodeSign(null, encodeGrant(grant), serverPair.privateKey)).toString('base64') } as unknown as Frame;
+    };
+    h.socket().receive(grantFor('/usr/bin/true', 1));
+    await flush();
+    expect(runs).toEqual(['/usr/bin/true']);
+    expect(confirm).not.toHaveBeenCalled();
+    h.socket().receive(grantFor('/usr/bin/false', 2));
+    await flush();
+    expect(confirm).toHaveBeenCalledTimes(1);
+    expect(runs).toEqual(['/usr/bin/true']);
   });
 
   it('R1: given NO policy file, should START anyway (deny-all), say why, write the pid file, mint a token and send a signed hello with an empty policy digest', async () => {

--- a/packages/cli/src/commands/__tests__/env-connect.test.ts
+++ b/packages/cli/src/commands/__tests__/env-connect.test.ts
@@ -139,6 +139,7 @@ function harness(overrides: Partial<EnvConnectHandlerDeps> & { policy?: string |
     confirm: async () => false,
     writeApprovals: async (path, content) => void approvalWrites.push({ path, content }),
     approvalId: () => 'ap_test',
+    challengeId: () => 'ch_test',
     onSignal: (handler) => void signals.push(handler),
     exit,
     ...rest,
@@ -183,12 +184,24 @@ describe('pagespace env connect <enrollmentId>', () => {
     expect(h.sockets).toHaveLength(0);
   });
 
-  it('R5: given policy mode "ask" without a TTY, should refuse to start with a clear message', async () => {
+  it('R5 (GA wave 2): given policy mode "ask" without a TTY, should START and say asks will wait for a click in the chat; a non-pre-approved grant is answered ask_pending:<id> with the frozen request, nothing runs', async () => {
     const h = harness({ policy: JSON.stringify({ mode: 'ask', principals: ['u1'], ops: [], roots: ['/home/me/proj'], envAllowlist: [] }) });
     const c = ctx(false);
-    expect(await h.handler(c.ctx, intent(['env', 'connect', 'enr_1']))).toBe(EXIT_RUNTIME_ERROR);
-    expect(c.err.text()).toMatch(/"ask" needs an interactive terminal/);
-    expect(h.sockets).toHaveLength(0);
+    expect(await h.handler(c.ctx, intent(['env', 'connect', 'enr_1']))).toBe(EXIT_SUCCESS);
+    expect(c.err.text()).toMatch(/wait for your click in the PageSpace chat/);
+    await flush();
+    h.socket().open();
+    await flush();
+    h.socket().receive({ type: 'ping', ts: 1 });
+    await flush();
+    const unsigned = { type: 'grant_exec' as const, cmd: '/usr/bin/true', args: [], cwd: '/home/me/proj', env: {} };
+    const request = grantRequestForFrame({ ...unsigned, grant: {}, sig: '' } as GrantFrame);
+    const grant: Grant = { grantId: 'g_chat', envId: 'env_1', principal: { userId: 'u1', sessionId: 's', conversationId: 'c' }, op: 'exec', argsHash: envBridgeHash(canonicalizeArgs(request.args)), iat: NOW - 1000, exp: NOW + 30_000, nonce: 'n_chat' };
+    h.socket().receive({ ...unsigned, grant: { ...grant, principal: { ...grant.principal } }, sig: Buffer.from(nodeSign(null, encodeGrant(grant), serverPair.privateKey)).toString('base64') } as unknown as Frame);
+    await flush();
+    const replies = h.socket().sent.map((raw) => decodeFrame(raw, { maxFrameBytes: 1 << 20 })).filter((d) => d.ok && d.frame.type === 'grant_denied');
+    expect(replies).toHaveLength(1);
+    expect((replies[0] as { frame: Extract<Frame, { type: 'grant_denied' }> }).frame).toMatchObject({ grantId: 'g_chat', reason: 'ask_pending:ch_test', pending: { challengeId: 'ch_test', expiresAt: NOW + 30_000, request: { cmd: '/usr/bin/true', cwd: '/home/me/proj' } } });
   });
 
   it('GA wave 2 · leaf 1: at start the daemon names the approvals file and how many approvals are in force (none ⇒ 0)', async () => {

--- a/packages/cli/src/commands/__tests__/env-enroll-policy.test.ts
+++ b/packages/cli/src/commands/__tests__/env-enroll-policy.test.ts
@@ -53,7 +53,7 @@ function memoryStore(): CredentialStore {
   };
 }
 
-const ENROLLED = { enrollmentId: 'enr_1', envId: 'env_1', serverKeyId: 'k1', serverPublicKey: 'U0VSVkVS', ownerId: OWNER };
+const ENROLLED = { enrollmentId: 'enr_1', envId: 'env_1', serverKeyId: 'k1', serverPublicKey: 'U0VSVkVS', ownerId: OWNER, serverPolicy: { ops: ['fs_read', 'fs_write'], checkpoint: false } };
 
 function deps(over: Partial<EnvEnrollHandlerDeps> & { existing?: OpenedPolicyFile | null; response?: Record<string, unknown> } = {}) {
   const { existing = null, response = ENROLLED, ...rest } = over;
@@ -84,7 +84,7 @@ describe('pagespace env enroll — scaffolds the policy with the OWNER as its on
     expect(d.writes).toHaveLength(1);
     expect(d.writes[0]!.path).toBe(`${HOME}/.pagespace/env-policy.json`);
     const policy = JSON.parse(d.writes[0]!.content) as Record<string, unknown>;
-    expect(policy).toEqual({ mode: 'ask', principals: [OWNER], ops: [], roots: [CWD], envAllowlist: [] });
+    expect(policy).toEqual({ mode: 'ask', principals: [OWNER], ops: ['fs_read', 'fs_write'], roots: [CWD], envAllowlist: [] });
     expect(c.out.text()).toContain(`${HOME}/.pagespace/env-policy.json`);
     expect(c.out.text()).toContain(OWNER);
   });
@@ -96,13 +96,71 @@ describe('pagespace env enroll — scaffolds the policy with the OWNER as its on
     expect(d.writes[0]!.path).toBe('/etc/ps/policy.json');
   });
 
-  it('given an EXISTING policy file, should never overwrite it — the owner\'s file is the owner\'s — and say it was kept', async () => {
-    const existing: OpenedPolicyFile = { uid: 501, mode: 0o100600, content: JSON.stringify({ mode: 'allowlist', principals: [OWNER], ops: ['fs_read'], roots: ['/srv'], envAllowlist: [] }) };
+  it('given an EXISTING policy file, should never overwrite it — the owner\'s file is the owner\'s — say it was kept, and print the diff of what it would have written', async () => {
+    const existing: OpenedPolicyFile = { uid: 501, mode: 0o100600, content: JSON.stringify({ mode: 'allowlist', principals: [OWNER], ops: ['fs_read'], roots: ['/srv'], envAllowlist: [] }, null, 2) + '\n' };
     const d = deps({ existing });
     const c = ctx();
     expect(await enroll(d, c)).toBe(EXIT_SUCCESS);
     expect(d.writes).toHaveLength(0);
     expect(c.out.text()).toMatch(/kept/i);
+    const out = c.out.text();
+    // Unified-style: lines only the existing file has are `-`, lines only the scaffold has are `+`.
+    expect(out).toMatch(/^-\s+"mode": "allowlist",$/m);
+    expect(out).toMatch(/^\+\s+"mode": "ask",$/m);
+    expect(out).toMatch(/^\+\s+"fs_write"$/m);
+    expect(out).toMatch(/^-\s+"\/srv"$/m);
+    expect(out).toMatch(new RegExp(`^\\+\\s+"${CWD}"$`, 'm'));
+  });
+
+  describe('GA wave 2 · leaf 3 — Tier A file ops headless, Tier B exec never', () => {
+    it('given a serverPolicy allowing fs_read only, should scaffold ops [fs_read]', async () => {
+      const d = deps({ response: { ...ENROLLED, serverPolicy: { ops: ['fs_read'], checkpoint: false } } });
+      const c = ctx();
+      expect(await enroll(d, c)).toBe(EXIT_SUCCESS);
+      expect((JSON.parse(d.writes[0]!.content) as { ops: string[] }).ops).toEqual(['fs_read']);
+    });
+
+    it('given a serverPolicy that ALLOWS exec, should NEVER write exec into the machine ops — exec reaches the ask verdict by construction', async () => {
+      const d = deps({ response: { ...ENROLLED, serverPolicy: { ops: ['exec', 'fs_write', 'fs_read'], checkpoint: false } } });
+      const c = ctx();
+      expect(await enroll(d, c)).toBe(EXIT_SUCCESS);
+      const policy = JSON.parse(d.writes[0]!.content) as { ops: string[] };
+      expect(policy.ops).toEqual(['fs_read', 'fs_write']);
+      expect(policy.ops).not.toContain('exec');
+      expect(c.out.text()).toMatch(/exec/);
+      expect(c.out.text()).toMatch(/ask/);
+    });
+
+    it('given a serverPolicy allowing only exec, should scaffold ops [] and say so', async () => {
+      const d = deps({ response: { ...ENROLLED, serverPolicy: { ops: ['exec'], checkpoint: false } } });
+      const c = ctx();
+      expect(await enroll(d, c)).toBe(EXIT_SUCCESS);
+      expect((JSON.parse(d.writes[0]!.content) as { ops: string[] }).ops).toEqual([]);
+    });
+
+    it('given a serverPolicy the strict shape refuses (unknown op, missing field, not an object), should scaffold ops [] — never guess', async () => {
+      for (const serverPolicy of [{ ops: ['fs_read', 'pty_open', 'root'], checkpoint: false }, { ops: ['fs_read'] }, 'fs_read', null, { ops: 'fs_read', checkpoint: false }]) {
+        const d = deps({ response: { ...ENROLLED, serverPolicy } });
+        const c = ctx();
+        expect(await enroll(d, c)).toBe(EXIT_SUCCESS);
+        expect((JSON.parse(d.writes[0]!.content) as { ops: string[] }).ops, JSON.stringify(serverPolicy)).toEqual([]);
+      }
+    });
+
+    it('given an older server that did not answer serverPolicy, should scaffold ops []', async () => {
+      const { serverPolicy: _omitted, ...withoutPolicy } = ENROLLED;
+      const d = deps({ response: withoutPolicy });
+      const c = ctx();
+      expect(await enroll(d, c)).toBe(EXIT_SUCCESS);
+      expect((JSON.parse(d.writes[0]!.content) as { ops: string[] }).ops).toEqual([]);
+    });
+
+    it('the scaffold is always mode ask with principals [owner] and mode 600 (the writer is the 0600 one), whatever the server policy', async () => {
+      const d = deps({ response: { ...ENROLLED, serverPolicy: { ops: ['exec', 'fs_read'], checkpoint: false } } });
+      const c = ctx();
+      await enroll(d, c);
+      expect(JSON.parse(d.writes[0]!.content)).toMatchObject({ mode: 'ask', principals: [OWNER] });
+    });
   });
 
   it('given an existing policy that does NOT name the owner, should keep it and WARN that the owner\'s own requests will be denied principal_not_allowed', async () => {

--- a/packages/cli/src/commands/env.ts
+++ b/packages/cli/src/commands/env.ts
@@ -32,6 +32,7 @@ import { generateMachineKeypair, signWithMachineKey } from '../env-bridge/keypai
 import type { GenerateMachineKeypair, SignWithMachineKey } from '../env-bridge/keypair.js';
 import { BridgeTokenError, mintBridgeToken, postJson, refusalOf } from '../env-bridge/token.js';
 import { defaultPolicyPath, openPolicyFile, parseMachinePolicyText, writePolicyFile, type OpenedPolicyFile } from '../env-bridge/policy.js';
+import { GRANT_OPS, type GrantOp } from '../env-bridge/lib-core.js';
 
 type Fetch = typeof globalThis.fetch;
 
@@ -58,48 +59,101 @@ export interface EnvEnrollHandlerDeps {
 }
 
 /**
+ * The ops the enroller may pre-approve on the machine: file operations only.
+ * `exec` is NEVER in this set (GA wave 2, Tier B): a shell command must reach
+ * the daemon's `ask` verdict by construction, so every exec class needs the
+ * owner's click on the exact normalised command, however permissive the
+ * server policy is. File operations inside the roots are Tier A — bounded by
+ * the roots, so a deliberate setup is enough and they run headless.
+ */
+export const HEADLESS_MACHINE_OPS: readonly GrantOp[] = ['fs_read', 'fs_write'];
+
+/**
+ * The machine `ops` to scaffold from what the server said it allows:
+ * `serverPolicy.ops ∩ HEADLESS_MACHINE_OPS`, in the headless set's order. The
+ * value comes off the wire and is checked strictly — an unrecognised shape or
+ * an op outside the closed union yields `[]` (ask about everything), never a
+ * guess.
+ */
+export function machineOpsFromServerPolicy(serverPolicy: unknown): GrantOp[] {
+  if (serverPolicy === null || typeof serverPolicy !== 'object') return [];
+  const { ops, checkpoint } = serverPolicy as { ops?: unknown; checkpoint?: unknown };
+  if (typeof checkpoint !== 'boolean') return [];
+  if (!Array.isArray(ops) || !ops.every((op) => typeof op === 'string' && (GRANT_OPS as readonly string[]).includes(op))) return [];
+  const allowed = ops as GrantOp[];
+  return HEADLESS_MACHINE_OPS.filter((op) => allowed.includes(op));
+}
+
+/**
  * The policy scaffolded at enrol, while the owner is at the keyboard (D-6,
  * invariant 13 — defence in depth): `principals` is the machine's OWNER and
  * nobody else, so this daemon refuses every other user even if the server
- * were wrong about who may bind. `mode: ask` with no pre-approved ops means
- * every kind of request prompts the first time; the only root is the
- * directory `enroll` ran in. The owner edits from there.
+ * were wrong about who may bind. `mode: ask` with the server-allowed FILE ops
+ * pre-approved (never `exec`) means file work inside the root runs headless
+ * and every command prompts; the only root is the directory `enroll` ran in.
+ * The owner edits from there.
  */
-export function scaffoldedPolicy(input: { ownerId: string; root: string }): string {
-  return `${JSON.stringify({ mode: 'ask', principals: [input.ownerId], ops: [], roots: [input.root], envAllowlist: [] }, null, 2)}\n`;
+export function scaffoldedPolicy(input: { ownerId: string; root: string; ops?: readonly GrantOp[] }): string {
+  return `${JSON.stringify({ mode: 'ask', principals: [input.ownerId], ops: [...(input.ops ?? [])], roots: [input.root], envAllowlist: [] }, null, 2)}\n`;
 }
 
-type PolicyScaffoldOutcome = { path: string; scaffolded: boolean; kept: boolean; warning: string | null; error: string | null };
+/**
+ * A minimal line diff for "here is what enroll would have written": lines
+ * only in `existing` are `-`, lines only in `scaffold` are `+`, shared lines
+ * are printed once with a leading space. Order follows the scaffold, then
+ * the existing file's extras. Good enough to read; not a patch.
+ */
+export function describePolicyDiff(existing: string, scaffold: string): string {
+  const before = existing.split('\n').filter((line) => line.length > 0);
+  const after = scaffold.split('\n').filter((line) => line.length > 0);
+  const lines: string[] = [];
+  const remaining = [...before];
+  for (const line of after) {
+    const index = remaining.indexOf(line);
+    if (index === -1) {
+      lines.push(`+${line}`);
+    } else {
+      lines.push(` ${line}`);
+      remaining.splice(index, 1);
+    }
+  }
+  for (const line of remaining) lines.push(`-${line}`);
+  return lines.join('\n');
+}
 
-/** Write the scaffold IFF no policy file exists; never touch an existing one, but say when it does not name the owner. */
-async function scaffoldPolicyForOwner(deps: EnvEnrollHandlerDeps, env: Readonly<Record<string, string | undefined>>, ownerId: string): Promise<PolicyScaffoldOutcome> {
+type PolicyScaffoldOutcome = { path: string; scaffolded: boolean; kept: boolean; ops: readonly GrantOp[]; diff: string | null; warning: string | null; error: string | null };
+
+/** Write the scaffold IFF no policy file exists; never touch an existing one, but say when it does not name the owner — and show the diff it would have written. */
+async function scaffoldPolicyForOwner(deps: EnvEnrollHandlerDeps, env: Readonly<Record<string, string | undefined>>, ownerId: string, ops: readonly GrantOp[]): Promise<PolicyScaffoldOutcome> {
   const path = defaultPolicyPath(env, deps.homedir);
   let existing: OpenedPolicyFile | null;
   try {
     existing = deps.openPolicy(path);
   } catch (error) {
     // Unreadable is not "missing": leave whatever is there alone.
-    return { path, scaffolded: false, kept: true, warning: null, error: `could not read the existing policy: ${messageOf(error)}` };
+    return { path, scaffolded: false, kept: true, ops, diff: null, warning: null, error: `could not read the existing policy: ${messageOf(error)}` };
   }
+  const content = scaffoldedPolicy({ ownerId, root: deps.cwd(), ops });
   if (existing !== null) {
     const parsed = parseMachinePolicyText(existing.content);
     const warning =
       parsed !== null && !parsed.principals.includes(ownerId)
         ? `The existing policy at ${path} does not name you (${ownerId}) in "principals", so requests from your own sessions will be denied principal_not_allowed until you add it.`
         : null;
-    return { path, scaffolded: false, kept: true, warning, error: null };
+    return { path, scaffolded: false, kept: true, ops, diff: describePolicyDiff(existing.content, content), warning, error: null };
   }
   // Never guess a root for someone's machine (Codex P2 on #2582): the scaffold
   // must be a policy `connect` will accept, so it is parsed with the same
   // strict parser before it is written. The filesystem root, a relative
   // directory, or one with `..` are all refused — and refused OUT LOUD.
   const root = deps.cwd();
-  const content = scaffoldedPolicy({ ownerId, root });
   if (parseMachinePolicyText(content) === null) {
     return {
       path,
       scaffolded: false,
       kept: false,
+      ops,
+      diff: null,
       warning: null,
       error:
         `the directory you ran enroll in (${root}) is not a valid root — a root must be an absolute directory other than the filesystem root, without ".." segments — so nothing was written. ` +
@@ -108,9 +162,9 @@ async function scaffoldPolicyForOwner(deps: EnvEnrollHandlerDeps, env: Readonly<
   }
   try {
     await deps.writePolicyFile(path, content);
-    return { path, scaffolded: true, kept: false, warning: null, error: null };
+    return { path, scaffolded: true, kept: false, ops, diff: null, warning: null, error: null };
   } catch (error) {
-    return { path, scaffolded: false, kept: false, warning: null, error: messageOf(error) };
+    return { path, scaffolded: false, kept: false, ops, diff: null, warning: null, error: messageOf(error) };
   }
 }
 
@@ -179,7 +233,7 @@ export function createEnvEnrollHandler(deps: EnvEnrollHandlerDeps): CommandHandl
       ctx.stderr.write(`Enrollment refused: ${await refusalOf(response)}\n`);
       return EXIT_RUNTIME_ERROR;
     }
-    const result = (await response.json()) as { enrollmentId: string; envId: string; serverKeyId: string; serverPublicKey: string; ownerId?: string };
+    const result = (await response.json()) as { enrollmentId: string; envId: string; serverKeyId: string; serverPublicKey: string; ownerId?: string; serverPolicy?: unknown };
 
     const credential: MachineHostCredential = { ...pending, envId: result.envId, serverPublicKey: result.serverPublicKey, serverKeyId: result.serverKeyId };
     // (Codex C11) The code is spent and the server has pinned this key. The
@@ -200,21 +254,27 @@ export function createEnvEnrollHandler(deps: EnvEnrollHandlerDeps): CommandHandl
     // The key is pinned; from here on nothing can un-enrol. The policy
     // scaffold (D-6) is best-effort and reported, never a reason to fail.
     const ownerId = typeof result.ownerId === 'string' && result.ownerId.length > 0 ? result.ownerId : null;
-    const policy = ownerId === null ? null : await scaffoldPolicyForOwner(deps, ctx.env, ownerId);
+    // Tier A: the FILE ops the server allows run headless from the start. Tier
+    // B: `exec` is never pre-approved here, so every command reaches `ask`.
+    const ops = machineOpsFromServerPolicy(result.serverPolicy);
+    const policy = ownerId === null ? null : await scaffoldPolicyForOwner(deps, ctx.env, ownerId, ops);
 
     if (intent.flags.json) {
-      ctx.stdout.write(`${JSON.stringify({ enrollmentId: result.enrollmentId, envId: result.envId, serverKeyId: result.serverKeyId, host, ownerId, policy: policy && { path: policy.path, scaffolded: policy.scaffolded, kept: policy.kept } })}\n`);
+      ctx.stdout.write(`${JSON.stringify({ enrollmentId: result.enrollmentId, envId: result.envId, serverKeyId: result.serverKeyId, host, ownerId, policy: policy && { path: policy.path, scaffolded: policy.scaffolded, kept: policy.kept, ops: policy.ops } })}\n`);
     } else {
       ctx.stdout.write(
         `Enrolled this machine as environment ${result.envId} on ${host}.\n` +
           `Pinned server signing key ${result.serverKeyId}. The machine key stays in this machine's credential store (profile "${machineProfileName(result.enrollmentId)}").\n`,
       );
       if (policy?.scaffolded) {
+        const headless = policy.ops.length > 0 ? `pre-approved ops ${policy.ops.join(', ')} (file work inside the root runs without asking)` : 'no pre-approved ops';
         ctx.stdout.write(
-          `Wrote a starter policy to ${policy.path}: principals [${ownerId}] (you, and nobody else — a machine is driven by its owner only), mode ask, no pre-approved ops, root ${deps.cwd()}. Edit it to allow more; "pagespace env policy" shows what is in force.\n`,
+          `Wrote a starter policy to ${policy.path}: principals [${ownerId}] (you, and nobody else — a machine is driven by its owner only), mode ask, ${headless}, root ${deps.cwd()}. ` +
+            'Commands (exec) are never pre-approved by enroll: each program needs your approval the first time, in the chat or in this terminal. Edit the file to allow more; "pagespace env policy" shows what is in force.\n',
         );
       } else if (policy?.kept) {
         ctx.stdout.write(`Kept the existing policy at ${policy.path}.\n`);
+        if (policy.diff !== null) ctx.stdout.write(`Enroll would have written (- existing, + scaffold):\n${policy.diff}\n`);
       }
     }
     if (ownerId === null) ctx.stderr.write('The server did not say who the owner of this environment is, so no policy was scaffolded; create ~/.pagespace/env-policy.json yourself with "principals": [<your user id>].\n');

--- a/packages/cli/src/commands/env/connect.ts
+++ b/packages/cli/src/commands/env/connect.ts
@@ -37,10 +37,12 @@ import type { CommandHandler } from '../../router/router.js';
 import { signWithMachineKey, type SignWithMachineKey } from '../../env-bridge/keypair.js';
 import { ed25519Verify, envBridgeHash } from '../../env-bridge/crypto.js';
 import { createAuditLog, defaultAuditPath } from '../../env-bridge/audit-log.js';
-import { createAskPrompter } from '../../env-bridge/ask.js';
+import { createAskPrompter, describeScope, describeSubject } from '../../env-bridge/ask.js';
+import { createApprovalsStore, defaultApprovalsPath, writeApprovalsFile } from '../../env-bridge/approvals-store.js';
+import { resolveCommand, type CommandResolverDeps } from '../../env-bridge/command-resolver.js';
+import { APPROVAL_SCOPES, type ApprovalScope } from '../../env-bridge/lib-core.js';
 import { createDispatcher, DAEMON_CAPABILITIES } from '../../env-bridge/dispatcher.js';
 import { createNodeExecRunner, type ExecRunner } from '../../env-bridge/exec-runner.js';
-import type { CommandResolverDeps } from '../../env-bridge/command-resolver.js';
 import { createFsRunner, type FsRunner } from '../../env-bridge/fs-runner.js';
 import { createDaemonNonceStore } from '../../env-bridge/nonce-store.js';
 import { createPathProbe } from '../../env-bridge/path-probe.js';
@@ -89,6 +91,12 @@ export interface EnvConnectHandlerDeps {
   readonly createFsRunner: () => FsRunner;
   readonly createSocket: SocketFactory;
   readonly confirm: (message: string) => Promise<boolean>;
+  /** How long a terminal approval is remembered (GA wave 2); omitted ⇒ the default scope. */
+  readonly chooseScope?: (subjects: readonly string[]) => Promise<ApprovalScope>;
+  /** The atomic 0600 writer for `~/.pagespace/env-approvals.json`. */
+  readonly writeApprovals: (path: string, content: string) => Promise<void>;
+  /** Id for an approval the terminal prompt writes. */
+  readonly approvalId: () => string;
   /** Register a handler for SIGINT / SIGTERM. */
   readonly onSignal: (handler: (signal: string) => void) => void;
   readonly exit: (code: number) => void;
@@ -158,7 +166,19 @@ export function createEnvConnectHandler(deps: EnvConnectHandlerDeps): CommandHan
     };
     const execRunner = deps.createExecRunner(resolver);
     const fsRunner = deps.createFsRunner();
-    const ask = loaded.policy?.mode === 'ask' && ctx.isTTY ? createAskPrompter({ confirm: deps.confirm, write: (chunk) => ctx.stderr.write(chunk) }) : null;
+    const ask = loaded.policy?.mode === 'ask' && ctx.isTTY ? createAskPrompter({ confirm: deps.confirm, chooseScope: deps.chooseScope, write: (chunk) => ctx.stderr.write(chunk) }) : null;
+
+    // Durable approvals (GA wave 2): the machine's own file, through the same
+    // one-descriptor adapter and trust rules as the policy. Re-read at every
+    // decision; written only after an owner's byte-compared approval.
+    const approvalsPath = defaultApprovalsPath(ctx.env, deps.homedir);
+    const approvals = createApprovalsStore({ path: approvalsPath, uid: deps.uid, open: deps.openPolicy, write: deps.writeApprovals, now: deps.now, log });
+    const approvalsLoaded = approvals.reload();
+    ctx.stderr.write(
+      approvalsLoaded.reason === null || approvalsLoaded.reason === 'missing'
+        ? `Approvals ${approvalsPath}: ${approvalsLoaded.approvals.length} in force.\n`
+        : `Approvals ${approvalsPath}: ignored (${approvalsLoaded.reason}) — every non-pre-approved request will ask.\n`,
+    );
 
     const dispatcher = createDispatcher({
       envId: credential.envId,
@@ -178,6 +198,9 @@ export function createEnvConnectHandler(deps: EnvConnectHandlerDeps): CommandHan
       fsRunner,
       audit,
       ask,
+      approvals,
+      resolveArgv0: (name) => resolveCommand(name, resolver),
+      ids: { approvalId: deps.approvalId },
       log,
       limits: DEFAULT_FRAME_LIMITS,
     });
@@ -292,6 +315,17 @@ async function clackConfirm(message: string): Promise<boolean> {
   return answer === true;
 }
 
+/** The scope picker after an approval; Ctrl-C here is a decline (the prompter treats a throw as one). */
+async function clackChooseScope(subjects: readonly string[]): Promise<ApprovalScope> {
+  const answer = await clack.select<ApprovalScope>({
+    message: `Remember this approval of ${subjects.map(describeSubject).join(', ')} for how long?`,
+    initialValue: '30d',
+    options: APPROVAL_SCOPES.map((scope) => ({ value: scope, label: describeScope(scope) })),
+  });
+  if (clack.isCancel(answer)) throw new Error('cancelled');
+  return answer;
+}
+
 export const envConnectHandler: CommandHandler = createEnvConnectHandler({
   createCredentialStore,
   fetch: (...args) => globalThis.fetch(...args),
@@ -310,6 +344,9 @@ export const envConnectHandler: CommandHandler = createEnvConnectHandler({
   createFsRunner: () => createFsRunner(),
   createSocket: (url, headers) => new WebSocket(url, { headers }),
   confirm: clackConfirm,
+  chooseScope: clackChooseScope,
+  writeApprovals: writeApprovalsFile,
+  approvalId: () => `local_${crypto.randomUUID()}`,
   onSignal: (handler) => {
     process.on('SIGINT', () => handler('SIGINT'));
     process.on('SIGTERM', () => handler('SIGTERM'));

--- a/packages/cli/src/commands/env/connect.ts
+++ b/packages/cli/src/commands/env/connect.ts
@@ -14,8 +14,10 @@
  *  - the policy file is loaded once and its status printed — missing or
  *    untrusted ⇒ the daemon still starts, advertises, and denies everything
  *    (`no_policy`), never crashes (invariant 5);
- *  - `ask` mode needs a terminal to ask on: headless + `ask` refuses to
- *    start rather than silently deny or silently allow.
+ *  - `ask` mode asks in the terminal when there is one, and otherwise (or
+ *    with PAGESPACE_ENV_ASK=chat) freezes each request under a challenge for
+ *    the owner's click in the PageSpace chat (GA wave 2, Tier B) — never a
+ *    silent deny, never a silent allow.
  *
  * AUTH-EXEMPT (`run.ts`): a machine has no login; its key is its credential.
  * Long-running (`routes.ts`): the handler resolves once the first connect is
@@ -39,6 +41,7 @@ import { ed25519Verify, envBridgeHash } from '../../env-bridge/crypto.js';
 import { createAuditLog, defaultAuditPath } from '../../env-bridge/audit-log.js';
 import { createAskPrompter, describeScope, describeSubject } from '../../env-bridge/ask.js';
 import { createApprovalsStore, defaultApprovalsPath, writeApprovalsFile } from '../../env-bridge/approvals-store.js';
+import { createChallengeStore } from '../../env-bridge/challenge-store.js';
 import { resolveCommand, type CommandResolverDeps } from '../../env-bridge/command-resolver.js';
 import { APPROVAL_SCOPES, type ApprovalScope } from '../../env-bridge/lib-core.js';
 import { createDispatcher, DAEMON_CAPABILITIES } from '../../env-bridge/dispatcher.js';
@@ -97,11 +100,20 @@ export interface EnvConnectHandlerDeps {
   readonly writeApprovals: (path: string, content: string) => Promise<void>;
   /** Id for an approval the terminal prompt writes. */
   readonly approvalId: () => string;
+  /** Id for a pending chat approval (a challenge). */
+  readonly challengeId: () => string;
   /** Register a handler for SIGINT / SIGTERM. */
   readonly onSignal: (handler: (signal: string) => void) => void;
   readonly exit: (code: number) => void;
   /** Test hook: observe the live connection and runner. */
   readonly onStarted?: (controls: { connection: BridgeConnection; execRunner: ExecRunner }) => void;
+}
+
+/** `PAGESPACE_ENV_ASK=chat` sends every ask to the PageSpace chat even when a terminal is attached; without a terminal the chat is the only place to ask. */
+export const ASK_MODE_ENV_VAR = 'PAGESPACE_ENV_ASK';
+
+function askInChat(ctx: Parameters<CommandHandler>[0]): boolean {
+  return !ctx.isTTY || ctx.env[ASK_MODE_ENV_VAR]?.trim().toLowerCase() === 'chat';
 }
 
 export function pidFilePath(homedir: string, enrollmentId: string): string {
@@ -148,9 +160,12 @@ export function createEnvConnectHandler(deps: EnvConnectHandlerDeps): CommandHan
       ctx.stderr.write(`Policy ${policyPath}: mode ${loaded.policy.mode}, principals ${loaded.policy.principals.join(', ') || '(none)'}, ops ${loaded.policy.ops.join(', ') || '(none)'}, roots ${loaded.policy.roots.join(', ')}\n`);
       const principalsWarning = describePrincipalsWarning(loaded.policy);
       if (principalsWarning) ctx.stderr.write(`${principalsWarning}\n`);
-      if (loaded.policy.mode === 'ask' && !ctx.isTTY) {
-        ctx.stderr.write('Policy mode "ask" needs an interactive terminal to ask on, and there is none (stdin is not a TTY). Use mode "allowlist" or "deny" for a headless machine, or run env connect in a terminal.\n');
-        return EXIT_RUNTIME_ERROR;
+      if (loaded.policy.mode === 'ask') {
+        ctx.stderr.write(
+          askInChat(ctx)
+            ? `Policy mode "ask": requests that are not pre-approved will wait for your click in the PageSpace chat${ctx.isTTY ? ` (${ASK_MODE_ENV_VAR}=chat)` : ' (no terminal to ask on)'}.\n`
+            : `Policy mode "ask": requests that are not pre-approved will prompt in this terminal (set ${ASK_MODE_ENV_VAR}=chat to answer in the PageSpace chat instead).\n`,
+        );
       }
     }
 
@@ -167,6 +182,9 @@ export function createEnvConnectHandler(deps: EnvConnectHandlerDeps): CommandHan
     const execRunner = deps.createExecRunner(resolver);
     const fsRunner = deps.createFsRunner();
     const ask = loaded.policy?.mode === 'ask' && ctx.isTTY ? createAskPrompter({ confirm: deps.confirm, chooseScope: deps.chooseScope, write: (chunk) => ctx.stderr.write(chunk) }) : null;
+    // Tier B: a request the terminal cannot (or should not) be asked about is
+    // frozen here and answered by the owner's click in the chat.
+    const challenges = createChallengeStore({ newId: deps.challengeId });
 
     // Durable approvals (GA wave 2): the machine's own file, through the same
     // one-descriptor adapter and trust rules as the policy. Re-read at every
@@ -201,6 +219,8 @@ export function createEnvConnectHandler(deps: EnvConnectHandlerDeps): CommandHan
       approvals,
       resolveArgv0: (name) => resolveCommand(name, resolver),
       ids: { approvalId: deps.approvalId },
+      challenges,
+      preferChat: askInChat(ctx),
       log,
       limits: DEFAULT_FRAME_LIMITS,
     });
@@ -347,6 +367,7 @@ export const envConnectHandler: CommandHandler = createEnvConnectHandler({
   chooseScope: clackChooseScope,
   writeApprovals: writeApprovalsFile,
   approvalId: () => `local_${crypto.randomUUID()}`,
+  challengeId: () => `ch_${crypto.randomUUID()}`,
   onSignal: (handler) => {
     process.on('SIGINT', () => handler('SIGINT'));
     process.on('SIGTERM', () => handler('SIGTERM'));

--- a/packages/cli/src/env-bridge/__tests__/approvals-store.test.ts
+++ b/packages/cli/src/env-bridge/__tests__/approvals-store.test.ts
@@ -1,0 +1,212 @@
+/**
+ * GA wave 2, leaf 1 — durable approvals on the machine:
+ * `~/.pagespace/env-approvals.json`, keyed (envId, userId, op, subject) with a
+ * chosen expiry, read through ONE descriptor with the same owner/mode checks
+ * as `env-policy.json`, and treated as EMPTY on any defect — never partial.
+ */
+import { describe, expect, it } from 'vitest';
+import { THIRTY_DAYS_MS, type DurableApproval } from '@pagespace/lib/env-bridge/decide-approval';
+import type { OpenedPolicyFile } from '../policy.js';
+import { APPROVALS_FILE_NAME, createApprovalsStore, defaultApprovalsPath, type ApprovalsStoreDeps } from '../approvals-store.js';
+
+const UID = 501;
+const NOW = 1_800_000_000_000;
+const PATH = '/home/me/.pagespace/env-approvals.json';
+
+const row = (over: Partial<DurableApproval> = {}): DurableApproval => ({ approvalId: 'ch_1', envId: 'env_1', userId: 'u1', op: 'exec', subject: 'exec:/usr/bin/git', scope: '30d', createdAt: NOW - 1000, expiresAt: NOW + THIRTY_DAYS_MS, ...over });
+const file = (approvals: DurableApproval[]) => JSON.stringify({ version: 1, approvals });
+
+interface Fs {
+  content: string | null;
+  stat: { uid: number; mode: number };
+  openError?: Error;
+}
+
+function harness(fs: Fs = { content: null, stat: { uid: UID, mode: 0o100600 } }, over: Partial<ApprovalsStoreDeps> = {}) {
+  const writes: string[] = [];
+  const logs: string[] = [];
+  const deps: ApprovalsStoreDeps = {
+    path: PATH,
+    uid: UID,
+    open: (): OpenedPolicyFile | null => {
+      if (fs.openError) throw fs.openError;
+      if (fs.content === null) return null;
+      return { uid: fs.stat.uid, mode: fs.stat.mode, content: fs.content };
+    },
+    write: async (_path, content) => {
+      writes.push(content);
+      fs.content = content;
+    },
+    now: () => NOW,
+    log: (line) => void logs.push(line),
+    ...over,
+  };
+  return { store: createApprovalsStore(deps), writes, logs, fs };
+}
+
+describe('the file: read through one descriptor, refused exactly as env-policy.json is', () => {
+  it('given no file, should have no durable approvals (and say why)', () => {
+    const h = harness();
+    expect(h.store.entries()).toEqual([]);
+    expect(h.store.reload()).toMatchObject({ reason: 'missing', approvals: [] });
+  });
+
+  it('given a valid file, should expose its rows', () => {
+    const h = harness({ content: file([row()]), stat: { uid: UID, mode: 0o100600 } });
+    expect(h.store.entries()).toEqual([row()]);
+  });
+
+  it('given a file writable by group or world, should ignore it (deny-all for approvals = ask) — exactly as the policy loader does', () => {
+    for (const mode of [0o100660, 0o100602, 0o100666]) {
+      const h = harness({ content: file([row()]), stat: { uid: UID, mode } });
+      expect(h.store.entries(), mode.toString(8)).toEqual([]);
+      expect(h.store.reload().reason).toBe('writable_by_others');
+    }
+  });
+
+  it('given a file owned by another user, should ignore it', () => {
+    const h = harness({ content: file([row()]), stat: { uid: 0, mode: 0o100600 } });
+    expect(h.store.entries()).toEqual([]);
+    expect(h.store.reload().reason).toBe('wrong_owner');
+  });
+
+  it('given an open that throws (not ENOENT), should fail closed as unreadable', () => {
+    const h = harness({ content: 'x', stat: { uid: UID, mode: 0o100600 }, openError: new Error('EACCES') });
+    expect(h.store.entries()).toEqual([]);
+    expect(h.store.reload().reason).toBe('unreadable');
+  });
+
+  it('given invalid JSON, should be EMPTY', () => {
+    const h = harness({ content: '{ not json', stat: { uid: UID, mode: 0o100600 } });
+    expect(h.store.entries()).toEqual([]);
+    expect(h.store.reload().reason).toBe('invalid_json');
+  });
+
+  it('given one bad row among good ones, should be EMPTY — never partial', () => {
+    const h = harness({ content: JSON.stringify({ version: 1, approvals: [row(), { approvalId: 'bad' }] }), stat: { uid: UID, mode: 0o100600 } });
+    expect(h.store.entries()).toEqual([]);
+    expect(h.store.reload().reason).toBe('invalid_schema');
+  });
+
+  it('should re-read the file on every entries() call so an out-of-band edit, chmod or delete takes effect at the next decision', () => {
+    const h = harness({ content: file([row()]), stat: { uid: UID, mode: 0o100600 } });
+    expect(h.store.entries()).toHaveLength(1);
+    h.fs.stat = { uid: UID, mode: 0o100664 };
+    expect(h.store.entries()).toHaveLength(0);
+    h.fs.stat = { uid: UID, mode: 0o100600 };
+    h.fs.content = null;
+    expect(h.store.entries()).toHaveLength(0);
+  });
+
+  it('defaultApprovalsPath: PAGESPACE_ENV_APPROVALS wins, else ~/.pagespace/env-approvals.json', () => {
+    expect(APPROVALS_FILE_NAME).toBe('env-approvals.json');
+    expect(defaultApprovalsPath({}, '/home/me')).toBe(PATH);
+    expect(defaultApprovalsPath({ PAGESPACE_ENV_APPROVALS: '/etc/ps/a.json' }, '/home/me')).toBe('/etc/ps/a.json');
+  });
+});
+
+describe('remembering an approval: once ⇒ nothing, session ⇒ this process only, 30d / until_revoked ⇒ the file', () => {
+  it('given scope 30d, should write the rows to the file with expiresAt = createdAt + 30 days and expose them', async () => {
+    const h = harness();
+    await h.store.remember({ approvalId: 'ch_1', envId: 'env_1', userId: 'u1', op: 'exec', subjects: ['exec:/usr/bin/git', 'builtin:cd'], scope: '30d' });
+    expect(h.writes).toHaveLength(1);
+    const written = JSON.parse(h.writes[0]!) as { version: number; approvals: DurableApproval[] };
+    expect(written.version).toBe(1);
+    expect(written.approvals).toEqual([
+      { approvalId: 'ch_1', envId: 'env_1', userId: 'u1', op: 'exec', subject: 'exec:/usr/bin/git', scope: '30d', createdAt: NOW, expiresAt: NOW + THIRTY_DAYS_MS },
+      { approvalId: 'ch_1', envId: 'env_1', userId: 'u1', op: 'exec', subject: 'builtin:cd', scope: '30d', createdAt: NOW, expiresAt: NOW + THIRTY_DAYS_MS },
+    ]);
+    expect(h.store.entries()).toHaveLength(2);
+    expect(h.writes[0]!.endsWith('\n')).toBe(true);
+  });
+
+  it('given scope until_revoked, should write rows with no expiry', async () => {
+    const h = harness();
+    await h.store.remember({ approvalId: 'ch_2', envId: 'env_1', userId: 'u1', op: 'fs_read', subjects: ['root:/home/me/proj'], scope: 'until_revoked' });
+    expect(h.store.entries()).toEqual([expect.objectContaining({ approvalId: 'ch_2', scope: 'until_revoked', expiresAt: null })]);
+  });
+
+  it('given scope session, should remember in memory only — nothing written, gone with the process', async () => {
+    const h = harness();
+    await h.store.remember({ approvalId: 'ch_3', envId: 'env_1', userId: 'u1', op: 'exec', subjects: ['exec:/bin/ls'], scope: 'session' });
+    expect(h.writes).toHaveLength(0);
+    expect(h.store.entries()).toEqual([expect.objectContaining({ approvalId: 'ch_3', scope: 'session', expiresAt: null })]);
+  });
+
+  it('given scope once, should remember NOTHING', async () => {
+    const h = harness();
+    await h.store.remember({ approvalId: 'ch_4', envId: 'env_1', userId: 'u1', op: 'exec', subjects: ['exec:/bin/ls'], scope: 'once' });
+    expect(h.writes).toHaveLength(0);
+    expect(h.store.entries()).toEqual([]);
+  });
+
+  it('should MERGE with the rows already in the file (read-merge-write), never clobber them', async () => {
+    const h = harness({ content: file([row()]), stat: { uid: UID, mode: 0o100600 } });
+    await h.store.remember({ approvalId: 'ch_9', envId: 'env_1', userId: 'u1', op: 'exec', subjects: ['exec:/bin/rm'], scope: '30d' });
+    expect(h.store.entries().map((a) => a.approvalId)).toEqual(['ch_1', 'ch_9']);
+  });
+
+  it('given the existing file is REFUSED (wrong owner / writable by others / invalid), should NOT overwrite it — the approval is kept for this process only and the refusal is logged', async () => {
+    const h = harness({ content: file([row()]), stat: { uid: 0, mode: 0o100600 } });
+    await h.store.remember({ approvalId: 'ch_5', envId: 'env_1', userId: 'u1', op: 'exec', subjects: ['exec:/bin/ls'], scope: '30d' });
+    expect(h.writes).toHaveLength(0);
+    expect(h.logs.join('\n')).toMatch(/wrong_owner/);
+    // Held in memory so the owner's click still counts for the life of the daemon.
+    expect(h.store.entries()).toEqual([expect.objectContaining({ approvalId: 'ch_5' })]);
+  });
+
+  it('given the write fails, should keep the approval in memory and log — never throw into the dispatcher', async () => {
+    const h = harness(undefined, { write: async () => { throw new Error('EROFS'); } });
+    await expect(h.store.remember({ approvalId: 'ch_6', envId: 'env_1', userId: 'u1', op: 'exec', subjects: ['exec:/bin/ls'], scope: '30d' })).resolves.toBeUndefined();
+    expect(h.logs.join('\n')).toMatch(/EROFS/);
+    expect(h.store.entries()).toEqual([expect.objectContaining({ approvalId: 'ch_6' })]);
+  });
+});
+
+describe('revoking exactly one approval', () => {
+  it('given an approvalId, should delete every row of THAT approval from the file and from memory, and nothing else', async () => {
+    const h = harness({ content: file([row(), row({ subject: 'builtin:cd' }), row({ approvalId: 'ch_2', subject: 'exec:/bin/rm' })]), stat: { uid: UID, mode: 0o100600 } });
+    await h.store.remember({ approvalId: 'ch_3', envId: 'env_1', userId: 'u1', op: 'exec', subjects: ['exec:/bin/ls'], scope: 'session' });
+    expect(await h.store.revoke('ch_1')).toBe(2);
+    expect(h.store.entries().map((a) => a.approvalId)).toEqual(['ch_2', 'ch_3']);
+    expect(await h.store.revoke('ch_3')).toBe(1);
+    expect(h.store.entries().map((a) => a.approvalId)).toEqual(['ch_2']);
+    expect(await h.store.revoke('nope')).toBe(0);
+  });
+
+  it('prune(now) should drop expired rows from the file', async () => {
+    const h = harness({ content: file([row({ expiresAt: NOW - 1 }), row({ approvalId: 'live' })]), stat: { uid: UID, mode: 0o100600 } });
+    expect(await h.store.prune(NOW)).toBe(1);
+    expect(h.store.entries().map((a) => a.approvalId)).toEqual(['live']);
+  });
+});
+
+describe('the production writer', () => {
+  it('writeApprovalsFile writes 0600 via a temp file and rename (atomic: a crash mid-write cannot leave a half file)', async () => {
+    const { writeApprovalsFile } = await import('../approvals-store.js');
+    const { mkdtempSync, readFileSync, statSync, readdirSync, rmSync } = await import('node:fs');
+    const { tmpdir } = await import('node:os');
+    const dir = mkdtempSync(`${tmpdir()}/ps-approvals-`);
+    try {
+      const path = `${dir}/nested/env-approvals.json`;
+      await writeApprovalsFile(path, '{"version":1,"approvals":[]}\n');
+      expect(readFileSync(path, 'utf8')).toBe('{"version":1,"approvals":[]}\n');
+      expect(statSync(path).mode & 0o777).toBe(0o600);
+      expect(statSync(`${dir}/nested`).mode & 0o777).toBe(0o700);
+      expect(readdirSync(`${dir}/nested`)).toEqual(['env-approvals.json']);
+      await writeApprovalsFile(path, '{"version":1,"approvals":[]}\n');
+      expect(readdirSync(`${dir}/nested`)).toEqual(['env-approvals.json']);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('never imports anything but node:fs / node:path / lib-core (no network, no child_process)', async () => {
+    const { readFileSync } = await import('node:fs');
+    const source = readFileSync(new URL('../approvals-store.ts', import.meta.url), 'utf8');
+    const imports = [...source.matchAll(/from '([^']+)'/g)].map((m) => m[1]);
+    expect(imports.every((s) => s === 'node:fs' || s === 'node:fs/promises' || s === 'node:path' || s === './lib-core.js' || s === './policy.js')).toBe(true);
+    expect(source).not.toMatch(/fetch\(|from 'ws'|child_process/);
+  });
+});
+

--- a/packages/cli/src/env-bridge/__tests__/ask.test.ts
+++ b/packages/cli/src/env-bridge/__tests__/ask.test.ts
@@ -1,49 +1,66 @@
 import { describe, expect, it, vi } from 'vitest';
 import type { NormalizedRequest } from '@pagespace/lib/env-bridge/decide-execution';
-import { approvalKey, createAskPrompter, renderAskPrompt, type AskInput } from '../ask.js';
+import { createAskPrompter, describeScope, describeSubject, renderAskPrompt, type AskInput } from '../ask.js';
 
 const request: NormalizedRequest = { op: 'exec', cmd: 'npm', args: ['test'], cwd: '/real/proj', paths: [], env: { CI: '1' }, timeoutMs: 5_000, maxBytes: 4096, clamped: true };
-const input: AskInput = { grantId: 'g1', principal: { userId: 'u1', sessionId: 's1', conversationId: 'c1' }, op: 'exec', request };
+const input: AskInput = { grantId: 'g1', principal: { userId: 'u1', sessionId: 's1', conversationId: 'c1' }, op: 'exec', request, subjects: ['exec:/usr/local/bin/npm'] };
 
-describe('ask prompter (invariant 5: `ask` mode prompts once per new (principal, session) and per non-allowlisted op)', () => {
-  it('renderAskPrompt should show EXACTLY the normalized request: principal, op, cmd/args, cwd, paths, env, caps, clamped', () => {
+describe('ask prompter (invariant 5) — shows the exact normalized request, remembers NOTHING itself (GA wave 2: approvals live in the store, keyed by subject)', () => {
+  it('renderAskPrompt should show EXACTLY the normalized request: principal, op, cmd/args, cwd, paths, env, caps, clamped — and what an approval would cover', () => {
     const text = renderAskPrompt(input);
-    for (const needle of ['u1', 's1', 'exec', 'npm', 'test', '/real/proj', 'CI=1', '5000', '4096', 'clamped']) expect(text).toContain(needle);
+    for (const needle of ['u1', 's1', 'exec', 'npm', 'test', '/real/proj', 'CI=1', '5000', '4096', 'clamped', '/usr/local/bin/npm', 'any chat', 'never covers other programs']) expect(text).toContain(needle);
+    expect(text).not.toMatch(/same user and session/);
   });
 
-  it('approvalKey should distinguish user, session and op', () => {
-    expect(approvalKey(input.principal, 'exec')).not.toBe(approvalKey(input.principal, 'fs_read'));
-    expect(approvalKey(input.principal, 'exec')).not.toBe(approvalKey({ ...input.principal, sessionId: 's2' }, 'exec'));
-    expect(approvalKey(input.principal, 'exec')).toBe(approvalKey({ ...input.principal, conversationId: 'other' }, 'exec'));
+  it('renderAskPrompt for a request with no subjects should say it cannot be remembered', () => {
+    expect(renderAskPrompt({ ...input, subjects: null })).toMatch(/cannot be remembered/);
   });
 
-  it('given a first request for a (principal, session, op), should prompt; given an approved repeat, should NOT prompt again', async () => {
+  it('given an approved prompt, should answer approved with the DEFAULT scope (30d) when no scope chooser is supplied', async () => {
     const confirm = vi.fn(async () => true);
     const prompter = createAskPrompter({ confirm, write: () => undefined });
-    expect(await prompter.ask(input)).toBe(true);
-    expect(await prompter.ask({ ...input, grantId: 'g2' })).toBe(true);
-    expect(confirm).toHaveBeenCalledTimes(1);
+    expect(await prompter.ask(input)).toEqual({ approved: true, scope: '30d' });
   });
 
-  it('given a new op for the same session, or a new session, should prompt again', async () => {
+  it('given a scope chooser, should ask it with the subjects and answer with the chosen scope', async () => {
+    const chooseScope = vi.fn(async () => 'until_revoked' as const);
+    const prompter = createAskPrompter({ confirm: async () => true, chooseScope, write: () => undefined });
+    expect(await prompter.ask(input)).toEqual({ approved: true, scope: 'until_revoked' });
+    expect(chooseScope).toHaveBeenCalledWith(['exec:/usr/local/bin/npm']);
+  });
+
+  it('given a request with no subjects, should NOT ask for a scope and answer once', async () => {
+    const chooseScope = vi.fn(async () => '30d' as const);
+    const prompter = createAskPrompter({ confirm: async () => true, chooseScope, write: () => undefined });
+    expect(await prompter.ask({ ...input, subjects: null })).toEqual({ approved: true, scope: 'once' });
+    expect(chooseScope).not.toHaveBeenCalled();
+  });
+
+  it('should prompt EVERY time it is asked — nothing is cached here any more (a repeat is the store\'s business, keyed by subject, not by session)', async () => {
     const confirm = vi.fn(async () => true);
     const prompter = createAskPrompter({ confirm, write: () => undefined });
     await prompter.ask(input);
-    await prompter.ask({ ...input, op: 'fs_read', request: { ...request, op: 'fs_read', paths: ['/real/proj/a'] } });
-    await prompter.ask({ ...input, principal: { ...input.principal, sessionId: 's2' } });
-    expect(confirm).toHaveBeenCalledTimes(3);
-  });
-
-  it('given a declined prompt, should return false and NOT remember it — the next request asks again', async () => {
-    const confirm = vi.fn(async () => false);
-    const prompter = createAskPrompter({ confirm, write: () => undefined });
-    expect(await prompter.ask(input)).toBe(false);
-    expect(await prompter.ask(input)).toBe(false);
+    await prompter.ask({ ...input, grantId: 'g2' });
     expect(confirm).toHaveBeenCalledTimes(2);
   });
 
-  it('given a confirm that throws (terminal closed), should treat it as declined', async () => {
-    const prompter = createAskPrompter({ confirm: async () => { throw new Error('closed'); }, write: () => undefined });
-    expect(await prompter.ask(input)).toBe(false);
+  it('given a declined prompt, should answer not approved', async () => {
+    const prompter = createAskPrompter({ confirm: async () => false, write: () => undefined });
+    expect(await prompter.ask(input)).toEqual({ approved: false });
+  });
+
+  it('given a confirm or scope chooser that throws (terminal closed), should treat it as declined', async () => {
+    expect(await createAskPrompter({ confirm: async () => { throw new Error('closed'); }, write: () => undefined }).ask(input)).toEqual({ approved: false });
+    expect(await createAskPrompter({ confirm: async () => true, chooseScope: async () => { throw new Error('closed'); }, write: () => undefined }).ask(input)).toEqual({ approved: false });
+  });
+
+  it('describeSubject / describeScope read as English', () => {
+    expect(describeSubject('exec:/usr/bin/git')).toBe('/usr/bin/git');
+    expect(describeSubject('builtin:cd')).toBe('cd (shell builtin)');
+    expect(describeSubject('root:/home/u/proj')).toBe('files under /home/u/proj');
+    expect(describeScope('once')).toMatch(/only/);
+    expect(describeScope('session')).toMatch(/daemon stops/);
+    expect(describeScope('30d')).toMatch(/30 days/);
+    expect(describeScope('until_revoked')).toMatch(/revoke/);
   });
 });

--- a/packages/cli/src/env-bridge/__tests__/challenge-store.test.ts
+++ b/packages/cli/src/env-bridge/__tests__/challenge-store.test.ts
@@ -1,0 +1,93 @@
+/**
+ * GA wave 2, leaf 4 — the challenge store: a frozen request under an id whose
+ * TTL is the grant's `exp`, bounded and evicted synchronously like the nonce
+ * store, reusing the id for a repeat of the same subject.
+ */
+import { describe, expect, it } from 'vitest';
+import type { Grant } from '@pagespace/lib/env-bridge/grant';
+import type { NormalizedRequest } from '@pagespace/lib/env-bridge/decide-execution';
+import { createChallengeStore, MAX_PENDING_CHALLENGES } from '../challenge-store.js';
+
+const NOW = 1_800_000_000_000;
+const grant = (over: Partial<Grant> = {}): Grant => ({ grantId: 'g1', envId: 'env_1', principal: { userId: 'u1', sessionId: 's1', conversationId: 'c1' }, op: 'exec', argsHash: 'h1', iat: NOW - 1000, exp: NOW + 30_000, nonce: 'n1', ...over });
+const request: NormalizedRequest = { op: 'exec', cmd: 'git', args: ['status'], cwd: '/p', paths: [], env: {}, timeoutMs: 1000, maxBytes: 1024, clamped: false };
+
+function store(max?: number) {
+  let n = 0;
+  return createChallengeStore({ newId: () => `ch_${++n}`, ...(max !== undefined && { max }) });
+}
+
+describe('issue / take', () => {
+  it('given an ask, should freeze the request under a new id with TTL = the grant exp', () => {
+    const s = store();
+    const g = grant();
+    const pending = s.issue({ grant: g, request, subjects: ['exec:/usr/bin/git'] }, NOW);
+    expect(pending).toMatchObject({ id: 'ch_1', exp: NOW + 30_000, issuedAt: NOW, request, subjects: ['exec:/usr/bin/git'] });
+    expect(pending!.grant).toBe(g);
+    expect(s.size()).toBe(1);
+    expect(s.peek('ch_1', NOW)).toBe(pending);
+    expect(s.take('ch_1', NOW)).toBe(pending);
+    expect(s.size()).toBe(0);
+    expect(s.take('ch_1', NOW)).toBeUndefined();
+  });
+
+  it('given a second ask for the SAME subject while one is pending, should reuse the id and the FIRST frozen request, not grow the map', () => {
+    const s = store();
+    const first = s.issue({ grant: grant(), request, subjects: ['exec:/usr/bin/git'] }, NOW);
+    const second = s.issue({ grant: grant({ grantId: 'g2', argsHash: 'h2', nonce: 'n2' }), request: { ...request, args: ['log'] }, subjects: ['exec:/usr/bin/git'] }, NOW + 1000);
+    expect(second).toBe(first);
+    expect(s.size()).toBe(1);
+  });
+
+  it('given a different subject, user or op, should issue a new id', () => {
+    const s = store();
+    s.issue({ grant: grant(), request, subjects: ['exec:/usr/bin/git'] }, NOW);
+    expect(s.issue({ grant: grant(), request: { ...request, cmd: 'rm' }, subjects: ['exec:/bin/rm'] }, NOW)!.id).toBe('ch_2');
+    expect(s.issue({ grant: grant({ principal: { userId: 'u2', sessionId: 's', conversationId: 'c' } }), request, subjects: ['exec:/usr/bin/git'] }, NOW)!.id).toBe('ch_3');
+    expect(s.issue({ grant: grant({ op: 'fs_read' }), request: { ...request, op: 'fs_read' }, subjects: ['exec:/usr/bin/git'] }, NOW)!.id).toBe('ch_4');
+    expect(s.size()).toBe(4);
+  });
+
+  it('given an unresolvable request (subjects null), should key the reuse on the exact args hash', () => {
+    const s = store();
+    const a = s.issue({ grant: grant({ argsHash: 'hA' }), request, subjects: null }, NOW);
+    expect(s.issue({ grant: grant({ argsHash: 'hA' }), request, subjects: null }, NOW)).toBe(a);
+    expect(s.issue({ grant: grant({ argsHash: 'hB' }), request, subjects: null }, NOW)!.id).toBe('ch_2');
+  });
+});
+
+describe('expiry and bound — evicted synchronously like the nonce store', () => {
+  it('given a challenge past its grant exp, should refuse to hand it back (expired challenge is refused) and forget it', () => {
+    const s = store();
+    s.issue({ grant: grant(), request, subjects: ['exec:/usr/bin/git'] }, NOW);
+    expect(s.peek('ch_1', NOW + 30_000)).toBeDefined();
+    expect(s.take('ch_1', NOW + 30_001)).toBeUndefined();
+    expect(s.size()).toBe(0);
+  });
+
+  it('after an expired challenge is evicted, the same subject gets a NEW id', () => {
+    const s = store();
+    s.issue({ grant: grant(), request, subjects: ['exec:/usr/bin/git'] }, NOW);
+    expect(s.issue({ grant: grant({ exp: NOW + 90_000 }), request, subjects: ['exec:/usr/bin/git'] }, NOW + 60_000)!.id).toBe('ch_2');
+    expect(s.size()).toBe(1);
+  });
+
+  it('evictExpired(now) should drop only the expired entries', () => {
+    const s = store();
+    s.issue({ grant: grant({ exp: NOW + 1000 }), request, subjects: ['a'] }, NOW);
+    s.issue({ grant: grant({ exp: NOW + 60_000 }), request, subjects: ['b'] }, NOW);
+    s.evictExpired(NOW + 2000);
+    expect(s.size()).toBe(1);
+    expect(s.peek('ch_2', NOW + 2000)).toBeDefined();
+  });
+
+  it('should hold at most MAX_PENDING_CHALLENGES live entries — a further ask is refused (null), never evicted early', () => {
+    const s = store(3);
+    for (let i = 0; i < 3; i += 1) expect(s.issue({ grant: grant(), request, subjects: [`s${i}`] }, NOW)).not.toBeNull();
+    expect(s.issue({ grant: grant(), request, subjects: ['s99'] }, NOW)).toBeNull();
+    expect(s.size()).toBe(3);
+    // A repeat of a pending subject is still answered from the map when full.
+    expect(s.issue({ grant: grant(), request, subjects: ['s0'] }, NOW)!.id).toBe('ch_1');
+    expect(MAX_PENDING_CHALLENGES).toBe(64);
+  });
+});

--- a/packages/cli/src/env-bridge/__tests__/dispatcher.test.ts
+++ b/packages/cli/src/env-bridge/__tests__/dispatcher.test.ts
@@ -10,6 +10,7 @@ import type { PathProbe } from '@pagespace/lib/env-bridge/confine-path';
 import { createDispatcher, DAEMON_CAPABILITIES, type DispatcherDeps } from '../dispatcher.js';
 import { createDaemonNonceStore } from '../nonce-store.js';
 import { createApprovalsStore } from '../approvals-store.js';
+import { createChallengeStore } from '../challenge-store.js';
 import { generateMachineKeypair, signWithMachineKey } from '../keypair.js';
 import { ed25519Verify, envBridgeHash } from '../crypto.js';
 import type { AuditEntry } from '../audit-log.js';
@@ -453,6 +454,72 @@ describe('dispatcher — every grant: verifyGrant → decideExecution → runner
       const h = durableHarness(false, '30d', { policy: () => POLICY });
       expect(await h.dispatcher.handle(fromSession('s1'))).toMatchObject({ kind: 'reply', frame: { type: 'exec_result' } });
       expect(h.audits[0]?.verdict).toBe('allow');
+    });
+  });
+
+  describe('GA wave 2 · leaf 4 — the challenge store: an ask with no terminal freezes the request and answers ask_pending:<id>', () => {
+    const BIN: Record<string, string> = { tool: '/usr/bin/tool', rm: '/bin/rm' };
+    function chatHarness(overrides: Partial<DispatcherDeps> = {}) {
+      let n = 0;
+      const challenges = createChallengeStore({ newId: () => `ch_${++n}` });
+      return { ...harness({ policy: () => ASK_POLICY, ask: null, challenges, resolveArgv0: (name) => BIN[name] ?? null, ...overrides }), challenges };
+    }
+
+    it('given an ask verdict and no prompter, should freeze the NORMALISED request under a challenge whose TTL is the grant exp, answer a SIGNED grant_denied ask_pending:<id> carrying it verbatim, audit ask:pending:<id>, and run nothing', async () => {
+      const h = chatHarness();
+      const frame = execFrame({ env: { CI: '1', LD_PRELOAD: '/evil.so' }, timeoutMs: 999_999 });
+      const result = await h.dispatcher.handle(frame);
+      expect(result).toMatchObject({ kind: 'reply', frame: { type: 'grant_denied', grantId: 'grant_1', reason: 'ask_pending:ch_1' } });
+      const denied = (result as { frame: Extract<Frame, { type: 'grant_denied' }> }).frame;
+      expect(denied.pending).toEqual({ challengeId: 'ch_1', expiresAt: NOW + 30_000, request: { op: 'exec', cmd: 'tool', args: ['a'], cwd: ROOT, paths: [], env: { CI: '1' }, timeoutMs: 10_000, maxBytes: 4096, clamped: true } });
+      expect(verified(denied)).toMatchObject({ ok: true });
+      expect(h.audits[0]).toMatchObject({ grantId: 'grant_1', verdict: 'ask:pending:ch_1', argsHash: expect.any(String) });
+      expect(h.spawnRun).not.toHaveBeenCalled();
+      expect(h.challenges.size()).toBe(1);
+      expect(h.challenges.peek('ch_1', NOW)).toMatchObject({ request: denied.pending!.request, subjects: ['exec:/usr/bin/tool'], exp: NOW + 30_000 });
+    });
+
+    it('given a second ask for the same subject while one is pending, should answer the SAME id and not grow the store', async () => {
+      const h = chatHarness();
+      await h.dispatcher.handle(execFrame());
+      expect(await h.dispatcher.handle(execFrame({ args: ['b'] }))).toMatchObject({ kind: 'reply', frame: { reason: 'ask_pending:ch_1' } });
+      expect(h.challenges.size()).toBe(1);
+      expect(await h.dispatcher.handle(execFrame({ cmd: 'rm' }))).toMatchObject({ kind: 'reply', frame: { reason: 'ask_pending:ch_2' } });
+      expect(h.challenges.size()).toBe(2);
+    });
+
+    it('given a prompter AND preferChat, should go to the chat and never prompt the terminal', async () => {
+      const ask: AskPrompter & { calls: number } = { calls: 0, ask: async () => { ask.calls += 1; return { approved: true, scope: '30d' }; } };
+      const h = chatHarness({ ask, preferChat: true });
+      expect(await h.dispatcher.handle(execFrame())).toMatchObject({ kind: 'reply', frame: { reason: 'ask_pending:ch_1' } });
+      expect(ask.calls).toBe(0);
+    });
+
+    it('given a prompter and no preference, should prompt the terminal and not touch the store', async () => {
+      const ask: AskPrompter = { ask: async () => ({ approved: false }) };
+      const h = chatHarness({ ask });
+      expect(await h.dispatcher.handle(execFrame())).toMatchObject({ kind: 'reply', frame: { reason: 'declined' } });
+      expect(h.challenges.size()).toBe(0);
+    });
+
+    it('given the store is full, should deny ask_unavailable (audited as such) rather than evict a pending question', async () => {
+      const challenges = createChallengeStore({ newId: () => 'ch_x', max: 1 });
+      const h = chatHarness({ challenges });
+      await h.dispatcher.handle(execFrame());
+      expect(await h.dispatcher.handle(execFrame({ cmd: 'rm' }))).toMatchObject({ kind: 'reply', frame: { reason: 'ask_unavailable' } });
+      expect(h.audits[1]?.verdict).toBe('deny:ask_unavailable:challenges_full');
+    });
+
+    it('given a durable approval covering the subject, should run without freezing anything', async () => {
+      const approvals = createApprovalsStore({ path: '/p', uid: 501, open: () => ({ uid: 501, mode: 0o100600, content: JSON.stringify({ version: 1, approvals: [{ approvalId: 'old', envId: ENV_ID, userId: 'u1', op: 'exec', subject: 'exec:/usr/bin/tool', scope: 'until_revoked', createdAt: 1, expiresAt: null }] }) }), write: async () => undefined, now: () => NOW });
+      const h = chatHarness({ approvals });
+      expect(await h.dispatcher.handle(execFrame())).toMatchObject({ kind: 'reply', frame: { type: 'exec_result' } });
+      expect(h.challenges.size()).toBe(0);
+    });
+
+    it('given no prompter and no challenge store, should deny ask_unavailable (unchanged)', async () => {
+      const h = harness({ policy: () => ASK_POLICY, ask: null });
+      expect(await h.dispatcher.handle(execFrame())).toMatchObject({ kind: 'reply', frame: { reason: 'ask_unavailable' } });
     });
   });
 

--- a/packages/cli/src/env-bridge/__tests__/dispatcher.test.ts
+++ b/packages/cli/src/env-bridge/__tests__/dispatcher.test.ts
@@ -566,12 +566,18 @@ describe('dispatcher — every grant: verifyGrant → decideExecution → runner
       expect(await h.dispatcher.handle(click())).toMatchObject({ kind: 'reply', frame: { type: 'exec_result' } });
     });
 
-    it('given a click for a challenge the daemon never froze (a guessed id, or an approval the SERVER "recorded"), should deny approval_unknown and run nothing', async () => {
+    it('COMPROMISED SERVER: a server-signed grant carrying an approvalIntent whose challengeId this daemon has NEVER frozen (the server manufacturing a "covered" request out of thin air) ⇒ approval_mismatch, nothing executes, NOTHING is remembered', async () => {
       const h = clickHarness();
-      expect(await h.dispatcher.handle(click({}, { challengeId: 'ch_never' }))).toMatchObject({ kind: 'reply', frame: { type: 'grant_denied', reason: 'approval_unknown' } });
-      expect(h.audits[0]?.verdict).toBe('deny:approval_unknown:ch_never');
+      // Nothing pending on the machine at all; the server presents a valid signature, a valid intent, a policy-allowed op.
+      expect(h.challenges.size()).toBe(0);
+      expect(await h.dispatcher.handle(click({}, { challengeId: 'ch_never' }))).toMatchObject({ kind: 'reply', frame: { type: 'grant_denied', reason: 'approval_mismatch' } });
+      expect(h.audits[0]?.verdict).toBe('deny:approval_mismatch:unknown_challenge:ch_never');
       expect(h.spawnRun).not.toHaveBeenCalled();
       expect(h.writes).toHaveLength(0);
+      expect(h.deps.approvals!.entries()).toEqual([]);
+      // And it stays that way on a retry with a different scope or id: the file is authoritative for allow.
+      expect(await h.dispatcher.handle(click({}, { challengeId: 'ch_never_2', scope: 'until_revoked' }))).toMatchObject({ kind: 'reply', frame: { reason: 'approval_mismatch' } });
+      expect(h.deps.approvals!.entries()).toEqual([]);
     });
 
     it('given a click after the intent expiry or after the challenge TTL, should deny approval_expired', async () => {
@@ -582,7 +588,7 @@ describe('dispatcher — every grant: verifyGrant → decideExecution → runner
       const late = clickHarness({ now: () => now });
       await late.dispatcher.handle(execFrame());
       now = NOW + 31_000; // past the frozen grant's exp: the challenge is evicted (the click's own grant is fresh)
-      expect(await late.dispatcher.handle(click({}, { expiresAt: NOW + 60_000 }, PRINCIPAL, { iat: now - 1000, exp: now + 30_000 }))).toMatchObject({ kind: 'reply', frame: { reason: 'approval_unknown' } });
+      expect(await late.dispatcher.handle(click({}, { expiresAt: NOW + 60_000 }, PRINCIPAL, { iat: now - 1000, exp: now + 30_000 }))).toMatchObject({ kind: 'reply', frame: { reason: 'approval_mismatch' } });
       expect(h.spawnRun).not.toHaveBeenCalled();
       expect(late.spawnRun).not.toHaveBeenCalled();
     });
@@ -667,7 +673,7 @@ describe('dispatcher — every grant: verifyGrant → decideExecution → runner
       const before = h.approvals.entries().length;
       await h.dispatcher.handle(approvalRevoke('ch_9'));
       await h.dispatcher.handle(execFrame({ cmd: 'rm' }));
-      expect(await h.dispatcher.handle(signedGrant({ type: 'grant_exec', cmd: 'tool', cwd: ROOT }, { approvalIntent: { challengeId: 'server_recorded', scope: 'until_revoked', expiresAt: NOW + 30_000 } }))).toMatchObject({ kind: 'reply', frame: { reason: 'approval_unknown' } });
+      expect(await h.dispatcher.handle(signedGrant({ type: 'grant_exec', cmd: 'tool', cwd: ROOT }, { approvalIntent: { challengeId: 'server_recorded', scope: 'until_revoked', expiresAt: NOW + 30_000 } }))).toMatchObject({ kind: 'reply', frame: { reason: 'approval_mismatch' } });
       expect(h.approvals.entries().length).toBe(before);
       expect(h.spawnRun).toHaveBeenCalledTimes(1); // only rm (covered by ch_2)
     });

--- a/packages/cli/src/env-bridge/__tests__/dispatcher.test.ts
+++ b/packages/cli/src/env-bridge/__tests__/dispatcher.test.ts
@@ -638,7 +638,12 @@ describe('dispatcher — every grant: verifyGrant → decideExecution → runner
 
     it('given a signed approval revoke, should delete exactly that approval\'s rows, audit approval_revoked:<id>:<n>, and report approval_revoked — NOT revoke_verified: the key and the enrollment stand', async () => {
       const h = revokeHarness();
-      expect(await h.dispatcher.handle(approvalRevoke('ch_1'))).toEqual({ kind: 'approval_revoked', approvalId: 'ch_1', removed: 2 });
+      const result = await h.dispatcher.handle(approvalRevoke('ch_1'));
+      expect(result).toMatchObject({ kind: 'approval_revoked', approvalId: 'ch_1', removed: 2, frame: { type: 'approval_revoke_result', approvalId: 'ch_1', removed: 2 } });
+      // Codex P2 on #2583: the ack is machine-signed over {approvalId, removed} — the server may only claim what this machine did.
+      const ack = (result as { frame: Frame }).frame;
+      expect(verified(ack)).toMatchObject({ ok: true });
+      expect(verified({ ...ack, removed: 3 } as Frame)).toEqual({ ok: false, reason: 'bad_signature' });
       expect(h.approvals.entries().map((a) => a.approvalId)).toEqual(['ch_2']);
       expect(h.audits[0]?.verdict).toBe('approval_revoked:ch_1:2');
       // The revoked program now asks again; the untouched one still runs.
@@ -648,7 +653,7 @@ describe('dispatcher — every grant: verifyGrant → decideExecution → runner
 
     it('given an approval revoke for an id the machine does not hold, should report 0 removed and change nothing', async () => {
       const h = revokeHarness();
-      expect(await h.dispatcher.handle(approvalRevoke('ch_nope'))).toEqual({ kind: 'approval_revoked', approvalId: 'ch_nope', removed: 0 });
+      expect(await h.dispatcher.handle(approvalRevoke('ch_nope'))).toMatchObject({ kind: 'approval_revoked', approvalId: 'ch_nope', removed: 0, frame: { type: 'approval_revoke_result', removed: 0 } });
       expect(h.approvals.entries()).toHaveLength(3);
     });
 

--- a/packages/cli/src/env-bridge/__tests__/dispatcher.test.ts
+++ b/packages/cli/src/env-bridge/__tests__/dispatcher.test.ts
@@ -9,12 +9,13 @@ import type { MachinePolicy } from '@pagespace/lib/env-bridge/policy-types';
 import type { PathProbe } from '@pagespace/lib/env-bridge/confine-path';
 import { createDispatcher, DAEMON_CAPABILITIES, type DispatcherDeps } from '../dispatcher.js';
 import { createDaemonNonceStore } from '../nonce-store.js';
+import { createApprovalsStore } from '../approvals-store.js';
 import { generateMachineKeypair, signWithMachineKey } from '../keypair.js';
 import { ed25519Verify, envBridgeHash } from '../crypto.js';
 import type { AuditEntry } from '../audit-log.js';
 import type { ExecRunner } from '../exec-runner.js';
 import type { FsRunner } from '../fs-runner.js';
-import type { AskPrompter } from '../ask.js';
+import type { AskInput, AskPrompter } from '../ask.js';
 
 // ---- a real server key and a real machine key -------------------------------
 const serverPair = generateKeyPairSync('ed25519');
@@ -269,7 +270,16 @@ describe('dispatcher — every grant: verifyGrant → decideExecution → runner
 
   describe('ask mode', () => {
     function askHarness(answer: boolean | (() => boolean), overrides: Partial<DispatcherDeps> = {}) {
-      const ask: AskPrompter & { calls: number } = { calls: 0, ask: async () => { ask.calls += 1; return typeof answer === 'function' ? answer() : answer; } };
+      const ask: AskPrompter & { calls: number; inputs: AskInput[] } = {
+        calls: 0,
+        inputs: [],
+        ask: async (input) => {
+          ask.calls += 1;
+          ask.inputs.push(input);
+          const approved = typeof answer === 'function' ? answer() : answer;
+          return approved ? { approved: true, scope: '30d' } : { approved: false };
+        },
+      };
       return { ...harness({ policy: () => ASK_POLICY, ask, ...overrides }), ask };
     }
 
@@ -285,7 +295,7 @@ describe('dispatcher — every grant: verifyGrant → decideExecution → runner
       const h = askHarness(true);
       expect(await h.dispatcher.handle(execFrame())).toMatchObject({ kind: 'reply', frame: { type: 'exec_result', exitCode: 0 } });
       expect(h.spawnRun).toHaveBeenCalledTimes(1);
-      expect(h.audits[0]?.verdict).toBe('allow');
+      expect(h.audits[0]?.verdict).toBe('allow:approved:30d');
     });
 
     it('added-1: verifyGrant is called EXACTLY once per grant even when the owner approves — the held Grant is reused, never re-verified', async () => {
@@ -317,7 +327,7 @@ describe('dispatcher — every grant: verifyGrant → decideExecution → runner
 
     it('added-5: the normalized request handed to the prompt is frozen — it cannot be mutated while the owner reads it', async () => {
       let seen: NormalizedRequest | null = null;
-      const ask: AskPrompter = { ask: async (input) => { seen = input.request; return false; } };
+      const ask: AskPrompter = { ask: async (input) => { seen = input.request; return { approved: false }; } };
       const h = harness({ policy: () => ASK_POLICY, ask });
       await h.dispatcher.handle(execFrame());
       expect(Object.isFrozen(seen)).toBe(true);
@@ -327,6 +337,122 @@ describe('dispatcher — every grant: verifyGrant → decideExecution → runner
     it('given an ask verdict with NO prompter available (headless), should deny `ask_unavailable` rather than run or hang', async () => {
       const h = harness({ policy: () => ASK_POLICY, ask: null });
       expect(await h.dispatcher.handle(execFrame())).toMatchObject({ kind: 'reply', frame: { type: 'grant_denied', reason: 'ask_unavailable' } });
+    });
+  });
+
+  describe('GA wave 2 · leaf 1 — durable approvals keyed (envId, userId, op, subject), never the session', () => {
+    const BIN: Record<string, string> = { tool: '/usr/bin/tool', rm: '/bin/rm' };
+    function durableHarness(answer: boolean | (() => boolean), scope: 'once' | 'session' | '30d' | 'until_revoked' = '30d', overrides: Partial<DispatcherDeps> = {}) {
+      const fs = { content: null as string | null };
+      const writes: string[] = [];
+      const approvals = createApprovalsStore({
+        path: '/home/me/.pagespace/env-approvals.json',
+        uid: 501,
+        open: () => (fs.content === null ? null : { uid: 501, mode: 0o100600, content: fs.content }),
+        write: async (_p, content) => {
+          writes.push(content);
+          fs.content = content;
+        },
+        now: () => NOW,
+      });
+      const ask: AskPrompter & { calls: number } = {
+        calls: 0,
+        ask: async () => {
+          ask.calls += 1;
+          const approved = typeof answer === 'function' ? answer() : answer;
+          return approved ? { approved: true, scope } : { approved: false };
+        },
+      };
+      const ids = { approvalId: () => 'ap_1' };
+      return { ...harness({ policy: () => ASK_POLICY, ask, approvals, resolveArgv0: (name) => BIN[name] ?? null, ids, ...overrides }), ask, approvals, fs, writes };
+    }
+    const fromSession = (session: string, extra: Partial<Extract<GrantFrame, { type: 'grant_exec' }>> = {}) =>
+      signedGrant({ type: 'grant_exec', cmd: 'tool', args: ['a'], cwd: ROOT, env: { CI: '1' }, ...extra }, { principal: { ...PRINCIPAL, sessionId: session, conversationId: `conv_${session}` } });
+
+    it('given an approval of `tool a` (30d), a later `tool b` from a NEW session and conversation runs with NO prompt, audited allow:approval:<id>', async () => {
+      const h = durableHarness(true);
+      expect(await h.dispatcher.handle(fromSession('s1'))).toMatchObject({ kind: 'reply', frame: { type: 'exec_result' } });
+      expect(h.ask.calls).toBe(1);
+      expect(h.writes).toHaveLength(1);
+      expect(JSON.parse(h.writes[0]!)).toEqual({ version: 1, approvals: [{ approvalId: 'ap_1', envId: ENV_ID, userId: 'u1', op: 'exec', subject: 'exec:/usr/bin/tool', scope: '30d', createdAt: NOW, expiresAt: NOW + 30 * 24 * 3600 * 1000 }] });
+      expect(await h.dispatcher.handle(fromSession('s2', { args: ['b'] }))).toMatchObject({ kind: 'reply', frame: { type: 'exec_result' } });
+      expect(h.ask.calls).toBe(1);
+      expect(h.audits[1]?.verdict).toBe('allow:approval:ap_1');
+      expect(h.spawnRun).toHaveBeenCalledTimes(2);
+    });
+
+    it('given an approval of `tool`, a later `rm` prompts again (subject differs) and a declined prompt runs nothing', async () => {
+      const h = durableHarness(() => h.ask.calls === 1);
+      await h.dispatcher.handle(fromSession('s1'));
+      expect(await h.dispatcher.handle(fromSession('s1', { cmd: 'rm', args: ['-rf', 'x'] }))).toMatchObject({ kind: 'reply', frame: { type: 'grant_denied', reason: 'declined' } });
+      expect(h.ask.calls).toBe(2);
+      expect(h.spawnRun).toHaveBeenCalledTimes(1);
+    });
+
+    it('given the prompt is answered with scope once, nothing is remembered: the same command from the same session prompts again', async () => {
+      const h = durableHarness(true, 'once');
+      await h.dispatcher.handle(fromSession('s1'));
+      await h.dispatcher.handle(fromSession('s1'));
+      expect(h.ask.calls).toBe(2);
+      expect(h.writes).toHaveLength(0);
+      expect(h.approvals.entries()).toEqual([]);
+    });
+
+    it('given scope session, the approval is remembered in this process only — nothing written', async () => {
+      const h = durableHarness(true, 'session');
+      await h.dispatcher.handle(fromSession('s1'));
+      await h.dispatcher.handle(fromSession('s2'));
+      expect(h.ask.calls).toBe(1);
+      expect(h.writes).toHaveLength(0);
+    });
+
+    it('given a request whose programs cannot be pinned down (`sh -c` with substitution), the prompt says so (subjects null) and NOTHING is remembered even on approval', async () => {
+      const h = durableHarness(true);
+      const frame = () => fromSession('s1', { cmd: 'sh', args: ['-c', 'tool $(rm -rf x)'] });
+      // `sh` resolves, so the request is well formed; its subjects are still null.
+      const withSh = { ...h, dispatcher: createDispatcher({ ...h.deps, resolveArgv0: (name) => ({ ...BIN, sh: '/bin/sh' })[name] ?? null }) };
+      await withSh.dispatcher.handle(frame());
+      await withSh.dispatcher.handle(frame());
+      expect(h.ask.calls).toBe(2);
+      expect(h.writes).toHaveLength(0);
+    });
+
+    it('given a durable approval in the FILE from an earlier daemon run, a fresh daemon runs the covered command with no prompt (a new chat does not re-prompt)', async () => {
+      const h = durableHarness(false);
+      h.fs.content = JSON.stringify({ version: 1, approvals: [{ approvalId: 'old', envId: ENV_ID, userId: 'u1', op: 'exec', subject: 'exec:/usr/bin/tool', scope: 'until_revoked', createdAt: 1, expiresAt: null }] });
+      expect(await h.dispatcher.handle(fromSession('s9'))).toMatchObject({ kind: 'reply', frame: { type: 'exec_result' } });
+      expect(h.ask.calls).toBe(0);
+    });
+
+    it('given an approval for ANOTHER user or another env in the file, should still prompt (all four key parts)', async () => {
+      const h = durableHarness(false);
+      h.fs.content = JSON.stringify({ version: 1, approvals: [
+        { approvalId: 'o1', envId: ENV_ID, userId: 'u2', op: 'exec', subject: 'exec:/usr/bin/tool', scope: 'until_revoked', createdAt: 1, expiresAt: null },
+        { approvalId: 'o2', envId: 'env_other', userId: 'u1', op: 'exec', subject: 'exec:/usr/bin/tool', scope: 'until_revoked', createdAt: 1, expiresAt: null },
+      ] });
+      expect(await h.dispatcher.handle(fromSession('s9'))).toMatchObject({ kind: 'reply', frame: { type: 'grant_denied', reason: 'declined' } });
+      expect(h.ask.calls).toBe(1);
+    });
+
+    it('given a file the daemon does not trust (writable by others), no approval in it counts', async () => {
+      const h = durableHarness(false, '30d', {});
+      const store = createApprovalsStore({ path: '/p', uid: 501, open: () => ({ uid: 501, mode: 0o100666, content: JSON.stringify({ version: 1, approvals: [{ approvalId: 'old', envId: ENV_ID, userId: 'u1', op: 'exec', subject: 'exec:/usr/bin/tool', scope: 'until_revoked', createdAt: 1, expiresAt: null }] }) }), write: async () => undefined, now: () => NOW });
+      const d = createDispatcher({ ...h.deps, approvals: store });
+      expect(await d.handle(fromSession('s9'))).toMatchObject({ kind: 'reply', frame: { type: 'grant_denied', reason: 'declined' } });
+    });
+
+    it('an approval is written ONLY after the byte-compare allowed the request: a drift between prompt and answer (approval_mismatch) remembers nothing', async () => {
+      const probe = fakeProbe();
+      const h = durableHarness(() => { probe.existing[ROOT] = `${ROOT}-elsewhere`; probe.existing[`${ROOT}-elsewhere`] = `${ROOT}-elsewhere`; return true; }, '30d', { probe });
+      expect(await h.dispatcher.handle(fromSession('s1'))).toMatchObject({ kind: 'reply', frame: { type: 'grant_denied', reason: 'approval_mismatch' } });
+      expect(h.writes).toHaveLength(0);
+      expect(h.approvals.entries()).toEqual([]);
+    });
+
+    it('a policy that PRE-APPROVES the op never consults approvals and audits plain allow', async () => {
+      const h = durableHarness(false, '30d', { policy: () => POLICY });
+      expect(await h.dispatcher.handle(fromSession('s1'))).toMatchObject({ kind: 'reply', frame: { type: 'exec_result' } });
+      expect(h.audits[0]?.verdict).toBe('allow');
     });
   });
 

--- a/packages/cli/src/env-bridge/__tests__/dispatcher.test.ts
+++ b/packages/cli/src/env-bridge/__tests__/dispatcher.test.ts
@@ -3,7 +3,7 @@ import { createHash, generateKeyPairSync, sign as nodeSign } from 'node:crypto';
 import { canonicalizeArgs, decodeBase64, encodeGrant, verifyGrant, type ApprovalIntent, type Grant } from '@pagespace/lib/env-bridge/grant';
 import { grantRequestForFrame, type GrantFrame } from '@pagespace/lib/env-bridge/grant-args';
 import { decideExecution, type NormalizedRequest } from '@pagespace/lib/env-bridge/decide-execution';
-import { encodeRevokeForSigning, verifyMachineResult, type MachineResultFrame } from '@pagespace/lib/env-bridge/machine-signatures';
+import { encodeApprovalRevokeForSigning, encodeRevokeForSigning, verifyMachineResult, type MachineResultFrame } from '@pagespace/lib/env-bridge/machine-signatures';
 import { execOutputCeiling, fsReadContentCeiling, type Frame } from '@pagespace/lib/env-bridge/frame-codec';
 import type { MachinePolicy } from '@pagespace/lib/env-bridge/policy-types';
 import type { PathProbe } from '@pagespace/lib/env-bridge/confine-path';
@@ -615,6 +615,61 @@ describe('dispatcher — every grant: verifyGrant → decideExecution → runner
       await h.dispatcher.handle(genuine);
       expect(await h.dispatcher.handle(genuine)).toMatchObject({ kind: 'reply', frame: { reason: 'replayed' } });
       expect(h.spawnRun).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('GA wave 2 · leaf 8 — the server revokes ONE approval over the signed revoke frame; the machine file stays authoritative for ALLOW', () => {
+    const approvalRevoke = (approvalId: string, issuedAt = NOW, keyId = serverKeyId): Frame => ({ type: 'revoke', approvalId, issuedAt, sig: serverSign(encodeApprovalRevokeForSigning({ envId: ENV_ID, enrollmentId: ENROLLMENT_ID, keyId, issuedAt, approvalId })), reason: 'owner' });
+    function revokeHarness() {
+      const fs = { content: JSON.stringify({ version: 1, approvals: [
+        { approvalId: 'ch_1', envId: ENV_ID, userId: 'u1', op: 'exec', subject: 'exec:/usr/bin/tool', scope: 'until_revoked', createdAt: 1, expiresAt: null },
+        { approvalId: 'ch_1', envId: ENV_ID, userId: 'u1', op: 'exec', subject: 'builtin:cd', scope: 'until_revoked', createdAt: 1, expiresAt: null },
+        { approvalId: 'ch_2', envId: ENV_ID, userId: 'u1', op: 'exec', subject: 'exec:/bin/rm', scope: 'until_revoked', createdAt: 1, expiresAt: null },
+      ] }) as string | null };
+      const approvals = createApprovalsStore({ path: '/p', uid: 501, open: () => (fs.content === null ? null : { uid: 501, mode: 0o100600, content: fs.content }), write: async (_p, c) => { fs.content = c; }, now: () => NOW });
+      return { ...harness({ policy: () => ASK_POLICY, ask: null, approvals, resolveArgv0: (name) => ({ tool: '/usr/bin/tool', rm: '/bin/rm' })[name] ?? null }), approvals, fs };
+    }
+
+    it('given a signed approval revoke, should delete exactly that approval\'s rows, audit approval_revoked:<id>:<n>, and report approval_revoked — NOT revoke_verified: the key and the enrollment stand', async () => {
+      const h = revokeHarness();
+      expect(await h.dispatcher.handle(approvalRevoke('ch_1'))).toEqual({ kind: 'approval_revoked', approvalId: 'ch_1', removed: 2 });
+      expect(h.approvals.entries().map((a) => a.approvalId)).toEqual(['ch_2']);
+      expect(h.audits[0]?.verdict).toBe('approval_revoked:ch_1:2');
+      // The revoked program now asks again; the untouched one still runs.
+      expect(await h.dispatcher.handle(execFrame())).toMatchObject({ kind: 'reply', frame: { type: 'grant_denied', reason: 'ask_unavailable' } });
+      expect(await h.dispatcher.handle(execFrame({ cmd: 'rm' }))).toMatchObject({ kind: 'reply', frame: { type: 'exec_result' } });
+    });
+
+    it('given an approval revoke for an id the machine does not hold, should report 0 removed and change nothing', async () => {
+      const h = revokeHarness();
+      expect(await h.dispatcher.handle(approvalRevoke('ch_nope'))).toEqual({ kind: 'approval_revoked', approvalId: 'ch_nope', removed: 0 });
+      expect(h.approvals.entries()).toHaveLength(3);
+    });
+
+    it('given an approval revoke NOT signed by the pinned key, or signed for another id, should drop it and delete nothing', async () => {
+      const h = revokeHarness();
+      const forged = { ...approvalRevoke('ch_1'), approvalId: 'ch_2' } as Frame;
+      expect(await h.dispatcher.handle(forged)).toEqual({ kind: 'dropped', reason: 'revoke_bad_signature' });
+      expect(await h.dispatcher.handle(approvalRevoke('ch_1', NOW, 'other-key'))).toEqual({ kind: 'dropped', reason: 'revoke_bad_signature' });
+      expect(h.approvals.entries()).toHaveLength(3);
+      expect(h.audits.map((a) => a.verdict)).toEqual(['dropped:approval_revoke_bad_signature', 'dropped:approval_revoke_bad_signature']);
+    });
+
+    it('given a signed approval revoke with the id STRIPPED, should drop it — it can never become an enrollment revoke (no deleteKey)', async () => {
+      const h = revokeHarness();
+      const { approvalId: _dropped, ...stripped } = approvalRevoke('ch_1') as Extract<Frame, { type: 'revoke' }>;
+      expect(await h.dispatcher.handle(stripped as Frame)).toEqual({ kind: 'dropped', reason: 'revoke_bad_signature' });
+    });
+
+    it('THE ASYMMETRY: nothing the server sends can ADD an approval — a revoke frame, a grant, a click for a challenge the machine never froze: the store only grows after the machine\'s own byte-compared approval', async () => {
+      const h = revokeHarness();
+      await h.dispatcher.handle(approvalRevoke('ch_1')); // tool is no longer covered
+      const before = h.approvals.entries().length;
+      await h.dispatcher.handle(approvalRevoke('ch_9'));
+      await h.dispatcher.handle(execFrame({ cmd: 'rm' }));
+      expect(await h.dispatcher.handle(signedGrant({ type: 'grant_exec', cmd: 'tool', cwd: ROOT }, { approvalIntent: { challengeId: 'server_recorded', scope: 'until_revoked', expiresAt: NOW + 30_000 } }))).toMatchObject({ kind: 'reply', frame: { reason: 'approval_unknown' } });
+      expect(h.approvals.entries().length).toBe(before);
+      expect(h.spawnRun).toHaveBeenCalledTimes(1); // only rm (covered by ch_2)
     });
   });
 

--- a/packages/cli/src/env-bridge/__tests__/dispatcher.test.ts
+++ b/packages/cli/src/env-bridge/__tests__/dispatcher.test.ts
@@ -1,6 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { createHash, generateKeyPairSync, sign as nodeSign } from 'node:crypto';
-import { canonicalizeArgs, decodeBase64, encodeGrant, verifyGrant, type Grant } from '@pagespace/lib/env-bridge/grant';
+import { canonicalizeArgs, decodeBase64, encodeGrant, verifyGrant, type ApprovalIntent, type Grant } from '@pagespace/lib/env-bridge/grant';
 import { grantRequestForFrame, type GrantFrame } from '@pagespace/lib/env-bridge/grant-args';
 import { decideExecution, type NormalizedRequest } from '@pagespace/lib/env-bridge/decide-execution';
 import { encodeRevokeForSigning, verifyMachineResult, type MachineResultFrame } from '@pagespace/lib/env-bridge/machine-signatures';
@@ -520,6 +520,101 @@ describe('dispatcher — every grant: verifyGrant → decideExecution → runner
     it('given no prompter and no challenge store, should deny ask_unavailable (unchanged)', async () => {
       const h = harness({ policy: () => ASK_POLICY, ask: null });
       expect(await h.dispatcher.handle(execFrame())).toMatchObject({ kind: 'reply', frame: { reason: 'ask_unavailable' } });
+    });
+  });
+
+  describe('GA wave 2 · leaf 7 — the click: the daemon byte-compares the re-issued request against the one it froze; only a match writes the approval and runs', () => {
+    const BIN: Record<string, string> = { tool: '/usr/bin/tool', rm: '/bin/rm' };
+    const INTENT: ApprovalIntent = { challengeId: 'ch_1', scope: '30d', expiresAt: NOW + 30_000 };
+    function clickHarness(overrides: Partial<DispatcherDeps> = {}) {
+      let n = 0;
+      const challenges = createChallengeStore({ newId: () => `ch_${++n}` });
+      const fs = { content: null as string | null };
+      const writes: string[] = [];
+      const approvals = createApprovalsStore({ path: '/p', uid: 501, open: () => (fs.content === null ? null : { uid: 501, mode: 0o100600, content: fs.content }), write: async (_p, c) => { writes.push(c); fs.content = c; }, now: () => NOW });
+      return { ...harness({ policy: () => ASK_POLICY, ask: null, challenges, approvals, resolveArgv0: (name) => BIN[name] ?? null, ...overrides }), challenges, writes };
+    }
+    /** The click: the SAME unsigned frame, a fresh grant, plus the server-signed intent. */
+    const click = (extra: Partial<Extract<GrantFrame, { type: 'grant_exec' }>> = {}, intent: Partial<ApprovalIntent> = {}, principal = PRINCIPAL, grantOverrides: Partial<Grant> = {}) =>
+      signedGrant({ type: 'grant_exec', cmd: 'tool', args: ['a'], cwd: ROOT, env: { CI: '1' }, ...extra }, { approvalIntent: { ...INTENT, ...intent }, principal: { ...principal, sessionId: 'later', conversationId: 'later' }, ...grantOverrides });
+
+    it('given a click whose re-issued request is BYTE-IDENTICAL to the frozen one, should run it, audit allow:click:<id>:<scope>, remember the approval under the challenge id, and spend the challenge', async () => {
+      const h = clickHarness();
+      expect(await h.dispatcher.handle(execFrame())).toMatchObject({ kind: 'reply', frame: { reason: 'ask_pending:ch_1' } });
+      const result = await h.dispatcher.handle(click());
+      expect(result).toMatchObject({ kind: 'reply', frame: { type: 'exec_result', exitCode: 0 } });
+      expect(h.spawnRun).toHaveBeenCalledTimes(1);
+      expect(h.spawnRun.mock.calls[0]![0]).toMatchObject({ cmd: 'tool', args: ['a'], cwd: ROOT, env: { CI: '1' } });
+      expect(h.audits[1]).toMatchObject({ grantId: 'grant_2', verdict: 'allow:click:ch_1:30d' });
+      expect(JSON.parse(h.writes[0]!)).toMatchObject({ approvals: [expect.objectContaining({ approvalId: 'ch_1', subject: 'exec:/usr/bin/tool', scope: '30d', userId: 'u1' })] });
+      expect(h.challenges.size()).toBe(0);
+      // And a third request for the same program from a new chat is now covered: no challenge, no click.
+      expect(await h.dispatcher.handle(execFrame({ args: ['zzz'] }))).toMatchObject({ kind: 'reply', frame: { type: 'exec_result' } });
+    });
+
+    it('EXIT CRITERION: a chat click cannot introduce a request the machine did not frame — a click over DIFFERENT bytes is approval_mismatch, executes nothing, remembers nothing, is audited', async () => {
+      const h = clickHarness();
+      await h.dispatcher.handle(execFrame());
+      for (const different of [click({ cmd: 'rm', args: ['-rf', 'x'] }), click({ args: ['b'] }), click({ env: { CI: '2' } }), click({ cwd: `${ROOT}/file` })]) {
+        expect(await h.dispatcher.handle(different)).toMatchObject({ kind: 'reply', frame: { type: 'grant_denied', reason: 'approval_mismatch' } });
+      }
+      expect(h.spawnRun).not.toHaveBeenCalled();
+      expect(h.writes).toHaveLength(0);
+      expect(h.audits.slice(1).every((a) => a.verdict.startsWith('deny:approval_mismatch'))).toBe(true);
+      // The genuine question is still pending: a matching click can still answer it.
+      expect(h.challenges.size()).toBe(1);
+      expect(await h.dispatcher.handle(click())).toMatchObject({ kind: 'reply', frame: { type: 'exec_result' } });
+    });
+
+    it('given a click for a challenge the daemon never froze (a guessed id, or an approval the SERVER "recorded"), should deny approval_unknown and run nothing', async () => {
+      const h = clickHarness();
+      expect(await h.dispatcher.handle(click({}, { challengeId: 'ch_never' }))).toMatchObject({ kind: 'reply', frame: { type: 'grant_denied', reason: 'approval_unknown' } });
+      expect(h.audits[0]?.verdict).toBe('deny:approval_unknown:ch_never');
+      expect(h.spawnRun).not.toHaveBeenCalled();
+      expect(h.writes).toHaveLength(0);
+    });
+
+    it('given a click after the intent expiry or after the challenge TTL, should deny approval_expired', async () => {
+      const h = clickHarness();
+      await h.dispatcher.handle(execFrame());
+      expect(await h.dispatcher.handle(click({}, { expiresAt: NOW - 1 }))).toMatchObject({ kind: 'reply', frame: { reason: 'approval_expired' } });
+      let now = NOW;
+      const late = clickHarness({ now: () => now });
+      await late.dispatcher.handle(execFrame());
+      now = NOW + 31_000; // past the frozen grant's exp: the challenge is evicted (the click's own grant is fresh)
+      expect(await late.dispatcher.handle(click({}, { expiresAt: NOW + 60_000 }, PRINCIPAL, { iat: now - 1000, exp: now + 30_000 }))).toMatchObject({ kind: 'reply', frame: { reason: 'approval_unknown' } });
+      expect(h.spawnRun).not.toHaveBeenCalled();
+      expect(late.spawnRun).not.toHaveBeenCalled();
+    });
+
+    it('given a click carrying ANOTHER user\'s principal for a challenge frozen for u1, should deny approval_mismatch', async () => {
+      const h = clickHarness({ policy: () => ({ ...ASK_POLICY, principals: ['u1', 'u2'] }) });
+      await h.dispatcher.handle(execFrame());
+      expect(await h.dispatcher.handle(click({}, {}, { ...PRINCIPAL, userId: 'u2' }))).toMatchObject({ kind: 'reply', frame: { reason: 'approval_mismatch' } });
+      expect(h.spawnRun).not.toHaveBeenCalled();
+    });
+
+    it('given scope once, should run and remember nothing; given until_revoked, should remember with no expiry', async () => {
+      const once = clickHarness();
+      await once.dispatcher.handle(execFrame());
+      expect(await once.dispatcher.handle(click({}, { scope: 'once' }))).toMatchObject({ kind: 'reply', frame: { type: 'exec_result' } });
+      expect(once.writes).toHaveLength(0);
+      const forever = clickHarness();
+      await forever.dispatcher.handle(execFrame());
+      await forever.dispatcher.handle(click({}, { scope: 'until_revoked' }));
+      expect(JSON.parse(forever.writes[0]!)).toMatchObject({ approvals: [expect.objectContaining({ approvalId: 'ch_1', scope: 'until_revoked', expiresAt: null })] });
+    });
+
+    it('a click is only ever a fresh grant: the intent rides the signature (a forged one is bad_signature) and its nonce is spent like any other', async () => {
+      const h = clickHarness();
+      await h.dispatcher.handle(execFrame());
+      const forged = click();
+      const tampered = { ...forged, grant: { ...forged.grant, approvalIntent: { ...INTENT, scope: 'until_revoked' } } } as GrantFrame;
+      expect(await h.dispatcher.handle(tampered)).toMatchObject({ kind: 'reply', frame: { reason: 'bad_signature' } });
+      const genuine = click();
+      await h.dispatcher.handle(genuine);
+      expect(await h.dispatcher.handle(genuine)).toMatchObject({ kind: 'reply', frame: { reason: 'replayed' } });
+      expect(h.spawnRun).toHaveBeenCalledTimes(1);
     });
   });
 

--- a/packages/cli/src/env-bridge/__tests__/invariants.test.ts
+++ b/packages/cli/src/env-bridge/__tests__/invariants.test.ts
@@ -124,11 +124,15 @@ describe('daemon structural invariants', () => {
       const codec = readFileSync(join(HERE, '..', '..', '..', 'lib', 'src', 'env-bridge', 'frame-codec.ts'), 'utf8');
       const types = [...codec.matchAll(/z\.literal\('([a-z_]+)'\)/g)].map((m) => m[1]);
       expect(types.length).toBeGreaterThan(10);
-      expect(types.filter((t) => /approv|allow|remember/.test(t as string))).toEqual([]);
-      // `approvalId` appears exactly once in the codec: on the revoke schema. `approvalIntent` never does — it lives inside the opaque grant, parsed only by verifyGrant.
-      const approvalIdLines = codec.split('\n').filter((line) => line.includes('approvalId') && !line.trimStart().startsWith('/**') && !line.trimStart().startsWith('*'));
-      expect(approvalIdLines).toHaveLength(1);
-      expect(approvalIdLines[0]).toMatch(/z\.literal\('revoke'\)/);
+      // The only approval-shaped types: `revoke` (server → machine, DELETES one) and the machine → server ACK of that deletion. Neither can add.
+      expect(types.filter((t) => /approv|allow|remember/.test(t as string))).toEqual(['approval_revoke_result']);
+      expect(codec).toMatch(/MACHINE_TO_SERVER_FRAME_TYPES[^;]*'approval_revoke_result'/);
+      expect(codec).not.toMatch(/SERVER_TO_MACHINE_FRAME_TYPES[^;]*'approval_revoke_result'/);
+      // `approvalId` appears on exactly those two schemas. `approvalIntent` never does — it lives inside the opaque grant, parsed only by verifyGrant.
+      const approvalIdLines = codec.split('\n').filter((line) => line.includes('approvalId') && !line.trimStart().startsWith('/**') && !line.trimStart().startsWith('*') && !line.trimStart().startsWith('//'));
+      expect(approvalIdLines).toHaveLength(2);
+      expect(approvalIdLines.some((line) => /z\.literal\('revoke'\)/.test(line))).toBe(true);
+      expect(approvalIdLines.some((line) => /z\.literal\('approval_revoke_result'\)/.test(line))).toBe(true);
       expect(codec).not.toMatch(/approvalIntent/);
       // And the daemon never routes a frame by an approval-shaped type.
       expect(dispatcher).not.toMatch(/frame\.type === '(approve|approval|allow)/);

--- a/packages/cli/src/env-bridge/__tests__/invariants.test.ts
+++ b/packages/cli/src/env-bridge/__tests__/invariants.test.ts
@@ -82,6 +82,31 @@ describe('daemon structural invariants', () => {
     expect(source).not.toMatch(/GrantFrame|ExecutionRequest\b/);
   });
 
+  describe('GA wave 2 — the approvals asymmetry: the machine file is authoritative for ALLOW; the server can only REVOKE', () => {
+    const dispatcher = read(join(HERE, 'dispatcher.ts'));
+    const store = read(join(HERE, 'approvals-store.ts'));
+
+    it('approvals-store.ts reads and writes ONLY the local file (node:fs) — it has no network, no socket, no frame input', () => {
+      const imports = [...store.matchAll(/from '([^']+)'/g)].map((m) => m[1]);
+      expect(imports.every((s) => s === 'node:fs/promises' || s === 'node:path' || s === './lib-core.js' || s === './policy.js')).toBe(true);
+      expect(store).not.toMatch(/fetch\(|from 'ws'|Frame\b/);
+    });
+
+    it('the dispatcher writes an approval in exactly TWO places, both after a byte-compared allow (a terminal answer, a click that matched) — never from a revoke or any other frame', () => {
+      const writes = [...dispatcher.matchAll(/approvals\.remember\(/g)];
+      expect(writes).toHaveLength(2);
+      const revokeStart = dispatcher.indexOf('const handleRevoke');
+      for (const w of writes) expect(w.index).toBeLessThan(revokeStart);
+      expect(dispatcher.slice(revokeStart)).not.toMatch(/remember\(/);
+      expect(dispatcher.slice(revokeStart)).toMatch(/approvals\.revoke\(frame\.approvalId\)/);
+    });
+
+    it('decideExecution is fed the machine\'s own approvals (deps.approvals) and nothing carried by the grant or the frame', () => {
+      expect(dispatcher).toMatch(/approvals: \{ entries: deps\.approvals\?\.entries\(\) \?\? \[\]/);
+      expect(dispatcher).not.toMatch(/grant\.approvals|frame\.approvals/);
+    });
+  });
+
   describe('GA wave 1 — the two docblocks that used to lie', () => {
     const dispatcher = read(join(HERE, 'dispatcher.ts'));
     const auditLog = read(join(HERE, 'audit-log.ts'));

--- a/packages/cli/src/env-bridge/__tests__/invariants.test.ts
+++ b/packages/cli/src/env-bridge/__tests__/invariants.test.ts
@@ -92,13 +92,46 @@ describe('daemon structural invariants', () => {
       expect(store).not.toMatch(/fetch\(|from 'ws'|Frame\b/);
     });
 
-    it('the dispatcher writes an approval in exactly TWO places, both after a byte-compared allow (a terminal answer, a click that matched) — never from a revoke or any other frame', () => {
+    it('(a) the ONLY writer to the approvals store is the daemon\'s own remember() after a byte-compared allow (the terminal prompt, the click that matched) — no frame handler and no code path passes server-supplied data into approvals.remember()', () => {
       const writes = [...dispatcher.matchAll(/approvals\.remember\(/g)];
       expect(writes).toHaveLength(2);
+      // Both sit inside handleGrant, AFTER the second decideExecution (the byte-compare) allowed, and BEFORE handleRevoke.
+      const handleGrantStart = dispatcher.indexOf('const handleGrant');
       const revokeStart = dispatcher.indexOf('const handleRevoke');
-      for (const w of writes) expect(w.index).toBeLessThan(revokeStart);
+      for (const w of writes) {
+        expect(w.index).toBeGreaterThan(handleGrantStart);
+        expect(w.index).toBeLessThan(revokeStart);
+        const preceding = dispatcher.slice(handleGrantStart, w.index);
+        expect(preceding).toMatch(/localApproval: \{ grantId: grant\.grantId, approvedAt: (deps\.now\(\)|now), request: (shown|frozen\.request) \}/);
+        expect(preceding).toMatch(/kind (===|!==) 'allow'/);
+      }
+      // What is remembered comes from the daemon's OWN state (the verdict's subjects, the frozen challenge), never from the frame or the grant.
+      for (const w of writes) {
+        const call = dispatcher.slice(w.index, dispatcher.indexOf(';', w.index));
+        expect(call).toMatch(/subjects(: frozen\.subjects)?,/);
+        expect(call).not.toMatch(/frame\.|grant\.args|request\./);
+      }
       expect(dispatcher.slice(revokeStart)).not.toMatch(/remember\(/);
       expect(dispatcher.slice(revokeStart)).toMatch(/approvals\.revoke\(frame\.approvalId\)/);
+      // No other daemon file writes approvals at all.
+      for (const file of daemonFiles) {
+        if (name(file) === 'env-bridge/dispatcher.ts' || name(file) === 'env-bridge/approvals-store.ts') continue;
+        expect(read(file), name(file)).not.toMatch(/\.remember\(/);
+      }
+    });
+
+    it('(b) the frame codec has NO frame type that can ADD an approval — the only approval-shaped frame is `revoke` with `approvalId`', () => {
+      const codec = readFileSync(join(HERE, '..', '..', '..', 'lib', 'src', 'env-bridge', 'frame-codec.ts'), 'utf8');
+      const types = [...codec.matchAll(/z\.literal\('([a-z_]+)'\)/g)].map((m) => m[1]);
+      expect(types.length).toBeGreaterThan(10);
+      expect(types.filter((t) => /approv|allow|remember/.test(t as string))).toEqual([]);
+      // `approvalId` appears exactly once in the codec: on the revoke schema. `approvalIntent` never does — it lives inside the opaque grant, parsed only by verifyGrant.
+      const approvalIdLines = codec.split('\n').filter((line) => line.includes('approvalId') && !line.trimStart().startsWith('/**') && !line.trimStart().startsWith('*'));
+      expect(approvalIdLines).toHaveLength(1);
+      expect(approvalIdLines[0]).toMatch(/z\.literal\('revoke'\)/);
+      expect(codec).not.toMatch(/approvalIntent/);
+      // And the daemon never routes a frame by an approval-shaped type.
+      expect(dispatcher).not.toMatch(/frame\.type === '(approve|approval|allow)/);
     });
 
     it('decideExecution is fed the machine\'s own approvals (deps.approvals) and nothing carried by the grant or the frame', () => {

--- a/packages/cli/src/env-bridge/approvals-store.ts
+++ b/packages/cli/src/env-bridge/approvals-store.ts
@@ -1,0 +1,198 @@
+/**
+ * Durable approvals on the machine — `~/.pagespace/env-approvals.json`
+ * (GA wave 2, leaf 1).
+ *
+ * Before this wave an `ask` answer lived in a `Set` keyed `(userId,
+ * sessionId, op)` inside the daemon process: a new chat asked again, and one
+ * approval of `git status` covered every later `exec` in that session,
+ * unseen. Approvals are now keyed `(envId, userId, op, subject)` — see
+ * `decide-approval.ts` for what a subject is — with an expiry the owner
+ * chose: `once` (never remembered), `session` (this process only),
+ * `30d` (the default) or `until_revoked` (the file, until a revoke).
+ *
+ * THE FILE IS AUTHORITATIVE FOR ALLOW. The daemon reads approvals from this
+ * file and from its own memory, and from nowhere else — never from the
+ * server. PageSpace may only REVOKE an approval (over the signed `revoke`
+ * frame, by id); it cannot write one. That asymmetry is what makes a
+ * compromised server unable to widen what runs here, and it is pinned by
+ * `__tests__/invariants.test.ts`.
+ *
+ * Trust rules are the policy file's, through the SAME one-descriptor adapter
+ * (`openPolicyFile`, CWE-367): owned by the daemon's uid, not writable by
+ * group or world, opened with `O_NOFOLLOW`. A file that fails any check, or
+ * whose contents the strict parser refuses, contributes NOTHING — never a
+ * partial list — and is never overwritten by this daemon. The file is
+ * re-read at every decision, so an out-of-band edit, chmod or delete takes
+ * effect at the next request.
+ *
+ * Writes are atomic (temp file + rename, 0600) and never throw into the
+ * dispatcher: a write that fails leaves the approval in memory for the life
+ * of the process and says so.
+ */
+import { mkdir, rename, unlink, writeFile } from 'node:fs/promises';
+import { dirname } from 'node:path';
+import { approvalExpiry, isDurableScope, parseApprovalsFile, serializeApprovalsFile, type ApprovalScope, type DurableApproval, type GrantOp } from './lib-core.js';
+import type { OpenedPolicyFile, PolicyLoadReason } from './policy.js';
+
+export const APPROVALS_FILE_NAME = 'env-approvals.json';
+export const APPROVALS_PATH_ENV_VAR = 'PAGESPACE_ENV_APPROVALS';
+
+/** Group or world write bits — the same mask the policy loader uses. */
+const WRITABLE_BY_OTHERS_MASK = 0o022;
+
+export interface ApprovalsStoreDeps {
+  readonly path: string;
+  /** The uid the daemon runs as; the file must be owned by it. */
+  readonly uid: number;
+  /** ONE open: fstat identity and content together; `null` when missing; throws ⇒ unreadable. */
+  readonly open: (path: string) => OpenedPolicyFile | null;
+  /** Atomic 0600 write (production: `writeApprovalsFile`). */
+  readonly write: (path: string, content: string) => Promise<void>;
+  readonly now: () => number;
+  readonly log?: (line: string) => void;
+}
+
+export interface ApprovalsLoad {
+  /** The rows in force from the FILE (never partial: any defect ⇒ `[]`). */
+  readonly approvals: readonly DurableApproval[];
+  /** Why the file contributed nothing; `null` when it was read. `missing` is the ordinary first state. */
+  readonly reason: PolicyLoadReason | null;
+}
+
+/** What one owner decision remembers: every subject the request named, under one id, for one scope. */
+export interface RememberApprovalInput {
+  readonly approvalId: string;
+  readonly envId: string;
+  readonly userId: string;
+  readonly op: GrantOp;
+  readonly subjects: readonly string[];
+  readonly scope: ApprovalScope;
+}
+
+export interface ApprovalsStore {
+  /** Durable rows (re-read from the file now) plus this process's session rows. */
+  entries(): readonly DurableApproval[];
+  /** Re-read the file and say why it was or was not trusted. */
+  reload(): ApprovalsLoad;
+  /** Remember an owner's decision per its scope. Never throws. */
+  remember(input: RememberApprovalInput): Promise<void>;
+  /** Delete every row of exactly this approval, file and memory. @returns rows removed. */
+  revoke(approvalId: string): Promise<number>;
+  /** Drop expired rows from the file. @returns rows removed. */
+  prune(now: number): Promise<number>;
+}
+
+export function defaultApprovalsPath(env: Readonly<Record<string, string | undefined>>, homedir: string): string {
+  const fromEnv = env[APPROVALS_PATH_ENV_VAR]?.trim();
+  return fromEnv && fromEnv.length > 0 ? fromEnv : `${homedir}/.pagespace/${APPROVALS_FILE_NAME}`;
+}
+
+export function createApprovalsStore(deps: ApprovalsStoreDeps): ApprovalsStore {
+  /** `session`-scoped rows: this process only. */
+  const session: DurableApproval[] = [];
+  /** Durable rows the file refused to take (refused file, failed write): this process only, so the click still counts. */
+  const unwritten: DurableApproval[] = [];
+  const log = deps.log ?? (() => undefined);
+
+  const load = (): ApprovalsLoad => {
+    let opened: OpenedPolicyFile | null;
+    try {
+      opened = deps.open(deps.path);
+    } catch {
+      return { approvals: [], reason: 'unreadable' };
+    }
+    if (opened === null) return { approvals: [], reason: 'missing' };
+    if (opened.uid !== deps.uid) return { approvals: [], reason: 'wrong_owner' };
+    if ((opened.mode & WRITABLE_BY_OTHERS_MASK) !== 0) return { approvals: [], reason: 'writable_by_others' };
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(opened.content);
+    } catch {
+      return { approvals: [], reason: 'invalid_json' };
+    }
+    const approvals = parseApprovalsFile(parsed);
+    if (approvals === null) return { approvals: [], reason: 'invalid_schema' };
+    return { approvals, reason: null };
+  };
+
+  /** Read-merge-write. Refuses to touch a file that exists but is not trusted. @returns whether the file now holds `next`. */
+  const writeDurable = async (next: readonly DurableApproval[], loaded: ApprovalsLoad): Promise<boolean> => {
+    if (loaded.reason !== null && loaded.reason !== 'missing') {
+      log(`not writing ${deps.path}: the existing file is refused (${loaded.reason}); the approval is kept for this process only`);
+      return false;
+    }
+    try {
+      await deps.write(deps.path, serializeApprovalsFile(next));
+      return true;
+    } catch (error) {
+      log(`could not write ${deps.path}: ${error instanceof Error ? error.message : String(error)}; the approval is kept for this process only`);
+      return false;
+    }
+  };
+
+  return {
+    entries: () => [...load().approvals, ...unwritten, ...session],
+    reload: load,
+    async remember(input) {
+      if (input.scope === 'once') return;
+      const createdAt = deps.now();
+      const rows: DurableApproval[] = input.subjects.map((subject) => ({
+        approvalId: input.approvalId,
+        envId: input.envId,
+        userId: input.userId,
+        op: input.op,
+        subject,
+        scope: input.scope,
+        createdAt,
+        expiresAt: approvalExpiry(input.scope, createdAt),
+      }));
+      if (!isDurableScope(input.scope)) {
+        session.push(...rows);
+        return;
+      }
+      const loaded = load();
+      const written = await writeDurable([...loaded.approvals, ...rows], loaded);
+      if (!written) unwritten.push(...rows);
+    },
+    async revoke(approvalId) {
+      let removed = 0;
+      for (const set of [session, unwritten]) {
+        for (let i = set.length - 1; i >= 0; i -= 1) {
+          if (set[i]?.approvalId === approvalId) {
+            set.splice(i, 1);
+            removed += 1;
+          }
+        }
+      }
+      const loaded = load();
+      const kept = loaded.approvals.filter((a) => a.approvalId !== approvalId);
+      const fromFile = loaded.approvals.length - kept.length;
+      if (fromFile > 0 && (await writeDurable(kept, loaded))) removed += fromFile;
+      return removed;
+    },
+    async prune(now) {
+      const loaded = load();
+      const kept = loaded.approvals.filter((a) => a.expiresAt === null || a.expiresAt > now);
+      const dropped = loaded.approvals.length - kept.length;
+      if (dropped === 0) return 0;
+      return (await writeDurable(kept, loaded)) ? dropped : 0;
+    },
+  };
+}
+
+/**
+ * The production writer: directory 0700, a 0600 temp file beside the target,
+ * then `rename` — so a reader never sees a half-written file and a crash
+ * leaves the previous file intact.
+ */
+export async function writeApprovalsFile(path: string, content: string): Promise<void> {
+  await mkdir(dirname(path), { recursive: true, mode: 0o700 });
+  const temp = `${path}.${process.pid}.tmp`;
+  try {
+    await writeFile(temp, content, { mode: 0o600, flag: 'wx' });
+    await rename(temp, path);
+  } catch (error) {
+    await unlink(temp).catch(() => undefined);
+    throw error;
+  }
+}

--- a/packages/cli/src/env-bridge/approvals-store.ts
+++ b/packages/cli/src/env-bridge/approvals-store.ts
@@ -31,7 +31,7 @@
  */
 import { mkdir, rename, unlink, writeFile } from 'node:fs/promises';
 import { dirname } from 'node:path';
-import { approvalExpiry, isDurableScope, parseApprovalsFile, serializeApprovalsFile, type ApprovalScope, type DurableApproval, type GrantOp } from './lib-core.js';
+import { APPROVALS_FILE_VERSION, approvalExpiry, isDurableScope, parseApprovalsFile, type ApprovalScope, type DurableApproval, type GrantOp } from './lib-core.js';
 import type { OpenedPolicyFile, PolicyLoadReason } from './policy.js';
 
 export const APPROVALS_FILE_NAME = 'env-approvals.json';
@@ -80,6 +80,11 @@ export interface ApprovalsStore {
   revoke(approvalId: string): Promise<number>;
   /** Drop expired rows from the file. @returns rows removed. */
   prune(now: number): Promise<number>;
+}
+
+/** The canonical serialisation the daemon writes (pretty, trailing newline); only durable scopes ever reach the file. */
+export function serializeApprovalsFile(approvals: readonly DurableApproval[]): string {
+  return `${JSON.stringify({ version: APPROVALS_FILE_VERSION, approvals: approvals.filter((a) => isDurableScope(a.scope)) }, null, 2)}\n`;
 }
 
 export function defaultApprovalsPath(env: Readonly<Record<string, string | undefined>>, homedir: string): string {

--- a/packages/cli/src/env-bridge/ask.ts
+++ b/packages/cli/src/env-bridge/ask.ts
@@ -1,17 +1,26 @@
 /**
- * The owner's prompt for `ask` mode (invariant 5). The daemon asks once per
- * new (principal, session) and per op that is not pre-approved in the
- * policy; an approval is remembered for the life of the process, a decline is
- * not (the next request asks again). What the owner sees is EXACTLY the
- * `NormalizedRequest` the `ask` verdict carried — confined cwd and paths,
- * scrubbed env, clamped caps — because that is what `decideExecution` will
- * re-normalize and compare against on approval (`approval_mismatch`).
+ * The owner's terminal prompt for `ask` mode (invariant 5). The daemon asks
+ * about a request whose op is not pre-approved in the policy AND that no
+ * durable approval covers (`decide-approval.ts`). What the owner sees is
+ * EXACTLY the `NormalizedRequest` the `ask` verdict carried — confined cwd
+ * and paths, scrubbed env, clamped caps — because that is what
+ * `decideExecution` will re-normalize and compare against on approval
+ * (`approval_mismatch`).
  *
- * The prompt primitive is injected: `env connect` supplies `@clack/prompts`'
- * confirm; tests supply a function. A prompt that throws (stdin closed) is
- * a decline.
+ * THIS MODULE REMEMBERS NOTHING (GA wave 2, leaf 1). It used to keep a `Set`
+ * keyed `(userId, sessionId, op)`, which is why approving `git status` once
+ * covered every later `exec` in that session unseen. An approval is now
+ * remembered by the dispatcher, in the approvals store, keyed on the
+ * SUBJECTS the verdict carried (`exec:/usr/bin/git`, `root:/home/u/proj`)
+ * and for the scope the owner chose here — `once`, `session`, `30d` (the
+ * default) or `until_revoked`. The prompt says which subjects an approval
+ * would cover, or that this request cannot be remembered at all.
+ *
+ * The prompt primitives are injected: `env connect` supplies
+ * `@clack/prompts`' confirm and select; tests supply functions. A prompt
+ * that throws (stdin closed) is a decline.
  */
-import type { GrantOp, GrantPrincipal } from './lib-core.js';
+import { DEFAULT_APPROVAL_SCOPE, type ApprovalScope, type GrantOp, type GrantPrincipal } from './lib-core.js';
 import type { NormalizedRequest } from './lib-core.js';
 
 export interface AskInput {
@@ -19,20 +28,42 @@ export interface AskInput {
   readonly principal: GrantPrincipal;
   readonly op: GrantOp;
   readonly request: NormalizedRequest;
+  /** What an approval would be remembered under; `null` = it cannot be remembered, the owner is asked every time. */
+  readonly subjects: readonly string[] | null;
 }
 
+export type AskAnswer = { readonly approved: false } | { readonly approved: true; readonly scope: ApprovalScope };
+
 export interface AskPrompter {
-  ask(input: AskInput): Promise<boolean>;
+  ask(input: AskInput): Promise<AskAnswer>;
 }
 
 export interface AskPrompterDeps {
   readonly confirm: (message: string) => Promise<boolean>;
+  /** How long to remember an approval; omitted ⇒ `DEFAULT_APPROVAL_SCOPE`. Only asked when the request has subjects. */
+  readonly chooseScope?: (subjects: readonly string[]) => Promise<ApprovalScope>;
   readonly write: (chunk: string) => void;
 }
 
-/** One approval covers one (user, session, op); the conversation is not part of the key. */
-export function approvalKey(principal: GrantPrincipal, op: GrantOp): string {
-  return `${principal.userId} ${principal.sessionId} ${op}`;
+/** A subject as the owner reads it. */
+export function describeSubject(subject: string): string {
+  if (subject.startsWith('exec:')) return subject.slice('exec:'.length);
+  if (subject.startsWith('builtin:')) return `${subject.slice('builtin:'.length)} (shell builtin)`;
+  if (subject.startsWith('root:')) return `files under ${subject.slice('root:'.length)}`;
+  return subject;
+}
+
+export function describeScope(scope: ApprovalScope): string {
+  switch (scope) {
+    case 'once':
+      return 'this request only';
+    case 'session':
+      return 'until this daemon stops';
+    case '30d':
+      return 'for 30 days';
+    case 'until_revoked':
+      return 'until you revoke it';
+  }
 }
 
 export function renderAskPrompt(input: AskInput): string {
@@ -48,16 +79,17 @@ export function renderAskPrompt(input: AskInput): string {
   const env = Object.entries(request.env).map(([name, value]) => `${name}=${value}`);
   lines.push(`  env        ${env.length > 0 ? env.join(' ') : '(none)'}`);
   lines.push(`  limits     timeout ${request.timeoutMs} ms, output ${request.maxBytes} bytes${request.clamped ? ' (clamped to your policy)' : ''}`);
-  lines.push('Approving also covers further requests for this op from the same user and session while this daemon runs.');
+  if (input.subjects === null) {
+    lines.push('This request cannot be remembered (its programs cannot be pinned down): approving covers this request only, and you will be asked again next time.');
+  } else {
+    lines.push(`Approving covers ${input.op} of: ${input.subjects.map(describeSubject).join(', ')} — for user ${input.principal.userId}, from any chat, for the time you choose next. It never covers other programs.`);
+  }
   return lines.join('\n');
 }
 
 export function createAskPrompter(deps: AskPrompterDeps): AskPrompter {
-  const approved = new Set<string>();
   return {
     async ask(input) {
-      const key = approvalKey(input.principal, input.op);
-      if (approved.has(key)) return true;
       deps.write(`${renderAskPrompt(input)}\n`);
       let answer = false;
       try {
@@ -65,8 +97,17 @@ export function createAskPrompter(deps: AskPrompterDeps): AskPrompter {
       } catch {
         answer = false;
       }
-      if (answer) approved.add(key);
-      return answer;
+      if (!answer) return { approved: false };
+      if (input.subjects === null) return { approved: true, scope: 'once' };
+      let scope: ApprovalScope = DEFAULT_APPROVAL_SCOPE;
+      if (deps.chooseScope !== undefined) {
+        try {
+          scope = await deps.chooseScope(input.subjects);
+        } catch {
+          return { approved: false };
+        }
+      }
+      return { approved: true, scope };
     },
   };
 }

--- a/packages/cli/src/env-bridge/challenge-store.ts
+++ b/packages/cli/src/env-bridge/challenge-store.ts
@@ -1,0 +1,117 @@
+/**
+ * Pending chat approvals on the daemon — the challenge store (GA wave 2,
+ * leaf 4; Tier B).
+ *
+ * When a request reaches the `ask` verdict and there is no terminal to ask on
+ * (or the owner prefers the chat), the daemon does not deny and forget: it
+ * FREEZES the exact normalised request under a challenge id, answers
+ * `grant_denied ask_pending:<id>` carrying that frozen request (signed, so the
+ * card in the chat shows what the machine will run and nothing else), and
+ * waits. The owner's click comes back as a fresh grant carrying a
+ * server-signed `approvalIntent { challengeId }`; the dispatcher looks the
+ * frozen request up HERE and byte-compares the new request against it before
+ * anything runs (leaf 7). A click can only ever unblock a request this store
+ * is still holding.
+ *
+ * Bounded and evicted synchronously exactly like `nonce-store.ts`: the TTL of
+ * a challenge is the grant's own `exp` (the whole authorization, prompt
+ * included, is bounded by the grant — `decide-execution.ts`), `evictExpired`
+ * runs before every use with no `await` between it and the lookup, and the
+ * map never holds more than MAX_PENDING_CHALLENGES live entries. A second ask
+ * for the same subject while one is pending REUSES the id (and the first
+ * frozen request) rather than growing the map: the agent retrying is not a
+ * new question.
+ */
+import type { Grant, NormalizedRequest } from './lib-core.js';
+
+/** Live entries at most; a further ask while this many are pending is refused (`ask_unavailable`), never evicted early. */
+export const MAX_PENDING_CHALLENGES = 64;
+
+export interface PendingChallenge {
+  readonly id: string;
+  /** The VERIFIED grant of the request that was frozen (its principal and op are what a click must match). */
+  readonly grant: Grant;
+  /** The frozen `NormalizedRequest` the owner is shown and the click is compared against. */
+  readonly request: NormalizedRequest;
+  /** What a durable approval of it would be keyed on; `null` = nothing durable can be written. */
+  readonly subjects: readonly string[] | null;
+  /** ms since epoch — the grant's `exp`. */
+  readonly exp: number;
+  readonly issuedAt: number;
+}
+
+export interface IssueChallengeInput {
+  readonly grant: Grant;
+  readonly request: NormalizedRequest;
+  readonly subjects: readonly string[] | null;
+}
+
+export interface ChallengeStore {
+  /** Freeze a request; reuse the pending id for the same (user, op, subject). `null` when the store is full. */
+  issue(input: IssueChallengeInput, now: number): PendingChallenge | null;
+  /** Read a live challenge without consuming it; `undefined` when unknown or expired. */
+  peek(id: string, now: number): PendingChallenge | undefined;
+  /** Consume a live challenge; `undefined` when unknown or expired (an expired one is dropped). */
+  take(id: string, now: number): PendingChallenge | undefined;
+  /** Forget challenges whose grants have expired. Called before every use. */
+  evictExpired(now: number): void;
+  /** Live entries — for tests and a status line, never for a decision. */
+  size(): number;
+}
+
+export interface ChallengeStoreDeps {
+  readonly newId: () => string;
+  readonly max?: number;
+}
+
+/** The reuse key: one pending question per (user, op, subject set); an unresolvable request keys on its exact args. */
+function reuseKey(input: IssueChallengeInput): string {
+  const subject = input.subjects === null ? `args:${input.grant.argsHash}` : input.subjects.join(' ');
+  return `${input.grant.principal.userId} ${input.grant.op} ${subject}`;
+}
+
+export function createChallengeStore(deps: ChallengeStoreDeps): ChallengeStore {
+  const max = deps.max ?? MAX_PENDING_CHALLENGES;
+  const byId = new Map<string, PendingChallenge>();
+  const byKey = new Map<string, string>();
+
+  const drop = (id: string) => {
+    const entry = byId.get(id);
+    if (entry === undefined) return;
+    byId.delete(id);
+    for (const [key, pendingId] of byKey) if (pendingId === id) byKey.delete(key);
+  };
+
+  const evictExpired = (now: number) => {
+    for (const [id, entry] of byId) if (entry.exp < now) drop(id);
+  };
+
+  return {
+    issue(input, now) {
+      evictExpired(now);
+      const key = reuseKey(input);
+      const existingId = byKey.get(key);
+      if (existingId !== undefined) {
+        const existing = byId.get(existingId);
+        if (existing !== undefined) return existing;
+      }
+      if (byId.size >= max) return null;
+      const entry: PendingChallenge = { id: deps.newId(), grant: input.grant, request: input.request, subjects: input.subjects, exp: input.grant.exp, issuedAt: now };
+      byId.set(entry.id, entry);
+      byKey.set(key, entry.id);
+      return entry;
+    },
+    peek(id, now) {
+      evictExpired(now);
+      return byId.get(id);
+    },
+    take(id, now) {
+      evictExpired(now);
+      const entry = byId.get(id);
+      if (entry !== undefined) drop(id);
+      return entry;
+    },
+    evictExpired,
+    size: () => byId.size,
+  };
+}

--- a/packages/cli/src/env-bridge/dispatcher.ts
+++ b/packages/cli/src/env-bridge/dispatcher.ts
@@ -116,7 +116,12 @@ export interface DispatcherDeps {
   readonly gates?: DecisionGates;
 }
 
-export type DispatchResult = { readonly kind: 'reply'; readonly frame: Frame } | { readonly kind: 'revoke_verified' } | { readonly kind: 'dropped'; readonly reason: string };
+export type DispatchResult =
+  | { readonly kind: 'reply'; readonly frame: Frame }
+  | { readonly kind: 'revoke_verified' }
+  /** ONE durable approval was deleted on the server's signed request (GA wave 2); the enrollment and the key stand. */
+  | { readonly kind: 'approval_revoked'; readonly approvalId: string; readonly removed: number }
+  | { readonly kind: 'dropped'; readonly reason: string };
 
 export interface Dispatcher {
   handle(frame: Frame): Promise<DispatchResult>;
@@ -305,8 +310,17 @@ export function createDispatcher(deps: DispatcherDeps): Dispatcher {
   const handleRevoke = async (frame: Extract<Frame, { type: 'revoke' }>): Promise<DispatchResult> => {
     const verdict = verifyRevoke({ frame, envId: deps.envId, enrollmentId: deps.enrollmentId, keyId: deps.serverKeyId, issuedAt: frame.issuedAt, serverPublicKey: deps.serverPublicKey, verify: deps.verify });
     if (!verdict.ok) {
-      await deps.audit.record({ grantId: null, principal: null, op: 'revoke', verdict: 'dropped:revoke_bad_signature', argsHash: null, exitCode: null });
+      await deps.audit.record({ grantId: null, principal: null, op: 'revoke', verdict: frame.approvalId !== undefined ? 'dropped:approval_revoke_bad_signature' : 'dropped:revoke_bad_signature', argsHash: null, exitCode: null });
       return { kind: 'dropped', reason: 'revoke_bad_signature' };
+    }
+    if (frame.approvalId !== undefined) {
+      // THE ASYMMETRY (GA wave 2, leaf 8): the server may delete exactly one
+      // approval by id — verified under the approval-revoke domain — and can
+      // never add one: no frame writes to the approvals store, and this
+      // branch never touches the key or the enrollment.
+      const removed = deps.approvals === undefined ? 0 : await deps.approvals.revoke(frame.approvalId);
+      await deps.audit.record({ grantId: null, principal: null, op: 'revoke', verdict: `approval_revoked:${frame.approvalId}:${removed}`, argsHash: null, exitCode: null });
+      return { kind: 'approval_revoked', approvalId: frame.approvalId, removed };
     }
     await deps.audit.record({ grantId: null, principal: null, op: 'revoke', verdict: 'revoked', argsHash: null, exitCode: null });
     return { kind: 'revoke_verified' };

--- a/packages/cli/src/env-bridge/dispatcher.ts
+++ b/packages/cli/src/env-bridge/dispatcher.ts
@@ -205,6 +205,37 @@ export function createDispatcher(deps: DispatcherDeps): Dispatcher {
     let decision = gates.decideExecution(decideInput);
     const roots = decideInput.machinePolicy?.roots ?? [];
 
+    if (grant.approvalIntent !== undefined && decision.kind === 'ask') {
+      // THE CLICK (Tier B, leaf 7). The server re-issued the request with the
+      // owner's signed intent. The daemon honours it ONLY against a request it
+      // froze itself: look the challenge up by id, re-normalise THIS request
+      // (already done above — `decision.request`), and byte-compare the two
+      // through the existing LocalApproval path. Only a match writes the
+      // durable approval and runs. A server that "recorded" an approval, a
+      // guessed id, or a click over different bytes all stop here.
+      const intent = grant.approvalIntent;
+      const now = deps.now();
+      const frozen = deps.challenges?.peek(intent.challengeId, now);
+      if (frozen === undefined) return denied(grant.grantId, 'approval_unknown', { grant, op: grant.op, verdict: `deny:approval_unknown:${intent.challengeId}` });
+      if (intent.expiresAt < now || frozen.exp < now) return denied(grant.grantId, 'approval_expired', { grant, op: grant.op });
+      if (frozen.grant.principal.userId !== grant.principal.userId || frozen.grant.op !== grant.op) {
+        return denied(grant.grantId, 'approval_mismatch', { grant, op: grant.op, verdict: `deny:approval_mismatch:principal:${intent.challengeId}` });
+      }
+      const compared = gates.decideExecution({ ...decideInput, localApproval: { grantId: grant.grantId, approvedAt: now, request: frozen.request } });
+      if (compared.kind !== 'allow') {
+        const reason = compared.kind === 'deny' ? compared.reason : 'approval_mismatch';
+        return denied(grant.grantId, reason, { grant, op: grant.op, verdict: `deny:${reason}:${intent.challengeId}` });
+      }
+      // Matched: the challenge is spent, the approval remembered under ITS id
+      // (what the server can later revoke), and the frozen request runs.
+      deps.challenges?.take(intent.challengeId, now);
+      if (frozen.subjects !== null && intent.scope !== 'once' && deps.approvals !== undefined) {
+        await deps.approvals.remember({ approvalId: intent.challengeId, envId: deps.envId, userId: grant.principal.userId, op: grant.op, subjects: frozen.subjects, scope: intent.scope });
+      }
+      decision = { kind: 'allow', request: compared.request, basis: { kind: 'fresh_approval' } };
+      allowVerdict = `allow:click:${intent.challengeId}:${intent.scope}`;
+    }
+
     if (decision.kind === 'ask') {
       // The verified Grant is HELD across the prompt; the wire grant is never
       // re-verified (its nonce is spent). The request the owner sees is frozen

--- a/packages/cli/src/env-bridge/dispatcher.ts
+++ b/packages/cli/src/env-bridge/dispatcher.ts
@@ -49,6 +49,7 @@ import type { AuditLog } from './audit-log.js';
 import type { ExecRunner } from './exec-runner.js';
 import type { FsRunner } from './fs-runner.js';
 import type { AskPrompter } from './ask.js';
+import type { ApprovalsStore } from './approvals-store.js';
 
 /** What this daemon can do in M1: shell and files. PTY is M2; checkpoints are never assumed (invariant 12). */
 export const DAEMON_CAPABILITIES: AdvertisedCapabilities = { shell: true, pty: false, fs: true, checkpoint: false };
@@ -88,6 +89,16 @@ export interface DispatcherDeps {
   readonly audit: AuditLog;
   /** `null` when the daemon cannot prompt (headless); an `ask` verdict is then a deny. */
   readonly ask: AskPrompter | null;
+  /**
+   * Durable approvals (GA wave 2): consulted by `decideExecution` after
+   * normalisation, written ONLY after an owner's approval of a byte-compared
+   * request. Omitted = nothing is ever remembered.
+   */
+  readonly approvals?: ApprovalsStore;
+  /** The PATH walk (`command-resolver.ts`) that turns an exec's argv0 into the subject an approval is keyed on. */
+  readonly resolveArgv0?: (name: string) => string | null;
+  /** Id source for approvals the TERMINAL prompt writes (a chat click's approval takes its challenge id). */
+  readonly ids?: { approvalId(): string };
   readonly log: (line: string) => void;
   /** The socket frame limit; bounds what an fs_read may return. */
   readonly limits: FrameLimits;
@@ -151,6 +162,8 @@ export function createDispatcher(deps: DispatcherDeps): Dispatcher {
     const grant = verdict.grant;
     if (grantPredatesDaemon(grant.iat, deps.startedAt)) return denied(grant.grantId, PREDATES_DAEMON_REASON, { grant, op: grant.op });
 
+    /** The audit word for an allow: how it came about. */
+    let allowVerdict = 'allow';
     const decideInput: DecideExecutionInput = {
       grant,
       request: executionRequestForFrame(frame),
@@ -158,6 +171,9 @@ export function createDispatcher(deps: DispatcherDeps): Dispatcher {
       serverPolicy: SERVER_POLICY_CARRIED_BY_SIGNATURE,
       capabilities: DAEMON_CAPABILITIES,
       probe: deps.probe,
+      // Durable approvals are read from the machine's own file (and this
+      // process's session set) — never from anything the server sent.
+      ...(deps.approvals !== undefined && { approvals: { entries: deps.approvals.entries(), now: deps.now(), resolveArgv0: deps.resolveArgv0 ?? (() => null) } }),
     };
     let decision = gates.decideExecution(decideInput);
     const roots = decideInput.machinePolicy?.roots ?? [];
@@ -168,12 +184,21 @@ export function createDispatcher(deps: DispatcherDeps): Dispatcher {
       // re-verified (its nonce is spent). The request the owner sees is frozen
       // and handed back unchanged as the approval.
       const shown = freezeRequest(decision.request);
-      const approved = await deps.ask.ask({ grantId: grant.grantId, principal: grant.principal, op: grant.op, request: shown });
-      if (!approved) return denied(grant.grantId, 'declined', { grant, op: grant.op, verdict: 'ask:declined' });
+      const subjects = decision.subjects;
+      const answer = await deps.ask.ask({ grantId: grant.grantId, principal: grant.principal, op: grant.op, request: shown, subjects });
+      if (!answer.approved) return denied(grant.grantId, 'declined', { grant, op: grant.op, verdict: 'ask:declined' });
       decision = gates.decideExecution({ ...decideInput, localApproval: { grantId: grant.grantId, approvedAt: deps.now(), request: shown } });
+      // Remembered ONLY once the byte-compare allowed it, and only under the
+      // subjects the owner was told about. `once` and null subjects remember nothing.
+      if (decision.kind === 'allow' && subjects !== null && answer.scope !== 'once' && deps.approvals !== undefined) {
+        await deps.approvals.remember({ approvalId: deps.ids?.approvalId() ?? `local_${grant.grantId}`, envId: deps.envId, userId: grant.principal.userId, op: grant.op, subjects, scope: answer.scope });
+      }
+      if (decision.kind === 'allow') decision = { ...decision, basis: { kind: 'fresh_approval' } };
+      allowVerdict = `allow:approved:${answer.scope}`;
     }
     if (decision.kind === 'deny') return denied(grant.grantId, decision.reason, { grant, op: grant.op });
     if (decision.kind !== 'allow') return denied(grant.grantId, 'ask_unresolved', { grant, op: grant.op });
+    if (decision.basis.kind === 'durable_approval') allowVerdict = `allow:approval:${decision.basis.approvalIds.join(',')}`;
 
     // Allow: the normalized request is the ONLY thing the runners ever see.
     const normalized = decision.request;
@@ -185,7 +210,7 @@ export function createDispatcher(deps: DispatcherDeps): Dispatcher {
           const ceiling = execOutputCeiling(deps.limits);
           const bounded = normalized.maxBytes > ceiling ? { ...normalized, maxBytes: ceiling, clamped: true } : normalized;
           const outcome = await deps.execRunner.run(bounded);
-          await deps.audit.record({ grantId: grant.grantId, principal: grant.principal, op: grant.op, verdict: 'allow', argsHash: grant.argsHash, exitCode: outcome.exitCode });
+          await deps.audit.record({ grantId: grant.grantId, principal: grant.principal, op: grant.op, verdict: allowVerdict, argsHash: grant.argsHash, exitCode: outcome.exitCode });
           return reply({ type: 'exec_result', grantId: grant.grantId, exitCode: outcome.exitCode, stdoutB64: outcome.stdout.toString('base64'), stderrB64: outcome.stderr.toString('base64'), truncated: outcome.truncated });
         }
         case 'fs_read': {
@@ -193,13 +218,13 @@ export function createDispatcher(deps: DispatcherDeps): Dispatcher {
           if (outcome.kind === 'unsupported') return denied(grant.grantId, `unsupported_${outcome.reason}`, { grant, op: grant.op });
           if (outcome.kind === 'too_large') return denied(grant.grantId, 'too_large', { grant, op: grant.op, verdict: `deny:too_large:${outcome.size}>${outcome.maxContentBytes}` });
           if (outcome.kind === 'error') return denied(grant.grantId, 'fs_error', { grant, op: grant.op, verdict: `deny:fs_error:${outcome.error}` });
-          await deps.audit.record({ grantId: grant.grantId, principal: grant.principal, op: grant.op, verdict: 'allow', argsHash: grant.argsHash, exitCode: null });
+          await deps.audit.record({ grantId: grant.grantId, principal: grant.principal, op: grant.op, verdict: allowVerdict, argsHash: grant.argsHash, exitCode: null });
           return reply({ type: 'fs_read_result', grantId: grant.grantId, found: outcome.found, ...(outcome.contentB64 !== undefined && { contentB64: outcome.contentB64 }) });
         }
         case 'fs_write': {
           const files = frame.type === 'grant_fs_write' ? frame.files.map((file) => ({ contentB64: file.contentB64, mode: file.mode ?? null })) : [];
           const outcome = await deps.fsRunner.write(normalized, files, { roots });
-          await deps.audit.record({ grantId: grant.grantId, principal: grant.principal, op: grant.op, verdict: outcome.ok ? 'allow' : `allow:write_failed:${outcome.error ?? ''}`, argsHash: grant.argsHash, exitCode: null });
+          await deps.audit.record({ grantId: grant.grantId, principal: grant.principal, op: grant.op, verdict: outcome.ok ? allowVerdict : `${allowVerdict}:write_failed:${outcome.error ?? ''}`, argsHash: grant.argsHash, exitCode: null });
           return reply({ type: 'fs_write_result', grantId: grant.grantId, ok: outcome.ok, ...(outcome.error !== undefined && { error: outcome.error }) });
         }
         case 'pty_open':

--- a/packages/cli/src/env-bridge/dispatcher.ts
+++ b/packages/cli/src/env-bridge/dispatcher.ts
@@ -41,7 +41,7 @@ import { decideExecution as libDecideExecution, type DecideExecutionInput, type 
 import type { AdvertisedCapabilities, MachinePolicy, ServerPolicy } from './lib-core.js';
 import type { PathProbe } from './lib-core.js';
 import { verifyRevoke } from './lib-core.js';
-import { execOutputCeiling, fsReadContentCeiling, type Frame, type FrameLimits } from './lib-core.js';
+import { execOutputCeiling, fsReadContentCeiling, type Frame, type FrameLimits, type PendingApproval } from './lib-core.js';
 import type { SignWithMachineKey } from './keypair.js';
 import { grantPredatesDaemon, PREDATES_DAEMON_REASON, type DaemonNonceStore } from './nonce-store.js';
 import { signResultFrame, type UnsignedMachineResultFrame } from './result-signer.js';
@@ -50,6 +50,7 @@ import type { ExecRunner } from './exec-runner.js';
 import type { FsRunner } from './fs-runner.js';
 import type { AskPrompter } from './ask.js';
 import type { ApprovalsStore } from './approvals-store.js';
+import type { ChallengeStore } from './challenge-store.js';
 
 /** What this daemon can do in M1: shell and files. PTY is M2; checkpoints are never assumed (invariant 12). */
 export const DAEMON_CAPABILITIES: AdvertisedCapabilities = { shell: true, pty: false, fs: true, checkpoint: false };
@@ -99,6 +100,15 @@ export interface DispatcherDeps {
   readonly resolveArgv0?: (name: string) => string | null;
   /** Id source for approvals the TERMINAL prompt writes (a chat click's approval takes its challenge id). */
   readonly ids?: { approvalId(): string };
+  /**
+   * Pending chat approvals (GA wave 2, Tier B). With a store, an `ask`
+   * verdict that has no terminal to go to (or when `preferChat`) freezes the
+   * request under a challenge id and answers `ask_pending:<id>`; without one
+   * it is `ask_unavailable`, as before.
+   */
+  readonly challenges?: ChallengeStore;
+  /** Send asks to the chat even when a terminal prompter exists. */
+  readonly preferChat?: boolean;
   readonly log: (line: string) => void;
   /** The socket frame limit; bounds what an fs_read may return. */
   readonly limits: FrameLimits;
@@ -129,6 +139,21 @@ function freezeRequest(request: NormalizedRequest): NormalizedRequest {
 }
 
 const messageOf = (error: unknown): string => (error instanceof Error ? error.message : String(error));
+
+/** The frozen request as the frame codec carries it (fresh copies of the frozen arrays; every field, nothing else). */
+function pendingRequestOnTheWire(request: NormalizedRequest): PendingApproval['request'] {
+  return {
+    op: request.op,
+    ...(request.cmd !== undefined && { cmd: request.cmd }),
+    ...(request.args !== undefined && { args: [...request.args] }),
+    cwd: request.cwd,
+    paths: [...request.paths],
+    env: { ...request.env },
+    timeoutMs: request.timeoutMs,
+    maxBytes: request.maxBytes,
+    clamped: request.clamped,
+  };
+}
 
 export function createDispatcher(deps: DispatcherDeps): Dispatcher {
   const gates: DecisionGates = deps.gates ?? { verifyGrant: libVerifyGrant, decideExecution: libDecideExecution };
@@ -172,19 +197,29 @@ export function createDispatcher(deps: DispatcherDeps): Dispatcher {
       capabilities: DAEMON_CAPABILITIES,
       probe: deps.probe,
       // Durable approvals are read from the machine's own file (and this
-      // process's session set) — never from anything the server sent.
-      ...(deps.approvals !== undefined && { approvals: { entries: deps.approvals.entries(), now: deps.now(), resolveArgv0: deps.resolveArgv0 ?? (() => null) } }),
+      // process's session set) — never from anything the server sent. Always
+      // consulted (an absent store is an empty set) so an `ask` verdict
+      // carries the subjects a click or a prompt would approve.
+      approvals: { entries: deps.approvals?.entries() ?? [], now: deps.now(), resolveArgv0: deps.resolveArgv0 ?? (() => null) },
     };
     let decision = gates.decideExecution(decideInput);
     const roots = decideInput.machinePolicy?.roots ?? [];
 
     if (decision.kind === 'ask') {
-      if (deps.ask === null) return denied(grant.grantId, 'ask_unavailable', { grant, op: grant.op });
       // The verified Grant is HELD across the prompt; the wire grant is never
       // re-verified (its nonce is spent). The request the owner sees is frozen
       // and handed back unchanged as the approval.
       const shown = freezeRequest(decision.request);
       const subjects = decision.subjects;
+      if (deps.ask === null || deps.preferChat === true) {
+        // Tier B: no terminal (or the chat is preferred) — freeze the request
+        // under a challenge and let the owner's click in the chat answer it.
+        if (deps.challenges === undefined) return denied(grant.grantId, 'ask_unavailable', { grant, op: grant.op });
+        const pending = deps.challenges.issue({ grant, request: shown, subjects }, deps.now());
+        if (pending === null) return denied(grant.grantId, 'ask_unavailable', { grant, op: grant.op, verdict: 'deny:ask_unavailable:challenges_full' });
+        await deps.audit.record({ grantId: grant.grantId, principal: grant.principal, op: grant.op, verdict: `ask:pending:${pending.id}`, argsHash: grant.argsHash, exitCode: null });
+        return reply({ type: 'grant_denied', grantId: grant.grantId, reason: `ask_pending:${pending.id}`, pending: { challengeId: pending.id, expiresAt: pending.exp, request: pendingRequestOnTheWire(pending.request) } });
+      }
       const answer = await deps.ask.ask({ grantId: grant.grantId, principal: grant.principal, op: grant.op, request: shown, subjects });
       if (!answer.approved) return denied(grant.grantId, 'declined', { grant, op: grant.op, verdict: 'ask:declined' });
       decision = gates.decideExecution({ ...decideInput, localApproval: { grantId: grant.grantId, approvedAt: deps.now(), request: shown } });

--- a/packages/cli/src/env-bridge/dispatcher.ts
+++ b/packages/cli/src/env-bridge/dispatcher.ts
@@ -217,11 +217,14 @@ export function createDispatcher(deps: DispatcherDeps): Dispatcher {
       // (already done above — `decision.request`), and byte-compare the two
       // through the existing LocalApproval path. Only a match writes the
       // durable approval and runs. A server that "recorded" an approval, a
-      // guessed id, or a click over different bytes all stop here.
+      // guessed id, or a click over different bytes all stop here as
+      // approval_mismatch.
       const intent = grant.approvalIntent;
       const now = deps.now();
       const frozen = deps.challenges?.peek(intent.challengeId, now);
-      if (frozen === undefined) return denied(grant.grantId, 'approval_unknown', { grant, op: grant.op, verdict: `deny:approval_unknown:${intent.challengeId}` });
+      // No such frozen request on THIS machine: the click matches nothing the
+      // machine framed — including a challenge the server made up.
+      if (frozen === undefined) return denied(grant.grantId, 'approval_mismatch', { grant, op: grant.op, verdict: `deny:approval_mismatch:unknown_challenge:${intent.challengeId}` });
       if (intent.expiresAt < now || frozen.exp < now) return denied(grant.grantId, 'approval_expired', { grant, op: grant.op });
       if (frozen.grant.principal.userId !== grant.principal.userId || frozen.grant.op !== grant.op) {
         return denied(grant.grantId, 'approval_mismatch', { grant, op: grant.op, verdict: `deny:approval_mismatch:principal:${intent.challengeId}` });

--- a/packages/cli/src/env-bridge/dispatcher.ts
+++ b/packages/cli/src/env-bridge/dispatcher.ts
@@ -119,8 +119,8 @@ export interface DispatcherDeps {
 export type DispatchResult =
   | { readonly kind: 'reply'; readonly frame: Frame }
   | { readonly kind: 'revoke_verified' }
-  /** ONE durable approval was deleted on the server's signed request (GA wave 2); the enrollment and the key stand. */
-  | { readonly kind: 'approval_revoked'; readonly approvalId: string; readonly removed: number }
+  /** ONE durable approval was deleted on the server's signed request (GA wave 2); the enrollment and the key stand. `frame` is the machine-signed ack to send back. */
+  | { readonly kind: 'approval_revoked'; readonly approvalId: string; readonly removed: number; readonly frame: Frame }
   | { readonly kind: 'dropped'; readonly reason: string };
 
 export interface Dispatcher {
@@ -323,7 +323,8 @@ export function createDispatcher(deps: DispatcherDeps): Dispatcher {
       // branch never touches the key or the enrollment.
       const removed = deps.approvals === undefined ? 0 : await deps.approvals.revoke(frame.approvalId);
       await deps.audit.record({ grantId: null, principal: null, op: 'revoke', verdict: `approval_revoked:${frame.approvalId}:${removed}`, argsHash: null, exitCode: null });
-      return { kind: 'approval_revoked', approvalId: frame.approvalId, removed };
+      // The ACK (Codex P2 on #2583): machine-signed over {approvalId, removed}, so the server can only ever claim what this machine did.
+      return { kind: 'approval_revoked', approvalId: frame.approvalId, removed, frame: signResultFrame({ type: 'approval_revoke_result', approvalId: frame.approvalId, removed }, signer) };
     }
     await deps.audit.record({ grantId: null, principal: null, op: 'revoke', verdict: 'revoked', argsHash: null, exitCode: null });
     return { kind: 'revoke_verified' };

--- a/packages/cli/src/env-bridge/lib-core.ts
+++ b/packages/cli/src/env-bridge/lib-core.ts
@@ -22,6 +22,8 @@ export { executionRequestForFrame, GRANT_FRAME_TYPES, grantRequestForFrame } fro
 export type { GrantFrame } from '@pagespace/lib/env-bridge/grant-args';
 export { decideExecution } from '@pagespace/lib/env-bridge/decide-execution';
 export type { DecideExecutionInput, ExecutionVerdict, NormalizedRequest } from '@pagespace/lib/env-bridge/decide-execution';
+export { APPROVAL_SCOPES, DEFAULT_APPROVAL_SCOPE, approvalExpiry, isDurableScope, parseApprovalsFile, serializeApprovalsFile } from '@pagespace/lib/env-bridge/decide-approval';
+export type { ApprovalScope, DurableApproval } from '@pagespace/lib/env-bridge/decide-approval';
 export { parseMachinePolicy } from '@pagespace/lib/env-bridge/policy-types';
 export type { AdvertisedCapabilities, MachinePolicy, ServerPolicy } from '@pagespace/lib/env-bridge/policy-types';
 export type { PathProbe } from '@pagespace/lib/env-bridge/confine-path';

--- a/packages/cli/src/env-bridge/lib-core.ts
+++ b/packages/cli/src/env-bridge/lib-core.ts
@@ -30,7 +30,7 @@ export type { PathProbe } from '@pagespace/lib/env-bridge/confine-path';
 export { encodeHelloForSigning, encodeResultForSigning, resultHashForFrame, verifyRevoke } from '@pagespace/lib/env-bridge/machine-signatures';
 export type { MachineResultFrame, MachineResultFrameType } from '@pagespace/lib/env-bridge/machine-signatures';
 export { decodeFrame, encodeFrame, execOutputCeiling, fsReadContentCeiling } from '@pagespace/lib/env-bridge/frame-codec';
-export type { Frame, FrameLimits } from '@pagespace/lib/env-bridge/frame-codec';
+export type { Frame, FrameLimits, PendingApproval } from '@pagespace/lib/env-bridge/frame-codec';
 export { initialBridgeSession, isSupersededClose, reduceBridgeSession } from '@pagespace/lib/env-bridge/bridge-session';
 export type { BridgeEffect, BridgeSessionState, BridgeStatus, HelloFrame } from '@pagespace/lib/env-bridge/bridge-session';
 export { isHardDeniedEnvVar } from '@pagespace/lib/env-bridge/scrub-env';

--- a/packages/cli/src/env-bridge/lib-core.ts
+++ b/packages/cli/src/env-bridge/lib-core.ts
@@ -27,7 +27,7 @@ export type { ApprovalScope, DurableApproval } from '@pagespace/lib/env-bridge/d
 export { parseMachinePolicy } from '@pagespace/lib/env-bridge/policy-types';
 export type { AdvertisedCapabilities, MachinePolicy, ServerPolicy } from '@pagespace/lib/env-bridge/policy-types';
 export type { PathProbe } from '@pagespace/lib/env-bridge/confine-path';
-export { encodeApprovalRevokeForSigning, encodeHelloForSigning, encodeResultForSigning, resultHashForFrame, verifyRevoke } from '@pagespace/lib/env-bridge/machine-signatures';
+export { encodeApprovalRevokeForSigning, encodeHelloForSigning, encodeResultForSigning, machineResultBindingId, resultHashForFrame, verifyRevoke } from '@pagespace/lib/env-bridge/machine-signatures';
 export type { MachineResultFrame, MachineResultFrameType } from '@pagespace/lib/env-bridge/machine-signatures';
 export { decodeFrame, encodeFrame, execOutputCeiling, fsReadContentCeiling } from '@pagespace/lib/env-bridge/frame-codec';
 export type { Frame, FrameLimits, PendingApproval } from '@pagespace/lib/env-bridge/frame-codec';

--- a/packages/cli/src/env-bridge/lib-core.ts
+++ b/packages/cli/src/env-bridge/lib-core.ts
@@ -22,7 +22,7 @@ export { executionRequestForFrame, GRANT_FRAME_TYPES, grantRequestForFrame } fro
 export type { GrantFrame } from '@pagespace/lib/env-bridge/grant-args';
 export { decideExecution } from '@pagespace/lib/env-bridge/decide-execution';
 export type { DecideExecutionInput, ExecutionVerdict, NormalizedRequest } from '@pagespace/lib/env-bridge/decide-execution';
-export { APPROVAL_SCOPES, DEFAULT_APPROVAL_SCOPE, approvalExpiry, isDurableScope, parseApprovalsFile, serializeApprovalsFile } from '@pagespace/lib/env-bridge/decide-approval';
+export { APPROVAL_SCOPES, APPROVALS_FILE_VERSION, DEFAULT_APPROVAL_SCOPE, approvalExpiry, isDurableScope, parseApprovalsFile } from '@pagespace/lib/env-bridge/decide-approval';
 export type { ApprovalScope, DurableApproval } from '@pagespace/lib/env-bridge/decide-approval';
 export { parseMachinePolicy } from '@pagespace/lib/env-bridge/policy-types';
 export type { AdvertisedCapabilities, MachinePolicy, ServerPolicy } from '@pagespace/lib/env-bridge/policy-types';

--- a/packages/cli/src/env-bridge/lib-core.ts
+++ b/packages/cli/src/env-bridge/lib-core.ts
@@ -17,7 +17,7 @@
  * `@pagespace/lib` specifier survives in any runtime import.
  */
 export { GRANT_OPS, GRANT_MAX_CLOCK_SKEW_MS, decodeBase64, verifyGrant } from '@pagespace/lib/env-bridge/grant';
-export type { Ed25519Verify, Grant, GrantOp, GrantPrincipal, GrantVerdict, HashBytes, NonceStore, VerifyGrantInput } from '@pagespace/lib/env-bridge/grant';
+export type { ApprovalIntent, Ed25519Verify, Grant, GrantOp, GrantPrincipal, GrantVerdict, HashBytes, NonceStore, VerifyGrantInput } from '@pagespace/lib/env-bridge/grant';
 export { executionRequestForFrame, GRANT_FRAME_TYPES, grantRequestForFrame } from '@pagespace/lib/env-bridge/grant-args';
 export type { GrantFrame } from '@pagespace/lib/env-bridge/grant-args';
 export { decideExecution } from '@pagespace/lib/env-bridge/decide-execution';

--- a/packages/cli/src/env-bridge/lib-core.ts
+++ b/packages/cli/src/env-bridge/lib-core.ts
@@ -27,7 +27,7 @@ export type { ApprovalScope, DurableApproval } from '@pagespace/lib/env-bridge/d
 export { parseMachinePolicy } from '@pagespace/lib/env-bridge/policy-types';
 export type { AdvertisedCapabilities, MachinePolicy, ServerPolicy } from '@pagespace/lib/env-bridge/policy-types';
 export type { PathProbe } from '@pagespace/lib/env-bridge/confine-path';
-export { encodeHelloForSigning, encodeResultForSigning, resultHashForFrame, verifyRevoke } from '@pagespace/lib/env-bridge/machine-signatures';
+export { encodeApprovalRevokeForSigning, encodeHelloForSigning, encodeResultForSigning, resultHashForFrame, verifyRevoke } from '@pagespace/lib/env-bridge/machine-signatures';
 export type { MachineResultFrame, MachineResultFrameType } from '@pagespace/lib/env-bridge/machine-signatures';
 export { decodeFrame, encodeFrame, execOutputCeiling, fsReadContentCeiling } from '@pagespace/lib/env-bridge/frame-codec';
 export type { Frame, FrameLimits, PendingApproval } from '@pagespace/lib/env-bridge/frame-codec';

--- a/packages/cli/src/env-bridge/result-signer.ts
+++ b/packages/cli/src/env-bridge/result-signer.ts
@@ -15,6 +15,7 @@
 import {
   encodeHelloForSigning,
   encodeResultForSigning,
+  machineResultBindingId,
   resultHashForFrame,
   type HelloFrame,
   type MachineResultFrame,
@@ -40,7 +41,8 @@ export function signResultFrame(unsigned: UnsignedMachineResultFrame, deps: Mach
   // a placeholder changes nothing (mirrors the server signer's provisional frame).
   const provisional = { ...unsigned, sig: '' } as MachineResultFrame;
   const resultHash = resultHashForFrame(provisional, deps.hash);
-  const sig = deps.sign(deps.privateKey, encodeResultForSigning({ grantId: unsigned.grantId, resultHash }));
+  // Bound to the grant it answers — or, for an approval-revoke ack, the namespaced approval id (the same rule the server verifies).
+  const sig = deps.sign(deps.privateKey, encodeResultForSigning({ grantId: machineResultBindingId(provisional), resultHash }));
   return { ...unsigned, sig } as MachineResultFrame;
 }
 

--- a/packages/cli/src/env-bridge/ws-client.ts
+++ b/packages/cli/src/env-bridge/ws-client.ts
@@ -146,6 +146,7 @@ export function createBridgeConnection(deps: BridgeConnectionDeps): BridgeConnec
           const result = await deps.dispatcher.handle(effect.frame);
           if (result.kind === 'reply') send(target, result.frame);
           else if (result.kind === 'revoke_verified') await revoke(target);
+          else if (result.kind === 'approval_revoked') deps.log(`approval ${result.approvalId} revoked by the server (${result.removed} row${result.removed === 1 ? '' : 's'} removed); still connected`);
           break;
         }
         case 'reject':

--- a/packages/cli/src/env-bridge/ws-client.ts
+++ b/packages/cli/src/env-bridge/ws-client.ts
@@ -146,7 +146,11 @@ export function createBridgeConnection(deps: BridgeConnectionDeps): BridgeConnec
           const result = await deps.dispatcher.handle(effect.frame);
           if (result.kind === 'reply') send(target, result.frame);
           else if (result.kind === 'revoke_verified') await revoke(target);
-          else if (result.kind === 'approval_revoked') deps.log(`approval ${result.approvalId} revoked by the server (${result.removed} row${result.removed === 1 ? '' : 's'} removed); still connected`);
+          else if (result.kind === 'approval_revoked') {
+            // Signed ack back to the server; the enrollment stands and the socket stays open.
+            send(target, result.frame);
+            deps.log(`approval ${result.approvalId} revoked by the server (${result.removed} row${result.removed === 1 ? '' : 's'} removed); acknowledged, still connected`);
+          }
           break;
         }
         case 'reject':

--- a/packages/lib/package.json
+++ b/packages/lib/package.json
@@ -213,6 +213,11 @@
       "import": "./dist/env-bridge/decide-bind.js",
       "require": "./dist/env-bridge/decide-bind.js"
     },
+    "./env-bridge/decide-approval": {
+      "types": "./dist/env-bridge/decide-approval.d.ts",
+      "import": "./dist/env-bridge/decide-approval.js",
+      "require": "./dist/env-bridge/decide-approval.js"
+    },
     "./env-bridge/decide-sign": {
       "types": "./dist/env-bridge/decide-sign.d.ts",
       "import": "./dist/env-bridge/decide-sign.js",

--- a/packages/lib/src/env-bridge/__tests__/decide-approval.test.ts
+++ b/packages/lib/src/env-bridge/__tests__/decide-approval.test.ts
@@ -62,6 +62,16 @@ describe('approvalSubjects — what an approval is keyed on', () => {
     }
   });
 
+  it('Codex P1 on #2583: substitution INSIDE double quotes is still substitution — `echo "$(rm x)"`, a backtick, or `${…}` in double quotes ⇒ null (ask); single quotes stay literal', () => {
+    for (const script of ['echo "$(rm -rf x)"', 'echo "`rm x`"', 'echo "${HOME}"', 'echo "a ${x:-$(rm x)} b"', 'git log "--format=$(rm x)"']) {
+      expect(approvalSubjects(shell(script), deps), script).toBeNull();
+    }
+    expect(approvalSubjects(shell("echo '$(rm x)'"), deps)).toEqual(['builtin:echo']);
+    expect(approvalSubjects(shell("echo '`rm x`' '${HOME}'"), deps)).toEqual(['builtin:echo']);
+    expect(shellCommandWords('echo "$(rm x)"')).toBeNull();
+    expect(shellCommandWords("echo '$(rm x)'")).toEqual(['echo']);
+  });
+
   it('given a script with env assignments, wrappers and control keywords, should still find the programs', () => {
     expect(approvalSubjects(shell('CI=1 FOO=bar git status'), deps)).toEqual(['exec:/usr/bin/git']);
     expect(approvalSubjects(shell('if git diff --quiet; then ls; else rm x; fi'), deps)).toEqual(['exec:/usr/bin/git', 'exec:/bin/ls', 'exec:/bin/rm']);

--- a/packages/lib/src/env-bridge/__tests__/decide-approval.test.ts
+++ b/packages/lib/src/env-bridge/__tests__/decide-approval.test.ts
@@ -17,6 +17,7 @@ import {
   matchApproval,
   parseApprovalsFile,
   shellCommandWords,
+  trimTrailing,
   type ApprovalMatchDeps,
   type DurableApproval,
 } from '../decide-approval';
@@ -207,6 +208,27 @@ describe('parseApprovalsFile — strict; ANY defect ⇒ null (empty), never a pa
     ['one bad entry among good ones', { version: 1, approvals: [approval(), { approvalId: 'x' }] }],
   ])('given %s, should return null — the WHOLE file is ignored', (_label, input) => {
     expect(parseApprovalsFile(input)).toBeNull();
+  });
+});
+
+describe('trimTrailing — the loop that replaced two `[…]+$` regexes (CodeQL js/polynomial-redos on #2583)', () => {
+  it('trims only trailing characters in the set, and a 100k-char run resolves in bounded time with the same result', () => {
+    expect(trimTrailing('ls)', ')}')).toBe('ls');
+    expect(trimTrailing('ls)}))', ')}')).toBe('ls');
+    expect(trimTrailing(')ls', ')}')).toBe(')ls');
+    expect(trimTrailing('/home/u/proj///', '/')).toBe('/home/u/proj');
+    expect(trimTrailing('', ')')).toBe('');
+    const run = `ls${')'.repeat(100_000)}`;
+    const started = performance.now();
+    expect(trimTrailing(run, ')}')).toBe('ls');
+    expect(shellCommandWords(`(${run}`)).toEqual(['ls']);
+    expect(performance.now() - started).toBeLessThan(200);
+    expect(approvalSubjects(fsRead(`${ROOT}/a`), { ...deps, roots: [`${ROOT}${'/'.repeat(100_000)}`] })).toEqual([`root:${ROOT}${'/'.repeat(100_000)}`]);
+  });
+
+  it('the module has no trailing-anchored `X+$` regex left', () => {
+    const source = readFileSync(join(import.meta.dirname, '..', 'decide-approval.ts'), 'utf8');
+    expect(source).not.toMatch(/\][+*]\$\//);
   });
 });
 

--- a/packages/lib/src/env-bridge/__tests__/decide-approval.test.ts
+++ b/packages/lib/src/env-bridge/__tests__/decide-approval.test.ts
@@ -1,0 +1,208 @@
+/**
+ * GA wave 2, leaf 2 — the pure approval matcher. An approval is keyed on
+ * `(envId, userId, op, subject)`: the resolved program for `exec`, a policy
+ * root for file operations — never a session. The matcher has no I/O: the
+ * program resolver and the clock are injected.
+ */
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import {
+  APPROVAL_SCOPES,
+  DEFAULT_APPROVAL_SCOPE,
+  THIRTY_DAYS_MS,
+  approvalExpiry,
+  approvalSubjects,
+  isDurableScope,
+  matchApproval,
+  parseApprovalsFile,
+  shellCommandWords,
+  type ApprovalMatchDeps,
+  type DurableApproval,
+} from '../decide-approval';
+import type { Grant } from '../grant';
+import type { NormalizedRequest } from '../decide-execution';
+
+const ROOT = '/home/u/proj';
+const OTHER_ROOT = '/srv/data';
+const NOW = 1_800_000_000_000;
+
+const BIN: Record<string, string> = { git: '/usr/bin/git', ls: '/bin/ls', rm: '/bin/rm', node: '/usr/local/bin/node', sh: '/bin/sh', bash: '/bin/bash', find: '/usr/bin/find' };
+const deps: ApprovalMatchDeps = { resolveArgv0: (name) => BIN[name] ?? null, roots: [ROOT, OTHER_ROOT] };
+
+const grant: Grant = { grantId: 'g1', envId: 'env1', principal: { userId: 'user_1', sessionId: 's1', conversationId: 'c1' }, op: 'exec', argsHash: 'h', iat: NOW - 1000, exp: NOW + 30_000, nonce: 'n1' };
+
+const exec = (cmd: string, args: readonly string[] = []): NormalizedRequest => ({ op: 'exec', cmd, args, cwd: ROOT, paths: [], env: {}, timeoutMs: 1000, maxBytes: 1024, clamped: false });
+const shell = (script: string): NormalizedRequest => exec('sh', ['-c', script]);
+const fsRead = (...paths: string[]): NormalizedRequest => ({ op: 'fs_read', cwd: ROOT, paths, env: {}, timeoutMs: 1000, maxBytes: 1024, clamped: false });
+
+function approval(over: Partial<DurableApproval> = {}): DurableApproval {
+  return { approvalId: 'a1', envId: 'env1', userId: 'user_1', op: 'exec', subject: 'exec:/usr/bin/git', scope: '30d', createdAt: NOW - 1000, expiresAt: NOW + THIRTY_DAYS_MS, ...over };
+}
+
+describe('approvalSubjects — what an approval is keyed on', () => {
+  it('given an exec whose command is a program, should key on the RESOLVED program path (an approval of `git status` covers `git …`)', () => {
+    expect(approvalSubjects(exec('git', ['status']), deps)).toEqual(['exec:/usr/bin/git']);
+    expect(approvalSubjects(exec('git', ['push', '--force']), deps)).toEqual(['exec:/usr/bin/git']);
+  });
+
+  it('given an exec that cannot be resolved to a program, should yield null — never a subject a later request could ride', () => {
+    expect(approvalSubjects(exec('nosuchtool'), deps)).toBeNull();
+  });
+
+  it('given `sh -c <script>` (what the bash tool always sends), should key on EVERY program the script names, never on the shell itself', () => {
+    expect(approvalSubjects(shell('git status'), deps)).toEqual(['exec:/usr/bin/git']);
+    expect(approvalSubjects(shell('git status && ls -la | rm -rf x'), deps)).toEqual(['exec:/usr/bin/git', 'exec:/bin/ls', 'exec:/bin/rm']);
+    expect(approvalSubjects(shell('cd src; git log'), deps)).toEqual(['builtin:cd', 'exec:/usr/bin/git']);
+  });
+
+  it('given a script the lexer cannot attribute to programs (substitution, eval, a nested shell, find -exec), should yield null so it is asked about every time', () => {
+    for (const script of ['git $(rm -rf x)', '`rm -rf x`', 'eval "rm -rf x"', 'sh -c "rm -rf x"', 'bash -lc "rm x"', 'exec rm x', 'source ./x.sh', '. ./x.sh', 'find . -exec rm {} \\;', 'xargs rm', 'sudo rm x', '"$CMD" x', '$X', 'case $x in a) rm x;; esac']) {
+      expect(approvalSubjects(shell(script), deps), script).toBeNull();
+    }
+  });
+
+  it('given a script with env assignments, wrappers and control keywords, should still find the programs', () => {
+    expect(approvalSubjects(shell('CI=1 FOO=bar git status'), deps)).toEqual(['exec:/usr/bin/git']);
+    expect(approvalSubjects(shell('if git diff --quiet; then ls; else rm x; fi'), deps)).toEqual(['exec:/usr/bin/git', 'exec:/bin/ls', 'exec:/bin/rm']);
+    expect(approvalSubjects(shell('for f in a b; do ls $f; done'), deps)).toEqual(['exec:/bin/ls']);
+    expect(approvalSubjects(shell('env FOO=1 git status'), deps)).toEqual(['exec:/usr/bin/git']);
+    expect(approvalSubjects(shell('! git diff --quiet'), deps)).toEqual(['exec:/usr/bin/git']);
+    expect(approvalSubjects(shell('(cd x && ls) > out.txt 2>&1'), deps)).toEqual(['builtin:cd', 'exec:/bin/ls']);
+    expect(approvalSubjects(shell('echo "a; rm x" | ls'), deps)).toEqual(['builtin:echo', 'exec:/bin/ls']);
+  });
+
+  it('given a file op, should key on the policy ROOT each path resolves inside (one subject per root touched)', () => {
+    expect(approvalSubjects(fsRead(`${ROOT}/a.txt`, `${ROOT}/b/c.txt`), deps)).toEqual([`root:${ROOT}`]);
+    expect(approvalSubjects(fsRead(`${ROOT}/a.txt`, `${OTHER_ROOT}/x`), deps)).toEqual([`root:${ROOT}`, `root:${OTHER_ROOT}`]);
+  });
+
+  it('given a file op path outside every root (cannot happen after confinePath, pinned anyway), should yield null', () => {
+    expect(approvalSubjects(fsRead('/etc/passwd'), deps)).toBeNull();
+    // A sibling directory that merely shares the root as a string prefix is NOT inside it.
+    expect(approvalSubjects(fsRead(`${ROOT}-other/x`), deps)).toBeNull();
+  });
+
+  it('given a pty_open, should yield null (no durable approval for a PTY)', () => {
+    expect(approvalSubjects({ ...exec('bash'), op: 'pty_open' }, deps)).toBeNull();
+  });
+});
+
+describe('shellCommandWords — the conservative lexer behind exec subjects', () => {
+  it('should split on ; && || | & and newlines, outside quotes only', () => {
+    expect(shellCommandWords('a; b && c || d | e & f\ng')).toEqual(['a', 'b', 'c', 'd', 'e', 'f', 'g']);
+    expect(shellCommandWords('a "x; y" \'p && q\'')).toEqual(['a']);
+  });
+  it('should return null for anything it cannot attribute to a program name', () => {
+    expect(shellCommandWords('')).toBeNull();
+    expect(shellCommandWords('   ')).toBeNull();
+    expect(shellCommandWords('a $(b)')).toBeNull();
+    expect(shellCommandWords('${CMD}')).toBeNull();
+    expect(shellCommandWords("'quoted' x")).toBeNull();
+    expect(shellCommandWords('a <(b)')).toBeNull();
+  });
+});
+
+describe('matchApproval — covered | ask | expired, keyed (envId, userId, op, subject), never the session', () => {
+  it('given a live approval for the subject, should be covered — from ANY session or conversation', () => {
+    expect(matchApproval([approval()], grant, exec('git', ['status']), NOW, deps)).toBe('covered');
+    expect(matchApproval([approval()], { ...grant, principal: { userId: 'user_1', sessionId: 'another', conversationId: 'new-chat' } }, exec('git', ['push']), NOW, deps)).toBe('covered');
+  });
+
+  it('given an approval of git, should NOT cover rm (subject differs) — ask', () => {
+    expect(matchApproval([approval()], grant, exec('rm', ['-rf', 'x']), NOW, deps)).toBe('ask');
+    expect(matchApproval([approval()], grant, shell('git status && rm -rf x'), NOW, deps)).toBe('ask');
+  });
+
+  it('given approvals for every program a script names, should cover the script', () => {
+    const both = [approval(), approval({ approvalId: 'a2', subject: 'exec:/bin/rm' })];
+    expect(matchApproval(both, grant, shell('git status && rm -rf x'), NOW, deps)).toBe('covered');
+  });
+
+  it('given a different env, user or op, should ask — the key is all four parts', () => {
+    expect(matchApproval([approval({ envId: 'env2' })], grant, exec('git'), NOW, deps)).toBe('ask');
+    expect(matchApproval([approval({ userId: 'user_2' })], grant, exec('git'), NOW, deps)).toBe('ask');
+    expect(matchApproval([approval({ op: 'fs_read' })], grant, exec('git'), NOW, deps)).toBe('ask');
+  });
+
+  it('given a grant whose op differs from the request op, should ask (the approval is for the grant\'s op)', () => {
+    expect(matchApproval([approval()], { ...grant, op: 'fs_read' }, exec('git'), NOW, deps)).toBe('ask');
+  });
+
+  it('given only an expired approval for the subject, should report expired (the daemon prunes it and asks)', () => {
+    expect(matchApproval([approval({ expiresAt: NOW - 1 })], grant, exec('git'), NOW, deps)).toBe('expired');
+    expect(matchApproval([approval({ expiresAt: NOW })], grant, exec('git'), NOW, deps)).toBe('expired');
+  });
+
+  it('given an expired and a live approval for the same subject, should be covered', () => {
+    expect(matchApproval([approval({ expiresAt: NOW - 1 }), approval({ approvalId: 'a2' })], grant, exec('git'), NOW, deps)).toBe('covered');
+  });
+
+  it('given an until_revoked approval (no expiry), should be covered at any time', () => {
+    expect(matchApproval([approval({ scope: 'until_revoked', expiresAt: null })], grant, exec('git'), NOW + 10 * THIRTY_DAYS_MS, deps)).toBe('covered');
+  });
+
+  it('given a request whose subjects are unresolvable, should ask even when approvals exist for everything', () => {
+    expect(matchApproval([approval(), approval({ approvalId: 'a2', subject: 'exec:/bin/rm' })], grant, shell('git $(rm x)'), NOW, deps)).toBe('ask');
+  });
+
+  it('given a file op inside an approved root, should be covered; outside it, ask', () => {
+    const rootApproval = approval({ op: 'fs_read', subject: `root:${ROOT}` });
+    expect(matchApproval([rootApproval], { ...grant, op: 'fs_read' }, fsRead(`${ROOT}/a`), NOW, deps)).toBe('covered');
+    expect(matchApproval([rootApproval], { ...grant, op: 'fs_read' }, fsRead(`${ROOT}/a`, `${OTHER_ROOT}/b`), NOW, deps)).toBe('ask');
+  });
+
+  it('given no approvals, should ask', () => {
+    expect(matchApproval([], grant, exec('git'), NOW, deps)).toBe('ask');
+  });
+});
+
+describe('scopes and expiry', () => {
+  it('should offer once | session | 30d | until_revoked, defaulting to 30d', () => {
+    expect([...APPROVAL_SCOPES]).toEqual(['once', 'session', '30d', 'until_revoked']);
+    expect(DEFAULT_APPROVAL_SCOPE).toBe('30d');
+    expect(THIRTY_DAYS_MS).toBe(30 * 24 * 60 * 60 * 1000);
+  });
+  it('approvalExpiry: 30d ⇒ now + 30 days; until_revoked and session ⇒ null; once ⇒ null', () => {
+    expect(approvalExpiry('30d', NOW)).toBe(NOW + THIRTY_DAYS_MS);
+    expect(approvalExpiry('until_revoked', NOW)).toBeNull();
+    expect(approvalExpiry('session', NOW)).toBeNull();
+    expect(approvalExpiry('once', NOW)).toBeNull();
+  });
+  it('isDurableScope: only 30d and until_revoked reach the file; once is not remembered, session lives in the daemon process', () => {
+    expect(APPROVAL_SCOPES.filter(isDurableScope)).toEqual(['30d', 'until_revoked']);
+  });
+});
+
+describe('parseApprovalsFile — strict; ANY defect ⇒ null (empty), never a partial list', () => {
+  const valid = { version: 1, approvals: [approval()] };
+
+  it('given a valid file, should return the approvals', () => {
+    expect(parseApprovalsFile(valid)).toEqual([approval()]);
+    expect(parseApprovalsFile({ version: 1, approvals: [] })).toEqual([]);
+  });
+
+  it.each([
+    ['not an object', 'nope'],
+    ['wrong version', { ...valid, version: 2 }],
+    ['extra top-level key', { ...valid, extra: 1 }],
+    ['extra entry key', { version: 1, approvals: [{ ...approval(), isAdmin: true }] }],
+    ['an op outside the union', { version: 1, approvals: [approval({ op: 'root' as never })] }],
+    ['a once scope in the file', { version: 1, approvals: [approval({ scope: 'once', expiresAt: null })] }],
+    ['a session scope in the file', { version: 1, approvals: [approval({ scope: 'session', expiresAt: null })] }],
+    ['30d without an expiry', { version: 1, approvals: [approval({ expiresAt: null })] }],
+    ['until_revoked WITH an expiry', { version: 1, approvals: [approval({ scope: 'until_revoked', expiresAt: NOW })] }],
+    ['an empty subject', { version: 1, approvals: [approval({ subject: '' })] }],
+    ['a subject with no namespace', { version: 1, approvals: [approval({ subject: '/usr/bin/git' })] }],
+    ['one bad entry among good ones', { version: 1, approvals: [approval(), { approvalId: 'x' }] }],
+  ])('given %s, should return null — the WHOLE file is ignored', (_label, input) => {
+    expect(parseApprovalsFile(input)).toBeNull();
+  });
+});
+
+describe('purity', () => {
+  it('decide-approval.ts performs no I/O and reads no clock', () => {
+    const source = readFileSync(join(import.meta.dirname, '..', 'decide-approval.ts'), 'utf8');
+    expect(source).not.toMatch(/from 'node:|from 'fs'|from 'ws'|child_process|Date\.now|new Date\(|Math\.random|crypto/);
+  });
+});

--- a/packages/lib/src/env-bridge/__tests__/decide-execution.test.ts
+++ b/packages/lib/src/env-bridge/__tests__/decide-execution.test.ts
@@ -3,6 +3,7 @@ import { decideExecution, type NormalizedRequest } from '../decide-execution';
 import type { Grant } from '../grant';
 import type { MachinePolicy, ServerPolicy, AdvertisedCapabilities } from '../policy-types';
 import type { PathProbe } from '../confine-path';
+import type { DurableApproval } from '../decide-approval';
 
 const ROOT = '/home/u/proj';
 const identityProbe: PathProbe = { realpath: (p) => p, isSymlink: () => false };
@@ -82,18 +83,18 @@ describe('decideExecution — the daemon is the policy enforcement point (invari
   });
 
   it('given all three allow, should return allow with a NORMALIZED request: confined cwd, scrubbed env, clamped timeout and bytes', () => {
-    expect(decide()).toEqual({ kind: 'allow', request: NORMALIZED });
+    expect(decide()).toEqual({ kind: 'allow', request: NORMALIZED, basis: { kind: 'preapproved_op' } });
   });
 
   describe('the ask → allow seam (major: approval must be pure and bound to the grant)', () => {
     const askPolicy: MachinePolicy = { ...machine, mode: 'ask', ops: ['fs_read'] };
 
     it('given mode ask and an op NOT pre-approved, should return ask carrying the exact NormalizedRequest the owner is approving (confined + scrubbed BEFORE asking)', () => {
-      expect(decide({ machinePolicy: askPolicy })).toEqual({ kind: 'ask', reason: 'op_not_preapproved', request: NORMALIZED });
+      expect(decide({ machinePolicy: askPolicy })).toEqual({ kind: 'ask', reason: 'op_not_preapproved', request: NORMALIZED, subjects: null });
     });
 
     it('given mode ask and an op that IS pre-approved, should allow without asking', () => {
-      expect(decide({ machinePolicy: { ...machine, mode: 'ask' } })).toEqual({ kind: 'allow', request: NORMALIZED });
+      expect(decide({ machinePolicy: { ...machine, mode: 'ask' } })).toEqual({ kind: 'allow', request: NORMALIZED, basis: { kind: 'preapproved_op' } });
     });
 
     // The owner approves exactly the NormalizedRequest the ask verdict showed them.
@@ -102,7 +103,7 @@ describe('decideExecution — the daemon is the policy enforcement point (invari
     it('given an approval whose request is the ask verdict\'s own NormalizedRequest, should allow it unchanged', () => {
       const asked = decide({ machinePolicy: askPolicy });
       if (asked.kind !== 'ask') throw new Error('expected ask');
-      expect(decide({ machinePolicy: askPolicy, localApproval: { grantId: grant.grantId, approvedAt: 30_000, request: asked.request } })).toEqual({ kind: 'allow', request: asked.request });
+      expect(decide({ machinePolicy: askPolicy, localApproval: { grantId: grant.grantId, approvedAt: 30_000, request: asked.request } })).toEqual({ kind: 'allow', request: asked.request, basis: { kind: 'fresh_approval' } });
     });
 
     it('given the filesystem DRIFTED between ask and approval (an in-root symlink now resolves elsewhere), should deny approval_mismatch — never execute what the owner did not see', () => {
@@ -131,7 +132,7 @@ describe('decideExecution — the daemon is the policy enforcement point (invari
     });
 
     it('given mode ask, a non-pre-approved op, and localApproval for THIS grantId within the grant TTL, should allow with the same NormalizedRequest', () => {
-      expect(decide({ machinePolicy: askPolicy, localApproval: approval })).toEqual({ kind: 'allow', request: NORMALIZED });
+      expect(decide({ machinePolicy: askPolicy, localApproval: approval })).toEqual({ kind: 'allow', request: NORMALIZED, basis: { kind: 'fresh_approval' } });
     });
 
     it('given localApproval for a DIFFERENT grantId, should still ask (an approval is bound to one grant)', () => {
@@ -255,7 +256,7 @@ describe('decideExecution — the daemon is the policy enforcement point (invari
     const fsGrant = { ...grant, op: 'fs_write' as const };
     const probe: PathProbe = { realpath: (p) => (p === ROOT || p === `${ROOT}/src` ? p : null), isSymlink: () => false };
     const verdict = decide({ grant: fsGrant, request: { op: 'fs_write', paths: [`${ROOT}/src/new.ts`] }, probe });
-    expect(verdict).toEqual({ kind: 'allow', request: { op: 'fs_write', cwd: ROOT, paths: [`${ROOT}/src/new.ts`], env: {}, timeoutMs: machine.maxTimeoutMs, maxBytes: machine.maxBytes, clamped: false } });
+    expect(verdict).toEqual({ kind: 'allow', request: { op: 'fs_write', cwd: ROOT, paths: [`${ROOT}/src/new.ts`], env: {}, timeoutMs: machine.maxTimeoutMs, maxBytes: machine.maxBytes, clamped: false }, basis: { kind: 'preapproved_op' } });
   });
 
   describe('malformed request shapes are refused BEFORE the policy gates ("allow" must mean executable)', () => {
@@ -357,5 +358,54 @@ describe('decideExecution — the daemon is the policy enforcement point (invari
     const b = decide();
     expect(a).toEqual(b);
     expect(JSON.stringify(request)).toBe(before);
+  });
+});
+
+describe('GA wave 2 — durable approvals are consulted AFTER confinePath and scrubEnv, against the normalised request', () => {
+  const askPolicy: MachinePolicy = { ...machine, mode: 'ask', ops: [] };
+  const BIN: Record<string, string> = { ls: '/bin/ls', rm: '/bin/rm' };
+  const resolveArgv0 = (name: string) => BIN[name] ?? null;
+  const lsApproval: DurableApproval = { approvalId: 'ap1', envId: grant.envId, userId: grant.principal.userId, op: 'exec', subject: 'exec:/bin/ls', scope: '30d', createdAt: 0, expiresAt: 100_000 };
+  const consult = (entries: DurableApproval[] = [lsApproval], now = 50_000) => ({ entries, now, resolveArgv0 });
+
+  it('given a live durable approval for the subject, should allow with basis durable_approval naming the approval id', () => {
+    expect(decide({ machinePolicy: askPolicy, approvals: consult() })).toEqual({ kind: 'allow', request: NORMALIZED, basis: { kind: 'durable_approval', approvalIds: ['ap1'] } });
+  });
+
+  it('given no covering approval, should ask and carry the SUBJECTS a click would approve', () => {
+    expect(decide({ machinePolicy: askPolicy, approvals: consult([]) })).toEqual({ kind: 'ask', reason: 'op_not_preapproved', request: NORMALIZED, subjects: ['exec:/bin/ls'] });
+    expect(decide({ machinePolicy: askPolicy, request: { ...request, cmd: 'rm' }, approvals: consult() })).toMatchObject({ kind: 'ask', subjects: ['exec:/bin/rm'] });
+  });
+
+  it('given only an expired approval, should ask (the daemon prunes it)', () => {
+    expect(decide({ machinePolicy: askPolicy, approvals: consult([lsApproval], 100_000) })).toMatchObject({ kind: 'ask' });
+  });
+
+  it('given an unresolvable subject, should ask with subjects null — nothing durable can ever be written for it', () => {
+    expect(decide({ machinePolicy: askPolicy, request: { ...request, cmd: 'sh', args: ['-c', 'ls $(rm x)'] }, approvals: consult() })).toMatchObject({ kind: 'ask', subjects: null });
+  });
+
+  it('given every policy gate fails, the approval is never consulted: a denied request stays denied whatever the file says', () => {
+    expect(decide({ machinePolicy: { ...askPolicy, principals: ['someone_else'] }, approvals: consult() })).toEqual({ kind: 'deny', reason: 'principal_not_allowed' });
+    expect(decide({ machinePolicy: askPolicy, request: { ...request, cwd: '/etc' }, approvals: consult() })).toEqual({ kind: 'deny', reason: 'cwd_denied' });
+  });
+
+  it('given a file op, the subject is the ROOT the confined path resolves inside — a retargeted symlink to another root cannot ride the first root\'s approval', () => {
+    const roots = [ROOT, '/srv/other'];
+    const policy: MachinePolicy = { ...askPolicy, roots };
+    const rootApproval: DurableApproval = { ...lsApproval, op: 'fs_read', subject: `root:${ROOT}` };
+    const readGrant = { ...grant, op: 'fs_read' as const };
+    const readRequest = { op: 'fs_read' as const, paths: [`${ROOT}/link`] };
+    const inRoot: PathProbe = { realpath: (p) => (p === `${ROOT}/link` ? `${ROOT}/real.txt` : p), isSymlink: () => false };
+    expect(decide({ machinePolicy: policy, grant: readGrant, request: readRequest, probe: inRoot, approvals: consult([rootApproval]) })).toMatchObject({ kind: 'allow', basis: { kind: 'durable_approval' } });
+    const retargeted: PathProbe = { realpath: (p) => (p === `${ROOT}/link` ? '/srv/other/secret' : p), isSymlink: () => false };
+    expect(decide({ machinePolicy: policy, grant: readGrant, request: readRequest, probe: retargeted, approvals: consult([rootApproval]) })).toMatchObject({ kind: 'ask', subjects: ['root:/srv/other'] });
+  });
+
+  it('given a fresh localApproval for this grant, that path answers first and stays byte-compared (untouched)', () => {
+    const asked = decide({ machinePolicy: askPolicy, approvals: consult([]) });
+    if (asked.kind !== 'ask') throw new Error('expected ask');
+    expect(decide({ machinePolicy: askPolicy, approvals: consult([]), localApproval: { grantId: grant.grantId, approvedAt: 30_000, request: asked.request } })).toEqual({ kind: 'allow', request: asked.request, basis: { kind: 'fresh_approval' } });
+    expect(decide({ machinePolicy: askPolicy, approvals: consult([]), localApproval: { grantId: grant.grantId, approvedAt: 30_000, request: { ...asked.request, cmd: 'rm' } } })).toEqual({ kind: 'deny', reason: 'approval_mismatch' });
   });
 });

--- a/packages/lib/src/env-bridge/__tests__/frame-codec.test.ts
+++ b/packages/lib/src/env-bridge/__tests__/frame-codec.test.ts
@@ -225,3 +225,24 @@ describe('execOutputCeiling — the largest raw stdout+stderr an exec_result can
     expect(execOutputCeiling({ maxFrameBytes: 10 })).toBe(0);
   });
 });
+
+describe('GA wave 2 — grant_denied may carry a PENDING frozen request', () => {
+  const pending = { challengeId: 'ch_1', expiresAt: 5, request: { op: 'exec', cmd: 'git', args: ['status'], cwd: '/p', paths: [], env: { CI: '1' }, timeoutMs: 1000, maxBytes: 1024, clamped: false } };
+  const limits = { maxFrameBytes: 65536 };
+
+  it('should decode a grant_denied with a well-formed pending request, and one without', () => {
+    expect(decodeFrame({ type: 'grant_denied', grantId: 'g1', reason: 'ask_pending:ch_1', pending, sig: B64 }, limits)).toMatchObject({ ok: true, frame: { pending } });
+    expect(decodeFrame({ type: 'grant_denied', grantId: 'g1', reason: 'x', sig: B64 }, limits)).toMatchObject({ ok: true });
+  });
+
+  it.each([
+    ['an extra field inside pending', { ...pending, isAdmin: true }],
+    ['an extra field inside the request', { ...pending, request: { ...pending.request, shell: true } }],
+    ['a missing cwd', { ...pending, request: { ...pending.request, cwd: undefined } }],
+    ['a non-positive timeout', { ...pending, request: { ...pending.request, timeoutMs: 0 } }],
+    ['an op outside the union', { ...pending, request: { ...pending.request, op: 'root' } }],
+    ['an empty challengeId', { ...pending, challengeId: '' }],
+  ])('given %s, should reject the whole frame as malformed', (_label, bad) => {
+    expect(decodeFrame({ type: 'grant_denied', grantId: 'g1', reason: 'ask_pending:ch_1', pending: bad, sig: B64 }, limits)).toEqual({ ok: false, reason: 'malformed' });
+  });
+});

--- a/packages/lib/src/env-bridge/__tests__/frame-codec.test.ts
+++ b/packages/lib/src/env-bridge/__tests__/frame-codec.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { decodeFrame, encodeFrame, FRAME_TYPES, FS_READ_ENVELOPE_OVERHEAD_BYTES, fsReadContentCeiling, execOutputCeiling, type Frame } from '../frame-codec';
+import { decodeFrame, encodeFrame, FRAME_TYPES, isMachineToServerFrame, FS_READ_ENVELOPE_OVERHEAD_BYTES, fsReadContentCeiling, execOutputCeiling, type Frame } from '../frame-codec';
 
 const LIMITS = { maxFrameBytes: 64 * 1024 };
 const B64 = Buffer.from('hello').toString('base64');
@@ -13,6 +13,7 @@ const SAMPLES: Record<Frame['type'], Frame> = {
   fs_read_result: { type: 'fs_read_result', grantId: 'g1', found: true, contentB64: B64, sig: B64 },
   fs_write_result: { type: 'fs_write_result', grantId: 'g1', ok: true, sig: B64 },
   grant_denied: { type: 'grant_denied', grantId: 'g1', reason: 'principal_not_allowed', sig: B64 },
+  approval_revoke_result: { type: 'approval_revoke_result', approvalId: 'ch_1', removed: 2, sig: B64 },
   pty_opened: { type: 'pty_opened', grantId: 'g1', sessionId: 'p1' },
   pty_data: { type: 'pty_data', sessionId: 'p1', seq: 0, dataB64: B64 },
   pty_exit: { type: 'pty_exit', sessionId: 'p1', code: 0 },
@@ -57,6 +58,7 @@ function generate(type: Frame['type'], r: () => number): Frame {
     case 'fs_read_result': return r() > 0.5 ? { type, grantId: randomStr(r), found: true, contentB64: randomB64(r), sig: B64 } : { type, grantId: randomStr(r), found: false, sig: B64 };
     case 'fs_write_result': return r() > 0.5 ? { type, grantId: randomStr(r), ok: true, sig: B64 } : { type, grantId: randomStr(r), ok: false, error: randomStr(r), sig: B64 };
     case 'grant_denied': return { type, grantId: randomStr(r), reason: randomStr(r), sig: B64 };
+    case 'approval_revoke_result': return { type, approvalId: randomStr(r), removed: randomInt(r, 8), sig: B64 };
     case 'pty_opened': return { type, grantId: randomStr(r), sessionId: randomStr(r) };
     case 'pty_data': return { type, sessionId: randomStr(r), seq: randomInt(r), dataB64: randomB64(r) };
     case 'pty_exit': return { type, sessionId: randomStr(r), code: randomInt(r, 256) };
@@ -244,5 +246,15 @@ describe('GA wave 2 — grant_denied may carry a PENDING frozen request', () => 
     ['an empty challengeId', { ...pending, challengeId: '' }],
   ])('given %s, should reject the whole frame as malformed', (_label, bad) => {
     expect(decodeFrame({ type: 'grant_denied', grantId: 'g1', reason: 'ask_pending:ch_1', pending: bad, sig: B64 }, limits)).toEqual({ ok: false, reason: 'malformed' });
+  });
+});
+
+describe('GA wave 2 — approval_revoke_result is a machine→server frame', () => {
+  it('decodes with approvalId + removed + sig, and rejects a missing count or an extra field', () => {
+    const limits = { maxFrameBytes: 65536 };
+    expect(decodeFrame({ type: 'approval_revoke_result', approvalId: 'ch_1', removed: 2, sig: B64 }, limits)).toMatchObject({ ok: true, frame: { type: 'approval_revoke_result', approvalId: 'ch_1', removed: 2 } });
+    expect(decodeFrame({ type: 'approval_revoke_result', approvalId: 'ch_1', sig: B64 }, limits)).toEqual({ ok: false, reason: 'malformed' });
+    expect(decodeFrame({ type: 'approval_revoke_result', approvalId: '', removed: 1, sig: B64 }, limits)).toEqual({ ok: false, reason: 'malformed' });
+    expect(isMachineToServerFrame({ type: 'approval_revoke_result', approvalId: 'ch_1', removed: 0, sig: '' })).toBe(true);
   });
 });

--- a/packages/lib/src/env-bridge/__tests__/grant.test.ts
+++ b/packages/lib/src/env-bridge/__tests__/grant.test.ts
@@ -307,3 +307,42 @@ describe('createMemoryNonceStore', () => {
     expect(s.has('n')).toBe(true);
   });
 });
+
+describe('GA wave 2 — approvalIntent: the owner\'s click rides the re-issued grant, signed under the pinned key', () => {
+  const INTENT = { challengeId: 'ch_1', scope: '30d' as const, expiresAt: NOW + 30_000 };
+  const request = { op: 'exec' as const, args: ARGS };
+  const nonces = () => createMemoryNonceStore();
+
+  it('given a grant carrying a well-formed approvalIntent signed by the server, should verify and hand the intent back on the Grant', () => {
+    const grant = makeGrant({ approvalIntent: INTENT });
+    const verdict = verifyGrant({ grant, signature: signWith(server.privateKey, grant), serverPublicKey, now: NOW, nonces: nonces(), expectedEnvId: ENV, request, verify, hash });
+    expect(verdict).toEqual({ ok: true, grant });
+  });
+
+  it('a grant WITHOUT an intent keeps the bytes it always had (no approvalIntent key is ever added)', () => {
+    expect(Buffer.from(encodeGrant(makeGrant())).toString()).not.toContain('approvalIntent');
+    expect(Buffer.from(encodeGrant(makeGrant({ approvalIntent: INTENT }))).toString()).toContain('"approvalIntent":{"challengeId":"ch_1","scope":"30d","expiresAt":');
+  });
+
+  it.each([
+    ['added after signing', makeGrant(), makeGrant({ approvalIntent: INTENT })],
+    ['removed after signing', makeGrant({ approvalIntent: INTENT }), makeGrant()],
+    ['challengeId altered', makeGrant({ approvalIntent: INTENT }), makeGrant({ approvalIntent: { ...INTENT, challengeId: 'ch_other' } })],
+    ['scope widened', makeGrant({ approvalIntent: INTENT }), makeGrant({ approvalIntent: { ...INTENT, scope: 'until_revoked' } })],
+    ['expiry extended', makeGrant({ approvalIntent: INTENT }), makeGrant({ approvalIntent: { ...INTENT, expiresAt: INTENT.expiresAt + 1 } })],
+  ])('given the intent %s, should deny bad_signature — a click cannot be forged or edited in flight', (_label, signed, presented) => {
+    const verdict = verifyGrant({ grant: presented, signature: signWith(server.privateKey, signed), serverPublicKey, now: NOW, nonces: nonces(), expectedEnvId: ENV, request, verify, hash });
+    expect(verdict).toEqual({ ok: false, reason: 'bad_signature' });
+  });
+
+  it.each([
+    ['an unknown scope', { ...INTENT, scope: 'forever' }],
+    ['an extra field', { ...INTENT, isAdmin: true }],
+    ['an empty challengeId', { ...INTENT, challengeId: '' }],
+    ['a missing expiry', { challengeId: 'ch_1', scope: '30d' }],
+  ])('given an intent with %s, should deny malformed', (_label, approvalIntent) => {
+    const grant = { ...makeGrant(), approvalIntent } as unknown as Grant;
+    const verdict = verifyGrant({ grant, signature: signWith(server.privateKey, grant), serverPublicKey, now: NOW, nonces: nonces(), expectedEnvId: ENV, request, verify, hash });
+    expect(verdict).toEqual({ ok: false, reason: 'malformed' });
+  });
+});

--- a/packages/lib/src/env-bridge/__tests__/machine-signatures.test.ts
+++ b/packages/lib/src/env-bridge/__tests__/machine-signatures.test.ts
@@ -16,6 +16,9 @@ import {
   encodeRevokeForSigning,
   resultHashForFrame,
   resultPayloadForFrame,
+  encodeApprovalRevokeForSigning,
+  REVOKE_APPROVAL_SIGNING_DOMAIN,
+  REVOKE_SIGNING_DOMAIN,
   verifyHello,
   verifyMachineResult,
   verifyRevoke,
@@ -185,6 +188,44 @@ describe('results — machine-signed over {grantId, resultHash} (invariant 7)', 
     expect(isMachineResultFrame({ type: 'pty_exit', sessionId: 's', code: 0 })).toBe(false);
     expect(isMachineResultFrame({ type: 'pong', ts: 1 })).toBe(false);
     expect(isMachineResultFrame({ type: 'exec_result', grantId: 'g', exitCode: 0, stdoutB64: '', stderrB64: '', truncated: false, sig: '' })).toBe(true);
+  });
+});
+
+describe('GA wave 2 — revoking ONE approval rides the revoke frame under its own domain', () => {
+  const binding = { envId: 'env_1', enrollmentId: 'enr_1', keyId: 'srv-k1', issuedAt: 1_800_000_000_000 };
+  const approvalRevoke = (key = server, approvalId = 'ch_1'): Extract<Frame, { type: 'revoke' }> => ({
+    type: 'revoke',
+    approvalId,
+    issuedAt: binding.issuedAt,
+    reason: 'owner_revoked_approval',
+    sig: signWith(key, encodeApprovalRevokeForSigning({ ...binding, approvalId })),
+  });
+  const check = (frame: Extract<Frame, { type: 'revoke' }>) => verifyRevoke({ frame, ...binding, serverPublicKey: spki(server), verify });
+
+  it('given an approval revoke signed by the pinned key for THIS enrollment and id, should verify', () => {
+    expect(check(approvalRevoke())).toEqual({ ok: true });
+  });
+
+  it('given the approvalId STRIPPED from a signed approval revoke, should deny bad_signature — it can never become an enrollment revoke (a key deletion)', () => {
+    const { approvalId: _dropped, ...stripped } = approvalRevoke();
+    expect(check(stripped as Extract<Frame, { type: 'revoke' }>)).toEqual({ ok: false, reason: 'bad_signature' });
+  });
+
+  it('given an approvalId ADDED to a signed enrollment revoke, should deny bad_signature — the reverse is closed too', () => {
+    const full: Extract<Frame, { type: 'revoke' }> = { type: 'revoke', issuedAt: binding.issuedAt, sig: signWith(server, encodeRevokeForSigning(binding)) };
+    expect(check(full)).toEqual({ ok: true });
+    expect(check({ ...full, approvalId: 'ch_1' })).toEqual({ ok: false, reason: 'bad_signature' });
+  });
+
+  it('given a different approvalId, enrollment, or a rogue key, should deny bad_signature', () => {
+    expect(check({ ...approvalRevoke(), approvalId: 'ch_other' })).toEqual({ ok: false, reason: 'bad_signature' });
+    expect(verifyRevoke({ frame: approvalRevoke(), ...binding, enrollmentId: 'enr_other', serverPublicKey: spki(server), verify })).toEqual({ ok: false, reason: 'bad_signature' });
+    expect(check(approvalRevoke(rogue))).toEqual({ ok: false, reason: 'bad_signature' });
+  });
+
+  it('the two domains differ, and the enrollment revoke bytes are exactly what they were', () => {
+    expect(REVOKE_APPROVAL_SIGNING_DOMAIN).not.toBe(REVOKE_SIGNING_DOMAIN);
+    expect(Buffer.from(encodeRevokeForSigning(binding)).toString()).toBe(JSON.stringify({ domain: REVOKE_SIGNING_DOMAIN, ...binding }));
   });
 });
 

--- a/packages/lib/src/env-bridge/__tests__/machine-signatures.test.ts
+++ b/packages/lib/src/env-bridge/__tests__/machine-signatures.test.ts
@@ -16,6 +16,8 @@ import {
   encodeRevokeForSigning,
   resultHashForFrame,
   resultPayloadForFrame,
+  machineResultBindingId,
+  approvalRevokeBindingId,
   encodeApprovalRevokeForSigning,
   REVOKE_APPROVAL_SIGNING_DOMAIN,
   REVOKE_SIGNING_DOMAIN,
@@ -94,12 +96,13 @@ const results: UnsignedResult = {
   fs_read_result: { type: 'fs_read_result', grantId: 'g2', found: true, contentB64: 'ZGF0YQ==' },
   fs_write_result: { type: 'fs_write_result', grantId: 'g3', ok: true },
   grant_denied: { type: 'grant_denied', grantId: 'g4', reason: 'policy_denied' },
+  approval_revoke_result: { type: 'approval_revoke_result', approvalId: 'ch_9', removed: 1 },
 };
 
 function signResult(body: Omit<MachineResultFrame, 'sig'>, key = machine): MachineResultFrame {
   const frame = { ...body, sig: '' } as MachineResultFrame;
   const resultHash = resultHashForFrame(frame, hash);
-  return { ...body, sig: signWith(key, encodeResultForSigning({ grantId: body.grantId, resultHash })) } as MachineResultFrame;
+  return { ...body, sig: signWith(key, encodeResultForSigning({ grantId: machineResultBindingId(frame), resultHash })) } as MachineResultFrame;
 }
 
 const PENDING = { challengeId: 'ch_1', expiresAt: 1_800_000_060_000, request: { op: 'exec' as const, cmd: 'git', args: ['status'], cwd: '/home/u/proj', paths: [], env: {}, timeoutMs: 1000, maxBytes: 1024, clamped: false } };
@@ -161,7 +164,7 @@ describe('results — machine-signed over {grantId, resultHash} (invariant 7)', 
 
   it('given the grantId swapped onto another grant after signing, should deny bad_signature (a result cannot be replayed under another grant)', () => {
     const signed = signResult(results.exec_result);
-    expect(verifyMachineResult({ frame: { ...signed, grantId: 'g-other' }, machinePublicKey: spki(machine), verify, hash })).toEqual({ ok: false, reason: 'bad_signature' });
+    expect(verifyMachineResult({ frame: { ...signed, grantId: 'g-other' } as MachineResultFrame, machinePublicKey: spki(machine), verify, hash })).toEqual({ ok: false, reason: 'bad_signature' });
   });
 
   it('given fs_read_result with contentB64 absent vs empty, should hash distinctly (absent is not empty)', () => {
@@ -183,7 +186,7 @@ describe('results — machine-signed over {grantId, resultHash} (invariant 7)', 
   });
 
   it('should name exactly the exec/fs/denied result frames — PTY frames and pong are outside this verifier by design ([D-2])', () => {
-    expect([...MACHINE_RESULT_FRAME_TYPES].sort()).toEqual(['exec_result', 'fs_read_result', 'fs_write_result', 'grant_denied']);
+    expect([...MACHINE_RESULT_FRAME_TYPES].sort()).toEqual(['approval_revoke_result', 'exec_result', 'fs_read_result', 'fs_write_result', 'grant_denied']);
     expect(isMachineResultFrame({ type: 'pty_data', sessionId: 's', seq: 0, dataB64: '' })).toBe(false);
     expect(isMachineResultFrame({ type: 'pty_exit', sessionId: 's', code: 0 })).toBe(false);
     expect(isMachineResultFrame({ type: 'pong', ts: 1 })).toBe(false);
@@ -226,6 +229,32 @@ describe('GA wave 2 — revoking ONE approval rides the revoke frame under its o
   it('the two domains differ, and the enrollment revoke bytes are exactly what they were', () => {
     expect(REVOKE_APPROVAL_SIGNING_DOMAIN).not.toBe(REVOKE_SIGNING_DOMAIN);
     expect(Buffer.from(encodeRevokeForSigning(binding)).toString()).toBe(JSON.stringify({ domain: REVOKE_SIGNING_DOMAIN, ...binding }));
+  });
+});
+
+describe('GA wave 2 (Codex P2 on #2583) — the approval-revoke ACK is a machine result signed over {approvalId, removed}', () => {
+  const ack = { type: 'approval_revoke_result' as const, approvalId: 'ch_1', removed: 2 };
+  const signAck = (body = ack, key = machine): MachineResultFrame => {
+    const frame = { ...body, sig: '' } as MachineResultFrame;
+    return { ...body, sig: signWith(key, encodeResultForSigning({ grantId: machineResultBindingId(frame), resultHash: resultHashForFrame(frame, hash) })) } as MachineResultFrame;
+  };
+
+  it('should verify under the pinned machine key, bound to the namespaced approval id (never a grant id)', () => {
+    expect(verifyMachineResult({ frame: signAck(), machinePublicKey: spki(machine), verify, hash })).toMatchObject({ ok: true });
+    expect(machineResultBindingId({ ...ack, sig: '' } as MachineResultFrame)).toBe('approval-revoke:ch_1');
+    expect(approvalRevokeBindingId('ch_1')).toBe('approval-revoke:ch_1');
+  });
+
+  it.each([
+    ['approvalId', { ...ack, approvalId: 'ch_2' }],
+    ['removed', { ...ack, removed: 0 }],
+  ])('given %s edited after signing, should deny bad_signature — the server may only claim what the machine signed', (_label, tampered) => {
+    const signed = signAck();
+    expect(verifyMachineResult({ frame: { ...tampered, sig: signed.sig } as MachineResultFrame, machinePublicKey: spki(machine), verify, hash })).toEqual({ ok: false, reason: 'bad_signature' });
+  });
+
+  it('given an ack signed by a rogue key, should deny bad_signature', () => {
+    expect(verifyMachineResult({ frame: signAck(ack, rogue), machinePublicKey: spki(machine), verify, hash })).toEqual({ ok: false, reason: 'bad_signature' });
   });
 });
 

--- a/packages/lib/src/env-bridge/__tests__/machine-signatures.test.ts
+++ b/packages/lib/src/env-bridge/__tests__/machine-signatures.test.ts
@@ -15,6 +15,7 @@ import {
   encodeResultForSigning,
   encodeRevokeForSigning,
   resultHashForFrame,
+  resultPayloadForFrame,
   verifyHello,
   verifyMachineResult,
   verifyRevoke,
@@ -98,6 +99,34 @@ function signResult(body: Omit<MachineResultFrame, 'sig'>, key = machine): Machi
   return { ...body, sig: signWith(key, encodeResultForSigning({ grantId: body.grantId, resultHash })) } as MachineResultFrame;
 }
 
+const PENDING = { challengeId: 'ch_1', expiresAt: 1_800_000_060_000, request: { op: 'exec' as const, cmd: 'git', args: ['status'], cwd: '/home/u/proj', paths: [], env: {}, timeoutMs: 1000, maxBytes: 1024, clamped: false } };
+
+describe('GA wave 2 — a grant_denied carrying a PENDING frozen request is signed over that request too', () => {
+  const denied = { type: 'grant_denied' as const, grantId: 'g5', reason: 'ask_pending:ch_1', pending: PENDING };
+
+  it('should verify when signed as sent, and its payload names every field of the frozen request', () => {
+    const frame = signResult(denied);
+    expect(verifyMachineResult({ frame, machinePublicKey: spki(machine), verify, hash })).toMatchObject({ ok: true });
+    expect(resultPayloadForFrame(frame)).toEqual({ type: 'grant_denied', grantId: 'g5', reason: 'ask_pending:ch_1', pending: PENDING });
+    // Absent pending hashes as null, distinctly from any present one.
+    expect(resultPayloadForFrame({ ...results.grant_denied, sig: '' } as MachineResultFrame)).toEqual({ type: 'grant_denied', grantId: 'g4', reason: 'policy_denied', pending: null });
+  });
+
+  it.each([
+    ['cmd', { ...PENDING, request: { ...PENDING.request, cmd: 'rm' } }],
+    ['args', { ...PENDING, request: { ...PENDING.request, args: ['push', '--force'] } }],
+    ['cwd', { ...PENDING, request: { ...PENDING.request, cwd: '/etc' } }],
+    ['env', { ...PENDING, request: { ...PENDING.request, env: { LD_PRELOAD: '/evil.so' } } }],
+    ['challengeId', { ...PENDING, challengeId: 'ch_other' }],
+    ['expiresAt', { ...PENDING, expiresAt: PENDING.expiresAt + 1 }],
+    ['removed', undefined],
+  ])('given pending.%s altered after signing, should deny bad_signature — the card can only show what the machine froze', (_label, pending) => {
+    const signed = signResult(denied);
+    const frame = { ...denied, ...(pending === undefined ? { pending: undefined } : { pending }), sig: signed.sig } as MachineResultFrame;
+    expect(verifyMachineResult({ frame, machinePublicKey: spki(machine), verify, hash })).toEqual({ ok: false, reason: 'bad_signature' });
+  });
+});
+
 describe('results — machine-signed over {grantId, resultHash} (invariant 7)', () => {
   it.each(Object.keys(results) as MachineResultFrame['type'][])('given a %s signed by the pinned key, should verify and return the resultHash it covers', (type) => {
     const frame = signResult(results[type]);
@@ -119,6 +148,7 @@ describe('results — machine-signed over {grantId, resultHash} (invariant 7)', 
     ['fs_write_result.ok', { ...results.fs_write_result, ok: false }],
     ['fs_write_result.error', { ...results.fs_write_result, error: 'disk full' }],
     ['grant_denied.reason', { ...results.grant_denied, reason: 'other' }],
+    ['grant_denied.pending (added)', { ...results.grant_denied, pending: PENDING }],
   ] as Array<[string, UnsignedResult[keyof UnsignedResult]]>)('given %s changed after signing, should deny bad_signature — every payload field is covered', (_label, tampered) => {
     const original = results[tampered.type];
     const signed = signResult(original);

--- a/packages/lib/src/env-bridge/decide-approval.ts
+++ b/packages/lib/src/env-bridge/decide-approval.ts
@@ -1,0 +1,374 @@
+/**
+ * Durable, scoped approvals — the pure matcher (GA wave 2, leaf 2).
+ *
+ * WHAT AN APPROVAL IS FOR. Before this wave the daemon remembered an `ask`
+ * answer under `(userId, sessionId, op)`: approving `git status` silently
+ * authorized every later `exec` in that session, unseen, and a new chat asked
+ * again. Both halves were wrong. An approval is now keyed on
+ *
+ *     (envId, userId, op, subject)
+ *
+ * where the SUBJECT is the thing the owner actually looked at: for `exec`, the
+ * resolved program (`exec:/usr/bin/git`); for `fs_read` / `fs_write`, the
+ * policy root the paths resolve inside (`root:/home/u/proj`). Never a session,
+ * never a conversation. Approving `git status` covers `git push` from a new
+ * chat tomorrow and does NOT cover `rm -rf`.
+ *
+ * `sh -c <script>`. The bash tool always sends `sh -c "<command line>"`, so
+ * the program is not `sh` — it is every program the script names. The lexer
+ * below (`shellCommandWords`) splits the script on the shell's list and pipe
+ * operators, drops env assignments, wrappers and control keywords, and keys
+ * on EACH command word. A script is covered only when EVERY word is. Anything
+ * the lexer cannot attribute to a program name — substitution, `eval`, a
+ * nested shell, `find -exec`, a quoted or variable command word — yields NO
+ * subject: such a request is asked about every time, and an approval can
+ * never be written for it. The shell itself is never a subject.
+ *
+ * Fail closed, by construction: an unresolvable subject is `ask`; an
+ * approvals file with ANY defect parses to `null` (empty), never partially.
+ *
+ * Pure: the program resolver (PATH walk) and the clock are injected; there is
+ * no I/O here. Consulted by `decideExecution` AFTER `confinePath` and
+ * `scrubEnv`, so a match is against the normalised request and a retargeted
+ * symlink cannot ride an old approval.
+ */
+import { z } from 'zod';
+import { GRANT_OPS, type Grant, type GrantOp } from './grant';
+import type { NormalizedRequest } from './decide-execution';
+
+export const APPROVAL_SCOPES = ['once', 'session', '30d', 'until_revoked'] as const;
+export type ApprovalScope = (typeof APPROVAL_SCOPES)[number];
+export const DEFAULT_APPROVAL_SCOPE: ApprovalScope = '30d';
+export const THIRTY_DAYS_MS = 30 * 24 * 60 * 60 * 1000;
+
+/** The scopes that reach `~/.pagespace/env-approvals.json`; `once` is never remembered, `session` lives in the daemon process only. */
+export const DURABLE_APPROVAL_SCOPES = ['30d', 'until_revoked'] as const satisfies readonly ApprovalScope[];
+export type DurableApprovalScope = (typeof DURABLE_APPROVAL_SCOPES)[number];
+
+export function isDurableScope(scope: ApprovalScope): scope is DurableApprovalScope {
+  return (DURABLE_APPROVAL_SCOPES as readonly ApprovalScope[]).includes(scope);
+}
+
+/** When an approval of `scope` granted at `now` stops covering; `null` = no expiry of its own. */
+export function approvalExpiry(scope: ApprovalScope, now: number): number | null {
+  return scope === '30d' ? now + THIRTY_DAYS_MS : null;
+}
+
+/**
+ * One row of the approvals file (or of the daemon's in-memory session set).
+ * `approvalId` is shared by every subject row one click produced, so the
+ * server can revoke "that approval" by the id it knows (the challenge id).
+ */
+export interface DurableApproval {
+  readonly approvalId: string;
+  readonly envId: string;
+  readonly userId: string;
+  readonly op: GrantOp;
+  /** `exec:<resolved program>`, `builtin:<name>` or `root:<policy root>`. */
+  readonly subject: string;
+  readonly scope: ApprovalScope;
+  readonly createdAt: number;
+  readonly expiresAt: number | null;
+}
+
+export interface ApprovalMatchDeps {
+  /** The daemon's PATH walk (`command-resolver.ts`): absolute path of a program, or `null`. */
+  readonly resolveArgv0: (name: string) => string | null;
+  /** The machine policy's roots — the subjects of file operations. */
+  readonly roots: readonly string[];
+}
+
+export type ApprovalMatch = 'covered' | 'ask' | 'expired';
+
+// ---- shell lexing -----------------------------------------------------------
+
+const SHELLS = new Set(['sh', 'bash', 'zsh', 'dash', 'ksh']);
+const BUILTINS = new Set(['cd', 'echo', 'export', 'pwd', 'true', 'false', 'test', '[', 'set', 'unset', 'printf', 'read', 'exit', 'return', 'shift', 'wait', 'type', 'alias', 'umask', 'ulimit', 'trap', 'hash', 'times', 'getopts', 'let', 'local', 'readonly', ':']);
+/** Words after which the next word is the command: a wrapper we look through. */
+const WRAPPERS = new Set(['env', 'nohup', 'time', 'nice', 'timeout', 'command', 'builtin']);
+/** Words that run something we cannot see: never a subject. */
+const OPAQUE = new Set(['eval', 'exec', 'source', '.', 'xargs', 'sudo', 'doas', 'su', 'watch', 'case', ...SHELLS]);
+/** Control keywords that precede a command on the same segment. */
+const PRECEDING_KEYWORDS = new Set(['if', 'then', 'else', 'elif', 'while', 'until', 'do', '!', '{', '(']);
+/** Segments that are pure syntax, not commands. */
+const BARE_KEYWORDS = new Set(['fi', 'done', 'esac', 'then', 'else', 'do', '}', ')']);
+const ENV_ASSIGNMENT = /^[A-Za-z_][A-Za-z0-9_]*=/;
+
+function basename(path: string): string {
+  const index = path.lastIndexOf('/');
+  return index === -1 ? path : path.slice(index + 1);
+}
+
+/** Split a script into command segments on `; && || | & \n`, honouring quotes and backslashes. Substitution ⇒ null. */
+function splitSegments(script: string): string[] | null {
+  const segments: string[] = [];
+  let current = '';
+  let quote: '"' | "'" | null = null;
+  for (let i = 0; i < script.length; i += 1) {
+    const ch = script[i] as string;
+    if (quote !== null) {
+      if (ch === '\\' && quote === '"' && i + 1 < script.length) {
+        current += ch + script[i + 1];
+        i += 1;
+        continue;
+      }
+      if (ch === quote) quote = null;
+      current += ch;
+      continue;
+    }
+    if (ch === '\\' && i + 1 < script.length) {
+      current += ch + script[i + 1];
+      i += 1;
+      continue;
+    }
+    if (ch === '`') return null;
+    if (ch === '$' && (script[i + 1] === '(' || script[i + 1] === '{')) return null;
+    if ((ch === '<' || ch === '>') && script[i + 1] === '(') return null;
+    if (ch === '"' || ch === "'") {
+      quote = ch;
+      current += ch;
+      continue;
+    }
+    // `2>&1`, `>&2`, `<&0`: a duplicated descriptor, not a background operator.
+    if (ch === '&' && (script[i - 1] === '>' || script[i - 1] === '<')) {
+      current += ch;
+      continue;
+    }
+    if (ch === ';' || ch === '|' || ch === '&' || ch === '\n') {
+      segments.push(current);
+      current = '';
+      continue;
+    }
+    current += ch;
+  }
+  if (quote !== null) return null;
+  segments.push(current);
+  return segments;
+}
+
+/** Whitespace-separated words of one segment, quotes kept on the word so a quoted command word is detectable. */
+function words(segment: string): string[] {
+  const out: string[] = [];
+  let current = '';
+  let quote: '"' | "'" | null = null;
+  for (let i = 0; i < segment.length; i += 1) {
+    const ch = segment[i] as string;
+    if (quote !== null) {
+      current += ch;
+      if (ch === quote) quote = null;
+      continue;
+    }
+    if (ch === '"' || ch === "'") {
+      quote = ch;
+      current += ch;
+      continue;
+    }
+    if (ch === ' ' || ch === '\t' || ch === '\r') {
+      if (current.length > 0) out.push(current);
+      current = '';
+      continue;
+    }
+    current += ch;
+  }
+  if (current.length > 0) out.push(current);
+  return out;
+}
+
+/**
+ * The command word of every simple command in a shell script, in order —
+ * or `null` when any part of it cannot be attributed to a program name.
+ * Conservative on purpose: this decides what a durable approval COVERS, so
+ * "I am not sure" must mean "ask", never "assume".
+ */
+export function shellCommandWords(script: string): string[] | null {
+  const segments = splitSegments(script);
+  if (segments === null) return null;
+  const out: string[] = [];
+  for (const segment of segments) {
+    let tokens = words(segment.trim());
+    // Grouping and control keywords that precede the command on this segment.
+    while (tokens.length > 0) {
+      const head = tokens[0] as string;
+      if (PRECEDING_KEYWORDS.has(head)) {
+        tokens = tokens.slice(1);
+        continue;
+      }
+      // `(cmd` / `{cmd` / `!cmd` without a space.
+      if ((head.startsWith('(') || head.startsWith('{') || head.startsWith('!')) && head.length > 1) {
+        tokens = [head.slice(1), ...tokens.slice(1)];
+        continue;
+      }
+      break;
+    }
+    // Trailing `)` / `}` on the last word, or as its own word.
+    tokens = tokens.filter((token) => !BARE_KEYWORDS.has(token)).map((token) => token.replace(/[)}]+$/, '')).filter((token) => token.length > 0);
+    if (tokens.length === 0) continue;
+    // `for x in …` names no program on its own segment; `case` is opaque (handled below).
+    if (tokens[0] === 'for' || tokens[0] === 'select' || tokens[0] === 'function') continue;
+    // Env assignments and wrappers, repeatedly (`env FOO=1 nohup git …`).
+    let index = 0;
+    for (;;) {
+      const token = tokens[index];
+      if (token === undefined) break;
+      if (ENV_ASSIGNMENT.test(token)) {
+        index += 1;
+        continue;
+      }
+      if (WRAPPERS.has(token)) {
+        index += 1;
+        // Skip the wrapper's own options (`timeout 5`, `nice -n 5` are approximated: any leading `-option` word).
+        while (tokens[index] !== undefined && (tokens[index] as string).startsWith('-')) index += 1;
+        if (token === 'timeout' && tokens[index] !== undefined && /^\d/.test(tokens[index] as string)) index += 1;
+        continue;
+      }
+      break;
+    }
+    const word = tokens[index];
+    if (word === undefined) continue; // assignments only: no program runs
+    if (word.startsWith('"') || word.startsWith("'") || word.includes('$') || word.includes('`')) return null;
+    const name = word.startsWith('\\') ? word.slice(1) : word;
+    if (OPAQUE.has(name) || OPAQUE.has(basename(name))) return null;
+    if (name === 'find' && tokens.slice(index + 1).some((t) => /^-(exec|execdir|ok|okdir|delete)$/.test(t))) return null;
+    out.push(name);
+  }
+  return out.length === 0 ? null : out;
+}
+
+// ---- subjects ---------------------------------------------------------------
+
+function isInsideRoot(path: string, root: string): boolean {
+  const base = root.replace(/\/+$/, '');
+  return path === base || path.startsWith(`${base}/`);
+}
+
+function programSubject(name: string, deps: ApprovalMatchDeps): string | null {
+  if (BUILTINS.has(name)) return `builtin:${name}`;
+  const resolved = deps.resolveArgv0(name);
+  return resolved === null ? null : `exec:${resolved}`;
+}
+
+/**
+ * The subjects a request is keyed on, or `null` when it has none it could be
+ * durably approved under (the request is then asked about every time).
+ */
+export function approvalSubjects(request: NormalizedRequest, deps: ApprovalMatchDeps): readonly string[] | null {
+  switch (request.op) {
+    case 'exec': {
+      const cmd = request.cmd;
+      if (cmd === undefined || cmd.length === 0) return null;
+      const args = request.args ?? [];
+      const shellName = basename(cmd);
+      if (SHELLS.has(shellName)) {
+        // Only the `-c <script>` form is understood; any other way of driving a shell is opaque.
+        const script = args[0] === '-c' ? args[1] : args[0] === '-lc' || args[0] === '-ec' ? args[1] : undefined;
+        if (script === undefined || args.length !== 2) return null;
+        const names = shellCommandWords(script);
+        if (names === null) return null;
+        const subjects: string[] = [];
+        for (const name of names) {
+          const subject = programSubject(name, deps);
+          if (subject === null) return null;
+          if (!subjects.includes(subject)) subjects.push(subject);
+        }
+        return subjects;
+      }
+      const subject = programSubject(cmd, deps);
+      return subject === null ? null : [subject];
+    }
+    case 'fs_read':
+    case 'fs_write': {
+      const subjects: string[] = [];
+      for (const path of request.paths) {
+        const root = deps.roots.find((candidate) => isInsideRoot(path, candidate));
+        if (root === undefined) return null;
+        const subject = `root:${root}`;
+        if (!subjects.includes(subject)) subjects.push(subject);
+      }
+      return subjects.length === 0 ? null : subjects;
+    }
+    case 'pty_open':
+      return null;
+    default:
+      return null;
+  }
+}
+
+// ---- matching ---------------------------------------------------------------
+
+export interface ApprovalCoverage {
+  readonly match: ApprovalMatch;
+  /** The subjects the request is keyed on (`null` = unresolvable). */
+  readonly subjects: readonly string[] | null;
+  /** On `covered`: the approval ids that cover it, for the audit line. */
+  readonly approvalIds: readonly string[];
+}
+
+/** The full answer; `matchApproval` is its verdict word. */
+export function findApprovalCoverage(approvals: readonly DurableApproval[], grant: Grant, request: NormalizedRequest, now: number, deps: ApprovalMatchDeps): ApprovalCoverage {
+  const subjects = approvalSubjects(request, deps);
+  if (subjects === null || grant.op !== request.op) return { match: 'ask', subjects, approvalIds: [] };
+  const ids: string[] = [];
+  let expired = false;
+  for (const subject of subjects) {
+    const candidates = approvals.filter((a) => a.envId === grant.envId && a.userId === grant.principal.userId && a.op === grant.op && a.subject === subject);
+    if (candidates.length === 0) return { match: 'ask', subjects, approvalIds: [] };
+    const live = candidates.find((a) => a.expiresAt === null || a.expiresAt > now);
+    if (live === undefined) {
+      expired = true;
+      continue;
+    }
+    if (!ids.includes(live.approvalId)) ids.push(live.approvalId);
+  }
+  return expired ? { match: 'expired', subjects, approvalIds: [] } : { match: 'covered', subjects, approvalIds: ids };
+}
+
+/**
+ * Is this normalised request covered by an unexpired approval for every
+ * subject it names? `expired` means every subject has an approval but at
+ * least one has only expired ones; `ask` means at least one has none (or the
+ * request has no subjects at all).
+ */
+export function matchApproval(approvals: readonly DurableApproval[], grant: Grant, request: NormalizedRequest, now: number, deps: ApprovalMatchDeps): ApprovalMatch {
+  return findApprovalCoverage(approvals, grant, request, now, deps).match;
+}
+
+// ---- the file ---------------------------------------------------------------
+
+export const APPROVALS_FILE_VERSION = 1;
+
+const approvalRowSchema = z
+  .object({
+    approvalId: z.string().min(1),
+    envId: z.string().min(1),
+    userId: z.string().min(1),
+    op: z.enum(GRANT_OPS),
+    subject: z.string().regex(/^(exec|builtin|root):.+$/),
+    scope: z.enum(DURABLE_APPROVAL_SCOPES),
+    createdAt: z.number().int().nonnegative(),
+    expiresAt: z.number().int().nonnegative().nullable(),
+  })
+  .strict()
+  .refine((row) => (row.scope === '30d' ? row.expiresAt !== null : row.expiresAt === null), 'expiry must match the scope');
+
+export const approvalsFileSchema = z
+  .object({
+    version: z.literal(APPROVALS_FILE_VERSION),
+    approvals: z.array(approvalRowSchema),
+  })
+  .strict();
+
+/**
+ * Parse the approvals file's contents. `null` for ANY defect — an unknown
+ * field, a scope that must never be persisted, an expiry that contradicts its
+ * scope, one bad row among good ones — so a damaged file can only ever make
+ * the machine ask MORE, never less. Never a partial list.
+ */
+export function parseApprovalsFile(input: unknown): DurableApproval[] | null {
+  const parsed = approvalsFileSchema.safeParse(input);
+  return parsed.success ? parsed.data.approvals : null;
+}
+
+/** The canonical serialisation the daemon writes (pretty, trailing newline). */
+export function serializeApprovalsFile(approvals: readonly DurableApproval[]): string {
+  return `${JSON.stringify({ version: APPROVALS_FILE_VERSION, approvals: approvals.filter((a) => isDurableScope(a.scope)) }, null, 2)}\n`;
+}

--- a/packages/lib/src/env-bridge/decide-approval.ts
+++ b/packages/lib/src/env-bridge/decide-approval.ts
@@ -94,6 +94,17 @@ const PRECEDING_KEYWORDS = new Set(['if', 'then', 'else', 'elif', 'while', 'unti
 const BARE_KEYWORDS = new Set(['fi', 'done', 'esac', 'then', 'else', 'do', '}', ')']);
 const ENV_ASSIGNMENT = /^[A-Za-z_][A-Za-z0-9_]*=/;
 
+/**
+ * Trim every trailing character that is in `chars`, by a backwards walk —
+ * never a `[…]+$` regex, which is polynomial on a long run of the character
+ * (CodeQL js/polynomial-redos on #2583; the script is agent-supplied).
+ */
+export function trimTrailing(value: string, chars: string): string {
+  let end = value.length;
+  while (end > 0 && chars.includes(value[end - 1] as string)) end -= 1;
+  return end === value.length ? value : value.slice(0, end);
+}
+
 function basename(path: string): string {
   const index = path.lastIndexOf('/');
   return index === -1 ? path : path.slice(index + 1);
@@ -205,7 +216,7 @@ export function shellCommandWords(script: string): string[] | null {
       break;
     }
     // Trailing `)` / `}` on the last word, or as its own word.
-    tokens = tokens.filter((token) => !BARE_KEYWORDS.has(token)).map((token) => token.replace(/[)}]+$/, '')).filter((token) => token.length > 0);
+    tokens = tokens.filter((token) => !BARE_KEYWORDS.has(token)).map((token) => trimTrailing(token, ')}')).filter((token) => token.length > 0);
     if (tokens.length === 0) continue;
     // `for x in …` names no program on its own segment; `case` is opaque (handled below).
     if (tokens[0] === 'for' || tokens[0] === 'select' || tokens[0] === 'function') continue;
@@ -241,7 +252,7 @@ export function shellCommandWords(script: string): string[] | null {
 // ---- subjects ---------------------------------------------------------------
 
 function isInsideRoot(path: string, root: string): boolean {
-  const base = root.replace(/\/+$/, '');
+  const base = trimTrailing(root, '/');
   return path === base || path.startsWith(`${base}/`);
 }
 

--- a/packages/lib/src/env-bridge/decide-approval.ts
+++ b/packages/lib/src/env-bridge/decide-approval.ts
@@ -367,8 +367,3 @@ export function parseApprovalsFile(input: unknown): DurableApproval[] | null {
   const parsed = approvalsFileSchema.safeParse(input);
   return parsed.success ? parsed.data.approvals : null;
 }
-
-/** The canonical serialisation the daemon writes (pretty, trailing newline). */
-export function serializeApprovalsFile(approvals: readonly DurableApproval[]): string {
-  return `${JSON.stringify({ version: APPROVALS_FILE_VERSION, approvals: approvals.filter((a) => isDurableScope(a.scope)) }, null, 2)}\n`;
-}

--- a/packages/lib/src/env-bridge/decide-approval.ts
+++ b/packages/lib/src/env-bridge/decide-approval.ts
@@ -112,6 +112,10 @@ function splitSegments(script: string): string[] | null {
         i += 1;
         continue;
       }
+      // Double quotes do NOT stop substitution (Codex P1 on #2583): `"$(…)"`,
+      // `"\`…\`"` and `"${…}"` run commands exactly as they would unquoted, so
+      // they are opaque here too. Single quotes are literal (POSIX).
+      if (quote === '"' && (ch === '`' || (ch === '$' && (script[i + 1] === '(' || script[i + 1] === '{')))) return null;
       if (ch === quote) quote = null;
       current += ch;
       continue;

--- a/packages/lib/src/env-bridge/decide-execution.ts
+++ b/packages/lib/src/env-bridge/decide-execution.ts
@@ -25,7 +25,9 @@
  * Deny order is FIXED and tested for every adjacent pair: malformed →
  * no_policy → policy_deny → principal_not_allowed → op_mismatch →
  * op_not_advertised → server_denied → machine_denied → cwd_denied →
- * path_denied → approval_expired → approval_mismatch → then `ask` or `allow`. `malformed` runs
+ * path_denied → approval_expired → approval_mismatch → then `allow` (pre-approved op,
+ * fresh approval, or a durable approval covering every subject — GA wave 2,
+ * `decide-approval.ts`) or `ask`. `malformed` runs
  * FIRST so "allow" always means "executable": an exec without a command or an
  * fs op without paths never reaches the runner as an allow. All policy gates
  * run BEFORE any path is confined, so a request denied by policy never reaches
@@ -66,6 +68,7 @@ import type { AdvertisedCapabilities, MachinePolicy, ServerPolicy } from './poli
 import { capabilityForOp } from './intersect-capabilities';
 import { confinePath, type PathResolver } from './confine-path';
 import { scrubEnv } from './scrub-env';
+import { findApprovalCoverage, type ApprovalMatchDeps, type DurableApproval } from './decide-approval';
 
 export interface ExecutionRequest {
   readonly op: GrantOp;
@@ -110,9 +113,21 @@ export type ExecDenyReason =
   | 'approval_expired'
   | 'approval_mismatch';
 
+/** How an `allow` came about — for the audit line, never for a decision. */
+export type AllowBasis =
+  | { readonly kind: 'preapproved_op' }
+  | { readonly kind: 'fresh_approval' }
+  | { readonly kind: 'durable_approval'; readonly approvalIds: readonly string[] };
+
 export type ExecutionVerdict =
-  | { readonly kind: 'allow'; readonly request: NormalizedRequest }
-  | { readonly kind: 'ask'; readonly reason: 'op_not_preapproved'; readonly request: NormalizedRequest }
+  | { readonly kind: 'allow'; readonly request: NormalizedRequest; readonly basis: AllowBasis }
+  | {
+      readonly kind: 'ask';
+      readonly reason: 'op_not_preapproved';
+      readonly request: NormalizedRequest;
+      /** What a durable approval of this request would be keyed on (`null`: nothing durable can be written; ask every time). */
+      readonly subjects: readonly string[] | null;
+    }
   | { readonly kind: 'deny'; readonly reason: ExecDenyReason };
 
 /**
@@ -139,6 +154,19 @@ export interface DecideExecutionInput {
   readonly capabilities: AdvertisedCapabilities;
   readonly probe: PathResolver;
   readonly localApproval?: LocalApproval;
+  /**
+   * The durable approvals in force on this machine (GA wave 2). Consulted
+   * AFTER confinement and scrubbing, against the normalised request, and
+   * only when the op is not pre-approved and no fresh `localApproval` is
+   * being answered. Omitted = none.
+   */
+  readonly approvals?: ApprovalConsultation;
+}
+
+export interface ApprovalConsultation extends Omit<ApprovalMatchDeps, 'roots'> {
+  readonly entries: readonly DurableApproval[];
+  /** ms since epoch, from the adapter's clock. */
+  readonly now: number;
 }
 
 function deny(reason: ExecDenyReason): ExecutionVerdict {
@@ -201,7 +229,7 @@ function resolveLimit(requested: number | undefined, cap: number): { readonly va
  * the same normalized request for the owner to approve, or a closed-union deny.
  */
 export function decideExecution(input: DecideExecutionInput): ExecutionVerdict {
-  const { grant, request, machinePolicy, serverPolicy, capabilities, probe, localApproval } = input;
+  const { grant, request, machinePolicy, serverPolicy, capabilities, probe, localApproval, approvals } = input;
 
   if (!isWellFormed(request)) return deny('malformed');
   if (machinePolicy === null) return deny('no_policy');
@@ -245,14 +273,25 @@ export function decideExecution(input: DecideExecutionInput): ExecutionVerdict {
     clamped: timeout.clamped || bytes.clamped,
   };
 
-  if (preapproved) return { kind: 'allow', request: normalized };
+  if (preapproved) return { kind: 'allow', request: normalized, basis: { kind: 'preapproved_op' } };
   if (localApproval !== undefined && localApproval.grantId === grant.grantId) {
     // The grant bounds the whole authorization, prompt included.
     if (!Number.isFinite(localApproval.approvedAt) || localApproval.approvedAt > grant.exp) return deny('approval_expired');
     // The approval is for the request the owner SAW. Anything that drifted
     // since — filesystem resolution, a tampered copy — is not what was approved.
     if (!sameBytes(canonicalizeArgs(localApproval.request), canonicalizeArgs(normalized))) return deny('approval_mismatch');
-    return { kind: 'allow', request: normalized };
+    return { kind: 'allow', request: normalized, basis: { kind: 'fresh_approval' } };
   }
-  return { kind: 'ask', reason: 'op_not_preapproved', request: normalized };
+
+  // Durable approvals (GA wave 2): matched against the NORMALISED request —
+  // confined cwd and paths, scrubbed env — so what an old approval covers is
+  // what would run now, not what was asked for. Every subject the request
+  // names must be covered; `expired` and `ask` both fall through to asking.
+  if (approvals !== undefined) {
+    const approvalDeps: ApprovalMatchDeps = { resolveArgv0: approvals.resolveArgv0, roots };
+    const coverage = findApprovalCoverage(approvals.entries, grant, normalized, approvals.now, approvalDeps);
+    if (coverage.match === 'covered') return { kind: 'allow', request: normalized, basis: { kind: 'durable_approval', approvalIds: coverage.approvalIds } };
+    return { kind: 'ask', reason: 'op_not_preapproved', request: normalized, subjects: coverage.subjects };
+  }
+  return { kind: 'ask', reason: 'op_not_preapproved', request: normalized, subjects: null };
 }

--- a/packages/lib/src/env-bridge/frame-codec.ts
+++ b/packages/lib/src/env-bridge/frame-codec.ts
@@ -104,7 +104,8 @@ const grantPtyOpen = z.object({
 const ptyInput = z.object({ type: z.literal('pty_input'), sessionId: nonEmpty, seq: nonNegInt, dataB64: b64 });
 const ptyResize = z.object({ type: z.literal('pty_resize'), sessionId: nonEmpty, cols: posInt, rows: posInt });
 const ptyKill = z.object({ type: z.literal('pty_kill'), sessionId: nonEmpty, signal: z.string().optional() });
-const revoke = z.object({ type: z.literal('revoke'), sig: b64, issuedAt: nonNegInt, reason: z.string().optional() });
+/** `approvalId` present ⇒ revoke ONE durable approval on the machine (GA wave 2); absent ⇒ revoke the enrollment (delete the key). Signed under different domains, so neither can be turned into the other. */
+const revoke = z.object({ type: z.literal('revoke'), sig: b64, issuedAt: nonNegInt, reason: z.string().optional(), approvalId: nonEmpty.optional() });
 const ping = z.object({ type: z.literal('ping'), ts: nonNegInt });
 
 const frameSchema = z.discriminatedUnion('type', [

--- a/packages/lib/src/env-bridge/frame-codec.ts
+++ b/packages/lib/src/env-bridge/frame-codec.ts
@@ -70,6 +70,8 @@ const ptyOpened = z.object({ type: z.literal('pty_opened'), grantId: nonEmpty, s
 const ptyData = z.object({ type: z.literal('pty_data'), sessionId: nonEmpty, seq: nonNegInt, dataB64: b64 });
 const ptyExit = z.object({ type: z.literal('pty_exit'), sessionId: nonEmpty, code: z.number().int() });
 const pong = z.object({ type: z.literal('pong'), ts: nonNegInt });
+/** The machine's signed acknowledgement of an approval revoke (GA wave 2): exactly this many rows were deleted for this id. */
+const approvalRevokeResult = z.object({ type: z.literal('approval_revoke_result'), approvalId: nonEmpty, removed: nonNegInt, sig: b64 });
 
 // ---- server → machine -----------------------------------------------------
 
@@ -109,7 +111,7 @@ const revoke = z.object({ type: z.literal('revoke'), sig: b64, issuedAt: nonNegI
 const ping = z.object({ type: z.literal('ping'), ts: nonNegInt });
 
 const frameSchema = z.discriminatedUnion('type', [
-  hello, execResult, fsReadResult, fsWriteResult, grantDenied, ptyOpened, ptyData, ptyExit, pong,
+  hello, execResult, fsReadResult, fsWriteResult, grantDenied, approvalRevokeResult, ptyOpened, ptyData, ptyExit, pong,
   grantExec, grantFsRead, grantFsWrite, grantPtyOpen, ptyInput, ptyResize, ptyKill, revoke, ping,
 ]);
 
@@ -120,7 +122,7 @@ export type FrameType = Frame['type'];
 
 /** The closed set. A `type` outside it is `unknown_type`, full stop. */
 export const FRAME_TYPES: ReadonlySet<FrameType> = new Set<FrameType>([
-  'hello', 'exec_result', 'fs_read_result', 'fs_write_result', 'grant_denied', 'pty_opened', 'pty_data', 'pty_exit', 'pong',
+  'hello', 'exec_result', 'fs_read_result', 'fs_write_result', 'grant_denied', 'approval_revoke_result', 'pty_opened', 'pty_data', 'pty_exit', 'pong',
   'grant_exec', 'grant_fs_read', 'grant_fs_write', 'grant_pty_open', 'pty_input', 'pty_resize', 'pty_kill', 'revoke', 'ping',
 ]);
 
@@ -131,7 +133,7 @@ export const FRAME_TYPES: ReadonlySet<FrameType> = new Set<FrameType>([
  * `exec_result` arriving from the server. Every frame type is in exactly one.
  */
 export const MACHINE_TO_SERVER_FRAME_TYPES: ReadonlySet<FrameType> = new Set<FrameType>([
-  'hello', 'exec_result', 'fs_read_result', 'fs_write_result', 'grant_denied', 'pty_opened', 'pty_data', 'pty_exit', 'pong',
+  'hello', 'exec_result', 'fs_read_result', 'fs_write_result', 'grant_denied', 'approval_revoke_result', 'pty_opened', 'pty_data', 'pty_exit', 'pong',
 ]);
 export const SERVER_TO_MACHINE_FRAME_TYPES: ReadonlySet<FrameType> = new Set<FrameType>([
   'grant_exec', 'grant_fs_read', 'grant_fs_write', 'grant_pty_open', 'pty_input', 'pty_resize', 'pty_kill', 'revoke', 'ping',

--- a/packages/lib/src/env-bridge/frame-codec.ts
+++ b/packages/lib/src/env-bridge/frame-codec.ts
@@ -44,7 +44,28 @@ const hello = z.object({ type: z.literal('hello'), envId: nonEmpty, capabilities
 const execResult = z.object({ type: z.literal('exec_result'), grantId: nonEmpty, exitCode: z.number().int(), stdoutB64: b64, stderrB64: b64, truncated: z.boolean(), sig: b64 });
 const fsReadResult = z.object({ type: z.literal('fs_read_result'), grantId: nonEmpty, found: z.boolean(), contentB64: b64.optional(), sig: b64 });
 const fsWriteResult = z.object({ type: z.literal('fs_write_result'), grantId: nonEmpty, ok: z.boolean(), error: z.string().optional(), sig: b64 });
-const grantDenied = z.object({ type: z.literal('grant_denied'), grantId: nonEmpty, reason: nonEmpty, sig: b64 });
+/**
+ * The request a daemon FROZE under a pending chat approval (GA wave 2): the
+ * exact normalised request the owner's card shows and the machine will
+ * byte-compare a click against. Carried on a `grant_denied` whose reason is
+ * `ask_pending:<challengeId>`; covered by the result signature like every
+ * other payload field, so the card shows what the machine signed.
+ */
+const pendingRequest = z
+  .object({
+    op: z.enum(['exec', 'fs_read', 'fs_write', 'pty_open']),
+    cmd: z.string().optional(),
+    args: z.array(z.string()).optional(),
+    cwd: nonEmpty,
+    paths: z.array(z.string()),
+    env: z.record(z.string(), z.string()),
+    timeoutMs: posInt,
+    maxBytes: posInt,
+    clamped: z.boolean(),
+  })
+  .strict();
+const pendingApproval = z.object({ challengeId: nonEmpty, expiresAt: nonNegInt, request: pendingRequest }).strict();
+const grantDenied = z.object({ type: z.literal('grant_denied'), grantId: nonEmpty, reason: nonEmpty, pending: pendingApproval.optional(), sig: b64 });
 const ptyOpened = z.object({ type: z.literal('pty_opened'), grantId: nonEmpty, sessionId: nonEmpty });
 const ptyData = z.object({ type: z.literal('pty_data'), sessionId: nonEmpty, seq: nonNegInt, dataB64: b64 });
 const ptyExit = z.object({ type: z.literal('pty_exit'), sessionId: nonEmpty, code: z.number().int() });
@@ -92,6 +113,8 @@ const frameSchema = z.discriminatedUnion('type', [
 ]);
 
 export type Frame = z.infer<typeof frameSchema>;
+/** The frozen request a `grant_denied ask_pending:<id>` carries. */
+export type PendingApproval = z.infer<typeof pendingApproval>;
 export type FrameType = Frame['type'];
 
 /** The closed set. A `type` outside it is `unknown_type`, full stop. */

--- a/packages/lib/src/env-bridge/grant.ts
+++ b/packages/lib/src/env-bridge/grant.ts
@@ -53,6 +53,21 @@ export interface GrantPrincipal {
   readonly conversationId: string;
 }
 
+/**
+ * The owner's click in the chat, carried on the grant that re-issues the
+ * request it answers (GA wave 2, Tier B). Signed with the grant under the
+ * pinned server key, so the daemon verifies it with the key it already
+ * holds and it cannot be moved onto another grant. The daemon honours it
+ * ONLY against a request it froze itself under `challengeId` (leaf 7).
+ */
+export interface ApprovalIntent {
+  readonly challengeId: string;
+  /** How long the machine should remember the approval — the owner's choice on the card. */
+  readonly scope: 'once' | 'session' | '30d' | 'until_revoked';
+  /** ms since epoch; the click is refused after this (the challenge's own TTL is the grant that froze it). */
+  readonly expiresAt: number;
+}
+
 export interface Grant {
   readonly grantId: string;
   /** The env this grant is for. A grant for another machine never runs here. */
@@ -66,6 +81,8 @@ export interface Grant {
   /** Expiry, ms since epoch. `exp - iat` must not exceed GRANT_MAX_TTL_MS. */
   readonly exp: number;
   readonly nonce: string;
+  /** Present only on a grant re-issued by the owner's click (GA wave 2). */
+  readonly approvalIntent?: ApprovalIntent;
 }
 
 export type GrantDenyReason =
@@ -134,6 +151,14 @@ const principalSchema = z
 
 // `.strict()` everywhere: an extra field is not "ignored", it is a malformed
 // grant. A privileged-looking `isAdmin: true` riding along must fail closed.
+const approvalIntentSchema = z
+  .object({
+    challengeId: z.string().min(1),
+    scope: z.enum(['once', 'session', '30d', 'until_revoked']),
+    expiresAt: z.number().int().nonnegative(),
+  })
+  .strict();
+
 const grantSchema = z
   .object({
     grantId: z.string().min(1),
@@ -144,6 +169,7 @@ const grantSchema = z
     iat: z.number().int().nonnegative(),
     exp: z.number().int().nonnegative(),
     nonce: z.string().min(1),
+    approvalIntent: approvalIntentSchema.optional(),
   })
   .strict();
 
@@ -166,6 +192,11 @@ export function encodeGrant(grant: Grant): Uint8Array {
     iat: grant.iat,
     exp: grant.exp,
     nonce: grant.nonce,
+    // Appended ONLY when present, so every grant without a click keeps the
+    // exact bytes it always had; a click cannot be added or altered in flight.
+    ...(grant.approvalIntent !== undefined && {
+      approvalIntent: { challengeId: grant.approvalIntent.challengeId, scope: grant.approvalIntent.scope, expiresAt: grant.approvalIntent.expiresAt },
+    }),
   };
   return new TextEncoder().encode(JSON.stringify(canonical));
 }

--- a/packages/lib/src/env-bridge/index.ts
+++ b/packages/lib/src/env-bridge/index.ts
@@ -15,6 +15,7 @@ export * from './intersect-capabilities';
 export * from './scrub-env';
 export * from './confine-path';
 export * from './decide-execution';
+export * from './decide-approval';
 export * from './frame-codec';
 export * from './bridge-session';
 export * from './resolve-timeout';

--- a/packages/lib/src/env-bridge/machine-signatures.ts
+++ b/packages/lib/src/env-bridge/machine-signatures.ts
@@ -38,6 +38,8 @@ import { canonicalizeArgs, constantTimeEqual, decodeBase64, type Ed25519Verify, 
 export const HELLO_SIGNING_DOMAIN = 'pagespace-env-bridge/hello/v1';
 export const RESULT_SIGNING_DOMAIN = 'pagespace-env-bridge/result/v1';
 export const REVOKE_SIGNING_DOMAIN = 'pagespace-env-bridge/revoke/v1';
+/** A revoke of ONE durable approval (GA wave 2): its own domain, so an approval revoke can never be replayed as an enrollment revoke by dropping the id, nor the reverse. */
+export const REVOKE_APPROVAL_SIGNING_DOMAIN = 'pagespace-env-bridge/revoke-approval/v1';
 
 export type { HelloFrame };
 export type RevokeFrame = Extract<Frame, { type: 'revoke' }>;
@@ -161,9 +163,19 @@ export interface RevokeBinding {
   readonly issuedAt: number;
 }
 
-/** Canonical bytes the server signs for a revoke. */
+/** Canonical bytes the server signs for a revoke of the ENROLLMENT (unchanged by GA wave 2: an approval revoke uses its own domain and function). */
 export function encodeRevokeForSigning(binding: RevokeBinding): Uint8Array {
   return encode({ domain: REVOKE_SIGNING_DOMAIN, envId: binding.envId, enrollmentId: binding.enrollmentId, keyId: binding.keyId, issuedAt: binding.issuedAt });
+}
+
+export interface ApprovalRevokeBinding extends RevokeBinding {
+  /** The durable approval to delete — the challenge id the click was answered under. */
+  readonly approvalId: string;
+}
+
+/** Canonical bytes the server signs to revoke ONE approval on the machine. The server may only ever REVOKE an approval this way; nothing on the wire can add one. */
+export function encodeApprovalRevokeForSigning(binding: ApprovalRevokeBinding): Uint8Array {
+  return encode({ domain: REVOKE_APPROVAL_SIGNING_DOMAIN, envId: binding.envId, enrollmentId: binding.enrollmentId, keyId: binding.keyId, issuedAt: binding.issuedAt, approvalId: binding.approvalId });
 }
 
 export interface VerifyRevokeInput extends RevokeBinding {
@@ -173,12 +185,21 @@ export interface VerifyRevokeInput extends RevokeBinding {
   readonly verify: Ed25519Verify;
 }
 
-/** The daemon's check before it honours a revoke (t08). `issuedAt` is taken from the binding the daemon supplies, and must equal the frame's. */
+/**
+ * The daemon's check before it honours a revoke (t08). `issuedAt` is taken
+ * from the binding the daemon supplies, and must equal the frame's. A frame
+ * carrying `approvalId` is verified under the approval-revoke domain over
+ * THAT id; one without it under the enrollment-revoke domain — so a captured
+ * approval revoke with the id stripped is `bad_signature`, never a key
+ * deletion, and an enrollment revoke with an id added is `bad_signature`
+ * too.
+ */
 export function verifyRevoke(input: VerifyRevokeInput): MachineSignatureVerdict {
   if (input.frame.issuedAt !== input.issuedAt) return { ok: false, reason: 'bad_signature' };
   const signature = decodeBase64(input.frame.sig);
   if (signature === null) return { ok: false, reason: 'malformed' };
-  const bytes = encodeRevokeForSigning({ envId: input.envId, enrollmentId: input.enrollmentId, keyId: input.keyId, issuedAt: input.issuedAt });
+  const binding = { envId: input.envId, enrollmentId: input.enrollmentId, keyId: input.keyId, issuedAt: input.issuedAt };
+  const bytes = input.frame.approvalId !== undefined ? encodeApprovalRevokeForSigning({ ...binding, approvalId: input.frame.approvalId }) : encodeRevokeForSigning(binding);
   return safeVerify(input.verify, bytes, signature, input.serverPublicKey);
 }
 

--- a/packages/lib/src/env-bridge/machine-signatures.ts
+++ b/packages/lib/src/env-bridge/machine-signatures.ts
@@ -106,7 +106,9 @@ export function resultPayloadForFrame(frame: MachineResultFrame): Record<string,
     case 'fs_write_result':
       return { type: frame.type, grantId: frame.grantId, ok: frame.ok, error: frame.error ?? null };
     case 'grant_denied':
-      return { type: frame.type, grantId: frame.grantId, reason: frame.reason };
+      // `pending` (a frozen request awaiting a chat click, GA wave 2) is
+      // signed too: the card renders what the MACHINE said it froze.
+      return { type: frame.type, grantId: frame.grantId, reason: frame.reason, pending: frame.pending ?? null };
   }
 }
 

--- a/packages/lib/src/env-bridge/machine-signatures.ts
+++ b/packages/lib/src/env-bridge/machine-signatures.ts
@@ -9,9 +9,11 @@
  *   replayed for another env, and neither the advertised capabilities nor the
  *   policy digest can be altered in flight.
  * - **result** (machine → server, invariant 7): every `exec_result`,
- *   `fs_read_result`, `fs_write_result` and `grant_denied` is signed over
- *   `{grantId, resultHash}` where `resultHash` covers EVERY payload field of
- *   the frame (`resultHashForFrame`). A result cannot be moved onto another
+ *   `fs_read_result`, `fs_write_result`, `grant_denied` and (GA wave 2)
+ *   `approval_revoke_result` is signed over `{grantId, resultHash}` — the
+ *   binding id is the grant, or the namespaced approval id for an ack
+ *   (`machineResultBindingId`) — where `resultHash` covers EVERY payload
+ *   field of the frame (`resultHashForFrame`). A result cannot be moved onto another
  *   grant, and no field of it can be edited between the machine and the agent.
  * - **revoke** (server → machine, invariant 8): signed over
  *   `{envId, enrollmentId, keyId, issuedAt}` — a revoke for one enrollment
@@ -43,11 +45,25 @@ export const REVOKE_APPROVAL_SIGNING_DOMAIN = 'pagespace-env-bridge/revoke-appro
 
 export type { HelloFrame };
 export type RevokeFrame = Extract<Frame, { type: 'revoke' }>;
-export type MachineResultFrame = Extract<Frame, { type: 'exec_result' | 'fs_read_result' | 'fs_write_result' | 'grant_denied' }>;
+export type MachineResultFrame = Extract<Frame, { type: 'exec_result' | 'fs_read_result' | 'fs_write_result' | 'grant_denied' | 'approval_revoke_result' }>;
 export type MachineResultFrameType = MachineResultFrame['type'];
 
 /** The machine frames that answer a grant and therefore MUST be signed (invariant 7). */
-export const MACHINE_RESULT_FRAME_TYPES: ReadonlySet<MachineResultFrameType> = new Set<MachineResultFrameType>(['exec_result', 'fs_read_result', 'fs_write_result', 'grant_denied']);
+export const MACHINE_RESULT_FRAME_TYPES: ReadonlySet<MachineResultFrameType> = new Set<MachineResultFrameType>(['exec_result', 'fs_read_result', 'fs_write_result', 'grant_denied', 'approval_revoke_result']);
+
+/** The correlation id an approval-revoke ack is bound to — namespaced so it can never collide with a grant id. */
+export function approvalRevokeBindingId(approvalId: string): string {
+  return `approval-revoke:${approvalId}`;
+}
+
+/**
+ * What a machine result is BOUND to in its signature and correlated by on
+ * the server: the grant it answers, or — for an approval-revoke ack (GA
+ * wave 2) — the namespaced approval id.
+ */
+export function machineResultBindingId(frame: MachineResultFrame): string {
+  return frame.type === 'approval_revoke_result' ? approvalRevokeBindingId(frame.approvalId) : frame.grantId;
+}
 
 export function isMachineResultFrame(frame: Frame): frame is MachineResultFrame {
   return (MACHINE_RESULT_FRAME_TYPES as ReadonlySet<string>).has(frame.type);
@@ -111,6 +127,9 @@ export function resultPayloadForFrame(frame: MachineResultFrame): Record<string,
       // `pending` (a frozen request awaiting a chat click, GA wave 2) is
       // signed too: the card renders what the MACHINE said it froze.
       return { type: frame.type, grantId: frame.grantId, reason: frame.reason, pending: frame.pending ?? null };
+    case 'approval_revoke_result':
+      // The ack covers the id AND the count: the server may only claim what the machine signed.
+      return { type: frame.type, approvalId: frame.approvalId, removed: frame.removed };
   }
 }
 
@@ -148,7 +167,7 @@ export function verifyMachineResult(input: VerifyMachineResultInput): MachineRes
   } catch {
     return { ok: false, reason: 'malformed' };
   }
-  const verdict = safeVerify(input.verify, encodeResultForSigning({ grantId: input.frame.grantId, resultHash }), signature, input.machinePublicKey);
+  const verdict = safeVerify(input.verify, encodeResultForSigning({ grantId: machineResultBindingId(input.frame), resultHash }), signature, input.machinePublicKey);
   return verdict.ok ? { ok: true, resultHash } : verdict;
 }
 

--- a/packages/lib/src/services/drive-envs/__tests__/local-env-enrollment.test.ts
+++ b/packages/lib/src/services/drive-envs/__tests__/local-env-enrollment.test.ts
@@ -126,6 +126,13 @@ describe('enrollLocalDriveEnv — the machine presents the code and its public k
     expect(result).toMatchObject({ ok: true, ownerId: 'user-1' });
   });
 
+  it('GA wave 2 · leaf 3: should answer the env\'s serverPolicy too, so the enroller can scaffold the file ops it allows (and never exec) into the machine policy', async () => {
+    const h = harness();
+    const created = await createLocal(h);
+    const result = await enrollLocalDriveEnv({ enrollmentId: created.enrollment.enrollmentId, code: created.enrollment.code, machinePublicKey, deps: h.deps });
+    expect(result).toMatchObject({ ok: true, serverPolicy: { ops: ['fs_read', 'fs_write'], checkpoint: false } });
+  });
+
   it('given the right code before expiry and a valid Ed25519 SPKI key, should pin key + fingerprint + server keyId, consume the code, and hand back the server public key to pin', async () => {
     const h = harness();
     const { env, enrollment } = await createLocal(h);
@@ -137,6 +144,7 @@ describe('enrollLocalDriveEnv — the machine presents the code and its public k
       serverKeyId: 'srv-k1',
       serverPublicKey: Buffer.from(identity.signingKey.publicKey).toString('base64'),
       ownerId: 'user-1',
+      serverPolicy: { ops: ['fs_read', 'fs_write'], checkpoint: false },
     });
     const sibling = h.fake.local.get(env.id)!;
     expect(sibling.machinePublicKey).toBe(machinePublicKey);

--- a/packages/lib/src/services/drive-envs/drive-envs.ts
+++ b/packages/lib/src/services/drive-envs/drive-envs.ts
@@ -352,8 +352,12 @@ export interface LocalEnvIdentityServiceDeps {
 }
 
 export type EnrollLocalDriveEnvResult =
-  /** `ownerId` rides the answer so the enroller can scaffold `principals: [owner]` on the machine (D-6, defence in depth). */
-  | { ok: true; envId: string; enrollmentId: string; serverKeyId: string; serverPublicKey: string; ownerId: string }
+  /**
+   * `ownerId` rides the answer so the enroller can scaffold `principals: [owner]` on the machine (D-6, defence in depth);
+   * `serverPolicy` rides it so the enroller can scaffold the FILE ops PageSpace may ask for into the machine policy
+   * (GA wave 2, Tier A) — the enroller never writes `exec` into machine `ops`, whatever this says (Tier B).
+   */
+  | { ok: true; envId: string; enrollmentId: string; serverKeyId: string; serverPublicKey: string; ownerId: string; serverPolicy: { ops: string[]; checkpoint: boolean } }
   | { ok: false; reason: 'not_found' | 'revoked' | 'already_enrolled' | 'bad_public_key' | 'race' | EnrollmentCodeDenyReason };
 
 /**
@@ -415,7 +419,10 @@ export async function enrollLocalDriveEnv({
     envId: row.envId,
     enrollmentId: row.enrollmentId,
     serverKeyId: deps.identity.signingKey.keyId,
-    serverPublicKey: Buffer.from(deps.identity.signingKey.publicKey).toString('base64'), ownerId: row.ownerId };
+    serverPublicKey: Buffer.from(deps.identity.signingKey.publicKey).toString('base64'),
+    ownerId: row.ownerId,
+    serverPolicy: { ops: [...row.serverPolicy.ops], checkpoint: row.serverPolicy.checkpoint },
+  };
 }
 
 export type IssueLocalEnvChallengeResult =

--- a/packages/lib/src/services/sandbox/__tests__/tool-runners.test.ts
+++ b/packages/lib/src/services/sandbox/__tests__/tool-runners.test.ts
@@ -9,13 +9,14 @@ import {
   CHECKPOINT_TIMEOUT_MS,
   DENIAL_MESSAGES,
   localRefusalToToolDenial,
+  pendingChallengeIdOf,
   type SandboxActorContext,
   type SandboxRunDeps,
 } from '../tool-runners';
 import type { ExecutableSandbox, SandboxRunResult } from '../sandbox-client/types';
 import type { CodeExecutionAuditInput } from '../audit';
 import { SANDBOX_ROOT } from '../sandbox-paths';
-import { LocalEnvServerDeniedError } from '../sandbox-client/local-env-sandbox-host';
+import { LocalEnvGrantDeniedError, LocalEnvServerDeniedError } from '../sandbox-client/local-env-sandbox-host';
 import { DEFAULT_READ_LINES, SANDBOX_MAX_OUTPUT_BYTES, MAX_LINE_BYTES } from '../execution-policy';
 import { LINE_ELISION_MARKER } from '../output-limit';
 import { LocalEnvUnsupportedError } from '../sandbox-host';
@@ -1996,6 +1997,42 @@ describe('a LOCAL environment\'s two refusals stay distinguishable all the way t
     const { deps } = makeDeps({ reconnect: async () => makeSandbox({ writeFiles: denied, readFileToBuffer: denied }) });
     const result = await run(deps);
     expect(result).toEqual({ success: false, reason: 'local_server_denied', error: DENIAL_MESSAGES.local_server_denied });
+  });
+
+  it('GA wave 2 · leaf 5: given the MACHINE answers ask_pending:<id> (frozen for the owner\'s click), bash should answer local_approval_required carrying the challengeId — never execution_failed', async () => {
+    const { deps } = makeDeps({
+      reconnect: async () =>
+        makeSandbox({
+          runCommand: async () => {
+            throw new LocalEnvGrantDeniedError('env-1', 'ask_pending:ch_42');
+          },
+        }),
+    });
+    const result = await runBashInSandbox({ command: 'git status', ctx: makeCtx(), deps });
+    expect(result).toMatchObject({ success: false, reason: 'local_approval_required', challengeId: 'ch_42' });
+    expect((result as { error: string }).error).toContain('ch_42');
+    expect((result as { error: string }).error).toContain('request_env_approval');
+  });
+
+  it.each([
+    ['writeSandboxFile', (deps: SandboxRunDeps) => writeSandboxFile({ path: 'a.txt', content: 'hi', ctx: makeCtx(), deps })],
+    ['readSandboxFile', (deps: SandboxRunDeps) => readSandboxFile({ path: 'a.txt', ctx: makeCtx(), deps })],
+    ['readSandboxFileForCopy', (deps: SandboxRunDeps) => readSandboxFileForCopy({ path: 'a.txt', ctx: makeCtx(), deps })],
+    ['editSandboxFile (read leg)', (deps: SandboxRunDeps) => editSandboxFile({ path: 'a.txt', oldString: 'x', newString: 'y', ctx: makeCtx(), deps })],
+  ] as const)('GA wave 2 · leaf 5: %s answers local_approval_required with the challengeId when the machine froze the request', async (_name, run) => {
+    const pending = async () => {
+      throw new LocalEnvGrantDeniedError('env-1', 'ask_pending:ch_7');
+    };
+    const { deps } = makeDeps({ reconnect: async () => makeSandbox({ writeFiles: pending, readFileToBuffer: pending }) });
+    expect(await run(deps)).toMatchObject({ success: false, reason: 'local_approval_required', challengeId: 'ch_7' });
+  });
+
+  it('GA wave 2 · leaf 5: any OTHER machine refusal stays execution_failed, and a bare or malformed ask_pending carries no id', async () => {
+    const { deps } = makeDeps({ reconnect: async () => makeSandbox({ runCommand: async () => { throw new LocalEnvGrantDeniedError('env-1', 'declined'); } }) });
+    expect(await runBashInSandbox({ command: 'x', ctx: makeCtx(), deps })).toEqual({ success: false, reason: 'execution_failed', error: DENIAL_MESSAGES.execution_failed });
+    expect(pendingChallengeIdOf('ask_pending:')).toBeNull();
+    expect(pendingChallengeIdOf('approval_mismatch')).toBeNull();
+    expect(pendingChallengeIdOf('ask_pending:ch_1')).toBe('ch_1');
   });
 
   it('given the server policy allows reading but not WRITING, editSandboxFile should read fine and answer local_server_denied on the write leg', async () => {

--- a/packages/lib/src/services/sandbox/tool-runners.ts
+++ b/packages/lib/src/services/sandbox/tool-runners.ts
@@ -46,7 +46,7 @@ import {
 import { getValidatedEnv } from '../../config/env-validation';
 import type { ExecutableSandbox, SandboxRunResult } from './sandbox-client/types';
 import { LocalEnvUnsupportedError } from './sandbox-host';
-import { LocalEnvServerDeniedError } from './sandbox-client/local-env-sandbox-host';
+import { LocalEnvGrantDeniedError, LocalEnvServerDeniedError } from './sandbox-client/local-env-sandbox-host';
 import type { CodeExecutionAuditInput, CodeExecutionAnomaly } from './audit';
 import type { UsageTrackingOutcome } from '../../monitoring/ai-monitoring';
 
@@ -435,15 +435,25 @@ export type SandboxToolDenialReason =
    * only the machine's owner, on the environment's settings page.
    */
   | 'local_server_denied'
+  /**
+   * The MACHINE froze this request under a challenge and is waiting for its
+   * owner's click in the chat (GA wave 2, Tier B). Not a refusal to retry
+   * around: the agent must call `request_env_approval` with the challenge
+   * id and stop. `challengeId` rides the failure so the model has it.
+   */
+  | 'local_approval_required'
   | 'error';
+
+/** A failure that carries the daemon's challenge id (only `local_approval_required` does). */
+export type SandboxToolFailure = { success: false; error: string; reason: SandboxToolDenialReason; challengeId?: string };
 
 export type BashToolResult =
   | { success: true; stdout: string; stderr: string; exitCode: number; truncated: boolean }
-  | { success: false; error: string; reason: SandboxToolDenialReason };
+  | SandboxToolFailure;
 
 export type WriteFileToolResult =
   | { success: true; path: string; bytesWritten: number }
-  | { success: false; error: string; reason: SandboxToolDenialReason };
+  | SandboxToolFailure;
 
 export type ReadFileToolResult =
   | {
@@ -467,7 +477,7 @@ export type ReadFileToolResult =
       /** Present iff `truncated`: says what is missing and how to get it. */
       notice?: string;
     }
-  | { success: false; error: string; reason: SandboxToolDenialReason };
+  | SandboxToolFailure;
 
 /**
  * `readSandboxFileForCopy`'s result. Deliberately NOT ReadFileToolResult: there
@@ -532,8 +542,22 @@ export const DENIAL_MESSAGES: Record<SandboxToolDenialReason, string> = {
   local_server_denied:
     'PageSpace refused to sign this request: the operation is not enabled in this local environment\'s server policy '
     + '(or the environment is revoked or paused). Retrying will not help — the machine\'s owner enables it on the environment\'s settings page.',
+  local_approval_required:
+    'This request needs the machine owner\'s approval in the chat before it runs. The machine has frozen the exact request under a challenge. '
+    + 'Call request_env_approval with this challengeId and STOP; when the owner answers, the outcome (and the command\'s output, if it ran) is returned as that tool\'s result. '
+    + 'Do not retry the command and do not rephrase it — the owner approves exactly what was frozen.',
   error: 'Code execution could not be completed.',
 };
+
+/** The reason prefix the daemon answers with while a request waits for the owner's click (`ask_pending:<challengeId>`). */
+export const ASK_PENDING_PREFIX = 'ask_pending:';
+
+/** The challenge id inside a daemon's `ask_pending:<id>` refusal, or null for any other refusal. */
+export function pendingChallengeIdOf(reason: string): string | null {
+  if (!reason.startsWith(ASK_PENDING_PREFIX)) return null;
+  const id = reason.slice(ASK_PENDING_PREFIX.length);
+  return id.length > 0 ? id : null;
+}
 
 /**
  * How a LOCAL env's server-side refusal reaches the AGENT.
@@ -564,8 +588,27 @@ export function localRefusalToToolDenial(refusal: string | undefined): SandboxTo
 
 function fail(
   reason: SandboxToolDenialReason,
-): { success: false; error: string; reason: SandboxToolDenialReason } {
+): SandboxToolFailure {
   return { success: false, error: DENIAL_MESSAGES[reason], reason };
+}
+
+/**
+ * How a LOCAL env's refusal that reached the runner as a thrown error becomes
+ * the agent's answer. Three words, three owners: the SERVER refused to sign
+ * (`local_server_denied`, fixed on the settings page); the MACHINE is waiting
+ * for its owner's click (`local_approval_required`, fixed by the owner in the
+ * chat — the challenge id rides along so the agent can ask); anything else is
+ * the generic execution failure it always was.
+ */
+function localFailureFor(error: unknown): SandboxToolFailure {
+  if (error instanceof LocalEnvServerDeniedError) return fail('local_server_denied');
+  if (error instanceof LocalEnvGrantDeniedError) {
+    const challengeId = pendingChallengeIdOf(error.reason);
+    if (challengeId !== null) {
+      return { success: false, reason: 'local_approval_required', error: `${DENIAL_MESSAGES.local_approval_required} challengeId: ${challengeId}`, challengeId };
+    }
+  }
+  return fail('execution_failed');
 }
 
 function acquireRequest(ctx: SandboxActorContext): AcquireSandboxRequest {
@@ -1049,8 +1092,7 @@ export async function runBashInSandbox({
       // The server refused to SIGN (GA wave 1): typed all the way to the
       // agent, because "PageSpace's policy for this machine excludes this"
       // and "the command died" have different owners and different fixes.
-      if (error instanceof LocalEnvServerDeniedError) return fail('local_server_denied');
-      return fail('execution_failed');
+      return localFailureFor(error);
     }
 
     const durationMs = deps.now().getTime() - startedAt.getTime();
@@ -1145,8 +1187,7 @@ export async function writeSandboxFile({
         durationMs,
         anomaly: 'nonzero_exit',
       });
-      if (error instanceof LocalEnvServerDeniedError) return fail('local_server_denied');
-      return fail('execution_failed');
+      return localFailureFor(error);
     }
     const durationMs = deps.now().getTime() - startedAt.getTime();
     await safeAudit(deps, ctx, {
@@ -1314,8 +1355,7 @@ export async function readSandboxFile({
         durationMs,
         anomaly: 'nonzero_exit',
       });
-      if (error instanceof LocalEnvServerDeniedError) return fail('local_server_denied');
-      return fail('execution_failed');
+      return localFailureFor(error);
     }
     const durationMs = deps.now().getTime() - startedAt.getTime();
     if (buffer === null) {
@@ -1440,8 +1480,7 @@ export async function readSandboxFileForCopy({
           durationMs,
           anomaly: 'nonzero_exit',
         });
-        if (error instanceof LocalEnvServerDeniedError) return fail('local_server_denied');
-        return fail('execution_failed');
+        return localFailureFor(error);
       }
       const durationMs = deps.now().getTime() - startedAt.getTime();
       if (buffer === null) {
@@ -1535,8 +1574,7 @@ export async function editSandboxFile({
     } catch (error) {
       const durationMs = deps.now().getTime() - startedAt.getTime();
       await safeAudit(deps, ctx, { code: `editFile ${path}`, exitCode: null, durationMs, anomaly: 'nonzero_exit' });
-      if (error instanceof LocalEnvServerDeniedError) return fail('local_server_denied');
-      return fail('execution_failed');
+      return localFailureFor(error);
     }
     if (buffer === null) {
       const durationMs = deps.now().getTime() - startedAt.getTime();
@@ -1559,8 +1597,7 @@ export async function editSandboxFile({
     } catch (error) {
       const durationMs = deps.now().getTime() - startedAt.getTime();
       await safeAudit(deps, ctx, { code: `editFile ${path}`, exitCode: null, durationMs, anomaly: 'nonzero_exit' });
-      if (error instanceof LocalEnvServerDeniedError) return fail('local_server_denied');
-      return fail('execution_failed');
+      return localFailureFor(error);
     }
     const durationMs = deps.now().getTime() - startedAt.getTime();
     await safeAudit(deps, ctx, {


### PR DESCRIPTION
GA wave 2 of the Local Environments epic (board `j945few5ssv75k5ad0bowbb4`, phase `pe9e4yxsw8rl1wq4223hdrys`, 8 leaves). Base: `pu/local-env-ga` (on top of wave 1, #2582). Plan `~/.claude/plans/elegant-stirring-crown.md` §2; review findings 3 and 6.

**The two one-sentence proofs**
- (a) **A new chat does not re-prompt for an approved subject:** approvals are keyed `(envId, userId, op, subject)` and persisted in `~/.pagespace/env-approvals.json`, so a grant for `tool b` from a brand-new session and conversation runs with zero prompts after `tool a` was approved once — pinned in `dispatcher.test.ts` ("a later `tool b` from a NEW session and conversation runs with NO prompt") and end to end through `env connect` in `env-connect.test.ts`.
- (b) **A click can only unblock a request the daemon itself froze:** the re-issued grant's `approvalIntent` is honoured only against a challenge in the daemon's own store, and the new request is re-normalised and byte-compared (`sameBytes(canonicalizeArgs(…))`) against the frozen one before anything runs — pinned as the EXIT CRITERION row in `dispatcher.test.ts`; removing the compare, or feeding the compare the new request instead of the frozen one, turns it red.

## Why
Approvals lived in an in-process `Set` keyed `(userId, sessionId, op)`: a new chat re-prompted (the founder's annoyance), and one approval of `git status` silently authorised every later `exec` in that session, unseen (the OWASP F1 finding). The threat this wave closes: a prompt injection on a shared page, read by the owner's own agent, becoming arbitrary code on the owner's laptop unattended. Two tiers: **file ops inside roots run headless** (Tier A, chosen once at enrolment); **`exec` is never headless** (Tier B) — every exec class needs the owner's click in the chat, on the exact normalised command, and the MACHINE verifies the click.

## Per leaf (one commit each; pure first)
1. **Re-key approvals** (`13a89c265`) — CLI `approvals-store.ts`: `(envId, userId, op, subject)`; subject = resolved program for exec (every program a `sh -c` line names, never the shell), the policy root for fs ops; scope `once | session | 30d (default) | until_revoked`; file read through the policy loader's one-descriptor adapter with the same owner/mode checks; any defect ⇒ empty, never partial; refused file never overwritten; atomic 0600 writes. The ask prompter remembers nothing itself (scope picker added). **Mutation 10/11** (survivor: a redundant `once` guard duplicated by the store, which is itself mutation-tested).
2. **`decide-approval` pure matcher** (`7f5ff7e4e`) — `packages/lib/src/env-bridge/decide-approval.ts` (+ `index.ts`, exports entry): `matchApproval(approvals, grant, request, now, deps) → covered | ask | expired`, no I/O (PATH resolver and clock injected). `decideExecution` consults it AFTER `confinePath` and `scrubEnv`; a retargeted symlink to another root cannot ride the first root's approval (tested). The `LocalApproval` byte-compare path is untouched as the fresh-prompt path. **Mutation 8/8.**
3. **Enroller scaffolds file ops, never exec** (`f942864ab`) — the enroll answer carries `serverPolicy`; `env enroll` writes `ops = serverPolicy.ops ∩ {fs_read, fs_write}`; `exec` is never written whatever the policy says (tested: a policy with `exec` scaffolds without it); wire shape checked strictly; never-overwrite kept, diff printed on an existing file. **Mutation 5/5.**
4. **Daemon challenge store** (`d4f320a30`) — on `ask` with no terminal (or `PAGESPACE_ENV_ASK=chat`) the request is frozen under a challenge id, TTL = grant `exp`, bounded (64) and evicted synchronously like `nonce-store.ts`, same-subject asks reuse the id; reply `grant_denied ask_pending:<id>` carrying the frozen request in a new optional `pending` field that the machine's result signature covers. `env connect` no longer refuses ask mode without a TTY. **Mutation 7/7** (dropping the TTL ⇒ "expired challenge is refused" red).
5. **`request_env_approval` client tool** (`4b3ed7c63`) — `apps/web/src/lib/ai/tools/env-approval-tools.ts`: no `execute`, injected in both chat turns with ask_user's discipline and ONLY when the bound session is on a local env (`local-env-binding.ts`); not in `baseTools`/`tool_search`/`execute_tool` (tested against the registry builder). Not `ask_user` — a test asserts neither the tool module nor the card imports it. Runners answer `local_approval_required` + `challengeId`. Pausing-tool plumbing defined once (`pausing-tools.ts`). Card fetches the frozen request from the route and renders principal/op/argv/cwd/paths/env/limits verbatim. **Mutation 3/3.**
6. **Click re-issues a grant, owner-only** (`99a139ff2`) — `approvalIntent { challengeId, scope, expiresAt }` signed INTO the grant under the pinned key (appended to the canonical bytes only when present: existing grants keep their bytes); `EnvBridgeClient` remembers `ask_pending` answers in a bounded, TTL'd pending store; `GET|POST /api/env-bridge/approvals/[challengeId]`: clicker must be `drive_env_local.ownerId` — a drive admin is 403 and audited ([D-6]); after the TTL ⇒ 410 `approval_expired`; Allow sends the SAME frame under the SAME principal with the intent and relays the machine's typed refusal. **Mutation 5/5.**
7. **Daemon byte-compares** (`0d1eef95e`) — look up by challenge id, refuse unframed/late/other-user clicks, then `decideExecution` with `localApproval: { request: frozen }` — only on match spend the challenge, remember under the challenge id, run. **EXIT CRITERION mutant red** (see proof b). 5/6 further mutants red (survivor: the duplicated `once` guard).
8. **Server revoke of one approval** (`9822ecdc3`) — `revoke` frame gains `approvalId`, signed under its OWN domain (`revoke-approval/v1`): a stripped id can never become a key deletion, an added id can never become an enrollment revoke, enrollment-revoke bytes unchanged. Daemon deletes exactly that approval's rows and stays connected. `DELETE /api/drives/[driveId]/envs/[envId]/approvals/[approvalId]` (owner or drive admin; honest `409 no_live_socket` when the machine is not there). **Mutation 5/5.**
9. **Asymmetry pinned** (`4e551f740`, requested on the leaf page): invariants (a) the only writer to the store is the daemon's own `remember()` after a byte-compared allow; (b) the codec has no frame type that can add an approval; dispatcher: a server-signed grant naming a challenge the daemon never froze ⇒ `approval_mismatch`, nothing runs, nothing remembered. All three mutants red.

## Exports-map check
```
git diff origin/pu/local-env-ga...HEAD -- apps packages/cli | grep -o "@pagespace/lib/[a-zA-Z0-9_/.-]*" | sort -u
```
20 subpaths, every one present in `packages/lib/package.json` (incl. the new `./env-bridge/decide-approval`).

## Verification (local, exact)
Worktree with no dist builds (load ~18, other agents running): lib/web/cli resolved from source via throwaway `vitest.wt.config.ts` files (uncommitted, in `.git/info/exclude`); every mutant applied by LINE INDEX with a script that restores the file and reports a missing needle, a no-op control per batch (the first sweep was BROKEN — the harness never ran vitest and reported all-green; fixed and re-run before anything was believed).
```
packages/cli: 22 files / 288 tests green (env-bridge + env commands); tsc clean via a throwaway tsconfig mapping lib/sdk to source
packages/lib: 21 files / 713 tests green (env-bridge, enrollment, tool-runners); tsc clean
apps/web: env-bridge, both approval routes, tools, resume, streams, hooks, card: green; tsc clean for every touched file (the only web errors are pre-existing dev-preview-store ones on the base); ESLint clean on every touched file
```
Five unrelated `apps/web/src/lib/ai/tools/__tests__` files fail ONLY under the throwaway source-resolving config (partial `vi.mock` shapes against `@pagespace/db` src); none is in this diff. **CI is the gate** for `bun run typecheck`, knip and those. knip ratchet run locally: the three findings this PR introduced are fixed; the remaining local findings are pre-existing worktree phantoms (`packages/lib/src/env-bridge/index.ts`, `digestsEqual`, env-contract types) not present in the diff.

## Review follow-ups (one commit each, red first, mutation by line index)
- `6c22e9300` Codex P1 — substitution inside double quotes is opaque (`echo "$(rm x)"` ⇒ ask; single quotes literal). Mutant red.
- `c3ed2e057` CodeQL — loop-based `trimTrailing` replaces both `[…]+$` regexes; 100k-char run bounded-time row.
- `81a937a62` Codex P1 — the card uses `fetchWithAuth` for GET and POST (CSRF token); raw fetch stub throws in every card test.
- `43580b704` Codex P1 — route truncates stdout/stderr to `ENV_APPROVAL_STDOUT_MAX_CHARS` / `ENV_APPROVAL_STDERR_MAX_CHARS` (exported once, used by schema and route); 300 KiB row validates with `truncated: true`. Mutant red.
- `9c329092c` Codex P2 — machine-signed `approval_revoke_result { approvalId, removed }` ack; server correlates with a 5 s wait; DELETE 200 only on the ack, 202 `unacknowledged`; forged ack ignored. Mutants (skip the ack signature check; drop `removed` from the payload) red.
- `4e551f740` leaf 8 asymmetry rows (invariants (a)/(b), compromised-server row); an unframed challenge is `approval_mismatch`.

## Known limitations (stated, not hidden)
- An approval revoke that finds no live socket (409) or gets no signed ack in 5 s (202 `unacknowledged`) is reported as such — the machine may still hold the approval; wave 3 mirrors approvals server-side and replays unacknowledged revokes on reconnect, keyed on the ack added here.
- The chat click must land on the replica holding the machine's socket (the same constraint every grant already has).
- The terminal prompt's default scope is 30 days (the design's default); the scope picker is shown.
- Leaf order: 7 was landed before 5/6 (it is the exit criterion and needed the grant change); the diff is the same.

## Board
All 8 leaves flipped `completed` on `pe9e4yxsw8rl1wq4223hdrys`; the asymmetry rows are named on leaf 8's page.

Do not merge — the founder merges. `PR_READY` follows once CI is green and threads are answered.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01F7yLZ7eEUvtJf6DZNfmeQP
