### PR TITLE
fix(web): mobile side panels no longer pop the keyboard on open

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -490,6 +490,10 @@ All notable user-facing changes to PageSpace are documented here. Format follows
 
 ### Fixed
 
+- **Phone: opening a side panel no longer pops the keyboard** — on a phone or in the iOS and
+  Android apps, tapping the menu button to open the navigation panel (or the assistant panel)
+  immediately focused the search box inside it, so the keyboard slid up over the panel you had just
+  opened. The panel now opens with nothing focused; tap the search box when you want it.
 - **The account menu no longer labels free accounts "Billing (Business)"** — the plan name in the
   avatar dropdown fell through to "Business" whenever the subscription lookup had not answered yet
   (every first paint, and permanently if the request failed), so a brand-new free user saw a paid

--- a/apps/web/src/components/layout/Layout.tsx
+++ b/apps/web/src/components/layout/Layout.tsx
@@ -573,7 +573,11 @@ function Layout({ children }: LayoutProps) {
               }
             }}
           >
-            <SheetContent side="left" className="w-full max-w-[22rem] border-r p-0 sm:max-w-sm">
+            <SheetContent
+              side="left"
+              className="w-full max-w-[22rem] border-r p-0 sm:max-w-sm"
+              onOpenAutoFocus={(event) => event.preventDefault()}
+            >
               <SheetHeader className="sr-only">
                 <SheetTitle>Navigation menu</SheetTitle>
                 <SheetDescription>Browse spaces and files</SheetDescription>
@@ -591,7 +595,11 @@ function Layout({ children }: LayoutProps) {
               }
             }}
           >
-            <SheetContent side="right" className="w-full max-w-[22rem] border-l p-0 sm:max-w-sm">
+            <SheetContent
+              side="right"
+              className="w-full max-w-[22rem] border-l p-0 sm:max-w-sm"
+              onOpenAutoFocus={(event) => event.preventDefault()}
+            >
               <SheetHeader className="sr-only">
                 <SheetTitle>Global Assistant panel</SheetTitle>
                 <SheetDescription>Chat with the global assistant</SheetDescription>

--- a/apps/web/src/components/layout/Layout.tsx
+++ b/apps/web/src/components/layout/Layout.tsx
@@ -57,6 +57,19 @@ interface LayoutProps {
   children?: React.ReactNode;
 }
 
