### PR TITLE
fix(ios): drop the manual signing identity that conflicts with automatic

### DIFF
--- a/apps/ios/ios/App/App.xcodeproj/project.pbxproj
+++ b/apps/ios/ios/App/App.xcodeproj/project.pbxproj
@@ -320,7 +320,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_ENTITLEMENTS = App/App.entitlements;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 5;
+				CURRENT_PROJECT_VERSION = 6;
 				DEVELOPMENT_TEAM = M96WTV3CKX;
 				INFOPLIST_FILE = App/Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = PageSpace;
@@ -330,7 +330,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.4;
+				MARKETING_VERSION = 1.5;
 				OTHER_SWIFT_FLAGS = "$(inherited) \"-DDEBUG\"";
 				PRODUCT_BUNDLE_IDENTIFIER = ai.pagespace.ios;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -346,9 +346,8 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_ENTITLEMENTS = App/App.entitlements;
-				CODE_SIGN_IDENTITY = "Apple Distribution";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 5;
+				CURRENT_PROJECT_VERSION = 6;
 				DEVELOPMENT_TEAM = M96WTV3CKX;
 				INFOPLIST_FILE = App/Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = PageSpace;
@@ -358,7 +357,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.4;
+				MARKETING_VERSION = 1.5;
 				PRODUCT_BUNDLE_IDENTIFIER = ai.pagespace.ios;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";


### PR DESCRIPTION
Blocks archiving. `#2568` set `CODE_SIGN_IDENTITY = "Apple Distribution"` on Release while `CODE_SIGN_STYLE` stayed `Automatic`, which Xcode rejects outright:

> App has conflicting provisioning settings. App is automatically signed for development, but a conflicting code signing identity Apple Distribution has been manually specified.

**The reasoning in #2568 was wrong.** It assumed a development identity on the Release config would produce an archive App Store Connect rejects. Under automatic signing it does not — Xcode substitutes the distribution certificate at *export* time from the method in `ExportOptions.plist` (`app-store`). The identity string in the Release config never constrained the archive, so the original value was already correct and the change turned a non-problem into a blocker.

Release now matches Debug: `CODE_SIGN_STYLE = Automatic`, no manual identity — the combination that has been building all along.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Release**
  * Updated the iOS app version to 1.5.
  * Incremented the internal build number to 6.
  * Streamlined Release signing configuration to use automatic code signing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->