### PR TITLE
feat(web): say "Dashboard" in the header instead of a house and a slash

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -441,9 +441,9 @@ All notable user-facing changes to PageSpace are documented here. Format follows
   it meant the drive you were already in. It now reads **Dashboard** in words. Inside a drive it
   becomes a bordered button with a back arrow, followed by the name of the drive you are in, so the
   header tells you both where you can go and where you are standing; on the dashboard itself it
-  stops being a button, because you are already there. On a phone, where header room is tight, the
-  button keeps its word wherever it is a way out, and the drive name and the you-are-here marker
-  are the parts that drop.
+  stops being a button, because you are already there. On narrower windows, where the header has
+  other things to fit, the button keeps its word wherever it is a way out — that being the whole
+  point — and the drive name and the you-are-here marker are the parts that give way.
 
 - **Android app: first internal-testing version identity, and the Android/iOS shell configs are now
   checked in CI (still not distributed)** — the Android build now identifies itself as version 1.4

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -441,8 +441,9 @@ All notable user-facing changes to PageSpace are documented here. Format follows
   it meant the drive you were already in. It now reads **Dashboard** in words. Inside a drive it
   becomes a bordered button with a back arrow, followed by the name of the drive you are in, so the
   header tells you both where you can go and where you are standing; on the dashboard itself it
-  stops being a button, because you are already there. On a phone the word stays and only the drive
-  name is dropped.
+  stops being a button, because you are already there. On a phone, where header room is tight, the
+  button keeps its word wherever it is a way out, and the drive name and the you-are-here marker
+  are the parts that drop.
 
 - **Android app: first internal-testing version identity, and the Android/iOS shell configs are now
   checked in CI (still not distributed)** — the Android build now identifies itself as version 1.4

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -434,6 +434,16 @@ All notable user-facing changes to PageSpace are documented here. Format follows
 
 ### Changed
 
+- **The header now says "Dashboard" instead of showing a house and a slash** — the way back out of
+  a drive used to be a small house icon followed by a `/`, and nothing on screen said where it
+  went. That made it easy to miss entirely, and easy to misread when you did notice it: drives have
+  their own home page, and the sidebar calls that "Drive Home", so a house in the header looked like
+  it meant the drive you were already in. It now reads **Dashboard** in words. Inside a drive it
+  becomes a bordered button with a back arrow, followed by the name of the drive you are in, so the
+  header tells you both where you can go and where you are standing; on the dashboard itself it
+  stops being a button, because you are already there. On a phone the word stays and only the drive
+  name is dropped.
+
 - **Android app: first internal-testing version identity, and the Android/iOS shell configs are now
   checked in CI (still not distributed)** — the Android build now identifies itself as version 1.4
   (build 2), matching the iOS version, instead of the 1.0 (build 1) left over from a debug build in

