### PR TITLE
Fix FAQ: clarify agent access control uses permission-scoped model by default

### DIFF
--- a/apps/marketing/src/app/faq/page.tsx
+++ b/apps/marketing/src/app/faq/page.tsx
@@ -161,7 +161,7 @@ const faqs: FAQItem[] = [
     id: "ai-access-to-content",
     question: "Will the AI touch content I haven't given it access to?",
     answer:
-      "No. Agents act as the user who asked them — they can only see and edit what you can see and edit.",
+      "No. Each agent is a permission-scoped principal with its own drive membership and access level — bound the same way a person is. Agents only see and edit content they've been granted access to through their own role in the drive. If you want an agent to inherit your access instead, you can enable user-scoped access per agent, but that's opt-in; the default is stricter and more secure.",
     category: "Working with AI",
   },
   {


### PR DESCRIPTION
The FAQ answer for 'Will the AI touch content I haven't given it access to?'
incorrectly described agents as acting with user-scoped access. The actual
default is that agents are permission-scoped principals with their own drive
membership and access level, bound the same way a person is. User-scoped
access is an optional per-agent configuration that defaults to false.

This aligns the FAQ with the actual implementation and the safer, more
interesting default behavior.

Fixes: #2597

Co-Authored-By: Claude Haiku 4.5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_0136JhFMeCsPovLFmb6uQ7Hj