### PR TITLE
fix(home): phone header keeps one row, and "you left off in" links to a real route

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,8 +16,9 @@ All notable user-facing changes to PageSpace are documented here. Format follows
   quick prompts underneath that put the same thing straight into the composer without sending it.
   Nothing is invented: the line only ever says what it can back up, and on a quiet day it just says
   you're caught up. Once you start a conversation the line tucks into a small strip under the
-  header instead of taking up the page, and you can still expand it. Collapse the left sidebar and
-  a small drive switcher stays next to the title, so you always know what the assistant can see.
+  header instead of taking up the page, and you can still expand it. On desktop, collapse the left
+  sidebar and a small drive switcher stays next to the title, so you always know what the assistant
+  can see; on a phone the sidebar sheet's own switcher covers that, so the header row stays one row.
 - **Channels, Files, Tasks and Calendar are one page each, with a drive focus** — each of those
   views used to exist twice: a dashboard version and a drive version, with different titles and a
   sidebar that only ever linked to whichever one you were in. Now "All drives" is a focus like any

--- a/apps/web/src/app/api/pulse/__tests__/compute-signals.test.ts
+++ b/apps/web/src/app/api/pulse/__tests__/compute-signals.test.ts
@@ -214,12 +214,20 @@ describe('computeLeftOffSignal', () => {
   // the `isTrashed` filter (the case below) still gets caught.
   it('returns the most recently viewed non-trashed, accessible page', async () => {
     seed(userPageViews, [
-      { userId: USER, viewedAt: new Date('2026-09-10T00:00:00Z'), id: 'p-new', title: 'Trip planning', isTrashed: false },
-      { userId: USER, viewedAt: new Date('2026-09-01T00:00:00Z'), id: 'p-old', title: 'Old page', isTrashed: false },
+      { userId: USER, viewedAt: new Date('2026-09-10T00:00:00Z'), id: 'p-new', driveId: 'd1', title: 'Trip planning', isTrashed: false },
+      { userId: USER, viewedAt: new Date('2026-09-01T00:00:00Z'), id: 'p-old', driveId: 'd1', title: 'Old page', isTrashed: false },
     ]);
     const result = await computeLeftOffSignal(USER, ['p-new', 'p-old'], NOW);
     expect(result.count).toBe(1);
     expect(result.subject?.title).toBe('Trip planning');
+  });
+
+  it('links to the page under its drive, the route that actually exists', async () => {
+    seed(userPageViews, [
+      { userId: USER, viewedAt: NOW, id: 'p-chan', driveId: 'd-team', title: 'Debate', isTrashed: false },
+    ]);
+    const result = await computeLeftOffSignal(USER, ['p-chan'], NOW);
+    expect(result.action.href).toBe('/dashboard/d-team/p-chan');
   });
 
   it('falls back past a trashed most-recent view (control row)', async () => {

--- a/apps/web/src/app/api/pulse/compute-signals.ts
+++ b/apps/web/src/app/api/pulse/compute-signals.ts
@@ -293,7 +293,7 @@ export async function computeLeftOffSignal(
   }
 
   const [row] = await db
-    .select({ pageId: pages.id, title: pages.title })
+    .select({ pageId: pages.id, driveId: pages.driveId, title: pages.title })
     .from(userPageViews)
     .innerJoin(pages, eq(pages.id, userPageViews.pageId))
     .where(
@@ -323,7 +323,10 @@ export async function computeLeftOffSignal(
     window: { since: now, kind: 'today' },
     computedAt: now,
     text: { lead: `you left off in ${row.title}`, short: `you left off in ${row.title}` },
-    action: { prompt: `Pick up ${row.title}`, href: `/pages/${row.pageId}` },
+    // The page's real route. There is no `/pages/:id` in the app — that
+    // landed on the not-found page — and `/p/:id` would only redirect here
+    // after a server round trip; the join already has the drive.
+    action: { prompt: `Pick up ${row.title}`, href: `/dashboard/${row.driveId}/${row.pageId}` },
   };
 }
 

--- a/apps/web/src/app/api/pulse/compute-signals.ts
+++ b/apps/web/src/app/api/pulse/compute-signals.ts
@@ -272,6 +272,12 @@ export async function computeMeetingTodaySignal(
   };
 }
 
+/**
+ * "Where you left off": the single most recently viewed page the user can
+ * still open, as a fact plus a link straight to it. Scoped to
+ * `accessiblePageIds`, so a view that outlived its access discloses neither
+ * the title nor the link.
+ */
 export async function computeLeftOffSignal(
   userId: string,
   accessiblePageIds: string[],

--- a/apps/web/src/components/ai/shared/AISelector.tsx
+++ b/apps/web/src/components/ai/shared/AISelector.tsx
@@ -99,7 +99,11 @@ export function AISelector({
             className
           )}
         >
-          <span className={selectedAgent ? "truncate min-w-0" : ""}>
+          {/* Always truncating, not just for an agent title: the button is
+              allowed to shrink below its intrinsic width (see the header in
+              GlobalAssistantView), so a label with nowhere to go must end in
+              an ellipsis rather than spill over its neighbours. */}
+          <span className="truncate min-w-0">
             {selectedAgent ? selectedAgent.title : 'Global Assistant'}
           </span>
           <ChevronDown className="h-4 w-4 opacity-50" />

--- a/apps/web/src/components/layout/middle-content/page-views/dashboard/GlobalAssistantView.tsx
+++ b/apps/web/src/components/layout/middle-content/page-views/dashboard/GlobalAssistantView.tsx
@@ -915,6 +915,13 @@ const GlobalAssistantView: React.FC = () => {
       <div className="flex items-center justify-between gap-2 p-4 border-[var(--separator)]">
         <div className="flex min-w-0 items-center space-x-2">
           <AISelector
+            // `shrink` overrides the shared button variant's own `shrink-0`
+            // (twMerge, later class wins), and `min-w-0` lets it fall below
+            // its intrinsic width. Without both, a long agent title keeps the
+            // button at full width and pushes the actions off the row — the
+            // truncate on the label inside can only act once the button
+            // itself is allowed to narrow.
+            className="min-w-0 shrink"
             selectedAgent={selectedAgent}
             onSelectAgent={handleSelectAgentForVoice}
             // The CONVERSATION's own liveness, not a raw chat status. Switching agent while

--- a/apps/web/src/components/layout/middle-content/page-views/dashboard/GlobalAssistantView.tsx
+++ b/apps/web/src/components/layout/middle-content/page-views/dashboard/GlobalAssistantView.tsx
@@ -912,8 +912,8 @@ const GlobalAssistantView: React.FC = () => {
     <AskUserAnswerProvider value={askUserAnswering}>
     <div data-testid="global-assistant-view" className="flex flex-col h-full">
       {/* Header */}
-      <div className="flex items-center justify-between p-4 border-[var(--separator)]">
-        <div className="flex items-center space-x-2">
+      <div className="flex items-center justify-between gap-2 p-4 border-[var(--separator)]">
+        <div className="flex min-w-0 items-center space-x-2">
           <AISelector
             selectedAgent={selectedAgent}
             onSelectAgent={handleSelectAgentForVoice}
@@ -922,15 +922,21 @@ const GlobalAssistantView: React.FC = () => {
             // longer reports "streaming" at all, because this client does not read a body.
             disabled={effectiveIsStreaming}
           />
-          {/* When the left sidebar (and its drive switcher) is hidden, the
-              scope the assistant can see would otherwise be invisible. */}
+          {/* When the left sidebar (and its drive switcher) is collapsed, the
+              scope the assistant can see would otherwise be invisible.
+
+              Desktop only (lg+), the same gate as DashboardCrumb's drive
+              crumb: below lg the sidebar is a sheet whatever `leftSidebarOpen`
+              says, its DriveSwitcher opens this same picker, and a phone
+              header row has no room for a second wordy control — it pushed
+              the New button off the right edge. */}
           {!leftSidebarOpen && isGlobalMode && (
-            <div className="rounded-lg bg-primary-soft">
+            <div className="hidden rounded-lg bg-primary-soft lg:block">
               <DriveSwitcher />
             </div>
           )}
         </div>
-        <div className="flex items-center space-x-2">
+        <div className="flex shrink-0 items-center space-x-2">
           <PlanChip conversationId={currentConversationId} messages={plainMessages} />
           <TasksDropdown messages={plainMessages} driveId={selectedAgent?.driveId || locationContext?.currentDrive?.id} />
           <Button


### PR DESCRIPTION
## Summary

Two fixes to the Home surface that landed with the Home Signals line (#2617's neighbour, `b3bb5e02`).

### 1. The "All drives" pill is desktop-only, and the header row cannot clip New

That commit put a `DriveSwitcher` pill next to the "Global Assistant" title whenever `leftSidebarOpen` is false, so the scope the assistant can see stays visible with the desktop sidebar collapsed. But `leftSidebarOpen` is a persisted flag that says nothing about a phone, where the sidebar is a sheet regardless. The pill rendered on every phone Home, and "All drives" plus its icon and chevrons pushed the New button off the right edge.

- The pill is now gated to `lg+`, the same breakpoint `DashboardCrumb` uses for its drive crumb and for the same reason: below `lg` the sidebar sheet's own `DriveSwitcher` opens the same picker, so nothing is lost on a phone.
- The header row gets `min-w-0` on the title group and `shrink-0` on the actions group, so a long title truncates instead of clipping New.
- The Unreleased changelog entry now says the collapsed-sidebar switcher is a desktop behaviour.

### 2. "you left off in …" no longer lands on the not-found page

The left-off signal's action href was `/pages/:id`, a route the app does not have, so the one link on the Home line 404'd for every page type. The query already joins `pages`, so it now selects the drive id too and links straight to `/dashboard/:driveId/:pageId`, the canonical page route and a single client-side navigation rather than a trip through the `/p/:id` server redirect.

## Test plan

- [x] `bun run typecheck` (apps/web) clean
- [x] ESLint on the changed files clean
- [x] `GlobalAssistantView` unit tests (25) pass
- [x] Pulse signal tests (50) pass, including a new fixture test pinning the left-off href shape
- [ ] Phone: open `/dashboard`, confirm the header is one row with the New button visible and no "All drives" pill
- [ ] Desktop with the left sidebar collapsed: confirm the pill still appears next to the title
- [ ] Click "you left off in …" on the Home line and land on the page (a channel included)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01G8nb6daBWXFsWXNgc3SE1m

---
_Generated by [Claude Code](https://claude.ai/code/session_01G8nb6daBWXFsWXNgc3SE1m)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - “Continue where you left off” links now open the correct page within its drive.
  - Improved dashboard header behavior to prevent controls from shrinking or overflowing.
  - Long assistant labels now truncate cleanly in compact layouts.
  - On smaller screens, the auxiliary drive switcher is hidden so the mobile sidebar’s switcher can be used instead.

- **Documentation**
  - Clarified when the Home screen’s drive switcher appears on desktop and mobile.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->