### PR TITLE
fix(ios): stop claiming Google is blocked in the app, and make a magic link finish inside it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,22 @@ All notable user-facing changes to PageSpace are documented here. Format follows
 
 ### Added
 
+- **iPhone and iPad: sign-in no longer tells you Google is blocked when it isn't, and an emailed
+  sign-in link now signs you in inside the app** — two things were wrong on the app's sign-in
+  screen. It showed a warning saying "Google sign-in is blocked in this app" and pushed you toward
+  an email link instead; that warning is meant for in-app browsers like Instagram's or Facebook's,
+  and the app's own window was being mistaken for one. Google sign-in has always worked in the
+  app, so the warning is gone there and the app no longer forces the email-link form open. A real
+  in-app browser still gets the warning, because there the advice is true. The email link was the
+  worse problem: it was the fallback the warning recommended, and it could not work at all. Tapping
+  it opened Safari, and the session it created stayed in Safari — the app never saw it and stayed
+  signed out. Ask for a sign-in link from the app now and the link opens **the app**, signs you in
+  there, and takes you where you were headed. The same link opened somewhere else — a laptop, a
+  friend's phone if you forwarded the mail — still signs that browser in as before, and hands out
+  nothing that would let it act as your phone. Links you request from a browser are unchanged. On
+  Android the link still opens Chrome and signs Chrome in; the app cannot receive links yet, which
+  needs a signed release build.
+
 - **Local Environments: create one from the app, get your enrollment code, and get a new one if
   you lose it (opt-in)** — a local Environment (your own computer, reached through the bridge) is
   now a choice in the ordinary "New environment" step rather than something only an API call could

--- a/apps/android/README.md
+++ b/apps/android/README.md
@@ -362,8 +362,18 @@ certificate and a real `assetlinks.json`. Until those exist **Android captures n
 https intent-filter is registered.
 
 When it does, mirror `apps/marketing/public/.well-known/apple-app-site-association` (the copy
-Caddy actually serves), currently `/invite/*` only, so both platforms capture the same links. Widening beyond these paths should still wait on prerequisite 2 — whole-host
+Caddy actually serves), currently `/invite/*` and `/auth/magic-link/*`, so both platforms capture
+the same links. Widening beyond these paths should still wait on prerequisite 2 — whole-host
 capture would strand users on `/dashboard` from every marketing, blog, or docs link.
+
+**Magic links reach the same wall.** The shared web layer already treats Android as a
+device-bound platform: a magic link requested from the Android app is minted for this device and
+emailed as `https://pagespace.ai/auth/magic-link/<token>`, and
+`apps/web/src/app/auth/magic-link/[token]/page.tsx` would redeem it into the secure store exactly
+as it does on iOS. But with no https intent-filter registered, **Android never receives the tap** —
+Chrome opens the link and signs Chrome in with a cookie, which is what happens today and is no
+worse than before. It is not fixed for Android, and it cannot be until prerequisite 1 lands; the
+server and web halves are simply already in place for when it does.
 
 A third prerequisite applies to the auth-callback paths specifically: `/api/auth/desktop/exchange`
 authenticates possession of the one-time code alone, with no PKCE verifier and no binding to the

--- a/apps/android/README.md
+++ b/apps/android/README.md
@@ -363,8 +363,9 @@ https intent-filter is registered.
 
 When it does, mirror `apps/marketing/public/.well-known/apple-app-site-association` (the copy
 Caddy actually serves), currently `/invite/*` and `/auth/magic-link/*`, so both platforms capture
-the same links. Widening beyond these paths should still wait on prerequisite 2 — whole-host
-capture would strand users on `/dashboard` from every marketing, blog, or docs link.
+the same links. Widening beyond those two paths is a separate decision from prerequisite 1:
+whole-host capture would strand users on `/dashboard` from every marketing, blog, or docs link,
+whatever the certificate situation.
 
 **Magic links reach the same wall.** The shared web layer already treats Android as a
 device-bound platform: a magic link requested from the Android app is minted for this device and

--- a/apps/ios/README.md
+++ b/apps/ios/README.md
@@ -33,8 +33,8 @@ This is a **remote-loading** app. The WebView loads the live site directly:
 
 ### Universal links (associated domains)
 
-`https://pagespace.ai/invite/*` opens in the app. Three pieces have to agree, and they broke
-independently before:
+`https://pagespace.ai/invite/*` and `https://pagespace.ai/auth/magic-link/*` open in the app.
+Three pieces have to agree, and they broke independently before:
 
 1. **Entitlement** — `applinks:pagespace.ai` in `App.entitlements`.
 2. **The AASA** — Caddy routes `/.well-known/*` to **marketing** (only `oauth-*` reaches web), so
@@ -42,8 +42,10 @@ independently before:
    `appID` is team plus bundle id (`M96WTV3CKX.ai.pagespace.ios`), and it must be served as
    `application/json` — the file is deliberately extensionless, so `apps/marketing/next.config.ts`
    sets the header.
-3. **Routing** — `apps/web/src/components/DeepLinkHandler.tsx`, mounted in
-   `DashboardLayoutClient`. Both halves are required: `App.getLaunchUrl()` for a cold start (the
+3. **Routing** — `apps/web/src/components/DeepLinkHandler.tsx`, mounted in the **root**
+   `apps/web/src/app/layout.tsx`, not the dashboard layout: a signed-out `/dashboard` is rewritten
+   to `/auth/signin`, and both an invite tap and a magic-link tap are very often signed out, so
+   mounted any lower the launch URL is never read. Both halves are required: `App.getLaunchUrl()` for a cold start (the
    URL is spent before any listener exists) and the `appUrlOpen` listener for a warm one (the
    native side only notifies plugins, it never calls `loadUrl`, so without a listener the WebView
    simply stays put). Which URLs resolve to which route is
@@ -56,8 +58,32 @@ which limits the blast radius but is not a licence to claim loosely.
 
 Navigation goes through the router, never `window.location`: in the iOS shell a top-level location
 change reaches Capacitor's `WKNavigationDelegate`, which cancels anything outside `server.url`'s
-`/dashboard` prefix and opens system Safari, blanking the WebView. `/invite/*` is outside that
-prefix.
+`/dashboard` prefix and opens system Safari, blanking the WebView. `/invite/*` and
+`/auth/magic-link/*` are both outside that prefix.
+
+### Magic links, and why they are a universal link
+
+A magic link requested from the app used to be unusable. `apps/web/src/lib/desktop-auth.ts` knew
+only about Electron, so the token was minted with no platform metadata and the email carried the
+plain `/api/auth/magic-link/verify?token=…` URL. iOS does not claim that path, so the tap opened
+Safari, the session cookie landed in **Safari's** cookie jar, and the WebView — which
+authenticates with a bearer token read from the Keychain (`platform-storage/ios-storage.ts`,
+`usesBearer() === true`) — stayed signed out. There was no path by which it could succeed.
+
+Now `apps/web/src/lib/auth/magic-link-platform-fields.ts` reports the shell and this device's id
+(the same id native Google / Apple sign-in use), the send route binds the link to it, and the
+adapter mints `https://pagespace.ai/auth/magic-link/<token>` instead — a claimed path, so the tap
+opens the app. `apps/web/src/app/auth/magic-link/[token]/page.tsx` then redeems the token with a
+same-origin `POST /api/auth/magic-link/verify`: the response's `Set-Cookie` lands in the WebView's
+own jar, and because the page presents the bound `deviceId`, the route also returns
+`sessionToken` / `csrfToken` / `deviceToken`, which the page writes to the Keychain — the same
+shape and the same store as `/api/auth/{apple,google}/native`.
+
+Bearer tokens are released **only** to the device the link was bound to. The same link opened
+anywhere else (a laptop browser, a second phone) still signs that browser in by cookie and
+receives no tokens, so a forwarded email cannot hand anyone a native session. The emailed URL for
+a link requested from a browser is unchanged, and that path stays unclaimed — a link requested in
+Safari must complete in Safari.
 
 Do **not** claim the OAuth callback paths. Native sign-in returns through the
 `pagespace://auth-exchange` custom scheme, and `/api/auth/desktop/exchange` redeems its code with
@@ -156,6 +182,9 @@ bundle exec fastlane release   # deliver: push metadata + submit the App Store v
       returns `M96WTV3CKX.ai.pagespace.ios` as `application/json`, **and** an
       `https://pagespace.ai/invite/...` link opens the app on a device from both a cold start and
       with the app already running (the two paths are handled separately — verify both)
+- [ ] Magic link verified on a device: request one **from the app**, tap it in Mail, and confirm
+      the app opens signed in (not Safari). Then open the same link on a Mac and confirm it signs
+      that browser in without handing out tokens
 - [ ] Build uploaded and finished **Processing** in App Store Connect
 - [ ] App privacy answers match `ios/App/PrivacyInfo.xcprivacy` (Email + User ID linked / App
       Functionality; Device ID / Analytics and Crash + Performance Data, not linked; Product

--- a/apps/ios/README.md
+++ b/apps/ios/README.md
@@ -183,8 +183,9 @@ bundle exec fastlane release   # deliver: push metadata + submit the App Store v
       `https://pagespace.ai/invite/...` link opens the app on a device from both a cold start and
       with the app already running (the two paths are handled separately — verify both)
 - [ ] Magic link verified on a device: request one **from the app**, tap it in Mail, and confirm
-      the app opens signed in (not Safari). Then open the same link on a Mac and confirm it signs
-      that browser in without handing out tokens
+      the app opens signed in (not Safari). Then request a **second** link from the app and open
+      that one on a Mac — the first is spent, so reusing it only proves `magic_link_used` — and
+      confirm the browser is signed in by cookie with no tokens handed out
 - [ ] Build uploaded and finished **Processing** in App Store Connect
 - [ ] App privacy answers match `ios/App/PrivacyInfo.xcprivacy` (Email + User ID linked / App
       Functionality; Device ID / Analytics and Crash + Performance Data, not linked; Product

--- a/apps/marketing/public/.well-known/apple-app-site-association
+++ b/apps/marketing/public/.well-known/apple-app-site-association
@@ -5,7 +5,8 @@
       {
         "appID": "M96WTV3CKX.ai.pagespace.ios",
         "paths": [
-          "/invite/*"
+          "/invite/*",
+          "/auth/magic-link/*"
         ]
       }
     ]

--- a/apps/web/src/app/api/auth/magic-link/__tests__/round-trip.test.ts
+++ b/apps/web/src/app/api/auth/magic-link/__tests__/round-trip.test.ts
@@ -128,7 +128,9 @@ vi.mock('@/lib/auth/cookie-config', () => ({
   appendSessionCookie: vi.fn(),
 }));
 vi.mock('@pagespace/lib/onboarding/home-drive', () => ({
-  provisionHomeDriveIfNeeded: vi.fn().mockResolvedValue(null),
+  // Shape matters: the route reads `.created`, so a bare null would make every
+  // test here take the provisioning catch instead of the real path.
+  provisionHomeDriveIfNeeded: vi.fn().mockResolvedValue({ driveId: 'home-drive', created: false }),
 }));
 vi.mock('@/lib/auth/native-invite-acceptance', () => ({
   consumeAnyInviteIfPresent: vi.fn().mockResolvedValue({ kind: null, invitedDriveId: null, invitedPageId: null, connectionId: null }),

--- a/apps/web/src/app/api/auth/magic-link/__tests__/round-trip.test.ts
+++ b/apps/web/src/app/api/auth/magic-link/__tests__/round-trip.test.ts
@@ -81,6 +81,31 @@ vi.mock('@pagespace/lib/auth/csrf-utils', () => ({
 vi.mock('@pagespace/lib/auth/constants', () => ({
   SESSION_DURATION_MS: 7 * 24 * 60 * 60 * 1000,
 }));
+vi.mock('@pagespace/lib/auth/device-auth-utils', () => ({
+  validateOrCreateDeviceToken: vi.fn().mockResolvedValue({
+    deviceToken: 'ps_dev_round_trip',
+    deviceTokenRecordId: 'dt-1',
+    isNew: true,
+  }),
+}));
+vi.mock('@pagespace/lib/auth/exchange-codes', () => ({
+  createExchangeCode: vi.fn().mockResolvedValue('exchange-code-round-trip'),
+}));
+vi.mock('@/lib/repositories/auth-repository', () => ({
+  authRepository: {
+    findUserById: vi.fn().mockResolvedValue({
+      id: 'user_test',
+      name: 'Test User',
+      email: 'user@example.com',
+      image: null,
+      emailVerified: null,
+      tokenVersion: 3,
+    }),
+  },
+}));
+vi.mock('@pagespace/lib/auth/account-lockout', () => ({
+  resetFailedLoginAttempts: vi.fn().mockResolvedValue(undefined),
+}));
 vi.mock('@pagespace/lib/auth/verification-utils', () => ({
   markEmailVerified: vi.fn().mockResolvedValue(undefined),
 }));
@@ -117,7 +142,7 @@ vi.mock('cookie', () => ({
 }));
 
 import { POST as sendPost } from '../send/route';
-import { GET as verifyGet } from '../verify/route';
+import { GET as verifyGet, POST as verifyPost } from '../verify/route';
 
 const buildSendRequest = (body: Record<string, unknown>) =>
   new Request('http://localhost/api/auth/magic-link/send', {
@@ -312,5 +337,120 @@ describe('magic-link round-trip — inviteToken metadata binding end-to-end', ()
     expect(location).toContain('/dashboard/drive_invited_abc');
     expect(location).toContain('invited=1');
     expect(location).toContain('auth=success');
+  });
+});
+
+describe('magic-link round-trip — requested from the iOS app', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.stubEnv('WEB_APP_URL', 'https://example.com');
+    vi.stubEnv('NODE_ENV', 'test');
+    sendEmailMock.mockResolvedValue(undefined);
+    generateTokenMock.mockReturnValue({
+      token: 'tok_round_trip',
+      hash: 'tok_hash',
+      tokenPrefix: 'tok_',
+    });
+    loadUserAccountByEmailMock.mockResolvedValue({ id: 'user_test', suspendedAt: null });
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  /** The metadata the adapter actually persisted, fed back through verify. */
+  const persistedMetadata = (): string | undefined => {
+    const insert = dbInsertMock.mock.results[0]?.value as { values: ReturnType<typeof vi.fn> };
+    const row = insert.values.mock.calls[0]?.[0] as { metadata?: string };
+    return row.metadata;
+  };
+
+  it('mints a universal link, binds the device, and redeems into bearer tokens on that device', async () => {
+    const sendResp = await sendPost(
+      buildSendRequest({
+        email: 'user@example.com',
+        tosAccepted: true,
+        platform: 'ios',
+        deviceId: 'dev_iphone',
+        deviceName: 'iOS App',
+        next: '/dashboard/drive_abc',
+      }),
+    );
+    expect(sendResp.status).toBe(200);
+
+    // The email carries the claimed page, not the API endpoint.
+    const url = extractUrlFromEmailCall();
+    expect(url).toBe('https://example.com/auth/magic-link/tok_round_trip?next=%2Fdashboard%2Fdrive_abc');
+
+    // The row remembers which device asked.
+    const metadata = persistedMetadata();
+    expect(metadata).toBeDefined();
+    expect(JSON.parse(metadata!)).toEqual({ platform: 'ios', deviceId: 'dev_iphone', deviceName: 'iOS App' });
+
+    verifyMagicLinkTokenMock.mockResolvedValue({
+      ok: true,
+      data: { userId: 'user_test', isNewUser: false, metadata },
+    });
+
+    // What the in-app page does with that URL.
+    const parsed = new URL(url);
+    const token = parsed.pathname.split('/').pop()!;
+    const next = parsed.searchParams.get('next')!;
+    const redeemResp = await verifyPost(
+      new Request('https://example.com/api/auth/magic-link/verify', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ token, next, deviceId: 'dev_iphone' }),
+      }),
+    );
+    expect(redeemResp.status).toBe(200);
+    const body = (await redeemResp.json()) as Record<string, unknown>;
+    expect(body).toEqual(
+      expect.objectContaining({
+        sessionToken: 'ps_sess_round_trip',
+        csrfToken: 'mock-csrf-token',
+        deviceToken: 'ps_dev_round_trip',
+        redirectTo: '/dashboard/drive_abc?auth=success',
+      }),
+    );
+  });
+
+  it('the same link opened in a browser signs that browser in by cookie, with no bearer tokens', async () => {
+    await sendPost(
+      buildSendRequest({
+        email: 'user@example.com',
+        tosAccepted: true,
+        platform: 'ios',
+        deviceId: 'dev_iphone',
+        deviceName: 'iOS App',
+      }),
+    );
+    const url = extractUrlFromEmailCall();
+    expect(url).toBe('https://example.com/auth/magic-link/tok_round_trip');
+    verifyMagicLinkTokenMock.mockResolvedValue({
+      ok: true,
+      data: { userId: 'user_test', isNewUser: false, metadata: persistedMetadata() },
+    });
+
+    const redeemResp = await verifyPost(
+      new Request('https://example.com/api/auth/magic-link/verify', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ token: 'tok_round_trip' }),
+      }),
+    );
+    const body = (await redeemResp.json()) as Record<string, unknown>;
+    expect(body.redirectTo).toBe('/dashboard?auth=success');
+    expect(body).not.toHaveProperty('sessionToken');
+    expect(body).not.toHaveProperty('deviceToken');
+  });
+
+  it('a link requested from a browser keeps the plain verify URL, which the app does not claim', async () => {
+    await sendPost(buildSendRequest({ email: 'user@example.com', tosAccepted: true }));
+
+    expect(extractUrlFromEmailCall()).toBe(
+      'https://example.com/api/auth/magic-link/verify?token=tok_round_trip',
+    );
+    expect(persistedMetadata()).toBeUndefined();
   });
 });

--- a/apps/web/src/app/api/auth/magic-link/send/__tests__/route.test.ts
+++ b/apps/web/src/app/api/auth/magic-link/send/__tests__/route.test.ts
@@ -515,6 +515,62 @@ describe('POST /api/auth/magic-link/send', () => {
     });
   });
 