+/**
+ * Radix focuses the first tabbable descendant when a sheet opens. On phones that is
+ * the sidebar search input (or the assistant textarea), which pops the keyboard over
+ * the panel the user just opened. Cancel that and focus the sheet container instead
+ * so focus still enters the modal for keyboard and screen-reader users.
+ */
+function focusSheetContainer(event: Event) {
+  event.preventDefault();
+  if (event.currentTarget instanceof HTMLElement) {
+    event.currentTarget.focus();
+  }
+}
+
 function Layout({ children }: LayoutProps) {
   const { isLoading, isAuthenticated } = useAuth();
   // Has THIS mount observed a successful auth check yet? Starts false on every fresh
@@ -575,8 +588,9 @@ function Layout({ children }: LayoutProps) {
           >
             <SheetContent
               side="left"
-              className="w-full max-w-[22rem] border-r p-0 sm:max-w-sm"
-              onOpenAutoFocus={(event) => event.preventDefault()}
+              className="w-full max-w-[22rem] border-r p-0 outline-none sm:max-w-sm"
+              tabIndex={-1}
+              onOpenAutoFocus={focusSheetContainer}
             >
               <SheetHeader className="sr-only">
                 <SheetTitle>Navigation menu</SheetTitle>
@@ -597,8 +611,9 @@ function Layout({ children }: LayoutProps) {
           >
             <SheetContent
               side="right"
-              className="w-full max-w-[22rem] border-l p-0 sm:max-w-sm"
-              onOpenAutoFocus={(event) => event.preventDefault()}
+              className="w-full max-w-[22rem] border-l p-0 outline-none sm:max-w-sm"
+              tabIndex={-1}
+              onOpenAutoFocus={focusSheetContainer}
             >
               <SheetHeader className="sr-only">
                 <SheetTitle>Global Assistant panel</SheetTitle>

--- a/apps/web/src/components/layout/__tests__/Layout.sheet-focus.test.tsx
+++ b/apps/web/src/components/layout/__tests__/Layout.sheet-focus.test.tsx
@@ -1,0 +1,144 @@
+/**
+ * Where focus lands when a mobile side panel opens.
+ *
+ * Radix Dialog focuses the first tabbable descendant on open. In the left sheet
+ * that is the sidebar search input (the drive switcher is a Skeleton while drives
+ * load), and on iOS/Capacitor a programmatically focused input raises the keyboard
+ * over the panel the user just opened. Layout cancels that auto-focus — but it
+ * must still move focus INTO the sheet, or keyboard and screen-reader users are
+ * left on the toolbar behind a modal. Both halves are asserted here against the
+ * real Sheet; everything else is mocked.
+ */
+
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const { layoutState } = vi.hoisted(() => ({
+  layoutState: {} as Record<string, unknown>,
+}));
+
+vi.mock('@/hooks/useAuth', () => ({
+  useAuth: () => ({ isLoading: false, isAuthenticated: true }),
+}));
+vi.mock('@/hooks/useSocket', () => ({ useSocket: () => undefined }));
+vi.mock('@/hooks/useAccessRevocation', () => ({ useAccessRevocation: () => undefined }));
+vi.mock('@/hooks/useNotificationToasts', () => ({ useNotificationToasts: () => undefined }));
+vi.mock('@/hooks/useDesktopNotifications', () => ({ useDesktopNotifications: () => undefined }));
+vi.mock('@/hooks/useNativeBadgeSync', () => ({ useNativeBadgeSync: () => undefined }));
+vi.mock('@/hooks/usePerformanceMonitor', () => ({ usePerformanceMonitor: () => undefined }));
+vi.mock('@/hooks/useIOSKeyboardInit', () => ({ useIOSKeyboardInit: () => undefined }));
+vi.mock('@/hooks/useMobileKeyboard', () => ({ dismissKeyboard: () => {} }));
+vi.mock('@/hooks/useTabSync', () => ({ useTabSync: () => undefined }));
+vi.mock('@/hooks/useHasHydrated', () => ({ useHasHydrated: () => true }));
+// Every media query matches: this is the phone layout.
+vi.mock('@/hooks/useBreakpoint', () => ({ useBreakpoint: () => true }));
+vi.mock('@/hooks/useDeviceTier', () => ({ useDeviceTier: () => ({ isTablet: false }) }));
+
+vi.mock('@/stores/useLayoutStore', () => ({
+  useLayoutStore: (selector: (state: Record<string, unknown>) => unknown) => selector(layoutState),
+}));
+vi.mock('@/stores/useEditingStore', () => ({
+  useEditingStore: {
+    getState: () => ({ clearAllSessions: () => {}, clearStaleSessions: () => {} }),
+  },
+}));
+vi.mock('next/navigation', () => ({
+  useRouter: () => ({ push: () => {}, replace: () => {}, prefetch: () => {} }),
+  usePathname: () => '/dashboard/drive-1/page-1',
+  useParams: () => ({ driveId: 'drive-1', pageId: 'page-1' }),
+}));
+vi.mock('@/components/ai/voice/realtime', () => ({
+  VoiceSessionBridge: () => null,
+  VoiceNavTrigger: () => <div />,
+  VoiceCallBar: () => <div />,
+}));
+vi.mock('@/components/layout/main-header', () => ({
+  default: () => <div data-testid="top-bar" />,
+}));
+// The sidebar as the first tabbable thing Radix would find: a search input.
+vi.mock('@/components/layout/left-sidebar/MemoizedSidebar', () => ({
+  default: () => <input placeholder="Search pages..." />,
+}));
+vi.mock('@/components/layout/middle-content/CenterPanel', () => ({ default: () => <div /> }));
+vi.mock('@/components/layout/right-sidebar', () => ({
+  default: () => <textarea placeholder="Message the assistant" />,
+}));
+vi.mock('@/components/layout/tabs', () => ({ TabBar: () => <div /> }));
+vi.mock('@/components/layout/DebugPanel', () => ({ DebugPanel: () => <div /> }));
+vi.mock('@/components/layout/NavigationProvider', () => ({
+  NavigationProvider: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}));
+vi.mock('@/contexts/GlobalChatContext', () => ({
+  GlobalChatProvider: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  useGlobalChatConversation: () => ({ currentConversationId: null }),
+}));
+vi.mock('@/contexts/VoiceSessionContext', () => ({
+  VoiceSessionProvider: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}));
+vi.mock('@/components/ui/resizable', () => ({
+  ResizablePanelGroup: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  ResizablePanel: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  ResizableHandle: () => <div />,
+}));
+vi.mock('motion/react', () => ({
+  motion: { div: ({ children }: { children: React.ReactNode }) => <div>{children}</div> },
+  AnimatePresence: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}));
+
+import Layout from '../Layout';
+
+beforeEach(() => {
+  Object.assign(layoutState, {
+    leftSidebarOpen: false,
+    rightSidebarOpen: false,
+    leftSheetOpen: false,
+    rightSheetOpen: false,
+    leftOverlayOpen: false,
+    rightSidebarPageTab: 'history',
+    leftSidebarSize: 20,
+    rightSidebarSize: 20,
+    toggleLeftSidebar: () => {},
+    toggleRightSidebar: () => {},
+    setRightSidebarOpen: () => {},
+    setLeftSheetOpen: () => {},
+    setRightSheetOpen: () => {},
+    setLeftOverlayOpen: () => {},
+    setRightSidebarPageTab: () => {},
+    setLeftSidebarSize: () => {},
+    setRightSidebarSize: () => {},
+  });
+});
+
+const renderOpen = (which: 'leftSheetOpen' | 'rightSheetOpen') => {
+  layoutState[which] = true;
+  render(
+    <Layout>
+      <div />
+    </Layout>,
+  );
+};
+
+describe('Layout — focus when a mobile sheet opens', () => {
+  it('should not focus the sidebar search input, which would raise the keyboard', () => {
+    renderOpen('leftSheetOpen');
+
+    const input = screen.getByPlaceholderText('Search pages...');
+    expect(document.activeElement).not.toBe(input);
+  });
+
+  it('should still move focus into the navigation sheet, not leave it on the page behind', () => {
+    renderOpen('leftSheetOpen');
+
+    const dialog = screen.getByRole('dialog', { name: 'Navigation menu' });
+    expect(document.activeElement).toBe(dialog);
+  });
+
+  it('should treat the assistant sheet the same way', () => {
+    renderOpen('rightSheetOpen');
+
+    const dialog = screen.getByRole('dialog', { name: 'Global Assistant panel' });
+    expect(document.activeElement).toBe(dialog);
+    expect(document.activeElement).not.toBe(screen.getByPlaceholderText('Message the assistant'));
+  });
+});


### PR DESCRIPTION
## Summary

On a phone or in the Capacitor apps, opening the left sidebar immediately focused the search box inside it and the keyboard slid up over the panel. The right (assistant) sheet did the same with its chat textarea.

**Cause.** Nothing sets `autoFocus`. The mobile panels are Radix Sheets, and Radix Dialog focuses the first tabbable descendant on open. `DriveSwitcher` renders a `Skeleton` while drives load, so the first tabbable element resolves to the search `Input`. WKWebView opens the keyboard on programmatic focus, undoing the `dismissKeyboard()` that `handleLeftPanelToggle` already runs.

**Fix.** Both `SheetContent`s in `apps/web/src/components/layout/Layout.tsx` get `tabIndex={-1}` and a shared `focusSheetContainer` handler for `onOpenAutoFocus`: it cancels Radix's descendant auto-focus and focuses the sheet container. The second half matters: Radix's own container fallback sits inside the not-prevented branch, and `Dialog.Content` is a plain div, so `preventDefault` alone leaves focus on the toolbar behind the modal (review finding, now addressed). Escape and focus trapping are unchanged.

Changelog: Fixed entry under Unreleased.

## Tests

`apps/web/src/components/layout/__tests__/Layout.sheet-focus.test.tsx` renders `Layout` with the real Sheet at the phone breakpoint, a search input as the sidebar and a textarea as the assistant panel, and asserts for each sheet that focus lands on the dialog and not on the input.

Mutation check: removing the handler fails all 3 tests; `preventDefault` without the container focus fails the 2 container assertions.

## Verification

- `bunx eslint` on the touched files, `tsc --noEmit -p apps/web`: clean.
- Not yet verified on device. Please check on iOS/Android: tap the menu button, the panel opens with no keyboard; tapping the search box still opens it; Escape / backdrop tap still closes both sheets.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BhEdm2Xe7KGsZMJGiikUCE
