### PR TITLE
feat(web): drive-scoped channels, files, tasks and calendar can reach their all-drives view, and back

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,8 @@ All notable user-facing changes to PageSpace are documented here. Format follows
   header: it names where you are ("All drives" or the drive's name) and opens a list with the
   all-drives view at the top and every drive below it. Files has no all-drives listing of its own,
   so its "All drives" entry goes to the Drives browser, which gets the same control pointing back
-  into each drive's files.
+  into each drive's files. Opening a drive from that browser, by click or from its right-click
+  menu, now lands in the drive's file browser instead of on the drive's home page.
 - **AI agents can format spreadsheets** — two new workspace tools, **Format Sheet** and
   **Conditional Formatting**, let an agent make a SHEET page presentable instead of leaving a grid
   of bare numbers. An agent declares what a table *is* (its range, header rows, which columns are

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,10 @@ All notable user-facing changes to PageSpace are documented here. Format follows
   all-drives view at the top and every drive below it. Files has no all-drives listing of its own,
   so its "All drives" entry goes to the Drives browser, which gets the same control pointing back
   into each drive's files. Opening a drive from that browser, by click or from its right-click
-  menu, now lands in the drive's file browser instead of on the drive's home page.
+  menu, now lands in the drive's file browser instead of on the drive's home page. The drive
+  picker in the header and sidebar does the same: switching drives while you are looking at files,
+  channels, tasks or the calendar keeps you in that section in the new drive, instead of dropping
+  you on its home page.
 - **AI agents can format spreadsheets** — two new workspace tools, **Format Sheet** and
   **Conditional Formatting**, let an agent make a SHEET page presentable instead of leaving a grid
   of bare numbers. An agent declares what a table *is* (its range, header rows, which columns are

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ All notable user-facing changes to PageSpace are documented here. Format follows
 
 ### Added
 
+- **Jump between a drive's channels, files, tasks or calendar and the all-drives version** — each
+  of those four views exists in two shapes: one drive, or everything you can see. The sidebar only
+  ever linked to whichever shape you were already in, so from inside a drive's task list there was
+  no way to reach "My Tasks" short of going back to the dashboard, and from the global calendar no
+  way into a particular drive's. Every one of these views now carries a scope control in its
+  header: it names where you are ("All drives" or the drive's name) and opens a list with the
+  all-drives view at the top and every drive below it. Files has no all-drives listing of its own,
+  so its "All drives" entry goes to the Drives browser, which gets the same control pointing back
+  into each drive's files.
 - **AI agents can format spreadsheets** — two new workspace tools, **Format Sheet** and
   **Conditional Formatting**, let an agent make a SHEET page presentable instead of leaving a grid
   of bare numbers. An agent declares what a table *is* (its range, header rows, which columns are

--- a/apps/web/src/components/calendar/CalendarView.tsx
+++ b/apps/web/src/components/calendar/CalendarView.tsx
@@ -6,6 +6,7 @@ import { format, addMonths, subMonths, addWeeks, subWeeks, addDays, subDays } fr
 import { Bot, ChevronLeft, ChevronRight, Plus, Calendar as CalendarIcon, List, LayoutGrid, Clock, PanelLeft, User } from 'lucide-react';
 import useSWR from 'swr';
 import { Button } from '@/components/ui/button';
+import { DriveScopeSwitcher } from '@/components/shared/DriveScopeSwitcher';
 import { Toggle } from '@/components/ui/toggle';
 import {
   Select,
@@ -455,6 +456,13 @@ export function CalendarView({ context, driveId, driveName: _driveName, classNam
           currentDate={currentDate}
           driveColorMap={driveColorMap}
           context={context}
+          scopeSwitcher={
+            <DriveScopeSwitcher
+              section="calendar"
+              driveId={isUserContext ? undefined : driveId}
+              compact
+            />
+          }
           calendarEntries={isUserContext ? calendarEntries : undefined}
           onToggleCalendar={toggleCalendar}
           onShowAllCalendars={showAll}
@@ -510,6 +518,8 @@ export function CalendarView({ context, driveId, driveName: _driveName, classNam
 
           {/* Title */}
           <h2 className="text-lg font-semibold">{getHeaderTitle()}</h2>
+
+          <DriveScopeSwitcher section="calendar" driveId={isUserContext ? undefined : driveId} />
         </div>
 
         <div className="flex items-center gap-2">

--- a/apps/web/src/components/calendar/MobileCalendarView.tsx
+++ b/apps/web/src/components/calendar/MobileCalendarView.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState, useCallback, useRef, useEffect, useMemo } from 'react';
+import { useState, useCallback, useRef, useEffect, useMemo, type ReactNode } from 'react';
 import {
   format,
   addMonths,
@@ -62,6 +62,8 @@ interface MobileCalendarViewProps {
   currentDate?: Date;
   driveColorMap?: Map<string | null, EventColorConfig> | null;
   context?: 'user' | 'drive';
+  /** Header control for jumping between this drive's calendar and the global one. */
+  scopeSwitcher?: ReactNode;
   calendarEntries?: CalendarEntryForMobile[];
   onToggleCalendar?: (key: string) => void;
   onShowAllCalendars?: () => void;
@@ -79,6 +81,7 @@ export function MobileCalendarView({
   currentDate: parentDate,
   driveColorMap,
   context = 'drive',
+  scopeSwitcher,
   calendarEntries,
   onToggleCalendar,
   onShowAllCalendars,
@@ -349,6 +352,8 @@ export function MobileCalendarView({
           >
             <ListTodo className="h-4 w-4" />
           </Button>
+
+          {scopeSwitcher}
 
           {calendarEntries && onToggleCalendar && onShowAllCalendars && onHideAllCalendars && (
             <Sheet>

--- a/apps/web/src/components/drives/DriveContextMenu.tsx
+++ b/apps/web/src/components/drives/DriveContextMenu.tsx
@@ -33,7 +33,8 @@ export function DriveContextMenu({ drive, children }: DriveContextMenuProps) {
   const removeDriveFromStore = useDriveStore((state) => state.removeDrive);
 
   const handleOpen = () => {
-    router.push(`/dashboard/${drive.id}`);
+    // Match the card click: from the Files surface a drive opens on its files.
+    router.push(`/dashboard/${drive.id}/files`);
   };
 
   const handleRename = async (newName: string) => {

--- a/apps/web/src/components/drives/DrivesBrowser.tsx
+++ b/apps/web/src/components/drives/DrivesBrowser.tsx
@@ -12,6 +12,7 @@ import {
   Star,
 } from "lucide-react";
 import { Button } from "@/components/ui/button";
+import { DriveScopeSwitcher } from "@/components/shared/DriveScopeSwitcher";
 import {
   Table,
   TableBody,
@@ -291,6 +292,7 @@ export default function DrivesBrowser() {
         <div className="flex items-center justify-between mb-6">
           <h1 className="text-2xl font-bold">Drives</h1>
           <div className="flex items-center gap-2">
+            <DriveScopeSwitcher section="files" />
             <Button
               variant={viewMode === "list" ? "secondary" : "ghost"}
               size="icon"

--- a/apps/web/src/components/drives/DrivesBrowser.tsx
+++ b/apps/web/src/components/drives/DrivesBrowser.tsx
@@ -147,7 +147,9 @@ export default function DrivesBrowser() {
     fetchWithAuth(`/api/drives/${drive.id}/access`, { method: "POST" }).catch(
       (err) => console.warn("Failed to record drive access:", err)
     );
-    router.push(`/dashboard/${drive.id}`);
+    // This browser is the Files surface, so opening a drive lands in its
+    // file browser rather than on the drive home.
+    router.push(`/dashboard/${drive.id}/files`);
   };
 
   if (isLoading && drives.length === 0) {

--- a/apps/web/src/components/files/FilesFinderContent.tsx
+++ b/apps/web/src/components/files/FilesFinderContent.tsx
@@ -5,6 +5,7 @@ import Link from 'next/link';
 import { Grip, List, Plus } from 'lucide-react';
 import { Skeleton } from '@/components/ui/skeleton';
 import { Button } from '@/components/ui/button';
+import { DriveScopeSwitcher } from '@/components/shared/DriveScopeSwitcher';
 import { usePageTree } from '@/hooks/usePageTree';
 import { useDriveStore } from '@/hooks/useDrive';
 import { findNodeAndParent } from '@/lib/tree/tree-utils';
@@ -119,6 +120,7 @@ export function FilesFinderContent({ driveId, currentPageId }: FilesFinderConten
             )}
           </div>
           <div className="flex items-center gap-2 shrink-0">
+            <DriveScopeSwitcher section="files" driveId={driveId} />
             <Button variant={viewMode === 'list' ? 'secondary' : 'ghost'} size="icon" onClick={() => setViewMode('list')}>
               <List className="h-4 w-4" />
             </Button>

--- a/apps/web/src/components/inbox/ChannelsCenterList.tsx
+++ b/apps/web/src/components/inbox/ChannelsCenterList.tsx
@@ -13,6 +13,7 @@ import { fetchWithAuth } from '@/lib/auth/auth-fetch';
 import { useInboxSocket } from '@/hooks/useInboxSocket';
 import { useEditingStore } from '@/stores/useEditingStore';
 import { ThreadUnreadBadge } from '@/components/inbox/ThreadUnreadBadge';
+import { DriveScopeSwitcher } from '@/components/shared/DriveScopeSwitcher';
 import type { InboxItem, InboxResponse } from '@pagespace/lib/types';
 
 const fetcher = async (url: string) => {
@@ -129,16 +130,19 @@ export default function ChannelsCenterList({ driveId }: ChannelsCenterListProps)
   return (
     <div className="h-full flex flex-col max-w-4xl mx-auto w-full">
       <div className="flex-shrink-0 px-4 pt-6 pb-4">
-        <div className="flex items-center gap-3 mb-4">
-          <div className="h-10 w-10 rounded-full bg-primary/10 flex items-center justify-center">
-            <Hash className="h-5 w-5 text-primary" />
+        <div className="flex items-center justify-between gap-3 mb-4">
+          <div className="flex items-center gap-3 min-w-0">
+            <div className="h-10 w-10 shrink-0 rounded-full bg-primary/10 flex items-center justify-center">
+              <Hash className="h-5 w-5 text-primary" />
+            </div>
+            <div className="min-w-0">
+              <h1 className="text-xl font-semibold">Channels</h1>
+              <p className="text-sm text-muted-foreground truncate">
+                {driveId ? 'Channels in this drive' : 'Channels across your drives'}
+              </p>
+            </div>
           </div>
-          <div>
-            <h1 className="text-xl font-semibold">Channels</h1>
-            <p className="text-sm text-muted-foreground">
-              {driveId ? 'Channels in this drive' : 'Channels across your drives'}
-            </p>
-          </div>
+          <DriveScopeSwitcher section="channels" driveId={driveId} />
         </div>
 
         <div className="relative">

--- a/apps/web/src/components/layout/navbar/useDrivePicker.ts
+++ b/apps/web/src/components/layout/navbar/useDrivePicker.ts
@@ -1,11 +1,12 @@
 "use client";
 
 import { useCallback, useMemo } from "react";
-import { useRouter } from "next/navigation";
+import { usePathname, useRouter } from "next/navigation";
 
 import { useDriveStore, type Drive } from "@/hooks/useDrive";
 import { useFavorites } from "@/hooks/useFavorites";
 import { fetchWithAuth } from "@/lib/auth/auth-fetch";
+import { driveDestinationHref } from "@/components/shared/DriveScopeSwitcher";
 
 const RECENT_LIMIT = 5;
 
@@ -21,6 +22,7 @@ const RECENT_LIMIT = 5;
  */
 export function useDrivePicker(query: string) {
   const router = useRouter();
+  const pathname = usePathname();
 
   const drives = useDriveStore((state) => state.drives);
   const currentDriveId = useDriveStore((state) => state.currentDriveId);
@@ -60,12 +62,14 @@ export function useDrivePicker(query: string) {
   const selectDrive = useCallback(
     (drive: Drive) => {
       setCurrentDrive(drive.id);
-      router.push(`/dashboard/${drive.id}`);
+      // Stay in the section you were in: a drive picked while looking at
+      // files (or channels, tasks, calendar) opens on that drive's files.
+      router.push(driveDestinationHref(pathname, drive.id));
       // Optimistic, so "Recent" reorders before the server has heard about it.
       updateDrive(drive.id, { lastAccessedAt: new Date().toISOString() });
       fetchWithAuth(`/api/drives/${drive.id}/access`, { method: "POST" }).catch(() => {});
     },
-    [router, setCurrentDrive, updateDrive]
+    [router, pathname, setCurrentDrive, updateDrive]
   );
 
   const isFavorite = useCallback((driveId: string) => driveIds.has(driveId), [driveIds]);

--- a/apps/web/src/components/shared/DriveScopeSwitcher.tsx
+++ b/apps/web/src/components/shared/DriveScopeSwitcher.tsx
@@ -1,0 +1,141 @@
+'use client';
+
+import { useEffect } from 'react';
+import Link from 'next/link';
+import { Check, ChevronsUpDown, Folder, Layers } from 'lucide-react';
+
+import { Button } from '@/components/ui/button';
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuLabel,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from '@/components/ui/dropdown-menu';
+import { useDriveStore } from '@/hooks/useDrive';
+import { cn } from '@/lib/utils';
+
+/**
+ * The four surfaces that exist both as a drive-scoped view
+ * (`/dashboard/[driveId]/<section>`) and as a global, cross-drive view.
+ */
+export type DriveScopedSection = 'channels' | 'files' | 'tasks' | 'calendar';
+
+/**
+ * The global counterpart of each section. Files has no cross-drive listing
+ * of its own, so the drives browser stands in for it — the same mapping the
+ * left sidebar's primary navigation uses.
+ */
+const GLOBAL_HREF: Record<DriveScopedSection, string> = {
+  channels: '/dashboard/channels',
+  files: '/dashboard/drives',
+  tasks: '/dashboard/tasks',
+  calendar: '/dashboard/calendar',
+};
+
+const ALL_DRIVES_LABEL = 'All drives';
+
+export function globalSectionHref(section: DriveScopedSection): string {
+  return GLOBAL_HREF[section];
+}
+
+export function driveSectionHref(section: DriveScopedSection, driveId: string): string {
+  return `/dashboard/${driveId}/${section}`;
+}
+
+interface DriveScopeSwitcherProps {
+  section: DriveScopedSection;
+  /** The drive the view is scoped to; omit on the global view. */
+  driveId?: string;
+  /** Icon-only trigger for tight mobile headers. */
+  compact?: boolean;
+  className?: string;
+}
+
+/**
+ * Lets a drive-scoped view jump to its global counterpart and back.
+ *
+ * Every section (channels, files, tasks, calendar) is reachable in two
+ * shapes: "this drive" and "everything I can see". The sidebar swaps its
+ * links depending on which shape you are in, which means the *other* shape
+ * has no affordance at all from inside the view. This one control sits in
+ * each view's header and offers both: the global view, and every drive's
+ * version of the same section.
+ *
+ * Drives come from the store and are allowed to be missing: the global
+ * entry is always rendered, so the way out never waits on a fetch.
+ */
+export function DriveScopeSwitcher({ section, driveId, compact = false, className }: DriveScopeSwitcherProps) {
+  const drives = useDriveStore((state) => state.drives);
+  const fetchDrives = useDriveStore((state) => state.fetchDrives);
+
+  useEffect(() => {
+    // Cached for five minutes inside the store; this is a no-op in the
+    // common case where the sidebar already loaded them.
+    fetchDrives();
+  }, [fetchDrives]);
+
+  const activeDrives = drives.filter((drive) => !drive.isTrashed);
+  const currentDrive = driveId ? drives.find((drive) => drive.id === driveId) : undefined;
+  const isGlobal = !driveId;
+
+  const currentLabel = isGlobal ? ALL_DRIVES_LABEL : (currentDrive?.name ?? 'This drive');
+  const CurrentIcon = isGlobal ? Layers : Folder;
+  const triggerTitle = isGlobal
+    ? `Viewing ${section} across all drives. Switch to a drive.`
+    : `Viewing ${section} in ${currentLabel}. Switch drive or view all drives.`;
+
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild>
+        <Button
+          variant="outline"
+          size={compact ? 'icon' : 'sm'}
+          className={cn(compact ? 'h-9 w-9 shrink-0' : 'h-9 max-w-[220px] gap-1.5', className)}
+          aria-label={compact ? triggerTitle : undefined}
+          title={triggerTitle}
+        >
+          <CurrentIcon className="h-4 w-4 shrink-0 text-muted-foreground" aria-hidden="true" />
+          {!compact && (
+            <>
+              <span className="truncate">{currentLabel}</span>
+              <ChevronsUpDown className="h-3.5 w-3.5 shrink-0 text-muted-foreground" aria-hidden="true" />
+            </>
+          )}
+        </Button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent align="end" className="w-64">
+        <DropdownMenuLabel className="text-xs font-normal text-muted-foreground">
+          Show {section} for
+        </DropdownMenuLabel>
+        <DropdownMenuItem asChild>
+          <Link href={GLOBAL_HREF[section]} aria-current={isGlobal ? 'page' : undefined}>
+            <Layers className="h-4 w-4 text-muted-foreground" aria-hidden="true" />
+            <span className="flex-1 truncate">{ALL_DRIVES_LABEL}</span>
+            {isGlobal && <Check className="h-4 w-4" aria-hidden="true" />}
+          </Link>
+        </DropdownMenuItem>
+        {activeDrives.length > 0 && (
+          <>
+            <DropdownMenuSeparator />
+            <div className="max-h-72 overflow-y-auto">
+              {activeDrives.map((drive) => {
+                const isCurrent = drive.id === driveId;
+                return (
+                  <DropdownMenuItem key={drive.id} asChild>
+                    <Link href={driveSectionHref(section, drive.id)} aria-current={isCurrent ? 'page' : undefined}>
+                      <Folder className="h-4 w-4 text-muted-foreground" aria-hidden="true" />
+                      <span className="flex-1 truncate">{drive.name}</span>
+                      {isCurrent && <Check className="h-4 w-4" aria-hidden="true" />}
+                    </Link>
+                  </DropdownMenuItem>
+                );
+              })}
+            </div>
+          </>
+        )}
+      </DropdownMenuContent>
+    </DropdownMenu>
+  );
+}

--- a/apps/web/src/components/shared/DriveScopeSwitcher.tsx
+++ b/apps/web/src/components/shared/DriveScopeSwitcher.tsx
@@ -44,6 +44,42 @@ export function driveSectionHref(section: DriveScopedSection, driveId: string): 
   return `/dashboard/${driveId}/${section}`;
 }
 
+const SECTIONS: DriveScopedSection[] = ['channels', 'files', 'tasks', 'calendar'];
+
+/**
+ * Which drive-scoped section, if any, the current route is showing.
+ *
+ * Recognises both shapes: `/dashboard/[driveId]/<section>` (with anything
+ * nested below it, e.g. a files sub-folder) and the global counterparts,
+ * including `/dashboard/drives` standing in for files.
+ */
+export function sectionForPathname(pathname: string | null | undefined): DriveScopedSection | null {
+  if (!pathname) return null;
+  const segments = pathname.split('/').filter(Boolean);
+  if (segments[0] !== 'dashboard' || segments.length < 2) return null;
+
+  const isSection = (value: string | undefined): value is DriveScopedSection =>
+    SECTIONS.includes(value as DriveScopedSection);
+
+  // Global shape: /dashboard/<section> — or /dashboard/drives for files.
+  if (segments.length === 2) {
+    if (segments[1] === 'drives') return 'files';
+    return isSection(segments[1]) ? segments[1] : null;
+  }
+  // Drive shape: /dashboard/<driveId>/<section>/...
+  return isSection(segments[2]) ? segments[2] : null;
+}
+
+/**
+ * Where switching to `driveId` should land, given where the user is now:
+ * the same section in the new drive when they are in one, else its home.
+ * A drive picked from a files view is wanted for its files.
+ */
+export function driveDestinationHref(pathname: string | null | undefined, driveId: string): string {
+  const section = sectionForPathname(pathname);
+  return section ? driveSectionHref(section, driveId) : `/dashboard/${driveId}`;
+}
+
 interface DriveScopeSwitcherProps {
   section: DriveScopedSection;
   /** The drive the view is scoped to; omit on the global view. */

--- a/apps/web/src/components/shared/__tests__/DriveScopeSwitcher.test.tsx
+++ b/apps/web/src/components/shared/__tests__/DriveScopeSwitcher.test.tsx
@@ -1,0 +1,118 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import type { Drive } from '@pagespace/lib/types';
+
+import { DriveScopeSwitcher, driveSectionHref, globalSectionHref } from '../DriveScopeSwitcher';
+import { useDriveStore } from '@/hooks/useDrive';
+
+// The switcher asks the store to (re)load drives on mount. With an empty
+// store that is a real fetch, which jsdom cannot make; the tests seed the
+// store directly, so the network never matters here.
+vi.mock('@/lib/auth/auth-fetch', () => ({
+  fetchWithAuth: vi.fn(async () => ({ ok: true, json: async () => [] })),
+}));
+
+const buildDrive = (overrides: Partial<Drive> = {}): Drive => ({
+  id: 'drive_eng',
+  name: 'Engineering',
+  slug: 'engineering',
+  ownerId: 'user_1',
+  isTrashed: false,
+  trashedAt: null,
+  createdAt: '2026-01-01T00:00:00.000Z',
+  updatedAt: '2026-01-01T00:00:00.000Z',
+  isOwned: true,
+  ...overrides,
+});
+
+const seedDrives = (drives: Drive[]) => {
+  // lastFetched = now so the component's fetchDrives() call is a cache hit
+  // and never touches the network.
+  useDriveStore.setState({ drives, currentDriveId: null, isLoading: false, lastFetched: Date.now() });
+};
+
+describe('DriveScopeSwitcher', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    seedDrives([]);
+  });
+
+  describe('hrefs', () => {
+    it('given each section, should map the global view to the same route the sidebar uses', () => {
+      expect(globalSectionHref('channels')).toBe('/dashboard/channels');
+      expect(globalSectionHref('files')).toBe('/dashboard/drives');
+      expect(globalSectionHref('tasks')).toBe('/dashboard/tasks');
+      expect(globalSectionHref('calendar')).toBe('/dashboard/calendar');
+    });
+
+    it('given a drive, should nest the section under that drive', () => {
+      expect(driveSectionHref('calendar', 'drive_eng')).toBe('/dashboard/drive_eng/calendar');
+    });
+  });
+
+  describe('inside a drive', () => {
+    it('given a known drive, should name it on the trigger', () => {
+      seedDrives([buildDrive()]);
+
+      render(<DriveScopeSwitcher section="tasks" driveId="drive_eng" />);
+
+      expect(screen.getByRole('button', { name: /Engineering/ })).toBeInTheDocument();
+    });
+
+    it('given a drive the store has not loaded, should still render a usable trigger', () => {
+      render(<DriveScopeSwitcher section="tasks" driveId="drive_missing" />);
+
+      expect(screen.getByRole('button', { name: /This drive/ })).toBeInTheDocument();
+    });
+
+    it('given the menu is open, should offer the global view and every other drive', async () => {
+      const user = userEvent.setup();
+      seedDrives([
+        buildDrive(),
+        buildDrive({ id: 'drive_design', name: 'Design', slug: 'design' }),
+        buildDrive({ id: 'drive_gone', name: 'Old', slug: 'old', isTrashed: true }),
+      ]);
+
+      render(<DriveScopeSwitcher section="tasks" driveId="drive_eng" />);
+      await user.click(screen.getByRole('button', { name: /Engineering/ }));
+
+      const allDrives = await screen.findByRole('menuitem', { name: /All drives/ });
+      expect(allDrives).toHaveAttribute('href', '/dashboard/tasks');
+
+      const design = screen.getByRole('menuitem', { name: /Design/ });
+      expect(design).toHaveAttribute('href', '/dashboard/drive_design/tasks');
+
+      const current = screen.getByRole('menuitem', { name: /Engineering/ });
+      expect(current).toHaveAttribute('aria-current', 'page');
+
+      expect(screen.queryByRole('menuitem', { name: /Old/ })).not.toBeInTheDocument();
+    });
+  });
+
+  describe('on the global view', () => {
+    it('given no drive, should say so on the trigger and mark the global entry current', async () => {
+      const user = userEvent.setup();
+      seedDrives([buildDrive()]);
+
+      render(<DriveScopeSwitcher section="files" />);
+      const trigger = screen.getByRole('button', { name: /All drives/ });
+      await user.click(trigger);
+
+      const allDrives = await screen.findByRole('menuitem', { name: /All drives/ });
+      expect(allDrives).toHaveAttribute('aria-current', 'page');
+      expect(allDrives).toHaveAttribute('href', '/dashboard/drives');
+
+      expect(screen.getByRole('menuitem', { name: /Engineering/ })).toHaveAttribute(
+        'href',
+        '/dashboard/drive_eng/files'
+      );
+    });
+
+    it('given compact mode, should keep the scope in the accessible name', () => {
+      render(<DriveScopeSwitcher section="calendar" compact />);
+
+      expect(screen.getByRole('button', { name: /across all drives/ })).toBeInTheDocument();
+    });
+  });
+});

--- a/apps/web/src/components/shared/__tests__/DriveScopeSwitcher.test.tsx
+++ b/apps/web/src/components/shared/__tests__/DriveScopeSwitcher.test.tsx
@@ -3,7 +3,13 @@ import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import type { Drive } from '@pagespace/lib/types';
 
-import { DriveScopeSwitcher, driveSectionHref, globalSectionHref } from '../DriveScopeSwitcher';
+import {
+  DriveScopeSwitcher,
+  driveDestinationHref,
+  driveSectionHref,
+  globalSectionHref,
+  sectionForPathname,
+} from '../DriveScopeSwitcher';
 import { useDriveStore } from '@/hooks/useDrive';
 
 // The switcher asks the store to (re)load drives on mount. With an empty
@@ -48,6 +54,41 @@ describe('DriveScopeSwitcher', () => {
 
     it('given a drive, should nest the section under that drive', () => {
       expect(driveSectionHref('calendar', 'drive_eng')).toBe('/dashboard/drive_eng/calendar');
+    });
+  });
+
+  describe('sectionForPathname', () => {
+    it('given a drive-scoped section route, should name the section, sub-paths included', () => {
+      expect(sectionForPathname('/dashboard/drive_eng/files')).toBe('files');
+      expect(sectionForPathname('/dashboard/drive_eng/files/page_9')).toBe('files');
+      expect(sectionForPathname('/dashboard/drive_eng/calendar')).toBe('calendar');
+    });
+
+    it('given a global section route, should name the section, with drives standing in for files', () => {
+      expect(sectionForPathname('/dashboard/drives')).toBe('files');
+      expect(sectionForPathname('/dashboard/tasks')).toBe('tasks');
+    });
+
+    it('given a route outside the four sections, should find nothing', () => {
+      expect(sectionForPathname('/dashboard')).toBeNull();
+      expect(sectionForPathname('/dashboard/drive_eng')).toBeNull();
+      expect(sectionForPathname('/dashboard/drive_eng/page_9')).toBeNull();
+      expect(sectionForPathname('/dashboard/dms')).toBeNull();
+      expect(sectionForPathname(null)).toBeNull();
+    });
+  });
+
+  describe('driveDestinationHref', () => {
+    it('given a files view, should send a picked drive to its files', () => {
+      expect(driveDestinationHref('/dashboard/drives', 'drive_eng')).toBe('/dashboard/drive_eng/files');
+      expect(driveDestinationHref('/dashboard/drive_x/files/page_1', 'drive_eng')).toBe(
+        '/dashboard/drive_eng/files'
+      );
+    });
+
+    it('given no section, should fall back to the drive home', () => {
+      expect(driveDestinationHref('/dashboard', 'drive_eng')).toBe('/dashboard/drive_eng');
+      expect(driveDestinationHref('/dashboard/drive_x/page_1', 'drive_eng')).toBe('/dashboard/drive_eng');
     });
   });
 

--- a/apps/web/src/components/tasks/TasksDashboard.tsx
+++ b/apps/web/src/components/tasks/TasksDashboard.tsx
@@ -57,6 +57,7 @@ import {
 import { DEFAULT_STATUS_CONFIG, type TaskStatusGroup } from '@/lib/task-status-config';
 import type { Task, TaskFilters, Drive, Pagination, StatusConfigsByTaskList } from './types';
 import { getStatusDisplay } from './task-helpers';
+import { DriveScopeSwitcher } from '@/components/shared/DriveScopeSwitcher';
 import { FilterControls } from './FilterControls';
 import { TaskCompactRow } from './TaskCompactRow';
 import { TaskDetailSheet } from './TaskDetailSheet';
@@ -651,6 +652,11 @@ export function TasksDashboard({ driveId: propDriveId }: TasksDashboardProps) {
                       <ArrowLeft className="h-4 w-4" />
                     </Button>
                     <h1 className="text-base font-semibold truncate flex-1">{title}</h1>
+                    <DriveScopeSwitcher
+                      section="tasks"
+                      driveId={isLocked ? selectedDriveId : undefined}
+                      compact
+                    />
                     <Button
                       variant="ghost"
                       size="icon"
@@ -783,6 +789,10 @@ export function TasksDashboard({ driveId: propDriveId }: TasksDashboardProps) {
                       <p className="text-sm text-muted-foreground">{description}</p>
                     </div>
                     <div className="flex items-center gap-2">
+                      <DriveScopeSwitcher
+                        section="tasks"
+                        driveId={isLocked ? selectedDriveId : undefined}
+                      />
                       {/* View toggle */}
                       <div className="hidden md:flex items-center bg-muted rounded-md p-0.5">
                         <button


### PR DESCRIPTION
## Summary

Channels, files, tasks and calendar each exist in two shapes: one drive (`/dashboard/[driveId]/<section>`) and everything the user can see. The sidebar links to whichever shape you are already in, so the other shape had no affordance from inside the view. A drive's task list could not reach My Tasks without going back to the dashboard, and the global calendar had no way into a particular drive's.

### Scope switcher in every header
- New `DriveScopeSwitcher` (`apps/web/src/components/shared/`) names the current scope ("All drives" or the drive's name) and opens a menu with the all-drives view at the top and every non-trashed drive below it, current one checked.
- Wired into: channels list (drive + global), tasks dashboard (desktop header, compact icon on mobile), drive files browser, Drives browser (which stands in as the global files view, matching the sidebar's mapping), and the calendar (desktop header + mobile header row).
- The global entry renders before drives load, so the way out never waits on a fetch.

### Opening a drive from a files view lands on its files
- Drives browser: card click and the context menu's "Open" now go to `/dashboard/[driveId]/files` instead of the drive home.
- Header crumb / sidebar drive picker: switching drives while on a files, channels, tasks or calendar view keeps that section in the new drive. Anywhere else still goes to the drive home. Mapping lives beside the switcher's route table (`sectionForPathname`, `driveDestinationHref`), and treats `/dashboard/drives` as the files section.

### Not changed
- The tasks dashboard's existing drive filter is untouched.
- The sidebar Favorites section still links a favorited drive to its home; it is a bookmark shelf rather than a files surface.

## Test plan
- [x] New `DriveScopeSwitcher.test.tsx`: 12 cases covering the global/drive href table, trashed drives hidden, current item marked, compact accessible name, route-to-section mapping and picker destinations.
- [x] Existing suites for tasks, files, calendar (`MobileCalendarView`), `DashboardCrumb`, `DriveSwitcherDialog` still pass.
- [x] `tsc --noEmit` and eslint clean on all touched files.
- [ ] Manual: on a phone-width calendar, confirm the compact scope trigger (36px, same as the month dropdown in that row) sits well beside the 32px icon buttons.

## Changelog
Entry added under Unreleased / Added.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01H5qj6LeFmbkH63TTYNbcNK

---
_Generated by [Claude Code](https://claude.ai/code/session_01H5qj6LeFmbkH63TTYNbcNK)_