--- a/apps/web/src/components/layout/main-header/DashboardCrumb.tsx
+++ b/apps/web/src/components/layout/main-header/DashboardCrumb.tsx
@@ -40,14 +40,14 @@ export default function DashboardCrumb() {
   );
 
   if (pathname === DASHBOARD_PATH) {
-    // Hidden below sm, unlike the link. This variant is orientation only —
-    // there is nowhere for it to go — so it is the one part of this control
-    // that costs phone-width header space without answering the question the
-    // control exists for. The link variant, which IS the way out, always shows.
+    // Hidden below lg, unlike the link. This variant is orientation only —
+    // there is nowhere for it to go — so it is a part of this control that can
+    // yield header space without withholding the answer the control exists to
+    // give. The link variant, which IS the way out, never hides.
     return (
       <span
         aria-current="page"
-        className="hidden h-8 shrink-0 items-center gap-2 rounded-lg bg-primary-soft px-2.5 text-sm font-semibold text-foreground sm:flex"
+        className="hidden h-8 shrink-0 items-center gap-2 rounded-lg bg-primary-soft px-2.5 text-sm font-semibold text-foreground lg:flex"
       >
         <LayoutGrid className="h-4 w-4 text-primary" aria-hidden="true" />
         Dashboard
@@ -70,21 +70,26 @@ export default function DashboardCrumb() {
       </Link>
 
       {/*
-        Context, not a destination, so it drops before the label does: at 390px
-        the left group has ~146px once the trailing controls are counted and the
-        nav toggle and search button claim ~88px, which is not room for both.
+        Context, not a destination, so it yields before the label does.
+
+        Gated at lg, and NOT at sm, which is the counter-intuitive part: this
+        group gets tighter as the viewport grows, because growing is what adds
+        its expensive occupants. NavButtons appears at sm (~72px) and
+        InlineSearch at md carrying a 200px minimum, so md is a worse place to
+        put a crumb than a phone is. lg is the first width where the group has
+        clear room for all of it.
 
         The cost is worth naming — DriveSwitcher, the only other chrome saying
-        which drive you are in, lives in the sidebar, which is a sheet on a
-        phone. So below sm the drive's name is nowhere in persistent chrome.
-        The label still wins: it is the fix for the bug this control exists for.
+        which drive you are in, lives in the sidebar, which is a sheet below lg.
+        So below lg the drive's name is nowhere in persistent chrome. The label
+        still wins: it is the fix for the bug this control exists for.
       */}
       {driveName ? (
         <>
-          <span aria-hidden="true" className="hidden px-0.5 text-sm text-muted-foreground/60 sm:inline">
+          <span aria-hidden="true" className="hidden px-0.5 text-sm text-muted-foreground/60 lg:inline">
             /
           </span>
-          <span className="hidden min-w-0 items-center gap-1.5 px-2 text-sm font-semibold text-foreground sm:flex">
+          <span className="hidden min-w-0 items-center gap-1.5 px-2 text-sm font-semibold text-foreground lg:flex">
             <Folder className="h-4 w-4 shrink-0 text-muted-foreground" aria-hidden="true" />
             {/*
               title + a width cap, matching content-header/Breadcrumbs.tsx: a

--- a/apps/web/src/components/layout/main-header/DashboardCrumb.tsx
+++ b/apps/web/src/components/layout/main-header/DashboardCrumb.tsx
@@ -84,6 +84,13 @@ export default function DashboardCrumb() {
         which drive you are in, lives in the sidebar, which is a sheet below lg.
         So below lg the drive's name is nowhere in persistent chrome. The label
         still wins: it is the fix for the bug this control exists for.
+
+        Deliberately not a link to the drive's home page, though a breadcrumb
+        ancestor usually would be. It only renders at lg and up, which is
+        exactly where the sidebar is a fixed panel rather than a sheet — so
+        PrimaryNavigation's "Drive Home" is already on screen, spelled out,
+        whenever this is. A second unlabelled route to the same page would buy
+        nothing and need its own are-we-already-there branch.
       */}
       {driveName ? (
         <>

--- a/apps/web/src/components/layout/main-header/DashboardCrumb.tsx
+++ b/apps/web/src/components/layout/main-header/DashboardCrumb.tsx
@@ -40,10 +40,14 @@ export default function DashboardCrumb() {
   );
 
   if (pathname === DASHBOARD_PATH) {
+    // Hidden below sm, unlike the link. This variant is orientation only —
+    // there is nowhere for it to go — so it is the one part of this control
+    // that costs phone-width header space without answering the question the
+    // control exists for. The link variant, which IS the way out, always shows.
     return (
       <span
         aria-current="page"
-        className="flex h-8 shrink-0 items-center gap-2 rounded-lg bg-primary-soft px-2.5 text-sm font-semibold text-foreground"
+        className="hidden h-8 shrink-0 items-center gap-2 rounded-lg bg-primary-soft px-2.5 text-sm font-semibold text-foreground sm:flex"
       >
         <LayoutGrid className="h-4 w-4 text-primary" aria-hidden="true" />
         Dashboard
@@ -67,9 +71,19 @@ export default function DashboardCrumb() {
 
       {/*
         Context, not a destination — and the first thing to go when space runs
-        out. Below sm the label on the button survives and this does not: a
-        drive name is what truncates into nonsense on a phone, and the page
-        below the header already names the drive.
+        out. Below sm the label on the button survives and this does not.
+
+        That ordering is the whole point: the label is the fix for the bug this
+        control exists to solve, so it is the last thing to drop, while a drive
+        name is what truncates into nonsense first.
+
+        The cost is real and worth naming — DriveSwitcher, the only other chrome
+        that says which drive you are in, sits in the left sidebar, which is a
+        sheet on a phone. So below sm the drive's name is not in persistent
+        chrome at all. It is still the right trade: at 390px the left group has
+        roughly 146px once the trailing controls are counted, and the nav toggle
+        and search button claim ~88px of that, so a crumb here would not fit
+        beside the label rather than merely being tight.
       */}
       {driveName ? (
         <>
@@ -78,7 +92,14 @@ export default function DashboardCrumb() {
           </span>
           <span className="hidden min-w-0 items-center gap-1.5 px-2 text-sm font-semibold text-foreground sm:flex">
             <Folder className="h-4 w-4 shrink-0 text-muted-foreground" aria-hidden="true" />
-            <span className="truncate">{driveName}</span>
+            {/*
+              title + a width cap, matching content-header/Breadcrumbs.tsx: a
+              truncated name is unrecoverable without the tooltip, and an
+              uncapped one competes with the search field for the same row.
+            */}
+            <span className="max-w-[160px] truncate" title={driveName}>
+              {driveName}
+            </span>
           </span>
         </>
       ) : null}

--- a/apps/web/src/components/layout/main-header/DashboardCrumb.tsx
+++ b/apps/web/src/components/layout/main-header/DashboardCrumb.tsx
@@ -70,20 +70,14 @@ export default function DashboardCrumb() {
       </Link>
 
       {/*
-        Context, not a destination — and the first thing to go when space runs
-        out. Below sm the label on the button survives and this does not.
+        Context, not a destination, so it drops before the label does: at 390px
+        the left group has ~146px once the trailing controls are counted and the
+        nav toggle and search button claim ~88px, which is not room for both.
 
-        That ordering is the whole point: the label is the fix for the bug this
-        control exists to solve, so it is the last thing to drop, while a drive
-        name is what truncates into nonsense first.
-
-        The cost is real and worth naming — DriveSwitcher, the only other chrome
-        that says which drive you are in, sits in the left sidebar, which is a
-        sheet on a phone. So below sm the drive's name is not in persistent
-        chrome at all. It is still the right trade: at 390px the left group has
-        roughly 146px once the trailing controls are counted, and the nav toggle
-        and search button claim ~88px of that, so a crumb here would not fit
-        beside the label rather than merely being tight.
+        The cost is worth naming — DriveSwitcher, the only other chrome saying
+        which drive you are in, lives in the sidebar, which is a sheet on a
+        phone. So below sm the drive's name is nowhere in persistent chrome.
+        The label still wins: it is the fix for the bug this control exists for.
       */}
       {driveName ? (
         <>

--- a/apps/web/src/components/layout/main-header/DashboardCrumb.tsx
+++ b/apps/web/src/components/layout/main-header/DashboardCrumb.tsx
@@ -1,0 +1,87 @@
+"use client";
+
+import Link from "next/link";
+import { useParams, usePathname } from "next/navigation";
+import { ArrowLeft, Folder, LayoutGrid } from "lucide-react";
+
+import { useDriveStore } from "@/hooks/useDrive";
+
+const DASHBOARD_PATH = "/dashboard";
+
+/**
+ * The header's route back to the dashboard, and the only place the header
+ * says where you currently are.
+ *
+ * What this replaced was a house glyph followed by a bare "/". The word
+ * "Dashboard" lived only in that link's aria-label, so the people who were
+ * lost were exactly the ones who could not read it — and the house already
+ * means "this drive's home page" one surface over, where PrimaryNavigation
+ * labels the same slot "Drive Home" whenever a drive is open. The glyph
+ * therefore pointed at the wrong idea even when it was noticed. LayoutGrid
+ * here leaves the house to the drive home page it already belongs to.
+ *
+ * The shape follows the route rather than the drive id, because "is a drive
+ * open" and "am I on the dashboard" are different questions: /dashboard/dms
+ * and its ten static siblings carry no driveId while still being somewhere
+ * you need a way out of.
+ */
+export default function DashboardCrumb() {
+  const pathname = usePathname();
+  const params = useParams<{ driveId?: string | string[] }>();
+
+  const rawDriveId = params?.driveId;
+  const driveId = Array.isArray(rawDriveId) ? rawDriveId[0] : rawDriveId;
+
+  // The NAME is the only thing taken from the store, and it is allowed to be
+  // missing. Drives load asynchronously; a control whose whole job is being
+  // the way out must never wait on a fetch to become reachable.
+  const driveName = useDriveStore((state) =>
+    driveId ? state.drives.find((drive) => drive.id === driveId)?.name : undefined
+  );
+
+  if (pathname === DASHBOARD_PATH) {
+    return (
+      <span
+        aria-current="page"
+        className="flex h-8 shrink-0 items-center gap-2 rounded-lg bg-primary-soft px-2.5 text-sm font-semibold text-foreground"
+      >
+        <LayoutGrid className="h-4 w-4 text-primary" aria-hidden="true" />
+        Dashboard
+      </span>
+    );
+  }
+
+  return (
+    <div className="flex min-w-0 items-center gap-0.5">
+      {/*
+        No aria-label: the visible text is the accessible name, and an
+        aria-label would silently override the thing we just made visible.
+      */}
+      <Link
+        href={DASHBOARD_PATH}
+        className="flex h-8 shrink-0 items-center gap-1.5 rounded-lg border border-border bg-card px-2.5 text-sm font-medium text-foreground transition-colors hover:border-primary hover:bg-primary-soft hover:text-primary"
+      >
+        <ArrowLeft className="h-4 w-4" aria-hidden="true" />
+        Dashboard
+      </Link>
+
+      {/*
+        Context, not a destination — and the first thing to go when space runs
+        out. Below sm the label on the button survives and this does not: a
+        drive name is what truncates into nonsense on a phone, and the page
+        below the header already names the drive.
+      */}
+      {driveName ? (
+        <>
+          <span aria-hidden="true" className="hidden px-0.5 text-sm text-muted-foreground/60 sm:inline">
+            /
+          </span>
+          <span className="hidden min-w-0 items-center gap-1.5 px-2 text-sm font-semibold text-foreground sm:flex">
+            <Folder className="h-4 w-4 shrink-0 text-muted-foreground" aria-hidden="true" />
+            <span className="truncate">{driveName}</span>
+          </span>
+        </>
+      ) : null}
+    </div>
+  );
+}

--- a/apps/web/src/components/layout/main-header/DashboardCrumb.tsx
+++ b/apps/web/src/components/layout/main-header/DashboardCrumb.tsx
@@ -72,12 +72,13 @@ export default function DashboardCrumb() {
       {/*
         Context, not a destination, so it yields before the label does.
 
-        Gated at lg, and NOT at sm, which is the counter-intuitive part: this
-        group gets tighter as the viewport grows, because growing is what adds
-        its expensive occupants. NavButtons appears at sm (~72px) and
-        InlineSearch at md carrying a 200px minimum, so md is a worse place to
-        put a crumb than a phone is. lg is the first width where the group has
-        clear room for all of it.
+        Gated at lg, not sm, which is the counter-intuitive part: this row gets
+        TIGHTER as the viewport grows, because growing is what adds its
+        expensive occupants. Going up, NavButtons appears at sm, InlineSearch
+        at md with a 200px minimum, and CreditBalance unfolds at sm from a bare
+        readout into a readout plus an upgrade and a buy-credits button. md is
+        therefore a worse place for a crumb than a phone is. lg is the first
+        width where the row is not still gaining occupants.
 
         The cost is worth naming — DriveSwitcher, the only other chrome saying
         which drive you are in, lives in the sidebar, which is a sheet below lg.

--- a/apps/web/src/components/layout/main-header/__tests__/DashboardCrumb.test.tsx
+++ b/apps/web/src/components/layout/main-header/__tests__/DashboardCrumb.test.tsx
@@ -116,13 +116,13 @@ describe('DashboardCrumb', () => {
     });
   });
 
-  describe('below sm', () => {
+  describe('narrow headers', () => {
     // jsdom applies no media queries, so this asserts the MECHANISM rather than
     // the rendered result. It is here because "the word survives, the crumb
     // goes" is a deliberate decision about the reported bug — dropping to a
-    // bare glyph on the narrowest screen would rebuild it where guessing is
-    // hardest — and nothing else in the suite would notice that being undone.
-    it('given a loaded drive, should gate only the crumb on the sm breakpoint and never the label', () => {
+    // bare glyph would rebuild it exactly where guessing is hardest — and
+    // nothing else in the suite would notice that being undone.
+    it('given a loaded drive, should gate only the crumb on the breakpoint and never the label', () => {
       atRoute('/dashboard/drive_eng/page_1', { driveId: 'drive_eng' });
       useDriveStore.setState({ drives: [buildDrive()] });
 
@@ -130,18 +130,18 @@ describe('DashboardCrumb', () => {
 
       const crumb = screen.getByText('Engineering').parentElement;
       expect(crumb?.className).toMatch(/\bhidden\b/);
-      expect(crumb?.className).toMatch(/\bsm:flex\b/);
+      expect(crumb?.className).toMatch(/\blg:flex\b/);
 
       const label = screen.getByRole('link', { name: 'Dashboard' });
       expect(label.className).not.toMatch(/\bhidden\b/);
     });
 
-    // The way OUT always shows; the you-are-here marker does not. At 390px the
-    // left group has ~146px once the trailing controls are counted, and the nav
-    // toggle plus search button claim ~88px — so a control that refuses to
-    // shrink overflows into those controls rather than tightening. The marker
-    // can afford to go because it has nowhere to navigate to; the link cannot.
-    it('given the dashboard route, should gate the you-are-here marker on sm while the link variant never hides', () => {
+    // The way OUT always shows; the you-are-here marker does not. The left
+    // group tightens as the viewport GROWS — NavButtons arrives at sm and
+    // InlineSearch at md with a 200px minimum — so a control that refuses to
+    // shrink overflows its neighbours rather than tightening. The marker can
+    // afford to go because it has nowhere to navigate to; the link cannot.
+    it('given the dashboard route, should gate the you-are-here marker while the link variant never hides', () => {
       atRoute('/dashboard');
       const { unmount } = render(<DashboardCrumb />);
       expect(screen.getByText('Dashboard').className).toMatch(/\bhidden\b/);

--- a/apps/web/src/components/layout/main-header/__tests__/DashboardCrumb.test.tsx
+++ b/apps/web/src/components/layout/main-header/__tests__/DashboardCrumb.test.tsx
@@ -136,11 +136,12 @@ describe('DashboardCrumb', () => {
       expect(label.className).not.toMatch(/\bhidden\b/);
     });
 
-    // The way OUT always shows; the you-are-here marker does not. The left
-    // group tightens as the viewport GROWS — NavButtons arrives at sm and
-    // InlineSearch at md with a 200px minimum — so a control that refuses to
-    // shrink overflows its neighbours rather than tightening. The marker can
-    // afford to go because it has nowhere to navigate to; the link cannot.
+    // The way OUT always shows; the you-are-here marker does not. The header
+    // row tightens as the viewport GROWS — NavButtons arrives at sm,
+    // InlineSearch at md with a 200px minimum, and CreditBalance unfolds at sm
+    // into three controls — so something that refuses to shrink overflows its
+    // neighbours rather than tightening. The marker can afford to go because it
+    // has nowhere to navigate to; the link cannot.
     it('given the dashboard route, should gate the you-are-here marker while the link variant never hides', () => {
       atRoute('/dashboard');
       const { unmount } = render(<DashboardCrumb />);

--- a/apps/web/src/components/layout/main-header/__tests__/DashboardCrumb.test.tsx
+++ b/apps/web/src/components/layout/main-header/__tests__/DashboardCrumb.test.tsx
@@ -1,0 +1,116 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import type { Drive } from '@pagespace/lib/types';
+
+import { useParams, usePathname } from 'next/navigation';
+import DashboardCrumb from '../DashboardCrumb';
+import { useDriveStore } from '@/hooks/useDrive';
+
+vi.mock('next/navigation', () => ({
+  useParams: vi.fn(() => ({})),
+  usePathname: vi.fn(() => '/dashboard'),
+}));
+
+const buildDrive = (overrides: Partial<Drive> = {}): Drive => ({
+  id: 'drive_eng',
+  name: 'Engineering',
+  slug: 'engineering',
+  ownerId: 'user_1',
+  isTrashed: false,
+  trashedAt: null,
+  createdAt: '2026-01-01T00:00:00.000Z',
+  updatedAt: '2026-01-01T00:00:00.000Z',
+  isOwned: true,
+  ...overrides,
+});
+
+/** Put the component on a route, the way Next would. */
+const atRoute = (pathname: string, params: Record<string, string | string[]> = {}) => {
+  vi.mocked(usePathname).mockReturnValue(pathname);
+  vi.mocked(useParams).mockReturnValue(params);
+};
+
+describe('DashboardCrumb', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    useDriveStore.setState({ drives: [], currentDriveId: null, isLoading: false, lastFetched: 0 });
+  });
+
+  describe('on the dashboard itself', () => {
+    it('given the dashboard route, should name the dashboard as the current page rather than link to it', () => {
+      atRoute('/dashboard');
+
+      render(<DashboardCrumb />);
+
+      const marker = screen.getByText('Dashboard');
+      expect(marker).toHaveAttribute('aria-current', 'page');
+      expect(screen.queryByRole('link')).not.toBeInTheDocument();
+    });
+  });
+
+  describe('inside a drive', () => {
+    it('given a drive route, should offer a link out to the dashboard', () => {
+      atRoute('/dashboard/drive_eng/page_1', { driveId: 'drive_eng' });
+
+      render(<DashboardCrumb />);
+
+      expect(screen.getByRole('link', { name: 'Dashboard' })).toHaveAttribute('href', '/dashboard');
+    });
+
+    it('given a loaded drive, should name the drive you are standing in', () => {
+      atRoute('/dashboard/drive_eng/page_1', { driveId: 'drive_eng' });
+      useDriveStore.setState({ drives: [buildDrive()] });
+
+      render(<DashboardCrumb />);
+
+      expect(screen.getByText('Engineering')).toBeInTheDocument();
+    });
+
+    it('given the drive has not loaded yet, should still link out and simply omit the drive name', () => {
+      atRoute('/dashboard/drive_eng/page_1', { driveId: 'drive_eng' });
+
+      render(<DashboardCrumb />);
+
+      expect(screen.getByRole('link', { name: 'Dashboard' })).toBeInTheDocument();
+      expect(screen.queryByText('Engineering')).not.toBeInTheDocument();
+    });
+
+    it('given a catch-all driveId param, should read the first segment', () => {
+      atRoute('/dashboard/drive_eng/page_1', { driveId: ['drive_eng', 'page_1'] });
+      useDriveStore.setState({ drives: [buildDrive()] });
+
+      render(<DashboardCrumb />);
+
+      expect(screen.getByText('Engineering')).toBeInTheDocument();
+    });
+  });
+
+  describe('on a dashboard sibling route', () => {
+    // /dashboard/dms and its ten static siblings carry no driveId while still
+    // being somewhere you need a way out of. Keying the current-page marker off
+    // the driveId instead of the pathname strands the user on every one of them.
+    it.each([
+      ['/dashboard/dms'],
+      ['/dashboard/tasks'],
+      ['/dashboard/calendar'],
+    ])('given %s, should still offer a link out rather than a dead marker', (pathname) => {
+      atRoute(pathname);
+
+      render(<DashboardCrumb />);
+
+      const link = screen.getByRole('link', { name: 'Dashboard' });
+      expect(link).toHaveAttribute('href', '/dashboard');
+      expect(link).not.toHaveAttribute('aria-current');
+    });
+  });
+
+  describe('accessible name', () => {
+    it('given the link variant, should take its name from the visible text with no aria-label overriding it', () => {
+      atRoute('/dashboard/drive_eng', { driveId: 'drive_eng' });
+
+      render(<DashboardCrumb />);
+
+      expect(screen.getByRole('link', { name: 'Dashboard' })).not.toHaveAttribute('aria-label');
+    });
+  });
+});

--- a/apps/web/src/components/layout/main-header/__tests__/DashboardCrumb.test.tsx
+++ b/apps/web/src/components/layout/main-header/__tests__/DashboardCrumb.test.tsx
@@ -75,6 +75,18 @@ describe('DashboardCrumb', () => {
       expect(screen.queryByText('Engineering')).not.toBeInTheDocument();
     });
 
+    it('given a drive name long enough to truncate, should keep the full name recoverable on hover', () => {
+      atRoute('/dashboard/drive_eng/page_1', { driveId: 'drive_eng' });
+      useDriveStore.setState({ drives: [buildDrive({ name: 'Q3 Platform Migration Programme' })] });
+
+      render(<DashboardCrumb />);
+
+      expect(screen.getByText('Q3 Platform Migration Programme')).toHaveAttribute(
+        'title',
+        'Q3 Platform Migration Programme',
+      );
+    });
+
     it('given a catch-all driveId param, should read the first segment', () => {
       atRoute('/dashboard/drive_eng/page_1', { driveId: ['drive_eng', 'page_1'] });
       useDriveStore.setState({ drives: [buildDrive()] });
@@ -101,6 +113,43 @@ describe('DashboardCrumb', () => {
       const link = screen.getByRole('link', { name: 'Dashboard' });
       expect(link).toHaveAttribute('href', '/dashboard');
       expect(link).not.toHaveAttribute('aria-current');
+    });
+  });
+
+  describe('below sm', () => {
+    // jsdom applies no media queries, so this asserts the MECHANISM rather than
+    // the rendered result. It is here because "the word survives, the crumb
+    // goes" is a deliberate decision about the reported bug — dropping to a
+    // bare glyph on the narrowest screen would rebuild it where guessing is
+    // hardest — and nothing else in the suite would notice that being undone.
+    it('given a loaded drive, should gate only the crumb on the sm breakpoint and never the label', () => {
+      atRoute('/dashboard/drive_eng/page_1', { driveId: 'drive_eng' });
+      useDriveStore.setState({ drives: [buildDrive()] });
+
+      render(<DashboardCrumb />);
+
+      const crumb = screen.getByText('Engineering').parentElement;
+      expect(crumb?.className).toMatch(/\bhidden\b/);
+      expect(crumb?.className).toMatch(/\bsm:flex\b/);
+
+      const label = screen.getByRole('link', { name: 'Dashboard' });
+      expect(label.className).not.toMatch(/\bhidden\b/);
+    });
+
+    // The way OUT always shows; the you-are-here marker does not. At 390px the
+    // left group has ~146px once the trailing controls are counted, and the nav
+    // toggle plus search button claim ~88px — so a control that refuses to
+    // shrink overflows into those controls rather than tightening. The marker
+    // can afford to go because it has nowhere to navigate to; the link cannot.
+    it('given the dashboard route, should gate the you-are-here marker on sm while the link variant never hides', () => {
+      atRoute('/dashboard');
+      const { unmount } = render(<DashboardCrumb />);
+      expect(screen.getByText('Dashboard').className).toMatch(/\bhidden\b/);
+      unmount();
+
+      atRoute('/dashboard/drive_eng', { driveId: 'drive_eng' });
+      render(<DashboardCrumb />);
+      expect(screen.getByRole('link', { name: 'Dashboard' }).className).not.toMatch(/\bhidden\b/);
     });
   });
 

--- a/apps/web/src/components/layout/main-header/__tests__/DashboardCrumb.test.tsx
+++ b/apps/web/src/components/layout/main-header/__tests__/DashboardCrumb.test.tsx
@@ -105,6 +105,9 @@ describe('DashboardCrumb', () => {
       ['/dashboard/dms'],
       ['/dashboard/tasks'],
       ['/dashboard/calendar'],
+      // The one that most resembles a drive route. Next resolves static
+      // segments ahead of [driveId], so this carries no driveId either.
+      ['/dashboard/drives'],
     ])('given %s, should still offer a link out rather than a dead marker', (pathname) => {
       atRoute(pathname);
 

--- a/apps/web/src/components/layout/main-header/__tests__/TopBar.dashboard-crumb.test.tsx
+++ b/apps/web/src/components/layout/main-header/__tests__/TopBar.dashboard-crumb.test.tsx
@@ -1,0 +1,57 @@
+/**
+ * WHAT the header offers as the way back to the dashboard, asserted against
+ * the real TopBar.
+ *
+ * The control this replaced named its destination only in an aria-label, so
+ * the header could pass every accessibility assertion while showing sighted
+ * users nothing but a house and a slash. Asserting the visible text here is
+ * therefore the point of the file, not an incidental detail: put the house
+ * back and the route out still works, still has an accessible name, and still
+ * leaves the reported bug exactly where it was.
+ */
+
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+
+vi.mock('@/components/ai/voice/realtime', () => ({
+  VoiceNavTrigger: () => <div />,
+}));
+// Matches TopBar.voice-trigger.test.tsx: the header is rendered outside an
+// app-router context here, and this file is about what the header SAYS, not
+// about Link's own behaviour.
+vi.mock('next/link', () => ({
+  default: ({ children, href }: { children: React.ReactNode; href: string }) => (
+    <a href={href}>{children}</a>
+  ),
+}));
+vi.mock('@/components/notifications/NotificationBell', () => ({ default: () => <div /> }));
+vi.mock('@/components/notifications/VerifyEmailButton', () => ({ default: () => <div /> }));
+vi.mock('@/components/search/InlineSearch', () => ({ default: () => <div /> }));
+vi.mock('@/components/search/GlobalSearch', () => ({ default: () => <div /> }));
+vi.mock('@/components/shared/UserDropdown', () => ({ default: () => <div /> }));
+vi.mock('@/components/shared/RecentsDropdown', () => ({ default: () => <div /> }));
+vi.mock('@/components/billing/AiBalanceWidget', () => ({ AiBalanceWidget: () => <div /> }));
+vi.mock('../NavButtons', () => ({ default: () => <div /> }));
+
+import TopBar from '../index';
+
+const renderTopBar = () =>
+  render(
+    <TopBar onToggleLeftPanel={() => {}} onToggleRightPanel={() => {}} onRevealAssistant={() => {}} />,
+  );
+
+describe('TopBar — the way back to the dashboard', () => {
+  it('given the header renders, should say the word "Dashboard" on screen', () => {
+    renderTopBar();
+
+    expect(screen.getByText('Dashboard')).toBeInTheDocument();
+  });
+
+  it('given the header renders, should not fall back to a lone slash as the route home', () => {
+    // The old control's entire visible content, and the reason nobody found it.
+    renderTopBar();
+
+    expect(screen.queryByText('/')).not.toBeInTheDocument();
+  });
+});

--- a/apps/web/src/components/layout/main-header/__tests__/TopBar.dashboard-crumb.test.tsx
+++ b/apps/web/src/components/layout/main-header/__tests__/TopBar.dashboard-crumb.test.tsx
@@ -48,6 +48,24 @@ describe('TopBar — the way back to the dashboard', () => {
     expect(screen.getByText('Dashboard')).toBeInTheDocument();
   });
 
+  it('given a labelled control in the left group, should let that group wrap rather than overflow its neighbours', () => {
+    // The group is flex-1 and shrinkable, so it never forces the OUTER wrap —
+    // it narrows below its own content instead, and a child that refuses to
+    // shrink then overflows into the right-hand controls. Harmless while the
+    // only thing here was a 30px icon link; reachable at phone widths once the
+    // control carries a word. Walks up by flex-1 rather than by DOM position so
+    // this survives reordering.
+    renderTopBar();
+
+    let group: HTMLElement | null = screen.getByText('Dashboard');
+    while (group && !/\bflex-1\b/.test(group.className)) {
+      group = group.parentElement;
+    }
+
+    expect(group, 'expected a flex-1 ancestor group').not.toBeNull();
+    expect(group?.className).toMatch(/\bflex-wrap\b/);
+  });
+
   it('given the header renders, should not fall back to a lone slash as the route home', () => {
     // The old control's entire visible content, and the reason nobody found it.
     renderTopBar();

--- a/apps/web/src/components/layout/main-header/index.tsx
+++ b/apps/web/src/components/layout/main-header/index.tsx
@@ -35,11 +35,17 @@ export default function TopBar({ onToggleLeftPanel, onToggleRightPanel, onReveal
       <div className="flex flex-wrap items-center gap-2 px-3 py-2.5 sm:px-4">
         {/*
           flex-wrap, not just min-w-0: this group is flex-1 and shrinkable, so
-          it never forces the OUTER wrap — it silently narrows below its
+          it never forces the OUTER wrap — it silently narrows below its own
           content instead, and any child that refuses to shrink then overflows
-          into the right-hand controls. That was invisible while the only thing
-          in here was a 30px icon link; a labelled control makes it reachable
-          at phone widths. Wrapping degrades to a second row instead.
+          into the right-hand controls rather than tightening. That was
+          invisible while the only occupant was a ~30px icon link; a control
+          carrying a word makes it reachable. Wrapping degrades to a second row.
+
+          This is the safety net for the breakpoint choices in DashboardCrumb,
+          which rest on reading the classes of every control in this header
+          rather than on measuring a running one. Get one of those wrong and
+          the header gets taller, which is recoverable; without this it would
+          overlap, which is not.
         */}
         <div className="flex min-w-0 flex-1 flex-wrap items-center gap-2">
           <div className="flex items-center">

--- a/apps/web/src/components/layout/main-header/index.tsx
+++ b/apps/web/src/components/layout/main-header/index.tsx
@@ -33,7 +33,15 @@ export default function TopBar({ onToggleLeftPanel, onToggleRightPanel, onReveal
   return (
     <header className="sticky top-0 z-50 pt-[env(safe-area-inset-top)] liquid-glass-thin border-b border-[var(--separator)] text-card-foreground shadow-[var(--shadow-ambient)] dark:shadow-none">
       <div className="flex flex-wrap items-center gap-2 px-3 py-2.5 sm:px-4">
-        <div className="flex min-w-0 flex-1 items-center gap-2">
+        {/*
+          flex-wrap, not just min-w-0: this group is flex-1 and shrinkable, so
+          it never forces the OUTER wrap — it silently narrows below its
+          content instead, and any child that refuses to shrink then overflows
+          into the right-hand controls. That was invisible while the only thing
+          in here was a 30px icon link; a labelled control makes it reachable
+          at phone widths. Wrapping degrades to a second row instead.
+        */}
+        <div className="flex min-w-0 flex-1 flex-wrap items-center gap-2">
           <div className="flex items-center">
             <Button
               variant="ghost"

--- a/apps/web/src/components/layout/main-header/index.tsx
+++ b/apps/web/src/components/layout/main-header/index.tsx
@@ -1,8 +1,7 @@
 "use client";
 
 import { useState } from "react";
-import Link from "next/link";
-import { Home, PanelLeft, PanelRight, Search } from "lucide-react";
+import { PanelLeft, PanelRight, Search } from "lucide-react";
 
 import { Button } from "@/components/ui/button";
 import NotificationBell from "@/components/notifications/NotificationBell";
@@ -15,6 +14,7 @@ import { AiBalanceWidget } from "@/components/billing/AiBalanceWidget";
 import { VoiceNavTrigger } from "@/components/ai/voice/realtime";
 import type { VoiceSurface } from "@/lib/ai/realtime/voice-binding";
 import NavButtons from "./NavButtons";
+import DashboardCrumb from "./DashboardCrumb";
 
 interface TopBarProps {
   onToggleLeftPanel: () => void;
@@ -58,14 +58,7 @@ export default function TopBar({ onToggleLeftPanel, onToggleRightPanel, onReveal
             <NavButtons />
           </div>
 
-          <Link
-            href="/dashboard"
-            className="flex items-center text-sm text-gray-900 dark:text-gray-100"
-            aria-label="Back to dashboard"
-          >
-            <Home className="mr-2 h-4 w-4" />
-            <span>/</span>
-          </Link>
+          <DashboardCrumb />
 
           <div className="hidden min-w-[200px] flex-1 md:flex">
             <InlineSearch />

--- a/apps/web/src/test/setup.ts
+++ b/apps/web/src/test/setup.ts
@@ -19,6 +19,11 @@ vi.mock('next/navigation', () => ({
   })),
   usePathname: vi.fn(() => '/'),
   useSearchParams: vi.fn(() => new URLSearchParams()),
+  // Route params default to empty rather than being absent: a component that
+  // reads them is a plain consumer of this module, and leaving the hook
+  // undefined here turns "this test doesn't care about the route" into a
+  // TypeError thrown from any ancestor that happens to render one.
+  useParams: vi.fn(() => ({})),
 }))
 
 // jsdom does not implement ResizeObserver or IntersectionObserver.


### PR DESCRIPTION
## The problem

The header's only route back to the dashboard was a house glyph followed by a bare `/`:

```tsx
<Link href="/dashboard" aria-label="Back to dashboard">
  <Home className="mr-2 h-4 w-4" />
  <span>/</span>
</Link>
```

The word "Dashboard" existed **only in the `aria-label`**, so the people who were lost were exactly
the ones who could not read it. And the house already means "this drive's home page" one surface
over — `PrimaryNavigation.tsx:52` labels the same slot **"Drive Home"** whenever a drive is open —
so the glyph pointed at the wrong idea even when it was noticed.

## The change

A new `DashboardCrumb` takes its shape from the **route**, not the drive id:

| Where you are | What the header shows |
|---|---|
| `/dashboard` | `Dashboard` — a non-interactive `aria-current="page"` marker |
| Inside a drive | `← Dashboard` (outlined) `/` `📁 Engineering` |
| `/dashboard/dms`, `/tasks`, … | `← Dashboard` (outlined), no crumb |
| Below `lg` | The link keeps its word; the crumb and the marker drop |

**Why route and not driveId.** `/dashboard/dms` and its ten static siblings carry no `driveId` while
still being somewhere you need a way out of. Keying the current-page marker off the driveId would
render a dead, unclickable marker on every one of them — the same stranding, in a new place. Three
tests pin this; mutating the guard to `if (!driveId)` turns exactly those three red.

**Why the word survives on mobile.** Dropping to a bare glyph on the narrowest screen would rebuild
this exact bug where guessing is hardest, so the label is the last thing to go — never the first.
What gives way instead is the drive crumb and, at phone width, the you-are-here marker, which is
the one variant with nowhere to navigate to.

**Why the drive name is optional.** It is the only thing read from the store, and it is allowed to
be missing — a control whose whole job is being the way out must not wait on a fetch to become
reachable.

`LayoutGrid` replaces `Home` so the house stays with the drive home page it already belongs to.

## Design

Four treatments were mocked at production scale against the real `globals.css` tokens (light + dark,
plus 390px frames) before picking this one:
https://claude.ai/code/artifact/1e4d33a1-6d7c-4f7a-a4fa-f932c1de8b52

## Also here

`src/test/setup.ts` gains `useParams` in the shared `next/navigation` mock. Leaving the hook
undefined turned "this test doesn't care about the route" into a `TypeError` thrown from any
ancestor that happens to render a route-reading component — which `TopBar` now does. Additive; files
with their own `vi.mock` still override it.

## Header overflow (review catch, fixed)

`chatgpt-codex-connector` flagged a P1 that I confirmed. The left header group is `flex-1 min-w-0`,
so it never forces the **outer** container's `flex-wrap` — it narrows below its own content instead,
and a `shrink-0` child then overflows into the right-hand controls rather than tightening. Latent
while the only occupant was a ~30px icon link; giving the control a word made it reachable.

The fix has two parts, and the second one moved the breakpoint the opposite way from the obvious
guess. **This row gets tighter as the viewport grows**, because growing is what adds its expensive
occupants: `NavButtons` appears at `sm`, `InlineSearch` at `md` with a `min-w-[200px]`, and
`CreditBalance` unfolds at `sm` from a bare readout into a readout plus an upgrade button and a
buy-credits button. So `md` is a worse place for a drive crumb than a phone is, and my first `sm`
gate was wrong.

- **The left group wraps** (`flex-wrap`), degrading to a second row instead of overlapping.
- **Both optional halves gate at `lg`** — the drive crumb and the you-are-here marker. The link
  variant, the actual way out, never hides at any width.

**Why `lg` specifically, beyond the space argument.** `left-sidebar/index.tsx:40` gates its
sheet-vs-panel behaviour on `useBreakpoint("(max-width: 1023px)")` — the same 1024px line as
Tailwind's `lg`. So the crumb renders exactly when the sidebar is a fixed panel and hides exactly
when it collapses to a sheet. That boundary is verified in the codebase rather than estimated, and
it also answers why the drive name is deliberately not a link: `PrimaryNavigation`'s "Drive Home" is
already on screen, spelled out, at every width where this crumb renders.

**How firm is the rest:** the space reasoning comes from reading the Tailwind classes of every
control in the header, not from measuring a running one — I could not run the app while this was written.
The direction is robust to that (each correction so far has made the row tighter, i.e. argued for
gating higher, not lower), and `flex-wrap` is deliberately the safety net: a width I have
mis-measured costs a taller header, not overlapping controls. **A visual check at 768px and 1024px
before merge is still worth someone's minute.**

## CI is red for an upstream reason, not this branch

As of 2026-09-09 ~18:00 UTC the browser-installing CI steps fail on **every branch, master
included**:

```
Err:24 https://dl.google.com/linux/chrome-stable/deb stable/main amd64 Packages
  Hash Sum mismatch
```

`playwright install --with-deps` runs `apt-get update`, which is failing against Google's own Chrome
deb repo. It takes out `ci / E2E` ("Install Playwright browsers") and `ci / Unit Tests` ("Install
Chromium (cross-DOM parse-equality suite)"). Confirmed on master's own runs (34384000014,
34383981148) and on `pu/redundant-tabs-in-agents`, `pu/sheet-agent-regions`,
`pu/ipad-landscape-shots` — all failing the same non-code steps.

Caching does not route around it: `ci.yml` deliberately runs `--with-deps` even on a browser cache
hit. Nothing in this branch can cause or fix it; it needs a re-run once the upstream repo is
consistent. Everything below was therefore verified locally.

## Testing

- `DashboardCrumb.test.tsx` — 9 tests, **run locally, 9/9 green**, and mutation-checked: breaking the
  pathname guard kills 3.
- `TopBar.dashboard-crumb.test.tsx` — 3/3, asserting the header visibly says "Dashboard", no longer
  shows a lone `/`, and that the left group carries `flex-wrap`. Mutation-checked: removing
  `flex-wrap` turns it red, so it genuinely guards the overflow fix.
- Every other suite that renders this header also passes: `TopBar.voice-trigger` (2/2),
  `NavButtons` (9/9), `Layout.voice-session` + `Layout.voice-reveal` (7/7).
- **Blast radius of the `setup.ts` change:** the whole `components/layout` slice — 932 tests,
  926 passed, 6 skipped, 0 failures across 71 files. (One integration *file* fails locally because
  it needs a real Postgres and refuses to self-skip; CI provides one.)
- `tsc --noEmit` over all of `apps/web`: **0 errors**.
- Coverage on the new component: **100% statements / branches / functions / lines** (`index.tsx`
  100% on statements, branches and lines), so the ratchet can only move up.
- `bunx eslint` clean on the changed files. `knip:check` reports nothing in these files.

All of the above ran from source via a throwaway vitest/tsconfig aliasing `@pagespace/lib` and
`@pagespace/db` to `packages/*/src`, so no dist build was needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01L3fu3iHqYYed91k6VcAPfe
