### PR TITLE
chore(release): @pagespace/sdk 2.4.0, @pagespace/cli 1.10.0, API contract 1.2.0

### DIFF
--- a/apps/marketing/src/app/docs/features/cli/page.tsx
+++ b/apps/marketing/src/app/docs/features/cli/page.tsx
@@ -27,7 +27,7 @@ Or run it without installing:
 npx -y -p @pagespace/cli pagespace <command>
 \`\`\`
 
-The current version is **1.9.0**. Installing gives you two binaries: \`pagespace\` (the CLI) and \`pagespace-mcp\` (the MCP server).
+The current version is **1.10.0**. Installing gives you two binaries: \`pagespace\` (the CLI) and \`pagespace-mcp\` (the MCP server).
 
 ## Sign in
 

--- a/apps/marketing/src/app/docs/features/sdk/page.tsx
+++ b/apps/marketing/src/app/docs/features/sdk/page.tsx
@@ -21,7 +21,7 @@ It's the same client the [\`pagespace\` CLI](/docs/features/cli) and the \`pages
 npm install @pagespace/sdk
 \`\`\`
 
-ESM only, with a single runtime dependency (\`zod\`). The current version is **2.3.0**.
+ESM only, with a single runtime dependency (\`zod\`). The current version is **2.4.0**.
 
 ## Quickstart
 

--- a/bun.lock
+++ b/bun.lock
@@ -454,7 +454,7 @@
     },
     "packages/cli": {
       "name": "@pagespace/cli",
-      "version": "1.9.0",
+      "version": "1.10.0",
       "bin": {
         "pagespace": "./dist/bin.js",
         "pagespace-mcp": "./dist/bin-pagespace-mcp.js",
@@ -565,7 +565,7 @@
     },
     "packages/sdk": {
       "name": "@pagespace/sdk",
-      "version": "2.3.0",
+      "version": "2.4.0",
       "dependencies": {
         "zod": "^4.1.8",
       },

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
-## [Unreleased]
+## [1.10.0] — 2026-09-12
 
 ### Added
 

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pagespace/cli",
-  "version": "1.9.0",
+  "version": "1.10.0",
   "description": "pagespace \u2014 the official CLI for PageSpace: browser-based login, drive/page/task management, and a `pagespace mcp` stdio server for coding agents.",
   "license": "MIT",
   "repository": {
@@ -41,7 +41,7 @@
     "@clack/prompts": "^1.7.0",
     "@modelcontextprotocol/sdk": "^1.29.0",
     "@napi-rs/keyring": "^1.3.0",
-    "@pagespace/sdk": "^2.3.0",
+    "@pagespace/sdk": "^2.4.0",
     "ws": "^8.18.3",
     "zod": "^4.1.8"
   },

--- a/packages/cli/src/commands/version.ts
+++ b/packages/cli/src/commands/version.ts
@@ -7,7 +7,7 @@ import type { CommandHandler } from '../router/router.js';
  * guarded by `commands/__tests__/version.test.ts`, which reads package.json
  * directly, so bumping one without the other fails the suite.
  */
-export const CLI_VERSION = '1.9.0';
+export const CLI_VERSION = '1.10.0';
 
 export const versionHandler: CommandHandler = async (ctx, intent) => {
   if (intent.flags.json) {

--- a/packages/lib/src/api-contract-version.ts
+++ b/packages/lib/src/api-contract-version.ts
@@ -9,5 +9,13 @@
  * is a MINOR bump and `MIN_SERVER_API_VERSION` deliberately stays at 1.0.0:
  * a client built against 1.1.0 still works against a 1.0.0 server for every
  * operation, it simply does not get to choose the address.
+ *
+ * 1.2.0 — `POST /api/mcp/sheets` gains two operations, `read-formatting` and
+ * `apply-format`, which expose a sheet's presentation (regions, conditional
+ * rules, frozen panes, column and cell formats) to SDK, CLI and MCP callers.
+ * ADR 0001 D5 lists "adding an operation" as MINOR, so `MIN_SERVER_API_VERSION`
+ * stays at 1.0.0 for the same reason 1.1.0 did: a client built against 1.2.0
+ * still works against an older server for every other operation, it simply
+ * cannot format a sheet there.
  */
-export const API_CONTRACT_VERSION = '1.1.0';
+export const API_CONTRACT_VERSION = '1.2.0';

--- a/packages/sdk/CHANGELOG.md
+++ b/packages/sdk/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
-## [Unreleased]
+## [2.4.0] — 2026-09-12
 
 ### Added
 

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pagespace/sdk",
-  "version": "2.3.0",
+  "version": "2.4.0",
   "description": "Typed TypeScript/JavaScript client SDK for the PageSpace API — drives, pages, tasks, roles, search, agents, and more.",
   "keywords": [
     "pagespace",

--- a/packages/sdk/src/version.ts
+++ b/packages/sdk/src/version.ts
@@ -5,7 +5,7 @@ import type { CompatibilityResult } from './errors.js';
  * guarded by `__tests__/version.test.ts`, which reads package.json directly,
  * so bumping one without the other fails the suite.
  */
-export const SDK_VERSION = '2.3.0';
+export const SDK_VERSION = '2.4.0';
 
 /**
  * The SDK's compiled-in floor for the server's API_CONTRACT_VERSION (ADR 0001


### PR DESCRIPTION
Cuts the npm release for the sheet-formatting work merged in #2611.

| package | from | to |
|---|---|---|
| `@pagespace/sdk` | 2.3.0 | **2.4.0** |
| `@pagespace/cli` | 1.9.0 | **1.10.0** |
| `API_CONTRACT_VERSION` | 1.1.0 | **1.2.0** |

Both bumps are MINOR — every change was additive: two new SDK operations, two new CLI verbs, and a CLI docs change that was already sitting unreleased.

## Three things beyond the obvious bump

**The CLI's dependency range had to move too.** `@pagespace/cli` depends on `@pagespace/sdk` as a real published dependency, not `workspace:*`, and its new `sheets formatting` / `sheets format` verbs call `sdk.sheets.readFormatting` and `sdk.sheets.applyFormat`. Publishing 1.10.0 against `^2.3.0` would let npm resolve an SDK that lacks those operations, and both verbs would fail at runtime with an undefined method. Now `^2.4.0`.

**`API_CONTRACT_VERSION` — #2611 should have bumped this and didn't.** It versions the operation registry contract, is hand-maintained, and ADR 0001 D5 lists *"adding an operation"* as MINOR. #2611 added two to `POST /api/mcp/sheets`. `MIN_SERVER_API_VERSION` deliberately stays at 1.0.0, for exactly the reason the existing 1.1.0 note gives: a client built against 1.2.0 still works against an older server for every other operation, it simply cannot format a sheet there. Safe to bump — nothing pins the literal value; the guard only asserts `MIN <= CONTRACT` and every other reference imports the constant.

**Each package carries its version twice.** `SDK_VERSION` and `CLI_VERSION` are compiled-in constants, each guarded by a test that reads `package.json` from disk. Both updated.

## Deliberately not touched

Root `CHANGELOG.md`. It is the **product** changelog (last release 1.7.1) and its `[Unreleased]` section holds entries from many PRs — the Home screen, the drive-focus work, iOS sign-in. Cutting a product release is a separate decision and yours to make, not something to fold into an npm bump.

## Verification

`bun.lock` regenerated with `bun install --lockfile-only`, which updates the lockfile without materialising `node_modules` — this worktree cannot afford a 10GB install at 98% disk.

- `bun install --frozen-lockfile --dry-run` → **rc=0**. Every CI job runs `--frozen-lockfile`, so this is the check that matters.
- **Controlled**, because a passing check that cannot fail proves nothing: adding a bogus dependency made it fail with `lockfile had changes, but lockfile is frozen` (rc=1), and restoring returned rc=0.
- The `^2.3.0` string bun keeps in the lockfile's CLI dependencies block is how it records a workspace-linked dep and does not trip that check — confirmed by the above, not assumed.

All four version invariants asserted directly:

```
sdk package.json 2.4.0  == SDK_VERSION 2.4.0    ✓
cli package.json 1.10.0 == CLI_VERSION 1.10.0   ✓
cli dep ^2.4.0 satisfied by sdk 2.4.0           ✓
MIN 1.0.0 <= API_CONTRACT 1.2.0                 ✓
```

Marketing docs updated as well — the SDK and CLI pages each state the current version in prose and would have been wrong the moment this publishes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UL6XP431Kes4BdJc4UTz9o


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added API contract support for `read-formatting` and `apply-format` operations on the Sheets API.

- **Releases**
  - Released CLI version 1.10.0.
  - Released SDK version 2.4.0.
  - Updated the CLI to use the latest SDK version.

- **Documentation**
  - Updated CLI and SDK documentation to reflect the current released versions.
  - Published release information for CLI 1.10.0 and SDK 2.4.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->