### PR TITLE
ci: drop Google's Chrome apt source before installing Chromium

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -107,7 +107,23 @@ jobs:
       # populated the cache. The download is the expensive part and the cache
       # already removes it; apt with everything present costs seconds.
       - name: Install Chromium (cross-DOM parse-equality suite)
-        run: bunx playwright install --with-deps chromium
+        # `--with-deps` shells out to `apt-get update`, which exits non-zero if
+        # ANY configured source fails — and Playwright treats that as fatal
+        # (exit 100). The runner image ships Google's Chrome apt repo, and on
+        # 2026-09-09 it began serving a Packages.gz whose hashes did not match
+        # its own Release file, so every job in this repo failed here, deploys
+        # included, for a reason entirely outside the repo.
+        #
+        # Nothing here needs that repo. Playwright installs its own Chromium
+        # build and takes its system libraries from Ubuntu's archive, which is
+        # why all 28 ubuntu sources fetched fine while only dl.google.com broke.
+        # Dropping the source makes the apt pass depend only on what we use.
+        #
+        # The glob covers both the .list and deb822 .sources forms, and `rm -f`
+        # is a no-op if the image ever stops shipping it.
+        run: |
+          sudo rm -f /etc/apt/sources.list.d/google-chrome*
+          bunx playwright install --with-deps chromium
         working-directory: apps/e2e
 
       # ADMIN_DATABASE_URL belongs here too, not only on the backfill/db-integration
@@ -329,7 +345,11 @@ jobs:
         run: bun run build --filter=web
 
       - name: Install Playwright browsers
-        run: bunx playwright install --with-deps chromium
+        # Drops Google's Chrome apt source first — see the long comment on the
+        # identical step in the unit-tests job for why.
+        run: |
+          sudo rm -f /etc/apt/sources.list.d/google-chrome*
+          bunx playwright install --with-deps chromium
         working-directory: apps/e2e
 
       - name: Start realtime server


### PR DESCRIPTION
## The outage

Every job in the repo has been failing since **~17:20 UTC today**, at the Chromium install step:

```
Get:29 https://dl.google.com/linux/chrome-stable/deb stable/main amd64 Packages [1405 B]
Err:29  Hash Sum mismatch
  Release file created at: Wed, 09 Sep 2026 17:16:59 +0000
E: Some index files failed to download. They have been ignored, or old ones used instead.
Failed to install browsers
Error: Installation process exited with code: 100
```

**Nothing in the repo caused it.** Google published a `Release` file at 17:16:59 whose hashes do not match the `Packages.gz` their CDN is serving. `playwright install --with-deps` shells out to `apt-get update`, which exits non-zero if *any* configured source fails, and Playwright treats that as fatal.

Evidence it is external:

| | |
|---|---|
| master `6b2d6b5c` @ 16:39 | green |
| master `0053b285` @ 17:36 | red — same 3 errors |
| master `a4861d8e` @ 17:37 | red — same 3 errors |

No relevant commits in between, and `pu/mobile-cal` hit it independently. In the failing log **all 28 Ubuntu sources fetch successfully** — only source #29, `dl.google.com`, fails.

**This blocks deploys too, not just PR checks.** `ci.yml` is `workflow_call`-only and is invoked from both `test.yml` and `docker-images.yml`, where the `ci` job gates `build-and-push` and `deploy-fly`.

## The fix

Nothing in this repo needs Google's apt repository. Playwright installs its own Chromium build and takes its system libraries (`libnss3`, `libatk*`, `libgbm*`, …) from Ubuntu's archive — the sources that are working. Verified: no workflow or e2e config references `google-chrome`, `chrome-stable`, `CHROME_PATH` or `channel: 'chrome'`, and `apps/e2e/playwright.config.ts` declares a single `chromium` project.

Dropping the source list entry means `apt-get update` never contacts `dl.google.com`, so it exits 0. Deterministic, and it recovers now rather than whenever Google repairs their CDN.

Applied to **both** install steps — `unit-tests` (line ~109) and `e2e` (line ~331) — since they are independent and there is no composite action to centralise into (`.github/actions/` does not exist; creating the repo's first one for two call sites in one file during an outage seemed like the wrong trade). Full rationale sits on the first occurrence, with a pointer on the second so they cannot drift.

## Deliberately not done

- **A retry wrapper** — does nothing here. The bad data is server-side and survived three re-runs over thirty minutes.
- **Gating apt on `cache-hit`** — the existing comment above that step records why it must not be: the cache restores the browser binary but not the system libraries it links against, so a missing lib would fail only on cache-hit runs and could never reproduce on the run that populated the cache.
- **Stripping all of `sources.list.d`** — broader blast radius, no benefit today.

## Verification

CI is the only place this reproduces, and right now it is easy to prove: every other run in the repo is red at exactly this step.

Watch this PR's own checks. Two things to confirm, not one:

1. **The install succeeds** — in the log, `apt-get update` should show only `azure.archive.ubuntu.com` sources, no `dl.google.com` line, no `Err:`.
2. **Chromium still launches.** That is what proves Ubuntu's archive supplied every library it links against. `E2E (agent-session user stories)` and the cross-DOM parse-equality suite in `Unit Tests` both drive a real browser, so those passing is the evidence — a browser that installed but could not start would fail them.

YAML validated locally (`yaml.safe_load`), both steps confirmed to carry the removal and to keep `--with-deps`.

## Follow-ups noted, not fixed here

- The `unit-tests` cache key comes from `playwright-core@^1.60.0` in `packages/editor`, while the browser is installed by `@playwright/test@^1.52.0` in `apps/e2e`. If those resolve differently the key can be stale relative to the revision installed.
- The `e2e` job has no browser cache at all and re-downloads ~170MB every run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