+  describe('device-bound platforms', () => {
+    it.each(['ios', 'android', 'desktop'] as const)(
+      'given platform %s with a device, forwards platform + device fields to the pipe',
+      async (platform) => {
+        const request = createMagicLinkRequest({
+          email: 'test@example.com',
+          platform,
+          deviceId: 'dev_1',
+          deviceName: 'Some device',
+        });
+        const response = await POST(request);
+
+        expect(response.status).toBe(200);
+        expect(pipeInner).toHaveBeenCalledWith(
+          expect.objectContaining({ platform, deviceId: 'dev_1', deviceName: 'Some device' }),
+        );
+      },
+    );
+
+    it.each(['ios', 'android', 'desktop'] as const)(
+      'given platform %s without a deviceId, returns 400 — a device-bound link needs its device',
+      async (platform) => {
+        const request = createMagicLinkRequest({
+          email: 'test@example.com',
+          platform,
+          deviceName: 'Some device',
+        });
+        const response = await POST(request);
+
+        expect(response.status).toBe(400);
+        expect(pipeInner).not.toHaveBeenCalled();
+      },
+    );
+
+    it('given platform web, needs no device fields', async () => {
+      const request = createMagicLinkRequest({ email: 'test@example.com', platform: 'web' });
+      const response = await POST(request);
+
+      expect(response.status).toBe(200);
+      expect(pipeInner).toHaveBeenCalledWith(expect.objectContaining({ platform: 'web' }));
+    });
+
+    it('given an unknown platform, returns 400', async () => {
+      const request = createMagicLinkRequest({
+        email: 'test@example.com',
+        platform: 'watchos',
+        deviceId: 'dev_1',
+        deviceName: 'Watch',
+      });
+      const response = await POST(request);
+
+      expect(response.status).toBe(400);
+      expect(pipeInner).not.toHaveBeenCalled();
+    });
+  });
+
   describe('inviteToken binding', () => {
     it('given a valid inviteToken whose email matches, forwards inviteToken to the pipe', async () => {
       resolveInviteContextMock.mockResolvedValueOnce({

--- a/apps/web/src/app/api/auth/magic-link/send/route.ts
+++ b/apps/web/src/app/api/auth/magic-link/send/route.ts
@@ -17,15 +17,19 @@ import { INVITE_TOKEN_MAX_LENGTH } from '@/lib/auth/oauth-state';
 
 const sendMagicLinkSchema = z.object({
   email: z.email({ message: 'Please enter a valid email address' }),
-  platform: z.enum(['web', 'desktop']).optional(),
+  // A shell that redeems on a specific device (desktop, or the iOS / Android
+  // app via a universal link) binds the link to that device; a browser sends
+  // no platform and gets a cookie session.
+  platform: z.enum(['web', 'desktop', 'ios', 'android']).optional(),
   deviceId: z.string().optional(),
   deviceName: z.string().optional(),
   next: z.string().min(1).max(2048).optional(),
   inviteToken: z.string().min(1).max(INVITE_TOKEN_MAX_LENGTH).optional(),
   tosAccepted: z.boolean(),
 }).refine(
-  (data) => data.platform !== 'desktop' || (data.deviceId && data.deviceName),
-  { message: 'deviceId and deviceName are required for desktop platform' }
+  (data) =>
+    data.platform === undefined || data.platform === 'web' || (data.deviceId && data.deviceName),
+  { message: 'deviceId and deviceName are required for a device-bound platform' }
 );
 
 export async function POST(req: Request) {

--- a/apps/web/src/app/api/auth/magic-link/verify/__tests__/desktop-verify.test.ts
+++ b/apps/web/src/app/api/auth/magic-link/verify/__tests__/desktop-verify.test.ts
@@ -62,6 +62,9 @@ vi.mock('@pagespace/lib/auth/magic-link-service', () => ({
   verifyMagicLinkToken: vi.fn(),
 }));
 
+vi.mock('@pagespace/lib/auth/account-lockout', () => ({
+  resetFailedLoginAttempts: vi.fn().mockResolvedValue(undefined),
+}));
 vi.mock('@pagespace/lib/auth/verification-utils', () => ({
   markEmailVerified: vi.fn(),
 }));
@@ -120,6 +123,7 @@ vi.mock('@/lib/auth/native-invite-acceptance', () => ({
 import { GET } from '../route';
 import { verifyMagicLinkToken } from '@pagespace/lib/auth/magic-link-service';
 import { createExchangeCode } from '@pagespace/lib/auth/exchange-codes';
+import { validateOrCreateDeviceToken } from '@pagespace/lib/auth/device-auth-utils';
 import { appendSessionCookie } from '@/lib/auth/cookie-config';
 import { provisionHomeDriveIfNeeded } from '@pagespace/lib/onboarding/home-drive';
 
@@ -157,6 +161,14 @@ describe('GET /api/auth/magic-link/verify - desktop platform', () => {
     await GET(createVerifyRequest());
 
     expect(appendSessionCookie).toHaveBeenCalled();
+  });
+
+  it('mints the device token for desktop — the platform the link was bound to', async () => {
+    await GET(createVerifyRequest());
+
+    expect(validateOrCreateDeviceToken).toHaveBeenCalledWith(
+      expect.objectContaining({ platform: 'desktop', deviceId: 'dev-123', deviceName: 'My Mac' }),
+    );
   });
 
   it('creates exchange code with correct session token', async () => {

--- a/apps/web/src/app/api/auth/magic-link/verify/__tests__/desktop-verify.test.ts
+++ b/apps/web/src/app/api/auth/magic-link/verify/__tests__/desktop-verify.test.ts
@@ -95,7 +95,9 @@ vi.mock('@/lib/auth/cookie-config', () => ({
 }));
 
 vi.mock('@pagespace/lib/onboarding/home-drive', () => ({
-  provisionHomeDriveIfNeeded: vi.fn().mockResolvedValue(null),
+  // Shape matters: the route reads `.created`, so a bare null would make every
+  // test here take the provisioning catch instead of the real path.
+  provisionHomeDriveIfNeeded: vi.fn().mockResolvedValue({ driveId: 'home-drive', created: false }),
 }));
 
 vi.mock('@/lib/repositories/auth-repository', () => ({

--- a/apps/web/src/app/api/auth/magic-link/verify/__tests__/native-verify.test.ts
+++ b/apps/web/src/app/api/auth/magic-link/verify/__tests__/native-verify.test.ts
@@ -236,7 +236,7 @@ describe('POST /api/auth/magic-link/verify — native-bound link', () => {
     expect(body.redirectTo).toBe('/dashboard?auth=success');
     expect(appendSessionCookie).toHaveBeenCalledWith(expect.any(Headers), 'ps_sess_mock');
     expect(loggers.auth.info).toHaveBeenCalledWith(
-      'Magic link redeemed away from the device it was minted for',
+      'Magic link redeemed with no device handoff',
       expect.objectContaining({ platform: 'ios' }),
     );
   });

--- a/apps/web/src/app/api/auth/magic-link/verify/__tests__/native-verify.test.ts
+++ b/apps/web/src/app/api/auth/magic-link/verify/__tests__/native-verify.test.ts
@@ -1,0 +1,473 @@
+/**
+ * Tests for the in-app door: POST /api/auth/magic-link/verify, and how GET
+ * treats a link that was minted for the iOS / Android shell.
+ *
+ * A native-bound link always creates the cookie session. Bearer tokens for the
+ * Keychain are released only to the device the link was bound to — proven by
+ * the presented deviceId — so a browser opening the same link, or the wrong
+ * device, gets a cookie and nothing more.
+ */
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+
+vi.mock('next/server', () => ({
+  NextResponse: {
+    redirect: vi.fn((url: string, init?: { status?: number; headers?: Headers }) => {
+      const headers = init?.headers ?? new Headers();
+      return new Response(null, {
+        status: init?.status ?? 302,
+        headers: { ...Object.fromEntries(headers.entries()), Location: url },
+      });
+    }),
+    json: (body: unknown, init?: ResponseInit) => new Response(JSON.stringify(body), {
+      status: init?.status ?? 200,
+      headers: init?.headers ?? new Headers({ 'Content-Type': 'application/json' }),
+    }),
+  },
+}));
+
+vi.mock('@pagespace/lib/auth/session-service', () => ({
+  sessionService: {
+    createSession: vi.fn().mockResolvedValue('ps_sess_mock'),
+    validateSession: vi.fn().mockResolvedValue({
+      sessionId: 'mock-sid',
+      userId: 'user-1',
+      type: 'user',
+      scopes: ['*'],
+      userRole: 'user',
+      tokenVersion: 0,
+      adminRoleVersion: 0,
+      expiresAt: new Date(Date.now() + 86400000),
+    }),
+    revokeAllUserSessions: vi.fn().mockResolvedValue(0),
+    revokeWebUserSessions: vi.fn().mockResolvedValue(0),
+    revokeAdminUserSessions: vi.fn().mockResolvedValue(0),
+  },
+}));
+vi.mock('@pagespace/lib/auth/csrf-utils', () => ({
+  generateCSRFToken: vi.fn().mockReturnValue('mock-csrf'),
+}));
+vi.mock('@pagespace/lib/auth/constants', () => ({
+  SESSION_DURATION_MS: 604800000,
+}));
+vi.mock('@pagespace/lib/auth/exchange-codes', () => ({
+  createExchangeCode: vi.fn().mockResolvedValue('exchange-code-abc'),
+}));
+vi.mock('@pagespace/lib/auth/device-auth-utils', () => ({
+  validateOrCreateDeviceToken: vi.fn().mockResolvedValue({
+    deviceToken: 'ps_dev_native',
+    deviceTokenRecordId: 'dt-1',
+    isNew: true,
+  }),
+}));
+
+vi.mock('@pagespace/lib/auth/magic-link-service', () => ({
+  verifyMagicLinkToken: vi.fn(),
+}));
+
+vi.mock('@pagespace/lib/auth/account-lockout', () => ({
+  resetFailedLoginAttempts: vi.fn().mockResolvedValue(undefined),
+}));
+vi.mock('@pagespace/lib/auth/verification-utils', () => ({
+  markEmailVerified: vi.fn(),
+}));
+
+vi.mock('@pagespace/lib/logging/logger-config', () => ({
+  loggers: {
+    auth: { info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+    security: {
+      warn: vi.fn(),
+    },
+  },
+}));
+vi.mock('@pagespace/lib/audit/audit-log', () => ({
+  auditRequest: vi.fn(),
+}));
+
+vi.mock('@pagespace/lib/monitoring/activity-tracker', () => ({
+  trackAuthEvent: vi.fn(),
+}));
+
+vi.mock('@/lib/auth', () => ({
+  getClientIP: vi.fn().mockReturnValue('127.0.0.1'),
+  revokeSessionsForLogin: vi.fn().mockResolvedValue(0),
+}));
+
+vi.mock('@/lib/auth/cookie-config', () => ({
+  appendSessionCookie: vi.fn(),
+}));
+
+vi.mock('@pagespace/lib/onboarding/home-drive', () => ({
+  provisionHomeDriveIfNeeded: vi.fn().mockResolvedValue(null),
+}));
+
+vi.mock('@/lib/repositories/auth-repository', () => ({
+  authRepository: {
+    findUserById: vi.fn().mockResolvedValue({
+      id: 'user-1',
+      tokenVersion: 7,
+    }),
+  },
+}));
+
+vi.mock('@/lib/repositories/drive-invite-repository', () => ({
+  driveInviteRepository: {
+    findUserVerificationStatusById: vi
+      .fn()
+      .mockResolvedValue({ email: 'user@example.com', emailVerified: null, suspendedAt: null }),
+  },
+}));
+
+vi.mock('@/lib/auth/native-invite-acceptance', () => ({
+  consumeAnyInviteIfPresent: vi.fn().mockResolvedValue({ kind: null, invitedDriveId: null, invitedPageId: null, connectionId: null }),
+  consumeAllInvitesForEmail: vi.fn().mockResolvedValue({ drivesAccepted: 0, pagesAccepted: 0, connectionsCreated: 0 }),
+}));
+
+import { GET, POST } from '../route';
+import { verifyMagicLinkToken } from '@pagespace/lib/auth/magic-link-service';
+import { createExchangeCode } from '@pagespace/lib/auth/exchange-codes';
+import { validateOrCreateDeviceToken } from '@pagespace/lib/auth/device-auth-utils';
+import { sessionService } from '@pagespace/lib/auth/session-service';
+import { appendSessionCookie } from '@/lib/auth/cookie-config';
+import { revokeSessionsForLogin } from '@/lib/auth';
+import { auditRequest } from '@pagespace/lib/audit/audit-log';
+import { loggers } from '@pagespace/lib/logging/logger-config';
+
+const iosMetadata = JSON.stringify({
+  platform: 'ios',
+  deviceId: 'dev-ios-1',
+  deviceName: 'iOS App',
+});
+
+const redeem = (body: Record<string, unknown>) =>
+  POST(
+    new Request('http://localhost/api/auth/magic-link/verify', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(body),
+    }),
+  );
+
+const json = async (response: Response) => (await response.json()) as Record<string, unknown>;
+
+describe('POST /api/auth/magic-link/verify — native-bound link', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(verifyMagicLinkToken).mockResolvedValue({
+      ok: true,
+      data: { userId: 'user-1', isNewUser: false, metadata: iosMetadata },
+    });
+  });
+
+  it('given the bound device, returns bearer tokens, the cookie, and the landing path', async () => {
+    const response = await redeem({ token: 'ps_magic_valid', deviceId: 'dev-ios-1' });
+
+    expect(response.status).toBe(200);
+    const body = await json(response);
+    expect(body).toEqual(
+      expect.objectContaining({
+        sessionToken: 'ps_sess_mock',
+        csrfToken: 'mock-csrf',
+        deviceToken: 'ps_dev_native',
+        redirectTo: '/dashboard?auth=success',
+        isNewUser: false,
+        user: expect.objectContaining({ id: 'user-1' }),
+      }),
+    );
+    expect(appendSessionCookie).toHaveBeenCalledWith(expect.any(Headers), 'ps_sess_mock');
+    expect(response.headers.get('Set-Cookie')).toContain('csrf_token=mock-csrf');
+  });
+
+  it('mints the device token for the platform the link was bound to — never a default', async () => {
+    await redeem({ token: 'ps_magic_valid', deviceId: 'dev-ios-1' });
+
+    expect(validateOrCreateDeviceToken).toHaveBeenCalledWith(
+      expect.objectContaining({ platform: 'ios', deviceId: 'dev-ios-1', userId: 'user-1', tokenVersion: 7 }),
+    );
+    expect(createExchangeCode).not.toHaveBeenCalled();
+  });
+
+  it('scopes the session and the fixation revoke to the bound device', async () => {
+    await redeem({ token: 'ps_magic_valid', deviceId: 'dev-ios-1' });
+
+    expect(revokeSessionsForLogin).toHaveBeenCalledWith('user-1', 'dev-ios-1', 'magic_link_login', 'magic-link');
+    expect(sessionService.createSession).toHaveBeenCalledWith(expect.objectContaining({ deviceId: 'dev-ios-1' }));
+  });
+
+  it('records the platform on the audit trail', async () => {
+    await redeem({ token: 'ps_magic_valid', deviceId: 'dev-ios-1' });
+
+    expect(auditRequest).toHaveBeenCalledWith(
+      expect.any(Request),
+      expect.objectContaining({
+        eventType: 'auth.login.success',
+        details: { method: 'magic_link', platform: 'ios' },
+      }),
+    );
+  });
+
+  it('given an Android-bound link, mints an android device token and reports that platform', async () => {
+    vi.mocked(verifyMagicLinkToken).mockResolvedValue({
+      ok: true,
+      data: {
+        userId: 'user-1',
+        isNewUser: false,
+        metadata: JSON.stringify({ platform: 'android', deviceId: 'dev-pixel', deviceName: 'Android App' }),
+      },
+    });
+
+    const body = await json(await redeem({ token: 'ps_magic_valid', deviceId: 'dev-pixel' }));
+
+    expect(body).toEqual(expect.objectContaining({ deviceToken: 'ps_dev_native' }));
+    expect(validateOrCreateDeviceToken).toHaveBeenCalledWith(
+      expect.objectContaining({ platform: 'android', deviceId: 'dev-pixel' }),
+    );
+  });
+
+  it('given a different device, withholds bearer tokens but still signs the cookie session in', async () => {
+    const response = await redeem({ token: 'ps_magic_valid', deviceId: 'dev-someone-else' });
+
+    expect(response.status).toBe(200);
+    const body = await json(response);
+    expect(body).not.toHaveProperty('sessionToken');
+    expect(body).not.toHaveProperty('csrfToken');
+    expect(body).not.toHaveProperty('deviceToken');
+    expect(body.redirectTo).toBe('/dashboard?auth=success');
+    expect(appendSessionCookie).toHaveBeenCalledWith(expect.any(Headers), 'ps_sess_mock');
+    expect(loggers.auth.info).toHaveBeenCalledWith(
+      'Magic link redeemed away from the device it was minted for',
+      expect.objectContaining({ platform: 'ios' }),
+    );
+  });
+
+  it('given a different device, does NOT rotate the bound phone\'s device token', async () => {
+    // Minting overwrites the stored hash, so minting for an absent device
+    // would destroy the credential that phone is still holding — on iOS the
+    // only one it has.
+    await redeem({ token: 'ps_magic_valid', deviceId: 'dev-someone-else' });
+
+    expect(validateOrCreateDeviceToken).not.toHaveBeenCalled();
+  });
+
+  it('given a different device, does NOT revoke the bound phone\'s sessions by device', async () => {
+    await redeem({ token: 'ps_magic_valid', deviceId: 'dev-someone-else' });
+
+    expect(revokeSessionsForLogin).toHaveBeenCalledWith('user-1', undefined, 'magic_link_login', 'magic-link');
+    expect(sessionService.createSession).toHaveBeenCalledWith(
+      expect.objectContaining({ deviceId: undefined }),
+    );
+  });
+
+  it('given no device at all (a plain browser), withholds tokens and mints nothing', async () => {
+    const response = await redeem({ token: 'ps_magic_valid' });
+
+    const body = await json(response);
+    expect(body).not.toHaveProperty('sessionToken');
+    expect(body).not.toHaveProperty('deviceToken');
+    expect(validateOrCreateDeviceToken).not.toHaveBeenCalled();
+    expect(auditRequest).toHaveBeenCalledWith(
+      expect.any(Request),
+      expect.objectContaining({ details: { method: 'magic_link' } }),
+    );
+  });
+
+  it('given a new user on the bound device, flags welcome on the landing path', async () => {
+    vi.mocked(verifyMagicLinkToken).mockResolvedValue({
+      ok: true,
+      data: { userId: 'user-1', isNewUser: true, metadata: iosMetadata },
+    });
+
+    const body = await json(await redeem({ token: 'ps_magic_valid', deviceId: 'dev-ios-1' }));
+
+    expect(body.redirectTo).toBe('/dashboard?auth=success&welcome=true');
+    expect(body.isNewUser).toBe(true);
+  });
+
+  it('honours a safe next and drops an unsafe one', async () => {
+    const safe = await json(await redeem({ token: 'ps_magic_valid', deviceId: 'dev-ios-1', next: '/dashboard/d1' }));
+    expect(safe.redirectTo).toBe('/dashboard/d1?auth=success');
+
+    vi.clearAllMocks();
+    vi.mocked(verifyMagicLinkToken).mockResolvedValue({
+      ok: true,
+      data: { userId: 'user-1', isNewUser: false, metadata: iosMetadata },
+    });
+    const unsafe = await json(await redeem({ token: 'ps_magic_valid', deviceId: 'dev-ios-1', next: '//evil.example/x' }));
+    expect(unsafe.redirectTo).toBe('/dashboard?auth=success');
+  });
+
+  it('given the device-token mint fails, degrades to the cookie session instead of failing the login', async () => {
+    vi.mocked(validateOrCreateDeviceToken).mockRejectedValueOnce(new Error('keystore down'));
+
+    const response = await redeem({ token: 'ps_magic_valid', deviceId: 'dev-ios-1' });
+
+    expect(response.status).toBe(200);
+    const body = await json(response);
+    expect(body).not.toHaveProperty('sessionToken');
+    // No user either: the caller must not read this as "signed in on this device".
+    expect(body.user).toBeNull();
+    expect(appendSessionCookie).toHaveBeenCalledWith(expect.any(Headers), 'ps_sess_mock');
+    expect(loggers.auth.warn).toHaveBeenCalledWith(
+      'Failed to create device handoff for magic link',
+      expect.objectContaining({ platform: 'ios' }),
+    );
+  });
+});
+
+describe('POST /api/auth/magic-link/verify — links with no device binding', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('given a plain web link, signs the cookie session in and mints no device token', async () => {
+    vi.mocked(verifyMagicLinkToken).mockResolvedValue({
+      ok: true,
+      data: { userId: 'user-1', isNewUser: false },
+    });
+
+    const response = await redeem({ token: 'ps_magic_valid', deviceId: 'dev-ios-1' });
+
+    expect(response.status).toBe(200);
+    const body = await json(response);
+    expect(body).not.toHaveProperty('sessionToken');
+    expect(body.user).toBeNull();
+    expect(validateOrCreateDeviceToken).not.toHaveBeenCalled();
+    expect(appendSessionCookie).toHaveBeenCalledWith(expect.any(Headers), 'ps_sess_mock');
+  });
+
+  it('given a platform this build does not know, treats it as unbound', async () => {
+    vi.mocked(verifyMagicLinkToken).mockResolvedValue({
+      ok: true,
+      data: {
+        userId: 'user-1',
+        isNewUser: false,
+        metadata: JSON.stringify({ platform: 'watchos', deviceId: 'dev-ios-1' }),
+      },
+    });
+
+    const body = await json(await redeem({ token: 'ps_magic_valid', deviceId: 'dev-ios-1' }));
+
+    expect(body).not.toHaveProperty('sessionToken');
+    expect(validateOrCreateDeviceToken).not.toHaveBeenCalled();
+    expect(revokeSessionsForLogin).toHaveBeenCalledWith('user-1', undefined, 'magic_link_login', 'magic-link');
+  });
+
+  it('given a desktop-bound link, mints nothing — the desktop handoff belongs to the emailed GET', async () => {
+    vi.mocked(verifyMagicLinkToken).mockResolvedValue({
+      ok: true,
+      data: {
+        userId: 'user-1',
+        isNewUser: false,
+        metadata: JSON.stringify({ platform: 'desktop', deviceId: 'dev-mac' }),
+      },
+    });
+
+    await redeem({ token: 'ps_magic_valid', deviceId: 'dev-mac' });
+
+    // A one-time code carrying session + CSRF + device tokens must never be
+    // created for a door that cannot hand it to anyone.
+    expect(createExchangeCode).not.toHaveBeenCalled();
+    expect(validateOrCreateDeviceToken).not.toHaveBeenCalled();
+  });
+
+  it('given a desktop-bound link, answers the cookie session only — the exchange code stays on GET', async () => {
+    vi.mocked(verifyMagicLinkToken).mockResolvedValue({
+      ok: true,
+      data: {
+        userId: 'user-1',
+        isNewUser: false,
+        metadata: JSON.stringify({ platform: 'desktop', deviceId: 'dev-mac' }),
+      },
+    });
+
+    const body = await json(await redeem({ token: 'ps_magic_valid', deviceId: 'dev-mac' }));
+
+    expect(body).not.toHaveProperty('sessionToken');
+    expect(body).not.toHaveProperty('exchangeCode');
+    expect(body.redirectTo).toBe('/dashboard?auth=success');
+  });
+});
+
+describe('POST /api/auth/magic-link/verify — failures', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it.each([
+    ['TOKEN_EXPIRED', 'magic_link_expired', 401],
+    ['TOKEN_ALREADY_USED', 'magic_link_used', 401],
+    ['TOKEN_NOT_FOUND', 'invalid_token', 401],
+    ['USER_SUSPENDED', 'account_suspended', 403],
+  ] as const)('maps %s to { error: %s } with status %i', async (code, error, status) => {
+    vi.mocked(verifyMagicLinkToken).mockResolvedValue({
+      ok: false,
+      error: { code, message: 'nope' },
+    } as Awaited<ReturnType<typeof verifyMagicLinkToken>>);
+
+    const response = await redeem({ token: 'ps_magic_bad', deviceId: 'dev-ios-1' });
+
+    expect(response.status).toBe(status);
+    expect(await json(response)).toEqual({ error });
+    expect(sessionService.createSession).not.toHaveBeenCalled();
+    expect(appendSessionCookie).not.toHaveBeenCalled();
+  });
+
+  it('rejects a body with no token', async () => {
+    const response = await redeem({ deviceId: 'dev-ios-1' });
+
+    expect(response.status).toBe(400);
+    expect(verifyMagicLinkToken).not.toHaveBeenCalled();
+  });
+
+  it('rejects a body that is not JSON', async () => {
+    const response = await POST(
+      new Request('http://localhost/api/auth/magic-link/verify', { method: 'POST', body: 'not json' }),
+    );
+
+    expect(response.status).toBe(400);
+  });
+
+  it('answers 500 with no cookie when the core throws', async () => {
+    vi.mocked(verifyMagicLinkToken).mockRejectedValue(new Error('db down'));
+
+    const response = await redeem({ token: 'ps_magic_valid' });
+
+    expect(response.status).toBe(500);
+    expect(await json(response)).toEqual({ error: 'server_error' });
+    expect(appendSessionCookie).not.toHaveBeenCalled();
+  });
+});
+
+describe('GET /api/auth/magic-link/verify — native-bound link opened in a browser', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(verifyMagicLinkToken).mockResolvedValue({
+      ok: true,
+      data: { userId: 'user-1', isNewUser: false, metadata: iosMetadata },
+    });
+  });
+
+  it('mints no device token — the phone is not here, and minting would rotate its credential', async () => {
+    await GET(
+      new Request('http://localhost/api/auth/magic-link/verify?token=ps_magic_valid', { method: 'GET' }),
+    );
+
+    expect(validateOrCreateDeviceToken).not.toHaveBeenCalled();
+    expect(revokeSessionsForLogin).toHaveBeenCalledWith('user-1', undefined, 'magic_link_login', 'magic-link');
+  });
+
+  it('signs the browser in with a cookie and never puts a token in the redirect', async () => {
+    const response = await GET(
+      new Request('http://localhost/api/auth/magic-link/verify?token=ps_magic_valid', { method: 'GET' }),
+    );
+
+    expect(response.status).toBe(302);
+    const location = response.headers.get('Location') || '';
+    expect(location).toContain('/dashboard');
+    expect(location).toContain('auth=success');
+    expect(location).not.toContain('desktopExchange');
+    expect(location).not.toContain('ps_dev_native');
+    expect(location).not.toContain('ps_sess_mock');
+    expect(createExchangeCode).not.toHaveBeenCalled();
+    expect(appendSessionCookie).toHaveBeenCalledWith(expect.any(Headers), 'ps_sess_mock');
+  });
+});

--- a/apps/web/src/app/api/auth/magic-link/verify/__tests__/native-verify.test.ts
+++ b/apps/web/src/app/api/auth/magic-link/verify/__tests__/native-verify.test.ts
@@ -97,7 +97,9 @@ vi.mock('@/lib/auth/cookie-config', () => ({
 }));
 
 vi.mock('@pagespace/lib/onboarding/home-drive', () => ({
-  provisionHomeDriveIfNeeded: vi.fn().mockResolvedValue(null),
+  // Shape matters: the route reads `.created`, so a bare null would make every
+  // test here take the provisioning catch instead of the real path.
+  provisionHomeDriveIfNeeded: vi.fn().mockResolvedValue({ driveId: 'home-drive', created: false }),
 }));
 
 vi.mock('@/lib/repositories/auth-repository', () => ({
@@ -382,7 +384,7 @@ describe('POST /api/auth/magic-link/verify — links with no device binding', ()
     const body = await json(await redeem({ token: 'ps_magic_valid', deviceId: 'dev-mac' }));
 
     expect(body).not.toHaveProperty('sessionToken');
-    expect(body).not.toHaveProperty('exchangeCode');
+    expect(body).not.toHaveProperty('deviceToken');
     expect(body.redirectTo).toBe('/dashboard?auth=success');
   });
 });

--- a/apps/web/src/app/api/auth/magic-link/verify/route.ts
+++ b/apps/web/src/app/api/auth/magic-link/verify/route.ts
@@ -48,13 +48,21 @@ import {
  * shape the response. Device metadata is normalised once into a closed union —
  * a platform the switch does not name gets nothing.
  *
- * A device token is minted ONLY for a device that is actually redeeming, never
- * for the one that merely asked. Minting is a rotation
- * (`atomicValidateOrCreateDeviceToken` overwrites the stored hash), so minting
- * on behalf of an absent device would invalidate the credential that device is
- * still holding — and on iOS the Keychain bearer is the only credential, so
- * that would sign the phone out whenever its own link was opened in a browser,
- * which is the common case.
+ * Minting a device token is a ROTATION —
+ * `atomicValidateOrCreateDeviceToken` overwrites the stored hash of the
+ * existing row — so minting on behalf of a device that is not making the
+ * request invalidates the credential that device is still holding. A mobile
+ * shell must therefore prove it is the redeemer before anything is minted for
+ * it: on iOS the Keychain bearer is the only credential it has, so minting at
+ * binding time would sign the phone out whenever its own link was opened in a
+ * browser — the common case, not the edge case.
+ *
+ * Desktop is the deliberate exception, unchanged from before this door
+ * existed: its handoff has always ridden the emailed GET, so any browser that
+ * opens a desktop-bound link rotates that desktop's token. That is a
+ * pre-existing wart (the Electron app recovers because it also holds a cookie
+ * session), and narrowing it is a separate change from this one — it would
+ * alter desktop sign-in, which this PR does not touch.
  */
 
 const verifyTokenSchema = z.object({
@@ -157,24 +165,12 @@ export async function GET(req: Request) {
       });
     }
 
-    // Log auth event
-    trackAuthEvent(result.userId, 'magic_link_login', {
-      ip: clientIP,
-      isNewUser: result.isNewUser,
-      userAgent: req.headers.get('user-agent'),
-    });
-
     const effectiveRedirectPath = await applyPasskeyFunnel(result.userId, result.redirectPath);
     const redirectUrl = new URL(effectiveRedirectPath, baseUrl);
     redirectUrl.searchParams.set('auth', 'success');
     applyRedirectParams(redirectUrl, result.redirectParams);
 
-    auditRequest(req, {
-      eventType: 'auth.login.success',
-      userId: result.userId,
-      sessionId: result.sessionId,
-      details: { method: 'magic_link' },
-    });
+    recordLoginSuccess({ req, result, clientIP, platform: undefined });
     loggers.auth.info('Magic link login successful', {
       userId: result.userId,
       isNewUser: result.isNewUser,
@@ -272,7 +268,7 @@ export async function POST(req: Request) {
 /**
  * Verify the token, sign the user in, and describe what each door may hand
  * out. Every access decision is here; nothing below the switch on
- * `confirmedDevice.platform` grants a device anything the switch did not name.
+ * `handoffDevice.platform` grants a device anything the switch did not name.
  */
 async function redeemMagicLink({
   req,
@@ -352,8 +348,8 @@ async function redeemMagicLink({
   }
 
   const deviceMeta = normalizeDeviceMeta(parsedMeta);
-  const confirmedDevice = confirmRedeemingDevice(deviceMeta, door);
-  if (deviceMeta && !confirmedDevice) {
+  const handoffDevice = handoffDeviceFor(deviceMeta, door);
+  if (deviceMeta && !handoffDevice) {
     loggers.auth.info('Magic link redeemed away from the device it was minted for', {
       userId,
       platform: deviceMeta.platform,
@@ -367,7 +363,7 @@ async function redeemMagicLink({
   // cross-device email link cannot identify the device, so the helper falls
   // back to the legacy all-web-session revoke. Admin-console sessions are scoped
   // separately and left intact.
-  await revokeSessionsForLogin(userId, confirmedDevice?.deviceId, 'magic_link_login', 'magic-link');
+  await revokeSessionsForLogin(userId, handoffDevice?.deviceId, 'magic_link_login', 'magic-link');
 
   // Mark email as verified (idempotent for existing users)
   try {
@@ -383,7 +379,7 @@ async function redeemMagicLink({
     type: 'user',
     scopes: ['*'],
     expiresInMs: SESSION_DURATION_MS,
-    deviceId: confirmedDevice?.deviceId,
+    deviceId: handoffDevice?.deviceId,
     createdByIp: clientIP !== 'unknown' ? clientIP : undefined,
   });
 
@@ -490,7 +486,7 @@ async function redeemMagicLink({
   // degrades to the cookie session, never to no session.
   let handoff: Handoff = { kind: 'none' };
   let user: PublicUser | null = null;
-  if (confirmedDevice) {
+  if (handoffDevice) {
     try {
       const userRow = await authRepository.findUserById(userId);
       if (userRow) {
@@ -504,18 +500,18 @@ async function redeemMagicLink({
         const { deviceToken } = await validateOrCreateDeviceToken({
           providedDeviceToken: undefined,
           userId,
-          deviceId: confirmedDevice.deviceId,
-          platform: confirmedDevice.platform,
+          deviceId: handoffDevice.deviceId,
+          platform: handoffDevice.platform,
           tokenVersion: userRow.tokenVersion,
           deviceName:
-            confirmedDevice.deviceName ||
+            handoffDevice.deviceName ||
             req.headers.get('user-agent') ||
-            defaultDeviceName(confirmedDevice.platform),
+            defaultDeviceName(handoffDevice.platform),
           userAgent: req.headers.get('user-agent') || undefined,
           ipAddress: clientIP !== 'unknown' ? clientIP : undefined,
         });
 
-        switch (confirmedDevice.platform) {
+        switch (handoffDevice.platform) {
           case 'desktop': {
             const exchangeCode = await createExchangeCode({
               sessionToken,
@@ -525,15 +521,15 @@ async function redeemMagicLink({
               userId,
               createdAt: Date.now(),
             });
-            handoff = { kind: 'desktop', deviceId: confirmedDevice.deviceId, exchangeCode };
+            handoff = { kind: 'desktop', deviceId: handoffDevice.deviceId, exchangeCode };
             break;
           }
           case 'ios':
           case 'android':
             handoff = {
               kind: 'native',
-              platform: confirmedDevice.platform,
-              deviceId: confirmedDevice.deviceId,
+              platform: handoffDevice.platform,
+              deviceId: handoffDevice.deviceId,
               deviceToken,
             };
             break;
@@ -542,7 +538,7 @@ async function redeemMagicLink({
     } catch (error) {
       loggers.auth.warn('Failed to create device handoff for magic link', {
         userId,
-        platform: confirmedDevice.platform,
+        platform: handoffDevice.platform,
         error: error instanceof Error ? error.message : String(error),
       });
       // Fall through to the cookie session, and do not report a user the
@@ -586,18 +582,29 @@ function normalizeDeviceMeta(parsed: MagicLinkMetadata | null): DeviceMagicLinkM
 }
 
 /**
- * Is the client making THIS request the device the link was minted for?
+ * Which device, if any, this request may have a handoff minted for.
  *
- * The one place that question is answered, because minting a device token is a
- * rotation: answering "yes" for a device that is not here destroys the
- * credential it still holds. `null` means no device handoff at all — the
- * redeemer still gets the ordinary cookie session.
+ * The one place that decision is made, because minting rotates the stored
+ * hash. `null` means no device handoff at all — the redeemer still gets the
+ * ordinary cookie session.
  *
- * Desktop is unchanged from before this door existed: its handoff is the
- * exchange code on the emailed GET, which only the desktop app can complete.
- * A mobile shell has to prove itself by presenting the device id it holds.
+ * The two platforms answer it differently, and the difference is the point:
+ *
+ * - A **mobile shell must prove it is the redeemer**, by presenting the device
+ *   id it holds. Nothing is minted for a phone that is not making the request.
+ * - **Desktop does not prove anything**, and is eligible on any browser that
+ *   opens the emailed link. That is the pre-existing behaviour, kept
+ *   deliberately: the exchange code has always ridden the emailed GET. It is
+ *   weaker than the mobile rule — see the note at the top of this file.
+ *
+ * `deviceId` is the mobile proof, so it is load-bearing here in a way it was
+ * not before: whoever holds both the magic-link token and the bound device id
+ * can obtain that device's bearer tokens. Both come from the same place (the
+ * app that requested the link), the token is single-use and short-lived, and
+ * no endpoint echoes a device id back to a caller — but a future change that
+ * exposed device ids would weaken this, and should reckon with it here.
  */
-function confirmRedeemingDevice(
+function handoffDeviceFor(
   deviceMeta: DeviceMagicLinkMetadata | null,
   door: Door,
 ): DeviceMagicLinkMetadata | null {

--- a/apps/web/src/app/api/auth/magic-link/verify/route.ts
+++ b/apps/web/src/app/api/auth/magic-link/verify/route.ts
@@ -7,7 +7,7 @@ import { createExchangeCode } from '@pagespace/lib/auth/exchange-codes';
 import { validateOrCreateDeviceToken } from '@pagespace/lib/auth/device-auth-utils';
 import {
   verifyMagicLinkToken,
-  type DesktopMagicLinkMetadata,
+  type DeviceMagicLinkMetadata,
   type MagicLinkMetadata,
 } from '@pagespace/lib/auth/magic-link-service';
 import { markEmailVerified } from '@pagespace/lib/auth/verification-utils';
@@ -31,9 +31,80 @@ import {
   type NativeInviteAcceptanceResult,
 } from '@/lib/auth/native-invite-acceptance';
 
+/**
+ * Magic-link redemption has one core and two doors.
+ *
+ * - `GET ?token=` is the emailed link for a browser (and the desktop app):
+ *   it sets the session cookie and redirects. A desktop-bound link
+ *   additionally carries an exchange code for the Electron handoff.
+ * - `POST { token }` is called by the in-app page a universal link opens
+ *   (`/auth/magic-link/[token]`). It sets the same cookie and answers JSON,
+ *   and — only to the device the link was minted for — hands back bearer
+ *   tokens for the Keychain, the same shape `/api/auth/{apple,google}/native`
+ *   return. The WebView never sees a cookie Safari set, so without this a
+ *   magic link cannot sign the app in at all.
+ *
+ * Everything that grants access lives in `redeemMagicLink`; the doors only
+ * shape the response. Device metadata is normalised once into a closed union —
+ * a platform the switch does not name gets nothing.
+ *
+ * A device token is minted ONLY for a device that is actually redeeming, never
+ * for the one that merely asked. Minting is a rotation
+ * (`atomicValidateOrCreateDeviceToken` overwrites the stored hash), so minting
+ * on behalf of an absent device would invalidate the credential that device is
+ * still holding — and on iOS the Keychain bearer is the only credential, so
+ * that would sign the phone out whenever its own link was opened in a browser,
+ * which is the common case.
+ */
+
 const verifyTokenSchema = z.object({
   token: z.string().min(1, 'Token is required'),
 });
+
+const redeemBodySchema = z.object({
+  token: z.string().min(1, 'Token is required'),
+  next: z.string().min(1).max(2048).optional(),
+  // The redeeming device's own id. Bearer tokens are released only when it
+  // equals the id the link was bound to at mint time.
+  deviceId: z.string().min(1).max(200).optional(),
+});
+
+/** Which door is redeeming — it decides which handoffs are even possible. */
+type Door =
+  /** The emailed link, opened in a browser (or by the desktop shell). */
+  | { kind: 'browser' }
+  /** The in-app page, presenting the device id it holds. */
+  | { kind: 'in-app'; presentedDeviceId: string | undefined };
+
+type Handoff =
+  | { kind: 'none' }
+  | { kind: 'desktop'; deviceId: string; exchangeCode: string }
+  | { kind: 'native'; platform: 'ios' | 'android'; deviceId: string; deviceToken: string };
+
+interface PublicUser {
+  id: string;
+  name: string | null;
+  email: string | null;
+  image: string | null;
+  emailVerified: Date | null;
+}
+
+type RedeemResult =
+  | { ok: false; errorCode: string }
+  | {
+      ok: true;
+      userId: string;
+      isNewUser: boolean;
+      sessionId: string;
+      sessionToken: string;
+      csrfToken: string;
+      /** Where the user lands, before any `?auth=success` decoration. */
+      redirectPath: string;
+      /** The decoration: invite outcome flags every door appends. */
+      redirectParams: Record<string, string>;
+      user: PublicUser | null;
+      handoff: Handoff;
+    };
 
 export async function GET(req: Request) {
   try {
@@ -42,11 +113,7 @@ export async function GET(req: Request) {
     const token = searchParams.get('token');
     // Re-validate next at the verify boundary — never trust the param across
     // the email round-trip even though the send route already validated.
-    const rawNext = searchParams.get('next');
-    const safeNext =
-      rawNext && isSafeNextPath({ path: rawNext, allowedPrefixes: SIGNIN_NEXT_ALLOWED_PREFIXES })
-        ? rawNext
-        : undefined;
+    const safeNext = resolveSafeNext(searchParams.get('next'));
 
     // Validate token format
     const validation = verifyTokenSchema.safeParse({ token });
@@ -54,346 +121,597 @@ export async function GET(req: Request) {
       return redirectWithError('invalid_token', req.url);
     }
 
-    // Verify the magic link token
-    const result = await verifyMagicLinkToken({ token: validation.data.token });
-
-    if (!result.ok) {
-      const errorMap: Record<string, string> = {
-        'TOKEN_EXPIRED': 'magic_link_expired',
-        'TOKEN_ALREADY_USED': 'magic_link_used',
-        'TOKEN_NOT_FOUND': 'invalid_token',
-        'USER_SUSPENDED': 'account_suspended',
-        'VALIDATION_FAILED': 'invalid_token',
-      };
-
-      const errorCode = errorMap[result.error.code] || 'invalid_token';
-      loggers.auth.warn('Magic link verification failed', {
-        error: result.error.code,
-        ip: clientIP,
-      });
-      auditRequest(req, {
-        eventType: 'auth.login.failure',
-        riskScore: 0.3,
-        details: { reason: `magic_link_${result.error.code.toLowerCase()}` },
-      });
-
-      // IP-keyed anomaly alerting (#977) — distinct from account lockout. Counts
-      // failures per source IP (Postgres-backed) and emits a brute-force/anomaly
-      // audit event when one IP crosses the threshold. Fire-and-forget and
-      // IP-scoped, so (consistent with the no-self-lockout design above) it can
-      // never lock out a legitimate user; it only raises a monitoring signal.
-      void reportAuthFailure({
-        identifier: clientIP,
-        ipAddress: clientIP,
-        endpoint: 'magic-link/verify',
-      }).catch(() => {
-        /* monitoring must never break the auth path */
-      });
-
-      return redirectWithError(errorCode, req.url);
-    }
-
-    const { userId, isNewUser, metadata } = result.data;
-
-    // Account-lockout recovery path. A valid, freshly-issued magic link proves
-    // the real user requested it, so it ALWAYS signs them in and clears any
-    // lock — even one set by failed passkey attempts. This is what makes the
-    // lockout safe against a denial-of-service: an attacker can never lock a
-    // victim out of their account because the magic-link channel is never
-    // blocked. We deliberately do NOT record failed magic-link verifications:
-    // a failed token carries no account identity to attribute (only the
-    // already-administrative USER_SUSPENDED does), and benign expired/used-link
-    // clicks would self-lock legitimate users for zero attacker-facing benefit.
-    await resetFailedLoginAttempts(userId);
-
-    // Parse metadata once. The shape carries optional desktop fields and an
-    // optional invite-token binding — desktop and invite can co-exist on the
-    // same row (invited user signing in from desktop).
-    let parsedMeta: MagicLinkMetadata | null = null;
-    if (metadata) {
-      try {
-        parsedMeta = JSON.parse(metadata) as MagicLinkMetadata;
-      } catch {
-        loggers.auth.warn('Invalid magic link metadata JSON', { userId, metadata: metadata.slice(0, 100) });
-      }
-    }
-
-    let desktopMeta: DesktopMagicLinkMetadata | null = null;
-    if (parsedMeta && parsedMeta.platform === 'desktop' && parsedMeta.deviceId) {
-      desktopMeta = {
-        platform: 'desktop',
-        deviceId: parsedMeta.deviceId,
-        ...(parsedMeta.deviceName !== undefined && { deviceName: parsedMeta.deviceName }),
-      };
-    }
-    const boundInviteToken = parsedMeta?.inviteToken;
-
-    // SESSION FIXATION PREVENTION: Revoke prior sessions before creating a new
-    // one. Scope to the desktop device when the magic link carries a deviceId; a
-    // cross-device email link cannot identify the device, so the helper falls
-    // back to the legacy all-web-session revoke. Admin-console sessions are scoped
-    // separately and left intact.
-    await revokeSessionsForLogin(userId, desktopMeta?.deviceId, 'magic_link_login', 'magic-link');
-
-    // Mark email as verified (idempotent for existing users)
-    try {
-      await markEmailVerified(userId);
-    } catch (error) {
-      loggers.auth.error('Failed to mark email as verified', error as Error, { userId });
-      // Continue with login anyway - email verification is secondary
-    }
-
-    // Create new session
-    const sessionToken = await sessionService.createSession({
-      userId,
-      type: 'user',
-      scopes: ['*'],
-      expiresInMs: SESSION_DURATION_MS,
-      deviceId: desktopMeta?.deviceId,
-      createdByIp: clientIP !== 'unknown' ? clientIP : undefined,
+    const result = await redeemMagicLink({
+      req,
+      token: validation.data.token,
+      safeNext,
+      clientIP,
+      door: { kind: 'browser' },
     });
-
-    // Validate session to get claims for CSRF generation
-    const sessionClaims = await sessionService.validateSession(sessionToken);
-    if (!sessionClaims) {
-      loggers.auth.error('Failed to validate newly created session', { userId });
-      return redirectWithError('session_error', req.url);
+    if (!result.ok) {
+      return redirectWithError(result.errorCode, req.url);
     }
 
-    // Generate CSRF token bound to session ID
-    const csrfToken = generateCSRFToken(sessionClaims.sessionId);
+    const baseUrl = resolveBaseUrl(req);
 
-    // Consume the invite atomically with authentication. The invite token was
-    // bound to the magic-link at mint time, validated against this email +
-    // pending-invite state then. We re-load the user's verification status
-    // here because the pipe needs the authoritative email + suspendedAt for
-    // the second validation gate inside acceptInviteForExistingUser.
-    //
-    // Wrapped in try/catch: the session is already committed; a DB blip on
-    // the verification-status lookup must not redirect the user to signin
-    // when they already hold a valid session. Worst case the invite stays
-    // pending and the user reclaims it from the consent page.
-    let inviteResult: NativeInviteAcceptanceResult | null = null;
-    let inviteError: string | null = null;
-    try {
-      const status = await driveInviteRepository.findUserVerificationStatusById(userId);
-      if (status) {
-        if (boundInviteToken) {
-          inviteResult = await consumeAnyInviteIfPresent({
-            request: req,
-            inviteToken: boundInviteToken,
-            user: { id: userId, suspendedAt: status.suspendedAt },
-            isNewUser,
-            email: status.email,
-          });
-          if (inviteResult.inviteError) {
-            inviteError = inviteResult.inviteError;
-            loggers.auth.info('Bound invite acceptance failed during magic link verify', {
-              userId,
-              reason: inviteResult.inviteError,
-            });
-          }
-        }
-        await consumeAllInvitesForEmail({
-          request: req,
-          email: status.email,
-          user: { id: userId, suspendedAt: status.suspendedAt },
-          now: new Date(),
-        });
-      } else {
-        loggers.auth.warn('Authenticated session has no user record on invite consume', {
-          userId,
-        });
+    // DESKTOP: the web session (cookies) is always created — this is a
+    // supplementary handoff. If the link opens outside the desktop device, the
+    // exchange code is ignored and the cookie session still works.
+    if (result.handoff.kind === 'desktop') {
+      // Redirect to the dashboard with exchange code — the dashboard page
+      // will detect this and trigger pagespace://auth-exchange client-side.
+      const desktopRedirectUrl = new URL(result.redirectPath, baseUrl);
+      desktopRedirectUrl.searchParams.set('auth', 'success');
+      desktopRedirectUrl.searchParams.set('desktopExchange', result.handoff.exchangeCode);
+      if (result.isNewUser) {
+        desktopRedirectUrl.searchParams.set('welcome', 'true');
       }
-    } catch (error) {
-      loggers.auth.error('Invite consume threw during magic link verify', error as Error, {
-        userId,
+      applyRedirectParams(desktopRedirectUrl, result.redirectParams);
+
+      recordLoginSuccess({ req, result, clientIP, platform: 'desktop' });
+      loggers.auth.info('Magic link login successful (desktop)', { userId: result.userId, ip: clientIP });
+
+      return NextResponse.redirect(desktopRedirectUrl.toString(), {
+        status: 302,
+        headers: buildSessionHeaders(result),
       });
-      // Continue with login — the session is valid; user can re-attempt invite.
-    }
-    const invitedDriveId = inviteResult?.invitedDriveId ?? null;
-
-    // Provision the Home drive unconditionally — idempotent, and run BEFORE the
-    // redirect branches so every login provisions, including page/connection
-    // invite logins whose redirect never consults the shared resolver below.
-    // Errors are logged and swallowed: the session is valid, and the next login
-    // through any auth path retries provisioning.
-    let provisionedDriveId: string | null = null;
-    try {
-      const provisionResult = await provisionHomeDriveIfNeeded(userId);
-      if (provisionResult.created) {
-        provisionedDriveId = provisionResult.driveId;
-      }
-    } catch (error) {
-      loggers.auth.error('Failed to provision Home drive', error as Error, { userId });
-    }
-
-    // DESKTOP: additionally create device token + exchange code for desktop token handoff
-    // The web session (cookies) is always created above — this is a supplementary step.
-    // If the magic link opens outside the desktop device, the cookie session still works.
-    if (desktopMeta) {
-      try {
-        const user = await authRepository.findUserById(userId);
-        if (user) {
-          const { deviceToken } = await validateOrCreateDeviceToken({
-            providedDeviceToken: undefined,
-            userId,
-            deviceId: desktopMeta.deviceId!,
-            platform: 'desktop',
-            tokenVersion: user.tokenVersion,
-            deviceName: desktopMeta.deviceName || req.headers.get('user-agent') || 'Desktop App',
-            userAgent: req.headers.get('user-agent') || undefined,
-            ipAddress: clientIP !== 'unknown' ? clientIP : undefined,
-          });
-
-          const exchangeCode = await createExchangeCode({
-            sessionToken,
-            csrfToken,
-            deviceToken,
-            provider: 'magic-link',
-            userId,
-            createdAt: Date.now(),
-          });
-
-          // Redirect to the dashboard with exchange code — the dashboard page
-          // will detect this and trigger pagespace://auth-exchange client-side.
-          // If the link was opened on a different device, the exchange code is
-          // ignored and the user still has a valid cookie session.
-          const baseUrl = process.env.WEB_APP_URL || process.env.NEXT_PUBLIC_APP_URL || new URL(req.url).origin;
-          const desktopRedirectPath =
-            inviteResult?.kind === 'connection'
-              ? '/dashboard/connections'
-              : inviteResult?.kind === 'page' && invitedDriveId && inviteResult.invitedPageId
-                ? `/dashboard/${invitedDriveId}/pages/${inviteResult.invitedPageId}`
-                : resolvePostLoginRedirectPath({
-                    provisionedDriveId, next: safeNext, invitedDriveId,
-                  });
-          const desktopRedirectUrl = new URL(desktopRedirectPath, baseUrl);
-          desktopRedirectUrl.searchParams.set('auth', 'success');
-          desktopRedirectUrl.searchParams.set('desktopExchange', exchangeCode);
-          if (isNewUser) {
-            desktopRedirectUrl.searchParams.set('welcome', 'true');
-          }
-          if (inviteResult?.kind === 'connection') {
-            desktopRedirectUrl.searchParams.set('connection_requested', '1');
-          } else if (invitedDriveId) {
-            desktopRedirectUrl.searchParams.set('invited', '1');
-          } else if (inviteError) {
-            desktopRedirectUrl.searchParams.set('inviteError', inviteError);
-          }
-
-          auditRequest(req, {
-            eventType: 'auth.login.success',
-            userId,
-            sessionId: sessionClaims.sessionId,
-            details: { method: 'magic_link', platform: 'desktop' },
-          });
-          trackAuthEvent(userId, 'magic_link_login', {
-            ip: clientIP,
-            isNewUser,
-            platform: 'desktop',
-            userAgent: req.headers.get('user-agent'),
-          });
-
-          loggers.auth.info('Magic link login successful (desktop)', { userId, ip: clientIP });
-
-          const headers = new Headers();
-          appendSessionCookie(headers, sessionToken);
-          const isProduction = process.env.NODE_ENV === 'production';
-          const secureFlag = isProduction ? '; Secure' : '';
-          headers.append('Set-Cookie', `csrf_token=${csrfToken}; Path=/; HttpOnly=false; SameSite=Lax; Max-Age=60${secureFlag}`);
-
-          return NextResponse.redirect(desktopRedirectUrl.toString(), { status: 302, headers });
-        }
-      } catch (error) {
-        loggers.auth.warn('Failed to create desktop exchange for magic link', {
-          userId,
-          error: error instanceof Error ? error.message : String(error),
-        });
-        // Fall through to normal web redirect
-      }
     }
 
     // Log auth event
-    trackAuthEvent(userId, 'magic_link_login', {
+    trackAuthEvent(result.userId, 'magic_link_login', {
       ip: clientIP,
-      isNewUser,
+      isNewUser: result.isNewUser,
       userAgent: req.headers.get('user-agent'),
     });
 
-    // Build response headers with session cookie
-    const headers = new Headers();
-    appendSessionCookie(headers, sessionToken);
-
-    // Determine redirect URL — kind-specific overrides win, then fall back to
-    // the shared helper so new-user provisioning and `next` still work.
-    const redirectPath =
-      inviteResult?.kind === 'connection'
-        ? '/dashboard/connections'
-        : inviteResult?.kind === 'page' && invitedDriveId && inviteResult.invitedPageId
-          ? `/dashboard/${invitedDriveId}/pages/${inviteResult.invitedPageId}`
-          : resolvePostLoginRedirectPath({
-              provisionedDriveId, next: safeNext, invitedDriveId,
-            });
-
-    // On-prem onboarding funnel: a user who just signed in via an admin-issued
-    // setup link and has no passkey yet is sent to first-run passkey enrollment
-    // (on-prem has no password and no email delivery, so a passkey is their only
-    // durable credential). Cloud/tenant are untouched. Enrollment is skippable
-    // and forwards to `next`, so this never hard-blocks the user.
-    // Wrapped like every other post-session DB call in this handler: the session
-    // is already committed, so a transient failure on the passkey lookup must
-    // NOT fall through to the outer catch (which returns without the session
-    // cookie and bounces the user to signin — fatal on-prem, where there is no
-    // other login channel). On error, skip the funnel and use the normal redirect.
-    let effectiveRedirectPath = redirectPath;
-    try {
-      if (isOnPrem() && !(await userHasPasskey(userId))) {
-        effectiveRedirectPath = `/auth/passkey-setup?next=${encodeURIComponent(redirectPath)}`;
-      }
-    } catch (error) {
-      loggers.auth.error('Passkey enrollment funnel check failed; using normal redirect', error as Error, {
-        userId,
-      });
-    }
-
-    const baseUrl = process.env.WEB_APP_URL || process.env.NEXT_PUBLIC_APP_URL || new URL(req.url).origin;
+    const effectiveRedirectPath = await applyPasskeyFunnel(result.userId, result.redirectPath);
     const redirectUrl = new URL(effectiveRedirectPath, baseUrl);
     redirectUrl.searchParams.set('auth', 'success');
-    if (inviteResult?.kind === 'connection') {
-      redirectUrl.searchParams.set('connection_requested', '1');
-    } else if (invitedDriveId) {
-      redirectUrl.searchParams.set('invited', '1');
-    } else if (inviteError) {
-      redirectUrl.searchParams.set('inviteError', inviteError);
-    }
-
-    // Store CSRF token in a temporary cookie for the client to retrieve
-    // This follows the pattern from login - client-side JS will read and store this
-    const isProduction = process.env.NODE_ENV === 'production';
-    const secureFlag = isProduction ? '; Secure' : '';
-    headers.append('Set-Cookie', `csrf_token=${csrfToken}; Path=/; HttpOnly=false; SameSite=Lax; Max-Age=60${secureFlag}`);
+    applyRedirectParams(redirectUrl, result.redirectParams);
 
     auditRequest(req, {
       eventType: 'auth.login.success',
-      userId,
-      sessionId: sessionClaims.sessionId,
+      userId: result.userId,
+      sessionId: result.sessionId,
       details: { method: 'magic_link' },
     });
     loggers.auth.info('Magic link login successful', {
-      userId,
-      isNewUser,
+      userId: result.userId,
+      isNewUser: result.isNewUser,
       ip: clientIP,
     });
 
     return NextResponse.redirect(redirectUrl.toString(), {
       status: 302,
-      headers,
+      headers: buildSessionHeaders(result),
     });
-
   } catch (error) {
     loggers.auth.error('Magic link verify error', error as Error);
     return redirectWithError('server_error', req.url);
+  }
+}
+
+/**
+ * In-app redemption. Same core as GET; answers JSON so the page that the
+ * universal link opened can store the session where the shell reads it.
+ */
+export async function POST(req: Request) {
+  try {
+    const clientIP = getClientIP(req);
+
+    let body: unknown;
+    try {
+      body = await req.json();
+    } catch {
+      return Response.json({ error: 'invalid_token' }, { status: 400 });
+    }
+    const validation = redeemBodySchema.safeParse(body);
+    if (!validation.success) {
+      return Response.json({ error: 'invalid_token' }, { status: 400 });
+    }
+    const { token, deviceId: presentedDeviceId } = validation.data;
+    const safeNext = resolveSafeNext(validation.data.next ?? null);
+
+    const result = await redeemMagicLink({
+      req,
+      token,
+      safeNext,
+      clientIP,
+      door: { kind: 'in-app', presentedDeviceId },
+    });
+    if (!result.ok) {
+      return Response.json({ error: result.errorCode }, { status: statusForError(result.errorCode) });
+    }
+
+    // Bearer tokens exist here only if the core confirmed this device. A
+    // laptop browser, a second phone, or a request with no device at all
+    // reaches this line with `kind: 'none'` and gets the cookie session
+    // alone, exactly like the emailed GET.
+    const nativeHandoff = result.handoff.kind === 'native' ? result.handoff : null;
+
+    // Same funnel as GET, on every path through this door — an on-prem user
+    // with no passkey needs enrollment whichever client redeemed the link.
+    const redirectPath = await applyPasskeyFunnel(result.userId, result.redirectPath);
+    // Relative-URL assembly only; the origin is thrown away below.
+    const redirectTo = new URL(redirectPath, 'http://placeholder.invalid');
+    redirectTo.searchParams.set('auth', 'success');
+    if (result.isNewUser) {
+      redirectTo.searchParams.set('welcome', 'true');
+    }
+    applyRedirectParams(redirectTo, result.redirectParams);
+
+    recordLoginSuccess({ req, result, clientIP, platform: nativeHandoff?.platform });
+    loggers.auth.info('Magic link login successful (in-app)', {
+      userId: result.userId,
+      isNewUser: result.isNewUser,
+      ip: clientIP,
+      platform: nativeHandoff?.platform ?? 'web',
+    });
+
+    const headers = buildSessionHeaders(result);
+    headers.set('Content-Type', 'application/json');
+    return new Response(
+      JSON.stringify({
+        redirectTo: `${redirectTo.pathname}${redirectTo.search}`,
+        isNewUser: result.isNewUser,
+        user: result.user,
+        ...(nativeHandoff && {
+          sessionToken: result.sessionToken,
+          csrfToken: result.csrfToken,
+          deviceToken: nativeHandoff.deviceToken,
+        }),
+      }),
+      { status: 200, headers },
+    );
+  } catch (error) {
+    loggers.auth.error('Magic link redeem error', error as Error);
+    return Response.json({ error: 'server_error' }, { status: 500 });
+  }
+}
+
+/**
+ * Verify the token, sign the user in, and describe what each door may hand
+ * out. Every access decision is here; nothing below the switch on
+ * `confirmedDevice.platform` grants a device anything the switch did not name.
+ */
+async function redeemMagicLink({
+  req,
+  token,
+  safeNext,
+  clientIP,
+  door,
+}: {
+  req: Request;
+  token: string;
+  safeNext: string | undefined;
+  clientIP: string;
+  door: Door;
+}): Promise<RedeemResult> {
+  // Verify the magic link token
+  const result = await verifyMagicLinkToken({ token });
+
+  if (!result.ok) {
+    const errorMap: Record<string, string> = {
+      'TOKEN_EXPIRED': 'magic_link_expired',
+      'TOKEN_ALREADY_USED': 'magic_link_used',
+      'TOKEN_NOT_FOUND': 'invalid_token',
+      'USER_SUSPENDED': 'account_suspended',
+      'VALIDATION_FAILED': 'invalid_token',
+    };
+
+    const errorCode = errorMap[result.error.code] || 'invalid_token';
+    loggers.auth.warn('Magic link verification failed', {
+      error: result.error.code,
+      ip: clientIP,
+    });
+    auditRequest(req, {
+      eventType: 'auth.login.failure',
+      riskScore: 0.3,
+      details: { reason: `magic_link_${result.error.code.toLowerCase()}` },
+    });
+
+    // IP-keyed anomaly alerting (#977) — distinct from account lockout. Counts
+    // failures per source IP (Postgres-backed) and emits a brute-force/anomaly
+    // audit event when one IP crosses the threshold. Fire-and-forget and
+    // IP-scoped, so (consistent with the no-self-lockout design above) it can
+    // never lock out a legitimate user; it only raises a monitoring signal.
+    void reportAuthFailure({
+      identifier: clientIP,
+      ipAddress: clientIP,
+      endpoint: 'magic-link/verify',
+    }).catch(() => {
+      /* monitoring must never break the auth path */
+    });
+
+    return { ok: false, errorCode };
+  }
+
+  const { userId, isNewUser, metadata } = result.data;
+
+  // Account-lockout recovery path. A valid, freshly-issued magic link proves
+  // the real user requested it, so it ALWAYS signs them in and clears any
+  // lock — even one set by failed passkey attempts. This is what makes the
+  // lockout safe against a denial-of-service: an attacker can never lock a
+  // victim out of their account because the magic-link channel is never
+  // blocked. We deliberately do NOT record failed magic-link verifications:
+  // a failed token carries no account identity to attribute (only the
+  // already-administrative USER_SUSPENDED does), and benign expired/used-link
+  // clicks would self-lock legitimate users for zero attacker-facing benefit.
+  await resetFailedLoginAttempts(userId);
+
+  // Parse metadata once. The shape carries optional device fields and an
+  // optional invite-token binding — device and invite can co-exist on the
+  // same row (invited user signing in from the desktop or mobile app).
+  let parsedMeta: MagicLinkMetadata | null = null;
+  if (metadata) {
+    try {
+      parsedMeta = JSON.parse(metadata) as MagicLinkMetadata;
+    } catch {
+      loggers.auth.warn('Invalid magic link metadata JSON', { userId, metadata: metadata.slice(0, 100) });
+    }
+  }
+
+  const deviceMeta = normalizeDeviceMeta(parsedMeta);
+  const confirmedDevice = confirmRedeemingDevice(deviceMeta, door);
+  if (deviceMeta && !confirmedDevice) {
+    loggers.auth.info('Magic link redeemed away from the device it was minted for', {
+      userId,
+      platform: deviceMeta.platform,
+      door: door.kind,
+    });
+  }
+  const boundInviteToken = parsedMeta?.inviteToken;
+
+  // SESSION FIXATION PREVENTION: Revoke prior sessions before creating a new
+  // one. Scope to the device only when THIS request is that device; a
+  // cross-device email link cannot identify the device, so the helper falls
+  // back to the legacy all-web-session revoke. Admin-console sessions are scoped
+  // separately and left intact.
+  await revokeSessionsForLogin(userId, confirmedDevice?.deviceId, 'magic_link_login', 'magic-link');
+
+  // Mark email as verified (idempotent for existing users)
+  try {
+    await markEmailVerified(userId);
+  } catch (error) {
+    loggers.auth.error('Failed to mark email as verified', error as Error, { userId });
+    // Continue with login anyway - email verification is secondary
+  }
+
+  // Create new session
+  const sessionToken = await sessionService.createSession({
+    userId,
+    type: 'user',
+    scopes: ['*'],
+    expiresInMs: SESSION_DURATION_MS,
+    deviceId: confirmedDevice?.deviceId,
+    createdByIp: clientIP !== 'unknown' ? clientIP : undefined,
+  });
+
+  // Validate session to get claims for CSRF generation
+  const sessionClaims = await sessionService.validateSession(sessionToken);
+  if (!sessionClaims) {
+    loggers.auth.error('Failed to validate newly created session', { userId });
+    return { ok: false, errorCode: 'session_error' };
+  }
+
+  // Generate CSRF token bound to session ID
+  const csrfToken = generateCSRFToken(sessionClaims.sessionId);
+
+  // Consume the invite atomically with authentication. The invite token was
+  // bound to the magic-link at mint time, validated against this email +
+  // pending-invite state then. We re-load the user's verification status
+  // here because the pipe needs the authoritative email + suspendedAt for
+  // the second validation gate inside acceptInviteForExistingUser.
+  //
+  // Wrapped in try/catch: the session is already committed; a DB blip on
+  // the verification-status lookup must not redirect the user to signin
+  // when they already hold a valid session. Worst case the invite stays
+  // pending and the user reclaims it from the consent page.
+  let inviteResult: NativeInviteAcceptanceResult | null = null;
+  let inviteError: string | null = null;
+  try {
+    const status = await driveInviteRepository.findUserVerificationStatusById(userId);
+    if (status) {
+      if (boundInviteToken) {
+        inviteResult = await consumeAnyInviteIfPresent({
+          request: req,
+          inviteToken: boundInviteToken,
+          user: { id: userId, suspendedAt: status.suspendedAt },
+          isNewUser,
+          email: status.email,
+        });
+        if (inviteResult.inviteError) {
+          inviteError = inviteResult.inviteError;
+          loggers.auth.info('Bound invite acceptance failed during magic link verify', {
+            userId,
+            reason: inviteResult.inviteError,
+          });
+        }
+      }
+      await consumeAllInvitesForEmail({
+        request: req,
+        email: status.email,
+        user: { id: userId, suspendedAt: status.suspendedAt },
+        now: new Date(),
+      });
+    } else {
+      loggers.auth.warn('Authenticated session has no user record on invite consume', {
+        userId,
+      });
+    }
+  } catch (error) {
+    loggers.auth.error('Invite consume threw during magic link verify', error as Error, {
+      userId,
+    });
+    // Continue with login — the session is valid; user can re-attempt invite.
+  }
+  const invitedDriveId = inviteResult?.invitedDriveId ?? null;
+
+  // Provision the Home drive unconditionally — idempotent, and run BEFORE the
+  // redirect branches so every login provisions, including page/connection
+  // invite logins whose redirect never consults the shared resolver below.
+  // Errors are logged and swallowed: the session is valid, and the next login
+  // through any auth path retries provisioning.
+  let provisionedDriveId: string | null = null;
+  try {
+    const provisionResult = await provisionHomeDriveIfNeeded(userId);
+    if (provisionResult.created) {
+      provisionedDriveId = provisionResult.driveId;
+    }
+  } catch (error) {
+    loggers.auth.error('Failed to provision Home drive', error as Error, { userId });
+  }
+
+  // Determine the landing path — kind-specific overrides win, then fall back
+  // to the shared helper so new-user provisioning and `next` still work.
+  const redirectPath =
+    inviteResult?.kind === 'connection'
+      ? '/dashboard/connections'
+      : inviteResult?.kind === 'page' && invitedDriveId && inviteResult.invitedPageId
+        ? `/dashboard/${invitedDriveId}/pages/${inviteResult.invitedPageId}`
+        : resolvePostLoginRedirectPath({
+            provisionedDriveId, next: safeNext, invitedDriveId,
+          });
+
+  const redirectParams: Record<string, string> = {};
+  if (inviteResult?.kind === 'connection') {
+    redirectParams.connection_requested = '1';
+  } else if (invitedDriveId) {
+    redirectParams.invited = '1';
+  } else if (inviteError) {
+    redirectParams.inviteError = inviteError;
+  }
+
+  // DEVICE HANDOFF: mint a device token for the device that is redeeming, and
+  // hand it over the way that device collects it — an exchange code for the
+  // desktop app, bearer tokens for the mobile shell. Nothing is minted for a
+  // device that is not here (see the rotation note at the top of this file).
+  // The web session above is always created first; a handoff failure logs and
+  // degrades to the cookie session, never to no session.
+  let handoff: Handoff = { kind: 'none' };
+  let user: PublicUser | null = null;
+  if (confirmedDevice) {
+    try {
+      const userRow = await authRepository.findUserById(userId);
+      if (userRow) {
+        user = {
+          id: userRow.id,
+          name: userRow.name,
+          email: userRow.email,
+          image: userRow.image,
+          emailVerified: userRow.emailVerified,
+        };
+        const { deviceToken } = await validateOrCreateDeviceToken({
+          providedDeviceToken: undefined,
+          userId,
+          deviceId: confirmedDevice.deviceId,
+          platform: confirmedDevice.platform,
+          tokenVersion: userRow.tokenVersion,
+          deviceName:
+            confirmedDevice.deviceName ||
+            req.headers.get('user-agent') ||
+            defaultDeviceName(confirmedDevice.platform),
+          userAgent: req.headers.get('user-agent') || undefined,
+          ipAddress: clientIP !== 'unknown' ? clientIP : undefined,
+        });
+
+        switch (confirmedDevice.platform) {
+          case 'desktop': {
+            const exchangeCode = await createExchangeCode({
+              sessionToken,
+              csrfToken,
+              deviceToken,
+              provider: 'magic-link',
+              userId,
+              createdAt: Date.now(),
+            });
+            handoff = { kind: 'desktop', deviceId: confirmedDevice.deviceId, exchangeCode };
+            break;
+          }
+          case 'ios':
+          case 'android':
+            handoff = {
+              kind: 'native',
+              platform: confirmedDevice.platform,
+              deviceId: confirmedDevice.deviceId,
+              deviceToken,
+            };
+            break;
+        }
+      }
+    } catch (error) {
+      loggers.auth.warn('Failed to create device handoff for magic link', {
+        userId,
+        platform: confirmedDevice.platform,
+        error: error instanceof Error ? error.message : String(error),
+      });
+      // Fall through to the cookie session, and do not report a user the
+      // caller would read as "fully signed in on this device".
+      handoff = { kind: 'none' };
+      user = null;
+    }
+  }
+
+  return {
+    ok: true,
+    userId,
+    isNewUser,
+    sessionId: sessionClaims.sessionId,
+    sessionToken,
+    csrfToken,
+    redirectPath,
+    redirectParams,
+    user,
+    handoff,
+  };
+}
+
+/**
+ * The one place a stored platform string becomes a device binding. Anything
+ * the switch does not name — a missing platform, a platform this build does
+ * not know, a row with no deviceId — is not a device binding at all.
+ */
+function normalizeDeviceMeta(parsed: MagicLinkMetadata | null): DeviceMagicLinkMetadata | null {
+  if (!parsed || !parsed.deviceId) return null;
+  const deviceName = parsed.deviceName !== undefined ? { deviceName: parsed.deviceName } : {};
+  switch (parsed.platform) {
+    case 'desktop':
+      return { platform: 'desktop', deviceId: parsed.deviceId, ...deviceName };
+    case 'ios':
+    case 'android':
+      return { platform: parsed.platform, deviceId: parsed.deviceId, ...deviceName };
+    default:
+      return null;
+  }
+}
+
+/**
+ * Is the client making THIS request the device the link was minted for?
+ *
+ * The one place that question is answered, because minting a device token is a
+ * rotation: answering "yes" for a device that is not here destroys the
+ * credential it still holds. `null` means no device handoff at all — the
+ * redeemer still gets the ordinary cookie session.
+ *
+ * Desktop is unchanged from before this door existed: its handoff is the
+ * exchange code on the emailed GET, which only the desktop app can complete.
+ * A mobile shell has to prove itself by presenting the device id it holds.
+ */
+function confirmRedeemingDevice(
+  deviceMeta: DeviceMagicLinkMetadata | null,
+  door: Door,
+): DeviceMagicLinkMetadata | null {
+  if (!deviceMeta) return null;
+  switch (deviceMeta.platform) {
+    case 'desktop':
+      return door.kind === 'browser' ? deviceMeta : null;
+    case 'ios':
+    case 'android':
+      return door.kind === 'in-app' && door.presentedDeviceId === deviceMeta.deviceId
+        ? deviceMeta
+        : null;
+  }
+}
+
+function defaultDeviceName(platform: DeviceMagicLinkMetadata['platform']): string {
+  switch (platform) {
+    case 'desktop':
+      return 'Desktop App';
+    case 'ios':
+      return 'iOS App';
+    case 'android':
+      return 'Android App';
+  }
+}
+
+function resolveSafeNext(rawNext: string | null): string | undefined {
+  return rawNext && isSafeNextPath({ path: rawNext, allowedPrefixes: SIGNIN_NEXT_ALLOWED_PREFIXES })
+    ? rawNext
+    : undefined;
+}
+
+function resolveBaseUrl(req: Request): string {
+  return process.env.WEB_APP_URL || process.env.NEXT_PUBLIC_APP_URL || new URL(req.url).origin;
+}
+
+function applyRedirectParams(url: URL, params: Record<string, string>): void {
+  for (const [key, value] of Object.entries(params)) {
+    url.searchParams.set(key, value);
+  }
+}
+
+/**
+ * On-prem onboarding funnel: a user who just signed in via an admin-issued
+ * setup link and has no passkey yet is sent to first-run passkey enrollment
+ * (on-prem has no password and no email delivery, so a passkey is their only
+ * durable credential). Cloud/tenant are untouched. Enrollment is skippable
+ * and forwards to `next`, so this never hard-blocks the user.
+ * Wrapped like every other post-session DB call in this handler: the session
+ * is already committed, so a transient failure on the passkey lookup must
+ * NOT fall through to the outer catch (which returns without the session
+ * cookie and bounces the user to signin — fatal on-prem, where there is no
+ * other login channel). On error, skip the funnel and use the normal redirect.
+ */
+async function applyPasskeyFunnel(userId: string, redirectPath: string): Promise<string> {
+  try {
+    if (isOnPrem() && !(await userHasPasskey(userId))) {
+      return `/auth/passkey-setup?next=${encodeURIComponent(redirectPath)}`;
+    }
+  } catch (error) {
+    loggers.auth.error('Passkey enrollment funnel check failed; using normal redirect', error as Error, {
+      userId,
+    });
+  }
+  return redirectPath;
+}
+
+/**
+ * Session cookie plus the short-lived, JS-readable CSRF cookie the client
+ * picks up after login (same pattern as the password login route).
+ */
+function buildSessionHeaders(result: Extract<RedeemResult, { ok: true }>): Headers {
+  const headers = new Headers();
+  appendSessionCookie(headers, result.sessionToken);
+  const isProduction = process.env.NODE_ENV === 'production';
+  const secureFlag = isProduction ? '; Secure' : '';
+  headers.append('Set-Cookie', `csrf_token=${result.csrfToken}; Path=/; HttpOnly=false; SameSite=Lax; Max-Age=60${secureFlag}`);
+  return headers;
+}
+
+function recordLoginSuccess({
+  req,
+  result,
+  clientIP,
+  platform,
+}: {
+  req: Request;
+  result: Extract<RedeemResult, { ok: true }>;
+  clientIP: string;
+  platform: DeviceMagicLinkMetadata['platform'] | undefined;
+}): void {
+  auditRequest(req, {
+    eventType: 'auth.login.success',
+    userId: result.userId,
+    sessionId: result.sessionId,
+    details: { method: 'magic_link', ...(platform && { platform }) },
+  });
+  trackAuthEvent(result.userId, 'magic_link_login', {
+    ip: clientIP,
+    isNewUser: result.isNewUser,
+    ...(platform && { platform }),
+    userAgent: req.headers.get('user-agent'),
+  });
+}
+
+function statusForError(errorCode: string): number {
+  switch (errorCode) {
+    case 'account_suspended':
+      return 403;
+    case 'server_error':
+    case 'session_error':
+      return 500;
+    default:
+      return 401;
   }
 }
 
@@ -410,11 +728,11 @@ function redirectWithError(error: string, requestUrl?: string): NextResponse {
 
 /**
  * Resolve the post-login dashboard redirect path. Single source of truth for
- * both the desktop exchange and web cookie flows so the two paths cannot drift
- * out of sync on the next redirect-rule change. A successfully consumed invite
- * always wins (lands the user on the drive they joined); a pre-validated
- * `next` is the fallback for non-invite flows. Pure on purpose — Home-drive
- * provisioning happens once in the GET handler, before any redirect branch.
+ * every door so they cannot drift on the next redirect-rule change. A
+ * successfully consumed invite always wins (lands the user on the drive they
+ * joined); a pre-validated `next` is the fallback for non-invite flows. Pure
+ * on purpose — Home-drive provisioning happens once in `redeemMagicLink`,
+ * before any redirect branch.
  */
 function resolvePostLoginRedirectPath({
   provisionedDriveId,

--- a/apps/web/src/app/api/auth/magic-link/verify/route.ts
+++ b/apps/web/src/app/api/auth/magic-link/verify/route.ts
@@ -65,6 +65,15 @@ import {
  * alter desktop sign-in, which this PR does not touch.
  */
 
+/** Verification failures, as the codes the doors report to the client. */
+const VERIFY_ERROR_CODES: Record<string, string> = {
+  TOKEN_EXPIRED: 'magic_link_expired',
+  TOKEN_ALREADY_USED: 'magic_link_used',
+  TOKEN_NOT_FOUND: 'invalid_token',
+  USER_SUSPENDED: 'account_suspended',
+  VALIDATION_FAILED: 'invalid_token',
+};
+
 const verifyTokenSchema = z.object({
   token: z.string().min(1, 'Token is required'),
 });
@@ -287,15 +296,7 @@ async function redeemMagicLink({
   const result = await verifyMagicLinkToken({ token });
 
   if (!result.ok) {
-    const errorMap: Record<string, string> = {
-      'TOKEN_EXPIRED': 'magic_link_expired',
-      'TOKEN_ALREADY_USED': 'magic_link_used',
-      'TOKEN_NOT_FOUND': 'invalid_token',
-      'USER_SUSPENDED': 'account_suspended',
-      'VALIDATION_FAILED': 'invalid_token',
-    };
-
-    const errorCode = errorMap[result.error.code] || 'invalid_token';
+    const errorCode = VERIFY_ERROR_CODES[result.error.code] || 'invalid_token';
     loggers.auth.warn('Magic link verification failed', {
       error: result.error.code,
       ip: clientIP,
@@ -460,14 +461,14 @@ async function redeemMagicLink({
 
   // Determine the landing path — kind-specific overrides win, then fall back
   // to the shared helper so new-user provisioning and `next` still work.
-  const redirectPath =
-    inviteResult?.kind === 'connection'
-      ? '/dashboard/connections'
-      : inviteResult?.kind === 'page' && invitedDriveId && inviteResult.invitedPageId
-        ? `/dashboard/${invitedDriveId}/pages/${inviteResult.invitedPageId}`
-        : resolvePostLoginRedirectPath({
-            provisionedDriveId, next: safeNext, invitedDriveId,
-          });
+  let redirectPath: string;
+  if (inviteResult?.kind === 'connection') {
+    redirectPath = '/dashboard/connections';
+  } else if (inviteResult?.kind === 'page' && invitedDriveId && inviteResult.invitedPageId) {
+    redirectPath = `/dashboard/${invitedDriveId}/pages/${inviteResult.invitedPageId}`;
+  } else {
+    redirectPath = resolvePostLoginRedirectPath({ provisionedDriveId, next: safeNext, invitedDriveId });
+  }
 
   const redirectParams: Record<string, string> = {};
   if (inviteResult?.kind === 'connection') {
@@ -568,11 +569,10 @@ async function redeemMagicLink({
  * not know, a row with no deviceId — is not a device binding at all.
  */
 function normalizeDeviceMeta(parsed: MagicLinkMetadata | null): DeviceMagicLinkMetadata | null {
-  if (!parsed || !parsed.deviceId) return null;
+  if (!parsed?.deviceId) return null;
   const deviceName = parsed.deviceName !== undefined ? { deviceName: parsed.deviceName } : {};
   switch (parsed.platform) {
     case 'desktop':
-      return { platform: 'desktop', deviceId: parsed.deviceId, ...deviceName };
     case 'ios':
     case 'android':
       return { platform: parsed.platform, deviceId: parsed.deviceId, ...deviceName };

--- a/apps/web/src/app/api/auth/magic-link/verify/route.ts
+++ b/apps/web/src/app/api/auth/magic-link/verify/route.ts
@@ -351,7 +351,7 @@ async function redeemMagicLink({
   const deviceMeta = normalizeDeviceMeta(parsedMeta);
   const handoffDevice = handoffDeviceFor(deviceMeta, door);
   if (deviceMeta && !handoffDevice) {
-    loggers.auth.info('Magic link redeemed away from the device it was minted for', {
+    loggers.auth.info('Magic link redeemed with no device handoff', {
       userId,
       platform: deviceMeta.platform,
       door: door.kind,

--- a/apps/web/src/app/auth/magic-link/[token]/page.tsx
+++ b/apps/web/src/app/auth/magic-link/[token]/page.tsx
@@ -1,0 +1,28 @@
+import { MagicLinkRedeem } from '@/components/auth/MagicLinkRedeem';
+
+/**
+ * Where a magic link requested from the iOS / Android app lands.
+ *
+ * The emailed link is `https://pagespace.ai/auth/magic-link/<token>`, claimed
+ * in the AASA so the tap opens the app; `DeepLinkHandler` routes it here with
+ * the router. The client half redeems the token with a same-origin POST so
+ * the session lands in the WebView (cookie) and, on the bound device, in the
+ * Keychain (bearer). Opened in a plain browser instead, the same page signs
+ * that browser in — a link must never be dead just because it was tapped
+ * somewhere else.
+ *
+ * Mirrors `/invite/[token]`: params are a single opaque segment, and the
+ * resolver in `lib/navigation/deep-links.ts` only routes that shape.
+ */
+export default async function MagicLinkPage({
+  params,
+  searchParams,
+}: {
+  params: Promise<{ token: string }>;
+  searchParams: Promise<{ next?: string | string[] }>;
+}) {
+  const { token } = await params;
+  const { next } = await searchParams;
+  const nextPath = typeof next === 'string' ? next : undefined;
+  return <MagicLinkRedeem token={token} next={nextPath} />;
+}

--- a/apps/web/src/app/auth/magic-link/[token]/page.tsx
+++ b/apps/web/src/app/auth/magic-link/[token]/page.tsx
@@ -1,5 +1,10 @@
 import { MagicLinkRedeem } from '@/components/auth/MagicLinkRedeem';
 
+interface MagicLinkPageProps {
+  params: Promise<{ token: string }>;
+  searchParams: Promise<{ next?: string | string[] }>;
+}
+
 /**
  * Where a magic link requested from the iOS / Android app lands.
  *
@@ -14,13 +19,7 @@ import { MagicLinkRedeem } from '@/components/auth/MagicLinkRedeem';
  * Mirrors `/invite/[token]`: params are a single opaque segment, and the
  * resolver in `lib/navigation/deep-links.ts` only routes that shape.
  */
-export default async function MagicLinkPage({
-  params,
-  searchParams,
-}: {
-  params: Promise<{ token: string }>;
-  searchParams: Promise<{ next?: string | string[] }>;
-}) {
+export default async function MagicLinkPage({ params, searchParams }: MagicLinkPageProps) {
   const { token } = await params;
   const { next } = await searchParams;
   const nextPath = typeof next === 'string' ? next : undefined;

--- a/apps/web/src/app/auth/signin/__tests__/signin-in-app-notice.test.tsx
+++ b/apps/web/src/app/auth/signin/__tests__/signin-in-app-notice.test.tsx
@@ -1,0 +1,107 @@
+/**
+ * The in-app-browser warning on the sign-in screen, end to end.
+ *
+ * This is the screen the bug was reported on: launching the iOS app showed
+ * "Google sign-in is blocked in this app" and forced the magic-link form open,
+ * on a platform where the Google button works natively.
+ *
+ * The chain under test is real — the page reads `useInAppBrowserNotice`, which
+ * reads `detectInAppBrowser`, which asks the Capacitor bridge before asking
+ * `inapp-spy`. Only the two leaves are mocked.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+
+const { mockInAppSpy, mockIsCapacitorApp } = vi.hoisted(() => ({
+  mockInAppSpy: vi.fn(),
+  mockIsCapacitorApp: vi.fn(),
+}));
+
+vi.mock('inapp-spy', () => ({ default: mockInAppSpy }));
+
+// Spread the real module: the page's other imports pull getPlatform etc. from here.
+vi.mock('@/lib/capacitor-bridge', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('@/lib/capacitor-bridge')>()),
+  isCapacitorApp: () => mockIsCapacitorApp(),
+}));
+
+vi.mock('next/navigation', () => ({
+  useRouter: () => ({ push: vi.fn(), replace: vi.fn() }),
+  useSearchParams: () => new URLSearchParams(),
+}));
+
+vi.mock('@/hooks/useAuthCSRF', () => ({
+  useAuthCSRF: () => ({ csrfToken: 'csrf', refreshToken: vi.fn() }),
+}));
+
+vi.mock('@/hooks/useOAuthSignIn', () => ({
+  useOAuthSignIn: () => ({
+    handleGoogleSignIn: vi.fn(),
+    handleAppleSignIn: vi.fn(),
+    isGoogleLoading: false,
+    isAppleLoading: false,
+    isWaitingForExternalAuth: false,
+    waitingProvider: null,
+    cancelExternalAuth: vi.fn(),
+  }),
+}));
+
+// The form is shown, not exercised; recovery is a separate concern with its
+// own suite.
+vi.mock('./../useSigninRecovery', () => ({ useSigninRecovery: () => ({ recovering: false }) }));
+
+vi.mock('@/components/auth', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('@/components/auth')>()),
+  GoogleOneTap: () => null,
+  MagicLinkForm: () => <div data-testid="magic-link-form" />,
+  PasskeyLoginButton: () => null,
+}));
+
+import SignInPage from '../page';
+
+const BANNER = /Google sign-in is blocked/i;
+const EMAIL_LINK_BUTTON = /use a magic link/i;
+
+describe('sign-in page — in-app browser warning', () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+    // inapp-spy flags every bare WKWebView, our own shell included.
+    mockInAppSpy.mockReturnValue({ isInApp: true, appName: undefined });
+  });
+
+  it('given the Capacitor shell, shows no warning and leaves the magic-link form collapsed', async () => {
+    mockIsCapacitorApp.mockReturnValue(true);
+
+    render(<SignInPage />);
+
+    await waitFor(() =>
+      expect(screen.getByRole('button', { name: EMAIL_LINK_BUTTON })).toBeInTheDocument(),
+    );
+    expect(screen.queryByText(BANNER)).not.toBeInTheDocument();
+    expect(screen.queryByTestId('magic-link-form')).not.toBeInTheDocument();
+  });
+
+  it('given a genuine in-app browser, warns and opens the magic-link form', async () => {
+    mockIsCapacitorApp.mockReturnValue(false);
+    mockInAppSpy.mockReturnValue({ isInApp: true, appName: 'Instagram' });
+
+    render(<SignInPage />);
+
+    await waitFor(() =>
+      expect(screen.getByText(/Google sign-in is blocked in Instagram/i)).toBeInTheDocument(),
+    );
+    expect(screen.getByTestId('magic-link-form')).toBeInTheDocument();
+  });
+
+  it('given a normal browser, shows no warning and leaves the form collapsed', async () => {
+    mockIsCapacitorApp.mockReturnValue(false);
+    mockInAppSpy.mockReturnValue({ isInApp: false, appName: undefined });
+
+    render(<SignInPage />);
+
+    await waitFor(() =>
+      expect(screen.getByRole('button', { name: EMAIL_LINK_BUTTON })).toBeInTheDocument(),
+    );
+    expect(screen.queryByText(BANNER)).not.toBeInTheDocument();
+  });
+});

--- a/apps/web/src/app/auth/signin/page.tsx
+++ b/apps/web/src/app/auth/signin/page.tsx
@@ -20,7 +20,8 @@ import { useAuthCSRF } from "@/hooks/useAuthCSRF";
 import { useOAuthSignIn } from "@/hooks/useOAuthSignIn";
 import { isOnPrem } from "@/lib/deployment-mode";
 import { resolveSigninNext } from "@/lib/auth/resolve-signin-next";
-import { detectInAppBrowser, getPreferredBrowserName } from "@/lib/auth/browser-detection";
+import { getPreferredBrowserName } from "@/lib/auth/browser-detection";
+import { useInAppBrowserNotice } from "@/hooks/useInAppBrowserNotice";
 import { useSigninRecovery } from "./useSigninRecovery";
 
 // Shared loading shell: the Suspense fallback (searchParams boundary) and the in-flight
@@ -40,7 +41,7 @@ function AuthLoading() {
 
 function SignInForm() {
   const [showMagicLink, setShowMagicLink] = useState(false);
-  const [inAppInfo, setInAppInfo] = useState<{ isInApp: boolean; appName: string | undefined }>({ isInApp: false, appName: undefined });
+  const inAppInfo = useInAppBrowserNotice();
   const searchParams = useSearchParams();
   const { csrfToken, refreshToken } = useAuthCSRF();
   const inviteToken = searchParams.get('invite') ?? undefined;
@@ -134,13 +135,12 @@ function SignInForm() {
     }
   }, [searchParams]);
 
+  // A genuine in-app browser cannot complete Google's web OAuth, so open the
+  // magic-link form for it. The Capacitor shell never reports in-app (native
+  // Google works there), so this leaves the app's sign-in screen alone.
   useEffect(() => {
-    const result = detectInAppBrowser();
-    if (result.isInApp) {
-      setInAppInfo({ isInApp: true, appName: result.appName });
-      setShowMagicLink(true);
-    }
-  }, []);
+    if (inAppInfo.isInApp) setShowMagicLink(true);
+  }, [inAppInfo.isInApp]);
 
   // While silent recovery is in flight, show a minimal loading state rather than the form,
   // so a user who is about to be auto-redirected never sees the form flash.

--- a/apps/web/src/app/auth/signup/SignUpClient.tsx
+++ b/apps/web/src/app/auth/signup/SignUpClient.tsx
@@ -18,7 +18,8 @@ import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert';
 import { useAuthCSRF } from '@/hooks/useAuthCSRF';
 import { useOAuthSignIn } from '@/hooks/useOAuthSignIn';
 import type { InviteContextData } from '@/lib/auth/invite-resolver';
-import { detectInAppBrowser, getPreferredBrowserName } from '@/lib/auth/browser-detection';
+import { getPreferredBrowserName } from '@/lib/auth/browser-detection';
+import { useInAppBrowserNotice } from '@/hooks/useInAppBrowserNotice';
 
 interface SignUpClientProps {
   inviteToken?: string;
@@ -29,7 +30,7 @@ interface SignUpClientProps {
 export function SignUpClient({ inviteToken, inviteContext, returnUrl }: SignUpClientProps) {
   const [error, setError] = useState<string | null>(null);
   const [showMagicLink, setShowMagicLink] = useState(false);
-  const [inAppInfo, setInAppInfo] = useState<{ isInApp: boolean; appName: string | undefined }>({ isInApp: false, appName: undefined });
+  const inAppInfo = useInAppBrowserNotice();
   const router = useRouter();
   const { csrfToken, refreshToken } = useAuthCSRF();
   const [passkeyLoading, setPasskeyLoading] = useState(false);
@@ -50,13 +51,12 @@ export function SignUpClient({ inviteToken, inviteContext, returnUrl }: SignUpCl
 
   const isAnyLoading = isGoogleLoading || isAppleLoading || passkeyLoading;
 
+  // A genuine in-app browser cannot complete Google's web OAuth, so open the
+  // magic-link form for it. The Capacitor shell never reports in-app (native
+  // Google works there), so this leaves the app's sign-in screen alone.
   useEffect(() => {
-    const result = detectInAppBrowser();
-    if (result.isInApp) {
-      setInAppInfo({ isInApp: true, appName: result.appName });
-      setShowMagicLink(true);
-    }
-  }, []);
+    if (inAppInfo.isInApp) setShowMagicLink(true);
+  }, [inAppInfo.isInApp]);
 
   const browserName = getPreferredBrowserName() ?? 'your browser';
   const appLabel = inAppInfo.appName ?? 'this app';

--- a/apps/web/src/app/auth/signup/__tests__/SignUpClient.in-app-notice.test.tsx
+++ b/apps/web/src/app/auth/signup/__tests__/SignUpClient.in-app-notice.test.tsx
@@ -1,0 +1,96 @@
+/**
+ * The in-app-browser warning, end to end at the page level.
+ *
+ * The chain under test is real: the page reads `useInAppBrowserNotice`, which
+ * reads `detectInAppBrowser`, which asks the Capacitor bridge before asking
+ * `inapp-spy`. Only the two leaves are mocked — the shell answer and what
+ * inapp-spy would say — so a regression anywhere between them fails here.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+
+const { mockInAppSpy, mockIsCapacitorApp } = vi.hoisted(() => ({
+  mockInAppSpy: vi.fn(),
+  mockIsCapacitorApp: vi.fn(),
+}));
+
+vi.mock('inapp-spy', () => ({ default: mockInAppSpy }));
+
+// Spread the real module: the page's other imports pull getPlatform etc. from here.
+vi.mock('@/lib/capacitor-bridge', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('@/lib/capacitor-bridge')>()),
+  isCapacitorApp: () => mockIsCapacitorApp(),
+}));
+
+vi.mock('next/navigation', () => ({
+  useRouter: () => ({ push: vi.fn(), replace: vi.fn() }),
+  useSearchParams: () => new URLSearchParams(),
+}));
+
+vi.mock('@/hooks/useAuthCSRF', () => ({
+  useAuthCSRF: () => ({ csrfToken: 'csrf', refreshToken: vi.fn() }),
+}));
+
+vi.mock('@/hooks/useOAuthSignIn', () => ({
+  useOAuthSignIn: () => ({
+    handleGoogleSignIn: vi.fn(),
+    handleAppleSignIn: vi.fn(),
+    isGoogleLoading: false,
+    isAppleLoading: false,
+    isWaitingForExternalAuth: false,
+    waitingProvider: null,
+    cancelExternalAuth: vi.fn(),
+  }),
+}));
+
+// Stub only the leaves that drag in Google's SDK / the send flow; the page's
+// own structure stays real.
+vi.mock('@/components/auth', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('@/components/auth')>()),
+  GoogleOneTap: () => null,
+  MagicLinkForm: () => <div data-testid="magic-link-form" />,
+  PasskeySignupButton: () => null,
+}));
+
+import { SignUpClient } from '../SignUpClient';
+
+const BANNER = /Google sign-in is blocked/i;
+
+describe('SignUpClient — in-app browser warning', () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+    // inapp-spy flags every bare WKWebView, our own shell included.
+    mockInAppSpy.mockReturnValue({ isInApp: true, appName: undefined });
+  });
+
+  it('given the Capacitor shell, shows no warning and leaves the magic-link form collapsed', async () => {
+    mockIsCapacitorApp.mockReturnValue(true);
+
+    render(<SignUpClient />);
+
+    // Wait for the effect that would have opened it, then assert it did not.
+    await waitFor(() => expect(screen.getByRole('button', { name: /sign up with email link/i })).toBeInTheDocument());
+    expect(screen.queryByText(BANNER)).not.toBeInTheDocument();
+    expect(screen.queryByTestId('magic-link-form')).not.toBeInTheDocument();
+  });
+
+  it('given a genuine in-app browser, warns and opens the magic-link form', async () => {
+    mockIsCapacitorApp.mockReturnValue(false);
+    mockInAppSpy.mockReturnValue({ isInApp: true, appName: 'Instagram' });
+
+    render(<SignUpClient />);
+
+    await waitFor(() => expect(screen.getByText(/Google sign-in is blocked in Instagram/i)).toBeInTheDocument());
+    expect(screen.getByTestId('magic-link-form')).toBeInTheDocument();
+  });
+
+  it('given a normal browser, shows no warning and leaves the form collapsed', async () => {
+    mockIsCapacitorApp.mockReturnValue(false);
+    mockInAppSpy.mockReturnValue({ isInApp: false, appName: undefined });
+
+    render(<SignUpClient />);
+
+    await waitFor(() => expect(screen.getByRole('button', { name: /sign up with email link/i })).toBeInTheDocument());
+    expect(screen.queryByText(BANNER)).not.toBeInTheDocument();
+  });
+});

--- a/apps/web/src/components/__tests__/DeepLinkHandler.test.tsx
+++ b/apps/web/src/components/__tests__/DeepLinkHandler.test.tsx
@@ -52,6 +52,14 @@ describe('DeepLinkHandler', () => {
     vi.restoreAllMocks();
   });
 
+  it('routes a magic link tapped while the app is running', async () => {
+    render(<DeepLinkHandler />);
+    await waitFor(() => expect(mockAddListener).toHaveBeenCalled());
+    warmStartHandler()({ url: 'https://pagespace.ai/auth/magic-link/ps_magic_warm' });
+    expect(mockPush).toHaveBeenCalledWith('/auth/magic-link/ps_magic_warm');
+    expect(mockOpenExternalUrl).not.toHaveBeenCalled();
+  });
+
   it('routes the launch URL on a cold start', async () => {
     // The launch URL is already spent by mount time, so a listener alone would
     // never see it.

--- a/apps/web/src/components/auth/MagicLinkForm.tsx
+++ b/apps/web/src/components/auth/MagicLinkForm.tsx
@@ -27,7 +27,7 @@ export interface MagicLinkFormProps {
 export function MagicLinkForm({ nextPath, inviteToken }: MagicLinkFormProps = {}) {
   // Resolved after mount, never during render — the shell is a `window` fact
   // the server does not have.
-  const { isNative } = useCapacitor();
+  const { isIOS } = useCapacitor();
   const formRef = useRef<HTMLFormElement>(null);
   const [email, setEmail] = useState('');
   const [acceptedTos, setAcceptedTos] = useState(false);
@@ -196,7 +196,11 @@ export function MagicLinkForm({ nextPath, inviteToken }: MagicLinkFormProps = {}
         <p className="text-center text-xs text-muted-foreground">
           The link expires in 5 minutes. Check your spam folder if you don&apos;t see it.
         </p>
-        {isNative && (
+        {/* iOS only, deliberately: the promise is true exactly where the app
+            can receive the link. Android registers no https intent-filter yet
+            (see apps/android/README.md), so its tap opens Chrome and signs
+            Chrome in — telling an Android user otherwise would be a lie. */}
+        {isIOS && (
           <p className="text-center text-xs text-muted-foreground">
             Open the link on this device and it will sign you in here.
           </p>

--- a/apps/web/src/components/auth/MagicLinkForm.tsx
+++ b/apps/web/src/components/auth/MagicLinkForm.tsx
@@ -8,7 +8,8 @@ import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import { Checkbox } from '@/components/ui/checkbox';
 import { Mail, ArrowLeft, Loader2, CheckCircle } from 'lucide-react';
-import { getDevicePlatformFields } from '@/lib/desktop-auth';
+import { getMagicLinkPlatformFields } from '@/lib/auth/magic-link-platform-fields';
+import { useCapacitor } from '@/hooks/useCapacitor';
 
 type FormState = 'input' | 'sending' | 'sent' | 'error';
 
@@ -24,6 +25,9 @@ export interface MagicLinkFormProps {
 }
 
 export function MagicLinkForm({ nextPath, inviteToken }: MagicLinkFormProps = {}) {
+  // Resolved after mount, never during render — the shell is a `window` fact
+  // the server does not have.
+  const { isNative } = useCapacitor();
   const formRef = useRef<HTMLFormElement>(null);
   const [email, setEmail] = useState('');
   const [acceptedTos, setAcceptedTos] = useState(false);
@@ -97,7 +101,7 @@ export function MagicLinkForm({ nextPath, inviteToken }: MagicLinkFormProps = {}
 
       const { csrfToken } = (await csrfResponse.json()) as { csrfToken: string };
 
-      const platformFields = await getDevicePlatformFields();
+      const platformFields = await getMagicLinkPlatformFields();
 
       // Send magic link request
       const response = await fetch('/api/auth/magic-link/send', {
@@ -192,6 +196,11 @@ export function MagicLinkForm({ nextPath, inviteToken }: MagicLinkFormProps = {}
         <p className="text-center text-xs text-muted-foreground">
           The link expires in 5 minutes. Check your spam folder if you don&apos;t see it.
         </p>
+        {isNative && (
+          <p className="text-center text-xs text-muted-foreground">
+            Open the link on this device and it will sign you in here.
+          </p>
+        )}
 
         <div className="flex flex-col gap-2">
           <Button

--- a/apps/web/src/components/auth/MagicLinkRedeem.tsx
+++ b/apps/web/src/components/auth/MagicLinkRedeem.tsx
@@ -94,8 +94,9 @@ export function MagicLinkRedeem({ token, next }: { token: string; next?: string 
     if (!response.ok) {
       const data = (await response.json().catch(() => ({}))) as { error?: string };
       const code = data.error ?? 'invalid_token';
-      // Our fault, so the link is still good and trying again can work. A
-      // rejected token is spent, and only a fresh link will do.
+      // Our fault, so the link itself is still good and trying again can
+      // work. Every other code means the link will never work again —
+      // spent, expired, or never ours — and only a fresh one will do.
       const retryable = code === 'server_error' || code === 'session_error';
       setStatus({ kind: 'error', message: ERROR_MESSAGES[code] ?? FALLBACK_MESSAGE, retryable });
       if (retryable) return;
@@ -138,11 +139,12 @@ export function MagicLinkRedeem({ token, next }: { token: string; next?: string 
         }
       } catch (error) {
         // Never leave the old entry behind. The server has already revoked
-        // this device's previous sessions and rotated its device token, so a
-        // stale bearer is not merely useless: `auth-fetch` prefers a stored
-        // bearer over the cookie, and the server rejects an invalid bearer
-        // outright rather than falling back — which would turn the valid
-        // cookie session we just received into 401s.
+        // this device's previous sessions (and, where it minted, rotated its
+        // device token), so a stale bearer is not merely useless:
+        // `auth-fetch` prefers a stored bearer over the cookie, and the
+        // server rejects an invalid bearer outright rather than falling back
+        // — which would turn the valid cookie session we just received into
+        // 401s.
         console.error('[MagicLinkRedeem] could not store the session; clearing the stale one', error);
         await getPlatformStorage()
           .clearSession()
@@ -179,11 +181,13 @@ export function MagicLinkRedeem({ token, next }: { token: string; next?: string 
   const run = useCallback(() => {
     setStatus({ kind: 'redeeming' });
     redeem().catch((error: unknown) => {
-      // Only pre-response failures reach here — everything after the response
-      // is handled inside `redeem`, because by then the user is signed in. So
-      // the token was never spent and a retry is honest. The reason stays in
-      // the console: `TypeError: Failed to fetch` tells the person who just
-      // tapped a link nothing they can act on.
+      // Everything after the response is handled inside `redeem`, because by
+      // then the user is signed in — so what reaches here is a request that
+      // never completed, the token was never spent, and offering a retry is
+      // honest. (The one exception is `router.replace` itself throwing, which
+      // would mean navigation is broken and no message helps.) The reason
+      // stays in the console: `TypeError: Failed to fetch` tells the person
+      // who just tapped a link nothing they can act on.
       console.error('[MagicLinkRedeem] redemption failed', error);
       setStatus({ kind: 'error', message: NETWORK_MESSAGE, retryable: true });
     });

--- a/apps/web/src/components/auth/MagicLinkRedeem.tsx
+++ b/apps/web/src/components/auth/MagicLinkRedeem.tsx
@@ -1,0 +1,176 @@
+'use client';
+
+import { useEffect, useRef, useState } from 'react';
+import { useRouter } from 'next/navigation';
+import { Loader2, ShieldAlert } from 'lucide-react';
+import { AuthShell } from '@/components/auth/AuthShell';
+import { isCapacitorApp } from '@/lib/capacitor-bridge';
+import { getPlatformStorage } from '@/lib/auth/platform-storage';
+
+type Status = { kind: 'redeeming' } | { kind: 'redirecting' } | { kind: 'error'; message: string };
+
+/** What `POST /api/auth/magic-link/verify` answers on success. */
+interface RedeemResponse {
+  redirectTo: string;
+  isNewUser: boolean;
+  user: {
+    id: string;
+    name: string | null;
+    email: string | null;
+    image: string | null;
+    emailVerified: string | null;
+  } | null;
+  // Present only when this is the device the link was minted for.
+  sessionToken?: string;
+  csrfToken?: string;
+  deviceToken?: string;
+}
+
+const ERROR_MESSAGES: Record<string, string> = {
+  magic_link_expired: 'This sign-in link has expired. Request a new one to continue.',
+  magic_link_used: 'This sign-in link has already been used. Request a new one to continue.',
+  account_suspended: 'This account has been suspended.',
+};
+
+const FALLBACK_MESSAGE = 'This sign-in link is not valid. Request a new one to continue.';
+
+const NETWORK_MESSAGE = 'We could not reach PageSpace to complete sign-in. Check your connection and open the link again.';
+
+/**
+ * Redeems a magic link the app was opened with.
+ *
+ * One same-origin POST does the work: its `Set-Cookie` lands in the WebView's
+ * own jar (the whole reason the link comes here instead of Safari), and when
+ * the server recognises this device it also returns bearer tokens, stored
+ * through the platform's secure store exactly as native Google / Apple
+ * sign-in store theirs. Navigation is `router.replace`, never
+ * `window.location`: a top-level load outside `/dashboard` reaches
+ * Capacitor's navigation delegate and blanks the WebView.
+ */
+export function MagicLinkRedeem({ token, next }: { token: string; next?: string }) {
+  const router = useRouter();
+  const [status, setStatus] = useState<Status>({ kind: 'redeeming' });
+  const started = useRef(false);
+
+  useEffect(() => {
+    // Once only, and deliberately without an "unmounted" guard around the
+    // navigation: the token is single-use, so a second run would spend a token
+    // that is already gone, and a run that completed but refused to navigate
+    // would strand the user on this page with nothing left to retry. React 18
+    // makes a setState after unmount a no-op, and the only thing that unmounts
+    // this component is the navigation below.
+    if (started.current) return;
+    started.current = true;
+
+    const run = async () => {
+      const native = isCapacitorApp();
+      // A secure store that cannot answer is not a reason to fail the sign-in;
+      // it only means this request cannot prove which device it is, so it
+      // takes the cookie-only path a browser takes.
+      let deviceId: string | undefined;
+      if (native) {
+        try {
+          deviceId = await getPlatformStorage().getDeviceId();
+        } catch (error) {
+          console.warn('[MagicLinkRedeem] could not read the device id', error);
+        }
+      }
+
+      const response = await fetch('/api/auth/magic-link/verify', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        credentials: 'include',
+        body: JSON.stringify({
+          token,
+          ...(next && { next }),
+          ...(deviceId && { deviceId }),
+        }),
+      });
+
+      if (!response.ok) {
+        const data = (await response.json().catch(() => ({}))) as { error?: string };
+        const code = data.error ?? 'invalid_token';
+        setStatus({ kind: 'error', message: ERROR_MESSAGES[code] ?? FALLBACK_MESSAGE });
+        // The sign-in page already maps these codes to a toast; landing there
+        // also gives the user the form to request a fresh link.
+        router.replace(`/auth/signin?error=${encodeURIComponent(code)}`);
+        return;
+      }
+
+      const data = (await response.json()) as RedeemResponse;
+
+      // The session is already granted at this point — the response set the
+      // cookie, and the token is spent. Everything below is about making that
+      // session durable in the shell, so a failure degrades the session rather
+      // than discarding it: a cookie-only app session works, and the user can
+      // sign in again later, where being stranded here leaves them no move at
+      // all.
+      if (native && deviceId) {
+        if (data.sessionToken) {
+          try {
+            await getPlatformStorage().storeSession({
+              sessionToken: data.sessionToken,
+              csrfToken: data.csrfToken ?? null,
+              deviceId,
+              deviceToken: data.deviceToken ?? null,
+            });
+          } catch (error) {
+            console.error('[MagicLinkRedeem] could not store the session', error);
+          }
+        } else {
+          // This device asked for the link and redeemed it, so the server
+          // should have recognised it. Reaching here means the device handoff
+          // failed server-side; the cookie carries the session until it
+          // expires, and there is no stored token to refresh it with.
+          console.warn('[MagicLinkRedeem] signed in by cookie only — no tokens for this device');
+        }
+      }
+
+      const { useAuthStore } = await import('@/stores/useAuthStore');
+      useAuthStore.getState().setAuthFailedPermanently(false);
+      if (data.user) {
+        useAuthStore.getState().setUser({
+          id: data.user.id,
+          name: data.user.name,
+          email: data.user.email,
+          image: data.user.image,
+          emailVerified: data.user.emailVerified ? new Date(data.user.emailVerified) : null,
+        });
+      }
+
+      setStatus({ kind: 'redirecting' });
+      router.replace(data.redirectTo);
+    };
+
+    run().catch((error: unknown) => {
+      // Keep the reason in the console, not in the copy: this text is read by
+      // someone who just tapped a link, and `TypeError: Failed to fetch` tells
+      // them nothing they can act on.
+      console.error('[MagicLinkRedeem] redemption failed', error);
+      setStatus({ kind: 'error', message: NETWORK_MESSAGE });
+    });
+  }, [router, token, next]);
+
+  return (
+    <AuthShell>
+      <div className="flex flex-col items-center gap-4 py-6 text-center">
+        {status.kind === 'error' ? (
+          <>
+            <ShieldAlert className="h-8 w-8 text-destructive" />
+            <div>
+              <p className="text-sm font-medium text-foreground">Sign-in failed</p>
+              <p className="mt-1 text-xs text-muted-foreground">{status.message}</p>
+            </div>
+          </>
+        ) : (
+          <>
+            <Loader2 className="h-8 w-8 animate-spin text-muted-foreground" />
+            <p className="text-sm font-medium text-foreground">
+              {status.kind === 'redirecting' ? 'Signed in — opening PageSpace…' : 'Signing you in…'}
+            </p>
+          </>
+        )}
+      </div>
+    </AuthShell>
+  );
+}

--- a/apps/web/src/components/auth/MagicLinkRedeem.tsx
+++ b/apps/web/src/components/auth/MagicLinkRedeem.tsx
@@ -11,7 +11,11 @@ import { getPlatformStorage } from '@/lib/auth/platform-storage';
 type Status =
   | { kind: 'redeeming' }
   | { kind: 'redirecting' }
-  /** `retryable` is false once the token is spent — retrying would only fail. */
+  /**
+   * Only reachable before the server has seen the token, so every error here
+   * is one a retry can clear. Once the response arrives the token is spent and
+   * the user is signed in; from that point nothing may show this screen.
+   */
   | { kind: 'error'; message: string; retryable: boolean };
 
 /** What `POST /api/auth/magic-link/verify` answers on success. */
@@ -101,16 +105,23 @@ export function MagicLinkRedeem({ token, next }: { token: string; next?: string 
       return;
     }
 
-    const data = (await response.json()) as RedeemResponse;
+    // THE USER IS SIGNED IN FROM HERE ON. The response set the session cookie
+    // and the token is spent, so nothing below may fail the sign-in: every
+    // step is best-effort, and the function ends in a navigation either way.
+    // Letting a failure here reach the caller's catch would show "sign-in
+    // failed" with a retry, to someone who is signed in, for a token that no
+    // retry can spend again.
+    let data: RedeemResponse | null = null;
+    try {
+      data = (await response.json()) as RedeemResponse;
+    } catch (error) {
+      console.error('[MagicLinkRedeem] could not read the success response', error);
+    }
 
-    // The session is already granted at this point — the response set the
-    // cookie, and the token is spent. Everything below is about making that
-    // session durable in the shell, so a failure degrades the session rather
-    // than discarding it.
-    if (native && deviceId) {
+    if (native) {
       const storage = getPlatformStorage();
       try {
-        if (data.sessionToken) {
+        if (deviceId && data?.sessionToken) {
           await storage.storeSession({
             sessionToken: data.sessionToken,
             csrfToken: data.csrfToken ?? null,
@@ -118,9 +129,10 @@ export function MagicLinkRedeem({ token, next }: { token: string; next?: string 
             deviceToken: data.deviceToken ?? null,
           });
         } else {
-          // This device asked for the link and redeemed it, so the server
-          // should have recognised it. Reaching here means the device handoff
-          // failed server-side, and whatever is stored is already stale.
+          // No tokens for this device: either it could not name itself (the
+          // device id was unreadable), the link was never bound to it, or the
+          // server's handoff failed. In all three the server has just revoked
+          // this device's sessions, so anything still stored is stale.
           console.warn('[MagicLinkRedeem] no tokens for this device; falling back to the cookie');
           await storage.clearSession();
         }
@@ -140,29 +152,38 @@ export function MagicLinkRedeem({ token, next }: { token: string; next?: string 
       }
     }
 
-    const { useAuthStore } = await import('@/stores/useAuthStore');
-    useAuthStore.getState().setAuthFailedPermanently(false);
-    if (data.user) {
-      useAuthStore.getState().setUser({
-        id: data.user.id,
-        name: data.user.name,
-        email: data.user.email,
-        image: data.user.image,
-        emailVerified: data.user.emailVerified ? new Date(data.user.emailVerified) : null,
-      });
+    // Priming the store is a convenience — the dashboard reloads it anyway —
+    // so a chunk that will not load must not strand a signed-in user here.
+    try {
+      const { useAuthStore } = await import('@/stores/useAuthStore');
+      useAuthStore.getState().setAuthFailedPermanently(false);
+      if (data?.user) {
+        useAuthStore.getState().setUser({
+          id: data.user.id,
+          name: data.user.name,
+          email: data.user.email,
+          image: data.user.image,
+          emailVerified: data.user.emailVerified ? new Date(data.user.emailVerified) : null,
+        });
+      }
+    } catch (error) {
+      console.error('[MagicLinkRedeem] could not prime the auth store', error);
     }
 
     setStatus({ kind: 'redirecting' });
-    router.replace(data.redirectTo);
+    // Without a readable body we cannot know where they were headed, but they
+    // are signed in, so the dashboard is the right place to land.
+    router.replace(data?.redirectTo ?? '/dashboard');
   }, [router, token, next]);
 
   const run = useCallback(() => {
     setStatus({ kind: 'redeeming' });
     redeem().catch((error: unknown) => {
-      // Keep the reason in the console, not in the copy: this text is read by
-      // someone who just tapped a link, and `TypeError: Failed to fetch` tells
-      // them nothing they can act on. The request never reached the server, so
-      // the token was not spent and this one is retryable.
+      // Only pre-response failures reach here — everything after the response
+      // is handled inside `redeem`, because by then the user is signed in. So
+      // the token was never spent and a retry is honest. The reason stays in
+      // the console: `TypeError: Failed to fetch` tells the person who just
+      // tapped a link nothing they can act on.
       console.error('[MagicLinkRedeem] redemption failed', error);
       setStatus({ kind: 'error', message: NETWORK_MESSAGE, retryable: true });
     });
@@ -190,9 +211,10 @@ export function MagicLinkRedeem({ token, next }: { token: string; next?: string 
               <p className="text-sm font-medium text-foreground">Sign-in failed</p>
               <p className="mt-1 text-xs text-muted-foreground">{status.message}</p>
             </div>
-            {/* Reopening the link cannot retry: the shell hands a URL to the
-                deep-link handler once per app run and it ignores repeats, so
-                the retry has to live here. */}
+            {/* The retry has to live here: `DeepLinkHandler` drops a repeat of
+                the URL it just handled, so re-tapping the same link does
+                nothing, and the user would otherwise have to restart the app
+                or ask for another link for a token that was never spent. */}
             {status.retryable && (
               <Button type="button" variant="outline" size="sm" onClick={run}>
                 Try again

--- a/apps/web/src/components/auth/MagicLinkRedeem.tsx
+++ b/apps/web/src/components/auth/MagicLinkRedeem.tsx
@@ -1,13 +1,18 @@
 'use client';
 
-import { useEffect, useRef, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import { useRouter } from 'next/navigation';
 import { Loader2, ShieldAlert } from 'lucide-react';
 import { AuthShell } from '@/components/auth/AuthShell';
+import { Button } from '@/components/ui/button';
 import { isCapacitorApp } from '@/lib/capacitor-bridge';
 import { getPlatformStorage } from '@/lib/auth/platform-storage';
 
-type Status = { kind: 'redeeming' } | { kind: 'redirecting' } | { kind: 'error'; message: string };
+type Status =
+  | { kind: 'redeeming' }
+  | { kind: 'redirecting' }
+  /** `retryable` is false once the token is spent — retrying would only fail. */
+  | { kind: 'error'; message: string; retryable: boolean };
 
 /** What `POST /api/auth/magic-link/verify` answers on success. */
 interface RedeemResponse {
@@ -32,13 +37,14 @@ const ERROR_MESSAGES: Record<string, string> = {
   account_suspended: 'This account has been suspended.',
   // A failure on our side says nothing about the link. Telling the user it is
   // invalid would send them to request a replacement that fails the same way.
-  server_error: 'Something went wrong on our end. Open the link again in a moment.',
-  session_error: 'Something went wrong on our end. Open the link again in a moment.',
+  server_error: 'Something went wrong on our end. Try again in a moment.',
+  session_error: 'Something went wrong on our end. Try again in a moment.',
 };
 
 const FALLBACK_MESSAGE = 'This sign-in link is not valid. Request a new one to continue.';
 
-const NETWORK_MESSAGE = 'We could not reach PageSpace to complete sign-in. Check your connection and open the link again.';
+const NETWORK_MESSAGE =
+  'We could not reach PageSpace to complete sign-in. Check your connection and try again.';
 
 /**
  * Redeems a magic link the app was opened with.
@@ -56,106 +62,123 @@ export function MagicLinkRedeem({ token, next }: { token: string; next?: string 
   const [status, setStatus] = useState<Status>({ kind: 'redeeming' });
   const started = useRef(false);
 
-  useEffect(() => {
-    // Once only, and deliberately without an "unmounted" guard around the
-    // navigation: the token is single-use, so a second run would spend a token
-    // that is already gone, and a run that completed but refused to navigate
-    // would strand the user on this page with nothing left to retry. A
-    // setState after unmount is a no-op in React 18+, so the worst case if the
-    // user does navigate away first is a redirect they asked for a moment ago.
-    // The ref survives StrictMode's mount/unmount/mount, which is what keeps
-    // the token from being spent twice.
-    if (started.current) return;
-    started.current = true;
-
-    const run = async () => {
-      const native = isCapacitorApp();
-      // A secure store that cannot answer is not a reason to fail the sign-in;
-      // it only means this request cannot prove which device it is, so it
-      // takes the cookie-only path a browser takes.
-      let deviceId: string | undefined;
-      if (native) {
-        try {
-          deviceId = await getPlatformStorage().getDeviceId();
-        } catch (error) {
-          console.warn('[MagicLinkRedeem] could not read the device id', error);
-        }
+  const redeem = useCallback(async () => {
+    const native = isCapacitorApp();
+    // A secure store that cannot answer is not a reason to fail the sign-in;
+    // it only means this request cannot prove which device it is, so it takes
+    // the cookie-only path a browser takes.
+    let deviceId: string | undefined;
+    if (native) {
+      try {
+        deviceId = await getPlatformStorage().getDeviceId();
+      } catch (error) {
+        console.warn('[MagicLinkRedeem] could not read the device id', error);
       }
+    }
 
-      const response = await fetch('/api/auth/magic-link/verify', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        credentials: 'include',
-        body: JSON.stringify({
-          token,
-          ...(next && { next }),
-          ...(deviceId && { deviceId }),
-        }),
-      });
+    const response = await fetch('/api/auth/magic-link/verify', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      credentials: 'include',
+      body: JSON.stringify({
+        token,
+        ...(next && { next }),
+        ...(deviceId && { deviceId }),
+      }),
+    });
 
-      if (!response.ok) {
-        const data = (await response.json().catch(() => ({}))) as { error?: string };
-        const code = data.error ?? 'invalid_token';
-        setStatus({ kind: 'error', message: ERROR_MESSAGES[code] ?? FALLBACK_MESSAGE });
-        // The sign-in page already maps these codes to a toast; landing there
-        // also gives the user the form to request a fresh link.
-        router.replace(`/auth/signin?error=${encodeURIComponent(code)}`);
-        return;
-      }
+    if (!response.ok) {
+      const data = (await response.json().catch(() => ({}))) as { error?: string };
+      const code = data.error ?? 'invalid_token';
+      // Our fault, so the link is still good and trying again can work. A
+      // rejected token is spent, and only a fresh link will do.
+      const retryable = code === 'server_error' || code === 'session_error';
+      setStatus({ kind: 'error', message: ERROR_MESSAGES[code] ?? FALLBACK_MESSAGE, retryable });
+      if (retryable) return;
+      // The sign-in page already maps these codes to a toast; landing there
+      // also gives the user the form to request a fresh link.
+      router.replace(`/auth/signin?error=${encodeURIComponent(code)}`);
+      return;
+    }
 
-      const data = (await response.json()) as RedeemResponse;
+    const data = (await response.json()) as RedeemResponse;
 
-      // The session is already granted at this point — the response set the
-      // cookie, and the token is spent. Everything below is about making that
-      // session durable in the shell, so a failure degrades the session rather
-      // than discarding it: a cookie-only app session works, and the user can
-      // sign in again later, where being stranded here leaves them no move at
-      // all.
-      if (native && deviceId) {
+    // The session is already granted at this point — the response set the
+    // cookie, and the token is spent. Everything below is about making that
+    // session durable in the shell, so a failure degrades the session rather
+    // than discarding it.
+    if (native && deviceId) {
+      const storage = getPlatformStorage();
+      try {
         if (data.sessionToken) {
-          try {
-            await getPlatformStorage().storeSession({
-              sessionToken: data.sessionToken,
-              csrfToken: data.csrfToken ?? null,
-              deviceId,
-              deviceToken: data.deviceToken ?? null,
-            });
-          } catch (error) {
-            console.error('[MagicLinkRedeem] could not store the session', error);
-          }
+          await storage.storeSession({
+            sessionToken: data.sessionToken,
+            csrfToken: data.csrfToken ?? null,
+            deviceId,
+            deviceToken: data.deviceToken ?? null,
+          });
         } else {
           // This device asked for the link and redeemed it, so the server
           // should have recognised it. Reaching here means the device handoff
-          // failed server-side; the cookie carries the session until it
-          // expires, and there is no stored token to refresh it with.
-          console.warn('[MagicLinkRedeem] signed in by cookie only — no tokens for this device');
+          // failed server-side, and whatever is stored is already stale.
+          console.warn('[MagicLinkRedeem] no tokens for this device; falling back to the cookie');
+          await storage.clearSession();
         }
+      } catch (error) {
+        // Never leave the old entry behind. The server has already revoked
+        // this device's previous sessions and rotated its device token, so a
+        // stale bearer is not merely useless: `auth-fetch` prefers a stored
+        // bearer over the cookie, and the server rejects an invalid bearer
+        // outright rather than falling back — which would turn the valid
+        // cookie session we just received into 401s.
+        console.error('[MagicLinkRedeem] could not store the session; clearing the stale one', error);
+        await getPlatformStorage()
+          .clearSession()
+          .catch((clearError: unknown) => {
+            console.error('[MagicLinkRedeem] could not clear the stale session either', clearError);
+          });
       }
+    }
 
-      const { useAuthStore } = await import('@/stores/useAuthStore');
-      useAuthStore.getState().setAuthFailedPermanently(false);
-      if (data.user) {
-        useAuthStore.getState().setUser({
-          id: data.user.id,
-          name: data.user.name,
-          email: data.user.email,
-          image: data.user.image,
-          emailVerified: data.user.emailVerified ? new Date(data.user.emailVerified) : null,
-        });
-      }
+    const { useAuthStore } = await import('@/stores/useAuthStore');
+    useAuthStore.getState().setAuthFailedPermanently(false);
+    if (data.user) {
+      useAuthStore.getState().setUser({
+        id: data.user.id,
+        name: data.user.name,
+        email: data.user.email,
+        image: data.user.image,
+        emailVerified: data.user.emailVerified ? new Date(data.user.emailVerified) : null,
+      });
+    }
 
-      setStatus({ kind: 'redirecting' });
-      router.replace(data.redirectTo);
-    };
+    setStatus({ kind: 'redirecting' });
+    router.replace(data.redirectTo);
+  }, [router, token, next]);
 
-    run().catch((error: unknown) => {
+  const run = useCallback(() => {
+    setStatus({ kind: 'redeeming' });
+    redeem().catch((error: unknown) => {
       // Keep the reason in the console, not in the copy: this text is read by
       // someone who just tapped a link, and `TypeError: Failed to fetch` tells
-      // them nothing they can act on.
+      // them nothing they can act on. The request never reached the server, so
+      // the token was not spent and this one is retryable.
       console.error('[MagicLinkRedeem] redemption failed', error);
-      setStatus({ kind: 'error', message: NETWORK_MESSAGE });
+      setStatus({ kind: 'error', message: NETWORK_MESSAGE, retryable: true });
     });
-  }, [router, token, next]);
+  }, [redeem]);
+
+  useEffect(() => {
+    // Once only: the token is single-use, so a second automatic run would
+    // spend a token that is already gone. The ref survives StrictMode's
+    // mount/unmount/mount, which is what makes that true. Deliberately no
+    // "unmounted" guard around the navigation — a run that completed but
+    // refused to navigate would strand the user on this page, and a setState
+    // after unmount is a no-op in React 18+.
+    if (started.current) return;
+    started.current = true;
+    run();
+  }, [run]);
 
   return (
     <AuthShell>
@@ -167,6 +190,14 @@ export function MagicLinkRedeem({ token, next }: { token: string; next?: string 
               <p className="text-sm font-medium text-foreground">Sign-in failed</p>
               <p className="mt-1 text-xs text-muted-foreground">{status.message}</p>
             </div>
+            {/* Reopening the link cannot retry: the shell hands a URL to the
+                deep-link handler once per app run and it ignores repeats, so
+                the retry has to live here. */}
+            {status.retryable && (
+              <Button type="button" variant="outline" size="sm" onClick={run}>
+                Try again
+              </Button>
+            )}
           </>
         ) : (
           <>

--- a/apps/web/src/components/auth/MagicLinkRedeem.tsx
+++ b/apps/web/src/components/auth/MagicLinkRedeem.tsx
@@ -30,6 +30,10 @@ const ERROR_MESSAGES: Record<string, string> = {
   magic_link_expired: 'This sign-in link has expired. Request a new one to continue.',
   magic_link_used: 'This sign-in link has already been used. Request a new one to continue.',
   account_suspended: 'This account has been suspended.',
+  // A failure on our side says nothing about the link. Telling the user it is
+  // invalid would send them to request a replacement that fails the same way.
+  server_error: 'Something went wrong on our end. Open the link again in a moment.',
+  session_error: 'Something went wrong on our end. Open the link again in a moment.',
 };
 
 const FALLBACK_MESSAGE = 'This sign-in link is not valid. Request a new one to continue.';
@@ -56,9 +60,11 @@ export function MagicLinkRedeem({ token, next }: { token: string; next?: string 
     // Once only, and deliberately without an "unmounted" guard around the
     // navigation: the token is single-use, so a second run would spend a token
     // that is already gone, and a run that completed but refused to navigate
-    // would strand the user on this page with nothing left to retry. React 18
-    // makes a setState after unmount a no-op, and the only thing that unmounts
-    // this component is the navigation below.
+    // would strand the user on this page with nothing left to retry. A
+    // setState after unmount is a no-op in React 18+, so the worst case if the
+    // user does navigate away first is a redirect they asked for a moment ago.
+    // The ref survives StrictMode's mount/unmount/mount, which is what keeps
+    // the token from being spent twice.
     if (started.current) return;
     started.current = true;
 

--- a/apps/web/src/components/auth/__tests__/MagicLinkForm.test.tsx
+++ b/apps/web/src/components/auth/__tests__/MagicLinkForm.test.tsx
@@ -25,8 +25,17 @@ vi.mock('sonner', () => ({
   toast: { error: vi.fn(), success: vi.fn(), info: vi.fn() },
 }));
 
-vi.mock('@/lib/desktop-auth', () => ({
-  getDevicePlatformFields: vi.fn().mockResolvedValue({}),
+const { mockGetMagicLinkPlatformFields } = vi.hoisted(() => ({
+  mockGetMagicLinkPlatformFields: vi.fn(),
+}));
+
+vi.mock('@/lib/auth/magic-link-platform-fields', () => ({
+  getMagicLinkPlatformFields: () => mockGetMagicLinkPlatformFields(),
+}));
+
+vi.mock('@/lib/capacitor-bridge', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('@/lib/capacitor-bridge')>()),
+  isCapacitorApp: () => false,
 }));
 
 import { MagicLinkForm } from '../MagicLinkForm';
@@ -56,6 +65,7 @@ const setupFetchMock = () => {
 describe('MagicLinkForm', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    mockGetMagicLinkPlatformFields.mockResolvedValue({});
   });
 
   describe('ToS gate', () => {
@@ -148,6 +158,30 @@ describe('MagicLinkForm', () => {
       const init = sendCall![1] as RequestInit;
       const body = JSON.parse(init.body as string) as Record<string, unknown>;
       expect(body).not.toHaveProperty('next');
+    });
+
+    it('given the native shell reports a device, sends platform + device fields so the link binds to this app', async () => {
+      mockGetMagicLinkPlatformFields.mockResolvedValue({
+        platform: 'ios',
+        deviceId: 'dev_ios_1',
+        deviceName: 'iOS App',
+      });
+      const fetchSpy = setupFetchMock();
+      render(<MagicLinkForm />);
+
+      await userEvent.type(screen.getByLabelText(/email/i), 'user@example.com');
+      await userEvent.click(screen.getByLabelText(/i agree/i));
+      await userEvent.click(screen.getByRole('button', { name: /sign-in link/i }));
+
+      const sendCall = fetchSpy.mock.calls.find(([url]) =>
+        typeof url === 'string' && url.includes('/api/auth/magic-link/send'),
+      );
+      expect(sendCall).toBeDefined();
+      const init = sendCall![1] as RequestInit;
+      const body = JSON.parse(init.body as string) as Record<string, unknown>;
+      expect(body).toEqual(
+        expect.objectContaining({ platform: 'ios', deviceId: 'dev_ios_1', deviceName: 'iOS App' }),
+      );
     });
   });
 });

--- a/apps/web/src/components/auth/__tests__/MagicLinkRedeem.test.tsx
+++ b/apps/web/src/components/auth/__tests__/MagicLinkRedeem.test.tsx
@@ -1,3 +1,4 @@
+import { StrictMode } from 'react';
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { render, screen, waitFor } from '@testing-library/react';
 
@@ -187,10 +188,17 @@ describe('MagicLinkRedeem', () => {
   });
 
   it('redeems exactly once across React strict-mode double effects', async () => {
+    // Rendered inside StrictMode on purpose: RTL does not add it, and without
+    // it this test passes with the `started` guard deleted — which is exactly
+    // the guard that keeps a single-use token from being spent twice.
     mockIsCapacitorApp.mockReturnValue(false);
     fetchSpy.mockResolvedValue(okResponse({ redirectTo: '/dashboard?auth=success', isNewUser: false, user: null }));
 
-    render(<MagicLinkRedeem token="ps_magic_abc" />);
+    render(
+      <StrictMode>
+        <MagicLinkRedeem token="ps_magic_abc" />
+      </StrictMode>,
+    );
 
     await waitFor(() => expect(mockReplace).toHaveBeenCalled());
     expect(fetchSpy).toHaveBeenCalledTimes(1);

--- a/apps/web/src/components/auth/__tests__/MagicLinkRedeem.test.tsx
+++ b/apps/web/src/components/auth/__tests__/MagicLinkRedeem.test.tsx
@@ -1,12 +1,14 @@
 import { StrictMode } from 'react';
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 
 const {
   mockReplace,
   mockIsCapacitorApp,
   mockGetDeviceId,
   mockStoreSession,
+  mockClearSession,
   mockSetUser,
   mockSetAuthFailedPermanently,
 } = vi.hoisted(() => ({
@@ -14,6 +16,7 @@ const {
   mockIsCapacitorApp: vi.fn(),
   mockGetDeviceId: vi.fn(),
   mockStoreSession: vi.fn(),
+  mockClearSession: vi.fn(),
   mockSetUser: vi.fn(),
   mockSetAuthFailedPermanently: vi.fn(),
 }));
@@ -30,6 +33,7 @@ vi.mock('@/lib/auth/platform-storage', () => ({
   getPlatformStorage: () => ({
     getDeviceId: mockGetDeviceId,
     storeSession: mockStoreSession,
+    clearSession: mockClearSession,
   }),
 }));
 
@@ -58,6 +62,7 @@ describe('MagicLinkRedeem', () => {
     vi.resetAllMocks();
     mockGetDeviceId.mockResolvedValue('dev_iphone');
     mockStoreSession.mockResolvedValue(undefined);
+    mockClearSession.mockResolvedValue(undefined);
     fetchSpy = vi.fn();
     global.fetch = fetchSpy as unknown as typeof fetch;
   });
@@ -105,7 +110,7 @@ describe('MagicLinkRedeem', () => {
     expect(mockStoreSession.mock.invocationCallOrder[0]).toBeLessThan(mockReplace.mock.invocationCallOrder[0]);
   });
 
-  it('in the app, when the server withholds tokens, stores nothing and still lands the user on the cookie session', async () => {
+  it('in the app, when the server withholds tokens, clears the stale entry and lands on the cookie session', async () => {
     mockIsCapacitorApp.mockReturnValue(true);
     fetchSpy.mockResolvedValue(okResponse({ redirectTo: '/dashboard?auth=success', isNewUser: false, user: null }));
 
@@ -114,6 +119,7 @@ describe('MagicLinkRedeem', () => {
     await waitFor(() => expect(mockReplace).toHaveBeenCalledWith('/dashboard?auth=success'));
     expect(mockStoreSession).not.toHaveBeenCalled();
     expect(mockSetUser).not.toHaveBeenCalled();
+    expect(mockClearSession).toHaveBeenCalled();
   });
 
   it('in a browser, presents no device and never touches the secure store', async () => {
@@ -173,6 +179,10 @@ describe('MagicLinkRedeem', () => {
 
     await waitFor(() => expect(mockReplace).toHaveBeenCalledWith('/dashboard?auth=success'));
     expect(screen.queryByText('Sign-in failed')).not.toBeInTheDocument();
+    // The old entry must not survive: the server already revoked this device's
+    // sessions and rotated its token, and auth-fetch would prefer that stale
+    // bearer over the cookie we just received.
+    expect(mockClearSession).toHaveBeenCalled();
   });
 
   it('when the device id cannot be read, falls back to the cookie-only path instead of failing', async () => {
@@ -202,5 +212,51 @@ describe('MagicLinkRedeem', () => {
 
     await waitFor(() => expect(mockReplace).toHaveBeenCalled());
     expect(fetchSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it('offers a retry after a transient failure, because reopening the link cannot retry', async () => {
+    // DeepLinkHandler remembers the URL it already handled, so tapping the
+    // same link again in the same app run does nothing. The retry has to be
+    // on this page or the user has to restart the app.
+    mockIsCapacitorApp.mockReturnValue(false);
+    fetchSpy.mockRejectedValueOnce(new Error('Failed to fetch'));
+    fetchSpy.mockResolvedValueOnce(
+      okResponse({ redirectTo: '/dashboard?auth=success', isNewUser: false, user: null }),
+    );
+
+    render(<MagicLinkRedeem token="ps_magic_abc" />);
+
+    const retry = await screen.findByRole('button', { name: /try again/i });
+    await userEvent.click(retry);
+
+    await waitFor(() => expect(mockReplace).toHaveBeenCalledWith('/dashboard?auth=success'));
+    expect(fetchSpy).toHaveBeenCalledTimes(2);
+  });
+
+  it('offers a retry when the server fails on its own side', async () => {
+    mockIsCapacitorApp.mockReturnValue(false);
+    fetchSpy.mockResolvedValueOnce(
+      new Response(JSON.stringify({ error: 'server_error' }), { status: 500 }),
+    );
+
+    render(<MagicLinkRedeem token="ps_magic_abc" />);
+
+    expect(await screen.findByRole('button', { name: /try again/i })).toBeInTheDocument();
+    expect(screen.getByText(/on our end/i)).toBeInTheDocument();
+    // A server fault says nothing about the link, so do not send the user off
+    // to request a replacement.
+    expect(mockReplace).not.toHaveBeenCalled();
+  });
+
+  it('offers no retry once the token is spent — only a fresh link will do', async () => {
+    mockIsCapacitorApp.mockReturnValue(false);
+    fetchSpy.mockResolvedValue(
+      new Response(JSON.stringify({ error: 'magic_link_used' }), { status: 401 }),
+    );
+
+    render(<MagicLinkRedeem token="ps_magic_abc" />);
+
+    await waitFor(() => expect(mockReplace).toHaveBeenCalledWith('/auth/signin?error=magic_link_used'));
+    expect(screen.queryByRole('button', { name: /try again/i })).not.toBeInTheDocument();
   });
 });

--- a/apps/web/src/components/auth/__tests__/MagicLinkRedeem.test.tsx
+++ b/apps/web/src/components/auth/__tests__/MagicLinkRedeem.test.tsx
@@ -185,7 +185,10 @@ describe('MagicLinkRedeem', () => {
     expect(mockClearSession).toHaveBeenCalled();
   });
 
-  it('when the device id cannot be read, falls back to the cookie-only path instead of failing', async () => {
+  it('when the device id cannot be read, falls back to the cookie-only path and still clears the stale entry', async () => {
+    // Presenting no device makes the server revoke every web session for this
+    // user — this phone's included — so anything left in the store is stale,
+    // and auth-fetch would prefer it over the cookie we just received.
     mockIsCapacitorApp.mockReturnValue(true);
     mockGetDeviceId.mockRejectedValue(new Error('preferences unavailable'));
     fetchSpy.mockResolvedValue(okResponse({ redirectTo: '/dashboard?auth=success', isNewUser: false, user: null }));
@@ -195,6 +198,7 @@ describe('MagicLinkRedeem', () => {
     await waitFor(() => expect(mockReplace).toHaveBeenCalledWith('/dashboard?auth=success'));
     expect(sentBody().body).toEqual({ token: 'ps_magic_abc' });
     expect(mockStoreSession).not.toHaveBeenCalled();
+    expect(mockClearSession).toHaveBeenCalled();
   });
 
   it('redeems exactly once across React strict-mode double effects', async () => {
@@ -258,5 +262,42 @@ describe('MagicLinkRedeem', () => {
 
     await waitFor(() => expect(mockReplace).toHaveBeenCalledWith('/auth/signin?error=magic_link_used'));
     expect(screen.queryByRole('button', { name: /try again/i })).not.toBeInTheDocument();
+  });
+
+  it('a failure after the response still lands the user, because they are already signed in', async () => {
+    // The cookie is set and the token is spent by then. Showing "sign-in
+    // failed" with a retry would lie to a signed-in user and burn the retry on
+    // a token no retry can spend again.
+    mockIsCapacitorApp.mockReturnValue(true);
+    mockStoreSession.mockRejectedValue(new Error('keychain locked'));
+    mockSetUser.mockImplementation(() => {
+      throw new Error('store blew up');
+    });
+    fetchSpy.mockResolvedValue(
+      okResponse({
+        redirectTo: '/dashboard/d1?auth=success',
+        isNewUser: false,
+        user,
+        sessionToken: 'ps_sess_1',
+        csrfToken: 'csrf_1',
+        deviceToken: 'ps_dev_1',
+      }),
+    );
+
+    render(<MagicLinkRedeem token="ps_magic_abc" />);
+
+    await waitFor(() => expect(mockReplace).toHaveBeenCalledWith('/dashboard/d1?auth=success'));
+    expect(screen.queryByText('Sign-in failed')).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: /try again/i })).not.toBeInTheDocument();
+  });
+
+  it('given a success with an unreadable body, lands the user on the dashboard rather than failing', async () => {
+    mockIsCapacitorApp.mockReturnValue(false);
+    fetchSpy.mockResolvedValue(new Response('not json', { status: 200 }));
+
+    render(<MagicLinkRedeem token="ps_magic_abc" />);
+
+    await waitFor(() => expect(mockReplace).toHaveBeenCalledWith('/dashboard'));
+    expect(screen.queryByText('Sign-in failed')).not.toBeInTheDocument();
   });
 });

--- a/apps/web/src/components/auth/__tests__/MagicLinkRedeem.test.tsx
+++ b/apps/web/src/components/auth/__tests__/MagicLinkRedeem.test.tsx
@@ -1,0 +1,198 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+
+const {
+  mockReplace,
+  mockIsCapacitorApp,
+  mockGetDeviceId,
+  mockStoreSession,
+  mockSetUser,
+  mockSetAuthFailedPermanently,
+} = vi.hoisted(() => ({
+  mockReplace: vi.fn(),
+  mockIsCapacitorApp: vi.fn(),
+  mockGetDeviceId: vi.fn(),
+  mockStoreSession: vi.fn(),
+  mockSetUser: vi.fn(),
+  mockSetAuthFailedPermanently: vi.fn(),
+}));
+
+vi.mock('next/navigation', () => ({ useRouter: () => ({ replace: mockReplace, push: vi.fn() }) }));
+
+// Spread the real module: other imports pull getPlatform etc. from here.
+vi.mock('@/lib/capacitor-bridge', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('@/lib/capacitor-bridge')>()),
+  isCapacitorApp: () => mockIsCapacitorApp(),
+}));
+
+vi.mock('@/lib/auth/platform-storage', () => ({
+  getPlatformStorage: () => ({
+    getDeviceId: mockGetDeviceId,
+    storeSession: mockStoreSession,
+  }),
+}));
+
+vi.mock('@/stores/useAuthStore', () => ({
+  useAuthStore: {
+    getState: () => ({ setUser: mockSetUser, setAuthFailedPermanently: mockSetAuthFailedPermanently }),
+  },
+}));
+
+// AuthShell animates with motion/react; keep the DOM plain.
+vi.mock('@/components/auth/AuthShell', () => ({
+  AuthShell: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+}));
+
+import { MagicLinkRedeem } from '../MagicLinkRedeem';
+
+const okResponse = (body: Record<string, unknown>) =>
+  new Response(JSON.stringify(body), { status: 200, headers: { 'Content-Type': 'application/json' } });
+
+const user = { id: 'u1', name: 'Jo', email: 'jo@example.com', image: null, emailVerified: null };
+
+describe('MagicLinkRedeem', () => {
+  let fetchSpy: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    vi.resetAllMocks();
+    mockGetDeviceId.mockResolvedValue('dev_iphone');
+    mockStoreSession.mockResolvedValue(undefined);
+    fetchSpy = vi.fn();
+    global.fetch = fetchSpy as unknown as typeof fetch;
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  const sentBody = () => {
+    const call = fetchSpy.mock.calls.find(([url]) => String(url).includes('/api/auth/magic-link/verify'));
+    if (!call) throw new Error('verify was never called');
+    const init = call[1] as RequestInit;
+    return { init, body: JSON.parse(init.body as string) as Record<string, unknown> };
+  };
+
+  it('in the app, presents this device, stores the returned tokens in the secure store, and lands the user', async () => {
+    mockIsCapacitorApp.mockReturnValue(true);
+    fetchSpy.mockResolvedValue(
+      okResponse({
+        redirectTo: '/dashboard/d1?auth=success',
+        isNewUser: false,
+        user,
+        sessionToken: 'ps_sess_1',
+        csrfToken: 'csrf_1',
+        deviceToken: 'ps_dev_1',
+      }),
+    );
+
+    render(<MagicLinkRedeem token="ps_magic_abc" next="/dashboard/d1" />);
+
+    await waitFor(() => expect(mockReplace).toHaveBeenCalledWith('/dashboard/d1?auth=success'));
+    const { init, body } = sentBody();
+    expect(init.method).toBe('POST');
+    expect(init.credentials).toBe('include');
+    expect(body).toEqual({ token: 'ps_magic_abc', next: '/dashboard/d1', deviceId: 'dev_iphone' });
+    expect(mockStoreSession).toHaveBeenCalledWith({
+      sessionToken: 'ps_sess_1',
+      csrfToken: 'csrf_1',
+      deviceId: 'dev_iphone',
+      deviceToken: 'ps_dev_1',
+    });
+    expect(mockSetAuthFailedPermanently).toHaveBeenCalledWith(false);
+    expect(mockSetUser).toHaveBeenCalledWith(expect.objectContaining({ id: 'u1', email: 'jo@example.com' }));
+    // Store first, then navigate: the dashboard's first request must find the bearer.
+    expect(mockStoreSession.mock.invocationCallOrder[0]).toBeLessThan(mockReplace.mock.invocationCallOrder[0]);
+  });
+
+  it('in the app, when the server withholds tokens, stores nothing and still lands the user on the cookie session', async () => {
+    mockIsCapacitorApp.mockReturnValue(true);
+    fetchSpy.mockResolvedValue(okResponse({ redirectTo: '/dashboard?auth=success', isNewUser: false, user: null }));
+
+    render(<MagicLinkRedeem token="ps_magic_abc" />);
+
+    await waitFor(() => expect(mockReplace).toHaveBeenCalledWith('/dashboard?auth=success'));
+    expect(mockStoreSession).not.toHaveBeenCalled();
+    expect(mockSetUser).not.toHaveBeenCalled();
+  });
+
+  it('in a browser, presents no device and never touches the secure store', async () => {
+    mockIsCapacitorApp.mockReturnValue(false);
+    fetchSpy.mockResolvedValue(okResponse({ redirectTo: '/dashboard?auth=success', isNewUser: true, user }));
+
+    render(<MagicLinkRedeem token="ps_magic_abc" />);
+
+    await waitFor(() => expect(mockReplace).toHaveBeenCalledWith('/dashboard?auth=success'));
+    expect(sentBody().body).toEqual({ token: 'ps_magic_abc' });
+    expect(mockGetDeviceId).not.toHaveBeenCalled();
+    expect(mockStoreSession).not.toHaveBeenCalled();
+  });
+
+  it('on a rejected token, shows the reason and sends the user to sign-in with the same code', async () => {
+    mockIsCapacitorApp.mockReturnValue(true);
+    fetchSpy.mockResolvedValue(
+      new Response(JSON.stringify({ error: 'magic_link_expired' }), { status: 401 }),
+    );
+
+    render(<MagicLinkRedeem token="ps_magic_abc" />);
+
+    await waitFor(() => expect(mockReplace).toHaveBeenCalledWith('/auth/signin?error=magic_link_expired'));
+    expect(screen.getByText(/expired/i)).toBeInTheDocument();
+    expect(mockStoreSession).not.toHaveBeenCalled();
+  });
+
+  it('on a network failure, shows actionable copy rather than the raw error', async () => {
+    mockIsCapacitorApp.mockReturnValue(false);
+    fetchSpy.mockRejectedValue(new Error('Failed to fetch'));
+
+    render(<MagicLinkRedeem token="ps_magic_abc" />);
+
+    await waitFor(() => expect(screen.getByText('Sign-in failed')).toBeInTheDocument());
+    expect(screen.getByText(/check your connection/i)).toBeInTheDocument();
+    expect(screen.queryByText(/Failed to fetch/)).not.toBeInTheDocument();
+    expect(mockReplace).not.toHaveBeenCalled();
+  });
+
+  it('when the secure store refuses to save, still lands the user on the cookie session', async () => {
+    // The token is already spent and the cookie is already set. Stranding the
+    // user here would leave them signed out with nothing to retry.
+    mockIsCapacitorApp.mockReturnValue(true);
+    mockStoreSession.mockRejectedValue(new Error('keychain locked'));
+    fetchSpy.mockResolvedValue(
+      okResponse({
+        redirectTo: '/dashboard?auth=success',
+        isNewUser: false,
+        user,
+        sessionToken: 'ps_sess_1',
+        csrfToken: 'csrf_1',
+        deviceToken: 'ps_dev_1',
+      }),
+    );
+
+    render(<MagicLinkRedeem token="ps_magic_abc" />);
+
+    await waitFor(() => expect(mockReplace).toHaveBeenCalledWith('/dashboard?auth=success'));
+    expect(screen.queryByText('Sign-in failed')).not.toBeInTheDocument();
+  });
+
+  it('when the device id cannot be read, falls back to the cookie-only path instead of failing', async () => {
+    mockIsCapacitorApp.mockReturnValue(true);
+    mockGetDeviceId.mockRejectedValue(new Error('preferences unavailable'));
+    fetchSpy.mockResolvedValue(okResponse({ redirectTo: '/dashboard?auth=success', isNewUser: false, user: null }));
+
+    render(<MagicLinkRedeem token="ps_magic_abc" />);
+
+    await waitFor(() => expect(mockReplace).toHaveBeenCalledWith('/dashboard?auth=success'));
+    expect(sentBody().body).toEqual({ token: 'ps_magic_abc' });
+    expect(mockStoreSession).not.toHaveBeenCalled();
+  });
+
+  it('redeems exactly once across React strict-mode double effects', async () => {
+    mockIsCapacitorApp.mockReturnValue(false);
+    fetchSpy.mockResolvedValue(okResponse({ redirectTo: '/dashboard?auth=success', isNewUser: false, user: null }));
+
+    render(<MagicLinkRedeem token="ps_magic_abc" />);
+
+    await waitFor(() => expect(mockReplace).toHaveBeenCalled());
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/web/src/hooks/__tests__/useInAppBrowserNotice.test.tsx
+++ b/apps/web/src/hooks/__tests__/useInAppBrowserNotice.test.tsx
@@ -1,0 +1,35 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { renderHook, waitFor } from '@testing-library/react';
+
+const { mockDetectInAppBrowser } = vi.hoisted(() => ({
+  mockDetectInAppBrowser: vi.fn(),
+}));
+
+vi.mock('@/lib/auth/browser-detection', () => ({
+  detectInAppBrowser: () => mockDetectInAppBrowser(),
+}));
+
+import { useInAppBrowserNotice } from '../useInAppBrowserNotice';
+
+describe('useInAppBrowserNotice', () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+  });
+
+  it('given a third-party in-app browser, should surface the notice after mount', async () => {
+    mockDetectInAppBrowser.mockReturnValue({ isInApp: true, appName: 'Instagram' });
+
+    const { result } = renderHook(() => useInAppBrowserNotice());
+
+    await waitFor(() => expect(result.current).toEqual({ isInApp: true, appName: 'Instagram' }));
+  });
+
+  it('given no in-app browser, should stay quiet', async () => {
+    mockDetectInAppBrowser.mockReturnValue({ isInApp: false, appName: undefined });
+
+    const { result } = renderHook(() => useInAppBrowserNotice());
+
+    await waitFor(() => expect(mockDetectInAppBrowser).toHaveBeenCalled());
+    expect(result.current).toEqual({ isInApp: false, appName: undefined });
+  });
+});

--- a/apps/web/src/hooks/useInAppBrowserNotice.ts
+++ b/apps/web/src/hooks/useInAppBrowserNotice.ts
@@ -1,0 +1,33 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { detectInAppBrowser } from '@/lib/auth/browser-detection';
+
+interface InAppBrowserNotice {
+  isInApp: boolean;
+  appName: string | undefined;
+}
+
+const NOT_IN_APP: InAppBrowserNotice = { isInApp: false, appName: undefined };
+
+/**
+ * Should the sign-in / sign-up screen warn that Google's web OAuth is blocked
+ * here and steer the user to a magic link?
+ *
+ * Resolved in an effect, never during render: the answer depends on
+ * `navigator` and `window.Capacitor`, and the server has neither. The initial
+ * state is therefore always "not in-app", which is also the right answer for
+ * the Capacitor shell (see `detectInAppBrowser`).
+ */
+export function useInAppBrowserNotice(): InAppBrowserNotice {
+  const [notice, setNotice] = useState<InAppBrowserNotice>(NOT_IN_APP);
+
+  useEffect(() => {
+    const result = detectInAppBrowser();
+    if (result.isInApp) {
+      setNotice({ isInApp: true, appName: result.appName });
+    }
+  }, []);
+
+  return notice;
+}

--- a/apps/web/src/lib/auth/__tests__/browser-detection.test.ts
+++ b/apps/web/src/lib/auth/__tests__/browser-detection.test.ts
@@ -1,0 +1,47 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const { mockInAppSpy, mockIsCapacitorApp } = vi.hoisted(() => ({
+  mockInAppSpy: vi.fn(),
+  mockIsCapacitorApp: vi.fn(),
+}));
+
+vi.mock('inapp-spy', () => ({ default: mockInAppSpy }));
+
+// Spread the real module: the bridge is imported by other auth helpers that
+// need getPlatform et al. to exist.
+vi.mock('@/lib/capacitor-bridge', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('@/lib/capacitor-bridge')>()),
+  isCapacitorApp: () => mockIsCapacitorApp(),
+}));
+
+import { detectInAppBrowser } from '../browser-detection';
+
+describe('detectInAppBrowser', () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+    // inapp-spy flags every bare WKWebView, our own shell included.
+    mockInAppSpy.mockReturnValue({ isInApp: true, appName: undefined });
+  });
+
+  it('given the Capacitor shell, should not report an in-app browser', () => {
+    mockIsCapacitorApp.mockReturnValue(true);
+
+    expect(detectInAppBrowser()).toEqual({ isInApp: false, appName: undefined });
+    // The exemption is decided before inapp-spy runs, not by overriding it.
+    expect(mockInAppSpy).not.toHaveBeenCalled();
+  });
+
+  it('given a genuine third-party in-app browser, should still report it', () => {
+    mockIsCapacitorApp.mockReturnValue(false);
+    mockInAppSpy.mockReturnValue({ isInApp: true, appName: 'Instagram' });
+
+    expect(detectInAppBrowser()).toEqual({ isInApp: true, appName: 'Instagram' });
+  });
+
+  it('given a normal browser, should report not in-app', () => {
+    mockIsCapacitorApp.mockReturnValue(false);
+    mockInAppSpy.mockReturnValue({ isInApp: false, appName: undefined });
+
+    expect(detectInAppBrowser().isInApp).toBe(false);
+  });
+});

--- a/apps/web/src/lib/auth/browser-detection.ts
+++ b/apps/web/src/lib/auth/browser-detection.ts
@@ -1,7 +1,23 @@
 import InAppSpy from 'inapp-spy';
+import { isCapacitorApp } from '@/lib/capacitor-bridge';
 
-export function detectInAppBrowser() {
-  if (typeof navigator === 'undefined') return { isInApp: false, appName: undefined };
+const NOT_IN_APP = { isInApp: false, appName: undefined } as const;
+
+/**
+ * Is this page running inside a third-party in-app browser (Instagram,
+ * Facebook, Telegram, …) where Google's web OAuth is refused?
+ *
+ * Our own Capacitor shell is a WKWebView too, so `inapp-spy` flags it — but it
+ * is not a third-party browser: Google sign-in there goes through the native
+ * `@capgo/capacitor-social-login` plugin, never the blocked web flow. Answer
+ * "no" for the shell before asking `inapp-spy`, so genuine in-app browsers
+ * keep their warning and the app never tells users a working button is
+ * blocked. Platform knowledge stays in `capacitor-bridge`, the one sanctioned
+ * reader of `window.Capacitor`.
+ */
+export function detectInAppBrowser(): { isInApp: boolean; appName: string | undefined } {
+  if (typeof navigator === 'undefined') return NOT_IN_APP;
+  if (isCapacitorApp()) return NOT_IN_APP;
   // Don't pass ua — lets inapp-spy use all detection methods including
   // non-UA signals (e.g. Telegram detects via window.TelegramWebviewProxy)
   return InAppSpy();

--- a/apps/web/src/lib/auth/magic-link-adapters.ts
+++ b/apps/web/src/lib/auth/magic-link-adapters.ts
@@ -67,8 +67,9 @@ export const buildMagicLinkPorts = (): MagicLinkPorts => ({
     const { token, hash, tokenPrefix } = generateToken('ps_magic');
     const metadataObj: Record<string, unknown> = {};
     const boundDevice = boundDevicePlatform(platform, deviceId);
-    if (boundDevice && deviceId) {
+    if (boundDevice) {
       metadataObj.platform = boundDevice;
+      // Non-null whenever boundDevice is — that is what the predicate decides.
       metadataObj.deviceId = deviceId;
       if (deviceName) metadataObj.deviceName = deviceName;
     }

--- a/apps/web/src/lib/auth/magic-link-adapters.ts
+++ b/apps/web/src/lib/auth/magic-link-adapters.ts
@@ -66,8 +66,9 @@ export const buildMagicLinkPorts = (): MagicLinkPorts => ({
   }) => {
     const { token, hash, tokenPrefix } = generateToken('ps_magic');
     const metadataObj: Record<string, unknown> = {};
-    if (platform === 'desktop' && deviceId) {
-      metadataObj.platform = platform;
+    const boundDevice = boundDevicePlatform(platform, deviceId);
+    if (boundDevice && deviceId) {
+      metadataObj.platform = boundDevice;
       metadataObj.deviceId = deviceId;
       if (deviceName) metadataObj.deviceName = deviceName;
     }
@@ -87,10 +88,9 @@ export const buildMagicLinkPorts = (): MagicLinkPorts => ({
     return { token };
   },
 
-  sendMagicLinkEmail: async ({ email, token, next }) => {
+  sendMagicLinkEmail: async ({ email, token, next, platform, deviceId }) => {
     try {
-      const nextSuffix = next ? `&next=${encodeURIComponent(next)}` : '';
-      const magicLinkUrl = `${resolveAppUrl()}/api/auth/magic-link/verify?token=${encodeURIComponent(token)}${nextSuffix}`;
+      const magicLinkUrl = buildMagicLinkUrl({ token, next, platform, deviceId });
       await sendEmail({
         to: email,
         subject: 'Sign in to PageSpace',
@@ -104,3 +104,55 @@ export const buildMagicLinkPorts = (): MagicLinkPorts => ({
     }
   },
 });
+
+/** Path prefix of the in-app magic-link page; must match the AASA and resolver. */
+const MAGIC_LINK_APP_PATH = '/auth/magic-link';
+
+/**
+ * Which device-bound platform this link belongs to, or `null` for an ordinary
+ * browser link.
+ *
+ * One predicate, because two callers ask the same question and must not drift:
+ * the token metadata records the binding, and the emailed URL has to match it.
+ * A universal link with no binding behind it would open the app and then fail
+ * to sign it in — the original bug, silently restored.
+ */
+function boundDevicePlatform(
+  platform: 'web' | 'desktop' | 'ios' | 'android' | undefined,
+  deviceId: string | undefined,
+): 'desktop' | 'ios' | 'android' | null {
+  if (!deviceId || platform === undefined || platform === 'web') return null;
+  return platform;
+}
+
+/**
+ * The URL the email carries.
+ *
+ * A link requested from the iOS / Android shell is a universal link
+ * (`/auth/magic-link/<token>`, claimed in the AASA and routed by
+ * `apps/web/src/lib/navigation/deep-links.ts`) so the tap lands in the app,
+ * whose page redeems the token into the Keychain. Everything else keeps the
+ * plain verify endpoint: that path is deliberately NOT claimed, so a link
+ * requested from Safari on an iPhone stays in Safari where its cookie works.
+ */
+function buildMagicLinkUrl({
+  token,
+  next,
+  platform,
+  deviceId,
+}: {
+  token: string;
+  next?: string;
+  platform?: 'web' | 'desktop' | 'ios' | 'android';
+  deviceId?: string;
+}): string {
+  const base = resolveAppUrl();
+  const encodedToken = encodeURIComponent(token);
+  const boundDevice = boundDevicePlatform(platform, deviceId);
+  if (boundDevice === 'ios' || boundDevice === 'android') {
+    const nextSuffix = next ? `?next=${encodeURIComponent(next)}` : '';
+    return `${base}${MAGIC_LINK_APP_PATH}/${encodedToken}${nextSuffix}`;
+  }
+  const nextSuffix = next ? `&next=${encodeURIComponent(next)}` : '';
+  return `${base}/api/auth/magic-link/verify?token=${encodedToken}${nextSuffix}`;
+}

--- a/apps/web/src/lib/auth/magic-link-platform-fields.ts
+++ b/apps/web/src/lib/auth/magic-link-platform-fields.ts
@@ -1,0 +1,37 @@
+import { getDesktopDeviceInfo } from '@/lib/desktop-auth';
+import { getPlatform, isCapacitorApp } from '@/lib/capacitor-bridge';
+import { getPlatformStorage } from '@/lib/auth/platform-storage';
+
+/**
+ * The device a magic link should be bound to, as the send route expects it.
+ *
+ * Desktop keeps its Electron device identity. The iOS / Android shell binds
+ * the link to the same `deviceId` the native OAuth routes use (the one
+ * `PlatformStorage.getDeviceId()` persists), so the in-app page that redeems
+ * the universal link can prove it is the requesting device and receive
+ * Keychain tokens. A browser sends nothing and gets a cookie session.
+ *
+ * Deliberately separate from `desktop-auth.getDevicePlatformFields()`: the
+ * passkey routes that consume that helper accept only `web | desktop`, so
+ * widening it there would 400 every passkey ceremony in the app.
+ */
+type MagicLinkPlatformFields =
+  | { platform: 'desktop' | 'ios' | 'android'; deviceId: string; deviceName: string }
+  | Record<string, never>;
+
+const NATIVE_DEVICE_NAME = { ios: 'iOS App', android: 'Android App' } as const;
+
+export async function getMagicLinkPlatformFields(): Promise<MagicLinkPlatformFields> {
+  const desktop = await getDesktopDeviceInfo();
+  if (desktop) {
+    return { platform: 'desktop', deviceId: desktop.deviceId, deviceName: desktop.deviceName };
+  }
+
+  if (!isCapacitorApp()) return {};
+
+  const platform = getPlatform();
+  if (platform === 'web') return {};
+
+  const deviceId = await getPlatformStorage().getDeviceId();
+  return { platform, deviceId, deviceName: NATIVE_DEVICE_NAME[platform] };
+}

--- a/apps/web/src/lib/auth/magic-link-platform-fields.ts
+++ b/apps/web/src/lib/auth/magic-link-platform-fields.ts
@@ -32,6 +32,15 @@ export async function getMagicLinkPlatformFields(): Promise<MagicLinkPlatformFie
   const platform = getPlatform();
   if (platform === 'web') return {};
 
-  const deviceId = await getPlatformStorage().getDeviceId();
-  return { platform, deviceId, deviceName: NATIVE_DEVICE_NAME[platform] };
+  // A secure store that cannot answer is not a reason to refuse the user a
+  // sign-in link — the same judgement `MagicLinkRedeem` makes on the redeem
+  // side. Without a device id the link simply is not device-bound, so it
+  // arrives as an ordinary browser link that still works.
+  try {
+    const deviceId = await getPlatformStorage().getDeviceId();
+    return { platform, deviceId, deviceName: NATIVE_DEVICE_NAME[platform] };
+  } catch (error) {
+    console.warn('[magic-link] could not read the device id; sending an unbound link', error);
+    return {};
+  }
 }

--- a/apps/web/src/lib/navigation/__tests__/deep-links.test.ts
+++ b/apps/web/src/lib/navigation/__tests__/deep-links.test.ts
@@ -79,4 +79,61 @@ describe('resolveDeepLink', () => {
     // would extend that surface before the binding exists.
     expect(resolveDeepLink('pagespace://auth-exchange?code=stolen')).toBeNull();
   });
+
+  describe('magic links requested from the app', () => {
+    it('routes a claimed magic link to the in-app redemption page', () => {
+      expect(resolveDeepLink('https://pagespace.ai/auth/magic-link/ps_magic_abc')).toEqual({
+        kind: 'route',
+        path: '/auth/magic-link/ps_magic_abc',
+      });
+    });
+
+    it('carries `next` through, re-encoded, because the page forwards it to the server', () => {
+      expect(
+        resolveDeepLink('https://pagespace.ai/auth/magic-link/ps_magic_abc?next=%2Fdashboard%2Fd1'),
+      ).toEqual({
+        kind: 'route',
+        path: '/auth/magic-link/ps_magic_abc?next=%2Fdashboard%2Fd1',
+      });
+    });
+
+    it('drops every query param other than `next`', () => {
+      expect(resolveDeepLink('https://pagespace.ai/auth/magic-link/ps_magic_abc?utm=x#f')).toEqual({
+        kind: 'route',
+        path: '/auth/magic-link/ps_magic_abc',
+      });
+    });
+
+    it('tolerates a trailing slash', () => {
+      expect(resolveDeepLink('https://pagespace.ai/auth/magic-link/ps_magic_abc/')).toEqual({
+        kind: 'route',
+        path: '/auth/magic-link/ps_magic_abc',
+      });
+    });
+
+    it('does not treat a multi-segment path as a token', () => {
+      expect(resolveDeepLink('https://pagespace.ai/auth/magic-link/a/b')).toEqual({
+        kind: 'external',
+        url: 'https://pagespace.ai/auth/magic-link/a/b',
+      });
+    });
+
+    it('hands a malformed escape back to the browser instead of throwing', () => {
+      expect(resolveDeepLink('https://pagespace.ai/auth/magic-link/%')).toEqual({
+        kind: 'external',
+        url: 'https://pagespace.ai/auth/magic-link/%',
+      });
+    });
+
+    it('leaves the rest of /auth alone — only the magic-link page is claimed', () => {
+      expect(resolveDeepLink('https://pagespace.ai/auth/signin')).toEqual({
+        kind: 'external',
+        url: 'https://pagespace.ai/auth/signin',
+      });
+    });
+
+    it('still refuses a lookalike host', () => {
+      expect(resolveDeepLink('https://pagespace.ai.evil.example/auth/magic-link/ps_magic_abc')).toBeNull();
+    });
+  });
 });

--- a/apps/web/src/lib/navigation/deep-links.ts
+++ b/apps/web/src/lib/navigation/deep-links.ts
@@ -22,6 +22,14 @@ const CLAIMED_HOST = 'pagespace.ai';
  */
 const INVITE_PATH = /^\/invite\/([^/]+)\/?$/;
 
+/**
+ * A magic link requested from the app — see
+ * `apps/web/src/app/auth/magic-link/[token]/page.tsx`. Same shape as an
+ * invite: one opaque segment. The page also reads `?next=`, so that one query
+ * param is carried through (the server re-validates it against its allowlist).
+ */
+const MAGIC_LINK_PATH = /^\/auth\/magic-link\/([^/]+)\/?$/;
+
 export type DeepLinkTarget =
   /** An in-app route. Navigate with the router — never `window.location`. */
   | { kind: 'route'; path: string }
@@ -57,6 +65,18 @@ export function resolveDeepLink(rawUrl: string): DeepLinkTarget | null {
       return { kind: 'route', path: `/invite/${encodeURIComponent(decodeURIComponent(invite[1]))}` };
     } catch {
       // Not a token we could have issued. Let the browser render the error.
+      return { kind: 'external', url: url.toString() };
+    }
+  }
+
+  const magicLink = MAGIC_LINK_PATH.exec(url.pathname);
+  if (magicLink) {
+    try {
+      const token = encodeURIComponent(decodeURIComponent(magicLink[1]));
+      const next = url.searchParams.get('next');
+      const query = next ? `?next=${encodeURIComponent(next)}` : '';
+      return { kind: 'route', path: `/auth/magic-link/${token}${query}` };
+    } catch {
       return { kind: 'external', url: url.toString() };
     }
   }

--- a/packages/lib/src/auth/magic-link-service.ts
+++ b/packages/lib/src/auth/magic-link-service.ts
@@ -36,6 +36,25 @@ export interface DesktopMagicLinkMetadata {
 }
 
 /**
+ * Metadata stored with a magic link requested from the iOS / Android shell.
+ * The emailed link is a universal link that opens the app, whose page redeems
+ * the token and — only when it presents this same `deviceId` — receives
+ * bearer tokens for the Keychain instead of relying on a cookie the WebView
+ * never sees.
+ */
+export interface NativeMagicLinkMetadata {
+  platform: 'ios' | 'android';
+  deviceId: string;
+  deviceName?: string;
+}
+
+/** Any device-bound magic link: the shell that requested it, and which device. */
+export type DeviceMagicLinkMetadata = DesktopMagicLinkMetadata | NativeMagicLinkMetadata;
+
+/** Every platform a device-bound magic link can be minted for. */
+export type MagicLinkDevicePlatform = DeviceMagicLinkMetadata['platform'];
+
+/**
  * Metadata stored with an invite-bound magic link. The verify route reads
  * `inviteToken` after authenticating and consumes the invite via the existing
  * acceptance pipe — atomic with session creation, no URL param round-trip.
@@ -44,7 +63,7 @@ export interface DesktopMagicLinkMetadata {
  * accepting an invite); they are separate fields under the same JSON envelope.
  */
 export interface MagicLinkMetadata {
-  platform?: 'desktop';
+  platform?: MagicLinkDevicePlatform;
   deviceId?: string;
   deviceName?: string;
   inviteToken?: string;

--- a/packages/lib/src/services/invites/__tests__/pipes.test.ts
+++ b/packages/lib/src/services/invites/__tests__/pipes.test.ts
@@ -495,6 +495,23 @@ describe('requestMagicLink', () => {
     );
   });
 
+  it('given a native platform, should forward it to sendMagicLinkEmail so the adapter can mint a universal link', async () => {
+    const ports = buildMagicLinkPorts();
+    await requestMagicLink(ports)(
+      baseMagicLinkInput({ platform: 'ios', deviceId: 'dev_1', deviceName: 'iOS App' }),
+    );
+
+    expect(ports.sendMagicLinkEmail).toHaveBeenCalledOnce();
+    // Both halves travel together: the adapter decides "device-bound" from the
+    // pair, and must reach the same answer the token metadata did.
+    expect(ports.sendMagicLinkEmail).toHaveBeenCalledWith({
+      email: 'user@example.com',
+      token: 'ps_magic_xyz',
+      platform: 'ios',
+      deviceId: 'dev_1',
+    });
+  });
+
   it('given a next on the input, should forward it to sendMagicLinkEmail (and not to createTokenAndPersist)', async () => {
     const ports = buildMagicLinkPorts();
     await requestMagicLink(ports)(

--- a/packages/lib/src/services/invites/pipes.ts
+++ b/packages/lib/src/services/invites/pipes.ts
@@ -210,6 +210,8 @@ export const requestMagicLink =
       email: input.email,
       token,
       ...(input.next !== undefined && input.inviteToken === undefined && { next: input.next }),
+      ...(input.platform !== undefined && { platform: input.platform }),
+      ...(input.deviceId !== undefined && { deviceId: input.deviceId }),
     });
 
     return { ok: true, data: undefined };

--- a/packages/lib/src/services/invites/ports.ts
+++ b/packages/lib/src/services/invites/ports.ts
@@ -65,7 +65,7 @@ export interface MagicLinkPorts {
   createTokenAndPersist: (input: {
     userId: string;
     expiresAt: Date;
-    platform?: 'web' | 'desktop' | 'ios';
+    platform?: 'web' | 'desktop' | 'ios' | 'android';
     deviceId?: string;
     deviceName?: string;
     // Invite token bound to this magic-link at mint time. Persisted in the
@@ -78,6 +78,13 @@ export interface MagicLinkPorts {
     email: string;
     token: string;
     next?: string;
+    // Which shell asked for the link, and which device. The adapter picks the
+    // URL from the pair: a native shell that named a device gets a universal
+    // link that opens the app, everything else the plain verify endpoint.
+    // Both are needed because a link is only device-bound when both are
+    // present, and that must be the same judgement the token metadata made.
+    platform?: 'web' | 'desktop' | 'ios' | 'android';
+    deviceId?: string;
   }) => Promise<void>;
 }
 

--- a/packages/lib/src/services/invites/types.ts
+++ b/packages/lib/src/services/invites/types.ts
@@ -70,7 +70,7 @@ export interface RequestMagicLinkInput {
   email: string;
   now: Date;
   expiryMinutes?: number;
-  platform?: 'web' | 'desktop' | 'ios';
+  platform?: 'web' | 'desktop' | 'ios' | 'android';
   deviceId?: string;
   deviceName?: string;
   // Same-origin redirect target embedded in the verify URL. The caller must


### PR DESCRIPTION
Fixes the two sign-in defects blocking the iOS App Store submission. Both were found by running the 1.4 build on a simulator against production.

## Bug 1 — the "Google sign-in is blocked" warning was false in the app

`detectInAppBrowser` was a bare `InAppSpy()` call. A Capacitor WKWebView *is* a WebView, so our own shell was flagged as a third-party in-app browser: `/auth/signin` and `/auth/signup` showed **"Google sign-in is blocked in this app"** and force-opened the magic-link form. Google works fine there — it goes through the native `@capgo/capacitor-social-login` plugin, never the blocked web OAuth flow.

The shell is now exempted **before** `inapp-spy` is consulted, following the precedent already in `GoogleOneTap.tsx`. A genuine in-app browser (Instagram, Facebook, Telegram) still gets the warning, and still gets the magic-link form opened for it.

Sign-in and sign-up each carried their own copy of the state and effect. They now share `useInAppBrowserNotice`, so the next change to this rule cannot land in one and miss the other. Swept every `detectInAppBrowser` consumer: those two pages plus `GoogleOneTap` (already correct). The marketing app has its own hand-rolled UA regex and is out of scope.

## Bug 2 — a magic link requested in the app could not complete

`desktop-auth.getDevicePlatformFields` knew only about Electron, so a link requested from the app was minted with no platform metadata and emailed as a plain `/api/auth/magic-link/verify?token=` URL. iOS does not claim that path, so the tap opened Safari and the session cookie landed in **Safari's** jar, while the WebView authenticates by a bearer token read from the Keychain. There was no path by which it could succeed.

The chain now:

1. `getMagicLinkPlatformFields` reports the shell and this device's id — the same id native Google/Apple sign-in use.
2. The send route accepts `ios`/`android`, and requires a device for any non-web platform.
3. The adapter records the binding and emails `https://pagespace.ai/auth/magic-link/<token>` — newly claimed in the AASA, resolved by `resolveDeepLink` **in the same commit** (claiming a path the resolver returns `null` for is the documented regression, so the two move together).
4. `/auth/magic-link/[token]` redeems it with a same-origin `POST`: the `Set-Cookie` lands in the WebView's own jar, and the response carries `sessionToken`/`csrfToken`/`deviceToken`, which the page writes to the Keychain — the shape and store `/api/auth/{apple,google}/native` already use.

Navigation is `router.replace` throughout; no `window.location`, which the iOS shell's navigation delegate would throw to Safari.

`verify/route.ts` grew a second door, not a second implementation: GET and POST share `redeemMagicLink`, and only the handoff differs. The GET contract is unchanged — the existing `route.test.ts` and `desktop-verify.test.ts` pass with no assertion edits.

### A device token is minted only for the device that is actually redeeming

This is the subtle part, and my first draft got it wrong. Minting is a **rotation** — `atomicValidateOrCreateDeviceToken` overwrites the stored hash of the existing row. Minting at binding time would therefore have invalidated the credential the phone is still holding, and on iOS the Keychain bearer is the only credential. A magic link requested in the app but opened anywhere else (Gmail's in-app browser, a laptop, "Open in Safari") would have **signed the phone out** — and that is the common case, not the edge case.

`confirmRedeemingDevice` answers "is this request that device?" in one place: desktop through the emailed GET as before, a mobile shell only by presenting the device id it holds. Nothing is minted, and no sessions are revoked by device, for a device that is not here. Everyone else gets the ordinary cookie session and nothing more, so a forwarded email cannot hand anyone a native session.

## Review round (commits 2 and 3)

Two automated reviewers and a self-review pass found real problems, all fixed:

- **A failed Keychain write left the stale credential in place.** The code claimed to degrade to the cookie session; it did not. The server has already revoked that device's sessions and rotated its device token by then, and `auth-fetch` prefers a stored bearer while the server rejects an invalid bearer outright rather than falling back — so the valid cookie session would have become 401s. The store is now always replaced or cleared, never left.
- **"Open the link again" was advice the user could not take.** `DeepLinkHandler` ignores a repeat of a URL it already handled, so reopening the link in the same app run is a no-op. The error state now has a **Try again** button, shown only where retrying can work (transport failure or a 5xx from us, where the token was never spent).
- **The new "signs you in here" line was false on Android**, where the tap opens Chrome. Gated to iOS.
- **A locked keystore blocked sending a link at all**; it now degrades to an unbound browser link.
- **The file's headline invariant was false for desktop** — desktop is eligible on any browser that opens the emailed link, as on master. The prose states the carve-out, and `confirmRedeemingDevice` (which confirmed nothing for one of three platforms) is now `handoffDeviceFor`.
- **A transient 500 told the user their link was invalid.** It now says the fault was ours.
- **Two docs were wrong**: the iOS checklist reused a spent token for the Mac check, and the Android README named the wrong prerequisite.
- **Test defects**: the strict-mode test never rendered in `StrictMode` (it passed with the once-only guard deleted), and `provisionHomeDriveIfNeeded` was mocked as bare `null` in three files, so every test in them silently took the provisioning catch. The sign-in page — the screen the bug was reported on — had no page-level test while sign-up did.

A third pass over the redeem page — the file the first two rounds changed most — found two more:

- **Every post-response failure was reported as a network failure**, and offered as a retry. A malformed success body, a chunk-load failure on the auth store, and the navigation all reached the same catch as the `fetch` rejection, but by then the cookie is set and the token is spent: a signed-in user saw "we could not reach PageSpace" and a Try again that re-POSTed a spent token to be told the link was already used. Everything after the response is best-effort now and ends in a navigation either way, so the retry is only offered where the token is genuinely unspent.
- **The stale-credential clear was skipped in the case that needed it most.** It was gated on `native && deviceId`, so it did not run when the device id was unreadable — which is precisely when the server, given no device, revokes every web session for that user including this phone's, leaving a revoked bearer that `auth-fetch` prefers over the fresh cookie.

Two review comments I did not act on, with reasons in-thread: removing `HttpOnly=false` from the CSRF cookie (pre-existing, identical on master, three writers — removing it newly exposes a cookie that is currently hidden from scripts, which deserves its own change), and requiring `https:` in `resolveAppUrl` (not introduced here, and it would break local development over `http://localhost`).

## What I verified

- **Tests**: all touched and adjacent suites pass (auth pages, navigation, magic-link routes, platform storage, OAuth hooks, the `capacitor-allow-navigation` guard from #2576). 6 new test files, 5 extended. Two failures in `magic-link-adapters.test.ts` are a pre-existing local source-harness artifact — they fail identically on `master` and pass on CI.
- **Mutation-checked, not just green.** 18 mutants, re-run after every round of fixes including the final simplification pass — all RED, zero survivors — including "release tokens to any device", "mint for the bound device instead of the confirmed one", "desktop handoff fires on the in-app door", "resolver drops the magic-link route", and "redeem page fails instead of degrading when the store throws". Two rounds of this found real gaps: nothing had asserted the desktop path mints a *desktop* token, and the page-level Bug 1 fix had no test until I added one.
- **Typecheck**: `apps/web` and `packages/lib` both clean, 0 errors, run from source against a worktree tsconfig (no dist builds — other agents were on the machine).
- **ESLint**: clean over all 23 touched web files.
- **knip**: no findings against any file in this diff.
- **Middleware**: confirmed by reading, not by route tests — `/api/auth/magic-link/` is in the public-API allowlist, `/auth/` in the public-page list, magic-link is not cloud-gated, and the same-origin POST satisfies origin validation. Route tests call handlers directly and would never have caught a block here.
- **Adversarial re-review** of the full diff after it was written, which is where the device-rotation defect above came from.

## What still needs a device

**I did not run this on a simulator or a device.** Everything above is static analysis and tests. Specifically unverified:

- That the universal link actually opens the app. The AASA must be deployed with marketing first, and Apple's CDN caches it — redeploy, `curl` the live URL, then reinstall the app before testing. Note `/invite/*` routing from #2569 has not been device-verified either.
- The real cold-start and warm-start paths, and the Keychain write on a real device.
- That the banner is gone on the real sign-in screen and the Google button works.

`apps/ios/README.md` has a checklist item for exactly this: request a link **from the app**, tap it in Mail, confirm the app opens signed in, then open the same link on a Mac and confirm it signs that browser in without handing out tokens.

## Noticed while reviewing this diff, deliberately not fixed here

`isUniqueConstraintError` in `apps/web/src/lib/auth/magic-link-adapters.ts` tests `err.code === '23505'` on the top-level error. Drizzle 0.45.2 rethrows driver errors as `DrizzleQueryError` with the pg error on `.cause`, so that check plausibly never matches in production — meaning the concurrent-signup race recovery below it never runs and a losing request 500s instead of re-loading the surviving user. Its two tests pass because they inject a raw `Error` with a top-level `code`, which is not the shape drizzle produces.

This is pre-existing (unchanged on `master`), in a different flow (first-time account creation), and fixing it means changing error handling plus rewriting those tests around a wrapped error. That is its own change with its own verification, not something to fold into an iOS sign-in fix. Flagging it so it is not lost.

## Android

Android uses the same shared web layer and is fully served by the server and web halves: a link requested from the Android app is minted for that device and emailed as `/auth/magic-link/<token>`, and the page would redeem it into the secure store exactly as on iOS. But Android registers **no https intent-filter** (it needs a release signing certificate and a real `assetlinks.json` first — prerequisite 1 in its README), so the tap still lands in Chrome and signs Chrome in by cookie. That is what happens today and is no worse. **Magic links are not fixed for Android**, and I have said so in `apps/android/README.md` rather than half-doing it.

## Docs

`apps/ios/README.md` gains the magic-link story and the device checklist item, and its stale claim that `DeepLinkHandler` is mounted in `DashboardLayoutClient` is corrected (it moved to the root layout in `bcc538c2d`). Changelog entry added.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014Ui4oFV9f4eEaC2CuHu5Pu
